### PR TITLE
pybind/rados: notify callback reconnect

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1373,6 +1373,7 @@ class TestCommand(object):
         eq(u"pool '\u9ec5' created", out)
 
 
+@attr('watch')
 class TestWatchNotify(object):
     OID = "test_watch_notify"
 
@@ -1401,8 +1402,9 @@ class TestWatchNotify(object):
         def callback(notify_id, notifier_id, watch_id, data):
             with self.lock:
                 if watch_id not in self.notify_cnt:
-                    self.notify_cnt[watch_id] = 0
-                self.notify_cnt[watch_id] += 1
+                    self.notify_cnt[watch_id] = 1
+                elif  self.notify_data[watch_id] != data:
+                    self.notify_cnt[watch_id] += 1
                 self.notify_data[watch_id] = data
         return callback
 


### PR DESCRIPTION
when testing with socket injection, reconnect won't call error callback
for each reconnect, the callback will be called.
changing the callback count of notify by the data and increass only
when the data is changed, if the data is the same, we probably reconnecting
due to socket injection.

Fixes: https://tracker.ceph.com/issues/45721
Signed-off-by: Nitzan Mordechai nmordec@redhat.com





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
