### PR TITLE
rgw/lua: allow read access to object data

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -6,18 +6,26 @@ Lua Scripting
 
 .. contents::
 
-This feature allows users to assign execution context to Lua scripts. The three supported contexts are ``preRequest``" which will execute a script before each
-operation is performed, ``postRequest`` which will execute after each operation is performed, and ``background`` which will execute within a specified time interval.
-A request context script may be constrained to operations belonging to a specific tenant's users.
-The request context script can also access fields in the request and modify some fields. All Lua language features can be used.
+This feature allows users to assign execution context to Lua scripts. The supported contexts are:
 
-By default, all lua standard libraries are available in the script, however, in order to allow for other lua modules to be used in the script, we support adding packages to an allowlist:
+ - ``prerequest`` which will execute a script before each operation is performed
+ - ``postrequest`` which will execute after each operation is performed
+ - ``background`` which will execute within a specified time interval
+ - ``getdata`` which will execute on objects' data when objects are downloaded
+ - ``putdata`` which will execute on objects' data when objects are uploaded
+
+A request (pre or post) or data (get or put) context script may be constrained to operations belonging to a specific tenant's users.
+The request context script can also access fields in the request and modify certain fields, as well as the `Global RGW Table`_.
+The data context script can access the content of the object as well as the request fields and the `Global RGW Table`_. 
+All Lua language features can be used in all contexts.
+
+By default, all Lua standard libraries are available in the script, however, in order to allow for other Lua modules to be used in the script, we support adding packages to an allowlist:
 
   - All packages in the allowlist are being re-installed using the luarocks package manager on radosgw restart. Therefore a restart is needed for adding or removing of packages to take effect 
-  - To add a package that contains C source code that needs to be compiled, use the `--allow-compilation` flag. In this case a C compiler needs to be available on the host
-  - Lua packages are installed in, and used from, a directory local to the radosgw. Meaning that lua packages in the allowlist are separated from any lua packages available on the host.
-    By default, this directory would be `/tmp/luarocks/<entity name>`. Its prefix part (`/tmp/luarocks/`) could be set to a different location via the `rgw_luarocks_location` configuration parameter. 
-    Note that this parameter should not be set to one of the default locations where luarocks install packages (e.g. `$HOME/.luarocks`, `/usr/lib64/lua`, `/usr/share/lua`)
+  - To add a package that contains C source code that needs to be compiled, use the ``--allow-compilation`` flag. In this case a C compiler needs to be available on the host
+  - Lua packages are installed in, and used from, a directory local to the radosgw. Meaning that Lua packages in the allowlist are separated from any Lua packages available on the host.
+    By default, this directory would be ``/tmp/luarocks/<entity name>``. Its prefix part (``/tmp/luarocks/``) could be set to a different location via the ``rgw_luarocks_location`` configuration parameter. 
+    Note that this parameter should not be set to one of the default locations where luarocks install packages (e.g. ``$HOME/.luarocks``, ``/usr/lib64/lua``, ``/usr/share/lua``).
 	
 
 .. toctree::
@@ -32,7 +40,7 @@ To upload a script:
 
 ::
    
-   # radosgw-admin script put --infile={lua-file} --context={preRequest|postRequest|background} [--tenant={tenant-name}]
+   # radosgw-admin script put --infile={lua-file} --context={prerequest|postrequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 
 * When uploading a script with the ``background`` context, a tenant name may not be specified.
@@ -42,14 +50,14 @@ To print the content of the script to standard output:
 
 ::
    
-   # radosgw-admin script get --context={preRequest|postRequest|background} [--tenant={tenant-name}]
+   # radosgw-admin script get --context={prerequest|postrequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 
 To remove the script:
 
 ::
    
-   # radosgw-admin script rm --context={preRequest|postRequest|background} [--tenant={tenant-name}]
+   # radosgw-admin script rm --context={prerequest|postrequest|background|getdata|putdata} [--tenant={tenant-name}]
 
 
 Package Management via CLI
@@ -149,7 +157,7 @@ Request Fields
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
 | ``Request.Bucket.Tenant``                          | string   | tenant of the bucket                                         | no       | no        | yes      |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
-| ``Request.Bucket.Name``                            | string   | bucket name (writeable only in `preRequest` context)         | no       | yes       | no       |
+| ``Request.Bucket.Name``                            | string   | bucket name (writeable only in ``prerequest`` context)       | no       | yes       | no       |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
 | ``Request.Bucket.Marker``                          | string   | bucket marker (initial id)                                   | no       | no        | yes      |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
@@ -306,12 +314,32 @@ Operations Log
 ~~~~~~~~~~~~~~
 The ``Request.Log()`` function prints the requests into the operations log. This function has no parameters. It returns 0 for success and an error code if it fails.
 
+Tracing
+~~~~~~~
+Tracing functions can be used only in the ``postrequest`` context.
+
+- ``Request.Trace.SetAttribute(<key>, <value>)`` - sets the attribute for the request's trace.
+  The function takes two arguments: the first is the ``key``, which should be a string, and the second is the ``value``, which can either be a string or a number (integer or double).
+  You may then locate specific traces by using this attribute.
+
+- ``Request.Trace.AddEvent(<name>, <attributes>)`` - adds an event to the first span of the request's trace
+  An event is defined by event name, event time, and zero or more event attributes.
+  The function accepts one or two arguments: A string containing the event ``name`` should be the first argument, followed by the event ``attributes``, which is optional for events without attributes.
+  An event's attributes must be a table of strings.
+
 Background Context
 --------------------
 The ``background`` context may be used for purposes that include analytics, monitoring, caching data for other context executions.
 - Background script execution default interval is 5 seconds.
 
-Global ``RGW`` Table
+Data Context
+--------------------
+Both ``getdata`` and ``putdata`` contexts have the following fields:
+- ``Data`` which is read-only and iterable (byte by byte). In case that an object is uploaded or retrieved in multiple chunks, the ``Data`` field will hold data of one chunk at a time.
+- ``Offset`` which is holding the offset of the chunk within the entire object.
+- The ``Request`` fields and the background ``RGW`` table are also available in these contexts.
+
+Global RGW Table
 --------------------
 The ``RGW`` Lua table is accessible from all contexts and saves data written to it
 during execution so that it may be read and used later during other executions, from the same context of a different one.
@@ -329,19 +357,6 @@ to atomically increment and decrement numeric values in it. For that the followi
 - if the value of ``key`` is not numeric, the execution of the script would fail
 - if we try to increment or decrement by non-numeric values, the execution of the script would fail
 
-
-Tracing
-~~~~~~~
-Tracing functions can be used only in `postRequest` context.
-
-- ``Request.Trace.SetAttribute()`` - sets the attribute for the request's trace.
-  Takes two arguments. The first is the `key`, which should be a string. The second is the value, which can either be a string or a number.
-  Using the attribute, you can locate specific traces.
-
-- ``Request.Trace.AddEvent()`` - adds an event to the first span of the request's trace
-  An event is defined by event name, event time, and zero or more event attributes.
-  Therefore, the function accepts one or two arguments. A string containing the event name should be the first argument, followed by the event attributes, which is optional for events without attributes.
-  An event's attributes must be a table of strings.
 
 Lua Code Samples
 ----------------
@@ -419,7 +434,7 @@ Lua Code Samples
 
 - Add metadata to objects that was not originally sent by the client:
 
-In the `preRequest` context we should add:
+In the ``prerequest`` context we should add:
 
 .. code-block:: lua
 
@@ -427,7 +442,7 @@ In the `preRequest` context we should add:
     Request.HTTP.Metadata["x-amz-meta-mydata"] = "my value"
   end
 
-In the `postRequest` context we look at the metadata:
+In the ``postrequest`` context we look at the metadata:
 
 .. code-block:: lua
 
@@ -446,7 +461,7 @@ First we should add the following packages to the allowlist:
   # radosgw-admin script-package add --package=luasocket --allow-compilation
 
 
-Then, do a restart for the radosgw and upload the following script to the `postRequest` context:
+Then, do a restart for the radosgw and upload the following script to the ``postrequest`` context:
 
 .. code-block:: lua
 
@@ -483,7 +498,7 @@ Tracing is disabled by default, so we should enable tracing for this specific bu
 
 
 If `tracing is enabled <https://docs.ceph.com/en/latest/jaegertracing/#how-to-enable-tracing-in-ceph/>`_ on the RGW, the value of Request.Trace.Enable is true, so we should disable tracing for all other requests that do not match the bucket name.
-In the `preRequest` context:
+In the ``prerequest`` context:
 
 .. code-block:: lua
 
@@ -491,12 +506,12 @@ In the `preRequest` context:
       Request.Trace.Enable = false
   end
 
-Note that changing `Request.Trace.Enable` does not change the tracer's state, but disables or enables the tracing for the request only.
+Note that changing ``Request.Trace.Enable`` does not change the tracer's state, but disables or enables the tracing for the request only.
 
 
 - Add Information for requests traces
 
-in `postRequest` context, we can add attributes and events to the request's trace.
+in ``postrequest`` context, we can add attributes and events to the request's trace.
 
 .. code-block:: lua
 
@@ -510,4 +525,41 @@ in `postRequest` context, we can add attributes and events to the request's trac
   end
 
   Request.Trace.AddEvent("second event", event_attrs)
+
+- The entropy value of an object could be used to detect whether the object is encrypted. 
+  The following script calculates the entropy and size of uploaded objects and print to debug log
+
+in the ``putdata`` context, add the following script
+
+.. code-block:: lua
+
+	function object_entropy()
+		local byte_hist = {}
+		local byte_hist_size = 256 
+		for i = 1,byte_hist_size do
+			byte_hist[i] = 0 
+		end 
+		local total = 0 
+
+		for i, c in pairs(Data)  do
+			local byte = c:byte() + 1 
+			byte_hist[byte] = byte_hist[byte] + 1 
+			total = total + 1 
+		end 
+
+		entropy = 0 
+
+		for _, count in ipairs(byte_hist) do
+			if count ~= 0 then
+				local p = 1.0 * count / total
+				entropy = entropy - (p * math.log(p)/math.log(byte_hist_size))
+			end 
+		end 
+
+		return entropy
+	end
+
+	local full_name = Request.Bucket.Name.."\\"..Request.Object.Name
+	RGWDebugLog("entropy of chunk of: " .. full_name .. " at offset:" .. tostring(Offset)  ..  " is: " .. tostring(object_entropy()))
+	RGWDebugLog("payload size of chunk of: " .. full_name .. " is: " .. #Data)
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -162,8 +162,11 @@ set(librgw_common_srcs
   rgw_datalog.cc
   rgw_datalog_notify.cc
   cls_fifo_legacy.cc
+  rgw_log.cc
+  rgw_lua_request.cc
   rgw_lua_utils.cc
   rgw_lua.cc
+  rgw_lua_data_filter.cc
   rgw_bucket_encryption.cc
   rgw_tracer.cc
   rgw_lua_background.cc)
@@ -275,8 +278,6 @@ set(rgw_a_srcs
   rgw_frontend.cc
   rgw_http_client_curl.cc
   rgw_loadgen.cc
-  rgw_log.cc
-  rgw_lua_request.cc
   rgw_period_pusher.cc
   rgw_realm_reloader.cc
   rgw_realm_watcher.cc

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -121,6 +121,9 @@ static inline int posix_errortrans(int r)
   return r;
 }
 
+
+static const std::string LUA_CONTEXT_LIST("prerequest, postrequest, background, getdata, putdata");
+
 void usage()
 {
   cout << "usage: radosgw-admin <cmd> [options...]" << std::endl;
@@ -479,7 +482,7 @@ void usage()
   cout << "   --subscription            pubsub subscription name\n";
   cout << "   --event-id                event id in a pubsub subscription\n";
   cout << "\nScript options:\n";
-  cout << "   --context                 context in which the script runs. one of: preRequest, postRequest, background\n";
+  cout << "   --context                 context in which the script runs. one of: "+LUA_CONTEXT_LIST+"\n";
   cout << "   --package                 name of the lua package that should be added/removed to/from the allowlist\n";
   cout << "   --allow-compilation       package is allowed to compile C code as part of its installation\n";
   cout << "\nradoslist options:\n";
@@ -10395,7 +10398,7 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: " << LUA_CONTEXT_LIST << std::endl;
       return EINVAL;
     }
     if (script_ctx == rgw::lua::context::background && !tenant.empty()) {
@@ -10417,7 +10420,7 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: " << LUA_CONTEXT_LIST << std::endl;
       return EINVAL;
     }
     auto lua_manager = store->get_lua_manager();
@@ -10441,7 +10444,7 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: " << LUA_CONTEXT_LIST << std::endl;
       return EINVAL;
     }
     auto lua_manager = store->get_lua_manager();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -51,6 +51,10 @@ namespace rgw::sal {
   using Attrs = std::map<std::string, ceph::buffer::list>;
 }
 
+namespace rgw::lua {
+  class Background;
+}
+
 using ceph::crypto::MD5;
 
 #define RGW_ATTR_PREFIX  "user.rgw."
@@ -1809,6 +1813,9 @@ struct req_state : DoutPrefixProvider {
 
   //Principal tags that come in as part of AssumeRoleWithWebIdentity
   std::vector<std::pair<std::string, std::string>> principal_tags;
+
+  rgw::lua::Background* lua_background = nullptr;
+  rgw::sal::LuaManager* lua_manager = nullptr;
 
   req_state(CephContext* _cct, RGWEnv* e, uint64_t id);
   ~req_state();

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -25,6 +25,12 @@ context to_context(const std::string& s)
   if (strcasecmp(s.c_str(), "background") == 0) {
     return context::background;
   }
+  if (strcasecmp(s.c_str(), "getdata") == 0) {
+    return context::getData;
+  }
+  if (strcasecmp(s.c_str(), "putdata") == 0) {
+    return context::putData;
+  }
   return context::none;
 }
 
@@ -37,6 +43,10 @@ std::string to_string(context ctx)
       return "postrequest";
     case context::background:
       return "background";
+    case context::getData:
+      return "getdata";
+    case context::putData:
+      return "putdata";
     case context::none:
       break;
   }

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -7,6 +7,7 @@
 #include "common/dout.h"
 #include "rgw_sal_fwd.h"
 
+class DoutPrefixProvider;
 class lua_State;
 class rgw_user;
 class DoutPrefixProvider;
@@ -21,6 +22,8 @@ enum class context {
   preRequest,
   postRequest,
   background,
+  getData,
+  putData,
   none
 };
 

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -177,5 +177,5 @@ void Background::create_background_metatable(lua_State* L) {
   create_metatable<rgw::lua::RGWTable>(L, true, &rgw_map, &table_mutex);
 }
 
-} //namespace lua
+} //namespace rgw::lua
 

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -226,5 +226,5 @@ public:
     void resume(rgw::sal::Store* _store) override;
 };
 
-} //namepsace lua
+} //namepsace rgw::lua
 

--- a/src/rgw/rgw_lua_data_filter.cc
+++ b/src/rgw/rgw_lua_data_filter.cc
@@ -1,0 +1,142 @@
+#include "rgw_lua_data_filter.h"
+#include "rgw_lua_utils.h"
+#include "rgw_lua_request.h"
+#include "rgw_lua_background.h"
+#include <lua.hpp>
+
+namespace rgw::lua {
+
+void push_bufferlist_byte(lua_State* L, bufferlist::iterator& it) {
+    char byte[1];
+    it.copy(1, byte);
+    lua_pushlstring(L, byte, 1);
+}
+
+struct BufferlistMetaTable : public EmptyMetaTable {
+
+  static std::string TableName() {return "Data";}
+  static std::string Name() {return TableName() + "Meta";}
+  
+  static int IndexClosure(lua_State* L) {
+    auto bl = reinterpret_cast<bufferlist*>(lua_touserdata(L, lua_upvalueindex(1)));
+    const auto index = luaL_checkinteger(L, 2);
+    if (index <= 0 || index > bl->length()) {
+      // lua arrays start from 1
+      lua_pushnil(L);
+      return ONE_RETURNVAL;
+    }
+    auto it = bl->begin(index-1);
+    if (it != bl->end()) {
+      push_bufferlist_byte(L, it);
+    } else {
+      lua_pushnil(L);
+    }
+    
+    return ONE_RETURNVAL;
+  }
+
+  static int PairsClosure(lua_State* L) {
+    auto bl = reinterpret_cast<bufferlist*>(lua_touserdata(L, lua_upvalueindex(1)));
+    ceph_assert(bl);
+    lua_pushlightuserdata(L, bl);
+    lua_pushcclosure(L, stateless_iter, ONE_UPVAL); // push the stateless iterator function
+    lua_pushnil(L);                                 // indicate this is the first call
+    // return stateless_iter, nil
+
+    return TWO_RETURNVALS;
+  }
+  
+  static int stateless_iter(lua_State* L) {
+    // based on: http://lua-users.org/wiki/GeneralizedPairsAndIpairs
+    auto bl = reinterpret_cast<bufferlist*>(lua_touserdata(L, lua_upvalueindex(1)));
+    lua_Integer index;
+    if (lua_isnil(L, -1)) {
+      index = 1;
+    } else {
+      index = luaL_checkinteger(L, -1) + 1;
+    }
+
+    // lua arrays start from 1
+    auto it = bl->begin(index-1);
+
+    if (index > bl->length()) {
+      // index of the last element was provided
+      lua_pushnil(L);
+      lua_pushnil(L);
+      // return nil, nil
+    } else {
+      lua_pushinteger(L, index);
+      push_bufferlist_byte(L, it);
+      // return key, value
+    }
+
+    return TWO_RETURNVALS;
+  }
+  
+  static int LenClosure(lua_State* L) {
+    const auto bl = reinterpret_cast<bufferlist*>(lua_touserdata(L, lua_upvalueindex(1)));
+
+    lua_pushinteger(L, bl->length());
+
+    return ONE_RETURNVAL;
+  }
+};
+
+int RGWObjFilter::execute(bufferlist& bl, off_t offset, const char* op_name) const {
+  auto L = luaL_newstate();
+  lua_state_guard lguard(L);
+
+  open_standard_libs(L);
+
+  create_debug_action(L, s->cct);  
+
+  // create the "Data" table
+  create_metatable<BufferlistMetaTable>(L, true, &bl);
+  lua_getglobal(L, BufferlistMetaTable::TableName().c_str());
+  ceph_assert(lua_istable(L, -1));
+
+  // create the "Request" table
+  request::create_top_metatable(L, s, op_name);
+
+  // create the "Offset" variable
+  lua_pushinteger(L, offset);
+  lua_setglobal(L, "Offset");
+
+  if (s->lua_background) {
+    // create the "RGW" table
+    s->lua_background->create_background_metatable(L);
+    lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
+    ceph_assert(lua_istable(L, -1));
+  }
+
+  try {
+    // execute the lua script
+    if (luaL_dostring(L, script.c_str()) != LUA_OK) {
+      const std::string err(lua_tostring(L, -1));
+      ldpp_dout(s, 1) << "Lua ERROR: " << err << dendl;
+      return -EINVAL;
+    }
+  } catch (const std::runtime_error& e) {
+    ldpp_dout(s, 1) << "Lua ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int RGWGetObjFilter::handle_data(bufferlist& bl,
+                  off_t bl_ofs,
+                  off_t bl_len) {
+  filter.execute(bl, bl_ofs, "get_obj");
+  // return value is ignored since we don't want to fail execution if lua script fails
+  return RGWGetObj_Filter::handle_data(bl, bl_ofs, bl_len);
+}
+
+int RGWPutObjFilter::process(bufferlist&& data, uint64_t logical_offset) {
+  filter.execute(data, logical_offset, "put_obj");
+  // return value is ignored since we don't want to fail execution if lua script fails
+  return rgw::putobj::Pipe::process(std::move(data), logical_offset); 
+}
+
+} // namespace rgw::lua
+

--- a/src/rgw/rgw_lua_data_filter.h
+++ b/src/rgw/rgw_lua_data_filter.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "rgw_op.h"
+
+class DoutPrefixProvider;
+
+namespace rgw::lua {
+
+class RGWObjFilter {
+  req_state* const s;
+  const std::string script;
+
+public:
+  RGWObjFilter(req_state* s,
+      const std::string& script) : 
+    s(s), script(script) {}
+
+  int execute(bufferlist& bl, off_t offset, const char* op_name) const;
+};
+
+class RGWGetObjFilter : public RGWGetObj_Filter {
+  const RGWObjFilter filter;
+
+public:
+  RGWGetObjFilter(req_state* s,
+      const std::string& script,
+      RGWGetObj_Filter* next) : RGWGetObj_Filter(next), filter(s, script) 
+  {}
+
+  ~RGWGetObjFilter() override = default;
+
+  int handle_data(bufferlist& bl,
+                  off_t bl_ofs,
+                  off_t bl_len) override;
+
+};
+
+class RGWPutObjFilter : public rgw::putobj::Pipe {
+  const RGWObjFilter filter;
+
+public:
+  RGWPutObjFilter(req_state* s,
+      const std::string& script,
+      rgw::sal::DataProcessor* next) : rgw::putobj::Pipe(next), filter(s, script) 
+  {}
+
+  ~RGWPutObjFilter() override = default;
+
+  int process(bufferlist&& data, uint64_t logical_offset) override;
+};
+} // namespace rgw::lua
+

--- a/src/rgw/rgw_lua_request.h
+++ b/src/rgw/rgw_lua_request.h
@@ -4,14 +4,15 @@
 #include "include/common_fwd.h"
 #include "rgw_sal_fwd.h"
 
-struct req_state;
+struct lua_State;
+class req_state;
 class RGWREST;
 class OpsLogSink;
-namespace rgw::lua {
-  class Background;
-}
 
 namespace rgw::lua::request {
+
+// create the request metatable
+void create_top_metatable(lua_State* L, req_state* s, const char* op_name);
 
 // execute a lua script in the Request context
 int execute(
@@ -20,8 +21,7 @@ int execute(
     OpsLogSink* olog,
     req_state *s, 
     const char* op_name,
-    const std::string& script,
-    rgw::lua::Background* background = nullptr);
+    const std::string& script);
 
-}
+} // namespace rgw::lua::request
 

--- a/src/rgw/rgw_lua_utils.cc
+++ b/src/rgw/rgw_lua_utils.cc
@@ -73,4 +73,5 @@ void open_standard_libs(lua_State* L) {
   lua_settable(L, -3);
 }
 
-}
+} // namespace rgw::lua
+

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -310,5 +310,6 @@ struct StringMapMetaTable : public EmptyMetaTable {
     return ONE_RETURNVAL;
   }
 };
-}
+
+} // namespace rgw::lua
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -52,6 +52,8 @@
 #include "rgw_notify_event_type.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#include "rgw_lua_data_filter.h"
+#include "rgw_lua.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
@@ -2084,6 +2086,20 @@ int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
   return send_response_data(bl, bl_ofs, bl_len);
 }
 
+int RGWGetObj::get_lua_filter(std::unique_ptr<RGWGetObj_Filter>* filter, RGWGetObj_Filter* cb) {
+  std::string script;
+  const auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::getData, script);
+  if (rc == -ENOENT) {
+    // no script, nothing to do
+    return 0;
+  } else if (rc < 0) {
+    ldpp_dout(this, 5) << "WARNING: failed to read data script. error: " << rc << dendl;
+    return rc;
+  }
+  filter->reset(new rgw::lua::RGWGetObjFilter(s, script, cb));
+  return 0;
+}
+
 bool RGWGetObj::prefetch_data()
 {
   /* HEAD request, stop prefetch*/
@@ -2135,6 +2151,7 @@ void RGWGetObj::execute(optional_yield y)
   RGWGetObj_Filter* filter = (RGWGetObj_Filter *)&cb;
   boost::optional<RGWGetObj_Decompress> decompress;
   std::unique_ptr<RGWGetObj_Filter> decrypt;
+  std::unique_ptr<RGWGetObj_Filter> run_lua;
   map<string, bufferlist>::iterator attr_iter;
 
   perfcounter->inc(l_rgw_get);
@@ -2201,6 +2218,15 @@ void RGWGetObj::execute(optional_yield y)
     return;
   }
   /* end gettorrent */
+
+  // run lua script on decompressed and decrypted data - first filter runs last
+  op_ret = get_lua_filter(&run_lua, filter);
+  if (run_lua != nullptr) {
+    filter = run_lua.get();
+  }
+  if (op_ret < 0) {
+    goto done_err;
+  }
 
   op_ret = rgw_compression_info_from_attrset(attrs, need_decompress, cs_info);
   if (op_ret < 0) {
@@ -2283,6 +2309,7 @@ void RGWGetObj::execute(optional_yield y)
   if (op_ret < 0) {
     goto done_err;
   }
+
 
   if (!get_data || ofs > end) {
     send_response_data(bl, 0, 0);
@@ -3842,6 +3869,20 @@ static CompressorRef get_compressor_plugin(const req_state *s,
   return Compressor::create(s->cct, alg);
 }
 
+int RGWPutObj::get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter, rgw::sal::DataProcessor* cb) {
+  std::string script;
+  const auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
+  if (rc == -ENOENT) {
+    // no script, nothing to do
+    return 0;
+  } else if (rc < 0) {
+    ldpp_dout(this, 5) << "WARNING: failed to read data script. error: " << rc << dendl;
+    return rc;
+  }
+  filter->reset(new rgw::lua::RGWPutObjFilter(s, script, cb));
+  return 0;
+}
+
 void RGWPutObj::execute(optional_yield y)
 {
   char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
@@ -4039,6 +4080,7 @@ void RGWPutObj::execute(optional_yield y)
   boost::optional<RGWPutObj_Compress> compressor;
 
   std::unique_ptr<rgw::sal::DataProcessor> encrypt;
+  std::unique_ptr<rgw::sal::DataProcessor> run_lua;
 
   if (!append) { // compression and encryption only apply to full object uploads
     op_ret = get_encrypt_filter(&encrypt, filter);
@@ -4058,6 +4100,14 @@ void RGWPutObj::execute(optional_yield y)
         // always send incompressible hint when rgw is itself doing compression
         s->object->set_compressed();
       }
+    }
+    // run lua script before data is compressed and encrypted - last filter runs first
+    op_ret = get_lua_filter(&run_lua, filter);
+    if (op_ret < 0) {
+      return;
+    }
+    if (run_lua) {
+      filter = &*run_lua;
     }
   }
   tracepoint(rgw_op, before_data_transfer, s->req_id.c_str());

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -437,6 +437,11 @@ public:
     *filter = nullptr;
     return 0;
   }
+
+  // get lua script to run as a "get object" filter 
+  int get_lua_filter(std::unique_ptr<RGWGetObj_Filter>* filter, 
+      RGWGetObj_Filter* cb);
+
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
@@ -1275,6 +1280,10 @@ public:
                                  rgw::sal::DataProcessor *cb) {
     return 0;
   }
+
+  // get lua script to run as a "put object" filter 
+  int get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter, 
+      rgw::sal::DataProcessor* cb);
 
   int get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len);
   int get_data(const off_t fst, const off_t lst, bufferlist& bl);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -363,7 +363,7 @@
      --event-id                event id in a pubsub subscription
   
   Script options:
-     --context                 context in which the script runs. one of: preRequest, postRequest, background
+     --context                 context in which the script runs. one of: prerequest, postrequest, background, getdata, putdata
      --package                 name of the lua package that should be added/removed to/from the allowlist
      --allow-compilation       package is allowed to compile C code as part of its installation
   

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -6,6 +6,7 @@
 #include "rgw/rgw_sal_rados.h"
 #include "rgw/rgw_lua_request.h"
 #include "rgw/rgw_lua_background.h"
+#include "rgw/rgw_lua_data_filter.h"
 
 using namespace std;
 using namespace rgw;
@@ -770,10 +771,11 @@ TEST(TestRGWLuaBackground, RequestScript)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
   // to make sure test is consistent we have to puase the background
   lua_background.pause();
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "hello"), "from request");
   // now we resume and let the background set the value
@@ -920,8 +922,9 @@ TEST(TestRGWLuaBackground, TableValues)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "string value");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -940,8 +943,9 @@ TEST(TestRGWLuaBackground, TablePersist)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "string value");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -951,7 +955,7 @@ TEST(TestRGWLuaBackground, TablePersist)
     RGW["key4"] = RGW["key2"]
   )";
   
-  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "string value");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -973,12 +977,14 @@ TEST(TestRGWLuaBackground, TableValuesFromRequest)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
+
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val1");
   s.err.ret = -99;
   s.err.message = "hi";
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key1"), -99);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key2"), "hi");
@@ -1001,10 +1007,11 @@ TEST(TestRGWLuaBackground, TableInvalidValue)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val2");
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "val1");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -1026,8 +1033,9 @@ TEST(TestRGWLuaBackground, TableErase)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "string value");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -1042,7 +1050,7 @@ TEST(TestRGWLuaBackground, TableErase)
     RGW["size"] = #RGW
   )";
   
-  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -1067,8 +1075,9 @@ TEST(TestRGWLuaBackground, TableIterate)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
   EXPECT_EQ(get_table_value<std::string>(lua_background, "key1"), "string value");
   EXPECT_EQ(get_table_value<long long int>(lua_background, "key2"), 42);
@@ -1092,8 +1101,9 @@ TEST(TestRGWLuaBackground, TableIncrement)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
 }
 
@@ -1114,8 +1124,9 @@ TEST(TestRGWLuaBackground, TableIncrementBy)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
 }
 
@@ -1134,8 +1145,9 @@ TEST(TestRGWLuaBackground, TableDecrement)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
 }
 
@@ -1156,8 +1168,9 @@ TEST(TestRGWLuaBackground, TableDecrementBy)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_EQ(rc, 0);
 }
 
@@ -1173,8 +1186,9 @@ TEST(TestRGWLuaBackground, TableIncrementValueError)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
   
   request_script = R"(
@@ -1183,7 +1197,7 @@ TEST(TestRGWLuaBackground, TableIncrementValueError)
     RGW.increment("key1")
   )";
 
-  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
   
   request_script = R"(
@@ -1192,7 +1206,7 @@ TEST(TestRGWLuaBackground, TableIncrementValueError)
     RGW.increment("key1", "kaboom")
   )";
 
-  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
 }
 
@@ -1208,8 +1222,9 @@ TEST(TestRGWLuaBackground, TableIncrementError)
   )";
 
   DEFINE_REQ_STATE;
+  s.lua_background = &lua_background;
 
-  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
   
   request_script = R"(
@@ -1217,7 +1232,7 @@ TEST(TestRGWLuaBackground, TableIncrementError)
     RGW.increment = 11
   )";
 
-  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
+  rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script);
   ASSERT_NE(rc, 0);
 }
 
@@ -1268,3 +1283,53 @@ TEST(TestRGWLua, TracingAddEvent)
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
   ASSERT_EQ(rc, 0);
 }
+
+TEST(TestRGWLua, Data)
+{
+  const std::string script = R"(
+    local expected = "The quick brown fox jumps over the lazy dog"
+    local actual = ""
+    RGW["key1"] = 0
+    
+    for i, c in pairs(Data) do
+      actual = actual .. c
+      RGW.increment("key1")
+    end 
+    assert(expected == actual)
+    assert(#Data == #expected);
+    assert(RGW["key1"] == #Data)
+    assert(Request.RGWId == "foo")
+    assert(Offset == 12345678)
+  )";
+
+  MAKE_STORE;
+  TestBackground lua_background(store.get(), "");
+  DEFINE_REQ_STATE;
+  s.host_id = "foo";
+  s.lua_background = &lua_background;
+  lua::RGWObjFilter filter(&s, script);
+  bufferlist bl;
+  bl.append("The quick brown fox jumps over the lazy dog");
+  off_t offset = 12345678;
+  const auto rc = filter.execute(bl, offset, "put_obj");
+  ASSERT_EQ(rc, 0);
+}
+
+TEST(TestRGWLua, WriteDataFail)
+{
+  const std::string script = R"(
+    Data[1] = "h"
+    Data[2] = "e"
+    Data[3] = "l"
+    Data[4] = "l"
+    Data[5] = "o"
+  )";
+
+  DEFINE_REQ_STATE;
+  lua::RGWObjFilter filter(&s, script);
+  bufferlist bl;
+  bl.append("The quick brown fox jumps over the lazy dog");
+  const auto rc = filter.execute(bl, 0, "put_obj");
+  ASSERT_NE(rc, 0);
+}
+


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

this PR is to reintroduce the change from this PR: https://github.com/ceph/ceph/pull/46550
that was reverted in: https://github.com/ceph/ceph/pull/47612

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
