### PR TITLE
pacific: cephadm: support for Oracle Linux 8

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6749,6 +6749,7 @@ class YumDnf(Packager):
         'scientific': ('centos', 'el'),
         'rocky': ('centos', 'el'),
         'almalinux': ('centos', 'el'),
+        'ol': ('centos', 'el'),
         'fedora': ('fedora', 'fc'),
         'mariner': ('mariner', 'cm'),
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57169

---

backport of https://github.com/ceph/ceph/pull/47523
parent tracker: https://tracker.ceph.com/issues/57080

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh