### PR TITLE
rgw/coroutine: check for null stack on wakeup

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -1019,7 +1019,9 @@ bool RGWCoroutine::drain_children(int num_cr_left,
 
 void RGWCoroutine::wakeup()
 {
-  stack->wakeup();
+  if (stack) {
+    stack->wakeup();
+  }
 }
 
 RGWCoroutinesEnv *RGWCoroutine::get_env() const


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/56920

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
