### PR TITLE
osd/scrub: improving scrub logs

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1685,10 +1685,8 @@ std::optional<requested_scrub_t> PG::validate_scrub_mode() const
  */
 void PG::on_info_history_change()
 {
-  dout(20) << __func__ << " for a " << (is_primary() ? "Primary" : "non-primary") <<dendl;
-
   ceph_assert(m_scrubber);
-  m_scrubber->on_maybe_registration_change(m_planned_scrub);
+  m_scrubber->on_primary_change(__func__, m_planned_scrub);
 }
 
 void PG::reschedule_scrub()
@@ -1705,10 +1703,9 @@ void PG::reschedule_scrub()
 void PG::on_primary_status_change(bool was_primary, bool now_primary)
 {
   // make sure we have a working scrubber when becoming a primary
-
   if (was_primary != now_primary) {
     ceph_assert(m_scrubber);
-    m_scrubber->on_primary_change(m_planned_scrub);
+    m_scrubber->on_primary_change(__func__, m_planned_scrub);
   }
 }
 
@@ -1742,10 +1739,10 @@ void PG::on_new_interval()
 
   assert(m_scrubber);
   // log some scrub data before we react to the interval
-  dout(20) << __func__ << (is_scrub_queued_or_active() ? " scrubbing " : " ")
+  dout(30) << __func__ << (is_scrub_queued_or_active() ? " scrubbing " : " ")
            << "flags: " << m_planned_scrub << dendl;
 
-  m_scrubber->on_maybe_registration_change(m_planned_scrub);
+  m_scrubber->on_primary_change(__func__, m_planned_scrub);
 }
 
 epoch_t PG::oldest_stored_osdmap() {

--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -227,7 +227,6 @@ PrimaryLogScrub::PrimaryLogScrub(PrimaryLogPG* pg) : PgScrubber{pg}, m_pl_pg{pg}
 
 void PrimaryLogScrub::_scrub_clear_state()
 {
-  dout(15) << __func__ << dendl;
   m_scrub_cstat = object_stat_collection_t();
 }
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -492,63 +492,57 @@ void PgScrubber::rm_from_osd_scrubbing()
   unregister_from_osd();
 }
 
-void PgScrubber::on_primary_change(const requested_scrub_t& request_flags)
+void PgScrubber::on_primary_change(
+  std::string_view caller,
+  const requested_scrub_t& request_flags)
 {
-  dout(10) << __func__ << (is_primary() ? " Primary " : " Replica ")
-	   << " flags: " << request_flags << dendl;
-
   if (!m_scrub_job) {
+    // we won't have a chance to see more logs from this function, thus:
+    dout(10) << fmt::format(
+		  "{}: (from {}& w/{}) {}.Reg-state:{:.7}. No scrub-job",
+		  __func__, caller, request_flags,
+		  (is_primary() ? "Primary" : "Replica/other"),
+		  registration_state())
+	     << dendl;
     return;
   }
 
-  dout(15) << __func__ << " scrub-job state: " << m_scrub_job->state_desc()
-	   << dendl;
-
+  auto pre_state = m_scrub_job->state_desc();
+  auto pre_reg = registration_state();
   if (is_primary()) {
     auto suggested = m_osds->get_scrub_services().determine_scrub_time(
-      request_flags,
-      m_pg->info,
-      m_pg->get_pgpool().info.opts);
+      request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
     m_osds->get_scrub_services().register_with_osd(m_scrub_job, suggested);
   } else {
     m_osds->get_scrub_services().remove_from_osd_queue(m_scrub_job);
   }
 
-  dout(15) << __func__ << " done " << registration_state() << dendl;
-}
-
-void PgScrubber::on_maybe_registration_change(
-  const requested_scrub_t& request_flags)
-{
-  dout(10) << __func__ << (is_primary() ? " Primary " : " Replica/other ")
-	   << registration_state() << " flags: " << request_flags << dendl;
-
-  on_primary_change(request_flags);
-  dout(15) << __func__ << " done " << registration_state() << dendl;
+  dout(10)
+    << fmt::format(
+	 "{} (from {} {}): {}. <{:.5}>&<{:.10}> --> <{:.5}>&<{:.14}>",
+	 __func__, caller, request_flags,
+	 (is_primary() ? "Primary" : "Replica/other"), pre_reg, pre_state,
+	 registration_state(), m_scrub_job->state_desc())
+    << dendl;
 }
 
 void PgScrubber::update_scrub_job(const requested_scrub_t& request_flags)
 {
-  dout(10) << __func__ << " flags: " << request_flags << dendl;
-
-  {
-    // verify that the 'in_q' status matches our "Primariority"
-    if (m_scrub_job && is_primary() && !m_scrub_job->in_queues) {
-      dout(1) << __func__ << " !!! primary but not scheduled! " << dendl;
-    }
+  dout(10) << fmt::format("{}: flags:<{}>", __func__, request_flags) << dendl;
+  // verify that the 'in_q' status matches our "Primariority"
+  if (m_scrub_job && is_primary() && !m_scrub_job->in_queues) {
+    dout(1) << __func__ << " !!! primary but not scheduled! " << dendl;
   }
 
   if (is_primary() && m_scrub_job) {
     ceph_assert(m_pg->is_locked());
     auto suggested = m_osds->get_scrub_services().determine_scrub_time(
-      request_flags,
-      m_pg->info,
-      m_pg->get_pgpool().info.opts);
+      request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
     m_osds->get_scrub_services().update_job(m_scrub_job, suggested);
     m_pg->publish_stats_to_osd();
   }
 
-  dout(15) << __func__ << " done " << registration_state() << dendl;
+  dout(15) << __func__ << ": done " << registration_state() << dendl;
 }
 
 void PgScrubber::scrub_requested(scrub_level_t scrub_level,

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -359,9 +359,8 @@ class PgScrubber : public ScrubPgIF,
 
   void rm_from_osd_scrubbing() final;
 
-  void on_primary_change(const requested_scrub_t& request_flags) final;
-
-  void on_maybe_registration_change(
+  void on_primary_change(
+    std::string_view caller,
     const requested_scrub_t& request_flags) final;
 
   void scrub_requested(scrub_level_t scrub_level,

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -386,7 +386,9 @@ struct ScrubPgIF {
    *
    * Following our status as Primary or replica.
    */
-  virtual void on_primary_change(const requested_scrub_t& request_flags) = 0;
+  virtual void on_primary_change(
+    std::string_view caller,
+    const requested_scrub_t& request_flags) = 0;
 
   /**
    * Recalculate the required scrub time.
@@ -395,9 +397,6 @@ struct ScrubPgIF {
    * i.e. the OSD "knows our name" if-f we are the Primary.
    */
   virtual void update_scrub_job(const requested_scrub_t& request_flags) = 0;
-
-  virtual void on_maybe_registration_change(
-    const requested_scrub_t& request_flags) = 0;
 
   // on the replica:
   virtual void handle_scrub_reserve_request(OpRequestRef op) = 0;


### PR DESCRIPTION
By:
- mainly: reducing the number of log lines;
- fixing the fmtlib formatting of utime_t, and
  creating an optional shorter utime_t format;
- clarifying some log messages;
