### PR TITLE
quincy: cephadm/ceph-volume: fix rm-cluster --zap

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -367,7 +367,8 @@ class TestDevice(object):
         monkeypatch.setattr(api, 'get_all_devices_vgs', lambda : [vg])
         lsblk = {"TYPE": "disk", "NAME": "nvme0n1"}
         data = {"/dev/nvme0n1": {"size": "6442450944"}}
-        device_info(devices=data, lsblk=lsblk)
+        lv = {"tags": {"ceph.osd_id": "1"}}
+        device_info(devices=data, lsblk=lsblk, lv=lv)
         disk = device.Device("/dev/nvme0n1")
         assert disk.available_lvm
         assert not disk.available
@@ -380,7 +381,8 @@ class TestDevice(object):
         monkeypatch.setattr(api, 'get_all_devices_vgs', lambda : [vg])
         lsblk = {"TYPE": "disk", "NAME": "nvme0n1"}
         data = {"/dev/nvme0n1": {"size": "6442450944"}}
-        device_info(devices=data, lsblk=lsblk)
+        lv = {"tags": {"ceph.osd_id": "1"}}
+        device_info(devices=data, lsblk=lsblk, lv=lv)
         disk = device.Device("/dev/nvme0n1")
         assert not disk.available_lvm
         assert not disk.available
@@ -395,7 +397,8 @@ class TestDevice(object):
         monkeypatch.setattr(api, 'get_all_devices_vgs', lambda : [vg1, vg2])
         lsblk = {"TYPE": "disk", "NAME": "nvme0n1"}
         data = {"/dev/nvme0n1": {"size": "6442450944"}}
-        device_info(devices=data, lsblk=lsblk)
+        lv = {"tags": {"ceph.osd_id": "1"}}
+        device_info(devices=data, lsblk=lsblk, lv=lv)
         disk = device.Device("/dev/nvme0n1")
         assert disk.available_lvm
         assert not disk.available

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7044,7 +7044,7 @@ def _zap_osds(ctx: CephadmContext) -> None:
         raise Error(f'Invalid JSON in ceph-volume inventory: {e}')
 
     for i in ls:
-        matches = [lv.get('cluster_fsid') == ctx.fsid for lv in i.get('lvs', [])]
+        matches = [lv.get('cluster_fsid') == ctx.fsid and i.get('ceph_device') for lv in i.get('lvs', [])]
         if any(matches) and all(matches):
             _zap(ctx, i.get('path'))
         elif any(matches):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57132

---

backport of https://github.com/ceph/ceph/pull/47562
parent tracker: https://tracker.ceph.com/issues/57100

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh