### PR TITLE
pacific: mgr/cephadm: set dashboard grafana-api-password when user provides one

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -68,6 +68,10 @@ class GrafanaService(CephadmService):
                 'http_addr': daemon_spec.ip if daemon_spec.ip else ''
             })
 
+        if 'dashboard' in self.mgr.get('mgr_map')['modules'] and spec.initial_admin_password:
+            self.mgr.check_mon_command(
+                {'prefix': 'dashboard set-grafana-api-password'}, inbuf=spec.initial_admin_password)
+
         config_file = {
             'files': {
                 "grafana.ini": grafana_ini,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57148

---

backport of https://github.com/ceph/ceph/pull/47545
parent tracker: https://tracker.ceph.com/issues/57095

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh