### PR TITLE
pacific: doc/rados/operations: add prompts to operating.rst

### DIFF
--- a/doc/rados/operations/operating.rst
+++ b/doc/rados/operations/operating.rst
@@ -10,87 +10,107 @@ Running Ceph with systemd
 
 For all distributions that support systemd (CentOS 7, Fedora, Debian
 Jessie 8 and later, SUSE), ceph daemons are now managed using native
-systemd files instead of the legacy sysvinit scripts.  For example::
+systemd files instead of the legacy sysvinit scripts.  For example:
 
-        sudo systemctl start ceph.target       # start all daemons
-        sudo systemctl status ceph-osd@12      # check status of osd.12
+.. prompt:: bash $
 
-To list the Ceph systemd units on a node, execute::
+   sudo systemctl start ceph.target       # start all daemons
+   sudo systemctl status ceph-osd@12      # check status of osd.12
 
-        sudo systemctl status ceph\*.service ceph\*.target
+To list the Ceph systemd units on a node, execute:
+
+.. prompt:: bash $
+
+   sudo systemctl status ceph\*.service ceph\*.target
 
 Starting all Daemons
 --------------------
 
 To start all daemons on a Ceph Node (irrespective of type), execute the
-following::
+following:
 
-	sudo systemctl start ceph.target
+.. prompt:: bash $
+
+   sudo systemctl start ceph.target
 
 
 Stopping all Daemons
 --------------------
 
 To stop all daemons on a Ceph Node (irrespective of type), execute the
-following::
+following:
 
-        sudo systemctl stop ceph\*.service ceph\*.target
+.. prompt:: bash $
+
+   sudo systemctl stop ceph\*.service ceph\*.target
 
 
 Starting all Daemons by Type
 ----------------------------
 
 To start all daemons of a particular type on a Ceph Node, execute one of the
-following::
+following:
 
-        sudo systemctl start ceph-osd.target
-        sudo systemctl start ceph-mon.target
-        sudo systemctl start ceph-mds.target
+.. prompt:: bash $
+
+   sudo systemctl start ceph-osd.target
+   sudo systemctl start ceph-mon.target
+   sudo systemctl start ceph-mds.target
 
 
 Stopping all Daemons by Type
 ----------------------------
 
 To stop all daemons of a particular type on a Ceph Node, execute one of the
-following::
+following:
 
-        sudo systemctl stop ceph-mon\*.service ceph-mon.target
-        sudo systemctl stop ceph-osd\*.service ceph-osd.target
-        sudo systemctl stop ceph-mds\*.service ceph-mds.target
+.. prompt:: bash $
+
+   sudo systemctl stop ceph-mon\*.service ceph-mon.target
+   sudo systemctl stop ceph-osd\*.service ceph-osd.target
+   sudo systemctl stop ceph-mds\*.service ceph-mds.target
 
 
 Starting a Daemon
 -----------------
 
 To start a specific daemon instance on a Ceph Node, execute one of the
-following::
+following:
 
-	sudo systemctl start ceph-osd@{id}
-	sudo systemctl start ceph-mon@{hostname}
-	sudo systemctl start ceph-mds@{hostname}
+.. prompt:: bash $
 
-For example::
+   sudo systemctl start ceph-osd@{id}
+   sudo systemctl start ceph-mon@{hostname}
+   sudo systemctl start ceph-mds@{hostname}
 
-	sudo systemctl start ceph-osd@1
-	sudo systemctl start ceph-mon@ceph-server
-	sudo systemctl start ceph-mds@ceph-server
+For example:
+
+.. prompt:: bash $
+
+   sudo systemctl start ceph-osd@1
+   sudo systemctl start ceph-mon@ceph-server
+   sudo systemctl start ceph-mds@ceph-server
 
 
 Stopping a Daemon
 -----------------
 
 To stop a specific daemon instance on a Ceph Node, execute one of the
-following::
+following:
 
-	sudo systemctl stop ceph-osd@{id}
-	sudo systemctl stop ceph-mon@{hostname}
-	sudo systemctl stop ceph-mds@{hostname}
+.. prompt:: bash $
 
-For example::
+   sudo systemctl stop ceph-osd@{id}
+   sudo systemctl stop ceph-mon@{hostname}
+   sudo systemctl stop ceph-mds@{hostname}
 
-	sudo systemctl stop ceph-osd@1
-	sudo systemctl stop ceph-mon@ceph-server
-	sudo systemctl stop ceph-mds@ceph-server
+For example:
+
+.. prompt:: bash $
+
+   sudo systemctl stop ceph-osd@1
+   sudo systemctl stop ceph-mon@ceph-server
+   sudo systemctl stop ceph-mds@ceph-server
 
 
 .. index:: Upstart; operating a cluster


### PR DESCRIPTION
This commit adds ".. prompt:: bash $"-style prompts to operating.rst.
This brings this file up to the standard established in 2020 when
Kefu added support for the ".. prompt::" directive.

This commit is a part of an initiative to modernize the presentation
of all BASH commands in the RADOS documentation.

The progress of this project can be tracked here:
https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 69d62c05ef0ac8b903944d9e8c8fe4fbb3f73275)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
