### PR TITLE
os/bluestore: assert on improper release in AvlAllocator

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -293,12 +293,16 @@ int AvlAllocator::_allocate(
     ceph_assert(align != 0);
     uint64_t* cursor = &lbas[cbits(align) - 1];
     start = _pick_block_after(cursor, size, unit);
-    dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
+    dout(20) << __func__
+             << std::hex << " first fit params: 0x" << start << "~" << size
+             << std::dec << dendl;
   }
   if (start == -1ULL) {
     do {
       start = _pick_block_fits(size, unit);
-      dout(20) << __func__ << " best fit=" << start << " size=" << size << dendl;
+      dout(20) << __func__
+               << std::hex << " best fit params: 0x" << start << "~" << size
+               << std::dec << dendl;
       if (start != uint64_t(-1ULL)) {
         break;
       }

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -105,6 +105,16 @@ void AvlAllocator::_add_to_tree(uint64_t start, uint64_t size)
     rs_before = std::prev(rs_after);
   }
 
+  if ((rs_before != range_tree.end() && rs_before->end > start) ||
+      (rs_after != range_tree.end() && rs_after->start < end)) {
+    derr << __func__ << " inconsistent tree state " << std::hex
+         << " 0x" << start << "~" << end - start
+         << std::dec << dendl;
+    _dump();
+  }
+  ceph_assert(rs_before == range_tree.end() || rs_before->end <= start);
+  ceph_assert(rs_after == range_tree.end() || rs_after->start >= end);
+
   bool merge_before = (rs_before != range_tree.end() && rs_before->end == start);
   bool merge_after = (rs_after != range_tree.end() && rs_after->start == end);
 
@@ -169,6 +179,14 @@ void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
 
   auto rs = range_tree.find(range_t{start, end}, range_tree.key_comp());
   /* Make sure we completely overlap with someone */
+  if (rs == range_tree.end() ||
+      rs->start > start ||
+      rs->end < end) {
+    derr << __func__ << " inconsistent tree state " << std::hex
+         << " 0x" << rs->start << "~" << rs->end - rs->start
+         << std::dec << dendl;
+    _dump();
+  }
   ceph_assert(rs != range_tree.end());
   ceph_assert(rs->start <= start);
   ceph_assert(rs->end >= end);
@@ -292,7 +310,9 @@ int AvlAllocator::_allocate(
   if (start == -1ULL) {
     return -ENOSPC;
   }
-
+  dout(20) << __func__ << " allocated 0x" << std::hex
+           << start << "~" << size
+           << std::dec << dendl;
   _remove_from_tree(start, size);
 
   *offset = start;
@@ -306,9 +326,9 @@ void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
     const auto offset = p.get_start();
     const auto length = p.get_len();
     ceph_assert(offset + length <= uint64_t(device_size));
-    ldout(cct, 10) << __func__ << std::hex
-      << " offset 0x" << offset
-      << " length 0x" << length
+    ldout(cct, 20) << __func__ << std::hex
+      << " 0x" << offset
+      << "~" << length
       << std::dec << dendl;
     _add_to_tree(offset, length);
   }
@@ -316,9 +336,9 @@ void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
 
 void AvlAllocator::_release(const PExtentVector& release_set) {
   for (auto& e : release_set) {
-    ldout(cct, 10) << __func__ << std::hex
-      << " offset 0x" << e.offset
-      << " length 0x" << e.length
+    ldout(cct, 20) << __func__ << std::hex
+      << " 0x" << e.offset
+      << "~" << e.length
       << std::dec << dendl;
     _add_to_tree(e.offset, e.length);
   }
@@ -346,14 +366,20 @@ AvlAllocator::AvlAllocator(CephContext* cct,
     cct->_conf.get_val<Option::size_t>("bluestore_avl_alloc_ff_max_search_bytes")),
   range_count_cap(max_mem / sizeof(range_seg_t)),
   cct(cct)
-{}
+{
+  ldout(cct, 10) << __func__ << " 0x" << std::hex << get_capacity() << "/"
+                 << get_block_size() << std::dec << dendl;
+}
 
 AvlAllocator::AvlAllocator(CephContext* cct,
 			   int64_t device_size,
 			   int64_t block_size,
 			   std::string_view name) :
   AvlAllocator(cct, device_size, block_size, 0 /* max_mem */, name)
-{}
+{
+  ldout(cct, 10) << __func__ << " 0x" << std::hex << get_capacity() << "/"
+                 << get_block_size() << std::dec << dendl;
+}
 
 AvlAllocator::~AvlAllocator()
 {
@@ -368,10 +394,10 @@ int64_t AvlAllocator::allocate(
   PExtentVector* extents)
 {
   ldout(cct, 10) << __func__ << std::hex
-                 << " want 0x" << want
-                 << " unit 0x" << unit
-                 << " max_alloc_size 0x" << max_alloc_size
-                 << " hint 0x" << hint
+                 << " 0x" << want
+                 << "/" << unit
+                 << "," << max_alloc_size
+                 << "," << hint
                  << std::dec << dendl;
   ceph_assert(std::has_single_bit(unit));
   ceph_assert(want % unit == 0);
@@ -450,8 +476,8 @@ void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
   std::lock_guard l(lock);
   ceph_assert(offset + length <= uint64_t(device_size));
   ldout(cct, 10) << __func__ << std::hex
-                 << " offset 0x" << offset
-                 << " length 0x" << length
+                 << " 0x" << offset
+                 << "~" << length
                  << std::dec << dendl;
   _add_to_tree(offset, length);
 }
@@ -463,8 +489,8 @@ void AvlAllocator::init_rm_free(uint64_t offset, uint64_t length)
   std::lock_guard l(lock);
   ceph_assert(offset + length <= uint64_t(device_size));
   ldout(cct, 10) << __func__ << std::hex
-                 << " offset 0x" << offset
-                 << " length 0x" << length
+                 << " 0x" << offset
+                 << "~" << length
                  << std::dec << dendl;
   _remove_from_tree(offset, length);
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13055,7 +13055,8 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
 {
   bool discard_queued = false;
   // it's expected we're called with lazy_release_lock already taken!
-  if (unlikely(cct->_conf->bluestore_debug_no_reuse_blocks)) {
+  if (unlikely(cct->_conf->bluestore_debug_no_reuse_blocks ||
+               txc->released.size() == 0)) {
       goto out;
   }
   discard_queued = bdev->try_discard(txc->released);

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -23,10 +23,10 @@ int64_t HybridAllocator::allocate(
   PExtentVector* extents)
 {
   ldout(cct, 10) << __func__ << std::hex
-                 << " want 0x" << want
-                 << " unit 0x" << unit
-                 << " max_alloc_size 0x" << max_alloc_size
-                 << " hint 0x" << hint
+                 << " 0x" << want
+                 << "/" << unit
+                 << "," << max_alloc_size
+                 << "," << hint
                  << std::dec << dendl;
   ceph_assert(std::has_single_bit(unit));
   ceph_assert(want % unit == 0);


### PR DESCRIPTION
Let's assert on unexpected unit release before we damage internal data structures.
Plus uniforms some logging output for avl/hybrid allocator with bitmap one to enable replay
tool usage.

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
