### PR TITLE
install-deps: bring argv parsing for --crimson and others

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -254,6 +254,20 @@ EOF
     fi
 }
 
+read -r -d '' usage <<EOF || true
+usage: $0 [option]...
+options:
+	--crimson: install dependencies for crimson (env. alt. WITH_SEASTAR)
+	--zbd: install dependencies for zbd (env. alt. WITH_ZBD)
+	--pmem: install dependencies for PMEM (env. alt. WITH_PMEM)
+	--rgw_motr: install dependencies for CORTX Motr (env. alt. WITH_RADOSGW_MOTR)
+\n
+EOF
+function usage_exit() {
+    printf "$usage"
+    exit
+}
+
 for_make_check=false
 if tty -s; then
     # interactive
@@ -326,6 +340,25 @@ else
     [ $WITH_ZBD ] && with_zbd=true || with_zbd=false
     [ $WITH_PMEM ] && with_pmem=true || with_pmem=false
     [ $WITH_RADOSGW_MOTR ] && with_rgw_motr=true || with_rgw_motr=false
+    while [ $# -ge 1 ]; do
+    case $1 in
+        --crimson)
+            with_seastar=true
+            ;;
+        --zbd)
+            with_zbd=true
+            ;;
+        --pmem)
+            with_pmem=true
+            ;;
+        --rgw_motr)
+            with_rgw_motr=true
+            ;;
+        *)
+            usage_exit
+    esac
+    shift
+    done
     source /etc/os-release
     case "$ID" in
     debian|ubuntu|devuan|elementary|softiron)


### PR DESCRIPTION
The `--crimson` argv switch is respected by many our development scripts like `vstart.sh` and `stop.sh`. However, `install-deps.sh` still requires setting the `WITH_SEASTAR` environment variable which departs from this convention.

This commit brings argv support for `--crimson`, `--jaeger` and `--zbd` while keeping the old, env-based way intact.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

CC: @JoshSalomon 



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
