### PR TITLE
include/buffer: clear_and_dispose() fix implicitly-declared operator= usage

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -594,13 +594,13 @@ struct error_code;
 	}
       }
       void clear_and_dispose() {
-	for (auto it = begin(); it != end(); /* nop */) {
-	  auto& node = *it;
-	  it = it->next;
-	  ptr_node::disposer()(&node);
-	}
-	_root.next = &_root;
-	_tail = &_root;
+        for (auto it = begin(); it != end(); /* nop */) {
+          auto& node = *it;
+          it = it->next;
+          ptr_node::disposer()(&node);
+        }
+        _root.next = &_root;
+        _tail = &_root;
       }
       iterator erase_after_and_dispose(iterator it) {
 	auto* to_dispose = &*std::next(it);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -594,13 +594,13 @@ struct error_code;
 	}
       }
       void clear_and_dispose() {
-        for (auto it = begin(); it != end(); /* nop */) {
-          auto& node = *it;
-          it = it->next;
-          ptr_node::disposer()(&node);
+        ptr_node::disposer dispose;
+        for (auto it = begin(), e = end(); it != e; /* nop */) {
+          auto& node = *it++;
+          dispose(&node);
         }
-        _root.next = &_root;
         _tail = &_root;
+        _root.next = _tail;
       }
       iterator erase_after_and_dispose(iterator it) {
 	auto* to_dispose = &*std::next(it);


### PR DESCRIPTION
Newer version of gcc deprecated few implicit definitions.
```
In file included from ../../src/include/rados/librados.hpp:11,
                 from hello_world.cc:14:
../../src/include/rados/buffer.h: In member function ‘void ceph::buffer::v15_2_0::list::buffers_t::clear_and_dispose()’:
../../src/include/rados/buffer.h:599:20: error: implicitly-declared ‘ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<ceph::buffer::v15_2_0::ptr_node>& ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<ceph::buffer::v15_2_0::ptr_node>::operator=(const ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<ceph::buffer::v15_2_0::ptr_node>&)’ is deprecated [-Werror=deprecated-copy]
  599 |           it = it->next;
      |                    ^~~~
../../src/include/rados/buffer.h:442:9: note: because ‘ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<ceph::buffer::v15_2_0::ptr_node>’ has user-provided ‘ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<T>::buffers_iterator(const ceph::buffer::v15_2_0::list::buffers_t::buffers_iterator<T>&) [with T = ceph::buffer::v15_2_0::ptr_node]’
  442 |         buffers_iterator(const buffers_iterator<T>& other)
```

~Fixes: https://tracker.ceph.com/issues/57152~
Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
