### PR TITLE
doc: virtio discard is supported since kernel 5.0

### DIFF
--- a/doc/rbd/qemu-rbd.rst
+++ b/doc/rbd/qemu-rbd.rst
@@ -165,8 +165,7 @@ for the block device. To do this, you must specify a
     qemu -m 1024 -drive format=raw,file=rbd:data/squeeze,id=drive1,if=none \
          -device driver=ide-hd,drive=drive1,discard_granularity=512
 
-Note that this uses the IDE driver. The virtio driver does not
-support discard.
+Note that this uses the IDE driver. The virtio driver supports discard since Linux kernel version 5.0.
 
 If using libvirt, edit your libvirt domain's configuration file using ``virsh
 edit`` to include the ``xmlns:qemu`` value. Then, add a ``qemu:commandline``


### PR DESCRIPTION
The Linux Kernel supports discard with the virtio driver sind version 5.0:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d548e65904ae43b0637d200a2441fc94e0589c30

Also, there's Qemu support:
https://git.qemu.org/?p=qemu.git;a=commitdiff;h=37b06f8d46fe602e630e4