### PR TITLE
quincy: mgr/volumes: prevent intermittent ParsingError failure in "clone cancel"

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
@@ -3,11 +3,7 @@ import errno
 import logging
 import sys
 import threading
-
-if sys.version_info >= (3, 2):
-    import configparser
-else:
-    import ConfigParser as configparser
+import configparser
 
 import cephfs
 
@@ -71,10 +67,7 @@ class MetadataManager(object):
         self.fs = fs
         self.mode = mode
         self.config_path = config_path
-        if sys.version_info >= (3, 2):
-            self.config = configparser.ConfigParser()
-        else:
-            self.config = configparser.SafeConfigParser()
+        self.config = configparser.ConfigParser()
 
     def refresh(self):
         fd = None


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57112

---

backport of https://github.com/ceph/ceph/pull/47067
parent tracker: https://tracker.ceph.com/issues/55583

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh