### PR TITLE
quincy: cmake: set $PATH for tests using jsonnet tools

### DIFF
--- a/monitoring/ceph-mixin/CMakeLists.txt
+++ b/monitoring/ceph-mixin/CMakeLists.txt
@@ -34,10 +34,12 @@ if(WITH_GRAFANA)
       add_tox_test(grafana-lint TOX_ENVS lint)
       add_tox_test(jsonnet-lint TOX_ENVS jsonnet-lint)
       set_property(TEST run-tox-jsonnet-lint PROPERTY
-          FIXTURES_REQUIRED venv-for-jsonnet-lint jsonnet)
+          FIXTURES_REQUIRED venv-for-jsonnet-lint jsonnet
+          ENVIRONMENT "PATH=${CMAKE_CURRENT_BINARY_DIR}:$ENV{PATH}")
       add_tox_test(jsonnet-check TOX_ENVS jsonnet-check)
       set_property(TEST run-tox-jsonnet-check PROPERTY
-          FIXTURES_REQUIRED venv-for-jsonnet-check jsonnet jsonnet-bundler)
+          FIXTURES_REQUIRED venv-for-jsonnet-check jsonnet jsonnet-bundler
+          ENVIRONMENT "PATH=${CMAKE_CURRENT_BINARY_DIR}:$ENV{PATH}")
 
       add_tox_test(alerts-check TOX_ENVS alerts-check)
       add_tox_test(alerts-lint TOX_ENVS alerts-lint)


### PR DESCRIPTION
backport of #47617

---

otherwise they would not able to find executables installed into
${CMAKE_CURRENT_BINARY_DIR}.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit 4a3afcf27769a512fba7e0194d2e3b6a55e06bca)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
