### PR TITLE
cls/rgw: restore backward-compatible encoding of cls_rgw_bucket_instance_entry

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -806,17 +806,23 @@ struct cls_rgw_bucket_instance_entry {
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode((uint8_t)reshard_status, bl);
+    { // fields removed in v2 but added back as empty in v3
+      std::string bucket_instance_id;
+      encode(bucket_instance_id, bl);
+      int32_t num_shards{-1};
+      encode(num_shards, bl);
+    }
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     uint8_t s;
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
-    if (struct_v < 2) { // fields removed from v2
+    if (struct_v != 2) { // fields removed from v2, added back in v3
       std::string bucket_instance_id;
       decode(bucket_instance_id, bl);
       int32_t num_shards{-1};


### PR DESCRIPTION
the encoding of `cls_rgw_bucket_instance_entry` changed in bd0b0e5d984c83504f88fa155a7dfc6f6571aa49 such that pacific/quincy OSDs cannot read the version written by reef OSDs
    
two fields (bucket_instance_id and num_shards) were removed in the v2 encoder, but the v1 decoder still expects them to be present
    
since we haven't released reef yet, we can fix this with a v3 that adds the fields back

Fixes: https://tracker.ceph.com/issues/57232

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
