### PR TITLE
crimson/os/seastore: move AsyncCleaner to EPM

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -26,7 +26,6 @@ class BtreeBackrefManager;
 namespace crimson::os::seastore {
 
 class BackrefManager;
-class AsyncCleaner;
 class SegmentProvider;
 
 struct backref_entry_t {
@@ -712,8 +711,7 @@ public:
   void complete_commit(
     Transaction &t,            ///< [in, out] current transaction
     paddr_t final_block_start, ///< [in] offset of initial block
-    journal_seq_t seq,         ///< [in] journal commit seq
-    AsyncCleaner *cleaner=nullptr ///< [out] optional segment stat listener
+    journal_seq_t seq          ///< [in] journal commit seq
   );
 
   /**

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -331,6 +331,7 @@ SeaStore::mkfs_ertr::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
         init_managers();
         return transaction_manager->mkfs();
       }).safe_then([this] {
+        init_managers();
         return transaction_manager->mount();
       }).safe_then([this] {
         return repeat_eagain([this] {
@@ -1860,9 +1861,10 @@ uuid_d SeaStore::get_fsid() const
 
 void SeaStore::init_managers()
 {
-  ceph_assert(!transaction_manager);
-  ceph_assert(!collection_manager);
-  ceph_assert(!onode_manager);
+  transaction_manager.reset();
+  collection_manager.reset();
+  onode_manager.reset();
+
   std::vector<Device*> sec_devices;
   for (auto &dev : secondaries) {
     sec_devices.emplace_back(dev.get());

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -21,7 +21,6 @@
 #include "crimson/osd/exceptions.h"
 
 #include "crimson/os/seastore/logging.h"
-#include "crimson/os/seastore/async_cleaner.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/cache.h"
 #include "crimson/os/seastore/lba_manager.h"
@@ -65,7 +64,6 @@ public:
   using base_iertr = Cache::base_iertr;
 
   TransactionManager(
-    AsyncCleanerRef async_cleaner,
     JournalRef journal,
     CacheRef cache,
     LBAManagerRef lba_manager,
@@ -620,7 +618,7 @@ public:
   }
 
   store_statfs_t store_stat() const {
-    return async_cleaner->stat();
+    return epm->get_stat();
   }
 
   ~TransactionManager();
@@ -628,7 +626,6 @@ public:
 private:
   friend class Transaction;
 
-  AsyncCleanerRef async_cleaner;
   CacheRef cache;
   LBAManagerRef lba_manager;
   JournalRef journal;
@@ -643,8 +640,8 @@ private:
 
 public:
   // Testing interfaces
-  auto get_async_cleaner() {
-    return async_cleaner.get();
+  auto get_epm() {
+    return epm.get();
   }
 
   auto get_lba_manager() {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -209,8 +209,7 @@ public:
    *
    * Read extent of type T at offset~length
    */
-  using read_extent_iertr = get_pin_iertr::extend_ertr<
-    SegmentManager::read_ertr>;
+  using read_extent_iertr = get_pin_iertr;
   template <typename T>
   using read_extent_ret = read_extent_iertr::future<
     TCachedExtentRef<T>>;

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -111,7 +111,6 @@ struct fltree_onode_manager_test_t
     auto t = create_mutate_transaction();
     std::invoke(f, *t);
     submit_transaction(std::move(t));
-    async_cleaner->run_until_halt().get0();
   }
 
   template <typename F>

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1693,7 +1693,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	  });
 	});
     }).unsafe_get0();
-    async_cleaner->run_until_halt().get0();
+    epm->run_background_work_until_halt().get0();
 
     // insert
     logger().warn("start inserting {} kvs ...", kvs.size());
@@ -1713,7 +1713,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	      });
 	    });
         }).unsafe_get0();
-        async_cleaner->run_until_halt().get0();
+        epm->run_background_work_until_halt().get0();
         ++iter;
       }
     }
@@ -1759,7 +1759,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	      });
 	    });
         }).unsafe_get0();
-        async_cleaner->run_until_halt().get0();
+        epm->run_background_work_until_halt().get0();
         ++iter;
       }
       kvs.erase_from_random(kvs.random_begin(), kvs.random_end());

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1591,7 +1591,6 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
       auto t = create_mutate_transaction();
       INTR(tree->bootstrap, *t).unsafe_get();
       submit_transaction(std::move(t));
-      async_cleaner->run_until_halt().get0();
     }
 
     // test insert
@@ -1599,7 +1598,6 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
       auto t = create_mutate_transaction();
       INTR(tree->insert, *t).unsafe_get();
       submit_transaction(std::move(t));
-      async_cleaner->run_until_halt().get0();
     }
     {
       auto t = create_read_transaction();
@@ -1621,7 +1619,6 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
       auto size = kvs.size() / 4 * 3;
       INTR_R(tree->erase, *t, size).unsafe_get();
       submit_transaction(std::move(t));
-      async_cleaner->run_until_halt().get0();
     }
     {
       auto t = create_read_transaction();
@@ -1642,7 +1639,6 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
       auto size = kvs.size();
       INTR_R(tree->erase, *t, size).unsafe_get();
       submit_transaction(std::move(t));
-      async_cleaner->run_until_halt().get0();
     }
     {
       auto t = create_read_transaction();

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -124,14 +124,14 @@ struct btree_test_base :
       block_size = segment_manager->get_block_size();
       next = segment_id_t{segment_manager->get_device_id(), 0};
       sms->add_segment_manager(segment_manager.get());
-      epm->add_device(segment_manager.get(), true);
+      epm->test_init_no_background(segment_manager.get());
       journal->set_write_pipeline(&pipeline);
 
       return journal->open_for_mkfs().discard_result();
     }).safe_then([this] {
       dummy_tail = journal_seq_t{0,
         paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0)};
-      return epm->open();
+      return epm->open_for_write();
     }).safe_then([this] {
       return seastar::do_with(
 	cache->create_transaction(

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -91,7 +91,7 @@ struct cache_test_t : public seastar_test_suite_t {
       epm.reset(new ExtentPlacementManager());
       cache.reset(new Cache(*epm));
       current = paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0);
-      epm->add_device(segment_manager.get(), true);
+      epm->test_init_no_background(segment_manager.get());
       return seastar::do_with(
           get_transaction(),
           [this](auto &ref_t) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -400,40 +400,7 @@ struct transaction_manager_test_t :
   }
 
   bool check_usage() {
-    auto t = create_weak_test_transaction();
-    SpaceTrackerIRef tracker(async_cleaner->get_empty_space_tracker());
-    with_trans_intr(
-      *t.t,
-      [this, &tracker](auto &t) {
-      return backref_manager->scan_mapped_space(
-        t,
-        [&tracker](
-          paddr_t paddr,
-          extent_len_t len,
-          extent_types_t type,
-          laddr_t laddr) {
-        if (paddr.get_addr_type() == paddr_types_t::SEGMENT) {
-          if (is_backref_node(type)) {
-            assert(laddr == L_ADDR_NULL);
-            tracker->allocate(
-              paddr.as_seg_paddr().get_segment_id(),
-              paddr.as_seg_paddr().get_segment_off(),
-              len);
-          } else if (laddr == L_ADDR_NULL) {
-            tracker->release(
-              paddr.as_seg_paddr().get_segment_id(),
-              paddr.as_seg_paddr().get_segment_off(),
-              len);
-          } else {
-            tracker->allocate(
-              paddr.as_seg_paddr().get_segment_id(),
-              paddr.as_seg_paddr().get_segment_off(),
-              len);
-          }
-        }
-      });
-    }).unsafe_get0();
-    return async_cleaner->debug_check_space(*tracker);
+    return async_cleaner->check_usage();
   }
 
   void replay() {


### PR DESCRIPTION
Also refer to https://github.com/ceph/ceph/pull/47489#issuecomment-1208188283

The generic device tiering work would probably break down into the following smaller items:
* Introduce generic interface for AsyncCleaner in EPM.
* Decouple trimming and segment reclaiming implementations for reuse.
* Split implementations between RBCleaner and SegmentCleaner.
* Design and implement generic device-tiering logic in the EPM, based on generations.
* Related tests.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
