### PR TITLE
quincy: build: Silence deprecation warnings from OpenSSL 3

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -33,12 +33,19 @@
 #include "common/debug.h"
 #include <errno.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 using std::ostringstream;
 using std::string;
 
 using ceph::bufferlist;
 using ceph::bufferptr;
 using ceph::Formatter;
+
 
 // use getentropy() if available. it uses the same source of randomness
 // as /dev/urandom without the filesystem overhead
@@ -603,3 +610,6 @@ CryptoHandler *CryptoHandler::create(int type)
     return NULL;
   }
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -27,6 +27,12 @@
 #  include <openssl/err.h>
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 namespace TOPNSPC::crypto::ssl {
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -213,3 +219,6 @@ void ssl::OpenSSLDigest::Final(unsigned char *digest) {
 }
 
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -22,6 +22,12 @@
 
 #include "include/ceph_assert.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 extern "C" {
   const EVP_MD *EVP_md5(void);
   const EVP_MD *EVP_sha1(void);
@@ -201,5 +207,8 @@ auto digest(const ceph::buffer::list& bl)
   return sha_digest_t<Digest::digest_size>{fingerprint};
 }
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #endif

--- a/src/common/openssl_opts_handler.cc
+++ b/src/common/openssl_opts_handler.cc
@@ -113,7 +113,14 @@ void load_module(const string &engine_conf)
   }
 
   OPENSSL_load_builtin_modules();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   ENGINE_load_builtin_engines();
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
   if (CONF_modules_load(
           conf, nullptr,

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -297,9 +297,8 @@ static ghobject_t test_ops_get_object_name(
     }
     if (pool < 0) {
       // the return type of `fmt::format` is `std::string`
-      using namespace fmt::literals;
       throw std::invalid_argument{
-        "Invalid pool '{}'"_format(*pool_arg)
+        fmt::format("Invalid pool '{}'", *pool_arg)
       };
     }
     return pool;

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -12,8 +12,6 @@
 #define LOGGER(subname_) crimson::get_logger(ceph_subsys_##subname_)
 #define LOG_PREFIX(x) constexpr auto FNAME = #x
 
-#ifdef NDEBUG
-
 #define LOG(level_, MSG, ...) \
   LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define LOGT(level_, MSG, t, ...) \
@@ -22,26 +20,6 @@
   LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOGT(subname_, level_, MSG, t, ...) \
   LOGGER(subname_).log(level_, "{}({}): " MSG, FNAME, (void*)&t , ##__VA_ARGS__)
-
-#else
-
-// do compile-time format string validation
-using namespace fmt::literals;
-template<seastar::log_level lv>
-void _LOG(seastar::logger& logger, std::string_view info) {
-  logger.log(lv, info.data());
-}
-
-#define LOG(level_, MSG, ...) \
-  _LOG<level_>(LOCAL_LOGGER, "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
-#define LOGT(level_, MSG, t_, ...) \
-  _LOG<level_>(LOCAL_LOGGER, "{}({}): " MSG ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
-#define SUBLOG(subname_, level_, MSG, ...) \
-  _LOG<level_>(LOGGER(subname_), "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
-#define SUBLOGT(subname_, level_, MSG, t_, ...) \
-  _LOG<level_>(LOGGER(subname_), "{}({}): " MSG ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
-
-#endif
 
 #define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
 #define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -109,3 +109,37 @@ enum class nextent_state_t : uint8_t {
 };
 
 }
+
+template <> struct fmt::formatter<crimson::os::seastore::onode::node_delta_op_t>
+  : fmt::formatter<std::string_view> {
+  using node_delta_op_t =  crimson::os::seastore::onode::node_delta_op_t;
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(node_delta_op_t op, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (op) {
+    case node_delta_op_t::INSERT:
+      name = "insert";
+      break;
+    case node_delta_op_t::SPLIT:
+      name = "split";
+      break;
+    case node_delta_op_t::SPLIT_INSERT:
+      name = "split_insert";
+      break;
+    case node_delta_op_t::UPDATE_CHILD_ADDR:
+      name = "update_child_addr";
+      break;
+    case node_delta_op_t::ERASE:
+      name = "erase";
+      break;
+    case node_delta_op_t::MAKE_TAIL:
+      name = "make_tail";
+      break;
+    case node_delta_op_t::SUBOP_UPDATE_VALUE:
+      name = "subop_update_value";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -35,6 +35,46 @@
 using std::string;
 using crimson::common::local_conf;
 
+template <> struct fmt::formatter<crimson::os::seastore::SeaStore::op_type_t>
+  : fmt::formatter<std::string_view> {
+  using op_type_t =  crimson::os::seastore::SeaStore::op_type_t;
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(op_type_t op, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (op) {
+      case op_type_t::TRANSACTION:
+      name = "transaction";
+      break;
+    case op_type_t::READ:
+      name = "read";
+      break;
+    case op_type_t::WRITE:
+      name = "write";
+      break;
+    case op_type_t::GET_ATTR:
+      name = "get_attr";
+      break;
+    case op_type_t::GET_ATTRS:
+      name = "get_attrs";
+      break;
+    case op_type_t::STAT:
+      name = "stat";
+      break;
+    case op_type_t::OMAP_GET_VALUES:
+      name = "omap_get_values";
+      break;
+    case op_type_t::OMAP_LIST:
+      name = "omap_list";
+      break;
+    case op_type_t::MAX:
+      name = "unknown";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};
+
 SET_SUBSYS(seastore);
 
 namespace crimson::os::seastore {

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -4,6 +4,8 @@
 #include <sys/mman.h>
 #include <string.h>
 
+#include <fmt/format.h>
+
 #include "include/buffer.h"
 
 #include "crimson/common/config_proxy.h"
@@ -23,6 +25,28 @@ SET_SUBSYS(seastore_device);
  * - DEBUG: INFO details, major read and write operations
  * - TRACE: DEBUG details
  */
+
+using segment_state_t = crimson::os::seastore::Segment::segment_state_t;
+
+template <> struct fmt::formatter<segment_state_t>: fmt::formatter<std::string_view> {
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(segment_state_t s, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (s) {
+    case segment_state_t::EMPTY:
+      name = "empty";
+      break;
+    case segment_state_t::OPEN:
+      name = "open";
+      break;
+    case segment_state_t::CLOSED:
+      name = "closed";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};
 
 namespace crimson::os::seastore::segment_manager::block {
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -415,7 +415,7 @@ void LogMonitor::log_external(const LogEntry& le)
     }
 
     if (fd >= 0) {
-      fmt::format_to(file_log_buffer, "{}\n", le);
+      fmt::format_to(std::back_inserter(file_log_buffer), "{}\n", le);
       int err = safe_write(fd, file_log_buffer.data(), file_log_buffer.size());
       file_log_buffer.clear();
       if (err < 0) {

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -1,5 +1,5 @@
 CherryPy==13.1.0
-more-itertools==4.1.0
+more-itertools==8.14.0
 PyJWT==2.0.1
 bcrypt==3.1.4
 python3-saml==1.4.1

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -8,8 +8,16 @@
 #include "rgw_rest.h"
 #include "rgw_sts.h"
 #include "rgw_web_idp.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include "jwt-cpp/jwt.h"
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #include "rgw_oidc_provider.h"
+
 
 namespace rgw::auth::sts {
 
@@ -227,3 +235,4 @@ public:
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;
 };
+

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "crimson/common/log.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/value.h"
 
@@ -34,6 +36,22 @@ struct test_item_t {
 };
 inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
   return os << "TestItem(#" << item.id << ", " << item.size << "B)";
+}
+
+enum class delta_op_t : uint8_t {
+  UPDATE_ID,
+  UPDATE_TAIL_MAGIC,
+};
+
+inline std::ostream& operator<<(std::ostream& os, const delta_op_t op) {
+  switch (op) {
+  case delta_op_t::UPDATE_ID:
+    return os << "update_id";
+  case delta_op_t::UPDATE_TAIL_MAGIC:
+    return os << "update_tail_magic";
+  default:
+    return os << "unknown";
+  }
 }
 
 template <value_magic_t MAGIC,
@@ -86,10 +104,6 @@ class TestValue final : public Value {
 
  public:
   class Recorder final : public ValueDeltaRecorder {
-    enum class delta_op_t : uint8_t {
-      UPDATE_ID,
-      UPDATE_TAIL_MAGIC,
-    };
 
    public:
     Recorder(ceph::bufferlist& encoded)


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/46330 to quincy to unbreak `make check`:
```
FAILED: src/crimson/CMakeFiles/crimson.dir/__/auth/AuthSessionHandler.cc.o 
/usr/bin/ccache /usr/bin/clang++-14 -DBOOST_ASIO_DISABLE_CONCEPTS -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT -DHAVE_CONFIG_H -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_TYPE_ERASE_MORE -DWITH_SEASTAR=1 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/include -I/home/jenkins-build/build/workspace/ceph-pull-requests/src -I/home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/include -I/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/seastar/gen/include -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/build/boost/include -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/build/include -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/src/xxHash -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/src/rapidjson/include -Werror -g -fPIC -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -DCEPH_DEBUG_MUTEX -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ftemplate-backtrace-limit=0 -Wno-non-virtual-dtor -std=gnu++17 -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -std=c++17 -MD -MT src/crimson/CMakeFiles/crimson.dir/__/auth/AuthSessionHandler.cc.o -MF src/crimson/CMakeFiles/crimson.dir/__/auth/AuthSessionHandler.cc.o.d -o src/crimson/CMakeFiles/crimson.dir/__/auth/AuthSessionHandler.cc.o -c /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:135:19: error: 'HMAC_CTX_new' is deprecated [-Werror,-Wdeprecated-declarations]
      : mpContext(HMAC_CTX_new()) {
                  ^
/usr/include/openssl/hmac.h:33:1: note: 'HMAC_CTX_new' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 HMAC_CTX *HMAC_CTX_new(void);
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:136:22: error: 'HMAC_Init_ex' is deprecated [-Werror,-Wdeprecated-declarations]
      const auto r = HMAC_Init_ex(mpContext, key, length, type, nullptr);
                     ^
/usr/include/openssl/hmac.h:43:1: note: 'HMAC_Init_ex' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:142:7: error: 'HMAC_CTX_free' is deprecated [-Werror,-Wdeprecated-declarations]
      HMAC_CTX_free(mpContext);
      ^
/usr/include/openssl/hmac.h:35:1: note: 'HMAC_CTX_free' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 void HMAC_CTX_free(HMAC_CTX *ctx);
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:146:35: error: 'HMAC_CTX_get_md' is deprecated [-Werror,-Wdeprecated-declarations]
      const EVP_MD * const type = HMAC_CTX_get_md(mpContext);
                                  ^
/usr/include/openssl/hmac.h:51:1: note: 'HMAC_CTX_get_md' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 const EVP_MD *HMAC_CTX_get_md(const HMAC_CTX *ctx);
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:147:22: error: 'HMAC_Init_ex' is deprecated [-Werror,-Wdeprecated-declarations]
      const auto r = HMAC_Init_ex(mpContext, nullptr, 0, type, nullptr);
                     ^
/usr/include/openssl/hmac.h:43:1: note: 'HMAC_Init_ex' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:154:24: error: 'HMAC_Update' is deprecated [-Werror,-Wdeprecated-declarations]
        const auto r = HMAC_Update(mpContext, input, length);
                       ^
/usr/include/openssl/hmac.h:45:1: note: 'HMAC_Update' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data,
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/auth/AuthSessionHandler.cc:23:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_crypto.h:162:22: error: 'HMAC_Final' is deprecated [-Werror,-Wdeprecated-declarations]
      const auto r = HMAC_Final(mpContext, digest, &s);
                     ^
/usr/include/openssl/hmac.h:47:1: note: 'HMAC_Final' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int HMAC_Final(HMAC_CTX *ctx, unsigned char *md,
^
/usr/include/openssl/macros.h:182:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/usr/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
7 errors generated.
```