### PR TITLE
admin: Fix check if PR or release branch docs build

### DIFF
--- a/admin/rtd-checkout-main
+++ b/admin/rtd-checkout-main
@@ -1,6 +1,9 @@
 # See .readthedocs.yml
 set -ex
-if git symbolic-ref HEAD; then
-  git checkout origin/main -- doc/releases
+re='^[0-9]+$'
+if [[ $READTHEDOCS_VERSION =~ $re ]]; then
+   echo "Building docs for PR $READTHEDOCS_VERSION.  Will not check out doc/releases from main branch."
+else
+   echo "Building docs for $READTHEDOCS_VERSION branch.  Will check out doc/releases from main branch."
 fi
 git status


### PR DESCRIPTION
Uses built-in RTD vars.  https://docs.readthedocs.io/en/stable/environment-variables.html.

Follow up to https://github.com/ceph/ceph/pull/46917#discussion_r942359130.

Signed-off-by: David Galloway <dgallowa@redhat.com>
(cherry picked from commit 585b746d7f9339b347440f6aef2735f4d0bd31f4)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
