### PR TITLE
quincy: mgr/dashboard: fix _rbd_image_refs caching

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -12,6 +12,7 @@
           selectionType="single"
           [hasDetails]="true"
           [status]="tableStatus"
+          [maxLimit]="25"
           [autoReload]="-1"
           (fetchData)="taskListService.fetch($event)"
           (setExpandedRow)="setExpandedRow($event)"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -205,12 +205,21 @@
           <span *ngIf="selectionType">
             {{ selectedCount }} <ng-container i18n="X selected">selected</ng-container> /
           </span>
-          <span *ngIf="rowCount != data?.length">
-            {{ rowCount }} <ng-container i18n="X found">found</ng-container> /
-          </span>
-          <span>
+
+          <!-- rowCount might have different semantics with or without serverSide.
+            We treat serverSide (backend-driven tables) as a specific case.
+          -->
+          <span *ngIf="!serverSide else serverSideTpl">
+            <span *ngIf="rowCount != data?.length">
+              {{ rowCount }} <ng-container i18n="X found">found</ng-container> /
+            </span>
             {{ data?.length || 0 }} <ng-container i18n="X total">total</ng-container>
           </span>
+
+          <ng-template #serverSideTpl>
+            {{ data?.length || 0 }} <ng-container i18n="X found">found</ng-container> /
+            {{ rowCount }} <ng-container i18n="X total">total</ng-container>
+          </ng-template>
         </div>
         <datatable-pager [pagerLeftArrowIcon]="paginationClasses.pagerPrevious"
                          [pagerRightArrowIcon]="paginationClasses.pagerNext"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -101,6 +101,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   // Page size to show. Set to 0 to show unlimited number of rows.
   @Input()
   limit? = 10;
+  @Input()
+  maxLimit? = 9999;
   // Has the row details?
   @Input()
   hasDetails = false;
@@ -630,7 +632,13 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   setLimit(e: any) {
     const value = Number(e.target.value);
     if (value > 0) {
-      this.userConfig.limit = value;
+      if (this.maxLimit && value > this.maxLimit) {
+        this.userConfig.limit = this.maxLimit;
+        // change input field to maxLimit
+        e.srcElement.value = this.maxLimit;
+      } else {
+        this.userConfig.limit = value;
+      }
     }
     if (this.serverSide) {
       this.reloadData();

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -241,6 +241,7 @@ class RbdConfiguration(object):
 
 
 class RbdService(object):
+    _rbd_inst = rbd.RBD()
 
     @classmethod
     def _rbd_disk_usage(cls, image, snaps, whole_object=True):
@@ -378,9 +379,32 @@ class RbdService(object):
 
     @classmethod
     @ttl_cache(10)
-    def _rbd_image_refs(cls, ioctx):
-        rbd_inst = rbd.RBD()
-        return rbd_inst.list2(ioctx)
+    def get_ioctx(cls, pool_name, namespace=''):
+        ioctx = mgr.rados.open_ioctx(pool_name)
+        ioctx.set_namespace(namespace)
+        return ioctx
+
+    @classmethod
+    @ttl_cache(30)
+    def _rbd_image_refs(cls, pool_name, namespace=''):
+        # We add and set the namespace here so that we cache by ioctx and namespace.
+        images = []
+        ioctx = cls.get_ioctx(pool_name, namespace)
+        images = cls._rbd_inst.list2(ioctx)
+        return images
+
+    @classmethod
+    @ttl_cache(30)
+    def _pool_namespaces(cls, pool_name, namespace=None):
+        namespaces = []
+        if namespace:
+            namespaces = [namespace]
+        else:
+            ioctx = cls.get_ioctx(pool_name, namespace=rados.LIBRADOS_ALL_NSPACES)
+            namespaces = cls._rbd_inst.namespace_list(ioctx)
+            # images without namespace
+            namespaces.append('')
+        return namespaces
 
     @classmethod
     def _rbd_image_stat(cls, ioctx, pool_name, namespace, image_name):
@@ -388,8 +412,7 @@ class RbdService(object):
 
     @classmethod
     def _rbd_image_stat_removing(cls, ioctx, pool_name, namespace, image_id):
-        rbd_inst = rbd.RBD()
-        img = rbd_inst.trash_get(ioctx, image_id)
+        img = cls._rbd_inst.trash_get(ioctx, image_id)
         img_spec = get_image_spec(pool_name, namespace, image_id)
 
         if img['source'] == 'REMOVING':
@@ -405,22 +428,13 @@ class RbdService(object):
     @classmethod
     def _rbd_pool_image_refs(cls, pool_names: List[str], namespace: Optional[str] = None):
         joint_refs = []
-        rbd_inst = rbd.RBD()
         for pool in pool_names:
-            with mgr.rados.open_ioctx(pool) as ioctx:
-                if namespace:
-                    namespaces = [namespace]
-                else:
-                    namespaces = rbd_inst.namespace_list(ioctx)
-                    # images without namespace
-                    namespaces.append('')
-                for current_namespace in namespaces:
-                    ioctx.set_namespace(current_namespace)
-                    image_refs = cls._rbd_image_refs(ioctx)
-                    for image in image_refs:
-                        image['namespace'] = current_namespace
-                        image['pool_name'] = pool
-                        joint_refs.append(image)
+            for current_namespace in cls._pool_namespaces(pool, namespace=namespace):
+                image_refs = cls._rbd_image_refs(pool, current_namespace)
+                for image in image_refs:
+                    image['namespace'] = current_namespace
+                    image['pool_name'] = pool
+                    joint_refs.append(image)
         return joint_refs
 
     @classmethod
@@ -456,20 +470,19 @@ class RbdService(object):
             end = len(image_refs)
         for image_ref in sorted(image_refs, key=lambda v: v[sort_by],
                                 reverse=descending)[offset:end]:
-            with mgr.rados.open_ioctx(image_ref['pool_name']) as ioctx:
-                ioctx.set_namespace(image_ref['namespace'])
+            ioctx = cls.get_ioctx(image_ref['pool_name'], namespace=image_ref['namespace'])
+            try:
+                stat = cls._rbd_image_stat(
+                    ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['name'])
+            except rbd.ImageNotFound:
+                # Check if the RBD has been deleted partially. This happens for example if
+                # the deletion process of the RBD has been started and was interrupted.
                 try:
-                    stat = cls._rbd_image_stat(
-                        ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['name'])
+                    stat = cls._rbd_image_stat_removing(
+                        ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['id'])
                 except rbd.ImageNotFound:
-                    # Check if the RBD has been deleted partially. This happens for example if
-                    # the deletion process of the RBD has been started and was interrupted.
-                    try:
-                        stat = cls._rbd_image_stat_removing(
-                            ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['id'])
-                    except rbd.ImageNotFound:
-                        continue
-                result.append(stat)
+                    continue
+            result.append(stat)
         return result, len(image_refs)
 
     @classmethod


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57142

---

backport of https://github.com/ceph/ceph/pull/47119
parent tracker: https://tracker.ceph.com/issues/56571

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh