### PR TITLE
quincy: mgr/snap_schedule: replace .snap with the client configured snap dir name

### DIFF
--- a/qa/suites/fs/functional/tasks/snap_schedule_snapdir.yaml
+++ b/qa/suites/fs/functional/tasks/snap_schedule_snapdir.yaml
@@ -1,0 +1,30 @@
+overrides:
+  ceph:
+    conf:
+      mgr:
+        debug mgr: 20
+        debug ms: 1
+        debug finisher: 20
+        debug client: 20
+    log-whitelist:
+      - OSD full dropping all updates
+      - OSD near full
+      - pausewr flag
+      - failsafe engaged, dropping updates
+      - failsafe disengaged, no longer dropping
+      - is full \(reached quota
+      - POOL_FULL
+      - POOL_BACKFILLFULL
+
+overrides:
+  kclient:
+    snapdirname: .customsnapkernel
+  ceph:
+    conf:
+      client:
+        client snapdir: .customsnapfuse
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_snap_schedules.TestSnapSchedulesSnapdir

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -33,6 +33,7 @@ class KernelMount(CephFSMount):
         self.client_config = client_config
         self.dynamic_debug = client_config.get('dynamic_debug', False)
         self.rbytes = client_config.get('rbytes', False)
+        self.snapdirname = client_config.get('snapdirname', '.snap')
         self.syntax_style = client_config.get('syntax', 'v2')
         self.inst = None
         self.addr = None
@@ -108,6 +109,8 @@ class KernelMount(CephFSMount):
             opts += ",rbytes"
         else:
             opts += ",norbytes"
+        if self.snapdirname != '.snap':
+            opts += f',snapdirname={self.snapdirname}'
 
         mount_cmd = ['sudo'] + self._nsenter_args
         stx_opt = self._make_mount_cmd_old_or_new_style()

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -275,8 +275,9 @@ class SnapSchedClient(CephfsClient):
                                                       start=start)[0]
                     time = datetime.now(timezone.utc)
                     with open_filesystem(self, fs_name) as fs_handle:
-                        snap_ts = time.strftime(SNAPSHOT_TS_FORMAT)
-                        snap_name = f'{path}/.snap/{SNAPSHOT_PREFIX}-{snap_ts}'
+                        snap_ts = time.strftime(SNAPSHOT_TS_FORMAT_TZ)
+                        snap_dir = self.mgr.rados.conf_get('client_snapdir')
+                        snap_name = f'{path}/{snap_dir}/{SNAPSHOT_PREFIX}-{snap_ts}'
                         fs_handle.mkdir(snap_name, 0o755)
                     log.info(f'created scheduled snapshot of {path}')
                     log.debug(f'created scheduled snapshot {snap_name}')
@@ -302,7 +303,8 @@ class SnapSchedClient(CephfsClient):
             prune_candidates = set()
             time = datetime.now(timezone.utc)
             with open_filesystem(self, sched.fs) as fs_handle:
-                with fs_handle.opendir(f'{path}/.snap') as d_handle:
+                snap_dir = self.mgr.rados.conf_get('client_snapdir')
+                with fs_handle.opendir(f'{path}/{snap_dir}') as d_handle:
                     dir_ = fs_handle.readdir(d_handle)
                     while dir_:
                         if dir_.d_name.decode('utf-8').startswith(f'{SNAPSHOT_PREFIX}-'):
@@ -318,7 +320,7 @@ class SnapSchedClient(CephfsClient):
                 for k in to_prune:
                     dirname = k[0].d_name.decode('utf-8')
                     log.debug(f'rmdir on {dirname}')
-                    fs_handle.rmdir(f'{path}/.snap/{dirname}')
+                    fs_handle.rmdir(f'{path}/{snap_dir}/{dirname}')
                 if to_prune:
                     with self.get_schedule_db(sched.fs) as conn_mgr:
                         db = conn_mgr.dbinfo.db

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -25,7 +25,13 @@ SNAP_DB_PREFIX = 'snap_db'
 # increment this every time the db schema changes and provide upgrade code
 SNAP_DB_VERSION = '0'
 SNAP_DB_OBJECT_NAME = f'{SNAP_DB_PREFIX}_v{SNAP_DB_VERSION}'
+# scheduled snapshots are tz suffixed
+SNAPSHOT_TS_FORMAT_TZ = '%Y-%m-%d-%H_%M_%S_%Z'
+# for backward compat snapshot name parsing
 SNAPSHOT_TS_FORMAT = '%Y-%m-%d-%H_%M_%S'
+# length of timestamp format (without tz suffix)
+# e.g.: scheduled-2022-04-19-05_39_00_UTC (len = "2022-04-19-05_39_00")
+SNAPSHOT_TS_FORMAT_LEN = 19
 SNAPSHOT_PREFIX = 'scheduled'
 
 log = logging.getLogger(__name__)
@@ -70,6 +76,7 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
     PRUNING_PATTERNS = OrderedDict([
         # n is for keep last n snapshots, uses the snapshot name timestamp
         # format for lowest granularity
+        # NOTE: prune set has tz suffix stripped out.
         ("n", SNAPSHOT_TS_FORMAT),
         # TODO remove M for release
         ("M", '%Y-%m-%d-%H_%M'),
@@ -110,6 +117,10 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
         keep = keep[:MAX_SNAPS_PER_PATH]
     return candidates - set(keep)
 
+def snap_name_to_timestamp(scheduled_snap_name: str) -> str:
+    """ extract timestamp from a schedule snapshot with tz suffix stripped out """
+    ts = scheduled_snap_name.lstrip(f'{SNAPSHOT_PREFIX}-')
+    return ts[0:SNAPSHOT_TS_FORMAT_LEN]
 
 class DBInfo():
     def __init__(self, fs: str, db: sqlite3.Connection):
@@ -310,8 +321,7 @@ class SnapSchedClient(CephfsClient):
                         if dir_.d_name.decode('utf-8').startswith(f'{SNAPSHOT_PREFIX}-'):
                             log.debug(f'add {dir_.d_name} to pruning')
                             ts = datetime.strptime(
-                                dir_.d_name.decode('utf-8').lstrip(f'{SNAPSHOT_PREFIX}-'),
-                                SNAPSHOT_TS_FORMAT)
+                                snap_name_to_timestamp(dir_.d_name.decode('utf-8')), SNAPSHOT_TS_FORMAT)
                             prune_candidates.add((dir_, ts))
                         else:
                             log.debug(f'skipping dir entry {dir_.d_name}')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57200 and https://tracker.ceph.com/issues/55385

---

backport of https://github.com/ceph/ceph/pull/45869 and https://github.com/ceph/ceph/pull/45945
parent tracker: https://tracker.ceph.com/issues/55234 and https://tracker.ceph.com/issues/54374

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh