### PR TITLE
quincy: osd/scrub: Reintroduce scrub starts message

### DIFF
--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -104,3 +104,14 @@ struct fmt::formatter<object_info_t> {
     return fmt::format_to(ctx.out(), ")");
   }
 };
+
+template <>
+struct fmt::formatter<pg_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const pg_t& pg, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{}.{:x}", pg.pool(), pg.m_seed);
+  }
+};

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2128,6 +2128,10 @@ PgScrubber::PgScrubber(PG* pg)
 void PgScrubber::set_scrub_begin_time()
 {
   scrub_begin_stamp = ceph_clock_now();
+  m_osds->clog->debug() << fmt::format(
+    "{} {} starts",
+    m_pg->info.pgid.pgid,
+    m_mode_desc);
 }
 
 void PgScrubber::set_scrub_duration()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56134

---

backport of https://github.com/ceph/ceph/pull/46438
parent tracker: https://tracker.ceph.com/issues/55798

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh