### PR TITLE
python-common/ceph/deployment: filter drives by actuators when creating osds

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -881,7 +881,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         else:
             metadata['device_nodes'] = devname
 
-        metadata['actuators'] = ""
+        metadata['actuators'] = None
         if os.path.isdir(sysdir + "/queue/independent_access_ranges/"):
             actuators = 0
             while os.path.isdir(sysdir + "/queue/independent_access_ranges/" + str(actuators)):

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -26,10 +26,11 @@ class DeviceSelection(object):
     """
 
     _supported_filters = [
-            "paths", "size", "vendor", "model", "rotational", "limit", "all"
+            "actuators", "paths", "size", "vendor", "model", "rotational", "limit", "all"
     ]
 
     def __init__(self,
+                 actuators=None,  # type: Optional[int]
                  paths=None,  # type: Optional[List[str]]
                  model=None,  # type: Optional[str]
                  size=None,  # type: Optional[str]
@@ -41,6 +42,8 @@ class DeviceSelection(object):
         """
         ephemeral drive group device specification
         """
+        self.actuators = actuators
+
         #: List of Device objects for devices paths.
         self.paths = [] if paths is None else [Device(path) for path in paths]  # type: List[Device]
 
@@ -66,7 +69,8 @@ class DeviceSelection(object):
         self.all = all
 
     def validate(self, name: str) -> None:
-        props = [self.model, self.vendor, self.size, self.rotational]  # type: List[Any]
+        props = [self.actuators, self.model, self.vendor, self.size,
+                 self.rotational]  # type: List[Any]
         if self.paths and any(p is not None for p in props):
             raise DriveGroupValidationError(
                 name,

--- a/src/python-common/ceph/deployment/drive_selection/filter.py
+++ b/src/python-common/ceph/deployment/drive_selection/filter.py
@@ -21,6 +21,8 @@ class FilterGenerator(object):
 
     def __iter__(self):
         # type: () -> Generator[Matcher, None, None]
+        if self.device_filter.actuators:
+            yield EqualityMatcher('actuators', self.device_filter.actuators)
         if self.device_filter.size:
             yield SizeMatcher('size', self.device_filter.size)
         if self.device_filter.model:


### PR DESCRIPTION
As storage capacities grow, multi-actuator technology introduced by Seagate addresses the downward pressure on performance that comes with growing drive capacities and areal densities. Having multiple actuators enables drives to maintain the performance needs of customers with data-intensive applications.

Our testing indicates that, for certain workloads, using one OSD per actuator increases performance over using one OSD per dual-actuator drive. Bandwidth for the combined OSDs can increase over 40% and IOPS can nearly double compared to the alternative.

Extending the change introduced to ceph-volume that detects drives with two or more actuators, this feature enables the administrator to set a simple configuration that creates two OSDs on any detected dual-actuator drives using the advanced OSD service specification.

```
$ cat ~/osd.yaml
service_type: osd
service_id: example_osd_spec
placement:
  host_pattern: '*'
spec:
  data_devices:
    actuators: 2
  osds_per_device: 2
$ ./bin/ceph orch apply -i ~/osd.yaml
...
```

Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates

Signed-off-by: Michael English <michael.english@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>