### PR TITLE
mds: fix stray evaluation using scrub and introduce new option

### DIFF
--- a/doc/cephfs/scrub.rst
+++ b/doc/cephfs/scrub.rst
@@ -143,3 +143,14 @@ The types of damage that can be reported and repaired by File System Scrub are:
 
 * BACKTRACE : Inode's backtrace in the data pool is corrupted.
 
+Evaluate strays using recursive scrub
+=====================================
+
+- In order to evaluate strays i.e. purge stray directories in ``~mdsdir`` use the following command::
+
+    ceph tell mds.<fsname>:0 scrub start ~mdsdir recursive
+
+- ``~mdsdir`` is not enqueued by default when scrubbing at the CephFS root. In order to perform stray evaluation
+  at root, run scrub with flag ``scrub_mdsdir``::
+
+    ceph tell mds.<fsname>:0 scrub start / scrub_mdsdir

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1189,7 +1189,8 @@ class CephFSMount(object):
         self.background_procs.append(rproc)
         return rproc
 
-    def create_n_files(self, fs_path, count, sync=False, dirsync=False, unlink=False, finaldirsync=False):
+    def create_n_files(self, fs_path, count, sync=False, dirsync=False,
+                       unlink=False, finaldirsync=False, hard_links=0):
         """
         Create n files.
 
@@ -1197,6 +1198,7 @@ class CephFSMount(object):
         :param dirsync: sync the containing directory after closing the file
         :param unlink: unlink the file after closing
         :param finaldirsync: sync the containing directory after closing the last file
+        :param hard_links: create given number of hard link(s) for each file
         """
 
         assert(self.is_mounted())
@@ -1205,8 +1207,12 @@ class CephFSMount(object):
 
         pyscript = dedent(f"""
             import os
+            import uuid
 
             n = {count}
+            create_hard_links = False
+            if {hard_links} > 0:
+                create_hard_links = True
             path = "{abs_path}"
 
             dpath = os.path.dirname(path)
@@ -1227,6 +1233,9 @@ class CephFSMount(object):
                         os.unlink(fpath)
                     if {dirsync}:
                         os.fsync(dirfd)
+                    if create_hard_links:
+                        for j in range({hard_links}):
+                            os.system(f"ln {{fpath}} {{dpath}}/{{fnameprefix}}_{{i}}_{{uuid.uuid4()}}")     
                 if {finaldirsync}:
                     os.fsync(dirfd)
             finally:

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -296,6 +296,36 @@ class TestScrubChecks(CephFSTestCase):
         command = "flush_path /"
         self.asok_command(mds_rank, command, success_validator)
 
+    def scrub_with_stray_evaluation(self, fs, mnt, path, flag, files=2000,
+                                    _hard_links=3):
+        fs.set_allow_new_snaps(True)
+
+        test_dir = "stray_eval_dir"
+        mnt.run_shell(["mkdir", test_dir])
+        client_path = os.path.join(mnt.mountpoint, test_dir)
+        mnt.create_n_files(fs_path=f"{test_dir}/file", count=files,
+                           hard_links=_hard_links)
+        mnt.run_shell(["mkdir", f"{client_path}/.snap/snap1-{test_dir}"])
+        mnt.run_shell(f"find {client_path}/ -type f -delete")
+        mnt.run_shell(["rmdir", f"{client_path}/.snap/snap1-{test_dir}"])
+        perf_dump = fs.rank_tell(["perf", "dump"], 0)
+        self.assertNotEqual(perf_dump.get('mds_cache').get('num_strays'),
+                            0, "mdcache.num_strays is zero")
+
+        log.info(
+            f"num of strays: {perf_dump.get('mds_cache').get('num_strays')}")
+
+        out_json = fs.run_scrub(["start", path, flag])
+        self.assertNotEqual(out_json, None)
+        self.assertEqual(out_json["return_code"], 0)
+
+        self.assertEqual(
+            fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
+
+        perf_dump = fs.rank_tell(["perf", "dump"], 0)
+        self.assertEqual(int(perf_dump.get('mds_cache').get('num_strays')),
+                         0, "mdcache.num_strays is non-zero")
+
     def test_scrub_repair(self):
         mds_rank = 0
         test_dir = "scrub_repair_path"
@@ -331,6 +361,20 @@ class TestScrubChecks(CephFSTestCase):
 
         # fragstat should be fixed
         self.mount_a.run_shell(["rmdir", test_dir])
+
+    def test_stray_evaluation_with_scrub(self):
+        """
+        test that scrub can iterate over ~mdsdir and evaluate strays
+        """
+        self.scrub_with_stray_evaluation(self.fs, self.mount_a, "~mdsdir",
+                                         "recursive")
+
+    def test_flag_scrub_mdsdir(self):
+        """
+        test flag scrub_mdsdir
+        """
+        self.scrub_with_stray_evaluation(self.fs, self.mount_a, "/",
+                                         "scrub_mdsdir")
 
     @staticmethod
     def json_validator(json_out, rc, element, expected_value):

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13026,7 +13026,8 @@ void MDCache::enqueue_scrub(
     }
     cs = new C_MDS_EnqueueScrub(tag_str, f, fin);
   }
-  cs->header = std::make_shared<ScrubHeader>(tag_str, is_internal, force, recursive, repair);
+  cs->header = std::make_shared<ScrubHeader>(tag_str, is_internal, force,
+                                             recursive, repair, scrub_mdsdir);
 
   mdr->internal_op_finish = cs;
   enqueue_scrub_work(mdr);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12958,19 +12958,24 @@ class C_MDS_EnqueueScrub : public Context
   std::string tag;
   Formatter *formatter;
   Context *on_finish;
+  bool dump_values;
 public:
   ScrubHeaderRef header;
-  C_MDS_EnqueueScrub(std::string_view tag, Formatter *f, Context *fin) :
-    tag(tag), formatter(f), on_finish(fin), header(nullptr) {}
+  C_MDS_EnqueueScrub(std::string_view tag, Formatter *f, Context *fin,
+                     bool dump_values = true) :
+    tag(tag), formatter(f), on_finish(fin), dump_values(dump_values),
+    header(nullptr) {}
 
   void finish(int r) override {
-    formatter->open_object_section("results");
-    formatter->dump_int("return_code", r);
-    if (r == 0) {
-      formatter->dump_string("scrub_tag", tag);
-      formatter->dump_string("mode", "asynchronous");
+    if (dump_values) {
+      formatter->open_object_section("results");
+      formatter->dump_int("return_code", r);
+      if (r == 0) {
+        formatter->dump_string("scrub_tag", tag);
+        formatter->dump_string("mode", "asynchronous");
+      }
+      formatter->close_section();
     }
-    formatter->close_section();
 
     r = 0;
     if (on_finish)
@@ -12982,7 +12987,7 @@ void MDCache::enqueue_scrub(
     std::string_view path,
     std::string_view tag,
     bool force, bool recursive, bool repair,
-    Formatter *f, Context *fin)
+    bool scrub_mdsdir, Formatter *f, Context *fin)
 {
   dout(10) << __func__ << " " << path << dendl;
 
@@ -13008,14 +13013,19 @@ void MDCache::enqueue_scrub(
 
   bool is_internal = false;
   std::string tag_str(tag);
-  if (tag_str.empty()) {
-    uuid_d uuid_gen;
-    uuid_gen.generate_random();
-    tag_str = uuid_gen.to_string();
+  C_MDS_EnqueueScrub *cs;
+  if ((path == "~mdsdir" && scrub_mdsdir)) {
     is_internal = true;
+    cs = new C_MDS_EnqueueScrub(tag_str, f, fin, false);
+  } else {
+    if (tag_str.empty()) {
+      uuid_d uuid_gen;
+      uuid_gen.generate_random();
+      tag_str = uuid_gen.to_string();
+      is_internal = true;
+    }
+    cs = new C_MDS_EnqueueScrub(tag_str, f, fin);
   }
-
-  C_MDS_EnqueueScrub *cs = new C_MDS_EnqueueScrub(tag_str, f, fin);
   cs->header = std::make_shared<ScrubHeader>(tag_str, is_internal, force, recursive, repair);
 
   mdr->internal_op_finish = cs;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -954,7 +954,7 @@ class MDCache {
    */
   void enqueue_scrub(std::string_view path, std::string_view tag,
                      bool force, bool recursive, bool repair,
-		     Formatter *f, Context *fin);
+                     bool scrub_mdsdir, Formatter *f, Context *fin);
   void repair_inode_stats(CInode *diri);
   void repair_dirfrag_stats(CDir *dir);
   void rdlock_dirfrags_stats(CInode *diri, MDSInternalContext *fin);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -286,7 +286,7 @@ void MDSDaemon::set_up_admin_socket()
   ceph_assert(r == 0);
   r = admin_socket->register_command("scrub start "
 				     "name=path,type=CephString "
-				     "name=scrubops,type=CephChoices,strings=force|recursive|repair,n=N,req=false "
+				     "name=scrubops,type=CephChoices,strings=force|recursive|repair|scrub_mdsdir,n=N,req=false "
 				     "name=tag,type=CephString,req=false",
 				     asok_hook,
 				     "scrub and inode and output results");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3003,7 +3003,7 @@ void MDSRank::command_tag_path(Formatter *f,
   C_SaferCond scond;
   {
     std::lock_guard l(mds_lock);
-    mdcache->enqueue_scrub(path, tag, true, true, false, f, &scond);
+    mdcache->enqueue_scrub(path, tag, true, true, false, false, f, &scond);
   }
   scond.wait();
 }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2972,6 +2972,7 @@ void MDSRank::command_scrub_start(Formatter *f,
   bool force = false;
   bool recursive = false;
   bool repair = false;
+  bool scrub_mdsdir = false;
   for (auto &op : scrubop_vec) {
     if (op == "force")
       force = true;
@@ -2979,9 +2980,17 @@ void MDSRank::command_scrub_start(Formatter *f,
       recursive = true;
     else if (op == "repair")
       repair = true;
+    else if (op == "scrub_mdsdir" && path == "/")
+      scrub_mdsdir = true;
   }
 
   std::lock_guard l(mds_lock);
+  if (scrub_mdsdir) {
+    MDSGatherBuilder gather(g_ceph_context);
+    mdcache->enqueue_scrub("~mdsdir", tag, false, true, false, f, gather.new_sub());
+    gather.set_finisher(new C_MDSInternalNoop);
+    gather.activate();
+  }
   mdcache->enqueue_scrub(path, tag, force, recursive, repair, f, on_finish);
   // scrub_dentry() finishers will dump the data for us; we're done!
 }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2987,11 +2987,13 @@ void MDSRank::command_scrub_start(Formatter *f,
   std::lock_guard l(mds_lock);
   if (scrub_mdsdir) {
     MDSGatherBuilder gather(g_ceph_context);
-    mdcache->enqueue_scrub("~mdsdir", tag, false, true, false, f, gather.new_sub());
+    mdcache->enqueue_scrub("~mdsdir", "", false, true, false, scrub_mdsdir,
+                           f, gather.new_sub());
     gather.set_finisher(new C_MDSInternalNoop);
     gather.activate();
   }
-  mdcache->enqueue_scrub(path, tag, force, recursive, repair, f, on_finish);
+  mdcache->enqueue_scrub(path, tag, force, recursive, repair, scrub_mdsdir,
+                         f, on_finish);
   // scrub_dentry() finishers will dump the data for us; we're done!
 }
 

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -35,9 +35,9 @@ class CInode;
 class ScrubHeader {
 public:
   ScrubHeader(std::string_view tag_, bool is_tag_internal_, bool force_,
-              bool recursive_, bool repair_)
+              bool recursive_, bool repair_, bool scrub_mdsdir_ = false)
     : tag(tag_), is_tag_internal(is_tag_internal_), force(force_),
-      recursive(recursive_), repair(repair_) {}
+      recursive(recursive_), repair(repair_), scrub_mdsdir(scrub_mdsdir_) {}
 
   // Set after construction because it won't be known until we've
   // started resolving path and locking
@@ -46,6 +46,7 @@ public:
   bool get_recursive() const { return recursive; }
   bool get_repair() const { return repair; }
   bool get_force() const { return force; }
+  bool get_scrub_mdsdir() const { return scrub_mdsdir; }
   bool is_internal_tag() const { return is_tag_internal; }
   inodeno_t get_origin() const { return origin; }
   const std::string& get_tag() const { return tag; }
@@ -69,6 +70,7 @@ protected:
   const bool force;
   const bool recursive;
   const bool repair;
+  const bool scrub_mdsdir;
   inodeno_t origin;
 
   bool repaired = false;  // May be set during scrub if repairs happened

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -655,6 +655,11 @@ void ScrubStack::scrub_status(Formatter *f) {
     have_more = false;
     auto& header = p.second;
 
+    if (mdcache->get_inode(header->get_origin())->is_mdsdir() 
+    && header->get_scrub_mdsdir() && header->get_tag().empty()) {
+      continue;
+    }
+
     std::string tag(header->get_tag());
     f->open_object_section(tag.c_str()); // scrub id
 
@@ -682,6 +687,12 @@ void ScrubStack::scrub_status(Formatter *f) {
         *optcss << ",";
       }
       *optcss << "force";
+    }
+    if (header->get_scrub_mdsdir()) {
+      if (have_more) {
+        *optcss << ",";
+      }
+      *optcss << "scrub_mdsdir";
     }
 
     f->dump_string("options", optcss->strv());

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -847,6 +847,18 @@ void ScrubStack::dispatch(const cref_t<Message> &m)
   }
 }
 
+bool ScrubStack::remove_inode_if_stacked(CInode *in) {
+  MDSCacheObject *obj = dynamic_cast<MDSCacheObject*>(in);
+  if(obj->item_scrub.is_on_list()) {
+    dout(20) << "removing inode " << *in << " from scrub_stack" << dendl;
+    obj->put(MDSCacheObject::PIN_SCRUBQUEUE);
+    obj->item_scrub.remove_myself();
+    stack_size--;
+    return true;
+  }
+  return false;
+}
+
 void ScrubStack::handle_scrub(const cref_t<MMDSScrub> &m)
 {
 

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -67,6 +67,11 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
       dout(10) << __func__ << " with {" << *in << "}" << ", already in scrubbing" << dendl;
       return -CEPHFS_EBUSY;
     }
+    if(in->state_test(CInode::STATE_PURGING)) {
+      dout(10) << *obj << " is purging, skip pushing into scrub stack" << dendl;
+      // treating this as success since purge will make sure this inode goes away
+      return 0;
+    }
 
     dout(10) << __func__ << " with {" << *in << "}" << ", top=" << top << dendl;
     in->scrub_initialize(header);
@@ -74,6 +79,11 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
     if (dir->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *dir << "}" << ", already in scrubbing" << dendl;
       return -CEPHFS_EBUSY;
+    }
+    if(dir->get_inode()->state_test(CInode::STATE_PURGING)) {
+      dout(10) << *obj << " is purging, skip pushing into scrub stack" << dendl;
+      // treating this as success since purge will make sure this dir inode goes away
+      return 0;
     }
 
     dout(10) << __func__ << " with {" << *dir << "}" << ", top=" << top << dendl;

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -101,6 +101,8 @@ public:
 
   void dispatch(const cref_t<Message> &m);
 
+  bool remove_inode_if_stacked(CInode *in);
+
   MDCache *mdcache;
 
 protected:

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -20,6 +20,7 @@
 #include "mds/MDLog.h"
 #include "mds/CDir.h"
 #include "mds/CDentry.h"
+#include "mds/ScrubStack.h"
 #include "events/EUpdate.h"
 #include "messages/MClientRequest.h"
 
@@ -299,6 +300,11 @@ void StrayManager::enqueue(CDentry *dn, bool trunc)
   ceph_assert(dnl);
   CInode *in = dnl->get_inode();
   ceph_assert(in);
+
+  //remove inode from scrub stack if it is being purged
+  if(mds->scrubstack->remove_inode_if_stacked(in)) {
+    dout(20) << "removed " << *in << " from the scrub stack" << dendl;
+  }
 
   /* We consider a stray to be purging as soon as it is enqueued, to avoid
    * enqueing it twice */


### PR DESCRIPTION
This PR fixes the OOM failure caused by race between Purge and Scrub while also
introduces a new option `scrub_mdsdir` to evaluate strays at root.

Fixes: https://tracker.ceph.com/issues/53724, https://tracker.ceph.com/issues/51824
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
