### PR TITLE
install-deps: remove outdated rhel8 devtool packages

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -421,10 +421,6 @@ EOF
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
                     $SUDO dnf -y module enable javapackages-tools
                 elif test $ID = rhel -a $MAJOR_VERSION = 8 ; then
-                    $SUDO dnf config-manager \
-			  --enable rhel-server-rhscl-8-rpms \
-			  --enable rhel-8-server-optional-rpms \
-			  --enable rhel-8-server-devtools-rpms
                     dts_ver=11
                     $SUDO dnf config-manager --set-enabled "codeready-builder-for-rhel-8-${ARCH}-rpms"
 		    $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/


### PR DESCRIPTION
these were accidentally resurrected in 65b1a13139873c1525456e05cd00aeb64da4e881

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
