### PR TITLE
quincy: mgr/dashboard: Hide maintenance option on expand cluster

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
@@ -45,8 +45,6 @@
           class="cd-header">Host Details</legend>
   <cd-hosts [hiddenColumns]="['services', 'status']"
             [hideToolHeader]="true"
-            [hideTitle]="true"
-            [hideSubmitBtn]="true"
             [hasTableDetails]="false"
             [showGeneralActionsOnly]="true">
   </cd-hosts>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
@@ -43,8 +43,7 @@
               i18n>Add Hosts</h4>
           <br>
           <cd-hosts [hiddenColumns]="['services']"
-                    [hideTitle]="true"
-                    [hideSubmitBtn]="true"
+                    [hideMaintenance]="true"
                     [hasTableDetails]="false"
                     [showGeneralActionsOnly]="true"></cd-hosts>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -80,7 +80,8 @@
           </div>
 
           <!-- Maintenance Mode -->
-          <div class="form-group row">
+          <div class="form-group row"
+               *ngIf="!hideMaintenance">
             <div class="cd-col-form-offset">
               <div class="custom-control custom-checkbox">
                 <input class="custom-control-input"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -32,6 +32,7 @@ export class HostFormComponent extends CdForm implements OnInit {
   pageURL: string;
   hostPattern = false;
   labelsOption: Array<SelectOption> = [];
+  hideMaintenance: boolean;
 
   messages = new SelectMessages({
     empty: $localize`There are no labels.`,
@@ -91,7 +92,7 @@ export class HostFormComponent extends CdForm implements OnInit {
         validators: [CdValidators.ip()]
       }),
       labels: new FormControl([]),
-      maintenance: new FormControl({ value: false, disabled: this.pageURL !== 'hosts' })
+      maintenance: new FormControl(false)
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -62,10 +62,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   hiddenColumns: string[] = [];
 
   @Input()
-  hideTitle = false;
-
-  @Input()
-  hideSubmitBtn = false;
+  hideMaintenance = false;
 
   @Input()
   hasTableDetails = true;
@@ -130,7 +127,9 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
         click: () =>
           this.router.url.includes('/hosts')
             ? this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.ADD] } }])
-            : (this.bsModalRef = this.modalService.show(HostFormComponent)),
+            : (this.bsModalRef = this.modalService.show(HostFormComponent, {
+                hideMaintenance: this.hideMaintenance
+              })),
         disable: (selection: CdTableSelection) => this.getDisable('add', selection)
       },
       {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57216

---

backport of https://github.com/ceph/ceph/pull/46702
parent tracker: https://tracker.ceph.com/issues/56070

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh