### PR TITLE
Ceph-mixin: Fix CephNodeNetworkPacket alerts

### DIFF
--- a/monitoring/ceph-mixin/config.libsonnet
+++ b/monitoring/ceph-mixin/config.libsonnet
@@ -4,5 +4,8 @@
 
     clusterLabel: 'cluster',
     showMultiCluster: false,
+
+    CephNodeNetworkPacketDropsThreshold: 0.005,
+    CephNodeNetworkPacketDropsPerSec: 10,
   },
 }

--- a/monitoring/ceph-mixin/prometheus_alerts.libsonnet
+++ b/monitoring/ceph-mixin/prometheus_alerts.libsonnet
@@ -512,16 +512,38 @@
         },
         {
           alert: 'CephNodeNetworkPacketDrops',
-          expr: '(  increase(node_network_receive_drop_total{device!="lo"}[1m]) +  increase(node_network_transmit_drop_total{device!="lo"}[1m])) / (  increase(node_network_receive_packets_total{device!="lo"}[1m]) +  increase(node_network_transmit_packets_total{device!="lo"}[1m])) >= 0.0001 or (  increase(node_network_receive_drop_total{device!="lo"}[1m]) +  increase(node_network_transmit_drop_total{device!="lo"}[1m])) >= 10',
+          expr: |||
+            (
+              rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_drop_total{device!="lo"}[1m])
+            ) / (
+              rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_packets_total{device!="lo"}[1m])
+            ) >= %(CephNodeNetworkPacketDropsThreshold)s and (
+              rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_drop_total{device!="lo"}[1m])
+            ) >= %(CephNodeNetworkPacketDropsPerSec)s
+          ||| % $._config,
           labels: { severity: 'warning', type: 'ceph_default', oid: '1.3.6.1.4.1.50495.1.2.1.8.2' },
           annotations: {
             summary: 'One or more NICs reports packet drops%(cluster)s' % $.MultiClusterSummary(),
-            description: 'Node {{ $labels.instance }} experiences packet drop > 0.01% or > 10 packets/s on interface {{ $labels.device }}.',
+            description: 'Node {{ $labels.instance }} experiences packet drop > %(CephNodeNetworkPacketDropsThreshold)s%% or > %(CephNodeNetworkPacketDropsPerSec)s packets/s on interface {{ $labels.device }}.' % { CephNodeNetworkPacketDropsThreshold: $._config.CephNodeNetworkPacketDropsThreshold * 100, CephNodeNetworkPacketDropsPerSec: $._config.CephNodeNetworkPacketDropsPerSec },
           },
         },
         {
           alert: 'CephNodeNetworkPacketErrors',
-          expr: '(  increase(node_network_receive_errs_total{device!="lo"}[1m]) +  increase(node_network_transmit_errs_total{device!="lo"}[1m])) / (  increase(node_network_receive_packets_total{device!="lo"}[1m]) +  increase(node_network_transmit_packets_total{device!="lo"}[1m])) >= 0.0001 or (  increase(node_network_receive_errs_total{device!="lo"}[1m]) +  increase(node_network_transmit_errs_total{device!="lo"}[1m])) >= 10',
+          expr: |||
+            (
+              rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_errs_total{device!="lo"}[1m])
+            ) / (
+              rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_packets_total{device!="lo"}[1m])
+            ) >= 0.0001 or (
+              rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+              rate(node_network_transmit_errs_total{device!="lo"}[1m])
+            ) >= 10
+          |||,
           labels: { severity: 'warning', type: 'ceph_default', oid: '1.3.6.1.4.1.50495.1.2.1.8.3' },
           annotations: {
             summary: 'One or more NICs reports packet errors%(cluster)s' % $.MultiClusterSummary(),

--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -459,9 +459,19 @@ groups:
           type: "ceph_default"
       - alert: "CephNodeNetworkPacketDrops"
         annotations:
-          description: "Node {{ $labels.instance }} experiences packet drop > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
+          description: "Node {{ $labels.instance }} experiences packet drop > 0.5% or > 10 packets/s on interface {{ $labels.device }}."
           summary: "One or more NICs reports packet drops"
-        expr: "(  increase(node_network_receive_drop_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_drop_total{device!=\"lo\"}[1m])) / (  increase(node_network_receive_packets_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_packets_total{device!=\"lo\"}[1m])) >= 0.0001 or (  increase(node_network_receive_drop_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_drop_total{device!=\"lo\"}[1m])) >= 10"
+        expr: |
+          (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0050000000000000001 and (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) >= 10
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.8.2"
           severity: "warning"
@@ -470,7 +480,17 @@ groups:
         annotations:
           description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
           summary: "One or more NICs reports packet errors"
-        expr: "(  increase(node_network_receive_errs_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_errs_total{device!=\"lo\"}[1m])) / (  increase(node_network_receive_packets_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_packets_total{device!=\"lo\"}[1m])) >= 0.0001 or (  increase(node_network_receive_errs_total{device!=\"lo\"}[1m]) +  increase(node_network_transmit_errs_total{device!=\"lo\"}[1m])) >= 10"
+        expr: |
+          (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0001 or (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) >= 10
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.8.3"
           severity: "warning"

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -375,32 +375,38 @@ tests:
            description: "Root volume is dangerously full: 4.811% free."
 
  # network packets dropped
- - interval: 1s
+ - interval: 1m
    input_series:
     - series: 'node_network_receive_drop_total{device="eth0",
       instance="node-exporter",job="node-exporter"}'
-      values: '1+1x500'
+      values: '0+600x10'
     - series: 'node_network_transmit_drop_total{device="eth0",
       instance="node-exporter",job="node-exporter"}'
-      values: '1+1x500'
+      values: '0+600x10'
+    - series: 'node_network_receive_packets_total{device="eth0",
+      instance="node-exporter",job="node-exporter"}'
+      values: '0+750x10'
+    - series: 'node_network_transmit_packets_total{device="eth0",
+      instance="node-exporter",job="node-exporter"}'
+      values: '0+750x10'
    promql_expr_test:
      - expr: |
          (
-           increase(node_network_receive_drop_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_drop_total{device!="lo"}[1m])
+           rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_drop_total{device!="lo"}[1m])
          ) / (
-           increase(node_network_receive_packets_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_packets_total{device!="lo"}[1m])
-         ) >= 0.0001 or (
-           increase(node_network_receive_drop_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_drop_total{device!="lo"}[1m])
+           rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_packets_total{device!="lo"}[1m])
+         ) >= 0.0050000000000000001 and (
+           rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_drop_total{device!="lo"}[1m])
          ) >= 10
 
        eval_time: 5m
        exp_samples:
          - labels: '{device="eth0", instance="node-exporter",
            job="node-exporter"}'
-           value: 1.2E+02
+           value: 8E-1
    alert_rule_test:
      - eval_time: 5m
        alertname: CephNodeNetworkPacketDrops
@@ -414,35 +420,41 @@ tests:
            type: ceph_default
          exp_annotations:
            summary: One or more NICs reports packet drops
-           description: "Node node-exporter experiences packet drop > 0.01% or > 10 packets/s on interface eth0."
+           description: "Node node-exporter experiences packet drop > 0.5% or > 10 packets/s on interface eth0."
 
  # network packets errors
- - interval: 1s
+ - interval: 1m
    input_series:
     - series: 'node_network_receive_errs_total{device="eth0",
       instance="node-exporter",job="node-exporter"}'
-      values: '1+1x500'
+      values: '0+600x10'
     - series: 'node_network_transmit_errs_total{device="eth0",
       instance="node-exporter",job="node-exporter"}'
-      values: '1+1x500'
+      values: '0+600x10'
+    - series: 'node_network_transmit_packets_total{device="eth0",
+      instance="node-exporter",job="node-exporter"}'
+      values: '0+750x10'
+    - series: 'node_network_receive_packets_total{device="eth0",
+      instance="node-exporter",job="node-exporter"}'
+      values: '0+750x10'
    promql_expr_test:
      - expr: |
          (
-           increase(node_network_receive_errs_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_errs_total{device!="lo"}[1m])
+           rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_errs_total{device!="lo"}[1m])
          ) / (
-           increase(node_network_receive_packets_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_packets_total{device!="lo"}[1m])
+           rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_packets_total{device!="lo"}[1m])
          ) >= 0.0001 or (
-           increase(node_network_receive_errs_total{device!="lo"}[1m]) +
-           increase(node_network_transmit_errs_total{device!="lo"}[1m])
+           rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+           rate(node_network_transmit_errs_total{device!="lo"}[1m])
          ) >= 10
 
        eval_time: 5m
        exp_samples:
          - labels: '{device="eth0", instance="node-exporter",
            job="node-exporter"}'
-           value: 1.2E+02
+           value: 8E-01
    alert_rule_test:
      - eval_time: 5m
        alertname: CephNodeNetworkPacketErrors


### PR DESCRIPTION
Currently the `CephNodeNetworkPacketDrops` and `CephNodeNetworkPacketErrors` alert queries count the amount of packet drops/errors per minute instead of per second as mentioned in the description. This commit fixes that and makes the threshold values customizable with slightly higher defaults

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
