### PR TITLE
rgw: start on a rgw::sal::ConfigStore for boostrapping other stores

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3482,6 +3482,17 @@ options:
   - dbstore
   - motr
   - daos
+- name: rgw_config_store
+  type: str
+  level: advanced
+  desc: Configuration storage backend
+  default: rados
+  services:
+  - rgw
+  enum_values:
+  - rados
+  - dbstore
+  - json
 - name: rgw_filter
   type: str
   level: advanced
@@ -3506,6 +3517,24 @@ options:
   level: advanced
   desc: prefix to the file names created by db backend store
   default: dbstore
+  services:
+  - rgw
+- name: dbstore_config_uri
+  type: str
+  level: advanced
+  desc: 'Config database URI. URIs beginning with file: refer to local files opened with SQLite.'
+  default: file:/var/lib/ceph/radosgw/dbstore-config.db
+  see_also:
+  - rgw_config_store
+  services:
+  - rgw
+- name: rgw_json_config
+  type: str
+  level: advanced
+  desc: Path to a json file that contains the static zone and zonegroup configuration. Requires rgw_config_store=json.
+  default: /var/lib/ceph/radosgw/config.json
+  see_also:
+  - rgw_config_store
   services:
   - rgw
 - name: motr_profile_fid

--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -62,6 +62,7 @@ SUBSYS(rgw, 1, 5)                 // log level for the Rados gateway
 SUBSYS(rgw_sync, 1, 5)
 SUBSYS(rgw_datacache, 1, 5)
 SUBSYS(rgw_access, 1, 5)
+SUBSYS(rgw_dbstore, 1, 5)
 SUBSYS(javaclient, 1, 5)
 SUBSYS(asok, 1, 5)
 SUBSYS(throttle, 1, 1)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -176,6 +176,8 @@ set(librgw_common_srcs
   rgw_lua_background.cc)
 
 list(APPEND librgw_common_srcs
+  store/immutable_config/store.cc
+  store/json_config/store.cc
   store/rados/config/impl.cc
   store/rados/config/period.cc
   store/rados/config/period_config.cc

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -175,6 +175,15 @@ set(librgw_common_srcs
   rgw_tracer.cc
   rgw_lua_background.cc)
 
+list(APPEND librgw_common_srcs
+  store/rados/config/impl.cc
+  store/rados/config/period.cc
+  store/rados/config/period_config.cc
+  store/rados/config/realm.cc
+  store/rados/config/store.cc
+  store/rados/config/zone.cc
+  store/rados/config/zonegroup.cc)
+
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
 endif()

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1887,8 +1887,9 @@ static int send_to_remote_or_url(RGWRESTConn *conn, const string& url,
   return send_to_url(url, opt_region, access, secret, info, in_data, parser);
 }
 
-static int commit_period(RGWRealm& realm, RGWPeriod& period,
-                         string remote, const string& url,
+static int commit_period(rgw::sal::ConfigStore* cfgstore,
+                         RGWRealm& realm, rgw::sal::RealmWriter& realm_writer,
+                         RGWPeriod& period, string remote, const string& url,
                          std::optional<string> opt_region,
                          const string& access, const string& secret,
                          bool force)
@@ -1902,16 +1903,16 @@ static int commit_period(RGWRealm& realm, RGWPeriod& period,
   if (store->get_zone()->get_id() == master_zone) {
     // read the current period
     RGWPeriod current_period;
-    int ret = current_period.init(dpp(), g_ceph_context,
-				  static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm.get_id(),
-				  null_yield);
+    int ret = cfgstore->read_period(dpp(), null_yield, realm.current_period,
+                                    std::nullopt, current_period);
     if (ret < 0) {
-      cerr << "Error initializing current period: "
-          << cpp_strerror(-ret) << std::endl;
+      cerr << "failed to load current period: " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     // the master zone can commit locally
-    ret = period.commit(dpp(), store, realm, current_period, cerr, null_yield, force);
+    ret = rgw::commit_period(dpp(), null_yield, cfgstore, store,
+                             realm, realm_writer, current_period,
+                             period, cerr, force);
     if (ret < 0) {
       cerr << "failed to commit period: " << cpp_strerror(-ret) << std::endl;
     }
@@ -1975,63 +1976,67 @@ static int commit_period(RGWRealm& realm, RGWPeriod& period,
   }
   // the master zone gave us back the period that it committed, so it's
   // safe to save it as our latest epoch
-  ret = period.store_info(dpp(), false, null_yield);
+  constexpr bool exclusive = false;
+  ret = cfgstore->create_period(dpp(), null_yield, exclusive, period);
   if (ret < 0) {
     cerr << "Error storing committed period " << period.get_id() << ": "
         << cpp_strerror(ret) << std::endl;
     return ret;
   }
-  ret = period.set_latest_epoch(dpp(), null_yield, period.get_epoch());
-  if (ret < 0) {
-    cerr << "Error updating period epoch: " << cpp_strerror(ret) << std::endl;
-    return ret;
-  }
-  ret = period.reflect(dpp(), null_yield);
+  ret = rgw::reflect_period(dpp(), null_yield, cfgstore, period);
   if (ret < 0) {
     cerr << "Error updating local objects: " << cpp_strerror(ret) << std::endl;
     return ret;
   }
-  realm.notify_new_period(dpp(), period, null_yield);
+  (void) cfgstore->realm_notify_new_period(dpp(), null_yield, period);
   return ret;
 }
 
-static int update_period(const string& realm_id, const string& realm_name,
-                         const string& period_id, const string& period_epoch,
-                         bool commit, const string& remote, const string& url,
+static int update_period(rgw::sal::ConfigStore* cfgstore,
+                         const string& realm_id, const string& realm_name,
+                         const string& period_epoch, bool commit,
+                         const string& remote, const string& url,
                          std::optional<string> opt_region,
                          const string& access, const string& secret,
                          Formatter *formatter, bool force)
 {
-  RGWRealm realm(realm_id, realm_name);
-  int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-  if (ret < 0 ) {
-    cerr << "Error initializing realm " << cpp_strerror(-ret) << std::endl;
+  RGWRealm realm;
+  std::unique_ptr<rgw::sal::RealmWriter> realm_writer;
+  int ret = rgw::read_realm(dpp(), null_yield, cfgstore,
+                            realm_id, realm_name,
+                            realm, &realm_writer);
+  if (ret < 0) {
+    cerr << "failed to load realm " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
-  epoch_t epoch = 0;
+  std::optional<epoch_t> epoch;
   if (!period_epoch.empty()) {
     epoch = atoi(period_epoch.c_str());
   }
-  RGWPeriod period(period_id, epoch);
-  ret = period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm.get_id(), null_yield);
+  RGWPeriod period;
+  ret = cfgstore->read_period(dpp(), null_yield, realm.current_period,
+                              epoch, period);
   if (ret < 0) {
-    cerr << "period init failed: " << cpp_strerror(-ret) << std::endl;
+    cerr << "failed to load current period: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
-  period.fork();
-  ret = period.update(dpp(), null_yield);
-  if(ret < 0) {
-    // Dropping the error message here, as both the ret codes were handled in
-    // period.update()
+  // convert to the realm's staging period
+  rgw::fork_period(dpp(), period);
+  // update the staging period with all of the realm's zonegroups
+  ret = rgw::update_period(dpp(), null_yield, cfgstore, period);
+  if (ret < 0) {
     return ret;
   }
-  ret = period.store_info(dpp(), false, null_yield);
+
+  constexpr bool exclusive = false;
+  ret = cfgstore->create_period(dpp(), null_yield, exclusive, period);
   if (ret < 0) {
     cerr << "failed to store period: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
   if (commit) {
-    ret = commit_period(realm, period, remote, url, opt_region, access, secret, force);
+    ret = commit_period(cfgstore, realm, *realm_writer, period, remote, url,
+                        opt_region, access, secret, force);
     if (ret < 0) {
       cerr << "failed to commit period: " << cpp_strerror(-ret) << std::endl;
       return ret;
@@ -2056,7 +2061,8 @@ static int init_bucket_for_sync(rgw::sal::User* user,
   return 0;
 }
 
-static int do_period_pull(RGWRESTConn *remote_conn, const string& url,
+static int do_period_pull(rgw::sal::ConfigStore* cfgstore,
+                          RGWRESTConn *remote_conn, const string& url,
                           std::optional<string> opt_region,
                           const string& access_key, const string& secret_key,
                           const string& realm_id, const string& realm_name,
@@ -2086,37 +2092,17 @@ static int do_period_pull(RGWRESTConn *remote_conn, const string& url,
     cerr << "request failed: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
-  ret = period->init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield, false);
-  if (ret < 0) {
-    cerr << "faile to init period " << cpp_strerror(-ret) << std::endl;
-    return ret;
-  }
   try {
     decode_json_obj(*period, &p);
   } catch (const JSONDecoder::err& e) {
     cout << "failed to decode JSON input: " << e.what() << std::endl;
     return -EINVAL;
   }
-  ret = period->store_info(dpp(), false, null_yield);
+  constexpr bool exclusive = false;
+  ret = cfgstore->create_period(dpp(), null_yield, exclusive, *period);
   if (ret < 0) {
     cerr << "Error storing period " << period->get_id() << ": " << cpp_strerror(ret) << std::endl;
   }
-  // store latest epoch (ignore errors)
-  period->update_latest_epoch(dpp(), period->get_epoch(), null_yield);
-  return 0;
-}
-
-static int read_current_period_id(rgw::sal::Store* store, const std::string& realm_id,
-                                  const std::string& realm_name,
-                                  std::string* period_id)
-{
-  RGWRealm realm(realm_id, realm_name);
-  int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-  if (ret < 0) {
-    std::cerr << "failed to read realm: " << cpp_strerror(-ret) << std::endl;
-    return ret;
-  }
-  *period_id = realm.get_current_period();
   return 0;
 }
 
@@ -3155,7 +3141,9 @@ void init_optional_bucket(std::optional<rgw_bucket>& opt_bucket,
 
 class SyncPolicyContext
 {
+  rgw::sal::ConfigStore* cfgstore;
   RGWZoneGroup zonegroup;
+  std::unique_ptr<rgw::sal::ZoneGroupWriter> zonegroup_writer;
 
   std::optional<rgw_bucket> b;
   std::unique_ptr<rgw::sal::Bucket> bucket;
@@ -3165,13 +3153,14 @@ class SyncPolicyContext
   std::optional<rgw_user> owner;
 
 public:
-  SyncPolicyContext(const string& zonegroup_id,
-                    const string& zonegroup_name,
-                    std::optional<rgw_bucket> _bucket) : zonegroup(zonegroup_id, zonegroup_name),
-                                                         b(_bucket) {}
+  SyncPolicyContext(rgw::sal::ConfigStore* cfgstore,
+                    std::optional<rgw_bucket> _bucket)
+      : cfgstore(cfgstore), b(std::move(_bucket)) {}
 
-  int init() {
-    int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+  int init(const string& zonegroup_id, const string& zonegroup_name) {
+    int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore,
+                                  zonegroup_id, zonegroup_name,
+                                  zonegroup, &zonegroup_writer);
     if (ret < 0) {
       cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
       return ret;
@@ -3202,7 +3191,7 @@ public:
 
   int write_policy() {
     if (!b) {
-      int ret = zonegroup.update(dpp(), null_yield);
+      int ret = zonegroup_writer->write(dpp(), null_yield, zonegroup);
       if (ret < 0) {
         cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -3305,50 +3294,61 @@ public:
   }
 };
 
-static int search_entities_by_zone(rgw_zone_id zone_id,
+static int search_entities_by_zone(rgw::sal::ConfigStore* cfgstore,
+                                   rgw_zone_id zone_id,
                                    RGWRealm *prealm,
-                                   RGWPeriod *pperiod,
-                                   RGWZoneGroup *pzonegroup,
-                                   bool *pfound)
+                                   RGWZoneGroup *pzonegroup)
 {
-  *pfound = false;
+  std::array<std::string, 128> realm_names;
+  rgw::sal::ListResult<std::string> listing;
 
-  auto& found = *pfound;
-
-  list<string> realms;
-  int r = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_realms(dpp(), realms);
-  if (r < 0) {
-    cerr << "failed to list realms: " << cpp_strerror(-r) << std::endl;
-    return r;
-  }
-
-  for (auto& realm_name : realms) {
-    string realm_id;
-    string period_id;
-    RGWRealm realm(realm_id, realm_name);
-    r = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+  do {
+    int r = cfgstore->list_realm_names(dpp(), null_yield, listing.next,
+                                       realm_names, listing);
     if (r < 0) {
-      cerr << "WARNING: can't open realm " << realm_name << ": " << cpp_strerror(-r) << " ... skipping" << std::endl;
-      continue;
+      cerr << "failed to list realms: " << cpp_strerror(-r) << std::endl;
+      return r;
     }
-    RGWPeriod period;
-    r = realm.find_zone(dpp(), zone_id, pperiod,
-                        pzonegroup, &found, null_yield);
 
-    if (found) {
-      *prealm = realm;
-      break;
-    }
-  }
+    for (const auto& realm_name : listing.entries) {
+      RGWRealm realm;
+      r = cfgstore->read_realm_by_name(dpp(), null_yield, realm_name,
+                                       realm, nullptr);
+      if (r < 0) {
+        cerr << "WARNING: failed to load realm " << realm_name
+            << ": " << cpp_strerror(r) << " ... skipping" << std::endl;
+        continue;
+      }
 
-  return 0;
+      RGWPeriod period;
+      r = cfgstore->read_period(dpp(), null_yield, realm.current_period,
+                                std::nullopt, period);
+      if (r < 0) {
+        cerr << "WARNING: failed to load current period for realm "
+            << realm_name << ": " << cpp_strerror(r) << " ... skipping" << std::endl;
+        continue;
+      }
+
+      for (auto& [zid, zonegroup] : period.period_map.zonegroups) {
+        if (zonegroup.zones.count(zone_id)) {
+          *prealm = std::move(realm);
+          *pzonegroup = std::move(zonegroup);
+          return 0;
+        }
+      } // foreach zonegroup in period
+    } // foreach realm_name in listing.entries
+  } while (!listing.next.empty());
+
+  return -ENOENT;
 }
 
-static int try_to_resolve_local_zone(string& zone_id, string& zone_name)
+static int try_to_resolve_local_zone(rgw::sal::ConfigStore* cfgstore,
+                                     string& zone_id, string& zone_name)
 {
   /* try to read zone info */
-  RGWZoneParams zone(zone_id, zone_name);
-  int r = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+  RGWZoneParams zone;
+  int r = rgw::read_zone(dpp(), null_yield, cfgstore,
+                         zone_id, zone_name, zone);
   if (r == -ENOENT) {
     ldpp_dout(dpp(), 20) << __func__ << "(): local zone not found (id=" << zone_id << ", name= " << zone_name << ")" << dendl;
     return r;
@@ -3380,7 +3380,8 @@ static void check_set_consistent(const string& resolved_param,
 }
 
 
-static int try_to_resolve_local_entities(string& realm_id, string& realm_name,
+static int try_to_resolve_local_entities(rgw::sal::ConfigStore* cfgstore,
+                                         string& realm_id, string& realm_name,
                                          string& zonegroup_id, string& zonegroup_name,
                                          string& zone_id, string& zone_name)
 {
@@ -3393,7 +3394,7 @@ static int try_to_resolve_local_entities(string& realm_id, string& realm_name,
    */
 
   ldpp_dout(dpp(), 20) << __func__ << "(): before: realm_id=" << realm_id << " realm_name=" << realm_name << " zonegroup_id=" << zonegroup_id << " zonegroup_name=" << zonegroup_name << " zone_id=" << zone_id << " zone_name=" << zone_name << dendl;
-  int r = try_to_resolve_local_zone(zone_id, zone_name);
+  int r = try_to_resolve_local_zone(cfgstore, zone_id, zone_name);
   if (r == -ENOENT) {
     /* this local zone doesn't exist, abort */
     return 0;
@@ -3407,18 +3408,15 @@ static int try_to_resolve_local_entities(string& realm_id, string& realm_name,
     return 0;
   }
 
-  bool found;
   RGWRealm realm;
-  RGWPeriod period;
   RGWZoneGroup zonegroup;
-  r = search_entities_by_zone(zone_id, &realm, &period, &zonegroup, &found);
+  r = search_entities_by_zone(cfgstore, zone_id, &realm, &zonegroup);
+  if (r == -ENOENT) {
+    return 0; // not found
+  }
   if (r < 0) {
     ldpp_dout(dpp(), 0) << "ERROR: error when searching for realm id (r=" << r << "), ignoring" << dendl;
     return r;
-  }
-
-  if (!found) {
-    return 0;
   }
 
   check_set_consistent(realm.get_id(), realm_id, "realm id (--realm-id)");
@@ -3429,16 +3427,6 @@ static int try_to_resolve_local_entities(string& realm_id, string& realm_name,
   ldpp_dout(dpp(), 20) << __func__ << "(): after: realm_id=" << realm_id << " realm_name=" << realm_name << " zonegroup_id=" << zonegroup_id << " zonegroup_name=" << zonegroup_name << " zone_id=" << zone_id << " zone_name=" << zone_name << dendl;
 
   return 0;
-}
-
-static bool empty_opt(std::optional<string>& os)
-{
-  return (!os || os->empty());
-}
-
-static string safe_opt(std::optional<string>& os)
-{
-  return os.value_or(string());
 }
 
 void init_realm_param(CephContext *cct, string& var, std::optional<string>& opt_var, const string& conf_name)
@@ -4520,7 +4508,7 @@ int main(int argc, const char **argv)
   StoreDestructor store_destructor(store);
 
   if (raw_storage_op) {
-    try_to_resolve_local_entities(realm_id, realm_name,
+    try_to_resolve_local_entities(cfgstore.get(), realm_id, realm_name,
                                   zonegroup_id, zonegroup_name,
                                   zone_id, zone_name);
 
@@ -4532,13 +4520,7 @@ int main(int argc, const char **argv)
 	  cerr << "missing period id" << std::endl;
 	  return EINVAL;
 	}
-	RGWPeriod period(period_id);
-	int ret = period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-	if (ret < 0) {
-	  cerr << "period.init failed: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	ret = period.delete_obj(dpp(), null_yield);
+        int ret = cfgstore->delete_period(dpp(), null_yield, period_id);
 	if (ret < 0) {
 	  cerr << "ERROR: couldn't delete period: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -4548,15 +4530,16 @@ int main(int argc, const char **argv)
       break;
     case OPT::PERIOD_GET:
       {
-	epoch_t epoch = 0;
+        std::optional<epoch_t> epoch;
 	if (!period_epoch.empty()) {
 	  epoch = atoi(period_epoch.c_str());
 	}
         if (staging) {
-          RGWRealm realm(realm_id, realm_name);
-          int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+          RGWRealm realm;
+          int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                    realm_id, realm_name, realm);
           if (ret < 0 ) {
-            cerr << "Error initializing realm " << cpp_strerror(-ret) << std::endl;
+            cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
             return -ret;
           }
           realm_id = realm.get_id();
@@ -4564,11 +4547,23 @@ int main(int argc, const char **argv)
           period_id = RGWPeriod::get_staging_id(realm_id);
           epoch = 1;
         }
-	RGWPeriod period(period_id, epoch);
-	int ret = period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id,
-			      null_yield, realm_name);
+        if (period_id.empty()) {
+          // use realm's current period
+          RGWRealm realm;
+          int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                    realm_id, realm_name, realm);
+          if (ret < 0 ) {
+            cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          period_id = realm.current_period;
+        }
+
+	RGWPeriod period;
+        int ret = cfgstore->read_period(dpp(), null_yield, period_id,
+                                        epoch, period);
 	if (ret < 0) {
-	  cerr << "period init failed: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load period: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 	encode_json("period", period, formatter.get());
@@ -4577,35 +4572,45 @@ int main(int argc, const char **argv)
       break;
     case OPT::PERIOD_GET_CURRENT:
       {
-        int ret = read_current_period_id(store, realm_id, realm_name, &period_id);
+        RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
 	if (ret < 0) {
+          std::cerr << "failed to load realm: " << cpp_strerror(ret) << std::endl;
 	  return -ret;
 	}
+
 	formatter->open_object_section("period_get_current");
-	encode_json("current_period", period_id, formatter.get());
+	encode_json("current_period", realm.current_period, formatter.get());
 	formatter->close_section();
 	formatter->flush(cout);
       }
       break;
     case OPT::PERIOD_LIST:
       {
-	list<string> periods;
-	int ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_periods(dpp(), periods);
-	if (ret < 0) {
-	  cerr << "failed to list periods: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	formatter->open_object_section("periods_list");
-	encode_json("periods", periods, formatter.get());
-	formatter->close_section();
-	formatter->flush(cout);
-      }
+        Formatter::ObjectSection periods_list{*formatter, "periods_list"};
+        Formatter::ArraySection periods{*formatter, "periods"};
+        rgw::sal::ListResult<std::string> listing;
+        std::array<std::string, 1000> period_ids; // list in pages of 1000
+        do {
+          int ret = cfgstore->list_period_ids(dpp(), null_yield, listing.next,
+                                              period_ids, listing);
+          if (ret < 0) {
+            std::cerr << "failed to list periods: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          for (const auto& id : listing.entries) {
+            encode_json("id", id, formatter.get());
+          }
+        } while (!listing.next.empty());
+      } // close sections periods and periods_list
+      formatter->flush(cout);
       break;
     case OPT::PERIOD_UPDATE:
       {
-        int ret = update_period(realm_id, realm_name, period_id, period_epoch,
-                                commit, remote, url, opt_region,
-                                access_key, secret_key,
+        int ret = update_period(cfgstore.get(), realm_id, realm_name,
+                                period_epoch, commit, remote, url,
+                                opt_region, access_key, secret_key,
                                 formatter.get(), yes_i_really_mean_it);
 	if (ret < 0) {
 	  return -ret;
@@ -4618,16 +4623,20 @@ int main(int argc, const char **argv)
         RGWRESTConn *remote_conn = nullptr;
         if (url.empty()) {
           // load current period for endpoints
-          RGWRealm realm(realm_id, realm_name);
-          int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-          if (ret < 0) {
-            cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
+          RGWRealm realm;
+          int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                    realm_id, realm_name, realm);
+          if (ret < 0 ) {
+            cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
             return -ret;
           }
-          RGWPeriod current_period(realm.get_current_period());
-          ret = current_period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+          period_id = realm.current_period;
+
+          RGWPeriod current_period;
+          ret = cfgstore->read_period(dpp(), null_yield, period_id,
+                                      std::nullopt, current_period);
           if (ret < 0) {
-            cerr << "failed to init current period: " << cpp_strerror(-ret) << std::endl;
+            cerr << "failed to load current period: " << cpp_strerror(-ret) << std::endl;
             return -ret;
           }
           if (remote.empty()) {
@@ -4644,8 +4653,8 @@ int main(int argc, const char **argv)
         }
 
         RGWPeriod period;
-        int ret = do_period_pull(remote_conn, url, opt_region,
-                                 access_key, secret_key,
+        int ret = do_period_pull(cfgstore.get(), remote_conn, url,
+                                 opt_region, access_key, secret_key,
                                  realm_id, realm_name, period_id, period_epoch,
                                  &period);
         if (ret < 0) {
@@ -4663,10 +4672,10 @@ int main(int argc, const char **argv)
     case OPT::GLOBAL_RATELIMIT_DISABLE:
       {
         if (realm_id.empty()) {
-          RGWRealm realm(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
           if (!realm_name.empty()) {
             // look up realm_id for the given realm_name
-            int ret = realm.read_id(dpp(), realm_name, realm_id, null_yield);
+            int ret = cfgstore->read_realm_id(dpp(), null_yield,
+                                              realm_name, realm_id);
             if (ret < 0) {
               cerr << "ERROR: failed to read realm for " << realm_name
                   << ": " << cpp_strerror(-ret) << std::endl;
@@ -4674,7 +4683,8 @@ int main(int argc, const char **argv)
             }
           } else {
             // use default realm_id when none is given
-            int ret = realm.read_default_id(dpp(), realm_id, null_yield);
+            int ret = cfgstore->read_default_realm_id(dpp(), null_yield,
+                                                      realm_id);
             if (ret < 0 && ret != -ENOENT) { // on ENOENT, use empty realm_id
               cerr << "ERROR: failed to read default realm: "
                   << cpp_strerror(-ret) << std::endl;
@@ -4684,7 +4694,8 @@ int main(int argc, const char **argv)
         }
 
         RGWPeriodConfig period_config;
-        int ret = period_config.read(dpp(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id, null_yield);
+        int ret = cfgstore->read_period_config(dpp(), null_yield, realm_id,
+                                               period_config);
         if (ret < 0 && ret != -ENOENT) {
           cerr << "ERROR: failed to read period config: "
               << cpp_strerror(-ret) << std::endl;
@@ -4732,7 +4743,9 @@ int main(int argc, const char **argv)
 
         if (opt_cmd != OPT::GLOBAL_RATELIMIT_GET) {
           // write the modified period config
-          ret = period_config.write(dpp(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id, null_yield);
+          constexpr bool exclusive = false;
+          ret = cfgstore->write_period_config(dpp(), null_yield, exclusive,
+                                              realm_id, period_config);
           if (ret < 0) {
             cerr << "ERROR: failed to write period config: "
                 << cpp_strerror(-ret) << std::endl;
@@ -4757,10 +4770,10 @@ int main(int argc, const char **argv)
     case OPT::GLOBAL_QUOTA_DISABLE:
       {
         if (realm_id.empty()) {
-          RGWRealm realm(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
           if (!realm_name.empty()) {
             // look up realm_id for the given realm_name
-            int ret = realm.read_id(dpp(), realm_name, realm_id, null_yield);
+            int ret = cfgstore->read_realm_id(dpp(), null_yield,
+                                              realm_name, realm_id);
             if (ret < 0) {
               cerr << "ERROR: failed to read realm for " << realm_name
                   << ": " << cpp_strerror(-ret) << std::endl;
@@ -4768,7 +4781,8 @@ int main(int argc, const char **argv)
             }
           } else {
             // use default realm_id when none is given
-            int ret = realm.read_default_id(dpp(), realm_id, null_yield);
+            int ret = cfgstore->read_default_realm_id(dpp(), null_yield,
+                                                      realm_id);
             if (ret < 0 && ret != -ENOENT) { // on ENOENT, use empty realm_id
               cerr << "ERROR: failed to read default realm: "
                   << cpp_strerror(-ret) << std::endl;
@@ -4778,7 +4792,8 @@ int main(int argc, const char **argv)
         }
 
         RGWPeriodConfig period_config;
-        int ret = period_config.read(dpp(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id, null_yield);
+        int ret = cfgstore->read_period_config(dpp(), null_yield, realm_id,
+                                               period_config);
         if (ret < 0 && ret != -ENOENT) {
           cerr << "ERROR: failed to read period config: "
               << cpp_strerror(-ret) << std::endl;
@@ -4809,7 +4824,9 @@ int main(int argc, const char **argv)
 
         if (opt_cmd != OPT::GLOBAL_QUOTA_GET) {
           // write the modified period config
-          ret = period_config.write(dpp(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id, null_yield);
+          constexpr bool exclusive = false;
+          ret = cfgstore->write_period_config(dpp(), null_yield, exclusive,
+                                              realm_id, period_config);
           if (ret < 0) {
             cerr << "ERROR: failed to write period config: "
                 << cpp_strerror(-ret) << std::endl;
@@ -4835,15 +4852,19 @@ int main(int argc, const char **argv)
 	  return EINVAL;
 	}
 
-	RGWRealm realm(realm_name, g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
-	int ret = realm.create(dpp(), null_yield);
+	RGWRealm realm;
+        realm.name = realm_name;
+
+        constexpr bool exclusive = true;
+	int ret = rgw::create_realm(dpp(), null_yield, cfgstore.get(),
+                                    exclusive, realm);
 	if (ret < 0) {
 	  cerr << "ERROR: couldn't create realm " << realm_name << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
         if (set_default) {
-          ret = realm.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_realm(dpp(), null_yield, cfgstore.get(), realm);
           if (ret < 0) {
             cerr << "failed to set realm " << realm_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -4855,19 +4876,21 @@ int main(int argc, const char **argv)
       break;
     case OPT::REALM_DELETE:
       {
-	if (empty_opt(opt_realm_name) && empty_opt(opt_realm_id)) {
+	if (realm_id.empty() && realm_name.empty()) {
 	  cerr << "missing realm name or id" << std::endl;
 	  return EINVAL;
 	}
-	RGWRealm realm(safe_opt(opt_realm_id), safe_opt(opt_realm_name));
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWRealm realm;
+        std::unique_ptr<rgw::sal::RealmWriter> writer;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm, &writer);
 	if (ret < 0) {
-	  cerr << "realm.init failed: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = realm.delete_obj(dpp(), null_yield);
+        ret = writer->remove(dpp(), null_yield);
 	if (ret < 0) {
-	  cerr << "ERROR: couldn't : " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to remove realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
@@ -4875,13 +4898,14 @@ int main(int argc, const char **argv)
       break;
     case OPT::REALM_GET:
       {
-	RGWRealm realm(realm_id, realm_name);
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
 	if (ret < 0) {
 	  if (ret == -ENOENT && realm_name.empty() && realm_id.empty()) {
 	    cerr << "missing realm name or id, or default realm not found" << std::endl;
 	  } else {
-	    cerr << "realm.init failed: " << cpp_strerror(-ret) << std::endl;
+	    cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
           }
 	  return -ret;
 	}
@@ -4891,9 +4915,8 @@ int main(int argc, const char **argv)
       break;
     case OPT::REALM_GET_DEFAULT:
       {
-	RGWRealm realm(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
 	string default_id;
-	int ret = realm.read_default_id(dpp(), default_id, null_yield);
+	int ret = cfgstore->read_default_realm_id(dpp(), null_yield, default_id);
 	if (ret == -ENOENT) {
 	  cout << "No default realm is set" << std::endl;
 	  return -ret;
@@ -4906,48 +4929,68 @@ int main(int argc, const char **argv)
       break;
     case OPT::REALM_LIST:
       {
-	RGWRealm realm(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
-	string default_id;
-	int ret = realm.read_default_id(dpp(), default_id, null_yield);
+        std::string default_id;
+        int ret = cfgstore->read_default_realm_id(dpp(), null_yield,
+                                                  default_id);
 	if (ret < 0 && ret != -ENOENT) {
 	  cerr << "could not determine default realm: " << cpp_strerror(-ret) << std::endl;
 	}
-	list<string> realms;
-	ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_realms(dpp(), realms);
-	if (ret < 0) {
-	  cerr << "failed to list realms: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	formatter->open_object_section("realms_list");
-	encode_json("default_info", default_id, formatter.get());
-	encode_json("realms", realms, formatter.get());
-	formatter->close_section();
-	formatter->flush(cout);
-      }
+
+        Formatter::ObjectSection realms_list{*formatter, "realms_list"};
+        encode_json("default_info", default_id, formatter.get());
+
+        Formatter::ArraySection realms{*formatter, "realms"};
+        rgw::sal::ListResult<std::string> listing;
+        std::array<std::string, 1000> names; // list in pages of 1000
+        do {
+          ret = cfgstore->list_realm_names(dpp(), null_yield, listing.next,
+                                           names, listing);
+          if (ret < 0) {
+            std::cerr << "failed to list realms: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          for (const auto& name : listing.entries) {
+            encode_json("name", name, formatter.get());
+          }
+        } while (!listing.next.empty());
+      } // close sections realms and realms_list
+      formatter->flush(cout);
       break;
     case OPT::REALM_LIST_PERIODS:
       {
-        int ret = read_current_period_id(store, realm_id, realm_name, &period_id);
-	if (ret < 0) {
-	  return -ret;
-	}
-	list<string> periods;
-	ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_periods(dpp(), period_id, periods, null_yield);
-	if (ret < 0) {
-	  cerr << "list periods failed: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	formatter->open_object_section("realm_periods_list");
+        // use realm's current period
+        RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
+        if (ret < 0) {
+          cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+        period_id = realm.current_period;
+
+        Formatter::ObjectSection periods_list{*formatter, "realm_periods_list"};
 	encode_json("current_period", period_id, formatter.get());
-	encode_json("periods", periods, formatter.get());
-	formatter->close_section();
-	formatter->flush(cout);
-      }
+
+        Formatter::ArraySection periods{*formatter, "periods"};
+
+        while (!period_id.empty()) {
+          RGWPeriod period;
+          ret = cfgstore->read_period(dpp(), null_yield, period_id,
+                                      std::nullopt, period);
+          if (ret < 0) {
+            cerr << "failed to load period id " << period_id
+                << ": " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          encode_json("id", period_id, formatter.get());
+          period_id = period.predecessor_uuid;
+        }
+      } // close sections periods and realm_periods_list
+      formatter->flush(cout);
       break;
 
     case OPT::REALM_RENAME:
       {
-	RGWRealm realm(realm_id, realm_name);
 	if (realm_new_name.empty()) {
 	  cerr << "missing realm new name" << std::endl;
 	  return EINVAL;
@@ -4956,14 +4999,18 @@ int main(int argc, const char **argv)
 	  cerr << "missing realm name or id" << std::endl;
 	  return EINVAL;
 	}
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+
+        RGWRealm realm;
+        std::unique_ptr<rgw::sal::RealmWriter> writer;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm, &writer);
 	if (ret < 0) {
-	  cerr << "realm.init failed: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = realm.rename(dpp(), realm_new_name, null_yield);
+        ret = writer->rename(dpp(), null_yield, realm, realm_new_name);
 	if (ret < 0) {
-	  cerr << "realm.rename failed: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "rename failed: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
         cout << "Realm name updated. Note that this change only applies to "
@@ -4977,9 +5024,11 @@ int main(int argc, const char **argv)
 	  cerr << "no realm name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWRealm realm(realm_id, realm_name);
 	bool new_realm = false;
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+        RGWRealm realm;
+        std::unique_ptr<rgw::sal::RealmWriter> writer;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm, &writer);
 	if (ret < 0 && ret != -ENOENT) {
 	  cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -4999,13 +5048,15 @@ int main(int argc, const char **argv)
 	if (new_realm) {
 	  cout << "clearing period and epoch for new realm" << std::endl;
 	  realm.clear_current_period_and_epoch();
-	  ret = realm.create(dpp(), null_yield);
+          constexpr bool exclusive = true;
+          ret = rgw::create_realm(dpp(), null_yield, cfgstore.get(),
+                                  exclusive, realm);
 	  if (ret < 0) {
 	    cerr << "ERROR: couldn't create new realm: " << cpp_strerror(-ret) << std::endl;
 	    return 1;
 	  }
 	} else {
-	  ret = realm.update(dpp(), null_yield);
+          ret = writer->write(dpp(), null_yield, realm);
 	  if (ret < 0) {
 	    cerr << "ERROR: couldn't store realm info: " << cpp_strerror(-ret) << std::endl;
 	    return 1;
@@ -5013,7 +5064,7 @@ int main(int argc, const char **argv)
 	}
 
         if (set_default) {
-          ret = realm.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_realm(dpp(), null_yield, cfgstore.get(), realm);
           if (ret < 0) {
             cerr << "failed to set realm " << realm_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5025,13 +5076,14 @@ int main(int argc, const char **argv)
 
     case OPT::REALM_DEFAULT:
       {
-	RGWRealm realm(realm_id, realm_name);
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+        RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
 	if (ret < 0) {
-	  cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = realm.set_as_default(dpp(), null_yield);
+        ret = rgw::set_default_realm(dpp(), null_yield, cfgstore.get(), realm);
 	if (ret < 0) {
 	  cerr << "failed to set realm as default: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5068,7 +5120,6 @@ int main(int argc, const char **argv)
           return -ret;
         }
         RGWRealm realm;
-        realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield, false);
         try {
           decode_json_obj(realm, &p);
         } catch (const JSONDecoder::err& e) {
@@ -5079,7 +5130,7 @@ int main(int argc, const char **argv)
         auto& current_period = realm.get_current_period();
         if (!current_period.empty()) {
           // pull the latest epoch of the realm's current period
-          ret = do_period_pull(nullptr, url, opt_region,
+          ret = do_period_pull(cfgstore.get(), nullptr, url, opt_region,
                                access_key, secret_key,
                                realm_id, realm_name, current_period, "",
                                &period);
@@ -5088,21 +5139,17 @@ int main(int argc, const char **argv)
             return -ret;
           }
         }
-        ret = realm.create(dpp(), null_yield, false);
-        if (ret < 0 && ret != -EEXIST) {
+        constexpr bool exclusive = false;
+        ret = rgw::create_realm(dpp(), null_yield, cfgstore.get(),
+                                exclusive, realm);
+        if (ret < 0) {
           cerr << "Error storing realm " << realm.get_id() << ": "
             << cpp_strerror(ret) << std::endl;
           return -ret;
-        } else if (ret ==-EEXIST) {
-	  ret = realm.update(dpp(), null_yield);
-	  if (ret < 0) {
-	    cerr << "Error storing realm " << realm.get_id() << ": "
-		 << cpp_strerror(ret) << std::endl;
-	  }
-	}
+        }
 
         if (set_default) {
-          ret = realm.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_realm(dpp(), null_yield, cfgstore.get(), realm);
           if (ret < 0) {
             cerr << "failed to set realm " << realm_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5120,29 +5167,41 @@ int main(int argc, const char **argv)
 	  return EINVAL;
 	}
 
-	RGWZoneGroup zonegroup(zonegroup_id,zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+        // load the zonegroup and zone params
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> zonegroup_writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &zonegroup_writer);
 	if (ret < 0) {
-	  cerr << "failed to initialize zonegroup " << zonegroup_name << " id " << zonegroup_id << ": "
-	       << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	RGWZoneParams zone(zone_id, zone_name);
-	ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup " << zonegroup_name << " id "
+              << zonegroup_id << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
+	RGWZoneParams zone_params;
+        std::unique_ptr<rgw::sal::ZoneWriter> zone_writer;
+        ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                             zone_id, zone_name, zone_params, &zone_writer);
+	if (ret < 0) {
+	  cerr << "unable to load zone: " << cpp_strerror(-ret) << std::endl;
+	  return -ret;
+	}
+
+        // update zone_params if necessary
         bool need_zone_update = false;
 
-        if (zone.realm_id != zonegroup.realm_id) {
-          zone.realm_id = zonegroup.realm_id;
+        if (zone_params.realm_id != zonegroup.realm_id) {
+          if (!zone_params.realm_id.empty()) {
+            cerr << "WARNING: overwriting zone realm_id=" << zone_params.realm_id
+                << " to match zonegroup realm_id=" << zonegroup.realm_id << std::endl;
+          }
+          zone_params.realm_id = zonegroup.realm_id;
           need_zone_update = true;
         }
 
         for (auto a : tier_config_add) {
-          ret = zone.tier_config.set(a.first, a.second);
+          ret = zone_params.tier_config.set(a.first, a.second);
           if (ret < 0) {
             cerr << "ERROR: failed to set configurable: " << a << std::endl;
             return EINVAL;
@@ -5151,33 +5210,51 @@ int main(int argc, const char **argv)
         }
 
         if (need_zone_update) {
-          ret = zone.update(dpp(), null_yield);
+          ret = zone_writer->write(dpp(), null_yield, zone_params);
           if (ret < 0) {
             cerr << "failed to save zone info: " << cpp_strerror(-ret) << std::endl;
             return -ret;
           }
         }
 
-        string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
+        const bool *pis_master = (is_master_set ? &is_master : nullptr);
+        const bool *pread_only = (is_read_only_set ? &read_only : nullptr);
+        const bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
+        const string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
 
-        bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
-        string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
+        // validate --tier-type if specified
+        const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
+        if (ptier_type) {
+          auto sync_mgr = static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager();
+          if (!sync_mgr->get_module(*ptier_type, nullptr)) {
+            ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
+                << *ptier_type << ",  valid sync modules: "
+                << sync_mgr->get_registered_module_names() << dendl;
+            return EINVAL;
+          }
+        }
+
         if (enable_features.empty()) { // enable all features by default
           enable_features.insert(rgw::zone_features::supported.begin(),
                                  rgw::zone_features::supported.end());
         }
 
-        ret = zonegroup.add_zone(dpp(), zone,
-                                 (is_master_set ? &is_master : NULL),
-                                 (is_read_only_set ? &read_only : NULL),
-                                 endpoints, ptier_type,
-                                 psync_from_all, sync_from, sync_from_rm,
-                                 predirect_zone, bucket_index_max_shards,
-				 static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager(),
-                                 enable_features, disable_features, null_yield);
+        // add/update the public zone information stored in the zonegroup
+        ret = rgw::add_zone_to_group(dpp(), zonegroup, zone_params,
+                                     pis_master, pread_only, endpoints,
+                                     ptier_type, psync_from_all,
+                                     sync_from, sync_from_rm,
+                                     predirect_zone, bucket_index_max_shards,
+                                     enable_features, disable_features);
+        if (ret < 0) {
+          return -ret;
+        }
+
+        // write the updated zonegroup
+        ret = zonegroup_writer->write(dpp(), null_yield, zonegroup);
 	if (ret < 0) {
-	  cerr << "failed to add zone " << zone_name << " to zonegroup " << zonegroup.get_name() << ": "
-	       << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to write updated zonegroup " << zonegroup.get_name()
+              << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
@@ -5191,14 +5268,19 @@ int main(int argc, const char **argv)
 	  cerr << "Missing zonegroup name" << std::endl;
 	  return EINVAL;
 	}
-	RGWRealm realm(realm_id, realm_name);
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
 	if (ret < 0) {
 	  cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
-	RGWZoneGroup zonegroup(zonegroup_name, is_master, g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm.get_id(), endpoints);
+	RGWZoneGroup zonegroup;
+        zonegroup.name = zonegroup_name;
+        zonegroup.is_master = is_master;
+        zonegroup.realm_id = realm.get_id();
+        zonegroup.endpoints = endpoints;
         zonegroup.api_name = (api_name.empty() ? zonegroup_name : api_name);
 
         zonegroup.enabled_features = enable_features;
@@ -5216,14 +5298,17 @@ int main(int argc, const char **argv)
           zonegroup.enabled_features.erase(i);
         }
 
-	ret = zonegroup.create(dpp(), null_yield);
+        constexpr bool exclusive = true;
+        ret = rgw::create_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                    exclusive, zonegroup);
 	if (ret < 0) {
 	  cerr << "failed to create zonegroup " << zonegroup_name << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
         if (set_default) {
-          ret = zonegroup.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                           zonegroup);
           if (ret < 0) {
             cerr << "failed to set zonegroup " << zonegroup_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5240,14 +5325,17 @@ int main(int argc, const char **argv)
 	  return EINVAL;
 	}
 
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup);
 	if (ret < 0) {
 	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
-	ret = zonegroup.set_as_default(dpp(), null_yield);
+        ret = rgw::set_default_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                         zonegroup);
 	if (ret < 0) {
 	  cerr << "failed to set zonegroup as default: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5256,18 +5344,20 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_DELETE:
       {
-	if (empty_opt(opt_zonegroup_id) && empty_opt(opt_zonegroup_name)) {
+	if (zonegroup_id.empty() && zonegroup_name.empty()) {
 	  cerr << "no zonegroup name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWZoneGroup zonegroup(safe_opt(opt_zonegroup_id), safe_opt(opt_zonegroup_name));
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj,
-				 null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &writer);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = zonegroup.delete_obj(dpp(), null_yield);
+        ret = writer->remove(dpp(), null_yield);
 	if (ret < 0) {
 	  cerr << "ERROR: couldn't delete zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5276,10 +5366,11 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_GET:
       {
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name, zonegroup);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
@@ -5289,36 +5380,40 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_LIST:
       {
-	RGWZoneGroup zonegroup;
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj,
-				 null_yield, false);
-	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-
-	list<string> zonegroups;
-	ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_zonegroups(dpp(), zonegroups);
-	if (ret < 0) {
-	  cerr << "failed to list zonegroups: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	string default_zonegroup;
-	ret = zonegroup.read_default_id(dpp(), default_zonegroup, null_yield);
+        RGWZoneGroup default_zonegroup;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      {}, {}, default_zonegroup);
 	if (ret < 0 && ret != -ENOENT) {
 	  cerr << "could not determine default zonegroup: " << cpp_strerror(-ret) << std::endl;
 	}
-	formatter->open_object_section("zonegroups_list");
-	encode_json("default_info", default_zonegroup, formatter.get());
-	encode_json("zonegroups", zonegroups, formatter.get());
-	formatter->close_section();
-	formatter->flush(cout);
-      }
+
+        Formatter::ObjectSection zonegroups_list{*formatter, "zonegroups_list"};
+        encode_json("default_info", default_zonegroup.id, formatter.get());
+
+        Formatter::ArraySection zonegroups{*formatter, "zonegroups"};
+        rgw::sal::ListResult<std::string> listing;
+        std::array<std::string, 1000> names; // list in pages of 1000
+        do {
+          ret = cfgstore->list_zonegroup_names(dpp(), null_yield, listing.next,
+                                               names, listing);
+          if (ret < 0) {
+            std::cerr << "failed to list zonegroups: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          for (const auto& name : listing.entries) {
+            encode_json("name", name, formatter.get());
+          }
+        } while (!listing.next.empty());
+      } // close sections zonegroups and zonegroups_list
+      formatter->flush(cout);
       break;
     case OPT::ZONEGROUP_MODIFY:
       {
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &writer);
 	if (ret < 0) {
 	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5332,7 +5427,7 @@ int main(int argc, const char **argv)
         }
 
 	if (is_master_set) {
-	  zonegroup.update_master(dpp(), is_master, null_yield);
+	  zonegroup.is_master = is_master;
           need_update = true;
         }
 
@@ -5351,8 +5446,8 @@ int main(int argc, const char **argv)
           need_update = true;
         } else if (!realm_name.empty()) {
           // get realm id from name
-          RGWRealm realm{g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj};
-          ret = realm.read_id(dpp(), realm_name, zonegroup.realm_id, null_yield);
+          ret = cfgstore->read_realm_id(dpp(), null_yield, realm_name,
+                                        zonegroup.realm_id);
           if (ret < 0) {
             cerr << "failed to find realm by name " << realm_name << std::endl;
             return -ret;
@@ -5384,7 +5479,7 @@ int main(int argc, const char **argv)
         }
 
         if (need_update) {
-	  ret = zonegroup.update(dpp(), null_yield);
+	  ret = writer->write(dpp(), null_yield, zonegroup);
 	  if (ret < 0) {
 	    cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;
 	    return -ret;
@@ -5392,7 +5487,8 @@ int main(int argc, const char **argv)
 	}
 
         if (set_default) {
-          ret = zonegroup.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                           zonegroup);
           if (ret < 0) {
             cerr << "failed to set zonegroup " << zonegroup_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5404,22 +5500,17 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_SET:
       {
-	RGWRealm realm(realm_id, realm_name);
-	int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWRealm realm;
+        int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                  realm_id, realm_name, realm);
 	bool default_realm_not_exist = (ret == -ENOENT && realm_id.empty() && realm_name.empty());
 
-	if (ret < 0 && !default_realm_not_exist ) {
+	if (ret < 0 && !default_realm_not_exist) {
 	  cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
 	RGWZoneGroup zonegroup;
-	ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj,
-			     null_yield, false);
-	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
 	ret = read_decode_json(infile, zonegroup);
 	if (ret < 0) {
 	  return 1;
@@ -5453,20 +5544,19 @@ int main(int argc, const char **argv)
             }
           }
         }
-	ret = zonegroup.create(dpp(), null_yield);
-	if (ret < 0 && ret != -EEXIST) {
+
+        // create/overwrite the zonegroup info
+        constexpr bool exclusive = false;
+        ret = rgw::create_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                    exclusive, zonegroup);
+	if (ret < 0) {
 	  cerr << "ERROR: couldn't create zonegroup info: " << cpp_strerror(-ret) << std::endl;
 	  return 1;
-	} else if (ret == -EEXIST) {
-	  ret = zonegroup.update(dpp(), null_yield);
-	  if (ret < 0) {
-	    cerr << "ERROR: couldn't store zonegroup info: " << cpp_strerror(-ret) << std::endl;
-	    return 1;
-	  }
 	}
 
         if (set_default) {
-          ret = zonegroup.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                           zonegroup);
           if (ret < 0) {
             cerr << "failed to set zonegroup " << zonegroup_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5478,8 +5568,11 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_REMOVE:
       {
-        RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-        int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &writer);
         if (ret < 0) {
           cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
           return -ret;
@@ -5504,9 +5597,15 @@ int main(int argc, const char **argv)
           }
         }
 
-        ret = zonegroup.remove_zone(dpp(), zone_id, null_yield);
+        ret = rgw::remove_zone_from_group(dpp(), zonegroup, zone_id);
         if (ret < 0) {
           cerr << "failed to remove zone: " << cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+
+        ret = writer->write(dpp(), null_yield, zonegroup);
+        if (ret < 0) {
+          cerr << "failed to write zonegroup: " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }
 
@@ -5524,13 +5623,16 @@ int main(int argc, const char **argv)
 	  cerr << "no zonegroup name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &writer);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = zonegroup.rename(dpp(), zonegroup_new_name, null_yield);
+        ret = writer->rename(dpp(), null_yield, zonegroup, zonegroup_new_name);
 	if (ret < 0) {
 	  cerr << "failed to rename zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5539,11 +5641,11 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_PLACEMENT_LIST:
       {
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj,
-				 null_yield);
+	RGWZoneGroup zonegroup;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name, zonegroup);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
@@ -5558,10 +5660,11 @@ int main(int argc, const char **argv)
 	  return EINVAL;
 	}
 
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name, zonegroup);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
@@ -5595,8 +5698,11 @@ int main(int argc, const char **argv)
       rule.storage_class = opt_storage_class.value_or(string());
     }
 
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> writer;
+        int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                      zonegroup_id, zonegroup_name,
+                                      zonegroup, &writer);
 	if (ret < 0) {
 	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5677,14 +5783,26 @@ int main(int argc, const char **argv)
         target.tier_targets.emplace(std::make_pair(storage_class, *pt));
       }
 
+      if (zonegroup.default_placement.empty()) {
+        zonegroup.default_placement.init(rule.name, RGW_STORAGE_CLASS_STANDARD);
+      }
     } else if (opt_cmd == OPT::ZONEGROUP_PLACEMENT_RM) {
       if (!opt_storage_class || opt_storage_class->empty()) {
         zonegroup.placement_targets.erase(placement_id);
+        if (zonegroup.default_placement.name == placement_id) {
+          // clear default placement
+          zonegroup.default_placement.clear();
+        }
       } else {
         auto iter = zonegroup.placement_targets.find(placement_id);
         if (iter != zonegroup.placement_targets.end()) {
           RGWZoneGroupPlacementTarget& info = zonegroup.placement_targets[placement_id];
           info.storage_classes.erase(*opt_storage_class);
+
+          if (zonegroup.default_placement == rule) {
+            // clear default storage class
+            zonegroup.default_placement.storage_class.clear();
+          }
 
 	      auto ptiter = info.tier_targets.find(*opt_storage_class);
 	      if (ptiter != info.tier_targets.end()) {
@@ -5701,8 +5819,7 @@ int main(int argc, const char **argv)
       zonegroup.default_placement = rule;
     }
 
-    zonegroup.post_process_params(dpp(), null_yield);
-    ret = zonegroup.update(dpp(), null_yield);
+    ret = writer->write(dpp(), null_yield, zonegroup);
     if (ret < 0) {
       cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;
       return -ret;
@@ -5718,13 +5835,16 @@ int main(int argc, const char **argv)
 	  cerr << "zone name not provided" << std::endl;
 	  return EINVAL;
         }
-	int ret;
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
+
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> zonegroup_writer;
 	/* if the user didn't provide zonegroup info , create stand alone zone */
 	if (!zonegroup_id.empty() || !zonegroup_name.empty()) {
-	  ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+          int ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                        zonegroup_id, zonegroup_name,
+                                        zonegroup, &zonegroup_writer);
 	  if (ret < 0) {
-	    cerr << "unable to initialize zonegroup " << zonegroup_name << ": " << cpp_strerror(-ret) << std::endl;
+	    cerr << "failed to load zonegroup " << zonegroup_name << ": " << cpp_strerror(-ret) << std::endl;
 	    return -ret;
 	  }
 	  if (realm_id.empty() && realm_name.empty()) {
@@ -5732,49 +5852,78 @@ int main(int argc, const char **argv)
 	  }
 	}
 
-	RGWZoneParams zone(zone_id, zone_name);
-	ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield, false);
-	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
+        // create the local zone params
+	RGWZoneParams zone_params;
+        zone_params.id = zone_id;
+        zone_params.name = zone_name;
 
-        zone.system_key.id = access_key;
-        zone.system_key.key = secret_key;
-	zone.realm_id = realm_id;
-        for (auto a : tier_config_add) {
-          int r = zone.tier_config.set(a.first, a.second);
+        zone_params.system_key.id = access_key;
+        zone_params.system_key.key = secret_key;
+	zone_params.realm_id = realm_id;
+        for (const auto& a : tier_config_add) {
+          int r = zone_params.tier_config.set(a.first, a.second);
           if (r < 0) {
             cerr << "ERROR: failed to set configurable: " << a << std::endl;
             return EINVAL;
           }
         }
 
-	ret = zone.create(dpp(), null_yield);
+        if (zone_params.realm_id.empty()) {
+          RGWRealm realm;
+          int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                    realm_id, realm_name, realm);
+          if (ret < 0 && ret != -ENOENT) {
+            cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          zone_params.realm_id = realm.id;
+          cerr << "NOTICE: set zone's realm_id=" << realm.id << std::endl;
+        }
+
+        constexpr bool exclusive = true;
+        int ret = rgw::create_zone(dpp(), null_yield, cfgstore.get(),
+                                   exclusive, zone_params);
 	if (ret < 0) {
 	  cerr << "failed to create zone " << zone_name << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
-	if (!zonegroup_id.empty() || !zonegroup_name.empty()) {
-          string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
-          bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
-          string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
+	if (zonegroup_writer) {
+          const bool *pis_master = (is_master_set ? &is_master : nullptr);
+          const bool *pread_only = (is_read_only_set ? &read_only : nullptr);
+          const bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
+          const string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
+
+          // validate --tier-type if specified
+          const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
+          if (ptier_type) {
+            auto sync_mgr = static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager();
+            if (!sync_mgr->get_module(*ptier_type, nullptr)) {
+              ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
+                  << *ptier_type << ",  valid sync modules: "
+                  << sync_mgr->get_registered_module_names() << dendl;
+              return EINVAL;
+            }
+          }
+
           if (enable_features.empty()) { // enable all features by default
             enable_features.insert(rgw::zone_features::supported.begin(),
                                    rgw::zone_features::supported.end());
           }
 
-	  ret = zonegroup.add_zone(dpp(), zone,
-                                   (is_master_set ? &is_master : NULL),
-                                   (is_read_only_set ? &read_only : NULL),
-                                   endpoints,
-                                   ptier_type,
-                                   psync_from_all,
-                                   sync_from, sync_from_rm,
-                                   predirect_zone, bucket_index_max_shards,
-				   static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager(),
-                                   enable_features, disable_features, null_yield);
+          // add/update the public zone information stored in the zonegroup
+          ret = rgw::add_zone_to_group(dpp(), zonegroup, zone_params,
+                                       pis_master, pread_only, endpoints,
+                                       ptier_type, psync_from_all,
+                                       sync_from, sync_from_rm,
+                                       predirect_zone, bucket_index_max_shards,
+                                       enable_features, disable_features);
+          if (ret < 0) {
+            return -ret;
+          }
+
+          // write the updated zonegroup
+          ret = zonegroup_writer->write(dpp(), null_yield, zonegroup);
 	  if (ret < 0) {
 	    cerr << "failed to add zone " << zone_name << " to zonegroup " << zonegroup.get_name()
 		 << ": " << cpp_strerror(-ret) << std::endl;
@@ -5783,13 +5932,14 @@ int main(int argc, const char **argv)
 	}
 
         if (set_default) {
-          ret = zone.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zone(dpp(), null_yield, cfgstore.get(),
+                                      zone_params);
           if (ret < 0) {
             cerr << "failed to set zone " << zone_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
         }
 
-	encode_json("zone", zone, formatter.get());
+	encode_json("zone", zone_params, formatter.get());
 	formatter->flush(cout);
       }
       break;
@@ -5799,13 +5949,16 @@ int main(int argc, const char **argv)
 	  cerr << "no zone name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone_params;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone_params);
 	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "unable to load zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = zone.set_as_default(dpp(), null_yield);
+
+        ret = rgw::set_default_zone(dpp(), null_yield, cfgstore.get(),
+                                    zone_params);
 	if (ret < 0) {
 	  cerr << "failed to set zone as default: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -5814,69 +5967,49 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONE_DELETE:
       {
-	if (empty_opt(opt_zone_id) && empty_opt(opt_zone_name)) {
+	if (zone_id.empty() && zone_name.empty()) {
 	  cerr << "no zone name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWZoneParams zone(safe_opt(opt_zone_id), safe_opt(opt_zone_name));
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone_params;
+        std::unique_ptr<rgw::sal::ZoneWriter> writer;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone_params, &writer);
 	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
-        list<string> zonegroups;
-	ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_zonegroups(dpp(), zonegroups);
+        ret = rgw::delete_zone(dpp(), null_yield, cfgstore.get(),
+                               zone_params, *writer);
 	if (ret < 0) {
-	  cerr << "failed to list zonegroups: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-
-        for (list<string>::iterator iter = zonegroups.begin(); iter != zonegroups.end(); ++iter) {
-          RGWZoneGroup zonegroup(string(), *iter);
-          int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-          if (ret < 0) {
-            cerr << "WARNING: failed to initialize zonegroup " << zonegroup_name << std::endl;
-            continue;
-          }
-          ret = zonegroup.remove_zone(dpp(), zone.get_id(), null_yield);
-          if (ret < 0 && ret != -ENOENT) {
-            cerr << "failed to remove zone " << zone.get_name() << " from zonegroup " << zonegroup.get_name() << ": "
-              << cpp_strerror(-ret) << std::endl;
-          }
-        }
-
-	ret = zone.delete_obj(dpp(), null_yield);
-	if (ret < 0) {
-	  cerr << "failed to delete zone " << zone.get_name() << ": " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to delete zone " << zone_params.get_name()
+              << ": " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
       }
       break;
     case OPT::ZONE_GET:
       {
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone_params;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone_params);
 	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	encode_json("zone", zone, formatter.get());
+	encode_json("zone", zone_params, formatter.get());
 	formatter->flush(cout);
       }
       break;
     case OPT::ZONE_SET:
       {
-	RGWZoneParams zone(zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield,
-			    false);
-	if (ret < 0) {
-	  return -ret;
-	}
-
-        ret = zone.read(dpp(), null_yield);
+	RGWZoneParams zone;
+        std::unique_ptr<rgw::sal::ZoneWriter> writer;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone, &writer);
         if (ret < 0 && ret != -ENOENT) {
-	  cerr << "zone.read() returned ret=" << ret << std::endl;
+	  cerr << "failed to load zone: " << cpp_strerror(ret) << std::endl;
           return -ret;
         }
 
@@ -5887,17 +6020,19 @@ int main(int argc, const char **argv)
 	  return 1;
 	}
 
-	if(zone.realm_id.empty()) {
-	  RGWRealm realm(realm_id, realm_name);
-	  int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	if (zone.realm_id.empty()) {
+	  RGWRealm realm;
+          ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                realm_id, realm_name, realm);
 	  if (ret < 0 && ret != -ENOENT) {
-	    cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
+	    cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
 	    return -ret;
 	  }
 	  zone.realm_id = realm.get_id();
+          cerr << "NOTICE: set zone's realm_id=" << zone.realm_id << std::endl;
 	}
 
-	if( !zone_name.empty() && !zone.get_name().empty() && zone.get_name() != zone_name) {
+	if (!zone_name.empty() && !zone.get_name().empty() && zone.get_name() != zone_name) {
 	  cerr << "Error: zone name " << zone_name << " is different than the zone name " << zone.get_name() << " in the provided json " << std::endl;
 	  return EINVAL;
 	}
@@ -5916,30 +6051,16 @@ int main(int argc, const char **argv)
           zone.set_id(orig_id);
         }
 
-	if (zone.get_id().empty()) {
-	  cerr << "no zone name id the json provided, assuming old format" << std::endl;
-	  if (zone_name.empty()) {
-	    cerr << "missing zone name"  << std::endl;
-	    return EINVAL;
-	  }
-	  zone.set_name(zone_name);
-	  zone.set_id(zone_name);
-	}
-
-	cerr << "zone id " << zone.get_id();
-	ret = zone.fix_pool_names(dpp(), null_yield);
-	if (ret < 0) {
-	  cerr << "ERROR: couldn't fix zone: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	ret = zone.write(dpp(), false, null_yield);
+        constexpr bool exclusive = false;
+        ret = rgw::create_zone(dpp(), null_yield, cfgstore.get(),
+                               exclusive, zone);
 	if (ret < 0) {
 	  cerr << "ERROR: couldn't create zone: " << cpp_strerror(-ret) << std::endl;
-	  return 1;
+	  return -ret;
 	}
 
         if (set_default) {
-          ret = zone.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zone(dpp(), null_yield, cfgstore.get(), zone);
           if (ret < 0) {
             cerr << "failed to set zone " << zone_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
@@ -5951,58 +6072,62 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONE_LIST:
       {
-	list<string> zones;
-	int ret = store->list_all_zones(dpp(), zones);
-	if (ret < 0) {
-	  cerr << "failed to list zones: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-
-	RGWZoneParams zone;
-	ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield, false);
-	if (ret < 0) {
-	  cerr << "failed to init zone: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-	string default_zone;
-	ret = zone.read_default_id(dpp(), default_zone, null_yield);
+        RGWZoneParams default_zone_params;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 {}, {}, default_zone_params);
 	if (ret < 0 && ret != -ENOENT) {
 	  cerr << "could not determine default zone: " << cpp_strerror(-ret) << std::endl;
 	}
-	formatter->open_object_section("zones_list");
-	encode_json("default_info", default_zone, formatter.get());
-	encode_json("zones", zones, formatter.get());
-	formatter->close_section();
-	formatter->flush(cout);
-      }
+
+        Formatter::ObjectSection zones_list{*formatter, "zones_list"};
+        encode_json("default_info", default_zone_params.id, formatter.get());
+
+        Formatter::ArraySection zones{*formatter, "zones"};
+        rgw::sal::ListResult<std::string> listing;
+        std::array<std::string, 1000> names; // list in pages of 1000
+        do {
+          ret = cfgstore->list_zone_names(dpp(), null_yield, listing.next,
+                                          names, listing);
+          if (ret < 0) {
+            std::cerr << "failed to list zones: " << cpp_strerror(-ret) << std::endl;
+            return -ret;
+          }
+          for (const auto& name : listing.entries) {
+            encode_json("name", name, formatter.get());
+          }
+        } while (!listing.next.empty());
+      } // close sections zones and zones_list
+      formatter->flush(cout);
       break;
     case OPT::ZONE_MODIFY:
       {
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone_params;
+        std::unique_ptr<rgw::sal::ZoneWriter> zone_writer;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone_params, &zone_writer);
         if (ret < 0) {
-	  cerr << "failed to init zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
         bool need_zone_update = false;
         if (!access_key.empty()) {
-          zone.system_key.id = access_key;
+          zone_params.system_key.id = access_key;
           need_zone_update = true;
         }
 
         if (!secret_key.empty()) {
-          zone.system_key.key = secret_key;
+          zone_params.system_key.key = secret_key;
           need_zone_update = true;
         }
 
         if (!realm_id.empty()) {
-          zone.realm_id = realm_id;
+          zone_params.realm_id = realm_id;
           need_zone_update = true;
         } else if (!realm_name.empty()) {
           // get realm id from name
-          RGWRealm realm{g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj};
-          ret = realm.read_id(dpp(), realm_name, zone.realm_id, null_yield);
+          ret = cfgstore->read_realm_id(dpp(), null_yield,
+                                        realm_name, zone_params.realm_id);
           if (ret < 0) {
             cerr << "failed to find realm by name " << realm_name << std::endl;
             return -ret;
@@ -6010,70 +6135,89 @@ int main(int argc, const char **argv)
           need_zone_update = true;
         }
 
-        if (tier_config_add.size() > 0) {
-          for (auto add : tier_config_add) {
-            int r = zone.tier_config.set(add.first, add.second);
-            if (r < 0) {
-              cerr << "ERROR: failed to set configurable: " << add << std::endl;
-              return EINVAL;
-            }
+        for (const auto& add : tier_config_add) {
+          ret = zone_params.tier_config.set(add.first, add.second);
+          if (ret < 0) {
+            cerr << "ERROR: failed to set configurable: " << add << std::endl;
+            return EINVAL;
           }
           need_zone_update = true;
         }
 
-        for (auto rm : tier_config_rm) {
+        for (const auto& rm : tier_config_rm) {
           if (!rm.first.empty()) { /* otherwise will remove the entire config */
-            zone.tier_config.erase(rm.first);
+            zone_params.tier_config.erase(rm.first);
             need_zone_update = true;
           }
         }
 
         if (need_zone_update) {
-          ret = zone.update(dpp(), null_yield);
+          ret = zone_writer->write(dpp(), null_yield, zone_params);
           if (ret < 0) {
             cerr << "failed to save zone info: " << cpp_strerror(-ret) << std::endl;
             return -ret;
           }
         }
 
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> zonegroup_writer;
+        ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                  zonegroup_id, zonegroup_name,
+                                  zonegroup, &zonegroup_writer);
 	if (ret < 0) {
-	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-        string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
-
-        bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
-        string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
-
-        ret = zonegroup.add_zone(dpp(), zone,
-                                 (is_master_set ? &is_master : NULL),
-                                 (is_read_only_set ? &read_only : NULL),
-                                 endpoints, ptier_type,
-                                 psync_from_all, sync_from, sync_from_rm,
-                                 predirect_zone, bucket_index_max_shards,
-				 static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager(),
-                                 enable_features, disable_features, null_yield);
-	if (ret < 0) {
-	  cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
-	ret = zonegroup.update(dpp(), null_yield);
+        const bool *pis_master = (is_master_set ? &is_master : nullptr);
+        const bool *pread_only = (is_read_only_set ? &read_only : nullptr);
+        const bool *psync_from_all = (sync_from_all_specified ? &sync_from_all : nullptr);
+        const string *predirect_zone = (redirect_zone_set ? &redirect_zone : nullptr);
+
+        // validate --tier-type if specified
+        const string *ptier_type = (tier_type_specified ? &tier_type : nullptr);
+        if (ptier_type) {
+          auto sync_mgr = static_cast<rgw::sal::RadosStore*>(store)->svc()->sync_modules->get_manager();
+          if (!sync_mgr->get_module(*ptier_type, nullptr)) {
+            ldpp_dout(dpp(), -1) << "ERROR: could not find sync module: "
+                << *ptier_type << ",  valid sync modules: "
+                << sync_mgr->get_registered_module_names() << dendl;
+            return EINVAL;
+          }
+        }
+
+        if (enable_features.empty()) { // enable all features by default
+          enable_features.insert(rgw::zone_features::supported.begin(),
+                                 rgw::zone_features::supported.end());
+        }
+
+        // add/update the public zone information stored in the zonegroup
+        ret = rgw::add_zone_to_group(dpp(), zonegroup, zone_params,
+                                     pis_master, pread_only, endpoints,
+                                     ptier_type, psync_from_all,
+                                     sync_from, sync_from_rm,
+                                     predirect_zone, bucket_index_max_shards,
+                                     enable_features, disable_features);
+        if (ret < 0) {
+          return -ret;
+        }
+
+        // write the updated zonegroup
+        ret = zonegroup_writer->write(dpp(), null_yield, zonegroup);
 	if (ret < 0) {
 	  cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
 
         if (set_default) {
-          ret = zone.set_as_default(dpp(), null_yield);
+          ret = rgw::set_default_zone(dpp(), null_yield, cfgstore.get(),
+                                      zone_params);
           if (ret < 0) {
             cerr << "failed to set zone " << zone_name << " as default: " << cpp_strerror(-ret) << std::endl;
           }
         }
 
-        encode_json("zone", zone, formatter.get());
+        encode_json("zone", zone_params, formatter.get());
         formatter->flush(cout);
       }
       break;
@@ -6087,28 +6231,43 @@ int main(int argc, const char **argv)
 	  cerr << "no zone name or id provided" << std::endl;
 	  return EINVAL;
 	}
-	RGWZoneParams zone(zone_id,zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+
+	RGWZoneParams zone_params;
+        std::unique_ptr<rgw::sal::ZoneWriter> zone_writer;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone_params, &zone_writer);
 	if (ret < 0) {
-	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
+	  cerr << "failed to load zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	ret = zone.rename(dpp(), zone_new_name, null_yield);
+
+	ret = zone_writer->rename(dpp(), null_yield, zone_params, zone_new_name);
 	if (ret < 0) {
 	  cerr << "failed to rename zone " << zone_name << " to " << zone_new_name << ": " << cpp_strerror(-ret)
 	       << std::endl;
 	  return -ret;
 	}
-	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+
+	RGWZoneGroup zonegroup;
+        std::unique_ptr<rgw::sal::ZoneGroupWriter> zonegroup_writer;
+        ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                  zonegroup_id, zonegroup_name,
+                                  zonegroup, &zonegroup_writer);
 	if (ret < 0) {
-	  cerr << "WARNING: failed to initialize zonegroup " << zonegroup_name << std::endl;
-	} else {
-	  ret = zonegroup.rename_zone(dpp(), zone, null_yield);
-	  if (ret < 0) {
-	    cerr << "Error in zonegroup rename for " << zone_name << ": " << cpp_strerror(-ret) << std::endl;
-	    return -ret;
-	  }
+	  cerr << "WARNING: failed to load zonegroup " << zonegroup_name << std::endl;
+          return EXIT_SUCCESS;
+	}
+
+        auto z = zonegroup.zones.find(zone_params.id);
+        if (z == zonegroup.zones.end()) {
+          return EXIT_SUCCESS;
+        }
+        z->second.name = zone_params.name;
+
+        ret = zonegroup_writer->write(dpp(), null_yield, zonegroup);
+        if (ret < 0) {
+          cerr << "Error in zonegroup rename for " << zone_name << ": " << cpp_strerror(-ret) << std::endl;
+          return -ret;
 	}
       }
       break;
@@ -6127,8 +6286,10 @@ int main(int argc, const char **argv)
           return EINVAL;
         }
 
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone;
+        std::unique_ptr<rgw::sal::ZoneWriter> writer;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone, &writer);
         if (ret < 0) {
 	  cerr << "failed to init zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -6136,8 +6297,9 @@ int main(int argc, const char **argv)
 
         if (opt_cmd == OPT::ZONE_PLACEMENT_ADD ||
 	    opt_cmd == OPT::ZONE_PLACEMENT_MODIFY) {
-	  RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	  ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	  RGWZoneGroup zonegroup;
+          ret = rgw::read_zonegroup(dpp(), null_yield, cfgstore.get(),
+                                    zonegroup_id, zonegroup_name, zonegroup);
 	  if (ret < 0) {
 	    cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
 	    return -ret;
@@ -6215,7 +6377,7 @@ int main(int argc, const char **argv)
           }
         }
 
-        ret = zone.update(dpp(), null_yield);
+        ret = writer->write(dpp(), null_yield, zone);
         if (ret < 0) {
           cerr << "failed to save zone info: " << cpp_strerror(-ret) << std::endl;
           return -ret;
@@ -6227,8 +6389,9 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONE_PLACEMENT_LIST:
       {
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone);
 	if (ret < 0) {
 	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -6244,8 +6407,9 @@ int main(int argc, const char **argv)
 	  return EINVAL;
 	}
 
-	RGWZoneParams zone(zone_id, zone_name);
-	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	RGWZoneParams zone;
+        int ret = rgw::read_zone(dpp(), null_yield, cfgstore.get(),
+                                 zone_id, zone_name, zone);
 	if (ret < 0) {
 	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
@@ -6253,7 +6417,7 @@ int main(int argc, const char **argv)
 	auto p = zone.placement_pools.find(placement_id);
 	if (p == zone.placement_pools.end()) {
 	  cerr << "ERROR: zone placement target '" << placement_id << "' not found" << std::endl;
-	  return -ENOENT;
+	  return ENOENT;
 	}
 	encode_json("placement_pools", p->second, formatter.get());
 	formatter->flush(cout);
@@ -6543,10 +6707,11 @@ int main(int argc, const char **argv)
         params["epoch"] = period_epoch;
 
       // load the period
-      RGWPeriod period(period_id);
-      int ret = period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+      RGWPeriod period;
+      int ret = cfgstore->read_period(dpp(), null_yield, period_id,
+                                      std::nullopt, period);
       if (ret < 0) {
-        cerr << "period init failed: " << cpp_strerror(-ret) << std::endl;
+        cerr << "failed to load period: " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
       // json format into a bufferlist
@@ -6567,9 +6732,9 @@ int main(int argc, const char **argv)
     return 0;
   case OPT::PERIOD_UPDATE:
     {
-      int ret = update_period(realm_id, realm_name, period_id, period_epoch,
-                              commit, remote, url, opt_region,
-                              access_key, secret_key,
+      int ret = update_period(cfgstore.get(), realm_id, realm_name,
+                              period_epoch, commit, remote, url,
+                              opt_region, access_key, secret_key,
                               formatter.get(), yes_i_really_mean_it);
       if (ret < 0) {
 	return -ret;
@@ -6579,19 +6744,26 @@ int main(int argc, const char **argv)
   case OPT::PERIOD_COMMIT:
     {
       // read realm and staging period
-      RGWRealm realm(realm_id, realm_name);
-      int ret = realm.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+      RGWRealm realm;
+      std::unique_ptr<rgw::sal::RealmWriter> realm_writer;
+      int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                realm_id, realm_name,
+                                realm, &realm_writer);
       if (ret < 0) {
         cerr << "Error initializing realm: " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
-      RGWPeriod period(RGWPeriod::get_staging_id(realm.get_id()), 1);
-      ret = period.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm.get_id(), null_yield);
+      period_id = rgw::get_staging_period_id(realm.id);
+      epoch_t epoch = 1;
+
+      RGWPeriod period;
+      ret = cfgstore->read_period(dpp(), null_yield, period_id, epoch, period);
       if (ret < 0) {
-        cerr << "period init failed: " << cpp_strerror(-ret) << std::endl;
+        cerr << "failed to load period: " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
-      ret = commit_period(realm, period, remote, url, opt_region, access_key, secret_key,
+      ret = commit_period(cfgstore.get(), realm, *realm_writer, period,
+                          remote, url, opt_region, access_key, secret_key,
                           yes_i_really_mean_it);
       if (ret < 0) {
         cerr << "failed to commit period: " << cpp_strerror(-ret) << std::endl;
@@ -8614,10 +8786,15 @@ next:
     int i = (specified_shard_id ? shard_id : 0);
 
     if (period_id.empty()) {
-      int ret = read_current_period_id(store, realm_id, realm_name, &period_id);
-      if (ret < 0) {
+      // use realm's current period
+      RGWRealm realm;
+      int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                realm_id, realm_name, realm);
+      if (ret < 0 ) {
+        cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
+      period_id = realm.current_period;
       std::cerr << "No --period given, using current period="
           << period_id << std::endl;
     }
@@ -8659,10 +8836,15 @@ next:
     int i = (specified_shard_id ? shard_id : 0);
 
     if (period_id.empty()) {
-      int ret = read_current_period_id(store, realm_id, realm_name, &period_id);
-      if (ret < 0) {
+      // use realm's current period
+      RGWRealm realm;
+      int ret = rgw::read_realm(dpp(), null_yield, cfgstore.get(),
+                                realm_id, realm_name, realm);
+      if (ret < 0 ) {
+        cerr << "failed to load realm: " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
+      period_id = realm.current_period;
       std::cerr << "No --period given, using current period="
           << period_id << std::endl;
     }
@@ -9320,8 +9502,8 @@ next:
     CHECK_TRUE(require_opt(opt_group_id), "ERROR: --group-id not specified", EINVAL);
     CHECK_TRUE(require_opt(opt_status), "ERROR: --status is not specified (options: forbidden, allowed, enabled)", EINVAL);
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9354,8 +9536,8 @@ next:
   }
 
   if (opt_cmd == OPT::SYNC_GROUP_GET) {
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9379,8 +9561,8 @@ next:
   if (opt_cmd == OPT::SYNC_GROUP_REMOVE) {
     CHECK_TRUE(require_opt(opt_group_id), "ERROR: --group-id not specified", EINVAL);
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9410,8 +9592,8 @@ next:
                             directional_flow_opt(*opt_flow_type)),
                            "ERROR: --flow-type invalid (options: symmetrical, directional)", EINVAL);
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9461,8 +9643,8 @@ next:
                             directional_flow_opt(*opt_flow_type)),
                            "ERROR: --flow-type invalid (options: symmetrical, directional)", EINVAL);
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9502,8 +9684,8 @@ next:
       CHECK_TRUE(require_non_empty_opt(opt_dest_zone_ids), "ERROR: --dest-zones not provided or is empty; should be list of zones or '*'", EINVAL);
     }
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9584,8 +9766,8 @@ next:
     CHECK_TRUE(require_opt(opt_group_id), "ERROR: --group-id not specified", EINVAL);
     CHECK_TRUE(require_opt(opt_pipe_id), "ERROR: --pipe-id not specified", EINVAL);
 
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }
@@ -9640,8 +9822,8 @@ next:
   }
 
   if (opt_cmd == OPT::SYNC_POLICY_GET) {
-    SyncPolicyContext sync_policy_ctx(zonegroup_id, zonegroup_name, opt_bucket);
-    ret = sync_policy_ctx.init();
+    SyncPolicyContext sync_policy_ctx(cfgstore.get(), opt_bucket);
+    ret = sync_policy_ctx.init(zonegroup_id, zonegroup_name);
     if (ret < 0) {
       return -ret;
     }

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1605,6 +1605,12 @@ public:
 
   /** Get the config for stores/filters */
   static Config get_config(bool admin, CephContext* cct);
+
+  /** Create a ConfigStore */
+  static auto create_config_store(const DoutPrefixProvider* dpp,
+                                  std::string_view type)
+      -> std::unique_ptr<rgw::sal::ConfigStore>;
+
 };
 
 /** @} */

--- a/src/rgw/rgw_sal_config.h
+++ b/src/rgw/rgw_sal_config.h
@@ -1,0 +1,301 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include "rgw_sal_fwd.h"
+
+class DoutPrefixProvider;
+class optional_yield;
+struct RGWPeriod;
+struct RGWPeriodConfig;
+struct RGWRealm;
+struct RGWZoneGroup;
+struct RGWZoneParams;
+
+namespace rgw::sal {
+
+/// Results of a listing operation
+template <typename T>
+struct ListResult {
+  /// The subspan of the input entries that contain results
+  std::span<T> entries;
+  /// The next marker to resume listing, or empty
+  std::string next;
+};
+
+/// Storage abstraction for realm/zonegroup/zone configuration
+class ConfigStore {
+ public:
+  virtual ~ConfigStore() {}
+
+  /// @group Realm
+  ///@{
+
+  /// Set the cluster-wide default realm id
+  virtual int write_default_realm_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y, bool exclusive,
+                                     std::string_view realm_id) = 0;
+  /// Read the cluster's default realm id
+  virtual int read_default_realm_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string& realm_id) = 0;
+  /// Delete the cluster's default realm id
+  virtual int delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                      optional_yield y) = 0;
+
+  /// Create a realm
+  virtual int create_realm(const DoutPrefixProvider* dpp,
+                           optional_yield y, bool exclusive,
+                           const RGWRealm& info,
+                           std::unique_ptr<RealmWriter>* writer) = 0;
+  /// Read a realm by id
+  virtual int read_realm_by_id(const DoutPrefixProvider* dpp,
+                               optional_yield y,
+                               std::string_view realm_id,
+                               RGWRealm& info,
+                               std::unique_ptr<RealmWriter>* writer) = 0;
+  /// Read a realm by name
+  virtual int read_realm_by_name(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_name,
+                                 RGWRealm& info,
+                                 std::unique_ptr<RealmWriter>* writer) = 0;
+  /// Read the cluster's default realm
+  virtual int read_default_realm(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 RGWRealm& info,
+                                 std::unique_ptr<RealmWriter>* writer) = 0;
+  /// Look up a realm id by its name
+  virtual int read_realm_id(const DoutPrefixProvider* dpp,
+                            optional_yield y, std::string_view realm_name,
+                            std::string& realm_id) = 0;
+  /// Notify the cluster of a new period, so radosgws can reload with the new
+  /// configuration
+  virtual int realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const RGWPeriod& period) = 0;
+  /// List up to 'entries.size()' realm names starting from the given marker
+  virtual int list_realm_names(const DoutPrefixProvider* dpp,
+                               optional_yield y, const std::string& marker,
+                               std::span<std::string> entries,
+                               ListResult<std::string>& result) = 0;
+  ///@}
+
+  /// @group Period
+  ///@{
+
+  /// Write a period and advance its latest epoch
+  virtual int create_period(const DoutPrefixProvider* dpp,
+                            optional_yield y, bool exclusive,
+                            const RGWPeriod& info) = 0;
+  /// Read a period by id and epoch. If no epoch is given, read the latest
+  virtual int read_period(const DoutPrefixProvider* dpp,
+                          optional_yield y, std::string_view period_id,
+                          std::optional<uint32_t> epoch, RGWPeriod& info) = 0;
+  /// Delete all period epochs with the given period id
+  virtual int delete_period(const DoutPrefixProvider* dpp,
+                            optional_yield y,
+                            std::string_view period_id) = 0;
+  /// List up to 'entries.size()' period ids starting from the given marker
+  virtual int list_period_ids(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              ListResult<std::string>& result) = 0;
+  ///@}
+
+  /// @group ZoneGroup
+  ///@{
+
+  /// Set the cluster-wide default zonegroup id
+  virtual int write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                         optional_yield y, bool exclusive,
+                                         std::string_view realm_id,
+                                         std::string_view zonegroup_id) = 0;
+  /// Read the cluster's default zonegroup id
+  virtual int read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view realm_id,
+                                        std::string& zonegroup_id) = 0;
+  /// Delete the cluster's default zonegroup id
+  virtual int delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view realm_id) = 0;
+
+  /// Create a zonegroup
+  virtual int create_zonegroup(const DoutPrefixProvider* dpp,
+                               optional_yield y, bool exclusive,
+                               const RGWZoneGroup& info,
+                               std::unique_ptr<ZoneGroupWriter>* writer) = 0;
+  /// Read a zonegroup by id
+  virtual int read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view zonegroup_id,
+                                   RGWZoneGroup& info,
+                                   std::unique_ptr<ZoneGroupWriter>* writer) = 0;
+  /// Read a zonegroup by name
+  virtual int read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view zonegroup_name,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<ZoneGroupWriter>* writer) = 0;
+  /// Read the cluster's default zonegroup
+  virtual int read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<ZoneGroupWriter>* writer) = 0;
+  /// List up to 'entries.size()' zonegroup names starting from the given marker
+  virtual int list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                   optional_yield y, const std::string& marker,
+                                   std::span<std::string> entries,
+                                   ListResult<std::string>& result) = 0;
+  ///@}
+
+  /// @group Zone
+  ///@{
+
+  /// Set the realm-wide default zone id
+  virtual int write_default_zone_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y, bool exclusive,
+                                    std::string_view realm_id,
+                                    std::string_view zone_id) = 0;
+  /// Read the realm's default zone id
+  virtual int read_default_zone_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view realm_id,
+                                   std::string& zone_id) = 0;
+  /// Delete the realm's default zone id
+  virtual int delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id) = 0;
+
+  /// Create a zone
+  virtual int create_zone(const DoutPrefixProvider* dpp,
+                          optional_yield y, bool exclusive,
+                          const RGWZoneParams& info,
+                          std::unique_ptr<ZoneWriter>* writer) = 0;
+  /// Read a zone by id
+  virtual int read_zone_by_id(const DoutPrefixProvider* dpp,
+                              optional_yield y,
+                              std::string_view zone_id,
+                              RGWZoneParams& info,
+                              std::unique_ptr<ZoneWriter>* writer) = 0;
+  /// Read a zone by id or name. If both are empty, try to load the
+  /// cluster's default zone
+  virtual int read_zone_by_name(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view zone_name,
+                                RGWZoneParams& info,
+                                std::unique_ptr<ZoneWriter>* writer) = 0;
+  /// Read the realm's default zone
+  virtual int read_default_zone(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view realm_id,
+                                RGWZoneParams& info,
+                                std::unique_ptr<ZoneWriter>* writer) = 0;
+  /// List up to 'entries.size()' zone names starting from the given marker
+  virtual int list_zone_names(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              ListResult<std::string>& result) = 0;
+  ///@}
+
+  /// @group PeriodConfig
+  ///@{
+
+  /// Read period config object
+  virtual int read_period_config(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_id,
+                                 RGWPeriodConfig& info) = 0;
+  /// Write period config object
+  virtual int write_period_config(const DoutPrefixProvider* dpp,
+                                  optional_yield y, bool exclusive,
+                                  std::string_view realm_id,
+                                  const RGWPeriodConfig& info) = 0;
+  ///@}
+
+}; // ConfigStore
+
+
+/// A handle to manage the atomic updates of an existing realm object. This
+/// is initialized on read, and any subsequent writes through this handle will
+/// fail with -ECANCELED if another writer updates the object in the meantime.
+class RealmWriter {
+ public:
+  virtual ~RealmWriter() {}
+
+  /// Overwrite an existing realm. Must not change id or name
+  virtual int write(const DoutPrefixProvider* dpp,
+                    optional_yield y,
+                    const RGWRealm& info) = 0;
+  /// Rename an existing realm. Must not change id
+  virtual int rename(const DoutPrefixProvider* dpp,
+                     optional_yield y,
+                     RGWRealm& info,
+                     std::string_view new_name) = 0;
+  /// Delete an existing realm
+  virtual int remove(const DoutPrefixProvider* dpp,
+                     optional_yield y) = 0;
+};
+
+/// A handle to manage the atomic updates of an existing zonegroup object. This
+/// is initialized on read, and any subsequent writes through this handle will
+/// fail with -ECANCELED if another writer updates the object in the meantime.
+class ZoneGroupWriter {
+ public:
+  virtual ~ZoneGroupWriter() {}
+
+  /// Overwrite an existing zonegroup. Must not change id or name
+  virtual int write(const DoutPrefixProvider* dpp,
+                    optional_yield y,
+                    const RGWZoneGroup& info) = 0;
+  /// Rename an existing zonegroup. Must not change id
+  virtual int rename(const DoutPrefixProvider* dpp,
+                     optional_yield y,
+                     RGWZoneGroup& info,
+                     std::string_view new_name) = 0;
+  /// Delete an existing zonegroup
+  virtual int remove(const DoutPrefixProvider* dpp,
+                     optional_yield y) = 0;
+};
+
+/// A handle to manage the atomic updates of an existing zone object. This
+/// is initialized on read, and any subsequent writes through this handle will
+/// fail with -ECANCELED if another writer updates the object in the meantime.
+class ZoneWriter {
+ public:
+  virtual ~ZoneWriter() {}
+
+  /// Overwrite an existing zone. Must not change id or name
+  virtual int write(const DoutPrefixProvider* dpp,
+                    optional_yield y,
+                    const RGWZoneParams& info) = 0;
+  /// Rename an existing zone. Must not change id
+  virtual int rename(const DoutPrefixProvider* dpp,
+                     optional_yield y,
+                     RGWZoneParams& info,
+                     std::string_view new_name) = 0;
+  /// Delete an existing zone
+  virtual int remove(const DoutPrefixProvider* dpp,
+                     optional_yield y) = 0;
+};
+
+} // namespace rgw::sal

--- a/src/rgw/rgw_sal_fwd.h
+++ b/src/rgw/rgw_sal_fwd.h
@@ -33,4 +33,9 @@ namespace rgw { namespace sal {
   class LuaManager;
   struct RGWRoleInfo;
 
+  class ConfigStore;
+  class RealmWriter;
+  class ZoneGroupWriter;
+  class ZoneWriter;
+
 } } // namespace rgw::sal

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1,11 +1,15 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <optional>
+
 #include "common/errno.h"
 
 #include "rgw_zone.h"
 #include "rgw_realm_watcher.h"
 #include "rgw_meta_sync_status.h"
+#include "rgw_sal_config.h"
+#include "rgw_string.h"
 #include "rgw_sync.h"
 
 #include "services/svc_zone.h"
@@ -53,6 +57,14 @@ RGWMetaSyncStatusManager::~RGWMetaSyncStatusManager(){}
 #define FIRST_EPOCH 1
 
 struct RGWAccessKey;
+
+/// Generate a random uuid for realm/period/zonegroup/zone ids
+static std::string gen_random_uuid()
+{
+  uuid_d uuid;
+  uuid.generate_random();
+  return uuid.to_string();
+}
 
 void encode_json_plain(const char *name, const RGWAccessKey& val, Formatter *f)
 {
@@ -1663,52 +1675,61 @@ void RGWZoneParams::dump(Formatter *f) const
 }
 
 namespace {
-int get_zones_pool_set(const DoutPrefixProvider *dpp, 
+
+void add_zone_pools(const RGWZoneParams& info,
+                    std::set<rgw_pool>& pools)
+{
+  pools.insert(info.domain_root);
+  pools.insert(info.control_pool);
+  pools.insert(info.gc_pool);
+  pools.insert(info.log_pool);
+  pools.insert(info.intent_log_pool);
+  pools.insert(info.usage_log_pool);
+  pools.insert(info.user_keys_pool);
+  pools.insert(info.user_email_pool);
+  pools.insert(info.user_swift_pool);
+  pools.insert(info.user_uid_pool);
+  pools.insert(info.otp_pool);
+  pools.insert(info.roles_pool);
+  pools.insert(info.reshard_pool);
+  pools.insert(info.oidc_pool);
+  pools.insert(info.notif_pool);
+
+  for (const auto& [pname, placement] : info.placement_pools) {
+    pools.insert(placement.index_pool);
+    for (const auto& [sname, sc] : placement.storage_classes.get_all()) {
+      if (sc.data_pool) {
+        pools.insert(sc.data_pool.get());
+      }
+    }
+    pools.insert(placement.data_extra_pool);
+  }
+}
+
+int get_zones_pool_set(const DoutPrefixProvider *dpp,
                        CephContext* cct,
                        RGWSI_SysObj* sysobj_svc,
-                       const list<string>& zones,
+                       const list<string>& zone_names,
                        const string& my_zone_id,
                        set<rgw_pool>& pool_names,
 		       optional_yield y)
 {
-  for(auto const& iter : zones) {
-    RGWZoneParams zone(iter);
+  for (const auto& name : zone_names) {
+    RGWZoneParams zone(name);
     int r = zone.init(dpp, cct, sysobj_svc, y);
     if (r < 0) {
-      ldpp_dout(dpp, 0) << "Error: init zone " << iter << ":" << cpp_strerror(-r) << dendl;
+      ldpp_dout(dpp, 0) << "Error: failed to load zone " << name
+          << " with " << cpp_strerror(-r) << dendl;
       return r;
     }
     if (zone.get_id() != my_zone_id) {
-      pool_names.insert(zone.domain_root);
-      pool_names.insert(zone.control_pool);
-      pool_names.insert(zone.gc_pool);
-      pool_names.insert(zone.log_pool);
-      pool_names.insert(zone.intent_log_pool);
-      pool_names.insert(zone.usage_log_pool);
-      pool_names.insert(zone.user_keys_pool);
-      pool_names.insert(zone.user_email_pool);
-      pool_names.insert(zone.user_swift_pool);
-      pool_names.insert(zone.user_uid_pool);
-      pool_names.insert(zone.otp_pool);
-      pool_names.insert(zone.roles_pool);
-      pool_names.insert(zone.reshard_pool);
-      pool_names.insert(zone.notif_pool);
-      for(auto& iter : zone.placement_pools) {
-	pool_names.insert(iter.second.index_pool);
-        for (auto& pi : iter.second.storage_classes.get_all()) {
-          if (pi.second.data_pool) {
-            pool_names.insert(pi.second.data_pool.get());
-          }
-        }
-	pool_names.insert(iter.second.data_extra_pool);
-      }
-      pool_names.insert(zone.oidc_pool);
+      add_zone_pools(zone, pool_names);
     }
   }
   return 0;
 }
 
-rgw_pool fix_zone_pool_dup(set<rgw_pool> pools,
+rgw_pool fix_zone_pool_dup(const set<rgw_pool>& pools,
                            const string& default_prefix,
                            const string& default_suffix,
                            const rgw_pool& suggested_pool)
@@ -1725,18 +1746,13 @@ rgw_pool fix_zone_pool_dup(set<rgw_pool> pools,
 
   rgw_pool pool(prefix + suffix);
   
-  if (pools.find(pool) == pools.end()) {
-    return pool;
-  } else {
-    while(true) {
-      pool =  prefix + "_" + std::to_string(std::rand()) + suffix;
-      if (pools.find(pool) == pools.end()) {
-	return pool;
-      }
-    }
-  }  
+  while (pools.count(pool)) {
+    pool = prefix + "_" + std::to_string(std::rand()) + suffix;
+  }
+  return pool;
 }
-}
+
+} // anonymous namespace
 
 int RGWZoneParams::fix_pool_names(const DoutPrefixProvider *dpp, optional_yield y)
 {
@@ -2059,6 +2075,793 @@ bool RGWPeriodMap::find_zone_by_name(const string& zone_name,
 
   return false;
 }
+
+namespace rgw {
+
+int read_realm(const DoutPrefixProvider* dpp, optional_yield y,
+               sal::ConfigStore* cfgstore,
+               std::string_view realm_id,
+               std::string_view realm_name,
+               RGWRealm& info,
+               std::unique_ptr<sal::RealmWriter>* writer)
+{
+  if (!realm_id.empty()) {
+    return cfgstore->read_realm_by_id(dpp, y, realm_id, info, writer);
+  }
+  if (!realm_name.empty()) {
+    return cfgstore->read_realm_by_name(dpp, y, realm_name, info, writer);
+  }
+  return cfgstore->read_default_realm(dpp, y, info, writer);
+}
+
+int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
+                 sal::ConfigStore* cfgstore, bool exclusive,
+                 RGWRealm& info,
+                 std::unique_ptr<sal::RealmWriter>* writer_out)
+{
+  if (info.name.empty()) {
+    ldpp_dout(dpp, -1) << __func__ << " requires a realm name" << dendl;
+    return -EINVAL;
+  }
+  if (info.id.empty()) {
+    info.id = gen_random_uuid();
+  }
+
+  // if the realm already has a current_period, just make sure it exists
+  std::optional<RGWPeriod> period;
+  if (!info.current_period.empty()) {
+    period.emplace();
+    int r = cfgstore->read_period(dpp, y, info.current_period,
+                                  std::nullopt, *period);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << __func__ << " failed to read realm's current_period="
+          << info.current_period << " with " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  // create the realm
+  std::unique_ptr<sal::RealmWriter> writer;
+  int r = cfgstore->create_realm(dpp, y, exclusive, info, &writer);
+  if (r < 0) {
+    return r;
+  }
+
+  if (!period) {
+    // initialize and exclusive-create the initial period
+    period.emplace();
+    period->id = gen_random_uuid();
+    period->period_map.id = period->id;
+    period->epoch = FIRST_EPOCH;
+    period->realm_id = info.id;
+    period->realm_name = info.name;
+
+    r = cfgstore->create_period(dpp, y, true, *period);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << __func__ << " failed to create the initial period id="
+          << period->id << " for realm " << info.name
+          << " with " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  // update the realm's current_period
+  r = realm_set_current_period(dpp, y, cfgstore, *writer, info, *period);
+  if (r < 0) {
+    return r;
+  }
+
+  // try to set as default. may race with another create, so pass exclusive=true
+  // so we don't override an existing default
+  r = set_default_realm(dpp, y, cfgstore, info, true);
+  if (r < 0 && r != -EEXIST) {
+    ldpp_dout(dpp, 0) << "WARNING: failed to set realm as default: "
+        << cpp_strerror(r) << dendl;
+  }
+
+  if (writer_out) {
+    *writer_out = std::move(writer);
+  }
+  return 0;
+}
+
+int set_default_realm(const DoutPrefixProvider* dpp, optional_yield y,
+                      sal::ConfigStore* cfgstore, const RGWRealm& info,
+                      bool exclusive)
+{
+  return cfgstore->write_default_realm_id(dpp, y, exclusive, info.id);
+}
+
+int realm_set_current_period(const DoutPrefixProvider* dpp, optional_yield y,
+                             sal::ConfigStore* cfgstore,
+                             sal::RealmWriter& writer, RGWRealm& realm,
+                             const RGWPeriod& period)
+{
+  // update realm epoch to match the period's
+  if (realm.epoch > period.realm_epoch) {
+    ldpp_dout(dpp, -1) << __func__ << " with old realm epoch "
+        << period.realm_epoch << ", current epoch=" << realm.epoch << dendl;
+    return -EINVAL;
+  }
+  if (realm.epoch == period.realm_epoch && realm.current_period != period.id) {
+    ldpp_dout(dpp, -1) << __func__ << " with same realm epoch "
+        << period.realm_epoch << ", but different period id "
+        << period.id << " != " << realm.current_period << dendl;
+    return -EINVAL;
+  }
+
+  realm.epoch = period.realm_epoch;
+  realm.current_period = period.id;
+
+  // update the realm object
+  int r = writer.write(dpp, y, realm);
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << __func__ << " failed to overwrite realm "
+        << realm.name << " with " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // reflect the zonegroup and period config
+  (void) reflect_period(dpp, y, cfgstore, period);
+  return 0;
+}
+
+int reflect_period(const DoutPrefixProvider* dpp, optional_yield y,
+                   sal::ConfigStore* cfgstore, const RGWPeriod& info)
+{
+  // overwrite the local period config and zonegroup objects
+  constexpr bool exclusive = false;
+
+  int r = cfgstore->write_period_config(dpp, y, exclusive, info.realm_id,
+                                        info.period_config);
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << __func__ << " failed to store period config for realm id="
+        << info.realm_id << " with " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (auto& [zonegroup_id, zonegroup] : info.period_map.zonegroups) {
+    r = cfgstore->create_zonegroup(dpp, y, exclusive, zonegroup, nullptr);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << __func__ << " failed to store zonegroup id="
+          << zonegroup_id << " with " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    if (zonegroup.is_master) {
+      // set master as default if no default exists
+      constexpr bool exclusive = true;
+      r = set_default_zonegroup(dpp, y, cfgstore, zonegroup, exclusive);
+      if (r == 0) {
+        ldpp_dout(dpp, 1) << "Set the period's master zonegroup "
+            << zonegroup.name << " as the default" << dendl;
+      }
+    }
+  }
+  return 0;
+}
+
+std::string get_staging_period_id(std::string_view realm_id)
+{
+  return string_cat_reserve(realm_id, ":staging");
+}
+
+void fork_period(const DoutPrefixProvider* dpp, RGWPeriod& info)
+{
+  ldpp_dout(dpp, 20) << __func__ << " realm id=" << info.realm_id
+      << " period id=" << info.id << dendl;
+
+  info.predecessor_uuid = std::move(info.id);
+  info.id = get_staging_period_id(info.realm_id);
+  info.period_map.reset();
+  info.realm_epoch++;
+}
+
+int update_period(const DoutPrefixProvider* dpp, optional_yield y,
+                  sal::ConfigStore* cfgstore, RGWPeriod& info)
+{
+  // clear zone short ids of removed zones. period_map.update() will add the
+  // remaining zones back
+  info.period_map.short_zone_ids.clear();
+
+  // list all zonegroups in the realm
+  rgw::sal::ListResult<std::string> listing;
+  std::array<std::string, 1000> zonegroup_names; // list in pages of 1000
+  do {
+    int ret = cfgstore->list_zonegroup_names(dpp, y, listing.next,
+                                             zonegroup_names, listing);
+    if (ret < 0) {
+      std::cerr << "failed to list zonegroups: " << cpp_strerror(-ret) << std::endl;
+      return -ret;
+    }
+    for (const auto& name : listing.entries) {
+      RGWZoneGroup zg;
+      ret = cfgstore->read_zonegroup_by_name(dpp, y, name, zg, nullptr);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "WARNING: failed to read zonegroup "
+            << name << ": " << cpp_strerror(-ret) << dendl;
+        continue;
+      }
+
+      if (zg.realm_id != info.realm_id) {
+        ldpp_dout(dpp, 20) << "skipping zonegroup " << zg.get_name()
+            << " with realm id " << zg.realm_id
+            << ", not on our realm " << info.realm_id << dendl;
+        continue;
+      }
+
+      if (zg.master_zone.empty()) {
+        ldpp_dout(dpp, 0) << "ERROR: zonegroup " << zg.get_name() << " should have a master zone " << dendl;
+        return -EINVAL;
+      }
+
+      if (zg.zones.find(zg.master_zone) == zg.zones.end()) {
+        ldpp_dout(dpp, 0) << "ERROR: zonegroup " << zg.get_name()
+                     << " has a non existent master zone "<< dendl;
+        return -EINVAL;
+      }
+
+      if (zg.is_master_zonegroup()) {
+        info.master_zonegroup = zg.get_id();
+        info.master_zone = zg.master_zone;
+      }
+
+      ret = info.period_map.update(zg, dpp->get_cct());
+      if (ret < 0) {
+        return ret;
+      }
+    } // foreach name in listing.entries
+  } while (!listing.next.empty());
+
+  // read the realm's current period config
+  int ret = cfgstore->read_period_config(dpp, y, info.realm_id,
+                                         info.period_config);
+  if (ret < 0 && ret != -ENOENT) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to read period config: "
+        << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
+                  sal::ConfigStore* cfgstore, sal::Store* store,
+                  RGWRealm& realm, sal::RealmWriter& realm_writer,
+                  const RGWPeriod& current_period,
+                  RGWPeriod& info, std::ostream& error_stream,
+                  bool force_if_stale)
+{
+  auto zone_svc = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone; // XXX
+
+  ldpp_dout(dpp, 20) << __func__ << " realm " << realm.id
+      << " period " << current_period.id << dendl;
+  // gateway must be in the master zone to commit
+  if (info.master_zone != zone_svc->get_zone_params().id) {
+    error_stream << "Cannot commit period on zone "
+        << zone_svc->get_zone_params().id << ", it must be sent to "
+        "the period's master zone " << info.master_zone << '.' << std::endl;
+    return -EINVAL;
+  }
+  // period predecessor must match current period
+  if (info.predecessor_uuid != current_period.id) {
+    error_stream << "Period predecessor " << info.predecessor_uuid
+        << " does not match current period " << current_period.id
+        << ". Use 'period pull' to get the latest period from the master, "
+        "reapply your changes, and try again." << std::endl;
+    return -EINVAL;
+  }
+  // realm epoch must be 1 greater than current period
+  if (info.realm_epoch != current_period.realm_epoch + 1) {
+    error_stream << "Period's realm epoch " << info.realm_epoch
+        << " does not come directly after current realm epoch "
+        << current_period.realm_epoch << ". Use 'realm pull' to get the "
+        "latest realm and period from the master zone, reapply your changes, "
+        "and try again." << std::endl;
+    return -EINVAL;
+  }
+  // did the master zone change?
+  if (info.master_zone != current_period.master_zone) {
+    // store the current metadata sync status in the period
+    int r = info.update_sync_status(dpp, store, current_period,
+                                    error_stream, force_if_stale);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to update metadata sync status: "
+          << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    // create an object with a new period id
+    info.period_map.id = info.id = gen_random_uuid();
+    info.epoch = FIRST_EPOCH;
+
+    constexpr bool exclusive = true;
+    r = cfgstore->create_period(dpp, y, exclusive, info);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to create new period: " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    // set as current period
+    r = realm_set_current_period(dpp, y, cfgstore, realm_writer, realm, info);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to update realm's current period: "
+          << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    ldpp_dout(dpp, 4) << "Promoted to master zone and committed new period "
+        << info.id << dendl;
+    (void) cfgstore->realm_notify_new_period(dpp, y, info);
+    return 0;
+  }
+  // period must be based on current epoch
+  if (info.epoch != current_period.epoch) {
+    error_stream << "Period epoch " << info.epoch << " does not match "
+        "predecessor epoch " << current_period.epoch << ". Use "
+        "'period pull' to get the latest epoch from the master zone, "
+        "reapply your changes, and try again." << std::endl;
+    return -EINVAL;
+  }
+  // set period as next epoch
+  info.id = current_period.id;
+  info.epoch = current_period.epoch + 1;
+  info.predecessor_uuid = current_period.predecessor_uuid;
+  info.realm_epoch = current_period.realm_epoch;
+  // write the period
+  constexpr bool exclusive = true;
+  int r = cfgstore->create_period(dpp, y, exclusive, info);
+  if (r == -EEXIST) {
+    // already have this epoch (or a more recent one)
+    return 0;
+  }
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to store period: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  r = reflect_period(dpp, y, cfgstore, info);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to update local objects: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ldpp_dout(dpp, 4) << "Committed new epoch " << info.epoch
+      << " for period " << info.id << dendl;
+  (void) cfgstore->realm_notify_new_period(dpp, y, info);
+  return 0;
+}
+
+
+int read_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                   sal::ConfigStore* cfgstore,
+                   std::string_view zonegroup_id,
+                   std::string_view zonegroup_name,
+                   RGWZoneGroup& info,
+                   std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  if (!zonegroup_id.empty()) {
+    return cfgstore->read_zonegroup_by_id(dpp, y, zonegroup_id, info, writer);
+  }
+  if (!zonegroup_name.empty()) {
+    return cfgstore->read_zonegroup_by_name(dpp, y, zonegroup_name, info, writer);
+  }
+
+  std::string realm_id;
+  int r = cfgstore->read_default_realm_id(dpp, y, realm_id);
+  if (r == -ENOENT) {
+    return cfgstore->read_zonegroup_by_name(dpp, y, default_zonegroup_name,
+                                            info, writer);
+  }
+  if (r < 0) {
+    return r;
+  }
+  return cfgstore->read_default_zonegroup(dpp, y, realm_id, info, writer);
+}
+
+int create_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                     sal::ConfigStore* cfgstore, bool exclusive,
+                     RGWZoneGroup& info)
+{
+  if (info.name.empty()) {
+    ldpp_dout(dpp, -1) << __func__ << " requires a zonegroup name" << dendl;
+    return -EINVAL;
+  }
+  if (info.id.empty()) {
+    info.id = gen_random_uuid();
+  }
+
+  // insert the default placement target if it doesn't exist
+  constexpr std::string_view default_placement_name = "default-placement";
+
+  RGWZoneGroupPlacementTarget placement_target;
+  placement_target.name = default_placement_name;
+
+  info.placement_targets.emplace(default_placement_name, placement_target);
+  if (info.default_placement.name.empty()) {
+    info.default_placement.name = default_placement_name;
+  }
+
+  int r = cfgstore->create_zonegroup(dpp, y, exclusive, info, nullptr);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to create zonegroup with "
+        << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // try to set as default. may race with another create, so pass exclusive=true
+  // so we don't override an existing default
+  r = set_default_zonegroup(dpp, y, cfgstore, info, true);
+  if (r < 0 && r != -EEXIST) {
+    ldpp_dout(dpp, 0) << "WARNING: failed to set zonegroup as default: "
+        << cpp_strerror(r) << dendl;
+  }
+
+  return 0;
+}
+
+int set_default_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                          sal::ConfigStore* cfgstore, const RGWZoneGroup& info,
+                          bool exclusive)
+{
+  return cfgstore->write_default_zonegroup_id(
+      dpp, y, exclusive, info.realm_id, info.id);
+}
+
+int add_zone_to_group(const DoutPrefixProvider* dpp, RGWZoneGroup& zonegroup,
+                      const RGWZoneParams& zone_params,
+                      const bool *pis_master, const bool *pread_only,
+                      const std::list<std::string>& endpoints,
+                      const std::string *ptier_type,
+                      const bool *psync_from_all,
+                      const std::list<std::string>& sync_from,
+                      const std::list<std::string>& sync_from_rm,
+                      const std::string *predirect_zone,
+                      std::optional<int> bucket_index_max_shards,
+                      const rgw::zone_features::set& enable_features,
+                      const rgw::zone_features::set& disable_features)
+{
+  const std::string& zone_id = zone_params.id;
+  const std::string& zone_name = zone_params.name;
+
+  if (zone_id.empty()) {
+    ldpp_dout(dpp, -1) << __func__ << " requires a zone id" << dendl;
+    return -EINVAL;
+  }
+  if (zone_name.empty()) {
+    ldpp_dout(dpp, -1) << __func__ << " requires a zone name" << dendl;
+    return -EINVAL;
+  }
+
+  // check for duplicate zone name on insert
+  if (!zonegroup.zones.count(zone_id)) {
+    for (const auto& [id, zone] : zonegroup.zones) {
+      if (zone.name == zone_name) {
+        ldpp_dout(dpp, 0) << "ERROR: found existing zone name " << zone_name
+            << " (" << id << ") in zonegroup " << zonegroup.name << dendl;
+        return -EEXIST;
+      }
+    }
+  }
+
+  if (pis_master) {
+    rgw_zone_id& master_zone = zonegroup.master_zone;
+    if (*pis_master) {
+      if (!master_zone.empty() && master_zone != zone_id) {
+        ldpp_dout(dpp, 0) << "NOTICE: overriding master zone: "
+            << master_zone << dendl;
+      }
+      master_zone = zone_id;
+    } else if (master_zone == zone_id) {
+      master_zone.clear();
+    }
+  }
+
+  // make sure the zone's placement targets are named in the zonegroup
+  for (const auto& [name, placement] : zone_params.placement_pools) {
+    auto target = RGWZoneGroupPlacementTarget{.name = name};
+    zonegroup.placement_targets.emplace(name, std::move(target));
+  }
+
+  RGWZone& zone = zonegroup.zones[zone_params.id];
+  zone.id = zone_params.id;
+  zone.name = zone_params.name;
+  if (!endpoints.empty()) {
+    zone.endpoints = endpoints;
+  }
+  if (pread_only) {
+    zone.read_only = *pread_only;
+  }
+  if (ptier_type) {
+    zone.tier_type = *ptier_type;
+  }
+  if (psync_from_all) {
+    zone.sync_from_all = *psync_from_all;
+  }
+  if (predirect_zone) {
+    zone.redirect_zone = *predirect_zone;
+  }
+  if (bucket_index_max_shards) {
+    zone.bucket_index_max_shards = *bucket_index_max_shards;
+  }
+
+  // add/remove sync_from
+  for (auto add : sync_from) {
+    zone.sync_from.insert(add);
+  }
+
+  for (const auto& rm : sync_from_rm) {
+    auto i = zone.sync_from.find(rm);
+    if (i == zone.sync_from.end()) {
+      ldpp_dout(dpp, 1) << "WARNING: zone \"" << rm
+          << "\" was not in sync_from" << dendl;
+      continue;
+    }
+    zone.sync_from.erase(i);
+  }
+
+  // add/remove supported features
+  zone.supported_features.insert(enable_features.begin(),
+                                 enable_features.end());
+
+  for (const auto& feature : disable_features) {
+    if (zonegroup.enabled_features.contains(feature)) {
+      ldpp_dout(dpp, -1) << "ERROR: Cannot disable zone feature \"" << feature
+          << "\" until it's been disabled in zonegroup " << zonegroup.name << dendl;
+      return -EINVAL;
+    }
+    auto i = zone.supported_features.find(feature);
+    if (i == zone.supported_features.end()) {
+      ldpp_dout(dpp, 1) << "WARNING: zone feature \"" << feature
+          << "\" was not enabled in zone " << zone.name << dendl;
+      continue;
+    }
+    zone.supported_features.erase(i);
+  }
+
+  const bool log_data = zonegroup.zones.size() > 1;
+  for (auto& [id, zone] : zonegroup.zones) {
+    zone.log_data = log_data;
+  }
+
+  return 0;
+}
+
+int remove_zone_from_group(const DoutPrefixProvider* dpp,
+                           RGWZoneGroup& zonegroup,
+                           const rgw_zone_id& zone_id)
+{
+  auto z = zonegroup.zones.find(zone_id);
+  if (z == zonegroup.zones.end()) {
+    return -ENOENT;
+  }
+  zonegroup.zones.erase(z);
+
+  if (zonegroup.master_zone == zone_id) {
+    // choose a new master zone
+    auto m = zonegroup.zones.begin();
+    if (m != zonegroup.zones.end()) {
+      zonegroup.master_zone = m->first;
+      ldpp_dout(dpp, 0) << "NOTICE: promoted " << m->second.name
+         << " as new master_zone of zonegroup " << zonegroup.name << dendl;
+    } else {
+      zonegroup.master_zone.clear();
+      ldpp_dout(dpp, 0) << "NOTICE: cleared master_zone of zonegroup "
+          << zonegroup.name << dendl;
+    }
+  }
+
+  const bool log_data = zonegroup.zones.size() > 1;
+  for (auto& [id, zone] : zonegroup.zones) {
+    zone.log_data = log_data;
+  }
+
+  return 0;
+}
+
+// try to remove the given zone id from every zonegroup in the cluster
+static int remove_zone_from_groups(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   sal::ConfigStore* cfgstore,
+                                   const rgw_zone_id& zone_id)
+{
+  std::array<std::string, 128> zonegroup_names;
+  sal::ListResult<std::string> listing;
+  do {
+    int r = cfgstore->list_zonegroup_names(dpp, y, listing.next,
+                                           zonegroup_names, listing);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to list zonegroups with "
+          << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    for (const auto& name : listing.entries) {
+      RGWZoneGroup zonegroup;
+      std::unique_ptr<sal::ZoneGroupWriter> writer;
+      r = cfgstore->read_zonegroup_by_name(dpp, y, name, zonegroup, &writer);
+      if (r < 0) {
+        ldpp_dout(dpp, 0) << "WARNING: failed to load zonegroup " << name
+            << " with " << cpp_strerror(r) << dendl;
+        continue;
+      }
+
+      r = remove_zone_from_group(dpp, zonegroup, zone_id);
+      if (r < 0) {
+        continue;
+      }
+
+      // write the updated zonegroup
+      r = writer->write(dpp, y, zonegroup);
+      if (r < 0) {
+        ldpp_dout(dpp, 0) << "WARNING: failed to write zonegroup " << name
+            << " with " << cpp_strerror(r) << dendl;
+        continue;
+      }
+      ldpp_dout(dpp, 0) << "Removed zone from zonegroup " << name << dendl;
+    }
+  } while (!listing.next.empty());
+
+  return 0;
+}
+
+
+int read_zone(const DoutPrefixProvider* dpp, optional_yield y,
+              sal::ConfigStore* cfgstore,
+              std::string_view zone_id,
+              std::string_view zone_name,
+              RGWZoneParams& info,
+              std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  if (!zone_id.empty()) {
+    return cfgstore->read_zone_by_id(dpp, y, zone_id, info, writer);
+  }
+  if (!zone_name.empty()) {
+    return cfgstore->read_zone_by_name(dpp, y, zone_name, info, writer);
+  }
+
+  std::string realm_id;
+  int r = cfgstore->read_default_realm_id(dpp, y, realm_id);
+  if (r == -ENOENT) {
+    return cfgstore->read_zone_by_name(dpp, y, default_zone_name, info, writer);
+  }
+  if (r < 0) {
+    return r;
+  }
+  return cfgstore->read_default_zone(dpp, y, realm_id, info, writer);
+}
+
+static int get_zones_pool_set(const DoutPrefixProvider *dpp, optional_yield y,
+                              rgw::sal::ConfigStore* cfgstore,
+                              std::string_view my_zone_id,
+                              std::set<rgw_pool>& pools)
+{
+  std::array<std::string, 128> zone_names;
+  sal::ListResult<std::string> listing;
+  do {
+    int r = cfgstore->list_zone_names(dpp, y, listing.next,
+                                      zone_names, listing);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to list zones with " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    for (const auto& name : listing.entries) {
+      RGWZoneParams info;
+      r = cfgstore->read_zone_by_name(dpp, y, name, info, nullptr);
+      if (r < 0) {
+        ldpp_dout(dpp, 0) << "failed to load zone " << name
+            << " with " << cpp_strerror(r) << dendl;
+        return r;
+      }
+      if (info.get_id() != my_zone_id) {
+        add_zone_pools(info, pools);
+      }
+    }
+  } while (!listing.next.empty());
+
+  return 0;
+}
+
+int init_zone_pool_names(const DoutPrefixProvider *dpp, optional_yield y,
+                         const std::set<rgw_pool>& pools, RGWZoneParams& info)
+{
+  info.domain_root = fix_zone_pool_dup(pools, info.name, ".rgw.meta:root", info.domain_root);
+  info.control_pool = fix_zone_pool_dup(pools, info.name, ".rgw.control", info.control_pool);
+  info.gc_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:gc", info.gc_pool);
+  info.lc_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:lc", info.lc_pool);
+  info.log_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log", info.log_pool);
+  info.intent_log_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:intent", info.intent_log_pool);
+  info.usage_log_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:usage", info.usage_log_pool);
+  info.user_keys_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:users.keys", info.user_keys_pool);
+  info.user_email_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:users.email", info.user_email_pool);
+  info.user_swift_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:users.swift", info.user_swift_pool);
+  info.user_uid_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:users.uid", info.user_uid_pool);
+  info.roles_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:roles", info.roles_pool);
+  info.reshard_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:reshard", info.reshard_pool);
+  info.otp_pool = fix_zone_pool_dup(pools, info.name, ".rgw.otp", info.otp_pool);
+  info.oidc_pool = fix_zone_pool_dup(pools, info.name, ".rgw.meta:oidc", info.oidc_pool);
+  info.notif_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:notif", info.notif_pool);
+
+  for (auto& [pname, placement] : info.placement_pools) {
+    placement.index_pool = fix_zone_pool_dup(pools, info.name, "." + default_bucket_index_pool_suffix, placement.index_pool);
+    placement.data_extra_pool= fix_zone_pool_dup(pools, info.name, "." + default_storage_extra_pool_suffix, placement.data_extra_pool);
+    for (auto& [sname, sc] : placement.storage_classes.get_all()) {
+      if (sc.data_pool) {
+        sc.data_pool = fix_zone_pool_dup(pools, info.name, "." + default_storage_pool_suffix, *sc.data_pool);
+      }
+    }
+  }
+
+  return 0;
+}
+
+int create_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                sal::ConfigStore* cfgstore, bool exclusive,
+                RGWZoneParams& info, std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  if (info.name.empty()) {
+    ldpp_dout(dpp, -1) << __func__ << " requires a zone name" << dendl;
+    return -EINVAL;
+  }
+  if (info.id.empty()) {
+    info.id = gen_random_uuid();
+  }
+
+  // add default placement with empty pool name
+  rgw_pool pool;
+  auto& placement = info.placement_pools["default-placement"];
+  placement.storage_classes.set_storage_class(
+      RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
+
+  // build a set of all pool names used by other zones
+  std::set<rgw_pool> pools;
+  int r = get_zones_pool_set(dpp, y, cfgstore, info.id, pools);
+  if (r < 0) {
+    return r;
+  }
+
+  // initialize pool names with the zone name prefix
+  r = init_zone_pool_names(dpp, y, pools, info);
+  if (r < 0) {
+    return r;
+  }
+
+  r = cfgstore->create_zone(dpp, y, exclusive, info, nullptr);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to create zone with "
+        << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // try to set as default. may race with another create, so pass exclusive=true
+  // so we don't override an existing default
+  r = set_default_zone(dpp, y, cfgstore, info, true);
+  if (r < 0 && r != -EEXIST) {
+    ldpp_dout(dpp, 0) << "WARNING: failed to set zone as default: "
+        << cpp_strerror(r) << dendl;
+  }
+
+  return 0;
+
+}
+
+int set_default_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                     sal::ConfigStore* cfgstore, const RGWZoneParams& info,
+                     bool exclusive)
+{
+  return cfgstore->write_default_zone_id(
+      dpp, y, exclusive, info.realm_id, info.id);
+}
+
+int delete_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                sal::ConfigStore* cfgstore, const RGWZoneParams& info,
+                sal::ZoneWriter& writer)
+{
+  // remove this zone from any zonegroups that contain it
+  int r = remove_zone_from_groups(dpp, y, cfgstore, info.id);
+  if (r < 0) {
+    return r;
+  }
+
+  return writer.remove(dpp, y);
+}
+
+} // namespace rgw
 
 static inline int conf_to_uint64(const JSONFormattable& config, const string& key, uint64_t *pval)
 {

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -79,7 +79,7 @@ class RGWSI_SysObj;
 class RGWSI_Zone;
 
 class RGWSystemMetaObj {
-protected:
+public:
   std::string id;
   std::string name;
 
@@ -1095,6 +1095,7 @@ class RGWPeriod;
 
 class RGWRealm : public RGWSystemMetaObj
 {
+public:
   std::string current_period;
   epoch_t epoch{0}; //< realm epoch, incremented for each new period
 
@@ -1207,6 +1208,7 @@ WRITE_CLASS_ENCODER(RGWPeriodLatestEpochInfo)
  */
 class RGWPeriod
 {
+public:
   std::string id; //< a uuid
   epoch_t epoch{0};
   std::string predecessor_uuid;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -4,7 +4,9 @@
 #ifndef CEPH_RGW_ZONE_H
 #define CEPH_RGW_ZONE_H
 
+#include <ostream>
 #include "rgw_common.h"
+#include "rgw_sal_fwd.h"
 #include "rgw_sync_policy.h"
 #include "rgw_zone_features.h"
 
@@ -371,7 +373,6 @@ struct RGWZoneParams : RGWSystemMetaObj {
   rgw_pool log_pool;
   rgw_pool intent_log_pool;
   rgw_pool usage_log_pool;
-
   rgw_pool user_keys_pool;
   rgw_pool user_email_pool;
   rgw_pool user_swift_pool;
@@ -380,6 +381,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   rgw_pool reshard_pool;
   rgw_pool otp_pool;
   rgw_pool oidc_pool;
+  rgw_pool notif_pool;
 
   RGWAccessKey system_key;
 
@@ -388,8 +390,6 @@ struct RGWZoneParams : RGWSystemMetaObj {
   std::string realm_id;
 
   JSONFormattable tier_config;
-
-  rgw_pool notif_pool;
 
   RGWZoneParams() : RGWSystemMetaObj() {}
   explicit RGWZoneParams(const std::string& name) : RGWSystemMetaObj(name){}
@@ -568,6 +568,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   }
 };
 WRITE_CLASS_ENCODER(RGWZoneParams)
+
 
 struct RGWZone {
   std::string id;
@@ -1385,5 +1386,138 @@ public:
   }
 };
 WRITE_CLASS_ENCODER(RGWPeriod)
+
+namespace rgw {
+
+/// Look up a realm by its id. If no id is given, look it up by name.
+/// If no name is given, fall back to the cluster's default realm.
+int read_realm(const DoutPrefixProvider* dpp, optional_yield y,
+               sal::ConfigStore* cfgstore,
+               std::string_view realm_id,
+               std::string_view realm_name,
+               RGWRealm& info,
+               std::unique_ptr<sal::RealmWriter>* writer = nullptr);
+
+/// Create a realm and its initial period. If the info.id is empty, a
+/// random uuid will be generated.
+int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
+                 sal::ConfigStore* cfgstore, bool exclusive,
+                 RGWRealm& info,
+                 std::unique_ptr<sal::RealmWriter>* writer = nullptr);
+
+/// Set the given realm as the cluster's default realm.
+int set_default_realm(const DoutPrefixProvider* dpp, optional_yield y,
+                      sal::ConfigStore* cfgstore, const RGWRealm& info,
+                      bool exclusive = false);
+
+/// Update the current_period of an existing realm.
+int realm_set_current_period(const DoutPrefixProvider* dpp, optional_yield y,
+                             sal::ConfigStore* cfgstore,
+                             sal::RealmWriter& writer, RGWRealm& realm,
+                             const RGWPeriod& period);
+
+/// Overwrite the local zonegroup and period config objects with the new
+/// configuration contained in the given period.
+int reflect_period(const DoutPrefixProvider* dpp, optional_yield y,
+                   sal::ConfigStore* cfgstore, const RGWPeriod& info);
+
+/// Return the staging period id for the given realm.
+std::string get_staging_period_id(std::string_view realm_id);
+
+/// Convert the given period into a separate staging period, where
+/// radosgw-admin can make changes to it without effecting the running
+/// configuration.
+void fork_period(const DoutPrefixProvider* dpp, RGWPeriod& info);
+
+/// Read all zonegroups in the period's realm and add them to the period.
+int update_period(const DoutPrefixProvider* dpp, optional_yield y,
+                  sal::ConfigStore* cfgstore, RGWPeriod& info);
+
+/// Validates the given 'staging' period and tries to commit it as the
+/// realm's new current period.
+int commit_period(const DoutPrefixProvider* dpp, optional_yield y,
+                  sal::ConfigStore* cfgstore, sal::Store* store,
+                  RGWRealm& realm, sal::RealmWriter& realm_writer,
+                  const RGWPeriod& current_period,
+                  RGWPeriod& info, std::ostream& error_stream,
+                  bool force_if_stale);
+
+
+/// Look up a zonegroup by its id. If no id is given, look it up by name.
+/// If no name is given, fall back to the cluster's default zonegroup.
+int read_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                   sal::ConfigStore* cfgstore,
+                   std::string_view zonegroup_id,
+                   std::string_view zonegroup_name,
+                   RGWZoneGroup& info,
+                   std::unique_ptr<sal::ZoneGroupWriter>* writer = nullptr);
+
+/// Initialize and create the given zonegroup. If the given info.id is empty,
+/// a random uuid will be generated. May fail with -EEXIST.
+int create_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                     sal::ConfigStore* cfgstore, bool exclusive,
+                     RGWZoneGroup& info);
+
+/// Set the given zonegroup as its realm's default zonegroup.
+int set_default_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
+                          sal::ConfigStore* cfgstore, const RGWZoneGroup& info,
+                          bool exclusive = false);
+
+/// Add a zone to the zonegroup, or update an existing zone entry.
+int add_zone_to_group(const DoutPrefixProvider* dpp,
+                      RGWZoneGroup& zonegroup,
+                      const RGWZoneParams& zone_params,
+                      const bool *pis_master, const bool *pread_only,
+                      const std::list<std::string>& endpoints,
+                      const std::string *ptier_type,
+                      const bool *psync_from_all,
+                      const std::list<std::string>& sync_from,
+                      const std::list<std::string>& sync_from_rm,
+                      const std::string *predirect_zone,
+                      std::optional<int> bucket_index_max_shards,
+                      const rgw::zone_features::set& enable_features,
+                      const rgw::zone_features::set& disable_features);
+
+/// Remove a zone by id from its zonegroup, promoting a new master zone if
+/// necessary.
+int remove_zone_from_group(const DoutPrefixProvider* dpp,
+                           RGWZoneGroup& info,
+                           const rgw_zone_id& zone_id);
+
+
+/// Look up a zone by its id. If no id is given, look it up by name. If no name
+/// is given, fall back to the realm's default zone.
+int read_zone(const DoutPrefixProvider* dpp, optional_yield y,
+              sal::ConfigStore* cfgstore,
+              std::string_view zone_id,
+              std::string_view zone_name,
+              RGWZoneParams& info,
+              std::unique_ptr<sal::ZoneWriter>* writer = nullptr);
+
+/// Initialize and create a new zone. If the given info.id is empty, a random
+/// uuid will be generated. Pool names are initialized with the zone name as a
+/// prefix. If any pool names conflict with existing zones, a random suffix is
+/// added.
+int create_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                sal::ConfigStore* cfgstore, bool exclusive,
+                RGWZoneParams& info,
+                std::unique_ptr<sal::ZoneWriter>* writer = nullptr);
+
+/// Initialize the zone's pool names using the zone name as a prefix. If a pool
+/// name conflicts with an existing zone's pool, add a unique suffix.
+int init_zone_pool_names(const DoutPrefixProvider *dpp, optional_yield y,
+                         const std::set<rgw_pool>& pools, RGWZoneParams& info);
+
+/// Set the given zone as its realm's default zone.
+int set_default_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                      sal::ConfigStore* cfgstore, const RGWZoneParams& info,
+                      bool exclusive = false);
+
+/// Delete an existing zone and remove it from any zonegroups that contain it.
+int delete_zone(const DoutPrefixProvider* dpp, optional_yield y,
+                sal::ConfigStore* cfgstore, const RGWZoneParams& info,
+                sal::ZoneWriter& writer);
+
+} // namespace rgw
 
 #endif

--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -9,7 +9,15 @@ set (CMAKE_INCLUDE_DIR ${CMAKE_INCLUDE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/common"
 set(dbstore_srcs
     common/dbstore_log.h
     common/dbstore.h
-    common/dbstore.cc)
+    common/dbstore.cc
+    config/store.cc)
+IF(USE_SQLITE)
+  list(APPEND dbstore_srcs
+      config/sqlite.cc
+      sqlite/connection.cc
+      sqlite/error.cc
+      sqlite/statement.cc)
+endif()
 
 set(dbstore_mgr_srcs
     dbstore_mgr.h
@@ -19,6 +27,7 @@ set(dbstore_mgr_srcs
 add_library(dbstore_lib ${dbstore_srcs})
 target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
 target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
+target_include_directories(dbstore_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 set(link_targets spawn)
 if(WITH_JAEGER)
   list(APPEND link_targets jaeger_base)

--- a/src/rgw/store/dbstore/common/connection_pool.h
+++ b/src/rgw/store/dbstore/common/connection_pool.h
@@ -1,0 +1,147 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <concepts>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <boost/circular_buffer.hpp>
+#include "common/dout.h"
+
+namespace rgw::dbstore {
+
+template <typename Connection>
+class ConnectionHandle;
+
+/// A thread-safe base class that manages a fixed-size pool of generic database
+/// connections and supports the reclamation of ConnectionHandles. This class
+/// is the subset of ConnectionPool which doesn't depend on the Factory type.
+template <typename Connection>
+class ConnectionPoolBase {
+ public:
+  ConnectionPoolBase(std::size_t max_connections)
+      : connections(max_connections)
+  {}
+ private:
+  friend class ConnectionHandle<Connection>;
+
+  // TODO: the caller may detect a connection error that prevents the connection
+  // from being reused. allow them to indicate these errors here
+  void put(std::unique_ptr<Connection> connection)
+  {
+    auto lock = std::scoped_lock{mutex};
+    connections.push_back(std::move(connection));
+
+    if (connections.size() == 1) { // was empty
+      cond.notify_one();
+    }
+  }
+ protected:
+  std::mutex mutex;
+  std::condition_variable cond;
+  boost::circular_buffer<std::unique_ptr<Connection>> connections;
+};
+
+/// Handle to a database connection borrowed from the pool. Automatically
+/// returns the connection to its pool on the handle's destruction.
+template <typename Connection>
+class ConnectionHandle {
+  ConnectionPoolBase<Connection>* pool = nullptr;
+  std::unique_ptr<Connection> conn;
+ public:
+  ConnectionHandle() noexcept = default;
+  ConnectionHandle(ConnectionPoolBase<Connection>* pool,
+                   std::unique_ptr<Connection> conn) noexcept
+    : pool(pool), conn(std::move(conn)) {}
+
+  ~ConnectionHandle() {
+    if (conn) {
+      pool->put(std::move(conn));
+    }
+  }
+
+  ConnectionHandle(ConnectionHandle&&) = default;
+  ConnectionHandle& operator=(ConnectionHandle&& o) noexcept {
+    if (conn) {
+      pool->put(std::move(conn));
+    }
+    conn = std::move(o.conn);
+    pool = o.pool;
+    return *this;
+  }
+
+  explicit operator bool() const noexcept { return static_cast<bool>(conn); }
+  Connection& operator*() const noexcept { return *conn; }
+  Connection* operator->() const noexcept { return conn.get(); }
+  Connection* get() const noexcept { return conn.get(); }
+};
+
+
+// factory_of concept requires the function signature:
+//   F(const DoutPrefixProvider*) -> std::unique_ptr<T>
+template <typename F, typename T>
+concept factory_of = requires (F factory, const DoutPrefixProvider* dpp) {
+  { factory(dpp) } -> std::same_as<std::unique_ptr<T>>;
+  requires std::move_constructible<F>;
+};
+
+
+/// Generic database connection pool that enforces a limit on open connections.
+template <typename Connection, factory_of<Connection> Factory>
+class ConnectionPool : public ConnectionPoolBase<Connection> {
+ public:
+  ConnectionPool(Factory factory, std::size_t max_connections)
+      : ConnectionPoolBase<Connection>(max_connections),
+        factory(std::move(factory))
+  {}
+
+  /// Borrow a connection from the pool. If all existing connections are in use,
+  /// use the connection factory to create another one. If we've reached the
+  /// limit on open connections, wait on a condition variable for the next one
+  /// returned to the pool.
+  auto get(const DoutPrefixProvider* dpp)
+      -> ConnectionHandle<Connection>
+  {
+    auto lock = std::unique_lock{this->mutex};
+    std::unique_ptr<Connection> conn;
+
+    if (!this->connections.empty()) {
+      // take an existing connection
+      conn = std::move(this->connections.front());
+      this->connections.pop_front();
+    } else if (total < this->connections.capacity()) {
+      // add another connection to the pool
+      conn = factory(dpp);
+      ++total;
+    } else {
+      // wait for the next put()
+      // TODO: support optional_yield
+      ldpp_dout(dpp, 4) << "ConnectionPool waiting on a connection" << dendl;
+      this->cond.wait(lock, [&] { return !this->connections.empty(); });
+      ldpp_dout(dpp, 4) << "ConnectionPool done waiting" << dendl;
+      conn = std::move(this->connections.front());
+      this->connections.pop_front();
+    }
+
+    return {this, std::move(conn)};
+  }
+ private:
+  Factory factory;
+  std::size_t total = 0;
+};
+
+} // namespace rgw::dbstore

--- a/src/rgw/store/dbstore/config/sqlite.cc
+++ b/src/rgw/store/dbstore/config/sqlite.cc
@@ -1,0 +1,2072 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <charconv>
+#include <initializer_list>
+#include <map>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
+#include <sqlite3.h>
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+#include "common/dout.h"
+#include "common/random_string.h"
+#include "rgw_zone.h"
+
+#include "common/connection_pool.h"
+#include "sqlite/connection.h"
+#include "sqlite/error.h"
+#include "sqlite/statement.h"
+#include "sqlite_schema.h"
+#include "sqlite.h"
+
+#define dout_subsys ceph_subsys_rgw_dbstore
+
+namespace rgw::dbstore::config {
+
+struct Prefix : DoutPrefixPipe {
+  std::string_view prefix;
+  Prefix(const DoutPrefixProvider& dpp, std::string_view prefix)
+      : DoutPrefixPipe(dpp), prefix(prefix) {}
+  unsigned get_subsys() const override { return dout_subsys; }
+  void add_prefix(std::ostream& out) const override {
+    out << prefix;
+  }
+};
+
+namespace {
+
+// parameter names for prepared statement bindings
+static constexpr const char* P1 = ":1";
+static constexpr const char* P2 = ":2";
+static constexpr const char* P3 = ":3";
+static constexpr const char* P4 = ":4";
+static constexpr const char* P5 = ":5";
+static constexpr const char* P6 = ":6";
+
+
+void read_text_rows(const DoutPrefixProvider* dpp,
+                    const sqlite::stmt_execution& stmt,
+                    std::span<std::string> entries,
+                    sal::ListResult<std::string>& result)
+{
+  result.entries = sqlite::read_text_rows(dpp, stmt, entries);
+  if (result.entries.size() < entries.size()) { // end of listing
+    result.next.clear();
+  } else {
+    result.next = result.entries.back();
+  }
+}
+
+struct RealmRow {
+  RGWRealm info;
+  int ver;
+  std::string tag;
+};
+
+void read_realm_row(const sqlite::stmt_execution& stmt, RealmRow& row)
+{
+  row.info.id = sqlite::column_text(stmt, 0);
+  row.info.name = sqlite::column_text(stmt, 1);
+  row.info.current_period = sqlite::column_text(stmt, 2);
+  row.info.epoch = sqlite::column_int(stmt, 3);
+  row.ver = sqlite::column_int(stmt, 4);
+  row.tag = sqlite::column_text(stmt, 5);
+}
+
+void read_period_row(const sqlite::stmt_execution& stmt, RGWPeriod& row)
+{
+  // just read the Data column and decode everything else from that
+  std::string data = sqlite::column_text(stmt, 3);
+
+  bufferlist bl = bufferlist::static_from_string(data);
+  auto p = bl.cbegin();
+  decode(row, p);
+}
+
+struct ZoneGroupRow {
+  RGWZoneGroup info;
+  int ver;
+  std::string tag;
+};
+
+void read_zonegroup_row(const sqlite::stmt_execution& stmt, ZoneGroupRow& row)
+{
+  std::string data = sqlite::column_text(stmt, 3);
+  row.ver = sqlite::column_int(stmt, 4);
+  row.tag = sqlite::column_text(stmt, 5);
+
+  bufferlist bl = bufferlist::static_from_string(data);
+  auto p = bl.cbegin();
+  decode(row.info, p);
+}
+
+struct ZoneRow {
+  RGWZoneParams info;
+  int ver;
+  std::string tag;
+};
+
+void read_zone_row(const sqlite::stmt_execution& stmt, ZoneRow& row)
+{
+  std::string data = sqlite::column_text(stmt, 3);
+  row.ver = sqlite::column_int(stmt, 4);
+  row.tag = sqlite::column_text(stmt, 5);
+
+  bufferlist bl = bufferlist::static_from_string(data);
+  auto p = bl.cbegin();
+  decode(row.info, p);
+}
+
+std::string generate_version_tag(CephContext* cct)
+{
+  static constexpr auto TAG_LEN = 24;
+  return gen_rand_alphanumeric(cct, TAG_LEN);
+}
+
+using SQLiteConnectionHandle = ConnectionHandle<sqlite::Connection>;
+
+using SQLiteConnectionPool = ConnectionPool<
+    sqlite::Connection, sqlite::ConnectionFactory>;
+
+} // anonymous namespace
+
+class SQLiteImpl : public SQLiteConnectionPool {
+ public:
+  using SQLiteConnectionPool::SQLiteConnectionPool;
+};
+
+
+SQLiteConfigStore::SQLiteConfigStore(std::unique_ptr<SQLiteImpl> impl)
+  : impl(std::move(impl))
+{
+}
+
+SQLiteConfigStore::~SQLiteConfigStore() = default;
+
+
+// Realm
+
+class SQLiteRealmWriter : public sal::RealmWriter {
+  SQLiteImpl* impl;
+  int ver;
+  std::string tag;
+  std::string realm_id;
+  std::string realm_name;
+ public:
+  SQLiteRealmWriter(SQLiteImpl* impl, int ver, std::string tag,
+                    std::string_view realm_id, std::string_view realm_name)
+    : impl(impl), ver(ver), tag(std::move(tag)),
+      realm_id(realm_id), realm_name(realm_name)
+  {}
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWRealm& info) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:realm_write "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after a conflict or delete
+    }
+    if (realm_id != info.id || realm_name != info.name) {
+      return -EINVAL; // can't modify realm id or name directly
+    }
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["realm_upd"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::realm_update5,
+                                            P1, P2, P3, P4, P5);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, info.id);
+      sqlite::bind_text(dpp, binding, P2, info.current_period);
+      sqlite::bind_int(dpp, binding, P3, info.epoch);
+      sqlite::bind_int(dpp, binding, P4, ver);
+      sqlite::bind_text(dpp, binding, P5, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        // our version is no longer consistent, so later writes would fail too
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "realm update failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::foreign_key_constraint) {
+        return -EINVAL; // refers to nonexistent CurrentPeriod
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    ++ver;
+    return 0;
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWRealm& info, std::string_view new_name) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:realm_rename "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    if (realm_id != info.id || realm_name != info.name) {
+      return -EINVAL; // can't modify realm id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "realm cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["realm_rename"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::realm_rename4,
+                                            P1, P2, P3, P4);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, realm_id);
+      sqlite::bind_text(dpp, binding, P2, new_name);
+      sqlite::bind_int(dpp, binding, P3, ver);
+      sqlite::bind_text(dpp, binding, P4, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "realm rename failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::unique_constraint) {
+        return -EEXIST; // Name already taken
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    info.name = std::string{new_name};
+    ++ver;
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:realm_remove "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["realm_del"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::realm_delete3, P1, P2, P3);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, realm_id);
+      sqlite::bind_int(dpp, binding, P2, ver);
+      sqlite::bind_text(dpp, binding, P3, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      impl = nullptr; // prevent any further writes after delete
+      if (!::sqlite3_changes(conn->db.get())) {
+        return -ECANCELED; // VersionNumber/Tag mismatch
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "realm delete failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    return 0;
+  }
+}; // SQLiteRealmWriter
+
+
+int SQLiteConfigStore::write_default_realm_id(const DoutPrefixProvider* dpp,
+                                              optional_yield y, bool exclusive,
+                                              std::string_view realm_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:write_default_realm_id "}; dpp = &prefix;
+
+  if (realm_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a realm id" << dendl;
+    return -EINVAL;
+  }
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["def_realm_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_realm_insert1, P1);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["def_realm_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_realm_upsert1, P1);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default realm insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::primary_key_constraint) {
+      return -EEXIST;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_realm_id(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string& realm_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_realm_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_realm_sel"];
+    if (!stmt) {
+      static constexpr std::string_view sql = schema::default_realm_select0;
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    realm_id = sqlite::column_text(reset, 0);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                               optional_yield y)
+
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:delete_default_realm_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_realm_del"];
+    if (!stmt) {
+      static constexpr std::string_view sql = schema::default_realm_delete0;
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval0(dpp, reset);
+
+    if (!::sqlite3_changes(conn->db.get())) {
+      return -ENOENT;
+    }
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default realm delete failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+int SQLiteConfigStore::create_realm(const DoutPrefixProvider* dpp,
+                                    optional_yield y, bool exclusive,
+                                    const RGWRealm& info,
+                                    std::unique_ptr<sal::RealmWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:create_realm "}; dpp = &prefix;
+
+  if (info.id.empty()) {
+    ldpp_dout(dpp, 0) << "realm cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.name.empty()) {
+    ldpp_dout(dpp, 0) << "realm cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  int ver = 1;
+  auto tag = generate_version_tag(dpp->get_cct());
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["realm_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::realm_insert4,
+                                            P1, P2, P3, P4);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["realm_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::realm_upsert4,
+                                            P1, P2, P3, P4);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, info.id);
+    sqlite::bind_text(dpp, binding, P2, info.name);
+    sqlite::bind_int(dpp, binding, P3, ver);
+    sqlite::bind_text(dpp, binding, P4, tag);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::primary_key_constraint) {
+      return -EEXIST; // ID already taken
+    } else if (e.code() == sqlite::errc::unique_constraint) {
+      return -EEXIST; // Name already taken
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<SQLiteRealmWriter>(
+        impl.get(), ver, std::move(tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_realm_by_id(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view realm_id,
+                                        RGWRealm& info,
+                                        std::unique_ptr<sal::RealmWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_realm_by_id "}; dpp = &prefix;
+
+  if (realm_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a realm id" << dendl;
+    return -EINVAL;
+  }
+
+  RealmRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["realm_sel_id"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::realm_select_id1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_realm_row(reset, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "realm decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteRealmWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+static void realm_select_by_name(const DoutPrefixProvider* dpp,
+                                 sqlite::Connection& conn,
+                                 std::string_view realm_name,
+                                 RealmRow& row)
+{
+  auto& stmt = conn.statements["realm_sel_name"];
+  if (!stmt) {
+    const std::string sql = fmt::format(schema::realm_select_name1, P1);
+    stmt = sqlite::prepare_statement(dpp, conn.db.get(), sql);
+  }
+  auto binding = sqlite::stmt_binding{stmt.get()};
+  sqlite::bind_text(dpp, binding, P1, realm_name);
+
+  auto reset = sqlite::stmt_execution{stmt.get()};
+  sqlite::eval1(dpp, reset);
+
+  read_realm_row(reset, row);
+}
+
+int SQLiteConfigStore::read_realm_by_name(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view realm_name,
+                                          RGWRealm& info,
+                                          std::unique_ptr<sal::RealmWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_realm_by_name "}; dpp = &prefix;
+
+  if (realm_name.empty()) {
+    ldpp_dout(dpp, 0) << "requires a realm name" << dendl;
+    return -EINVAL;
+  }
+
+  RealmRow row;
+  try {
+    auto conn = impl->get(dpp);
+    realm_select_by_name(dpp, *conn, realm_name, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "realm decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteRealmWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_realm(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          RGWRealm& info,
+                                          std::unique_ptr<sal::RealmWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_realm "}; dpp = &prefix;
+
+  RealmRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["realm_sel_def"];
+    if (!stmt) {
+      static constexpr std::string_view sql = schema::realm_select_default0;
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_realm_row(reset, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "realm decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteRealmWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_realm_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_name,
+                                     std::string& realm_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_realm_id "}; dpp = &prefix;
+
+  if (realm_name.empty()) {
+    ldpp_dout(dpp, 0) << "requires a realm name" << dendl;
+    return -EINVAL;
+  }
+
+  try {
+    auto conn = impl->get(dpp);
+
+    RealmRow row;
+    realm_select_by_name(dpp, *conn, realm_name, row);
+
+    realm_id = std::move(row.info.id);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "realm decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  return 0;
+}
+
+int SQLiteConfigStore::realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                               optional_yield y,
+                                               const RGWPeriod& period)
+{
+  return -ENOTSUP;
+}
+
+int SQLiteConfigStore::list_realm_names(const DoutPrefixProvider* dpp,
+                                        optional_yield y, const std::string& marker,
+                                        std::span<std::string> entries,
+                                        sal::ListResult<std::string>& result)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:list_realm_names "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["realm_sel_names"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::realm_select_names2, P1, P2);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, marker);
+    sqlite::bind_int(dpp, binding, P2, entries.size());
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    read_text_rows(dpp, reset, entries, result);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "realm select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+// Period
+
+int SQLiteConfigStore::create_period(const DoutPrefixProvider* dpp,
+                                     optional_yield y, bool exclusive,
+                                     const RGWPeriod& info)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:create_period "}; dpp = &prefix;
+
+  if (info.id.empty()) {
+    ldpp_dout(dpp, 0) << "period cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  encode(info, bl);
+  const auto data = std::string_view{bl.c_str(), bl.length()};
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["period_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::period_insert4,
+                                            P1, P2, P3, P4);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["period_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::period_upsert4,
+                                            P1, P2, P3, P4);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, info.id);
+    sqlite::bind_int(dpp, binding, P2, info.epoch);
+    sqlite::bind_text(dpp, binding, P3, info.realm_id);
+    sqlite::bind_text(dpp, binding, P4, data);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::foreign_key_constraint) {
+      return -EINVAL; // refers to nonexistent RealmID
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+static void period_select_epoch(const DoutPrefixProvider* dpp,
+                                sqlite::Connection& conn,
+                                std::string_view id, uint32_t epoch,
+                                RGWPeriod& row)
+{
+  auto& stmt = conn.statements["period_sel_epoch"];
+  if (!stmt) {
+    const std::string sql = fmt::format(schema::period_select_epoch2, P1, P2);
+    stmt = sqlite::prepare_statement(dpp, conn.db.get(), sql);
+  }
+  auto binding = sqlite::stmt_binding{stmt.get()};
+  sqlite::bind_text(dpp, binding, P1, id);
+  sqlite::bind_int(dpp, binding, P2, epoch);
+
+  auto reset = sqlite::stmt_execution{stmt.get()};
+  sqlite::eval1(dpp, reset);
+
+  read_period_row(reset, row);
+}
+
+static void period_select_latest(const DoutPrefixProvider* dpp,
+                                 sqlite::Connection& conn,
+                                 std::string_view id, RGWPeriod& row)
+{
+  auto& stmt = conn.statements["period_sel_latest"];
+  if (!stmt) {
+    const std::string sql = fmt::format(schema::period_select_latest1, P1);
+    stmt = sqlite::prepare_statement(dpp, conn.db.get(), sql);
+  }
+  auto binding = sqlite::stmt_binding{stmt.get()};
+  sqlite::bind_text(dpp, binding, P1, id);
+
+  auto reset = sqlite::stmt_execution{stmt.get()};
+  sqlite::eval1(dpp, reset);
+
+  read_period_row(reset, row);
+}
+
+int SQLiteConfigStore::read_period(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view period_id,
+                                   std::optional<uint32_t> epoch,
+                                   RGWPeriod& info)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_period "}; dpp = &prefix;
+
+  if (period_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a period id" << dendl;
+    return -EINVAL;
+  }
+
+  try {
+    auto conn = impl->get(dpp);
+    if (epoch) {
+      period_select_epoch(dpp, *conn, period_id, *epoch, info);
+    } else {
+      period_select_latest(dpp, *conn, period_id, info);
+    }
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "period decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::delete_period(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view period_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:delete_period "}; dpp = &prefix;
+
+  if (period_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a period id" << dendl;
+    return -EINVAL;
+  }
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["period_del"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::period_delete1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, period_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval0(dpp, reset);
+
+    if (!::sqlite3_changes(conn->db.get())) {
+      return -ENOENT;
+    }
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period delete failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::list_period_ids(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       const std::string& marker,
+                                       std::span<std::string> entries,
+                                       sal::ListResult<std::string>& result)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:list_period_ids "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["period_sel_ids"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::period_select_ids2, P1, P2);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, marker);
+    sqlite::bind_int(dpp, binding, P2, entries.size());
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    read_text_rows(dpp, reset, entries, result);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+// ZoneGroup
+
+class SQLiteZoneGroupWriter : public sal::ZoneGroupWriter {
+  SQLiteImpl* impl;
+  int ver;
+  std::string tag;
+  std::string zonegroup_id;
+  std::string zonegroup_name;
+ public:
+  SQLiteZoneGroupWriter(SQLiteImpl* impl, int ver, std::string tag,
+                        std::string_view zonegroup_id,
+                        std::string_view zonegroup_name)
+    : impl(impl), ver(ver), tag(std::move(tag)),
+      zonegroup_id(zonegroup_id), zonegroup_name(zonegroup_name)
+  {}
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneGroup& info) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zonegroup_write "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    if (zonegroup_id != info.id || zonegroup_name != info.name) {
+      return -EINVAL; // can't modify zonegroup id or name directly
+    }
+
+    bufferlist bl;
+    encode(info, bl);
+    const auto data = std::string_view{bl.c_str(), bl.length()};
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zonegroup_upd"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zonegroup_update5,
+                                            P1, P2, P3, P4, P5);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, info.id);
+      sqlite::bind_text(dpp, binding, P2, info.realm_id);
+      sqlite::bind_text(dpp, binding, P3, data);
+      sqlite::bind_int(dpp, binding, P4, ver);
+      sqlite::bind_text(dpp, binding, P5, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zonegroup update failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::foreign_key_constraint) {
+        return -EINVAL; // refers to nonexistent RealmID
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    return 0;
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneGroup& info, std::string_view new_name) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zonegroup_rename "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    if (zonegroup_id != info.get_id() || zonegroup_name != info.get_name()) {
+      return -EINVAL; // can't modify zonegroup id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "zonegroup cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zonegroup_rename"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zonegroup_rename4,
+                                            P1, P2, P3, P4);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, info.id);
+      sqlite::bind_text(dpp, binding, P2, new_name);
+      sqlite::bind_int(dpp, binding, P3, ver);
+      sqlite::bind_text(dpp, binding, P4, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zonegroup rename failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::unique_constraint) {
+        return -EEXIST; // Name already taken
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    info.name = std::string{new_name};
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zonegroup_remove "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zonegroup_del"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zonegroup_delete3,
+                                            P1, P2, P3);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, zonegroup_id);
+      sqlite::bind_int(dpp, binding, P2, ver);
+      sqlite::bind_text(dpp, binding, P3, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      impl = nullptr;
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zonegroup delete failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    return 0;
+  }
+}; // SQLiteZoneGroupWriter
+
+
+int SQLiteConfigStore::write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                  optional_yield y, bool exclusive,
+                                                  std::string_view realm_id,
+                                                  std::string_view zonegroup_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:write_default_zonegroup_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["def_zonegroup_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_zonegroup_insert2,
+                                            P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["def_zonegroup_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_zonegroup_upsert2,
+                                            P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+    sqlite::bind_text(dpp, binding, P2, zonegroup_id);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zonegroup insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                 optional_yield y,
+                                                 std::string_view realm_id,
+                                                 std::string& zonegroup_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_zonegroup_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_zonegroup_sel"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::default_zonegroup_select1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    zonegroup_id = sqlite::column_text(reset, 0);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zonegroup select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                   optional_yield y,
+                                                   std::string_view realm_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:delete_default_zonegroup_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_zonegroup_del"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::default_zonegroup_delete1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval0(dpp, reset);
+
+    if (!::sqlite3_changes(conn->db.get())) {
+      return -ENOENT;
+    }
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zonegroup delete failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+int SQLiteConfigStore::create_zonegroup(const DoutPrefixProvider* dpp,
+                                        optional_yield y, bool exclusive,
+                                        const RGWZoneGroup& info,
+                                        std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:create_zonegroup "}; dpp = &prefix;
+
+  if (info.id.empty()) {
+    ldpp_dout(dpp, 0) << "zonegroup cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.name.empty()) {
+    ldpp_dout(dpp, 0) << "zonegroup cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  int ver = 1;
+  auto tag = generate_version_tag(dpp->get_cct());
+
+  bufferlist bl;
+  encode(info, bl);
+  const auto data = std::string_view{bl.c_str(), bl.length()};
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["zonegroup_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::zonegroup_insert6,
+                                            P1, P2, P3, P4, P5, P6);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["zonegroup_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::zonegroup_upsert6,
+                                            P1, P2, P3, P4, P5, P6);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, info.id);
+    sqlite::bind_text(dpp, binding, P2, info.name);
+    sqlite::bind_text(dpp, binding, P3, info.realm_id);
+    sqlite::bind_text(dpp, binding, P4, data);
+    sqlite::bind_int(dpp, binding, P5, ver);
+    sqlite::bind_text(dpp, binding, P6, tag);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::foreign_key_constraint) {
+      return -EINVAL; // refers to nonexistent RealmID
+    } else if (e.code() == sqlite::errc::primary_key_constraint) {
+      return -EEXIST; // ID already taken
+    } else if (e.code() == sqlite::errc::unique_constraint) {
+      return -EEXIST; // Name already taken
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneGroupWriter>(
+        impl.get(), ver, std::move(tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            std::string_view zonegroup_id,
+                                            RGWZoneGroup& info,
+                                            std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_zonegroup_by_id "}; dpp = &prefix;
+
+  if (zonegroup_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a zonegroup id" << dendl;
+    return -EINVAL;
+  }
+
+  ZoneGroupRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zonegroup_sel_id"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zonegroup_select_id1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, zonegroup_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zonegroup_row(reset, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneGroupWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                              optional_yield y,
+                                              std::string_view zonegroup_name,
+                                              RGWZoneGroup& info,
+                                              std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_zonegroup_by_name "}; dpp = &prefix;
+
+  if (zonegroup_name.empty()) {
+    ldpp_dout(dpp, 0) << "requires a zonegroup name" << dendl;
+    return -EINVAL;
+  }
+
+  ZoneGroupRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zonegroup_sel_name"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zonegroup_select_name1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, zonegroup_name);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zonegroup_row(reset, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneGroupWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                              optional_yield y,
+                                              std::string_view realm_id,
+                                              RGWZoneGroup& info,
+                                              std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_zonegroup "}; dpp = &prefix;
+
+  ZoneGroupRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zonegroup_sel_def"];
+    if (!stmt) {
+      static constexpr std::string_view sql = schema::zonegroup_select_default0;
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zonegroup_row(reset, row);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneGroupWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            const std::string& marker,
+                                            std::span<std::string> entries,
+                                            sal::ListResult<std::string>& result)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:list_zonegroup_names "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zonegroup_sel_names"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zonegroup_select_names2, P1, P2);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    auto reset = sqlite::stmt_execution{stmt.get()};
+
+    sqlite::bind_text(dpp, binding, P1, marker);
+    sqlite::bind_int(dpp, binding, P2, entries.size());
+
+    read_text_rows(dpp, reset, entries, result);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zonegroup select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+// Zone
+
+class SQLiteZoneWriter : public sal::ZoneWriter {
+  SQLiteImpl* impl;
+  int ver;
+  std::string tag;
+  std::string zone_id;
+  std::string zone_name;
+ public:
+  SQLiteZoneWriter(SQLiteImpl* impl, int ver, std::string tag,
+                   std::string_view zone_id, std::string_view zone_name)
+    : impl(impl), ver(ver), tag(std::move(tag)),
+      zone_id(zone_id), zone_name(zone_name)
+  {}
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneParams& info) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zone_write "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    if (zone_id != info.id || zone_name != info.name) {
+      return -EINVAL; // can't modify zone id or name directly
+    }
+
+    bufferlist bl;
+    encode(info, bl);
+    const auto data = std::string_view{bl.c_str(), bl.length()};
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zone_upd"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zone_update5,
+                                            P1, P2, P3, P4, P5);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, info.id);
+      sqlite::bind_text(dpp, binding, P2, info.realm_id);
+      sqlite::bind_text(dpp, binding, P3, data);
+      sqlite::bind_int(dpp, binding, P4, ver);
+      sqlite::bind_text(dpp, binding, P5, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zone update failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::foreign_key_constraint) {
+        return -EINVAL; // refers to nonexistent RealmID
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    ++ver;
+    return 0;
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneParams& info, std::string_view new_name) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zone_rename "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    if (zone_id != info.id || zone_name != info.name) {
+      return -EINVAL; // can't modify zone id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "zonegroup cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zone_rename"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zone_rename4, P1, P2, P2, P3);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, info.id);
+      sqlite::bind_text(dpp, binding, P2, new_name);
+      sqlite::bind_int(dpp, binding, P3, ver);
+      sqlite::bind_text(dpp, binding, P4, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        impl = nullptr;
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zone rename failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::unique_constraint) {
+        return -EEXIST; // Name already taken
+      } else if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    info.name = std::string{new_name};
+    ++ver;
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    Prefix prefix{*dpp, "dbconfig:sqlite:zone_remove "}; dpp = &prefix;
+
+    if (!impl) {
+      return -EINVAL; // can't write after conflict or delete
+    }
+    try {
+      auto conn = impl->get(dpp);
+      auto& stmt = conn->statements["zone_del"];
+      if (!stmt) {
+        const std::string sql = fmt::format(schema::zone_delete3, P1, P2, P3);
+        stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+      auto binding = sqlite::stmt_binding{stmt.get()};
+      sqlite::bind_text(dpp, binding, P1, zone_id);
+      sqlite::bind_int(dpp, binding, P2, ver);
+      sqlite::bind_text(dpp, binding, P3, tag);
+
+      auto reset = sqlite::stmt_execution{stmt.get()};
+      sqlite::eval0(dpp, reset);
+
+      impl = nullptr;
+      if (!::sqlite3_changes(conn->db.get())) { // VersionNumber/Tag mismatch
+        return -ECANCELED;
+      }
+    } catch (const sqlite::error& e) {
+      ldpp_dout(dpp, 20) << "zone delete failed: " << e.what() << dendl;
+      if (e.code() == sqlite::errc::busy) {
+        return -EBUSY;
+      }
+      return -EIO;
+    }
+    return 0;
+  }
+}; // SQLiteZoneWriter
+
+
+int SQLiteConfigStore::write_default_zone_id(const DoutPrefixProvider* dpp,
+                                             optional_yield y, bool exclusive,
+                                             std::string_view realm_id,
+                                             std::string_view zone_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:write_default_zone_id "}; dpp = &prefix;
+
+  if (zone_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a zone id" << dendl;
+    return -EINVAL;
+  }
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["def_zone_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_zone_insert2, P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["def_zone_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::default_zone_upsert2, P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+    sqlite::bind_text(dpp, binding, P2, zone_id);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zone insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_zone_id(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            std::string_view realm_id,
+                                            std::string& zone_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_zone_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_zone_sel"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::default_zone_select1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    zone_id = sqlite::column_text(reset, 0);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zone select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                              optional_yield y,
+                                              std::string_view realm_id)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:delete_default_zone_id "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["def_zone_del"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::default_zone_delete1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval0(dpp, reset);
+
+    if (!::sqlite3_changes(conn->db.get())) {
+      return -ENOENT;
+    }
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "default zone delete failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+int SQLiteConfigStore::create_zone(const DoutPrefixProvider* dpp,
+                                   optional_yield y, bool exclusive,
+                                   const RGWZoneParams& info,
+                                   std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:create_zone "}; dpp = &prefix;
+
+  if (info.id.empty()) {
+    ldpp_dout(dpp, 0) << "zone cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.name.empty()) {
+    ldpp_dout(dpp, 0) << "zone cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  int ver = 1;
+  auto tag = generate_version_tag(dpp->get_cct());
+
+  bufferlist bl;
+  encode(info, bl);
+  const auto data = std::string_view{bl.c_str(), bl.length()};
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["zone_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::zone_insert6,
+                                            P1, P2, P3, P4, P5, P6);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["zone_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::zone_upsert6,
+                                            P1, P2, P3, P4, P5, P6);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, info.id);
+    sqlite::bind_text(dpp, binding, P2, info.name);
+    sqlite::bind_text(dpp, binding, P3, info.realm_id);
+    sqlite::bind_text(dpp, binding, P4, data);
+    sqlite::bind_int(dpp, binding, P5, ver);
+    sqlite::bind_text(dpp, binding, P6, tag);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zone insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::foreign_key_constraint) {
+      return -EINVAL; // refers to nonexistent RealmID
+    } else if (e.code() == sqlite::errc::primary_key_constraint) {
+      return -EEXIST; // ID already taken
+    } else if (e.code() == sqlite::errc::unique_constraint) {
+      return -EEXIST; // Name already taken
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneWriter>(
+        impl.get(), ver, std::move(tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_zone_by_id(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       std::string_view zone_id,
+                                       RGWZoneParams& info,
+                                       std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_zone_by_id "}; dpp = &prefix;
+
+  if (zone_id.empty()) {
+    ldpp_dout(dpp, 0) << "requires a zone id" << dendl;
+    return -EINVAL;
+  }
+
+  ZoneRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zone_sel_id"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zone_select_id1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, zone_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zone_row(reset, row);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zone select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_zone_by_name(const DoutPrefixProvider* dpp,
+                                         optional_yield y,
+                                         std::string_view zone_name,
+                                         RGWZoneParams& info,
+                                         std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_zone_by_name "}; dpp = &prefix;
+
+  if (zone_name.empty()) {
+    ldpp_dout(dpp, 0) << "requires a zone name" << dendl;
+    return -EINVAL;
+  }
+
+  ZoneRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zone_sel_name"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zone_select_name1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, zone_name);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zone_row(reset, row);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zone select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::read_default_zone(const DoutPrefixProvider* dpp,
+                                         optional_yield y,
+                                         std::string_view realm_id,
+                                         RGWZoneParams& info,
+                                         std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_default_zone "}; dpp = &prefix;
+
+  ZoneRow row;
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zone_sel_def"];
+    if (!stmt) {
+      static constexpr std::string_view sql = schema::zone_select_default0;
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    read_zone_row(reset, row);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zone select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+
+  info = std::move(row.info);
+  if (writer) {
+    *writer = std::make_unique<SQLiteZoneWriter>(
+        impl.get(), row.ver, std::move(row.tag), info.id, info.name);
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::list_zone_names(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       const std::string& marker,
+                                       std::span<std::string> entries,
+                                       sal::ListResult<std::string>& result)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:list_zone_names "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["zone_sel_names"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::zone_select_names2, P1, P2);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, marker);
+    sqlite::bind_int(dpp, binding, P2, entries.size());
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    read_text_rows(dpp, reset, entries, result);
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "zone select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+
+// PeriodConfig
+
+int SQLiteConfigStore::read_period_config(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view realm_id,
+                                          RGWPeriodConfig& info)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:read_period_config "}; dpp = &prefix;
+
+  try {
+    auto conn = impl->get(dpp);
+    auto& stmt = conn->statements["period_conf_sel"];
+    if (!stmt) {
+      const std::string sql = fmt::format(schema::period_config_select1, P1);
+      stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+    }
+    auto binding = sqlite::stmt_binding{stmt.get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+
+    auto reset = sqlite::stmt_execution{stmt.get()};
+    sqlite::eval1(dpp, reset);
+
+    std::string data = sqlite::column_text(reset, 0);
+    bufferlist bl = bufferlist::static_from_string(data);
+    auto p = bl.cbegin();
+    decode(info, p);
+
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "period config decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period config select failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::done) {
+      return -ENOENT;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+int SQLiteConfigStore::write_period_config(const DoutPrefixProvider* dpp,
+                                           optional_yield y, bool exclusive,
+                                           std::string_view realm_id,
+                                           const RGWPeriodConfig& info)
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:write_period_config "}; dpp = &prefix;
+
+  bufferlist bl;
+  encode(info, bl);
+  const auto data = std::string_view{bl.c_str(), bl.length()};
+
+  try {
+    auto conn = impl->get(dpp);
+    sqlite::stmt_ptr* stmt = nullptr;
+    if (exclusive) {
+      stmt = &conn->statements["period_conf_ins"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::period_config_insert2, P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    } else {
+      stmt = &conn->statements["period_conf_ups"];
+      if (!*stmt) {
+        const std::string sql = fmt::format(schema::period_config_upsert2, P1, P2);
+        *stmt = sqlite::prepare_statement(dpp, conn->db.get(), sql);
+      }
+    }
+    auto binding = sqlite::stmt_binding{stmt->get()};
+    sqlite::bind_text(dpp, binding, P1, realm_id);
+    sqlite::bind_text(dpp, binding, P2, data);
+
+    auto reset = sqlite::stmt_execution{stmt->get()};
+    sqlite::eval0(dpp, reset);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 20) << "period config decode failed: " << e.what() << dendl;
+    return -EIO;
+  } catch (const sqlite::error& e) {
+    ldpp_dout(dpp, 20) << "period config insert failed: " << e.what() << dendl;
+    if (e.code() == sqlite::errc::primary_key_constraint) {
+      return -EEXIST;
+    } else if (e.code() == sqlite::errc::busy) {
+      return -EBUSY;
+    }
+    return -EIO;
+  }
+  return 0;
+}
+
+namespace {
+
+int version_cb(void* user, int count, char** values, char** names)
+{
+  if (count != 1) {
+    return EINVAL;
+  }
+  std::string_view name = names[0];
+  if (name != "user_version") {
+    return EINVAL;
+  }
+  std::string_view value = values[0];
+  auto result = std::from_chars(value.begin(), value.end(),
+                                *reinterpret_cast<uint32_t*>(user));
+  if (result.ec != std::errc{}) {
+    return static_cast<int>(result.ec);
+  }
+  return 0;
+}
+
+void apply_schema_migrations(const DoutPrefixProvider* dpp, sqlite3* db)
+{
+  sqlite::execute(dpp, db, "PRAGMA foreign_keys = ON", nullptr, nullptr);
+
+  // initiate a transaction and read the current schema version
+  uint32_t version = 0;
+  sqlite::execute(dpp, db, "BEGIN; PRAGMA user_version", version_cb, &version);
+
+  const uint32_t initial_version = version;
+  ldpp_dout(dpp, 4) << "current schema version " << version << dendl;
+
+  // use the version as an index into schema::migrations
+  auto m = std::next(schema::migrations.begin(), version);
+
+  for (; m != schema::migrations.end(); ++m, ++version) {
+    try {
+      sqlite::execute(dpp, db, m->up, nullptr, nullptr);
+    } catch (const sqlite::error&) {
+      ldpp_dout(dpp, -1) << "ERROR: schema migration failed on v" << version
+          << ": " << m->description << dendl;
+      throw;
+    }
+  }
+
+  if (version > initial_version) {
+    // update the user_version and commit the transaction
+    const auto commit = fmt::format("PRAGMA user_version = {}; COMMIT", version);
+    sqlite::execute(dpp, db, commit.c_str(), nullptr, nullptr);
+
+    ldpp_dout(dpp, 4) << "upgraded database schema to version " << version << dendl;
+  } else {
+    // nothing to commit
+    sqlite::execute(dpp, db, "ROLLBACK", nullptr, nullptr);
+  }
+}
+
+} // anonymous namespace
+
+
+auto create_sqlite_store(const DoutPrefixProvider* dpp, const std::string& uri)
+  -> std::unique_ptr<config::SQLiteConfigStore>
+{
+  Prefix prefix{*dpp, "dbconfig:sqlite:create_sqlite_store "}; dpp = &prefix;
+
+  // build the connection pool
+  int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_URI | SQLITE_OPEN_READWRITE |
+      SQLITE_OPEN_NOMUTEX;
+  auto factory = sqlite::ConnectionFactory{uri, flags};
+
+  // sqlite does not support concurrent writers. we enforce this limitation by
+  // using a connection pool of size=1
+  static constexpr size_t max_connections = 1;
+  auto impl = std::make_unique<SQLiteImpl>(std::move(factory), max_connections);
+
+  // open a connection to apply schema migrations
+  auto conn = impl->get(dpp);
+  apply_schema_migrations(dpp, conn->db.get());
+
+  return std::make_unique<SQLiteConfigStore>(std::move(impl));
+}
+
+} // namespace rgw::dbstore::config

--- a/src/rgw/store/dbstore/config/sqlite.h
+++ b/src/rgw/store/dbstore/config/sqlite.h
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "rgw_sal_config.h"
+
+class DoutPrefixProvider;
+
+namespace rgw::dbstore::config {
+
+struct SQLiteImpl;
+
+class SQLiteConfigStore : public sal::ConfigStore {
+ public:
+  explicit SQLiteConfigStore(std::unique_ptr<SQLiteImpl> impl);
+  ~SQLiteConfigStore() override;
+
+  int write_default_realm_id(const DoutPrefixProvider* dpp,
+                             optional_yield y, bool exclusive,
+                             std::string_view realm_id) override;
+  int read_default_realm_id(const DoutPrefixProvider* dpp,
+                            optional_yield y,
+                            std::string& realm_id) override;
+  int delete_default_realm_id(const DoutPrefixProvider* dpp,
+                              optional_yield y) override;
+
+  int create_realm(const DoutPrefixProvider* dpp,
+                   optional_yield y, bool exclusive,
+                   const RGWRealm& info,
+                   std::unique_ptr<sal::RealmWriter>* writer) override;
+  int read_realm_by_id(const DoutPrefixProvider* dpp,
+                       optional_yield y,
+                       std::string_view realm_id,
+                       RGWRealm& info,
+                       std::unique_ptr<sal::RealmWriter>* writer) override;
+  int read_realm_by_name(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view realm_name,
+                         RGWRealm& info,
+                         std::unique_ptr<sal::RealmWriter>* writer) override;
+  int read_default_realm(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         RGWRealm& info,
+                         std::unique_ptr<sal::RealmWriter>* writer) override;
+  int read_realm_id(const DoutPrefixProvider* dpp,
+                    optional_yield y, std::string_view realm_name,
+                    std::string& realm_id) override;
+  int realm_notify_new_period(const DoutPrefixProvider* dpp,
+                              optional_yield y,
+                              const RGWPeriod& period) override;
+  int list_realm_names(const DoutPrefixProvider* dpp,
+                       optional_yield y, const std::string& marker,
+                       std::span<std::string> entries,
+                       sal::ListResult<std::string>& result) override;
+
+  int create_period(const DoutPrefixProvider* dpp,
+                    optional_yield y, bool exclusive,
+                    const RGWPeriod& info) override;
+  int read_period(const DoutPrefixProvider* dpp,
+                  optional_yield y, std::string_view period_id,
+                  std::optional<uint32_t> epoch, RGWPeriod& info) override;
+  int delete_period(const DoutPrefixProvider* dpp,
+                    optional_yield y,
+                    std::string_view period_id) override;
+  int list_period_ids(const DoutPrefixProvider* dpp,
+                      optional_yield y, const std::string& marker,
+                      std::span<std::string> entries,
+                      sal::ListResult<std::string>& result) override;
+
+  int write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                 optional_yield y, bool exclusive,
+                                 std::string_view realm_id,
+                                 std::string_view zonegroup_id) override;
+  int read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view realm_id,
+                                std::string& zonegroup_id) override;
+  int delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view realm_id) override;
+
+  int create_zonegroup(const DoutPrefixProvider* dpp,
+                       optional_yield y, bool exclusive,
+                       const RGWZoneGroup& info,
+                       std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  int read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           std::string_view zonegroup_id,
+                           RGWZoneGroup& info,
+                           std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  int read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                             optional_yield y,
+                             std::string_view zonegroup_name,
+                             RGWZoneGroup& info,
+                             std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  int read_default_zonegroup(const DoutPrefixProvider* dpp,
+                             optional_yield y,
+                             std::string_view realm_id,
+                             RGWZoneGroup& info,
+                             std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  int list_zonegroup_names(const DoutPrefixProvider* dpp,
+                           optional_yield y, const std::string& marker,
+                           std::span<std::string> entries,
+                           sal::ListResult<std::string>& result) override;
+
+  int write_default_zone_id(const DoutPrefixProvider* dpp,
+                            optional_yield y, bool exclusive,
+                            std::string_view realm_id,
+                            std::string_view zone_id) override;
+  int read_default_zone_id(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           std::string_view realm_id,
+                           std::string& zone_id) override;
+  int delete_default_zone_id(const DoutPrefixProvider* dpp,
+                             optional_yield y,
+                             std::string_view realm_id) override;
+
+  int create_zone(const DoutPrefixProvider* dpp,
+                  optional_yield y, bool exclusive,
+                  const RGWZoneParams& info,
+                  std::unique_ptr<sal::ZoneWriter>* writer) override;
+  int read_zone_by_id(const DoutPrefixProvider* dpp,
+                      optional_yield y,
+                      std::string_view zone_id,
+                      RGWZoneParams& info,
+                      std::unique_ptr<sal::ZoneWriter>* writer) override;
+  int read_zone_by_name(const DoutPrefixProvider* dpp,
+                        optional_yield y,
+                        std::string_view zone_name,
+                        RGWZoneParams& info,
+                        std::unique_ptr<sal::ZoneWriter>* writer) override;
+  int read_default_zone(const DoutPrefixProvider* dpp,
+                        optional_yield y,
+                        std::string_view realm_id,
+                        RGWZoneParams& info,
+                        std::unique_ptr<sal::ZoneWriter>* writer) override;
+  int list_zone_names(const DoutPrefixProvider* dpp,
+                      optional_yield y, const std::string& marker,
+                      std::span<std::string> entries,
+                      sal::ListResult<std::string>& result) override;
+
+  int read_period_config(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view realm_id,
+                         RGWPeriodConfig& info) override;
+  int write_period_config(const DoutPrefixProvider* dpp,
+                          optional_yield y, bool exclusive,
+                          std::string_view realm_id,
+                          const RGWPeriodConfig& info) override;
+
+ private:
+  std::unique_ptr<SQLiteImpl> impl;
+}; // SQLiteConfigStore
+
+
+auto create_sqlite_store(const DoutPrefixProvider* dpp, const std::string& uri)
+  -> std::unique_ptr<config::SQLiteConfigStore>;
+
+} // namespace rgw::dbstore::config

--- a/src/rgw/store/dbstore/config/sqlite_schema.h
+++ b/src/rgw/store/dbstore/config/sqlite_schema.h
@@ -1,0 +1,299 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <initializer_list>
+
+namespace rgw::dbstore::config::schema {
+
+struct Migration {
+  // human-readable description to help with debugging migration errors
+  const char* description = nullptr;
+  // series of sql statements to apply the schema migration
+  const char* up = nullptr;
+  // series of sql statements to undo the schema migration
+  const char* down = nullptr;
+};
+
+static constexpr std::initializer_list<Migration> migrations {{
+    .description = "create the initial ConfigStore tables",
+    .up = R"(
+CREATE TABLE IF NOT EXISTS Realms (
+  ID TEXT PRIMARY KEY NOT NULL,
+  Name TEXT UNIQUE NOT NULL,
+  CurrentPeriod TEXT,
+  Epoch INTEGER DEFAULT 0,
+  VersionNumber INTEGER,
+  VersionTag TEXT
+);
+CREATE TABLE IF NOT EXISTS Periods (
+  ID TEXT NOT NULL,
+  Epoch INTEGER DEFAULT 0,
+  RealmID TEXT NOT NULL REFERENCES Realms (ID),
+  Data TEXT NOT NULL,
+  PRIMARY KEY (ID, Epoch)
+);
+CREATE TABLE IF NOT EXISTS PeriodConfigs (
+  RealmID TEXT PRIMARY KEY NOT NULL REFERENCES Realms (ID),
+  Data TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ZoneGroups (
+  ID TEXT PRIMARY KEY NOT NULL,
+  Name TEXT UNIQUE NOT NULL,
+  RealmID TEXT NOT NULL REFERENCES Realms (ID),
+  Data TEXT NOT NULL,
+  VersionNumber INTEGER,
+  VersionTag TEXT
+);
+CREATE TABLE IF NOT EXISTS Zones (
+  ID TEXT PRIMARY KEY NOT NULL,
+  Name TEXT UNIQUE NOT NULL,
+  RealmID TEXT NOT NULL REFERENCES Realms (ID),
+  Data TEXT NOT NULL,
+  VersionNumber INTEGER,
+  VersionTag TEXT
+);
+CREATE TABLE IF NOT EXISTS DefaultRealms (
+  ID TEXT,
+  Empty TEXT PRIMARY KEY
+);
+CREATE TABLE IF NOT EXISTS DefaultZoneGroups (
+  ID TEXT,
+  RealmID TEXT PRIMARY KEY REFERENCES Realms (ID)
+);
+CREATE TABLE IF NOT EXISTS DefaultZones (
+  ID TEXT,
+  RealmID TEXT PRIMARY KEY REFERENCES Realms (ID)
+);
+)",
+    .down = R"(
+DROP TABLE IF EXISTS Realms;
+DROP TABLE IF EXISTS Periods;
+DROP TABLE IF EXISTS PeriodConfigs;
+DROP TABLE IF EXISTS ZoneGroups;
+DROP TABLE IF EXISTS Zones;
+DROP TABLE IF EXISTS DefaultRealms;
+DROP TABLE IF EXISTS DefaultZoneGroups;
+DROP TABLE IF EXISTS DefaultZones;
+)"
+  }
+};
+
+
+// DefaultRealms
+
+static constexpr const char* default_realm_insert1 =
+"INSERT INTO DefaultRealms (ID, Empty) VALUES ({}, '')";
+
+static constexpr const char* default_realm_upsert1 =
+R"(INSERT INTO DefaultRealms (ID, Empty) VALUES ({0}, '')
+ON CONFLICT(Empty) DO UPDATE SET ID = {0})";
+
+static constexpr const char* default_realm_select0 =
+"SELECT ID FROM DefaultRealms LIMIT 1";
+
+static constexpr const char* default_realm_delete0 =
+"DELETE FROM DefaultRealms";
+
+
+// Realms
+
+static constexpr const char* realm_update5 =
+"UPDATE Realms SET CurrentPeriod = {1}, Epoch = {2}, VersionNumber = {3} + 1 \
+WHERE ID = {0} AND VersionNumber = {3} AND VersionTag = {4}";
+
+static constexpr const char* realm_rename4 =
+"UPDATE Realms SET Name = {1}, VersionNumber = {2} + 1 \
+WHERE ID = {0} AND VersionNumber = {2} AND VersionTag = {3}";
+
+static constexpr const char* realm_delete3 =
+"DELETE FROM Realms WHERE ID = {} AND VersionNumber = {} AND VersionTag = {}";
+
+static constexpr const char* realm_insert4 =
+"INSERT INTO Realms (ID, Name, VersionNumber, VersionTag) \
+VALUES ({}, {}, {}, {})";
+
+static constexpr const char* realm_upsert4 =
+"INSERT INTO Realms (ID, Name, VersionNumber, VersionTag) \
+VALUES ({0}, {1}, {2}, {3}) \
+ON CONFLICT(ID) DO UPDATE SET Name = {1}, \
+VersionNumber = {2}, VersionTag = {3}";
+
+static constexpr const char* realm_select_id1 =
+"SELECT * FROM Realms WHERE ID = {} LIMIT 1";
+
+static constexpr const char* realm_select_name1 =
+"SELECT * FROM Realms WHERE Name = {} LIMIT 1";
+
+static constexpr const char* realm_select_default0 =
+"SELECT r.* FROM Realms r \
+INNER JOIN DefaultRealms d \
+ON d.ID = r.ID LIMIT 1";
+
+static constexpr const char* realm_select_names2 =
+"SELECT Name FROM Realms WHERE Name > {} \
+ORDER BY Name ASC LIMIT {}";
+
+
+// Periods
+
+static constexpr const char* period_insert4 =
+"INSERT INTO Periods (ID, Epoch, RealmID, Data) \
+VALUES ({}, {}, {}, {})";
+
+static constexpr const char* period_upsert4 =
+"INSERT INTO Periods (ID, Epoch, RealmID, Data) \
+VALUES ({0}, {1}, {2}, {3}) \
+ON CONFLICT DO UPDATE SET RealmID = {2}, Data = {3}";
+
+static constexpr const char* period_select_epoch2 =
+"SELECT * FROM Periods WHERE ID = {} AND Epoch = {} LIMIT 1";
+
+static constexpr const char* period_select_latest1 =
+"SELECT * FROM Periods WHERE ID = {} ORDER BY Epoch DESC LIMIT 1";
+
+static constexpr const char* period_delete1 =
+"DELETE FROM Periods WHERE ID = {}";
+
+static constexpr const char* period_select_ids2 =
+"SELECT ID FROM Periods WHERE ID > {} ORDER BY ID ASC LIMIT {}";
+
+
+// DefaultZoneGroups
+
+static constexpr const char* default_zonegroup_insert2 =
+"INSERT INTO DefaultZoneGroups (RealmID, ID) VALUES ({}, {})";
+
+static constexpr const char* default_zonegroup_upsert2 =
+"INSERT INTO DefaultZoneGroups (RealmID, ID) \
+VALUES ({0}, {1}) \
+ON CONFLICT(RealmID) DO UPDATE SET ID = {1}";
+
+static constexpr const char* default_zonegroup_select1 =
+"SELECT ID FROM DefaultZoneGroups WHERE RealmID = {}";
+
+static constexpr const char* default_zonegroup_delete1 =
+"DELETE FROM DefaultZoneGroups WHERE RealmID = {}";
+
+
+// ZoneGroups
+
+static constexpr const char* zonegroup_update5 =
+"UPDATE ZoneGroups SET RealmID = {1}, Data = {2}, VersionNumber = {3} + 1 \
+WHERE ID = {0} AND VersionNumber = {3} AND VersionTag = {4}";
+
+static constexpr const char* zonegroup_rename4 =
+"UPDATE ZoneGroups SET Name = {1}, VersionNumber = {2} + 1 \
+WHERE ID = {0} AND VersionNumber = {2} AND VersionTag = {3}";
+
+static constexpr const char* zonegroup_delete3 =
+"DELETE FROM ZoneGroups WHERE ID = {} \
+AND VersionNumber = {} AND VersionTag = {}";
+
+static constexpr const char* zonegroup_insert6 =
+"INSERT INTO ZoneGroups (ID, Name, RealmID, Data, VersionNumber, VersionTag) \
+VALUES ({}, {}, {}, {}, {}, {})";
+
+static constexpr const char* zonegroup_upsert6 =
+"INSERT INTO ZoneGroups (ID, Name, RealmID, Data, VersionNumber, VersionTag) \
+VALUES ({0}, {1}, {2}, {3}, {4}, {5}) \
+ON CONFLICT (ID) DO UPDATE SET Name = {1}, RealmID = {2}, \
+Data = {3}, VersionNumber = {4}, VersionTag = {5}";
+
+static constexpr const char* zonegroup_select_id1 =
+"SELECT * FROM ZoneGroups WHERE ID = {} LIMIT 1";
+
+static constexpr const char* zonegroup_select_name1 =
+"SELECT * FROM ZoneGroups WHERE Name = {} LIMIT 1";
+
+static constexpr const char* zonegroup_select_default0 =
+"SELECT z.* FROM ZoneGroups z \
+INNER JOIN DefaultZoneGroups d \
+ON d.ID = z.ID LIMIT 1";
+
+static constexpr const char* zonegroup_select_names2 =
+"SELECT Name FROM ZoneGroups WHERE Name > {} \
+ORDER BY Name ASC LIMIT {}";
+
+
+// DefaultZones
+
+static constexpr const char* default_zone_insert2 =
+"INSERT INTO DefaultZones (RealmID, ID) VALUES ({}, {})";
+
+static constexpr const char* default_zone_upsert2 =
+"INSERT INTO DefaultZones (RealmID, ID) VALUES ({0}, {1}) \
+ON CONFLICT(RealmID) DO UPDATE SET ID = {1}";
+
+static constexpr const char* default_zone_select1 =
+"SELECT ID FROM DefaultZones WHERE RealmID = {}";
+
+static constexpr const char* default_zone_delete1 =
+"DELETE FROM DefaultZones WHERE RealmID = {}";
+
+
+// Zones
+
+static constexpr const char* zone_update5 =
+"UPDATE Zones SET RealmID = {1}, Data = {2}, VersionNumber = {3} + 1 \
+WHERE ID = {0} AND VersionNumber = {3} AND VersionTag = {4}";
+
+static constexpr const char* zone_rename4 =
+"UPDATE Zones SET Name = {1}, VersionNumber = {2} + 1 \
+WHERE ID = {0} AND VersionNumber = {2} AND VersionTag = {3}";
+
+static constexpr const char* zone_delete3 =
+"DELETE FROM Zones WHERE ID = {} AND VersionNumber = {} AND VersionTag = {}";
+
+static constexpr const char* zone_insert6 =
+"INSERT INTO Zones (ID, Name, RealmID, Data, VersionNumber, VersionTag) \
+VALUES ({}, {}, {}, {}, {}, {})";
+
+static constexpr const char* zone_upsert6 =
+"INSERT INTO Zones (ID, Name, RealmID, Data, VersionNumber, VersionTag) \
+VALUES ({0}, {1}, {2}, {3}, {4}, {5}) \
+ON CONFLICT (ID) DO UPDATE SET Name = {1}, RealmID = {2}, \
+Data = {3}, VersionNumber = {4}, VersionTag = {5}";
+
+static constexpr const char* zone_select_id1 =
+"SELECT * FROM Zones WHERE ID = {} LIMIT 1";
+
+static constexpr const char* zone_select_name1 =
+"SELECT * FROM Zones WHERE Name = {} LIMIT 1";
+
+static constexpr const char* zone_select_default0 =
+"SELECT z.* FROM Zones z \
+INNER JOIN DefaultZones d \
+ON d.ID = z.ID LIMIT 1";
+
+static constexpr const char* zone_select_names2 =
+"SELECT Name FROM Zones WHERE Name > {} \
+ORDER BY Name ASC LIMIT {}";
+
+
+// PeriodConfigs
+
+static constexpr const char* period_config_insert2 =
+"INSERT INTO PeriodConfigs (RealmID, Data) VALUES ({}, {})";
+
+static constexpr const char* period_config_upsert2 =
+"INSERT INTO PeriodConfigs (RealmID, Data) VALUES ({0}, {1}) \
+ON CONFLICT (RealmID) DO UPDATE SET Data = {1}";
+
+static constexpr const char* period_config_select1 =
+"SELECT Data FROM PeriodConfigs WHERE RealmID = {} LIMIT 1";
+
+} // namespace rgw::dbstore::config::schema

--- a/src/rgw/store/dbstore/config/store.cc
+++ b/src/rgw/store/dbstore/config/store.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <stdexcept>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
+#include "store.h"
+#ifdef SQLITE_ENABLED
+#include "sqlite.h"
+#endif
+
+namespace rgw::dbstore {
+
+auto create_config_store(const DoutPrefixProvider* dpp, const std::string& uri)
+  -> std::unique_ptr<sal::ConfigStore>
+{
+#ifdef SQLITE_ENABLED
+  if (uri.starts_with("file:")) {
+    return config::create_sqlite_store(dpp, uri);
+  }
+#endif
+  throw std::runtime_error(fmt::format("unrecognized URI {}", uri));
+}
+
+} // namespace rgw::dbstore

--- a/src/rgw/store/dbstore/config/store.h
+++ b/src/rgw/store/dbstore/config/store.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include "rgw_sal_config.h"
+
+namespace rgw::dbstore {
+
+// ConfigStore factory
+auto create_config_store(const DoutPrefixProvider* dpp, const std::string& uri)
+  -> std::unique_ptr<sal::ConfigStore>;
+
+} // namespace rgw::dbstore

--- a/src/rgw/store/dbstore/sqlite/connection.cc
+++ b/src/rgw/store/dbstore/sqlite/connection.cc
@@ -1,0 +1,34 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "connection.h"
+#include "error.h"
+
+namespace rgw::dbstore::sqlite {
+
+db_ptr open_database(const char* filename, int flags)
+{
+  sqlite3* db = nullptr;
+  const int result = ::sqlite3_open_v2(filename, &db, flags, nullptr);
+  if (result != SQLITE_OK) {
+    throw std::system_error(result, sqlite::error_category());
+  }
+  // request extended result codes
+  (void) ::sqlite3_extended_result_codes(db, 1);
+  return db_ptr{db};
+}
+
+} // namespace rgw::dbstore::sqlite

--- a/src/rgw/store/dbstore/sqlite/connection.h
+++ b/src/rgw/store/dbstore/sqlite/connection.h
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <sqlite3.h>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
+#include "sqlite/statement.h"
+
+class DoutPrefixProvider;
+
+namespace rgw::dbstore::sqlite {
+
+// owning sqlite3 pointer
+struct db_deleter {
+  void operator()(sqlite3* p) const { ::sqlite3_close(p); }
+};
+using db_ptr = std::unique_ptr<sqlite3, db_deleter>;
+
+
+// open the database file or throw on error
+db_ptr open_database(const char* filename, int flags);
+
+
+struct Connection {
+  db_ptr db;
+  // map of statements, prepared on first use
+  std::map<std::string_view, stmt_ptr> statements;
+
+  explicit Connection(db_ptr db) : db(std::move(db)) {}
+};
+
+// sqlite connection factory for ConnectionPool
+class ConnectionFactory {
+  std::string uri;
+  int flags;
+ public:
+  ConnectionFactory(std::string uri, int flags)
+      : uri(std::move(uri)), flags(flags) {}
+
+  auto operator()(const DoutPrefixProvider* dpp)
+    -> std::unique_ptr<Connection>
+  {
+    auto db = open_database(uri.c_str(), flags);
+    return std::make_unique<Connection>(std::move(db));
+  }
+};
+
+} // namespace rgw::dbstore::sqlite

--- a/src/rgw/store/dbstore/sqlite/error.cc
+++ b/src/rgw/store/dbstore/sqlite/error.cc
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "error.h"
+
+namespace rgw::dbstore::sqlite {
+
+const std::error_category& error_category()
+{
+  struct category : std::error_category {
+    const char* name() const noexcept override {
+      return "dbstore:sqlite";
+    }
+    std::string message(int ev) const override {
+      return ::sqlite3_errstr(ev);
+    }
+    std::error_condition default_error_condition(int code) const noexcept override {
+      return {code & 0xFF, category()};
+    }
+  };
+  static category instance;
+  return instance;
+}
+
+} // namespace rgw::dbstore::sqlite

--- a/src/rgw/store/dbstore/sqlite/error.h
+++ b/src/rgw/store/dbstore/sqlite/error.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <system_error>
+#include <sqlite3.h>
+
+namespace rgw::dbstore::sqlite {
+
+// error category for sqlite extended result codes:
+//   https://www.sqlite.org/rescode.html
+const std::error_category& error_category();
+
+
+// sqlite exception type that carries the extended error code and message
+class error : public std::runtime_error {
+  std::error_code ec;
+ public:
+  error(const char* errmsg, std::error_code ec)
+      : runtime_error(errmsg), ec(ec) {}
+  error(sqlite3* db, std::error_code ec) : error(::sqlite3_errmsg(db), ec) {}
+  error(sqlite3* db, int result) : error(db, {result, error_category()}) {}
+  error(sqlite3* db) : error(db, ::sqlite3_extended_errcode(db)) {}
+  std::error_code code() const { return ec; }
+};
+
+
+// sqlite error conditions for primary and extended result codes
+//
+// 'primary' error_conditions will match 'primary' error_codes as well as any
+// 'extended' error_codes whose lowest 8 bits match that primary code. for
+// example, the error_condition for SQLITE_CONSTRAINT will match the error_codes
+// SQLITE_CONSTRAINT and SQLITE_CONSTRAINT_*
+enum class errc {
+  // primary result codes
+  ok = SQLITE_OK,
+  busy = SQLITE_BUSY,
+  constraint = SQLITE_CONSTRAINT,
+  row = SQLITE_ROW,
+  done = SQLITE_DONE,
+
+  // extended result codes
+  primary_key_constraint = SQLITE_CONSTRAINT_PRIMARYKEY,
+  foreign_key_constraint = SQLITE_CONSTRAINT_FOREIGNKEY,
+  unique_constraint = SQLITE_CONSTRAINT_UNIQUE,
+
+  // ..add conditions as needed
+};
+
+inline std::error_code make_error_code(errc e)
+{
+  return {static_cast<int>(e), error_category()};
+}
+
+inline std::error_condition make_error_condition(errc e)
+{
+  return {static_cast<int>(e), error_category()};
+}
+
+} // namespace rgw::dbstore::sqlite
+
+namespace std {
+
+// enable implicit conversions from sqlite::errc to std::error_condition
+template<> struct is_error_condition_enum<
+    rgw::dbstore::sqlite::errc> : public true_type {};
+
+} // namespace std

--- a/src/rgw/store/dbstore/sqlite/statement.cc
+++ b/src/rgw/store/dbstore/sqlite/statement.cc
@@ -1,0 +1,196 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "error.h"
+#include "statement.h"
+
+#define dout_subsys ceph_subsys_rgw_dbstore
+
+namespace rgw::dbstore::sqlite {
+
+// owning pointer to arbitrary memory allocated and returned by sqlite3
+struct sqlite_deleter {
+  template <typename T>
+  void operator()(T* p) { ::sqlite3_free(p); }
+};
+template <typename T>
+using sqlite_ptr = std::unique_ptr<T, sqlite_deleter>;
+
+
+stmt_ptr prepare_statement(const DoutPrefixProvider* dpp,
+                           sqlite3* db, std::string_view sql)
+{
+  sqlite3_stmt* stmt = nullptr;
+  int result = ::sqlite3_prepare_v2(db, sql.data(), sql.size(), &stmt, nullptr);
+  auto ec = std::error_code{result, sqlite::error_category()};
+  if (ec != sqlite::errc::ok) {
+    const char* errmsg = ::sqlite3_errmsg(db);
+    ldpp_dout(dpp, 1) << "preparation failed: " << errmsg
+        << " (" << ec << ")\nstatement: " << sql << dendl;
+    throw sqlite::error(errmsg, ec);
+  }
+  return stmt_ptr{stmt};
+}
+
+static int bind_index(const DoutPrefixProvider* dpp,
+                      const stmt_binding& stmt, const char* name)
+{
+  const int index = ::sqlite3_bind_parameter_index(stmt.get(), name);
+  if (index <= 0) {
+    ldpp_dout(dpp, 1) << "binding failed on parameter name="
+        << name << dendl;
+    sqlite3* db = ::sqlite3_db_handle(stmt.get());
+    throw sqlite::error(db);
+  }
+  return index;
+}
+
+void bind_text(const DoutPrefixProvider* dpp, const stmt_binding& stmt,
+               const char* name, std::string_view value)
+{
+  const int index = bind_index(dpp, stmt, name);
+
+  int result = ::sqlite3_bind_text(stmt.get(), index, value.data(),
+                                   value.size(), SQLITE_STATIC);
+  auto ec = std::error_code{result, sqlite::error_category()};
+  if (ec != sqlite::errc::ok) {
+    ldpp_dout(dpp, 1) << "binding failed on parameter name="
+        << name << " value=" << value << dendl;
+    sqlite3* db = ::sqlite3_db_handle(stmt.get());
+    throw sqlite::error(db, ec);
+  }
+}
+
+void bind_int(const DoutPrefixProvider* dpp, const stmt_binding& stmt,
+              const char* name, int value)
+{
+  const int index = bind_index(dpp, stmt, name);
+
+  int result = ::sqlite3_bind_int(stmt.get(), index, value);
+  auto ec = std::error_code{result, sqlite::error_category()};
+  if (ec != sqlite::errc::ok) {
+    ldpp_dout(dpp, 1) << "binding failed on parameter name="
+        << name << " value=" << value << dendl;
+    sqlite3* db = ::sqlite3_db_handle(stmt.get());
+    throw sqlite::error(db, ec);
+  }
+}
+
+void eval0(const DoutPrefixProvider* dpp, const stmt_execution& stmt)
+{
+  sqlite_ptr<char> sql;
+  if (dpp->get_cct()->_conf->subsys.should_gather<dout_subsys, 20>()) {
+    sql.reset(::sqlite3_expanded_sql(stmt.get()));
+  }
+
+  const int result = ::sqlite3_step(stmt.get());
+  auto ec = std::error_code{result, sqlite::error_category()};
+  sqlite3* db = ::sqlite3_db_handle(stmt.get());
+
+  if (ec != sqlite::errc::done) {
+    const char* errmsg = ::sqlite3_errmsg(db);
+    ldpp_dout(dpp, 20) << "evaluation failed: " << errmsg
+        << " (" << ec << ")\nstatement: " << sql.get() << dendl;
+    throw sqlite::error(errmsg, ec);
+  }
+  ldpp_dout(dpp, 20) << "evaluation succeeded: " << sql.get() << dendl;
+}
+
+void eval1(const DoutPrefixProvider* dpp, const stmt_execution& stmt)
+{
+  sqlite_ptr<char> sql;
+  if (dpp->get_cct()->_conf->subsys.should_gather<dout_subsys, 20>()) {
+    sql.reset(::sqlite3_expanded_sql(stmt.get()));
+  }
+
+  const int result = ::sqlite3_step(stmt.get());
+  auto ec = std::error_code{result, sqlite::error_category()};
+  if (ec != sqlite::errc::row) {
+    sqlite3* db = ::sqlite3_db_handle(stmt.get());
+    const char* errmsg = ::sqlite3_errmsg(db);
+    ldpp_dout(dpp, 1) << "evaluation failed: " << errmsg << " (" << ec
+        << ")\nstatement: " << sql.get() << dendl;
+    throw sqlite::error(errmsg, ec);
+  }
+  ldpp_dout(dpp, 20) << "evaluation succeeded: " << sql.get() << dendl;
+}
+
+int column_int(const stmt_execution& stmt, int column)
+{
+  return ::sqlite3_column_int(stmt.get(), column);
+}
+
+std::string column_text(const stmt_execution& stmt, int column)
+{
+  const unsigned char* text = ::sqlite3_column_text(stmt.get(), column);
+  // may be NULL
+  if (text) {
+    const std::size_t size = ::sqlite3_column_bytes(stmt.get(), column);
+    return {reinterpret_cast<const char*>(text), size};
+  } else {
+    return {};
+  }
+}
+
+auto read_text_rows(const DoutPrefixProvider* dpp,
+                    const stmt_execution& stmt,
+                    std::span<std::string> entries)
+  -> std::span<std::string>
+{
+  sqlite_ptr<char> sql;
+  if (dpp->get_cct()->_conf->subsys.should_gather<dout_subsys, 20>()) {
+    sql.reset(::sqlite3_expanded_sql(stmt.get()));
+  }
+
+  std::size_t count = 0;
+  while (count < entries.size()) {
+    const int result = ::sqlite3_step(stmt.get());
+    auto ec = std::error_code{result, sqlite::error_category()};
+    if (ec == sqlite::errc::done) {
+      break;
+    }
+    if (ec != sqlite::errc::row) {
+      sqlite3* db = ::sqlite3_db_handle(stmt.get());
+      const char* errmsg = ::sqlite3_errmsg(db);
+      ldpp_dout(dpp, 1) << "evaluation failed: " << errmsg << " (" << ec
+          << ")\nstatement: " << sql.get() << dendl;
+      throw sqlite::error(errmsg, ec);
+    }
+    entries[count] = column_text(stmt, 0);
+    ++count;
+  }
+  ldpp_dout(dpp, 20) << "statement evaluation produced " << count
+      << " results: " << sql.get() << dendl;
+
+  return entries.first(count);
+}
+
+void execute(const DoutPrefixProvider* dpp, sqlite3* db, const char* query,
+             sqlite3_callback callback, void* arg)
+{
+  char* errmsg = nullptr;
+  const int result = ::sqlite3_exec(db, query, callback, arg, &errmsg);
+  auto ec = std::error_code{result, sqlite::error_category()};
+  auto ptr = sqlite_ptr<char>{errmsg}; // free on destruction
+  if (ec != sqlite::errc::ok) {
+    ldpp_dout(dpp, 1) << "query execution failed: " << errmsg << " (" << ec
+        << ")\nquery: " << query << dendl;
+    throw sqlite::error(errmsg, ec);
+  }
+  ldpp_dout(dpp, 20) << "query execution succeeded: " << query << dendl;
+}
+
+} // namespace rgw::dbstore::sqlite

--- a/src/rgw/store/dbstore/sqlite/statement.h
+++ b/src/rgw/store/dbstore/sqlite/statement.h
@@ -1,0 +1,83 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <span>
+#include <string>
+
+#include <sqlite3.h>
+
+class DoutPrefixProvider;
+
+namespace rgw::dbstore::sqlite {
+
+// owning sqlite3_stmt pointer
+struct stmt_deleter {
+  void operator()(sqlite3_stmt* p) const { ::sqlite3_finalize(p); }
+};
+using stmt_ptr = std::unique_ptr<sqlite3_stmt, stmt_deleter>;
+
+// non-owning sqlite3_stmt pointer that clears binding state on destruction
+struct stmt_binding_deleter {
+  void operator()(sqlite3_stmt* p) const { ::sqlite3_clear_bindings(p); }
+};
+using stmt_binding = std::unique_ptr<sqlite3_stmt, stmt_binding_deleter>;
+
+// non-owning sqlite3_stmt pointer that clears execution state on destruction
+struct stmt_execution_deleter {
+  void operator()(sqlite3_stmt* p) const { ::sqlite3_reset(p); }
+};
+using stmt_execution = std::unique_ptr<sqlite3_stmt, stmt_execution_deleter>;
+
+
+// prepare the sql statement or throw on error
+stmt_ptr prepare_statement(const DoutPrefixProvider* dpp,
+                           sqlite3* db, std::string_view sql);
+
+// bind an input string for the given parameter name
+void bind_text(const DoutPrefixProvider* dpp, const stmt_binding& stmt,
+               const char* name, std::string_view value);
+
+// bind an input integer for the given parameter name
+void bind_int(const DoutPrefixProvider* dpp, const stmt_binding& stmt,
+              const char* name, int value);
+
+// evaluate a prepared statement, expecting no result rows
+void eval0(const DoutPrefixProvider* dpp, const stmt_execution& stmt);
+
+// evaluate a prepared statement, expecting a single result row
+void eval1(const DoutPrefixProvider* dpp, const stmt_execution& stmt);
+
+// return the given column as an integer
+int column_int(const stmt_execution& stmt, int column);
+
+// return the given column as text, or an empty string on NULL
+std::string column_text(const stmt_execution& stmt, int column);
+
+// read the text column from each result row into the given entries, and return
+// the sub-span of entries that contain results
+auto read_text_rows(const DoutPrefixProvider* dpp,
+                    const stmt_execution& stmt,
+                    std::span<std::string> entries)
+  -> std::span<std::string>;
+
+// execute a raw query without preparing a statement. the optional callback
+// can be used to read results
+void execute(const DoutPrefixProvider* dpp, sqlite3* db, const char* query,
+             sqlite3_callback callback, void* arg);
+
+} // namespace rgw::dbstore::sqlite

--- a/src/rgw/store/immutable_config/store.cc
+++ b/src/rgw/store/immutable_config/store.cc
@@ -1,0 +1,422 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_zone.h"
+#include "store.h"
+
+namespace rgw::sal {
+
+ImmutableConfigStore::ImmutableConfigStore(const RGWZoneGroup& zonegroup,
+                                           const RGWZoneParams& zone,
+                                           const RGWPeriodConfig& period_config)
+    : zonegroup(zonegroup), zone(zone), period_config(period_config)
+{
+}
+
+// Realm
+int ImmutableConfigStore::write_default_realm_id(const DoutPrefixProvider* dpp,
+                                                 optional_yield y, bool exclusive,
+                                                 std::string_view realm_id)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_default_realm_id(const DoutPrefixProvider* dpp,
+                                                optional_yield y,
+                                                std::string& realm_id)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                                  optional_yield y)
+{
+  return -EROFS;
+}
+
+
+int ImmutableConfigStore::create_realm(const DoutPrefixProvider* dpp,
+                                       optional_yield y, bool exclusive,
+                                       const RGWRealm& info,
+                                       std::unique_ptr<RealmWriter>* writer)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_realm_by_id(const DoutPrefixProvider* dpp,
+                                           optional_yield y,
+                                           std::string_view realm_id,
+                                           RGWRealm& info,
+                                           std::unique_ptr<RealmWriter>* writer)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::read_realm_by_name(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string_view realm_name,
+                                             RGWRealm& info,
+                                             std::unique_ptr<RealmWriter>* writer)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::read_default_realm(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             RGWRealm& info,
+                                             std::unique_ptr<RealmWriter>* writer)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::read_realm_id(const DoutPrefixProvider* dpp,
+                                        optional_yield y, std::string_view realm_name,
+                                        std::string& realm_id)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                                  optional_yield y,
+                                                  const RGWPeriod& period)
+{
+  return -ENOTSUP;
+}
+
+int ImmutableConfigStore::list_realm_names(const DoutPrefixProvider* dpp,
+                                           optional_yield y, const std::string& marker,
+                                           std::span<std::string> entries,
+                                           ListResult<std::string>& result)
+{
+  result.next.clear();
+  result.entries = entries.first(0);
+  return 0;
+}
+
+
+// Period
+int ImmutableConfigStore::create_period(const DoutPrefixProvider* dpp,
+                                        optional_yield y, bool exclusive,
+                                        const RGWPeriod& info)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_period(const DoutPrefixProvider* dpp,
+                                      optional_yield y, std::string_view period_id,
+                                      std::optional<uint32_t> epoch, RGWPeriod& info)
+{
+  return -ENOENT;
+}
+
+int ImmutableConfigStore::delete_period(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view period_id)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::list_period_ids(const DoutPrefixProvider* dpp,
+                                          optional_yield y, const std::string& marker,
+                                          std::span<std::string> entries,
+                                          ListResult<std::string>& result)
+{
+  result.next.clear();
+  result.entries = entries.first(0);
+  return 0;
+}
+
+
+// ZoneGroup
+
+class ImmutableZoneGroupWriter : public ZoneGroupWriter {
+ public:
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneGroup& info) override
+  {
+    return -EROFS;
+  }
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneGroup& info, std::string_view new_name) override
+  {
+    return -EROFS;
+  }
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    return -EROFS;
+  }
+};
+
+int ImmutableConfigStore::write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                     optional_yield y, bool exclusive,
+                                                     std::string_view realm_id,
+                                                     std::string_view zonegroup_id)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                    optional_yield y,
+                                                    std::string_view realm_id,
+                                                    std::string& zonegroup_id)
+{
+  if (!realm_id.empty()) {
+    return -ENOENT;
+  }
+  zonegroup_id = zonegroup.id;
+  return 0;
+}
+
+int ImmutableConfigStore::delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                      optional_yield y,
+                                                      std::string_view realm_id)
+{
+  return -EROFS;
+}
+
+
+int ImmutableConfigStore::create_zonegroup(const DoutPrefixProvider* dpp,
+                                           optional_yield y, bool exclusive,
+                                           const RGWZoneGroup& info,
+                                           std::unique_ptr<ZoneGroupWriter>* writer)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                               optional_yield y,
+                                               std::string_view zonegroup_id,
+                                               RGWZoneGroup& info,
+                                               std::unique_ptr<ZoneGroupWriter>* writer)
+{
+  if (zonegroup_id != zonegroup.id) {
+    return -ENOENT;
+  }
+
+  info = zonegroup;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneGroupWriter>();
+  }
+  return 0;
+}
+int ImmutableConfigStore::read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                                 optional_yield y,
+                                                 std::string_view zonegroup_name,
+                                                 RGWZoneGroup& info,
+                                                 std::unique_ptr<ZoneGroupWriter>* writer)
+{
+  if (zonegroup_name != zonegroup.name) {
+    return -ENOENT;
+  }
+
+  info = zonegroup;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneGroupWriter>();
+  }
+  return 0;
+}
+
+int ImmutableConfigStore::read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                                 optional_yield y,
+                                                 std::string_view realm_id,
+                                                 RGWZoneGroup& info,
+                                                 std::unique_ptr<ZoneGroupWriter>* writer)
+{
+  info = zonegroup;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneGroupWriter>();
+  }
+  return 0;
+}
+
+int ImmutableConfigStore::list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                               optional_yield y, const std::string& marker,
+                                               std::span<std::string> entries,
+                                               ListResult<std::string>& result)
+{
+  if (marker < zonegroup.name) {
+    entries[0] = zonegroup.name;
+    result.next = zonegroup.name;
+    result.entries = entries.first(1);
+  } else {
+    result.next.clear();
+    result.entries = entries.first(0);
+  }
+  return 0;
+}
+
+// Zone
+
+class ImmutableZoneWriter : public ZoneWriter {
+ public:
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneParams& info) override
+  {
+    return -EROFS;
+  }
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneParams& info, std::string_view new_name) override
+  {
+    return -EROFS;
+  }
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    return -EROFS;
+  }
+};
+
+int ImmutableConfigStore::write_default_zone_id(const DoutPrefixProvider* dpp,
+                                                optional_yield y, bool exclusive,
+                                                std::string_view realm_id,
+                                                std::string_view zone_id)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_default_zone_id(const DoutPrefixProvider* dpp,
+                                               optional_yield y,
+                                               std::string_view realm_id,
+                                               std::string& zone_id)
+{
+  if (realm_id.empty()) {
+    return -ENOENT;
+  }
+  zone_id = zone.id;
+  return 0;
+}
+
+int ImmutableConfigStore::delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                                 optional_yield y,
+                                                 std::string_view realm_id)
+{
+  return -EROFS;
+}
+
+
+int ImmutableConfigStore::create_zone(const DoutPrefixProvider* dpp,
+                                      optional_yield y, bool exclusive,
+                                      const RGWZoneParams& info,
+                                      std::unique_ptr<ZoneWriter>* writer)
+{
+  return -EROFS;
+}
+
+int ImmutableConfigStore::read_zone_by_id(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view zone_id,
+                                          RGWZoneParams& info,
+                                          std::unique_ptr<ZoneWriter>* writer)
+{
+  if (zone_id != zone.id) {
+    return -ENOENT;
+  }
+
+  info = zone;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneWriter>();
+  }
+  return 0;
+}
+
+int ImmutableConfigStore::read_zone_by_name(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            std::string_view zone_name,
+                                            RGWZoneParams& info,
+                                            std::unique_ptr<ZoneWriter>* writer)
+{
+  if (zone_name != zone.name) {
+    return -ENOENT;
+  }
+
+  info = zone;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneWriter>();
+  }
+  return 0;
+}
+
+int ImmutableConfigStore::read_default_zone(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            std::string_view realm_id,
+                                            RGWZoneParams& info,
+                                            std::unique_ptr<ZoneWriter>* writer)
+{
+  if (!realm_id.empty()) {
+    return -ENOENT;
+  }
+
+  info = zone;
+
+  if (writer) {
+    *writer = std::make_unique<ImmutableZoneWriter>();
+  }
+  return 0;
+}
+
+int ImmutableConfigStore::list_zone_names(const DoutPrefixProvider* dpp,
+                                          optional_yield y, const std::string& marker,
+                                          std::span<std::string> entries,
+                                          ListResult<std::string>& result)
+{
+  if (marker < zone.name) {
+    entries[0] = zone.name;
+    result.next = zone.name;
+    result.entries = entries.first(1);
+  } else {
+    result.next.clear();
+    result.entries = entries.first(0);
+  }
+  return 0;
+}
+
+
+// PeriodConfig
+int ImmutableConfigStore::read_period_config(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string_view realm_id,
+                                             RGWPeriodConfig& info)
+{
+  if (!realm_id.empty()) {
+    return -ENOENT;
+  }
+
+  info = period_config;
+  return 0;
+}
+
+int ImmutableConfigStore::write_period_config(const DoutPrefixProvider* dpp,
+                                              optional_yield y, bool exclusive,
+                                              std::string_view realm_id,
+                                              const RGWPeriodConfig& info)
+{
+  return -EROFS;
+}
+
+
+/// ImmutableConfigStore factory function
+auto create_immutable_config_store(const DoutPrefixProvider* dpp,
+                                   const RGWZoneGroup& zonegroup,
+                                   const RGWZoneParams& zone,
+                                   const RGWPeriodConfig& period_config)
+  -> std::unique_ptr<ConfigStore>
+{
+  return std::make_unique<ImmutableConfigStore>(zonegroup, zone, period_config);
+}
+
+} // namespace rgw::sal

--- a/src/rgw/store/immutable_config/store.h
+++ b/src/rgw/store/immutable_config/store.h
@@ -1,0 +1,180 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "rgw_sal_config.h"
+
+namespace rgw::sal {
+
+/// A read-only ConfigStore that serves the given default zonegroup and zone.
+class ImmutableConfigStore : public ConfigStore {
+ public:
+  explicit ImmutableConfigStore(const RGWZoneGroup& zonegroup,
+                                const RGWZoneParams& zone,
+                                const RGWPeriodConfig& period_config);
+
+  // Realm
+  virtual int write_default_realm_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y, bool exclusive,
+                                     std::string_view realm_id) override;
+  virtual int read_default_realm_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string& realm_id) override;
+  virtual int delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                      optional_yield y) override;
+
+  virtual int create_realm(const DoutPrefixProvider* dpp,
+                           optional_yield y, bool exclusive,
+                           const RGWRealm& info,
+                           std::unique_ptr<RealmWriter>* writer) override;
+  virtual int read_realm_by_id(const DoutPrefixProvider* dpp,
+                               optional_yield y,
+                               std::string_view realm_id,
+                               RGWRealm& info,
+                               std::unique_ptr<RealmWriter>* writer) override;
+  virtual int read_realm_by_name(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_name,
+                                 RGWRealm& info,
+                                 std::unique_ptr<RealmWriter>* writer) override;
+  virtual int read_default_realm(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 RGWRealm& info,
+                                 std::unique_ptr<RealmWriter>* writer) override;
+  virtual int read_realm_id(const DoutPrefixProvider* dpp,
+                            optional_yield y, std::string_view realm_name,
+                            std::string& realm_id) override;
+  virtual int realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const RGWPeriod& period) override;
+  virtual int list_realm_names(const DoutPrefixProvider* dpp,
+                               optional_yield y, const std::string& marker,
+                               std::span<std::string> entries,
+                               ListResult<std::string>& result) override;
+
+  // Period
+  virtual int create_period(const DoutPrefixProvider* dpp,
+                            optional_yield y, bool exclusive,
+                            const RGWPeriod& info) override;
+  virtual int read_period(const DoutPrefixProvider* dpp,
+                          optional_yield y, std::string_view period_id,
+                          std::optional<uint32_t> epoch, RGWPeriod& info) override;
+  virtual int delete_period(const DoutPrefixProvider* dpp,
+                            optional_yield y,
+                            std::string_view period_id) override;
+  virtual int list_period_ids(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              ListResult<std::string>& result) override;
+
+  // ZoneGroup
+  virtual int write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                         optional_yield y, bool exclusive,
+                                         std::string_view realm_id,
+                                         std::string_view zonegroup_id) override;
+  virtual int read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view realm_id,
+                                        std::string& zonegroup_id) override;
+  virtual int delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view realm_id) override;
+
+  virtual int create_zonegroup(const DoutPrefixProvider* dpp,
+                               optional_yield y, bool exclusive,
+                               const RGWZoneGroup& info,
+                               std::unique_ptr<ZoneGroupWriter>* writer) override;
+  virtual int read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view zonegroup_id,
+                                   RGWZoneGroup& info,
+                                   std::unique_ptr<ZoneGroupWriter>* writer) override;
+  virtual int read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view zonegroup_name,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<ZoneGroupWriter>* writer) override;
+  virtual int read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<ZoneGroupWriter>* writer) override;
+  virtual int list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                   optional_yield y, const std::string& marker,
+                                   std::span<std::string> entries,
+                                   ListResult<std::string>& result) override;
+
+  // Zone
+  virtual int write_default_zone_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y, bool exclusive,
+                                    std::string_view realm_id,
+                                    std::string_view zone_id) override;
+  virtual int read_default_zone_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view realm_id,
+                                   std::string& zone_id) override;
+  virtual int delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id) override;
+
+  virtual int create_zone(const DoutPrefixProvider* dpp,
+                          optional_yield y, bool exclusive,
+                          const RGWZoneParams& info,
+                          std::unique_ptr<ZoneWriter>* writer) override;
+  virtual int read_zone_by_id(const DoutPrefixProvider* dpp,
+                              optional_yield y,
+                              std::string_view zone_id,
+                              RGWZoneParams& info,
+                              std::unique_ptr<ZoneWriter>* writer) override;
+  virtual int read_zone_by_name(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view zone_name,
+                                RGWZoneParams& info,
+                                std::unique_ptr<ZoneWriter>* writer) override;
+  virtual int read_default_zone(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view realm_id,
+                                RGWZoneParams& info,
+                                std::unique_ptr<ZoneWriter>* writer) override;
+  virtual int list_zone_names(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              ListResult<std::string>& result) override;
+
+  // PeriodConfig
+  virtual int read_period_config(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_id,
+                                 RGWPeriodConfig& info) override;
+  virtual int write_period_config(const DoutPrefixProvider* dpp,
+                                  optional_yield y, bool exclusive,
+                                  std::string_view realm_id,
+                                  const RGWPeriodConfig& info) override;
+
+ private:
+  const RGWZoneGroup zonegroup;
+  const RGWZoneParams zone;
+  const RGWPeriodConfig period_config;
+}; // ImmutableConfigStore
+
+
+/// ImmutableConfigStore factory function
+auto create_immutable_config_store(const DoutPrefixProvider* dpp,
+                                   const RGWZoneGroup& zonegroup,
+                                   const RGWZoneParams& zone,
+                                   const RGWPeriodConfig& period_config)
+  -> std::unique_ptr<ConfigStore>;
+
+} // namespace rgw::sal

--- a/src/rgw/store/json_config/store.cc
+++ b/src/rgw/store/json_config/store.cc
@@ -1,0 +1,176 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <system_error>
+#include "include/buffer.h"
+#include "common/errno.h"
+#include "common/ceph_json.h"
+#include "rgw_zone.h"
+#include "store/immutable_config/store.h"
+#include "store.h"
+
+namespace rgw::sal {
+
+namespace {
+
+struct DecodedConfig {
+  RGWZoneGroup zonegroup;
+  RGWZoneParams zone;
+  RGWPeriodConfig period_config;
+
+  void decode_json(JSONObj *obj)
+  {
+    JSONDecoder::decode_json("zonegroup", zonegroup, obj);
+    JSONDecoder::decode_json("zone", zone, obj);
+    JSONDecoder::decode_json("period_config", period_config, obj);
+  }
+};
+
+static void parse_config(const DoutPrefixProvider* dpp, const char* filename)
+{
+  bufferlist bl;
+  std::string errmsg;
+  int r = bl.read_file(filename, &errmsg);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to read json config file '" << filename
+        << "': " << errmsg << dendl;
+    throw std::system_error(-r, std::system_category());
+  }
+
+  JSONParser p;
+  if (!p.parse(bl.c_str(), bl.length())) {
+    ldpp_dout(dpp, 0) << "failed to parse json config file" << dendl;
+    throw std::system_error(make_error_code(std::errc::invalid_argument));
+  }
+
+  DecodedConfig config;
+  try {
+    decode_json_obj(config, &p);
+  } catch (const JSONDecoder::err& e) {
+    ldpp_dout(dpp, 0) << "failed to decode JSON input: " << e.what() << dendl;
+    throw std::system_error(make_error_code(std::errc::invalid_argument));
+  }
+}
+
+void sanity_check_config(const DoutPrefixProvider* dpp, DecodedConfig& config)
+{
+  if (config.zonegroup.id.empty()) {
+    config.zonegroup.id = "default";
+  }
+  if (config.zonegroup.name.empty()) {
+    config.zonegroup.name = "default";
+  }
+  if (config.zonegroup.api_name.empty()) {
+    config.zonegroup.api_name = config.zonegroup.name;
+  }
+
+  if (config.zone.id.empty()) {
+    config.zone.id = "default";
+  }
+  if (config.zone.name.empty()) {
+    config.zone.name = "default";
+  }
+
+  // add default placement if it doesn't exist
+  rgw_pool pool;
+  RGWZonePlacementInfo placement;
+  placement.storage_classes.set_storage_class(
+      RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
+  config.zone.placement_pools.emplace("default-placement",
+                                      std::move(placement));
+
+  std::set<rgw_pool> pools;
+  int r = rgw::init_zone_pool_names(dpp, null_yield, pools, config.zone);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to set default zone pool names" << dendl;
+    throw std::system_error(-r, std::system_category());
+  }
+
+  // verify that config.zonegroup only contains config.zone
+  if (config.zonegroup.zones.size() > 1) {
+    ldpp_dout(dpp, 0) << "zonegroup cannot contain multiple zones" << dendl;
+    throw std::system_error(make_error_code(std::errc::invalid_argument));
+  }
+
+  if (config.zonegroup.zones.size() == 1) {
+    auto z = config.zonegroup.zones.begin();
+    if (z->first != config.zone.id) {
+      ldpp_dout(dpp, 0) << "zonegroup contains unknown zone id="
+          << z->first << dendl;
+      throw std::system_error(make_error_code(std::errc::invalid_argument));
+    }
+    if (z->second.id != config.zone.id) {
+      ldpp_dout(dpp, 0) << "zonegroup contains unknown zone id="
+          << z->second.id << dendl;
+      throw std::system_error(make_error_code(std::errc::invalid_argument));
+    }
+    if (z->second.name != config.zone.name) {
+      ldpp_dout(dpp, 0) << "zonegroup contains unknown zone name="
+          << z->second.name << dendl;
+      throw std::system_error(make_error_code(std::errc::invalid_argument));
+    }
+    if (config.zonegroup.master_zone != config.zone.id) {
+      ldpp_dout(dpp, 0) << "zonegroup contains unknown master_zone="
+          << config.zonegroup.master_zone << dendl;
+      throw std::system_error(make_error_code(std::errc::invalid_argument));
+    }
+  } else {
+    // add the zone to the group
+    const bool is_master = true;
+    const bool read_only = false;
+    std::list<std::string> endpoints;
+    std::list<std::string> sync_from;
+    std::list<std::string> sync_from_rm;
+    rgw::zone_features::set enable_features;
+    rgw::zone_features::set disable_features;
+
+    enable_features.insert(rgw::zone_features::supported.begin(),
+                           rgw::zone_features::supported.end());
+
+    int r = rgw::add_zone_to_group(dpp, config.zonegroup, config.zone,
+                                   &is_master, &read_only, endpoints,
+                                   nullptr, nullptr, sync_from, sync_from_rm,
+                                   nullptr, std::nullopt,
+                                   enable_features, disable_features);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to add zone to zonegroup: "
+          << cpp_strerror(r) << dendl;
+      throw std::system_error(-r, std::system_category());
+    }
+
+    config.zonegroup.enabled_features = std::move(enable_features);
+  }
+
+  // insert the default placement target if it doesn't exist
+  auto target = RGWZoneGroupPlacementTarget{.name = "default-placement"};
+  config.zonegroup.placement_targets.emplace(target.name, target);
+  if (config.zonegroup.default_placement.name.empty()) {
+    config.zonegroup.default_placement.name = target.name;
+  }
+}
+
+} // anonymous namespace
+
+auto create_json_config_store(const DoutPrefixProvider* dpp,
+                              const std::string& filename)
+    -> std::unique_ptr<ConfigStore>
+{
+  DecodedConfig config;
+  parse_config(dpp, filename.c_str());
+  sanity_check_config(dpp, config);
+  return create_immutable_config_store(dpp, config.zonegroup, config.zone,
+                                       config.period_config);
+}
+
+} // namespace rgw::sal

--- a/src/rgw/store/json_config/store.h
+++ b/src/rgw/store/json_config/store.h
@@ -1,0 +1,27 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "store/immutable_config/store.h"
+
+namespace rgw::sal {
+
+/// Create an immutable ConfigStore by parsing the zonegroup and zone from the
+/// given json filename.
+auto create_json_config_store(const DoutPrefixProvider* dpp,
+                              const std::string& filename)
+    -> std::unique_ptr<ConfigStore>;
+
+} // namespace rgw::sal

--- a/src/rgw/store/rados/config/impl.cc
+++ b/src/rgw/store/rados/config/impl.cc
@@ -1,0 +1,129 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "impl.h"
+
+#include "common/async/yield_context.h"
+#include "common/errno.h"
+#include "rgw_string.h"
+#include "rgw_zone.h"
+
+namespace rgw::rados {
+
+// default pool names
+constexpr std::string_view default_zone_root_pool = "rgw.root";
+constexpr std::string_view default_zonegroup_root_pool = "rgw.root";
+constexpr std::string_view default_realm_root_pool = "rgw.root";
+constexpr std::string_view default_period_root_pool = "rgw.root";
+
+static rgw_pool default_pool(std::string_view name,
+                             std::string_view default_name)
+{
+  return std::string{name_or_default(name, default_name)};
+}
+
+ConfigImpl::ConfigImpl(const ceph::common::ConfigProxy& conf)
+  : realm_pool(default_pool(conf->rgw_realm_root_pool,
+                            default_realm_root_pool)),
+    period_pool(default_pool(conf->rgw_period_root_pool,
+                             default_period_root_pool)),
+    zonegroup_pool(default_pool(conf->rgw_zonegroup_root_pool,
+                                default_zonegroup_root_pool)),
+    zone_pool(default_pool(conf->rgw_zone_root_pool,
+                           default_zone_root_pool))
+{
+}
+
+int ConfigImpl::read(const DoutPrefixProvider* dpp, optional_yield y,
+                     const rgw_pool& pool, const std::string& oid,
+                     bufferlist& bl, RGWObjVersionTracker* objv)
+{
+  librados::IoCtx ioctx;
+  int r = rgw_init_ioctx(dpp, &rados, pool, ioctx, true, false);
+  if (r < 0) {
+    return r;
+  }
+  librados::ObjectReadOperation op;
+  if (objv) {
+    objv->prepare_op_for_read(&op);
+  }
+  op.read(0, 0, &bl, nullptr);
+  return rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+}
+
+int ConfigImpl::write(const DoutPrefixProvider* dpp, optional_yield y,
+                      const rgw_pool& pool, const std::string& oid,
+                      Create create, const bufferlist& bl,
+                      RGWObjVersionTracker* objv)
+{
+  librados::IoCtx ioctx;
+  int r = rgw_init_ioctx(dpp, &rados, pool, ioctx, true, false);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::ObjectWriteOperation op;
+  switch (create) {
+    case Create::MustNotExist: op.create(true); break;
+    case Create::MayExist: op.create(false); break;
+    case Create::MustExist: op.assert_exists(); break;
+  }
+  if (objv) {
+    objv->prepare_op_for_write(&op);
+  }
+  op.write_full(bl);
+
+  r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  if (r >= 0 && objv) {
+    objv->apply_write();
+  }
+  return r;
+}
+
+int ConfigImpl::remove(const DoutPrefixProvider* dpp, optional_yield y,
+                       const rgw_pool& pool, const std::string& oid,
+                       RGWObjVersionTracker* objv)
+{
+  librados::IoCtx ioctx;
+  int r = rgw_init_ioctx(dpp, &rados, pool, ioctx, true, false);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::ObjectWriteOperation op;
+  if (objv) {
+    objv->prepare_op_for_write(&op);
+  }
+  op.remove();
+
+  r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  if (r >= 0 && objv) {
+    objv->apply_write();
+  }
+  return r;
+}
+
+int ConfigImpl::notify(const DoutPrefixProvider* dpp, optional_yield y,
+                       const rgw_pool& pool, const std::string& oid,
+                       bufferlist& bl, uint64_t timeout_ms)
+{
+  librados::IoCtx ioctx;
+  int r = rgw_init_ioctx(dpp, &rados, pool, ioctx, true, false);
+  if (r < 0) {
+    return r;
+  }
+  return rgw_rados_notify(dpp, ioctx, oid, bl, timeout_ms, nullptr, y);
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/impl.h
+++ b/src/rgw/store/rados/config/impl.h
@@ -1,0 +1,139 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "include/rados/librados.hpp"
+#include "common/dout.h"
+#include "rgw_basic_types.h"
+#include "rgw_tools.h"
+#include "rgw_sal_config.h"
+
+namespace rgw::rados {
+
+// write options that control object creation
+enum class Create {
+  MustNotExist, // fail with EEXIST if the object already exists
+  MayExist, // create if the object didn't exist, overwrite if it did
+  MustExist, // fail with ENOENT if the object doesn't exist
+};
+
+struct ConfigImpl {
+  librados::Rados rados;
+
+  const rgw_pool realm_pool;
+  const rgw_pool period_pool;
+  const rgw_pool zonegroup_pool;
+  const rgw_pool zone_pool;
+
+  ConfigImpl(const ceph::common::ConfigProxy& conf);
+
+  int read(const DoutPrefixProvider* dpp, optional_yield y,
+           const rgw_pool& pool, const std::string& oid,
+           bufferlist& bl, RGWObjVersionTracker* objv);
+
+  template <typename T>
+  int read(const DoutPrefixProvider* dpp, optional_yield y,
+           const rgw_pool& pool, const std::string& oid,
+           T& data, RGWObjVersionTracker* objv)
+  {
+    bufferlist bl;
+    int r = read(dpp, y, pool, oid, bl, objv);
+    if (r < 0) {
+      return r;
+    }
+    try {
+      auto p = bl.cbegin();
+      decode(data, p);
+    } catch (const buffer::error& err) {
+      ldpp_dout(dpp, 0) << "ERROR: failed to decode obj from "
+          << pool << ":" << oid << dendl;
+      return -EIO;
+    }
+    return 0;
+  }
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const rgw_pool& pool, const std::string& oid, Create create,
+            const bufferlist& bl, RGWObjVersionTracker* objv);
+
+  template <typename T>
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const rgw_pool& pool, const std::string& oid, Create create,
+            const T& data, RGWObjVersionTracker* objv)
+  {
+    bufferlist bl;
+    encode(data, bl);
+
+    return write(dpp, y, pool, oid, create, bl, objv);
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y,
+             const rgw_pool& pool, const std::string& oid,
+             RGWObjVersionTracker* objv);
+
+  int list(const DoutPrefixProvider* dpp, optional_yield y,
+           const rgw_pool& pool, const std::string& marker,
+           std::regular_invocable<std::string> auto filter,
+           std::span<std::string> entries,
+           sal::ListResult<std::string>& result)
+  {
+    librados::IoCtx ioctx;
+    int r = rgw_init_ioctx(dpp, &rados, pool, ioctx, true, false);
+    if (r < 0) {
+      return r;
+    }
+    librados::ObjectCursor oc;
+    if (!oc.from_str(marker)) {
+      ldpp_dout(dpp, 10) << "failed to parse cursor: " << marker << dendl;
+      return -EINVAL;
+    }
+    std::size_t count = 0;
+    try {
+      auto iter = ioctx.nobjects_begin(oc);
+      const auto end = ioctx.nobjects_end();
+      for (; count < entries.size() && iter != end; ++iter) {
+        std::string entry = filter(iter->get_oid());
+        if (!entry.empty()) {
+          entries[count++] = std::move(entry);
+        }
+      }
+      if (iter == end) {
+        result.next.clear();
+      } else {
+        result.next = iter.get_cursor().to_str();
+      }
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, 10) << "NObjectIterator exception " << e.what() << dendl;
+      return -EIO;
+    }
+    result.entries = entries.first(count);
+    return 0;
+  }
+
+  int notify(const DoutPrefixProvider* dpp, optional_yield y,
+             const rgw_pool& pool, const std::string& oid,
+             bufferlist& bl, uint64_t timeout_ms);
+};
+
+inline std::string_view name_or_default(std::string_view name,
+                                        std::string_view default_name)
+{
+  if (!name.empty()) {
+    return name;
+  }
+  return default_name;
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/period.cc
+++ b/src/rgw/store/rados/config/period.cc
@@ -1,0 +1,230 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "rgw_zone.h"
+#include "store/rados/config/store.h"
+
+#include "impl.h"
+
+namespace rgw::rados {
+
+// period oids
+constexpr std::string_view period_info_oid_prefix = "periods.";
+constexpr std::string_view period_latest_epoch_info_oid = ".latest_epoch";
+constexpr std::string_view period_staging_suffix = ":staging";
+
+static std::string period_oid(std::string_view period_id, uint32_t epoch)
+{
+  // omit the epoch for the staging period
+  if (period_id.ends_with(period_staging_suffix)) {
+    return string_cat_reserve(period_info_oid_prefix, period_id);
+  }
+  return fmt::format("{}{}.{}", period_info_oid_prefix, period_id, epoch);
+}
+
+static std::string latest_epoch_oid(const ceph::common::ConfigProxy& conf,
+                                    std::string_view period_id)
+{
+  return string_cat_reserve(
+      period_info_oid_prefix, period_id,
+      name_or_default(conf->rgw_period_latest_epoch_info_oid,
+                      period_latest_epoch_info_oid));
+}
+
+static int read_latest_epoch(const DoutPrefixProvider* dpp, optional_yield y,
+                             ConfigImpl* impl, std::string_view period_id,
+                             uint32_t& epoch, RGWObjVersionTracker* objv)
+{
+  const auto& pool = impl->period_pool;
+  const auto latest_oid = latest_epoch_oid(dpp->get_cct()->_conf, period_id);
+  RGWPeriodLatestEpochInfo latest;
+  int r = impl->read(dpp, y, pool, latest_oid, latest, objv);
+  if (r >= 0) {
+    epoch = latest.epoch;
+  }
+  return r;
+}
+
+static int write_latest_epoch(const DoutPrefixProvider* dpp, optional_yield y,
+                              ConfigImpl* impl, bool exclusive,
+                              std::string_view period_id, uint32_t epoch,
+                              RGWObjVersionTracker* objv)
+{
+  const auto& pool = impl->period_pool;
+  const auto latest_oid = latest_epoch_oid(dpp->get_cct()->_conf, period_id);
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+  RGWPeriodLatestEpochInfo latest{epoch};
+  return impl->write(dpp, y, pool, latest_oid, create, latest, objv);
+}
+
+static int delete_latest_epoch(const DoutPrefixProvider* dpp, optional_yield y,
+                               ConfigImpl* impl, std::string_view period_id,
+                               RGWObjVersionTracker* objv)
+{
+  const auto& pool = impl->period_pool;
+  const auto latest_oid = latest_epoch_oid(dpp->get_cct()->_conf, period_id);
+  return impl->remove(dpp, y, pool, latest_oid, objv);
+}
+
+static int update_latest_epoch(const DoutPrefixProvider* dpp, optional_yield y,
+                               ConfigImpl* impl, std::string_view period_id,
+                               uint32_t epoch)
+{
+  static constexpr int MAX_RETRIES = 20;
+
+  for (int i = 0; i < MAX_RETRIES; i++) {
+    uint32_t existing_epoch = 0;
+    RGWObjVersionTracker objv;
+    bool exclusive = false;
+
+    // read existing epoch
+    int r = read_latest_epoch(dpp, y, impl, period_id, existing_epoch, &objv);
+    if (r == -ENOENT) {
+      // use an exclusive create to set the epoch atomically
+      exclusive = true;
+      objv.generate_new_write_ver(dpp->get_cct());
+      ldpp_dout(dpp, 20) << "creating initial latest_epoch=" << epoch
+          << " for period=" << period_id << dendl;
+    } else if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed to read latest_epoch" << dendl;
+      return r;
+    } else if (epoch <= existing_epoch) {
+      r = -EEXIST; // fail with EEXIST if epoch is not newer
+      ldpp_dout(dpp, 10) << "found existing latest_epoch " << existing_epoch
+          << " >= given epoch " << epoch << ", returning r=" << r << dendl;
+      return r;
+    } else {
+      ldpp_dout(dpp, 20) << "updating latest_epoch from " << existing_epoch
+          << " -> " << epoch << " on period=" << period_id << dendl;
+    }
+
+    r = write_latest_epoch(dpp, y, impl, exclusive, period_id, epoch, &objv);
+    if (r == -EEXIST) {
+      continue; // exclusive create raced with another update, retry
+    } else if (r == -ECANCELED) {
+      continue; // write raced with a conflicting version, retry
+    }
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed to write latest_epoch" << dendl;
+      return r;
+    }
+    return 0; // return success
+  }
+
+  return -ECANCELED; // fail after max retries
+}
+
+int RadosConfigStore::create_period(const DoutPrefixProvider* dpp,
+                                    optional_yield y, bool exclusive,
+                                    const RGWPeriod& info)
+{
+  if (info.get_id().empty()) {
+    ldpp_dout(dpp, 0) << "period cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.get_epoch() == 0) {
+    ldpp_dout(dpp, 0) << "period cannot have an empty epoch" << dendl;
+    return -EINVAL;
+  }
+  const auto& pool = impl->period_pool;
+  const auto info_oid = period_oid(info.get_id(), info.get_epoch());
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+  RGWObjVersionTracker objv;
+  objv.generate_new_write_ver(dpp->get_cct());
+  int r = impl->write(dpp, y, pool, info_oid, create, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  (void) update_latest_epoch(dpp, y, impl.get(), info.get_id(), info.get_epoch());
+  return 0;
+}
+
+int RadosConfigStore::read_period(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view period_id,
+                                  std::optional<uint32_t> epoch,
+                                  RGWPeriod& info)
+{
+  int r = 0;
+  if (!epoch) {
+    epoch = 0;
+    r = read_latest_epoch(dpp, y, impl.get(), period_id, *epoch, nullptr);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  const auto& pool = impl->period_pool;
+  const auto info_oid = period_oid(period_id, *epoch);
+  return impl->read(dpp, y, pool, info_oid, info, nullptr);
+}
+
+int RadosConfigStore::delete_period(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string_view period_id)
+{
+  const auto& pool = impl->period_pool;
+
+  // read the latest_epoch
+  uint32_t latest_epoch = 0;
+  RGWObjVersionTracker latest_objv;
+  int r = read_latest_epoch(dpp, y, impl.get(), period_id,
+                            latest_epoch, &latest_objv);
+  if (r < 0 && r != -ENOENT) { // just delete epoch=0 on ENOENT
+    ldpp_dout(dpp, 0) << "failed to read latest epoch for period "
+        << period_id << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (uint32_t epoch = 0; epoch <= latest_epoch; epoch++) {
+    const auto info_oid = period_oid(period_id, epoch);
+    r = impl->remove(dpp, y, pool, info_oid, nullptr);
+    if (r < 0 && r != -ENOENT) { // ignore ENOENT
+      ldpp_dout(dpp, 0) << "failed to delete period " << info_oid
+          << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  return delete_latest_epoch(dpp, y, impl.get(), period_id, &latest_objv);
+}
+
+int RadosConfigStore::list_period_ids(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const std::string& marker,
+                                      std::span<std::string> entries,
+                                      sal::ListResult<std::string>& result)
+{
+  const auto& pool = impl->period_pool;
+  constexpr auto prefix = [] (std::string oid) -> std::string {
+      if (!oid.starts_with(period_info_oid_prefix)) {
+        return {};
+      }
+      if (!oid.ends_with(period_latest_epoch_info_oid)) {
+        return {};
+      }
+      // trim the prefix and suffix
+      const std::size_t count = oid.size() -
+          period_info_oid_prefix.size() -
+          period_latest_epoch_info_oid.size();
+      return oid.substr(period_info_oid_prefix.size(), count);
+    };
+
+  return impl->list(dpp, y, pool, marker, prefix, entries, result);
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/period_config.cc
+++ b/src/rgw/store/rados/config/period_config.cc
@@ -1,0 +1,55 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_zone.h"
+#include "store/rados/config/store.h"
+
+#include "impl.h"
+
+namespace rgw::rados {
+
+// period config oids
+constexpr std::string_view period_config_prefix = "period_config.";
+constexpr std::string_view period_config_realm_default = "default";
+
+std::string period_config_oid(std::string_view realm_id)
+{
+  if (realm_id.empty()) {
+    realm_id = period_config_realm_default;
+  }
+  return string_cat_reserve(period_config_prefix, realm_id);
+}
+
+int RadosConfigStore::read_period_config(const DoutPrefixProvider* dpp,
+                                         optional_yield y,
+                                         std::string_view realm_id,
+                                         RGWPeriodConfig& info)
+{
+  const auto& pool = impl->period_pool;
+  const auto oid = period_config_oid(realm_id);
+  return impl->read(dpp, y, pool, oid, info, nullptr);
+}
+
+int RadosConfigStore::write_period_config(const DoutPrefixProvider* dpp,
+                                          optional_yield y, bool exclusive,
+                                          std::string_view realm_id,
+                                          const RGWPeriodConfig& info)
+{
+  const auto& pool = impl->period_pool;
+  const auto oid = period_config_oid(realm_id);
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+  return impl->write(dpp, y, pool, oid, create, info, nullptr);
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/realm.cc
+++ b/src/rgw/store/rados/config/realm.cc
@@ -1,0 +1,364 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "rgw_realm_watcher.h"
+#include "rgw_zone.h"
+#include "store/rados/config/store.h"
+
+#include "impl.h"
+
+namespace rgw::rados {
+
+// realm oids
+constexpr std::string_view realm_names_oid_prefix = "realms_names.";
+constexpr std::string_view realm_info_oid_prefix = "realms.";
+constexpr std::string_view realm_control_oid_suffix = ".control";
+constexpr std::string_view default_realm_info_oid = "default.realm";
+
+static std::string realm_info_oid(std::string_view realm_id)
+{
+  return string_cat_reserve(realm_info_oid_prefix, realm_id);
+}
+static std::string realm_name_oid(std::string_view realm_id)
+{
+  return string_cat_reserve(realm_names_oid_prefix, realm_id);
+}
+static std::string realm_control_oid(std::string_view realm_id)
+{
+  return string_cat_reserve(realm_info_oid_prefix, realm_id,
+                            realm_control_oid_suffix);
+}
+static std::string default_realm_oid(const ceph::common::ConfigProxy& conf)
+{
+  return std::string{name_or_default(conf->rgw_default_realm_info_oid,
+                                     default_realm_info_oid)};
+}
+
+
+int RadosConfigStore::write_default_realm_id(const DoutPrefixProvider* dpp,
+                                             optional_yield y, bool exclusive,
+                                             std::string_view realm_id)
+{
+  const auto& pool = impl->realm_pool;
+  const auto oid = default_realm_oid(dpp->get_cct()->_conf);
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  default_info.default_id = realm_id;
+
+  return impl->write(dpp, y, pool, oid, create, default_info, nullptr);
+}
+
+int RadosConfigStore::read_default_realm_id(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            std::string& realm_id)
+{
+  const auto& pool = impl->realm_pool;
+  const auto oid = default_realm_oid(dpp->get_cct()->_conf);
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  int r = impl->read(dpp, y, pool, oid, default_info, nullptr);
+  if (r >= 0) {
+    realm_id = default_info.default_id;
+  }
+  return r;
+}
+
+int RadosConfigStore::delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                              optional_yield y)
+{
+  const auto& pool = impl->realm_pool;
+  const auto oid = default_realm_oid(dpp->get_cct()->_conf);
+
+  return impl->remove(dpp, y, pool, oid, nullptr);
+}
+
+
+class RadosRealmWriter : public sal::RealmWriter {
+  ConfigImpl* impl;
+  RGWObjVersionTracker objv;
+  std::string realm_id;
+  std::string realm_name;
+ public:
+  RadosRealmWriter(ConfigImpl* impl, RGWObjVersionTracker objv,
+                   std::string_view realm_id, std::string_view realm_name)
+    : impl(impl), objv(std::move(objv)),
+      realm_id(realm_id), realm_name(realm_name)
+  {
+  }
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWRealm& info) override
+  {
+    if (realm_id != info.get_id() || realm_name != info.get_name()) {
+      return -EINVAL; // can't modify realm id or name directly
+    }
+
+    const auto& pool = impl->realm_pool;
+    const auto info_oid = realm_info_oid(info.get_id());
+    return impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWRealm& info, std::string_view new_name) override
+  {
+    if (realm_id != info.get_id() || realm_name != info.get_name()) {
+      return -EINVAL; // can't modify realm id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "realm cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    const auto& pool = impl->realm_pool;
+    const auto name = RGWNameToId{info.get_id()};
+    const auto info_oid = realm_info_oid(info.get_id());
+    const auto old_oid = realm_name_oid(info.get_name());
+    const auto new_oid = realm_name_oid(new_name);
+
+    // link the new name
+    RGWObjVersionTracker new_objv;
+    new_objv.generate_new_write_ver(dpp->get_cct());
+    int r = impl->write(dpp, y, pool, new_oid, Create::MustNotExist,
+                        name, &new_objv);
+    if (r < 0) {
+      return r;
+    }
+
+    // write the info with updated name
+    info.set_name(std::string{new_name});
+    r = impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+    if (r < 0) {
+      // on failure, unlink the new name
+      (void) impl->remove(dpp, y, pool, new_oid, &new_objv);
+      return r;
+    }
+
+    // unlink the old name
+    (void) impl->remove(dpp, y, pool, old_oid, nullptr);
+
+    realm_name = new_name;
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    const auto& pool = impl->realm_pool;
+    const auto info_oid = realm_info_oid(realm_id);
+    int r = impl->remove(dpp, y, pool, info_oid, &objv);
+    if (r < 0) {
+      return r;
+    }
+    const auto name_oid = realm_name_oid(realm_name);
+    (void) impl->remove(dpp, y, pool, name_oid, nullptr);
+    const auto control_oid = realm_control_oid(realm_id);
+    (void) impl->remove(dpp, y, pool, control_oid, nullptr);
+    return 0;
+  }
+}; // RadosRealmWriter
+
+
+int RadosConfigStore::create_realm(const DoutPrefixProvider* dpp,
+                                   optional_yield y, bool exclusive,
+                                   const RGWRealm& info,
+                                   std::unique_ptr<sal::RealmWriter>* writer)
+{
+  if (info.get_id().empty()) {
+    ldpp_dout(dpp, 0) << "realm cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.get_name().empty()) {
+    ldpp_dout(dpp, 0) << "realm cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  const auto& pool = impl->realm_pool;
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  // write the realm info
+  const auto info_oid = realm_info_oid(info.get_id());
+  RGWObjVersionTracker objv;
+  objv.generate_new_write_ver(dpp->get_cct());
+
+  int r = impl->write(dpp, y, pool, info_oid, create, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  // write the realm name
+  const auto name_oid = realm_name_oid(info.get_name());
+  const auto name = RGWNameToId{info.get_id()};
+  RGWObjVersionTracker name_objv;
+  name_objv.generate_new_write_ver(dpp->get_cct());
+
+  r = impl->write(dpp, y, pool, name_oid, create, name, &name_objv);
+  if (r < 0) {
+    (void) impl->remove(dpp, y, pool, info_oid, &objv);
+    return r;
+  }
+
+  // create control object for watch/notify
+  const auto control_oid = realm_control_oid(info.get_id());
+  bufferlist empty_bl;
+  r = impl->write(dpp, y, pool, control_oid, Create::MayExist,
+                  empty_bl, nullptr);
+  if (r < 0) {
+    (void) impl->remove(dpp, y, pool, name_oid, &name_objv);
+    (void) impl->remove(dpp, y, pool, info_oid, &objv);
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosRealmWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_realm_by_id(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       std::string_view realm_id,
+                                       RGWRealm& info,
+                                       std::unique_ptr<sal::RealmWriter>* writer)
+{
+  const auto& pool = impl->realm_pool;
+  const auto info_oid = realm_info_oid(realm_id);
+  RGWObjVersionTracker objv;
+  int r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosRealmWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_realm_by_name(const DoutPrefixProvider* dpp,
+                                         optional_yield y,
+                                         std::string_view realm_name,
+                                         RGWRealm& info,
+                                         std::unique_ptr<sal::RealmWriter>* writer)
+{
+  const auto& pool = impl->realm_pool;
+
+  // look up realm id by name
+  RGWNameToId name;
+  const auto name_oid = realm_name_oid(realm_name);
+  int r = impl->read(dpp, y, pool, name_oid, name, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = realm_info_oid(name.obj_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosRealmWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_default_realm(const DoutPrefixProvider* dpp,
+                                         optional_yield y,
+                                         RGWRealm& info,
+                                         std::unique_ptr<sal::RealmWriter>* writer)
+{
+  const auto& pool = impl->realm_pool;
+
+  // read default realm id
+  RGWDefaultSystemMetaObjInfo default_info;
+  const auto default_oid = default_realm_oid(dpp->get_cct()->_conf);
+  int r = impl->read(dpp, y, pool, default_oid, default_info, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = realm_info_oid(default_info.default_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosRealmWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_realm_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string_view realm_name,
+                                    std::string& realm_id)
+{
+  const auto& pool = impl->realm_pool;
+  RGWNameToId name;
+
+  // look up realm id by name
+  const auto name_oid = realm_name_oid(realm_name);
+  int r = impl->read(dpp, y, pool, name_oid, name, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  realm_id = std::move(name.obj_id);
+  return 0;
+}
+
+int RadosConfigStore::realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                              optional_yield y,
+                                              const RGWPeriod& period)
+{
+  const auto& pool = impl->realm_pool;
+  const auto control_oid = realm_control_oid(period.get_realm());
+
+  bufferlist bl;
+  using ceph::encode;
+  // push the period to dependent zonegroups/zones
+  encode(RGWRealmNotify::ZonesNeedPeriod, bl);
+  encode(period, bl);
+  // reload the gateway with the new period
+  encode(RGWRealmNotify::Reload, bl);
+
+  constexpr uint64_t timeout_ms = 0;
+  return impl->notify(dpp, y, pool, control_oid, bl, timeout_ms);
+}
+
+int RadosConfigStore::list_realm_names(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       const std::string& marker,
+                                       std::span<std::string> entries,
+                                       sal::ListResult<std::string>& result)
+{
+  const auto& pool = impl->realm_pool;
+  constexpr auto prefix = [] (std::string oid) -> std::string {
+      if (!oid.starts_with(realm_names_oid_prefix)) {
+        return {};
+      }
+      return oid.substr(realm_names_oid_prefix.size());
+    };
+  return impl->list(dpp, y, pool, marker, prefix, entries, result);
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/store.cc
+++ b/src/rgw/store/rados/config/store.cc
@@ -1,0 +1,52 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "include/rados/librados.hpp"
+#include "common/errno.h"
+#include "impl.h"
+#include "store.h"
+
+namespace rgw::rados {
+
+RadosConfigStore::RadosConfigStore(std::unique_ptr<ConfigImpl> impl)
+  : impl(std::move(impl))
+{
+}
+
+RadosConfigStore::~RadosConfigStore() = default;
+
+
+auto create_config_store(const DoutPrefixProvider* dpp)
+    -> std::unique_ptr<RadosConfigStore>
+{
+  auto impl = std::make_unique<ConfigImpl>(dpp->get_cct()->_conf);
+
+  // initialize a Rados client
+  int r = impl->rados.init_with_context(dpp->get_cct());
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << "Rados client initialization failed with "
+        << cpp_strerror(-r) << dendl;
+    return nullptr;
+  }
+  r = impl->rados.connect();
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << "Rados client connection failed with "
+        << cpp_strerror(-r) << dendl;
+    return nullptr;
+  }
+
+  return std::make_unique<RadosConfigStore>(std::move(impl));
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/store.h
+++ b/src/rgw/store/rados/config/store.h
@@ -1,0 +1,182 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <string>
+#include "rgw_common.h"
+#include "rgw_sal_config.h"
+
+class DoutPrefixProvider;
+class optional_yield;
+
+namespace rgw::rados {
+
+struct ConfigImpl;
+
+class RadosConfigStore : public sal::ConfigStore {
+ public:
+  explicit RadosConfigStore(std::unique_ptr<ConfigImpl> impl);
+  virtual ~RadosConfigStore() override;
+
+  // Realm
+  virtual int write_default_realm_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y, bool exclusive,
+                                     std::string_view realm_id) override;
+  virtual int read_default_realm_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string& realm_id) override;
+  virtual int delete_default_realm_id(const DoutPrefixProvider* dpp,
+                                      optional_yield y) override;
+
+  virtual int create_realm(const DoutPrefixProvider* dpp,
+                           optional_yield y, bool exclusive,
+                           const RGWRealm& info,
+                           std::unique_ptr<sal::RealmWriter>* writer) override;
+  virtual int read_realm_by_id(const DoutPrefixProvider* dpp,
+                               optional_yield y,
+                               std::string_view realm_id,
+                               RGWRealm& info,
+                               std::unique_ptr<sal::RealmWriter>* writer) override;
+  virtual int read_realm_by_name(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_name,
+                                 RGWRealm& info,
+                                 std::unique_ptr<sal::RealmWriter>* writer) override;
+  virtual int read_default_realm(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 RGWRealm& info,
+                                 std::unique_ptr<sal::RealmWriter>* writer) override;
+  virtual int read_realm_id(const DoutPrefixProvider* dpp,
+                            optional_yield y, std::string_view realm_name,
+                            std::string& realm_id) override;
+  virtual int realm_notify_new_period(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const RGWPeriod& period) override;
+  virtual int list_realm_names(const DoutPrefixProvider* dpp,
+                               optional_yield y, const std::string& marker,
+                               std::span<std::string> entries,
+                               sal::ListResult<std::string>& result) override;
+
+  // Period
+  virtual int create_period(const DoutPrefixProvider* dpp,
+                            optional_yield y, bool exclusive,
+                            const RGWPeriod& info) override;
+  virtual int read_period(const DoutPrefixProvider* dpp,
+                          optional_yield y, std::string_view period_id,
+                          std::optional<uint32_t> epoch, RGWPeriod& info) override;
+  virtual int delete_period(const DoutPrefixProvider* dpp,
+                            optional_yield y,
+                            std::string_view period_id) override;
+  virtual int list_period_ids(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              sal::ListResult<std::string>& result) override;
+
+  // ZoneGroup
+  virtual int write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                         optional_yield y, bool exclusive,
+                                         std::string_view realm_id,
+                                         std::string_view zonegroup_id) override;
+  virtual int read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view realm_id,
+                                        std::string& zonegroup_id) override;
+  virtual int delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                          optional_yield y,
+                                          std::string_view realm_id) override;
+
+  virtual int create_zonegroup(const DoutPrefixProvider* dpp,
+                               optional_yield y, bool exclusive,
+                               const RGWZoneGroup& info,
+                               std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  virtual int read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view zonegroup_id,
+                                   RGWZoneGroup& info,
+                                   std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  virtual int read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view zonegroup_name,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  virtual int read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id,
+                                     RGWZoneGroup& info,
+                                     std::unique_ptr<sal::ZoneGroupWriter>* writer) override;
+  virtual int list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                   optional_yield y, const std::string& marker,
+                                   std::span<std::string> entries,
+                                   sal::ListResult<std::string>& result) override;
+
+  // Zone
+  virtual int write_default_zone_id(const DoutPrefixProvider* dpp,
+                                    optional_yield y, bool exclusive,
+                                    std::string_view realm_id,
+                                    std::string_view zone_id) override;
+  virtual int read_default_zone_id(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view realm_id,
+                                   std::string& zone_id) override;
+  virtual int delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view realm_id) override;
+
+  virtual int create_zone(const DoutPrefixProvider* dpp,
+                          optional_yield y, bool exclusive,
+                          const RGWZoneParams& info,
+                          std::unique_ptr<sal::ZoneWriter>* writer) override;
+  virtual int read_zone_by_id(const DoutPrefixProvider* dpp,
+                              optional_yield y,
+                              std::string_view zone_id,
+                              RGWZoneParams& info,
+                              std::unique_ptr<sal::ZoneWriter>* writer) override;
+  virtual int read_zone_by_name(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view zone_name,
+                                RGWZoneParams& info,
+                                std::unique_ptr<sal::ZoneWriter>* writer) override;
+  virtual int read_default_zone(const DoutPrefixProvider* dpp,
+                                optional_yield y,
+                                std::string_view realm_id,
+                                RGWZoneParams& info,
+                                std::unique_ptr<sal::ZoneWriter>* writer) override;
+  virtual int list_zone_names(const DoutPrefixProvider* dpp,
+                              optional_yield y, const std::string& marker,
+                              std::span<std::string> entries,
+                              sal::ListResult<std::string>& result) override;
+
+  // PeriodConfig
+  virtual int read_period_config(const DoutPrefixProvider* dpp,
+                                 optional_yield y,
+                                 std::string_view realm_id,
+                                 RGWPeriodConfig& info) override;
+  virtual int write_period_config(const DoutPrefixProvider* dpp,
+                                  optional_yield y, bool exclusive,
+                                  std::string_view realm_id,
+                                  const RGWPeriodConfig& info) override;
+
+ private:
+  std::unique_ptr<ConfigImpl> impl;
+}; // RadosConfigStore
+
+
+/// RadosConfigStore factory function
+auto create_config_store(const DoutPrefixProvider* dpp)
+    -> std::unique_ptr<RadosConfigStore>;
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/zone.cc
+++ b/src/rgw/store/rados/config/zone.cc
@@ -1,0 +1,312 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "rgw_zone.h"
+#include "store/rados/config/store.h"
+
+#include "impl.h"
+
+namespace rgw::rados {
+
+// zone oids
+constexpr std::string_view zone_info_oid_prefix = "zone_info.";
+constexpr std::string_view zone_names_oid_prefix = "zone_names.";
+
+std::string zone_info_oid(std::string_view zone_id)
+{
+  return string_cat_reserve(zone_info_oid_prefix, zone_id);
+}
+std::string zone_name_oid(std::string_view zone_id)
+{
+  return string_cat_reserve(zone_names_oid_prefix, zone_id);
+}
+std::string default_zone_oid(const ceph::common::ConfigProxy& conf,
+                             std::string_view realm_id)
+{
+  return fmt::format("{}.{}", conf->rgw_default_zone_info_oid, realm_id);
+}
+
+
+int RadosConfigStore::write_default_zone_id(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            bool exclusive,
+                                            std::string_view realm_id,
+                                            std::string_view zone_id)
+{
+  const auto& pool = impl->zone_pool;
+  const auto default_oid = default_zone_oid(dpp->get_cct()->_conf, realm_id);
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  default_info.default_id = zone_id;
+
+  return impl->write(dpp, y, pool, default_oid, create, default_info, nullptr);
+}
+
+int RadosConfigStore::read_default_zone_id(const DoutPrefixProvider* dpp,
+                                           optional_yield y,
+                                           std::string_view realm_id,
+                                           std::string& zone_id)
+{
+  const auto& pool = impl->zone_pool;
+  const auto default_oid = default_zone_oid(dpp->get_cct()->_conf, realm_id);
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  int r = impl->read(dpp, y, pool, default_oid, default_info, nullptr);
+  if (r >= 0) {
+    zone_id = default_info.default_id;
+  }
+  return r;
+}
+
+int RadosConfigStore::delete_default_zone_id(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string_view realm_id)
+{
+  const auto& pool = impl->zone_pool;
+  const auto default_oid = default_zone_oid(dpp->get_cct()->_conf, realm_id);
+
+  return impl->remove(dpp, y, pool, default_oid, nullptr);
+}
+
+
+class RadosZoneWriter : public sal::ZoneWriter {
+  ConfigImpl* impl;
+  RGWObjVersionTracker objv;
+  std::string zone_id;
+  std::string zone_name;
+ public:
+  RadosZoneWriter(ConfigImpl* impl, RGWObjVersionTracker objv,
+                  std::string_view zone_id, std::string_view zone_name)
+      : impl(impl), objv(std::move(objv)),
+        zone_id(zone_id), zone_name(zone_name)
+  {
+  }
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneParams& info) override
+  {
+    if (zone_id != info.get_id() || zone_name != info.get_name()) {
+      return -EINVAL; // can't modify zone id or name directly
+    }
+
+    const auto& pool = impl->zone_pool;
+    const auto info_oid = zone_info_oid(info.get_id());
+    return impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneParams& info, std::string_view new_name) override
+  {
+    if (zone_id != info.get_id() || zone_name != info.get_name()) {
+      return -EINVAL; // can't modify zone id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "zone cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    const auto& pool = impl->zone_pool;
+    const auto name = RGWNameToId{info.get_id()};
+    const auto info_oid = zone_info_oid(info.get_id());
+    const auto old_oid = zone_name_oid(info.get_name());
+    const auto new_oid = zone_name_oid(new_name);
+
+    // link the new name
+    RGWObjVersionTracker new_objv;
+    new_objv.generate_new_write_ver(dpp->get_cct());
+    int r = impl->write(dpp, y, pool, new_oid, Create::MustNotExist,
+                        name, &new_objv);
+    if (r < 0) {
+      return r;
+    }
+
+    // write the info with updated name
+    info.set_name(std::string{new_name});
+    r = impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+    if (r < 0) {
+      // on failure, unlink the new name
+      (void) impl->remove(dpp, y, pool, new_oid, &new_objv);
+      return r;
+    }
+
+    // unlink the old name
+    (void) impl->remove(dpp, y, pool, old_oid, nullptr);
+
+    zone_name = new_name;
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    const auto& pool = impl->zone_pool;
+    const auto info_oid = zone_info_oid(zone_id);
+    int r = impl->remove(dpp, y, pool, info_oid, &objv);
+    if (r < 0) {
+      return r;
+    }
+    const auto name_oid = zone_name_oid(zone_name);
+    (void) impl->remove(dpp, y, pool, name_oid, nullptr);
+    return 0;
+  }
+}; // RadosZoneWriter
+
+
+int RadosConfigStore::create_zone(const DoutPrefixProvider* dpp,
+                                  optional_yield y, bool exclusive,
+                                  const RGWZoneParams& info,
+                                  std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  if (info.get_id().empty()) {
+    ldpp_dout(dpp, 0) << "zone cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.get_name().empty()) {
+    ldpp_dout(dpp, 0) << "zone cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  const auto& pool = impl->zone_pool;
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  // write the zone info
+  const auto info_oid = zone_info_oid(info.get_id());
+  RGWObjVersionTracker objv;
+  objv.generate_new_write_ver(dpp->get_cct());
+
+  int r = impl->write(dpp, y, pool, info_oid, create, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  // write the zone name
+  const auto name_oid = zone_name_oid(info.get_name());
+  const auto name = RGWNameToId{info.get_id()};
+  RGWObjVersionTracker name_objv;
+  name_objv.generate_new_write_ver(dpp->get_cct());
+
+  r = impl->write(dpp, y, pool, name_oid, create, name, &name_objv);
+  if (r < 0) {
+    (void) impl->remove(dpp, y, pool, info_oid, &objv);
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_zone_by_id(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      std::string_view zone_id,
+                                      RGWZoneParams& info,
+                                      std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  const auto& pool = impl->zone_pool;
+  const auto info_oid = zone_info_oid(zone_id);
+  RGWObjVersionTracker objv;
+
+  int r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_zone_by_name(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view zone_name,
+                                        RGWZoneParams& info,
+                                        std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  const auto& pool = impl->zone_pool;
+
+  // look up zone id by name
+  const auto name_oid = zone_name_oid(zone_name);
+  RGWNameToId name;
+  int r = impl->read(dpp, y, pool, name_oid, name, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = zone_info_oid(name.obj_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_default_zone(const DoutPrefixProvider* dpp,
+                                        optional_yield y,
+                                        std::string_view realm_id,
+                                        RGWZoneParams& info,
+                                        std::unique_ptr<sal::ZoneWriter>* writer)
+{
+  const auto& pool = impl->zone_pool;
+
+  // read default zone id
+  const auto default_oid = default_zone_oid(dpp->get_cct()->_conf, realm_id);
+  RGWDefaultSystemMetaObjInfo default_info;
+  int r = impl->read(dpp, y, pool, default_oid, default_info, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = zone_info_oid(default_info.default_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::list_zone_names(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const std::string& marker,
+                                      std::span<std::string> entries,
+                                      sal::ListResult<std::string>& result)
+{
+  const auto& pool = impl->zone_pool;
+  constexpr auto prefix = [] (std::string oid) -> std::string {
+      if (!oid.starts_with(zone_names_oid_prefix)) {
+        return {};
+      }
+      return oid.substr(zone_names_oid_prefix.size());
+    };
+  return impl->list(dpp, y, pool, marker, prefix, entries, result);
+}
+
+} // namespace rgw::rados

--- a/src/rgw/store/rados/config/zonegroup.cc
+++ b/src/rgw/store/rados/config/zonegroup.cc
@@ -1,0 +1,315 @@
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "rgw_zone.h"
+#include "store/rados/config/store.h"
+
+#include "impl.h"
+
+namespace rgw::rados {
+
+// zonegroup oids
+constexpr std::string_view zonegroup_names_oid_prefix = "zonegroups_names.";
+constexpr std::string_view zonegroup_info_oid_prefix = "zonegroup_info.";
+constexpr std::string_view default_zonegroup_info_oid = "default.zonegroup";
+
+static std::string zonegroup_info_oid(std::string_view zonegroup_id)
+{
+  return string_cat_reserve(zonegroup_info_oid_prefix, zonegroup_id);
+}
+static std::string zonegroup_name_oid(std::string_view zonegroup_id)
+{
+  return string_cat_reserve(zonegroup_names_oid_prefix, zonegroup_id);
+}
+static std::string default_zonegroup_oid(const ceph::common::ConfigProxy& conf,
+                                         std::string_view realm_id)
+{
+  const auto prefix = name_or_default(conf->rgw_default_zonegroup_info_oid,
+                                      default_zonegroup_info_oid);
+  return fmt::format("{}.{}", prefix, realm_id);
+}
+
+
+int RadosConfigStore::write_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                 optional_yield y,
+                                                 bool exclusive,
+                                                 std::string_view realm_id,
+                                                 std::string_view zonegroup_id)
+{
+  const auto& pool = impl->zonegroup_pool;
+  const auto oid = default_zonegroup_oid(dpp->get_cct()->_conf, realm_id);
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  default_info.default_id = zonegroup_id;
+
+  return impl->write(dpp, y, pool, oid, create, default_info, nullptr);
+}
+
+int RadosConfigStore::read_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                optional_yield y,
+                                                std::string_view realm_id,
+                                                std::string& zonegroup_id)
+{
+  const auto& pool = impl->zonegroup_pool;
+  const auto oid = default_zonegroup_oid(dpp->get_cct()->_conf, realm_id);
+
+  RGWDefaultSystemMetaObjInfo default_info;
+  int r = impl->read(dpp, y, pool, oid, default_info, nullptr);
+  if (r >= 0) {
+    zonegroup_id = default_info.default_id;
+  }
+  return r;
+}
+
+int RadosConfigStore::delete_default_zonegroup_id(const DoutPrefixProvider* dpp,
+                                                  optional_yield y,
+                                                  std::string_view realm_id)
+{
+  const auto& pool = impl->zonegroup_pool;
+  const auto oid = default_zonegroup_oid(dpp->get_cct()->_conf, realm_id);
+  return impl->remove(dpp, y, pool, oid, nullptr);
+}
+
+
+class RadosZoneGroupWriter : public sal::ZoneGroupWriter {
+  ConfigImpl* impl;
+  RGWObjVersionTracker objv;
+  std::string zonegroup_id;
+  std::string zonegroup_name;
+ public:
+  RadosZoneGroupWriter(ConfigImpl* impl, RGWObjVersionTracker objv,
+                       std::string_view zonegroup_id,
+                       std::string_view zonegroup_name)
+    : impl(impl), objv(std::move(objv)),
+      zonegroup_id(zonegroup_id), zonegroup_name(zonegroup_name)
+  {
+  }
+
+  int write(const DoutPrefixProvider* dpp, optional_yield y,
+            const RGWZoneGroup& info) override
+  {
+    if (zonegroup_id != info.get_id() || zonegroup_name != info.get_name()) {
+      return -EINVAL; // can't modify zonegroup id or name directly
+    }
+
+    const auto& pool = impl->zonegroup_pool;
+    const auto info_oid = zonegroup_info_oid(info.get_id());
+    return impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+  }
+
+  int rename(const DoutPrefixProvider* dpp, optional_yield y,
+             RGWZoneGroup& info, std::string_view new_name) override
+  {
+    if (zonegroup_id != info.get_id() || zonegroup_name != info.get_name()) {
+      return -EINVAL; // can't modify zonegroup id or name directly
+    }
+    if (new_name.empty()) {
+      ldpp_dout(dpp, 0) << "zonegroup cannot have an empty name" << dendl;
+      return -EINVAL;
+    }
+
+    const auto& pool = impl->zonegroup_pool;
+    const auto name = RGWNameToId{info.get_id()};
+    const auto info_oid = zonegroup_info_oid(info.get_id());
+    const auto old_oid = zonegroup_name_oid(info.get_name());
+    const auto new_oid = zonegroup_name_oid(new_name);
+
+    // link the new name
+    RGWObjVersionTracker new_objv;
+    new_objv.generate_new_write_ver(dpp->get_cct());
+    int r = impl->write(dpp, y, pool, new_oid, Create::MustNotExist,
+                        name, &new_objv);
+    if (r < 0) {
+      return r;
+    }
+
+    // write the info with updated name
+    info.set_name(std::string{new_name});
+    r = impl->write(dpp, y, pool, info_oid, Create::MustExist, info, &objv);
+    if (r < 0) {
+      // on failure, unlink the new name
+      (void) impl->remove(dpp, y, pool, new_oid, &new_objv);
+      return r;
+    }
+
+    // unlink the old name
+    (void) impl->remove(dpp, y, pool, old_oid, nullptr);
+
+    zonegroup_name = new_name;
+    return 0;
+  }
+
+  int remove(const DoutPrefixProvider* dpp, optional_yield y) override
+  {
+    const auto& pool = impl->zonegroup_pool;
+    const auto info_oid = zonegroup_info_oid(zonegroup_id);
+    int r = impl->remove(dpp, y, pool, info_oid, &objv);
+    if (r < 0) {
+      return r;
+    }
+    const auto name_oid = zonegroup_name_oid(zonegroup_name);
+    (void) impl->remove(dpp, y, pool, name_oid, nullptr);
+    return 0;
+  }
+}; // RadosZoneGroupWriter
+
+
+int RadosConfigStore::create_zonegroup(const DoutPrefixProvider* dpp,
+                                       optional_yield y, bool exclusive,
+                                       const RGWZoneGroup& info,
+                                       std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  if (info.get_id().empty()) {
+    ldpp_dout(dpp, 0) << "zonegroup cannot have an empty id" << dendl;
+    return -EINVAL;
+  }
+  if (info.get_name().empty()) {
+    ldpp_dout(dpp, 0) << "zonegroup cannot have an empty name" << dendl;
+    return -EINVAL;
+  }
+
+  const auto& pool = impl->zonegroup_pool;
+  const auto create = exclusive ? Create::MustNotExist : Create::MayExist;
+
+  // write the zonegroup info
+  const auto info_oid = zonegroup_info_oid(info.get_id());
+  RGWObjVersionTracker objv;
+  objv.generate_new_write_ver(dpp->get_cct());
+
+  int r = impl->write(dpp, y, pool, info_oid, create, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  // write the zonegroup name
+  const auto name_oid = zonegroup_name_oid(info.get_name());
+  const auto name = RGWNameToId{info.get_id()};
+  RGWObjVersionTracker name_objv;
+  name_objv.generate_new_write_ver(dpp->get_cct());
+
+  r = impl->write(dpp, y, pool, name_oid, create, name, &name_objv);
+  if (r < 0) {
+    (void) impl->remove(dpp, y, pool, info_oid, &objv);
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneGroupWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_zonegroup_by_id(const DoutPrefixProvider* dpp,
+                                           optional_yield y,
+                                           std::string_view zonegroup_id,
+                                           RGWZoneGroup& info,
+                                           std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  const auto& pool = impl->zonegroup_pool;
+  const auto info_oid = zonegroup_info_oid(zonegroup_id);
+  RGWObjVersionTracker objv;
+
+  int r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneGroupWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_zonegroup_by_name(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string_view zonegroup_name,
+                                             RGWZoneGroup& info,
+                                             std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  const auto& pool = impl->zonegroup_pool;
+
+  // look up zonegroup id by name
+  RGWNameToId name;
+  const auto name_oid = zonegroup_name_oid(zonegroup_name);
+  int r = impl->read(dpp, y, pool, name_oid, name, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = zonegroup_info_oid(name.obj_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneGroupWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::read_default_zonegroup(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             std::string_view realm_id,
+                                             RGWZoneGroup& info,
+                                             std::unique_ptr<sal::ZoneGroupWriter>* writer)
+{
+  const auto& pool = impl->zonegroup_pool;
+
+  // read default zonegroup id
+  RGWDefaultSystemMetaObjInfo default_info;
+  const auto default_oid = default_zonegroup_oid(dpp->get_cct()->_conf, realm_id);
+  int r = impl->read(dpp, y, pool, default_oid, default_info, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const auto info_oid = zonegroup_info_oid(default_info.default_id);
+  RGWObjVersionTracker objv;
+  r = impl->read(dpp, y, pool, info_oid, info, &objv);
+  if (r < 0) {
+    return r;
+  }
+
+  if (writer) {
+    *writer = std::make_unique<RadosZoneGroupWriter>(
+        impl.get(), std::move(objv), info.get_id(), info.get_name());
+  }
+  return 0;
+}
+
+int RadosConfigStore::list_zonegroup_names(const DoutPrefixProvider* dpp,
+                                           optional_yield y,
+                                           const std::string& marker,
+                                           std::span<std::string> entries,
+                                           sal::ListResult<std::string>& result)
+{
+  const auto& pool = impl->zonegroup_pool;
+  constexpr auto prefix = [] (std::string oid) -> std::string {
+      if (!oid.starts_with(zonegroup_names_oid_prefix)) {
+        return {};
+      }
+      return oid.substr(zonegroup_names_oid_prefix.size());
+    };
+  return impl->list(dpp, y, pool, marker, prefix, entries, result);
+}
+
+} // namespace rgw::rados


### PR DESCRIPTION
adds a `rgw::sal::ConfigStore` that can read/write all realm/zonegroup/zone objects

adds a global `RGWZoneConfig` object for use above zipper

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
