### PR TITLE
common: fix a FTBFS in Journald.cc when building without systemd

### DIFF
--- a/src/common/Journald.h
+++ b/src/common/Journald.h
@@ -13,6 +13,9 @@ struct LogEntry;
 
 namespace ceph::logging {
 
+class Entry;
+class SubsystemMap;
+
 #ifdef WITH_SYSTEMD
 
 namespace detail {
@@ -36,9 +39,6 @@ class JournaldClient {
   int open_mem_file();
 };
 }
-
-class Entry;
-class SubsystemMap;
 
 /**
  * Logger to send local logs to journald


### PR DESCRIPTION
This came from Josh Salomon:

```
/home/jsalomon/src/prim_score/src/common/Journald.h:93:24: error: ‘SubsystemMap’ does not name a type
   93 |   JournaldLogger(const SubsystemMap *) {}
      |                        ^~~~~~~~~~~~
/home/jsalomon/src/prim_score/src/common/Journald.h:94:23: error: ‘Entry’ does not name a type
   94 |   int log_entry(const Entry &) {
      |
```

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
