### PR TITLE
 quincy: mgr/dashboard: add flag to automatically deploy loki/promtail service at bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5157,6 +5157,11 @@ def prepare_ssh(
             logger.info('Deploying %s service with default placement...' % t)
             cli(['orch', 'apply', t])
 
+    if ctx.with_centralized_logging:
+        for t in ['loki', 'promtail']:
+            logger.info('Deploying %s service with default placement...' % t)
+            cli(['orch', 'apply', t])
+
 
 def enable_cephadm_mgr_module(
     cli: Callable, wait_for_mgr_restart: Callable
@@ -9141,6 +9146,10 @@ def _get_parser():
         '--skip-monitoring-stack',
         action='store_true',
         help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter)')
+    parser_bootstrap.add_argument(
+        '--with-centralized-logging',
+        action='store_true',
+        help='Automatically provision centralized logging (promtail, loki)')
     parser_bootstrap.add_argument(
         '--apply-spec',
         help='Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57137

---

backport of https://github.com/ceph/ceph/pull/47346
parent tracker: https://tracker.ceph.com/issues/56964

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh