### PR TITLE
qa: replace 'sleep driven synchronization' with polling in keystone, barbican tasks

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,7 +27,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 17.0.0.0rc2
+      sha1: 20.0.0
       force-branch: master
       projects:
         - name: rgwcrypt
@@ -69,7 +69,7 @@ tasks:
           description: Swift Service
 - barbican:
     client.0:
-      sha1: 5.0.1
+      sha1: 13.0.0
       force-branch: master
       use-keystone-role: client.0
       keystone_authtoken:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -4,7 +4,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 17.0.0.0rc2
+      sha1: 20.0.0
       force-branch: master
       services:
         - name: swift
@@ -16,7 +16,7 @@ tasks:
       use-keystone-role: client.0
 - tempest:
     client.0:
-      sha1: train-last
+      sha1: 30.0.0
       force-branch: master
       use-keystone-role: client.0
       auth:

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -368,7 +368,7 @@ def create_secrets(ctx, config):
             barbican_sec_resp = sec_req.getresponse()
             if not (barbican_sec_resp.status >= 200 and
                     barbican_sec_resp.status < 300):
-                raise Exception("Cannot create secret")
+                raise Exception("Cannot create secret, status={} reason={} headers={}".format(barbican_sec_resp.status, barbican_sec_resp.reason, barbican_sec_resp.headers))
             barbican_data = json.loads(barbican_sec_resp.read().decode())
             if 'secret_ref' not in barbican_data:
                 raise ValueError("Malformed secret creation response")

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -16,6 +16,8 @@ from teuthology import contextutil
 from teuthology.orchestra import run
 from teuthology.exceptions import ConfigError
 
+from tasks.util.http import wait_for_http_endpoint
+
 log = logging.getLogger(__name__)
 
 
@@ -231,8 +233,11 @@ def run_barbican(ctx, config):
             check_status=False,
         )
 
-        # sleep driven synchronization
-        run_in_barbican_venv(ctx, client, ['sleep', '15'])
+        # wait for the endpoint to come up
+        barbican_host, barbican_port = ctx.barbican.endpoints[client]
+        barbican_url = 'http://{host}:{port}'.format(host=barbican_host,
+                                                     port=barbican_port)
+        wait_for_http_endpoint(barbican_url, remote)
     try:
         yield
     finally:

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -11,7 +11,8 @@ from teuthology import contextutil
 from teuthology.exceptions import ConfigError
 from tasks.ceph_manager import get_valgrind_args
 from tasks.util import get_remote_for_role
-from tasks.util.rgw import rgwadmin, wait_for_radosgw
+from tasks.util.rgw import rgwadmin
+from tasks.util.http import wait_for_http_endpoint
 from tasks.util.rados import (create_ec_pool,
                               create_replicated_pool,
                               create_cache_pool)
@@ -220,7 +221,7 @@ def start_rgw(ctx, config, clients):
         url = endpoint.url()
         log.info('Polling {client} until it starts accepting connections on {url}'.format(client=client, url=url))
         (remote,) = ctx.cluster.only(client).remotes.keys()
-        wait_for_radosgw(url, remote)
+        wait_for_http_endpoint(url, remote)
 
     try:
         yield

--- a/qa/tasks/util/http.py
+++ b/qa/tasks/util/http.py
@@ -1,0 +1,15 @@
+from io import StringIO
+
+def wait_for_http_endpoint(url, remote):
+    """ poll the given url until it starts accepting connections
+
+    add_daemon() doesn't wait until the daemon finishes startup, so this is used
+    to avoid racing with later tasks that expect it to be up and listening
+    """
+    remote.run(
+        args=['curl', url, '--retry-connrefused', '--retry', '8'],
+        check_status=True,
+        stdout=StringIO(),
+        stderr=StringIO(),
+        stdin=StringIO(),
+        )

--- a/qa/tasks/util/rgw.py
+++ b/qa/tasks/util/rgw.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import time
 
 from io import StringIO
 
@@ -70,30 +69,3 @@ def get_user_successful_ops(out, user):
     if len(summary) == 0:
         return 0
     return get_user_summary(out, user)['total']['successful_ops']
-
-def wait_for_radosgw(url, remote):
-    """ poll the given url until it starts accepting connections
-
-    add_daemon() doesn't wait until radosgw finishes startup, so this is used
-    to avoid racing with later tasks that expect radosgw to be up and listening
-    """
-    # TODO: use '--retry-connrefused --retry 8' when teuthology is running on
-    # Centos 8 and other OS's with an updated version of curl
-    curl_cmd = ['curl',
-                url]
-    exit_status = 0
-    num_retries = 8
-    for seconds in range(num_retries):
-        proc = remote.run(
-            args=curl_cmd,
-            check_status=False,
-            stdout=StringIO(),
-            stderr=StringIO(),
-            stdin=StringIO(),
-            )
-        exit_status = proc.exitstatus
-        if exit_status == 0:
-            break
-        time.sleep(2**seconds)
-
-    assert exit_status == 0


### PR DESCRIPTION
repurpose `wait_for_radosgw()` from qa/tasks/util/rgw.py for use in barbican and keystone

Fixes: https://tracker.ceph.com/issues/54247

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
