### PR TITLE
do_cmake.sh: build with python3.10 on ubuntu version >= 22.0

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -42,6 +42,13 @@ if [ -r /etc/os-release ]; then
           ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
           ARGS+=" -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
           ;;
+      ubuntu)
+          MAJOR_VER=$(echo "$VERSION_ID" | sed -e 's/\..*$//')
+          if [ "$MAJOR_VER" -ge "22" ] ; then
+              PYBUILD="3.10"
+          fi
+          ;;
+
   esac
 elif [ "$(uname)" == FreeBSD ] ; then
   PYBUILD="3"


### PR DESCRIPTION
Ubuntu 22.04 should be built with Python 3.10. Since we've updated jenkins nodes to 22.04, Pacific PRs seem to be using older python versions when running cmake, which causes failures like:

```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python3 (missing: Python3_LIBRARY Python3_INCLUDE_DIR
  Development) (found suitable exact version "3.8.10")
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindPython/Support.cmake:1181 (find_package_handle_standard_args)
  cmake/modules/FindPython3.cmake:181 (include)
  CMakeLists.txt:477 (find_package)
```

Although this version mixup primarily affects Pacific PRs, I think it makes sense to enforce this on all branches.

Fixes: https://tracker.ceph.com/issues/57230
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
