### PR TITLE
crimson/os/seastore/btree: link fixedkvbtree's nodes and logical extents with forward and backward pointers, and drop the pin_set

### DIFF
--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -18,6 +18,8 @@ set(crimson_seastore_srcs
   omap_manager.cc
   omap_manager/btree/btree_omap_manager.cc
   omap_manager/btree/omap_btree_node_impl.cc
+  btree/btree_range_pin.cc
+  btree/fixed_kv_node.cc
   onode.cc
   onode_manager/staged-fltree/node.cc
   onode_manager/staged-fltree/node_extent_manager.cc

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -7,6 +7,7 @@ set(crimson_seastore_srcs
   transaction_manager.cc
   transaction.cc
   cache.cc
+  root_block.cc
   lba_manager.cc
   async_cleaner.cc
   backref_manager.cc

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1424,23 +1424,27 @@ bool SegmentCleaner::check_usage()
       t,
       [&tracker](
         paddr_t paddr,
+	paddr_t backref_key,
         extent_len_t len,
         extent_types_t type,
         laddr_t laddr)
     {
       if (paddr.get_addr_type() == paddr_types_t::SEGMENT) {
         if (is_backref_node(type)) {
-          assert(laddr == L_ADDR_NULL);
+	  assert(laddr == L_ADDR_NULL);
+	  assert(backref_key != P_ADDR_NULL);
           tracker->allocate(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
             len);
         } else if (laddr == L_ADDR_NULL) {
+	  assert(backref_key == P_ADDR_NULL);
           tracker->release(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
             len);
         } else {
+	  assert(backref_key == P_ADDR_NULL);
           tracker->allocate(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
@@ -1724,6 +1728,7 @@ bool RBMCleaner::check_usage()
       t,
       [&tracker, &rbms](
         paddr_t paddr,
+	paddr_t backref_key,
         extent_len_t len,
         extent_types_t type,
         laddr_t laddr)
@@ -1732,14 +1737,17 @@ bool RBMCleaner::check_usage()
 	if (rbm->get_device_id() == paddr.get_device_id()) {
 	  if (is_backref_node(type)) {
 	    assert(laddr == L_ADDR_NULL);
+	    assert(backref_key != P_ADDR_NULL);
 	    tracker.allocate(
 	      paddr,
 	      len);
 	  } else if (laddr == L_ADDR_NULL) {
+	    assert(backref_key == P_ADDR_NULL);
 	    tracker.release(
 	      paddr,
 	      len);
 	  } else {
+	    assert(backref_key == P_ADDR_NULL);
 	    tracker.allocate(
 	      paddr,
 	      len);

--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -92,7 +92,8 @@ public:
   const_iterator insert(
     const_iterator iter,
     paddr_t key,
-    backref_map_val_t val) final {
+    backref_map_val_t val,
+    LogicalCachedExtent*) final {
     journal_insert(
       iter,
       key,
@@ -103,7 +104,8 @@ public:
 
   void update(
     const_iterator iter,
-    backref_map_val_t val) final {
+    backref_map_val_t val,
+    LogicalCachedExtent*) final {
     return journal_update(
       iter,
       val,

--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -130,4 +130,5 @@ using BackrefLeafNodeRef = BackrefLeafNode::Ref;
 template <> struct fmt::formatter<crimson::os::seastore::backref::backref_map_val_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::backref::BackrefInternalNode> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::backref::BackrefLeafNode> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::backref::backref_node_meta_t> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -76,7 +76,8 @@ class BackrefLeafNode
       paddr_t, paddr_le_t,
       backref_map_val_t, backref_map_val_le_t,
       BACKREF_NODE_SIZE,
-      BackrefLeafNode> {
+      BackrefLeafNode,
+      false> {
 public:
   template <typename... T>
   BackrefLeafNode(T&&... t) :

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -332,6 +332,17 @@ BtreeBackrefManager::merge_cached_backrefs(
   });
 }
 
+BtreeBackrefManager::check_child_trackers_ret
+BtreeBackrefManager::check_child_trackers(
+  Transaction &t) {
+  auto c = get_context(t);
+  return with_btree<BackrefBtree>(
+    cache, c,
+    [c](auto &btree) {
+    return btree.check_child_trackers(c);
+  });
+}
+
 BtreeBackrefManager::scan_mapped_space_ret
 BtreeBackrefManager::scan_mapped_space(
   Transaction &t,
@@ -419,7 +430,7 @@ BtreeBackrefManager::scan_mapped_space(
       BackrefBtree::mapped_space_visitor_t f =
 	[&scan_visitor, block_size, FNAME, c](
 	  paddr_t paddr, paddr_t key, extent_len_t len,
-	  depth_t depth, extent_types_t type) {
+	  depth_t depth, extent_types_t type, BackrefBtree::iterator&) {
 	TRACET("tree node {}~{} {}, depth={} used",
 	       c.trans, paddr, len, type, depth);
 	ceph_assert(paddr.is_absolute());

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -242,7 +242,8 @@ BtreeBackrefManager::new_mapping(
 	    c,
 	    *state.insert_iter,
 	    state.last_end,
-	    val
+	    val,
+	    nullptr
 	  ).si_then([&state, c, addr, len, key](auto &&p) {
 	    LOG_PREFIX(BtreeBackrefManager::new_mapping);
 	    auto [iter, inserted] = std::move(p);

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -328,6 +328,7 @@ BtreeBackrefManager::scan_mapped_space(
 	  ceph_assert(pos.get_val().laddr != L_ADDR_NULL);
 	  scan_visitor(
 	      pos.get_key(),
+	      P_ADDR_NULL,
 	      pos.get_val().len,
 	      pos.get_val().type,
 	      pos.get_val().laddr);
@@ -362,6 +363,7 @@ BtreeBackrefManager::scan_mapped_space(
 	ceph_assert(!is_backref_node(backref_entry.type));
 	scan_visitor(
 	    backref_entry.paddr,
+	    P_ADDR_NULL,
 	    backref_entry.len,
 	    backref_entry.type,
 	    backref_entry.laddr);
@@ -369,7 +371,7 @@ BtreeBackrefManager::scan_mapped_space(
     }).si_then([this, &scan_visitor, block_size, c, FNAME] {
       BackrefBtree::mapped_space_visitor_t f =
 	[&scan_visitor, block_size, FNAME, c](
-	  paddr_t paddr, extent_len_t len,
+	  paddr_t paddr, paddr_t key, extent_len_t len,
 	  depth_t depth, extent_types_t type) {
 	TRACET("tree node {}~{} {}, depth={} used",
 	       c.trans, paddr, len, type, depth);
@@ -377,7 +379,7 @@ BtreeBackrefManager::scan_mapped_space(
 	ceph_assert(len > 0 && len % block_size == 0);
 	ceph_assert(depth >= 1);
 	ceph_assert(is_backref_node(type));
-	return scan_visitor(paddr, len, type, L_ADDR_NULL);
+	return scan_visitor(paddr, key, len, type, L_ADDR_NULL);
       };
       return seastar::do_with(
 	std::move(f),
@@ -534,9 +536,10 @@ BtreeBackrefManager::get_cached_backref_entries_in_range(
 
 void BtreeBackrefManager::cache_new_backref_extent(
   paddr_t paddr,
+  paddr_t key,
   extent_types_t type)
 {
-  return cache.add_backref_extent(paddr, type);
+  return cache.add_backref_extent(paddr, key, type);
 }
 
 BtreeBackrefManager::retrieve_backref_extents_in_range_ret
@@ -545,10 +548,11 @@ BtreeBackrefManager::retrieve_backref_extents_in_range(
   paddr_t start,
   paddr_t end)
 {
+  auto backref_extents = cache.get_backref_extents_in_range(start, end);
   return seastar::do_with(
       std::vector<CachedExtentRef>(),
-      [this, &t, start, end](auto &extents) {
-    auto backref_extents = cache.get_backref_extents_in_range(start, end);
+      std::move(backref_extents),
+      [this, &t](auto &extents, auto &backref_extents) {
     return trans_intr::parallel_for_each(
       backref_extents,
       [this, &extents, &t](auto &ent) {
@@ -556,14 +560,28 @@ BtreeBackrefManager::retrieve_backref_extents_in_range(
       // so it must be alive
       assert(is_backref_node(ent.type));
       LOG_PREFIX(BtreeBackrefManager::retrieve_backref_extents_in_range);
-      DEBUGT("getting backref extent of type {} at {}",
-        t,
-        ent.type,
-        ent.paddr);
-      return cache.get_extent_by_type(
-        t, ent.type, ent.paddr, L_ADDR_NULL, BACKREF_NODE_SIZE
-      ).si_then([&extents](auto ext) {
-        extents.emplace_back(std::move(ext));
+      DEBUGT("getting backref extent of type {} at {}, key {}",
+	t,
+	ent.type,
+	ent.paddr,
+	ent.key);
+
+      auto c = get_context(t);
+      return with_btree_ret<BackrefBtree, CachedExtentRef>(
+	cache,
+	c,
+	[c, &ent](auto &btree) {
+	if (ent.type == extent_types_t::BACKREF_INTERNAL) {
+	  return btree.get_internal_if_live(
+	    c, ent.paddr, ent.key, BACKREF_NODE_SIZE);
+	} else {
+	  assert(ent.type == extent_types_t::BACKREF_LEAF);
+	  return btree.get_leaf_if_live(
+	    c, ent.paddr, ent.key, BACKREF_NODE_SIZE);
+	}
+      }).si_then([&extents](auto ext) {
+	ceph_assert(ext);
+	extents.emplace_back(std::move(ext));
       });
     }).si_then([&extents] {
       return std::move(extents);

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -120,7 +120,7 @@ BtreeBackrefManager::get_mapping(
       } else {
 	TRACET("{} got {}, {}",
 	       c.trans, offset, iter.get_key(), iter.get_val());
-	auto e = iter.get_pin();
+	auto e = iter.get_pin(c);
 	return get_mapping_ret(
 	  interruptible::ready_future_marker{},
 	  std::move(e));
@@ -157,7 +157,7 @@ BtreeBackrefManager::get_mappings(
 	  TRACET("{}~{} got {}, {}, repeat ...",
 	         c.trans, offset, end, pos.get_key(), pos.get_val());
 	  ceph_assert((pos.get_key().add_offset(pos.get_val().len)) > offset);
-	  ret.push_back(pos.get_pin());
+	  ret.push_back(pos.get_pin(c));
 	  return BackrefBtree::iterate_repeat_ret_inner(
 	    interruptible::ready_future_marker{},
 	    seastar::stop_iteration::no);
@@ -253,8 +253,8 @@ BtreeBackrefManager::new_mapping(
 	    state.ret = iter;
 	  });
 	});
-    }).si_then([](auto &&state) {
-      return state.ret->get_pin();
+    }).si_then([c](auto &&state) {
+      return state.ret->get_pin(c);
     });
 }
 

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -192,10 +192,10 @@ BtreeBackrefManager::new_mapping(
 	    state.last_end,
 	    val
 	  ).si_then([&state, c, addr, len, key](auto &&p) {
-	    LOG_PREFIX(BtreeBackrefManager::alloc_extent);
+	    LOG_PREFIX(BtreeBackrefManager::new_mapping);
 	    auto [iter, inserted] = std::move(p);
-	    TRACET("{}~{}, paddr={}, inserted at {}",
-	           c.trans, addr, len, key, state.last_end);
+	    TRACET("{}~{}, paddr={}, inserted at {}, leaf {}",
+	           c.trans, addr, len, key, state.last_end, *iter.get_leaf_node());
 	    ceph_assert(inserted);
 	    state.ret = iter;
 	  });
@@ -473,7 +473,8 @@ BtreeBackrefManager::remove_mapping(
 		-> remove_mapping_ret {
 	if (iter.is_end() || iter.get_key() != addr) {
 	  LOG_PREFIX(BtreeBackrefManager::remove_mapping);
-	  DEBUGT("paddr={} doesn't exist", c.trans, addr);
+	  WARNT("paddr={} doesn't exist, state: {}, leaf {}",
+	    c.trans, addr, iter.get_key(), *iter.get_leaf_node());
 	  return remove_mapping_iertr::make_ready_future<
 	    remove_mapping_result_t>(remove_mapping_result_t());
 	}

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -108,7 +108,10 @@ public:
     paddr_t start,
     paddr_t end) final;
 
-  void cache_new_backref_extent(paddr_t paddr, extent_types_t type) final;
+  void cache_new_backref_extent(
+    paddr_t paddr,
+    paddr_t key,
+    extent_types_t type) final;
 
 private:
   Cache &cache;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -33,7 +33,7 @@ public:
 
 using BackrefBtree = FixedKVBtree<
   paddr_t, backref_map_val_t, BackrefInternalNode,
-  BackrefLeafNode, BtreeBackrefPin, BACKREF_BLOCK_SIZE>;
+  BackrefLeafNode, BtreeBackrefPin, BACKREF_BLOCK_SIZE, false>;
 
 class BtreeBackrefManager : public BackrefManager {
 public:

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -17,10 +17,12 @@ public:
   BtreeBackrefPin() = default;
   BtreeBackrefPin(
     CachedExtentRef parent,
+    uint16_t pos,
     backref_map_val_t &val,
     backref_node_meta_t &&meta)
     : BtreeNodePin(
 	parent,
+	pos,
 	val.laddr,
 	val.len,
 	std::forward<backref_node_meta_t>(meta)),

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -75,6 +75,8 @@ public:
     Transaction &t,
     paddr_t offset) final;
 
+  check_child_trackers_ret check_child_trackers(Transaction &t) final;
+
   scan_mapped_space_ret scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) final;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -14,13 +14,16 @@ constexpr size_t BACKREF_BLOCK_SIZE = 4096;
 class BtreeBackrefPin : public BtreeNodePin<paddr_t, laddr_t> {
   extent_types_t type;
 public:
-  BtreeBackrefPin() = default;
+  BtreeBackrefPin(op_context_t<paddr_t> ctx)
+    : BtreeNodePin(ctx) {}
   BtreeBackrefPin(
+    op_context_t<paddr_t> ctx,
     CachedExtentRef parent,
     uint16_t pos,
     backref_map_val_t &val,
     backref_node_meta_t &&meta)
     : BtreeNodePin(
+	ctx,
 	parent,
 	pos,
 	val.laddr,

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -127,6 +127,9 @@ public:
     Transaction &t,
     paddr_t offset) = 0;
 
+  using check_child_trackers_ret = base_iertr::future<>;
+  virtual check_child_trackers_ret check_child_trackers(Transaction &t) = 0;
+
   /**
    * scan all extents in both tree and cache,
    * including backref extents, logical extents and lba extents,

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -96,7 +96,10 @@ public:
     paddr_t start,
     paddr_t end) = 0;
 
-  virtual void cache_new_backref_extent(paddr_t paddr, extent_types_t type) = 0;
+  virtual void cache_new_backref_extent(
+    paddr_t paddr,
+    paddr_t key,
+    extent_types_t type) = 0;
 
   /**
    * merge in-cache paddr_t -> laddr_t mappings to the on-disk backref tree
@@ -132,7 +135,7 @@ public:
   using scan_mapped_space_iertr = base_iertr;
   using scan_mapped_space_ret = scan_mapped_space_iertr::future<>;
   using scan_mapped_space_func_t = std::function<
-    void(paddr_t, extent_len_t, extent_types_t, laddr_t)>;
+    void(paddr_t, paddr_t, extent_len_t, extent_types_t, laddr_t)>;
   virtual scan_mapped_space_ret scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) = 0;

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -42,7 +42,7 @@ public:
    */
   using get_mapping_iertr = base_iertr::extend<
     crimson::ct_error::enoent>;
-  using get_mapping_ret = get_mapping_iertr::future<BackrefPinRef>;
+  using get_mapping_ret = get_mapping_iertr::future<BackrefMappingRef>;
   virtual get_mapping_ret  get_mapping(
     Transaction &t,
     paddr_t offset) = 0;
@@ -62,7 +62,7 @@ public:
    * Insert new paddr_t -> laddr_t mapping
    */
   using new_mapping_iertr = base_iertr;
-  using new_mapping_ret = new_mapping_iertr::future<BackrefPinRef>;
+  using new_mapping_ret = new_mapping_iertr::future<BackrefMappingRef>;
   virtual new_mapping_ret new_mapping(
     Transaction &t,
     paddr_t key,
@@ -139,17 +139,6 @@ public:
   virtual scan_mapped_space_ret scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) = 0;
-
-  virtual void complete_transaction(
-    Transaction &t,
-    std::vector<CachedExtentRef> &to_clear,	///< extents whose pins are to be cleared,
-						//   as the results of their retirements
-    std::vector<CachedExtentRef> &to_link	///< fresh extents whose pins are to be inserted
-						//   into backref manager's pin set
-  ) = 0;
-
-  virtual void add_pin(BackrefPin &pin) = 0;
-  virtual void remove_pin(BackrefPin &pin) = 0;
 
   virtual ~BackrefManager() {}
 };

--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -1,0 +1,36 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/btree/btree_range_pin.h"
+#include "crimson/os/seastore/btree/fixed_kv_node.h"
+
+namespace crimson::os::seastore {
+
+template <typename key_t, typename val_t>
+void BtreeNodePin<key_t, val_t>::link_extent(LogicalCachedExtent *ref) {
+  assert(ref->is_valid());
+  // it's only when reading logical extents from disk that we need to
+  // link them to lba leaves
+  if (!ref->is_pending() && !ref->is_exist_clean()) {
+    assert(parent);
+    assert(pos != std::numeric_limits<uint16_t>::max());
+    if (parent->is_initial_pending()) {
+      auto &p = ((FixedKVNode<key_t>&)*parent).get_stable_for_key(
+	pin.range.begin);
+      p.link_child(ref, pos);
+    } else if (parent->is_mutation_pending()) {
+      auto &p = (FixedKVNode<key_t>&)*parent->get_prior_instance();
+      p.link_child(ref, pos);
+    } else {
+      assert(!parent->is_pending() && parent->is_valid());
+      auto &p = (FixedKVNode<key_t>&)*parent;
+      p.link_child(ref, pos);
+    }
+    pos = std::numeric_limits<uint16_t>::max();
+  }
+  pin.set_extent(ref);
+}
+
+template void BtreeNodePin<laddr_t, paddr_t>::link_extent(LogicalCachedExtent*);
+template void BtreeNodePin<paddr_t, laddr_t>::link_extent(LogicalCachedExtent*);
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -8,7 +8,7 @@ namespace crimson::os::seastore {
 
 template <typename key_t, typename val_t>
 get_child_ret_t<LogicalCachedExtent>
-BtreeNodePin<key_t, val_t>::get_logical_extent(
+BtreeNodeMapping<key_t, val_t>::get_logical_extent(
   Transaction &t)
 {
   assert(parent);
@@ -22,7 +22,6 @@ BtreeNodePin<key_t, val_t>::get_logical_extent(
   return v;
 }
 
-template class BtreeNodePin<laddr_t, paddr_t>;
-template class BtreeNodePin<paddr_t, laddr_t>;
-
+template class BtreeNodeMapping<laddr_t, paddr_t>;
+template class BtreeNodeMapping<paddr_t, laddr_t>;
 } // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -41,6 +41,10 @@ struct fixed_kv_node_meta_t {
       (end > other.begin);
   }
 
+  bool is_in_range(const bound_t key) const {
+    return begin <= key && end > key;
+  }
+
   std::pair<fixed_kv_node_meta_t, fixed_kv_node_meta_t> split_into(bound_t pivot) const {
     return std::make_pair(
       fixed_kv_node_meta_t{begin, pivot, depth},
@@ -116,9 +120,13 @@ struct fixed_kv_node_meta_le_t {
 template <typename T>
 class btree_pin_set_t;
 
+template <typename node_key_t>
+class FixedKVNode;
+
 template <typename node_bound_t>
 class btree_range_pin_t : public boost::intrusive::set_base_hook<> {
   friend class btree_pin_set_t<node_bound_t>;
+  friend class FixedKVNode<node_bound_t>;
   fixed_kv_node_meta_t<node_bound_t> range;
 
   btree_pin_set_t<node_bound_t> *pins = nullptr;

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -17,7 +17,6 @@ template <typename node_key_t>
 struct op_context_t {
   Cache &cache;
   Transaction &trans;
-  btree_pin_set_t<node_key_t> *pins = nullptr;
 };
 
 constexpr uint16_t MAX_FIXEDKVBTREE_DEPTH = 8;
@@ -116,339 +115,8 @@ struct fixed_kv_node_meta_le_t {
   }
 };
 
-
-/**
- * btree_range_pin_t
- *
- * Element tracked by btree_pin_set_t below.  Encapsulates the intrusive_set
- * hook, the fixed_kv_node_meta_t representing the key range covered by a node,
- * and extent and ref members intended to hold a reference when the extent
- * should be pinned.
- */
-template <typename T>
-class btree_pin_set_t;
-
-template <typename node_key_t>
-class FixedKVNode;
-
-template <typename node_bound_t>
-class btree_range_pin_t : public boost::intrusive::set_base_hook<> {
-  friend class btree_pin_set_t<node_bound_t>;
-  friend class FixedKVNode<node_bound_t>;
-  fixed_kv_node_meta_t<node_bound_t> range;
-
-  btree_pin_set_t<node_bound_t> *pins = nullptr;
-
-  // We need to be able to remember extent without holding a reference,
-  // but we can do it more compactly -- TODO
-  CachedExtent *extent = nullptr;
-  CachedExtentRef ref;
-
-  using index_t = boost::intrusive::set<btree_range_pin_t>;
-
-  void acquire_ref() {
-    ref = CachedExtentRef(extent);
-  }
-
-  void drop_ref() {
-    ref.reset();
-  }
-
-public:
-  btree_range_pin_t() = default;
-  btree_range_pin_t(CachedExtent *extent)
-    : extent(extent) {}
-  btree_range_pin_t(const btree_range_pin_t &rhs, CachedExtent *extent)
-    : range(rhs.range), extent(extent) {}
-
-  bool has_ref() const {
-    return !!ref;
-  }
-
-  bool is_root() const {
-    return range.is_root();
-  }
-
-  void set_range(const fixed_kv_node_meta_t<node_bound_t> &nrange) {
-    range = nrange;
-  }
-  void set_extent(CachedExtent *nextent) {
-    ceph_assert(!extent);
-    extent = nextent;
-  }
-
-  CachedExtent &get_extent() {
-    assert(extent);
-    return *extent;
-  }
-
-  bool has_ref() {
-    return !!ref;
-  }
-
-  void take_pin(btree_range_pin_t &other)
-  {
-    ceph_assert(other.extent);
-    if (other.pins) {
-      other.pins->replace_pin(*this, other);
-      pins = other.pins;
-      other.pins = nullptr;
-
-      if (other.has_ref()) {
-	other.drop_ref();
-	acquire_ref();
-      }
-    }
-  }
-
-  friend bool operator<(
-    const btree_range_pin_t &lhs, const btree_range_pin_t &rhs) {
-    assert(lhs.range.depth == rhs.range.depth);
-    return lhs.range.begin < rhs.range.begin;
-  }
-  friend bool operator>(
-    const btree_range_pin_t &lhs, const btree_range_pin_t &rhs) {
-    assert(lhs.range.depth == rhs.range.depth);
-    return lhs.range.begin > rhs.range.begin;
-  }
-  friend bool operator==(
-    const btree_range_pin_t &lhs, const btree_range_pin_t &rhs) {
-    assert(lhs.range.depth == rhs.range.depth);
-    return lhs.range.begin == rhs.range.begin;
-  }
-
-  struct meta_cmp_t {
-    bool operator()(
-      const btree_range_pin_t &lhs, const fixed_kv_node_meta_t<node_bound_t> &rhs) const {
-      assert(lhs.range.depth == rhs.depth);
-      return lhs.range.begin < rhs.begin;
-    }
-    bool operator()(
-      const fixed_kv_node_meta_t<node_bound_t> &lhs, const btree_range_pin_t &rhs) const {
-      assert(lhs.depth == rhs.range.depth);
-      return lhs.begin < rhs.range.begin;
-    }
-  };
-
-  friend std::ostream &operator<<(
-    std::ostream &lhs,
-    const btree_range_pin_t<node_bound_t> &rhs) {
-    return lhs << "btree_range_pin_t("
-	       << "begin=" << rhs.range.begin
-	       << ", end=" << rhs.range.end
-	       << ", depth=" << rhs.range.depth
-	       << ", extent=" << rhs.extent
-	       << ")";
-  }
-
-  template <typename, typename>
-  friend class BtreeNodePin;
-  ~btree_range_pin_t()
-  {
-    ceph_assert(!pins == !is_linked());
-    ceph_assert(!ref);
-    if (pins) {
-      crimson::get_logger(ceph_subsys_seastore_lba
-	).debug("{}: removing {}", __func__, *this);
-      pins->remove_pin(*this, true);
-    }
-    extent = nullptr;
-  }
-
-};
-
-/**
- * btree_pin_set_t
- *
- * Ensures that for every cached node, all parent btree nodes required
- * to map it are present in cache.  Relocating these nodes can
- * therefore be done without further reads or cache space.
- *
- * Contains a btree_range_pin_t for every clean or dirty btree node
- * or LogicalCachedExtent instance in cache at any point in time.
- * For any btree node, the contained btree_range_pin_t will hold
- * a reference to that node pinning it in cache as long as that
- * node has children in the set.  This invariant can be violated
- * only by calling retire_extent and is repaired by calling
- * check_parent synchronously after adding any new extents.
- */
-template <typename node_bound_t>
-class btree_pin_set_t {
-  friend class btree_range_pin_t<node_bound_t>;
-  using pins_by_depth_t = std::array<
-    typename btree_range_pin_t<node_bound_t>::index_t,
-    MAX_FIXEDKVBTREE_DEPTH>;
-  pins_by_depth_t pins_by_depth;
-
-  /// Removes pin from set optionally checking whether parent has other children
-  void remove_pin(btree_range_pin_t<node_bound_t> &pin, bool do_check_parent)
-  {
-    crimson::get_logger(ceph_subsys_seastore_lba).debug("{}: {}", __func__, pin);
-    ceph_assert(pin.is_linked());
-    ceph_assert(pin.pins);
-    ceph_assert(!pin.ref);
-
-    auto &layer = pins_by_depth[pin.range.depth];
-    layer.erase(layer.s_iterator_to(pin));
-    pin.pins = nullptr;
-
-    if (do_check_parent) {
-      check_parent(pin);
-    }
-  }
-
-  void replace_pin(
-    btree_range_pin_t<node_bound_t> &to,
-    btree_range_pin_t<node_bound_t> &from)
-  {
-    assert(to.range.depth == from.range.depth);
-    pins_by_depth[from.range.depth].replace_node(
-      btree_range_pin_t<node_bound_t>::index_t::s_iterator_to(from), to);
-  }
-
-  /// Returns parent pin if exists
-  btree_range_pin_t<node_bound_t> *maybe_get_parent(
-    const fixed_kv_node_meta_t<node_bound_t> &meta)
-  {
-    auto cmeta = meta;
-    cmeta.depth++;
-    auto &layer = pins_by_depth[cmeta.depth];
-    auto iter = layer.upper_bound(
-      cmeta,
-      typename btree_range_pin_t<node_bound_t>::meta_cmp_t());
-    if (iter == layer.begin()) {
-      return nullptr;
-    } else {
-      --iter;
-      if (iter->range.is_parent_of(meta)) {
-	return &*iter;
-      } else {
-	return nullptr;
-      }
-    }
-  }
-
-  /// Returns earliest child pin if exist
-  const btree_range_pin_t<node_bound_t>
-  *maybe_get_first_child(const fixed_kv_node_meta_t<node_bound_t> &meta) const
-  {
-    if (meta.depth == 0) {
-      return nullptr;
-    }
-
-    auto cmeta = meta;
-    cmeta.depth--;
-
-    auto &layer = pins_by_depth[cmeta.depth];
-    auto iter = layer.lower_bound(
-      cmeta,
-      typename btree_range_pin_t<node_bound_t>::meta_cmp_t());
-    if (iter == layer.end()) {
-      return nullptr;
-    } else if (meta.is_parent_of(iter->range)) {
-      return &*iter;
-    } else {
-      return nullptr;
-    }
-  }
-
-  /// Releases pin if it has no children
-  void release_if_no_children(btree_range_pin_t<node_bound_t> &pin)
-  {
-    ceph_assert(pin.is_linked());
-    if (maybe_get_first_child(pin.range) == nullptr) {
-      pin.drop_ref();
-    }
-  }
-
-public:
-  btree_pin_set_t() {}
-  /// Adds pin to set, assumes set is consistent
-  void add_pin(btree_range_pin_t<node_bound_t> &pin)
-  {
-    ceph_assert(!pin.is_linked());
-    ceph_assert(!pin.pins);
-    ceph_assert(!pin.ref);
-
-    auto &layer = pins_by_depth[pin.range.depth];
-    auto [prev, inserted] = layer.insert(pin);
-    if (!inserted) {
-      crimson::get_logger(ceph_subsys_seastore_lba).error(
-	"{}: unable to add {} ({}), found {} ({})",
-	__func__,
-	pin,
-	*(pin.extent),
-	*prev,
-	*(prev->extent));
-      ceph_assert(0 == "impossible");
-      return;
-    }
-    pin.pins = this;
-    if (!pin.is_root()) {
-      auto *parent = maybe_get_parent(pin.range);
-      ceph_assert(parent);
-      if (!parent->has_ref()) {
-	crimson::get_logger(ceph_subsys_seastore_lba
-	  ).debug("{}: acquiring parent {}", __func__,
-	    static_cast<void*>(parent));
-	parent->acquire_ref();
-      } else {
-	crimson::get_logger(ceph_subsys_seastore_lba).debug(
-	  "{}: parent has ref {}", __func__,
-	  static_cast<void*>(parent));
-      }
-    }
-    if (maybe_get_first_child(pin.range) != nullptr) {
-      crimson::get_logger(ceph_subsys_seastore_lba).debug(
-	"{}: acquiring self {}", __func__, pin);
-      pin.acquire_ref();
-    }
-  }
-
-
-  /**
-   * retire/check_parent
-   *
-   * See BtreeLBAManager::complete_transaction.
-   * retire removes the specified pin from the set, but does not
-   * check parents.  After any new extents are added to the set,
-   * the caller is required to call check_parent to restore the
-   * invariant.
-   */
-  void retire(btree_range_pin_t<node_bound_t> &pin)
-  {
-    pin.drop_ref();
-    remove_pin(pin, false);
-  }
-
-  void check_parent(btree_range_pin_t<node_bound_t> &pin)
-  {
-    auto parent = maybe_get_parent(pin.range);
-    if (parent) {
-      crimson::get_logger(ceph_subsys_seastore_lba
-	).debug("{}: releasing parent {}", __func__, *parent);
-      release_if_no_children(*parent);
-    }
-  }
-
-  template <typename F>
-  void scan(F &&f) {
-    for (auto &layer : pins_by_depth) {
-      for (auto &i : layer) {
-	std::invoke(f, i);
-      }
-    }
-  }
-
-  ~btree_pin_set_t() {
-    for (auto &layer : pins_by_depth) {
-      ceph_assert(layer.empty());
-    }
-  }
-};
-
 template <typename key_t, typename val_t>
-class BtreeNodePin : public PhysicalNodePin<key_t, val_t> {
+class BtreeNodeMapping : public PhysicalNodeMapping<key_t, val_t> {
 
   op_context_t<key_t> ctx;
   /**
@@ -461,14 +129,14 @@ class BtreeNodePin : public PhysicalNodePin<key_t, val_t> {
 
   val_t value;
   extent_len_t len;
-  btree_range_pin_t<key_t> pin;
+  fixed_kv_node_meta_t<key_t> range;
   uint16_t pos = std::numeric_limits<uint16_t>::max();
 
 public:
   using val_type = val_t;
-  BtreeNodePin(op_context_t<key_t> ctx) : ctx(ctx) {}
+  BtreeNodeMapping(op_context_t<key_t> ctx) : ctx(ctx) {}
 
-  BtreeNodePin(
+  BtreeNodeMapping(
     op_context_t<key_t> ctx,
     CachedExtentRef parent,
     uint16_t pos,
@@ -479,9 +147,9 @@ public:
       parent(parent),
       value(value),
       len(len),
+      range(std::move(meta)),
       pos(pos)
   {
-    pin.set_range(std::move(meta));
     if (!parent->is_pending()) {
       this->child_pos = {parent, pos};
     }
@@ -491,21 +159,12 @@ public:
     return parent;
   }
 
-  btree_range_pin_t<key_t>& get_range_pin() {
-    return pin;
-  }
-
   CachedExtentRef get_parent() {
     return parent;
   }
 
-  void set_parent(CachedExtentRef pin) {
-    parent = pin;
-  }
-
-  void link_extent(LogicalCachedExtent *ref) final {
-    pin.set_extent(ref);
-    pos = std::numeric_limits<uint16_t>::max();
+  void set_parent(CachedExtentRef ext) {
+    parent = ext;
   }
 
   uint16_t get_pos() const final {
@@ -513,7 +172,7 @@ public:
   }
 
   extent_len_t get_length() const final {
-    ceph_assert(pin.range.end > pin.range.begin);
+    ceph_assert(range.end > range.begin);
     return len;
   }
 
@@ -527,22 +186,18 @@ public:
   }
 
   key_t get_key() const final {
-    return pin.range.begin;
+    return range.begin;
   }
 
-  PhysicalNodePinRef<key_t, val_t> duplicate() const final {
-    auto ret = std::unique_ptr<BtreeNodePin<key_t, val_t>>(
-      new BtreeNodePin<key_t, val_t>(ctx));
-    ret->pin.set_range(pin.range);
+  PhysicalNodeMappingRef<key_t, val_t> duplicate() const final {
+    auto ret = std::unique_ptr<BtreeNodeMapping<key_t, val_t>>(
+      new BtreeNodeMapping<key_t, val_t>(ctx));
+    ret->range = range;
     ret->value = value;
     ret->parent = parent;
     ret->len = len;
     ret->pos = pos;
     return ret;
-  }
-
-  void take_pin(PhysicalNodePin<key_t, val_t> &opin) final {
-    pin.take_pin(static_cast<BtreeNodePin<key_t, val_t>&>(opin).pin);
   }
 
   bool has_been_invalidated() const final {
@@ -553,7 +208,3 @@ public:
 };
 
 }
-
-#if FMT_VERSION >= 90000
-template <typename node_bound_t> struct fmt::formatter<crimson::os::seastore::btree_range_pin_t<node_bound_t>> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -453,6 +453,7 @@ class BtreeNodePin : public PhysicalNodePin<key_t, val_t> {
   val_t value;
   extent_len_t len;
   btree_range_pin_t<key_t> pin;
+  uint16_t pos = std::numeric_limits<uint16_t>::max();
 
 public:
   using val_type = val_t;
@@ -460,11 +461,16 @@ public:
 
   BtreeNodePin(
     CachedExtentRef parent,
+    uint16_t pos,
     val_t &value,
     extent_len_t len,
     fixed_kv_node_meta_t<key_t> &&meta)
-    : parent(parent), value(value), len(len) {
+    : parent(parent), value(value), len(len), pos(pos) {
     pin.set_range(std::move(meta));
+  }
+
+  CachedExtentRef get_parent() const final {
+    return parent;
   }
 
   btree_range_pin_t<key_t>& get_range_pin() {
@@ -479,9 +485,7 @@ public:
     parent = pin;
   }
 
-  void link_extent(LogicalCachedExtent *ref) final {
-    pin.set_extent(ref);
-  }
+  void link_extent(LogicalCachedExtent *ref) final;
 
   extent_len_t get_length() const final {
     ceph_assert(pin.range.end > pin.range.begin);

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -57,7 +57,8 @@ template <
   typename internal_node_t,
   typename leaf_node_t,
   typename pin_t,
-  size_t node_size>
+  size_t node_size,
+  bool leaf_has_children>
 class FixedKVBtree {
   static constexpr size_t MAX_DEPTH = 16;
   using self_type = FixedKVBtree<
@@ -66,7 +67,8 @@ class FixedKVBtree {
     internal_node_t,
     leaf_node_t,
     pin_t,
-    node_size>;
+    node_size,
+    leaf_has_children>;
 public:
   using InternalNodeRef = TCachedExtentRef<internal_node_t>;
   using LeafNodeRef = TCachedExtentRef<leaf_node_t>;
@@ -866,7 +868,8 @@ public:
       n_fixed_kv_extent->set_modify_time(fixed_kv_extent.get_modify_time());
       n_fixed_kv_extent->pin.set_range(n_fixed_kv_extent->get_node_meta());
 
-      if (fixed_kv_extent.get_type() == internal_node_t::TYPE) {
+      if (fixed_kv_extent.get_type() == internal_node_t::TYPE ||
+          leaf_node_t::do_has_children) {
         if (!fixed_kv_extent.is_pending()) {
           n_fixed_kv_extent->copy_sources.emplace(&fixed_kv_extent);
           n_fixed_kv_extent->prior_instance = &fixed_kv_extent;
@@ -2008,7 +2011,8 @@ template <
   typename internal_node_t,
   typename leaf_node_t,
   typename pin_t,
-  size_t node_size>
+  size_t node_size,
+  bool leaf_has_children>
 struct is_fixed_kv_tree<
   FixedKVBtree<
     node_key_t,
@@ -2016,7 +2020,8 @@ struct is_fixed_kv_tree<
     internal_node_t,
     leaf_node_t,
     pin_t,
-    node_size>> : std::true_type {};
+    node_size,
+    leaf_has_children>> : std::true_type {};
 
 template <
   typename tree_type_t,

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1052,13 +1052,13 @@ private:
         c.pins->add_pin(node.pin);
       }
     };
-    return c.cache.template get_extent<internal_node_t>(
+    return c.cache.template get_absent_extent<internal_node_t>(
       c.trans,
       offset,
       node_size,
       init_internal
     ).si_then([FNAME, c, offset, init_internal, depth, begin, end](
-                typename internal_node_t::Ref ret) {
+              typename internal_node_t::Ref ret) {
       SUBTRACET(
         seastore_fixedkv_tree,
         "read internal at offset {} {}",
@@ -1119,7 +1119,7 @@ private:
         c.pins->add_pin(node.pin);
       }
     };
-    return c.cache.template get_extent<leaf_node_t>(
+    return c.cache.template get_absent_extent<leaf_node_t>(
       c.trans,
       offset,
       node_size,

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -58,7 +58,7 @@ public:
   using iterator_fut = base_iertr::future<iterator>;
 
   using mapped_space_visitor_t = std::function<
-    void(paddr_t, extent_len_t, depth_t, extent_types_t)>;
+    void(paddr_t, node_key_t, extent_len_t, depth_t, extent_types_t)>;
 
   class iterator {
   public:
@@ -1172,6 +1172,7 @@ private:
 	iter.get_internal(root.get_depth()).node = root_node;
 	if (visitor) (*visitor)(
           root_node->get_paddr(),
+          root_node->get_node_meta().begin,
           root_node->get_length(),
           root.get_depth(),
           internal_node_t::TYPE);
@@ -1188,6 +1189,7 @@ private:
 	iter.leaf.node = root_node;
 	if (visitor) (*visitor)(
           root_node->get_paddr(),
+          root_node->get_node_meta().begin,
           root_node->get_length(),
           root.get_depth(),
           leaf_node_t::TYPE);
@@ -1221,6 +1223,7 @@ private:
       if (visitor)
         (*visitor)(
           node->get_paddr(),
+          node->get_node_meta().begin,
           node->get_length(),
           depth,
           node->get_type());
@@ -1294,6 +1297,7 @@ private:
       if (visitor)
         (*visitor)(
           node->get_paddr(),
+          node->get_node_meta().begin,
           node->get_length(),
           1,
           node->get_type());

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -77,7 +77,7 @@ public:
   using iterator_fut = base_iertr::future<iterator>;
 
   using mapped_space_visitor_t = std::function<
-    void(paddr_t, node_key_t, extent_len_t, depth_t, extent_types_t)>;
+    void(paddr_t, node_key_t, extent_len_t, depth_t, extent_types_t, iterator&)>;
 
   class iterator {
   public:
@@ -1377,7 +1377,8 @@ private:
         root_node->get_node_meta().begin,
         root_node->get_length(),
         get_root().get_depth(),
-        internal_node_t::TYPE);
+        internal_node_t::TYPE,
+        iter);
       return lookup_root_iertr::now();
     };
     auto on_found_leaf =
@@ -1388,7 +1389,8 @@ private:
         root_node->get_node_meta().begin,
         root_node->get_length(),
         get_root().get_depth(),
-        leaf_node_t::TYPE);
+        leaf_node_t::TYPE,
+        iter);
       return lookup_root_iertr::now();
     };
 
@@ -1465,7 +1467,8 @@ private:
           node->get_node_meta().begin,
           node->get_length(),
           depth,
-          node->get_type());
+          node->get_type(),
+          iter);
       return seastar::now();
     };
 
@@ -1532,7 +1535,8 @@ private:
           node->get_node_meta().begin,
           node->get_length(),
           1,
-          node->get_type());
+          node->get_type(),
+          iter);
       return seastar::now();
     };
 

--- a/src/crimson/os/seastore/btree/fixed_kv_node.cc
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.cc
@@ -1,0 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/btree/fixed_kv_node.h"
+
+namespace crimson::os::seastore {
+
+bool is_valid_child_ptr(ChildableCachedExtent* child) {
+  return child != nullptr && child != RESERVATION_PTR;
+}
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -217,15 +217,6 @@ struct FixedKVNode : ChildableCachedExtent {
     }
   }
 
-  struct child_pos_t {
-    FixedKVNodeRef stable_parent;
-    uint16_t pos = std::numeric_limits<uint16_t>::max();
-    CachedExtentRef child;
-    child_pos_t(CachedExtentRef child) : child(child) {}
-    child_pos_t(FixedKVNodeRef stable_parent, uint16_t pos)
-      : stable_parent(stable_parent), pos(pos) {}
-  };
-
   void link_child(ChildableCachedExtent* child, uint16_t pos) {
     assert(pos < get_node_size());
     assert(child);
@@ -236,20 +227,25 @@ struct FixedKVNode : ChildableCachedExtent {
     set_child_ptracker(child);
   }
 
-  template <typename iter_t>
-  child_pos_t get_child(Transaction &t, iter_t iter) {
+  virtual get_child_ret_t<LogicalCachedExtent>
+  get_logical_child(op_context_t<node_key_t> c, uint16_t pos) = 0;
+
+  template <typename T, typename iter_t>
+  get_child_ret_t<T> get_child(op_context_t<node_key_t> c, iter_t iter) {
     auto pos = iter.get_offset();
     assert(children.capacity());
     auto child = children[pos];
     if (is_valid_child_ptr(child)) {
-      return child_pos_t(child->get_transactional_view(t));
+      ceph_assert(child->get_type() == T::TYPE);
+      return c.cache.template get_extent_viewable_by_trans<T>(c.trans, (T*)child);
     } else if (is_pending()) {
       auto key = iter.get_key();
       auto &sparent = get_stable_for_key(key);
       auto spos = sparent.child_pos_for_key(key);
       auto child = sparent.children[spos];
       if (is_valid_child_ptr(child)) {
-	return child_pos_t(child->get_transactional_view(t));
+	ceph_assert(child->get_type() == T::TYPE);
+	return c.cache.template get_extent_viewable_by_trans<T>(c.trans, (T*)child);
       } else {
 	return child_pos_t(&sparent, spos);
       }
@@ -590,6 +586,12 @@ struct FixedKVInternalNode
       assert(this->validate_stable_children());
       this->copy_sources.clear();
     }
+  }
+
+  get_child_ret_t<LogicalCachedExtent>
+  get_logical_child(op_context_t<NODE_KEY>, uint16_t pos) final {
+    ceph_abort("impossible");
+    return get_child_ret_t<LogicalCachedExtent>(child_pos_t(nullptr, 0));
   }
 
   bool validate_stable_children() final {
@@ -958,6 +960,30 @@ struct FixedKVLeafNode
 
   uint16_t get_node_split_pivot() final {
     return this->get_split_pivot().get_offset();
+  }
+
+  get_child_ret_t<LogicalCachedExtent>
+  get_logical_child(op_context_t<NODE_KEY> c, uint16_t pos) final {
+    auto child = this->children[pos];
+    if (is_valid_child_ptr(child)) {
+      ceph_assert(child->is_logical());
+      return c.cache.template get_extent_viewable_by_trans<
+	LogicalCachedExtent>(c.trans, (LogicalCachedExtent*)child);
+    } else if (this->is_pending()) {
+      auto key = this->iter_idx(pos).get_key();
+      auto &sparent = this->get_stable_for_key(key);
+      auto spos = sparent.child_pos_for_key(key);
+      auto child = sparent.children[spos];
+      if (is_valid_child_ptr(child)) {
+	ceph_assert(child->is_logical());
+	return c.cache.template get_extent_viewable_by_trans<
+	  LogicalCachedExtent>(c.trans, (LogicalCachedExtent*)child);
+      } else {
+	return child_pos_t(&sparent, spos);
+      }
+    } else {
+      return child_pos_t(this, pos);
+    }
   }
 
   bool validate_stable_children() override {

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -109,7 +109,7 @@ struct FixedKVInternalNode
 	    ? &delta_buffer : nullptr;
   }
 
-  CachedExtentRef duplicate_for_write() override {
+  CachedExtentRef duplicate_for_write(Transaction&) override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new node_type_t(*this));
   };
@@ -338,7 +338,7 @@ struct FixedKVLeafNode
     return this->is_mutation_pending() ? &delta_buffer : nullptr;
   }
 
-  CachedExtentRef duplicate_for_write() override {
+  CachedExtentRef duplicate_for_write(Transaction&) override {
     assert(delta_buffer.empty());
     return CachedExtentRef(new node_type_t(*this));
   };

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -915,7 +915,8 @@ template <
   typename VAL,
   typename VAL_LE,
   size_t node_size,
-  typename node_type_t>
+  typename node_type_t,
+  bool has_children>
 struct FixedKVLeafNode
   : FixedKVNode<NODE_KEY>,
     common::FixedKVNodeLayout<
@@ -941,6 +942,8 @@ struct FixedKVLeafNode
   FixedKVLeafNode(const FixedKVLeafNode &rhs)
     : FixedKVNode<NODE_KEY>(rhs),
       node_layout_t(this->get_bptr().c_str()) {}
+
+  static constexpr bool do_has_children = has_children;
 
   uint16_t get_node_split_pivot() final {
     return this->get_split_pivot().get_offset();

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -28,25 +28,8 @@ namespace crimson::os::seastore {
  * Base class enabling recursive lookup between internal and leaf nodes.
  */
 template <typename node_key_t>
-struct FixedKVNode : CachedExtent {
+struct FixedKVNode : ChildableCachedExtent {
   using FixedKVNodeRef = TCachedExtentRef<FixedKVNode>;
-  struct parent_tracker_t
-    : public boost::intrusive_ref_counter<
-	parent_tracker_t, boost::thread_unsafe_counter> {
-    parent_tracker_t(FixedKVNodeRef parent)
-      : parent(parent) {}
-    parent_tracker_t(FixedKVNode* parent)
-      : parent(parent) {}
-    FixedKVNodeRef parent = nullptr;
-    ~parent_tracker_t() {
-      // this is parent's tracker, reset it
-      if (parent->my_tracker == this) {
-	parent->my_tracker = nullptr;
-      }
-    }
-  };
-
-  using parent_tracker_ref = boost::intrusive_ptr<parent_tracker_t>;
   btree_range_pin_t<node_key_t> pin;
 
   struct copy_source_cmp_t {
@@ -98,20 +81,24 @@ struct FixedKVNode : CachedExtent {
    * 	   its "prior_instance" if the node is the result of a rewrite), with which
    * 	   the lba range of this node overlaps.
    */
-  std::vector<CachedExtent*> children;
+  std::vector<ChildableCachedExtent*> children;
   std::set<FixedKVNodeRef, copy_source_cmp_t> copy_sources;
   uint16_t capacity = 0;
   parent_tracker_t* my_tracker = nullptr;
-  parent_tracker_ref parent_tracker;
   RootBlockRef root_block;
 
+  bool is_linked() {
+    assert(!has_parent_tracker() || !(bool)root_block);
+    return (bool)has_parent_tracker() || (bool)root_block;
+  }
+
   FixedKVNode(uint16_t capacity, ceph::bufferptr &&ptr)
-    : CachedExtent(std::move(ptr)),
+    : ChildableCachedExtent(std::move(ptr)),
       pin(this),
       children(capacity, nullptr),
       capacity(capacity) {}
   FixedKVNode(const FixedKVNode &rhs)
-    : CachedExtent(rhs),
+    : ChildableCachedExtent(rhs),
       pin(rhs.pin, this),
       children(rhs.capacity, nullptr),
       capacity(rhs.capacity) {}
@@ -128,6 +115,8 @@ struct FixedKVNode : CachedExtent {
     set_child_ptracker(child);
   }
 
+  virtual bool is_leaf_and_has_children() const = 0;
+
   template<typename iter_t>
   void insert_child_ptr(iter_t iter, ChildableCachedExtent* child) {
     auto raw_children = children.data();
@@ -136,8 +125,18 @@ struct FixedKVNode : CachedExtent {
       &raw_children[offset + 1],
       &raw_children[offset],
       (get_node_size() - offset) * sizeof(ChildableCachedExtent*));
-    children[offset] = child;
-    set_child_ptracker(child);
+    if (child) {
+      children[offset] = child;
+      set_child_ptracker(child);
+    } else {
+      // this can only happen when reserving lba spaces
+      ceph_assert(is_leaf_and_has_children());
+      // this is to avoid mistakenly copying pointers from
+      // copy sources when committing this lba node, because
+      // we rely on pointers' "nullness" to avoid copying
+      // pointers for updated values
+      children[offset] = RESERVATION_PTR;
+    }
   }
 
   template<typename iter_t>
@@ -227,7 +226,7 @@ struct FixedKVNode : CachedExtent {
       : stable_parent(stable_parent), pos(pos) {}
   };
 
-  void link_child(FixedKVNode* child, uint16_t pos) {
+  void link_child(ChildableCachedExtent* child, uint16_t pos) {
     assert(pos < get_node_size());
     assert(child);
     ceph_assert(!is_pending());
@@ -242,14 +241,14 @@ struct FixedKVNode : CachedExtent {
     auto pos = iter.get_offset();
     assert(children.capacity());
     auto child = children[pos];
-    if (child) {
+    if (is_valid_child_ptr(child)) {
       return child_pos_t(child->get_transactional_view(t));
     } else if (is_pending()) {
       auto key = iter.get_key();
       auto &sparent = get_stable_for_key(key);
       auto spos = sparent.child_pos_for_key(key);
       auto child = sparent.children[spos];
-      if (child) {
+      if (is_valid_child_ptr(child)) {
 	return child_pos_t(child->get_transactional_view(t));
       } else {
 	return child_pos_t(&sparent, spos);
@@ -357,10 +356,9 @@ struct FixedKVNode : CachedExtent {
       return;
     }
     ceph_assert(!root_block);
-    parent_tracker = prior.parent_tracker;
-    auto &parent = parent_tracker->parent;
-    assert(parent);
-    assert(parent->is_valid());
+    take_prior_parent_tracker();
+    assert(is_parent_valid());
+    auto parent = get_parent_node<FixedKVNode>();
     //TODO: can this search be avoided?
     auto off = parent->lower_bound_offset(get_node_meta().begin);
     assert(parent->get_key_from_idx(off) == get_node_meta().begin);
@@ -385,7 +383,7 @@ struct FixedKVNode : CachedExtent {
     assert(prior.my_tracker || prior.is_children_empty());
 
     if (prior.my_tracker) {
-      prior.my_tracker->parent.reset(this);
+      prior.my_tracker->reset_parent(this);
       my_tracker = prior.my_tracker;
       // All my initial pending children is pointing to the original
       // tracker which has been dropped by the above line, so need
@@ -401,8 +399,8 @@ struct FixedKVNode : CachedExtent {
     ceph_assert(end <= children.end());
     for (auto it = begin; it != end; it++) {
       auto child = *it;
-      if (child) {
-	set_child_ptracker((FixedKVNode*)child);
+      if (is_valid_child_ptr(child)) {
+	set_child_ptracker(child);
       }
     }
   }
@@ -485,7 +483,7 @@ struct FixedKVNode : CachedExtent {
   }
 
   void on_invalidated(Transaction &t) final {
-    parent_tracker.reset();
+    reset_parent_tracker();
   }
 
   bool is_rewrite() {
@@ -495,17 +493,17 @@ struct FixedKVNode : CachedExtent {
   void on_initial_write() final {
     // All in-memory relative addrs are necessarily block-relative
     resolve_relative_addrs(get_paddr());
-    ceph_assert(
-      parent_tracker
-	? (parent_tracker->parent && parent_tracker->parent->is_valid())
-	: true);
+    if (pin.is_root()) {
+      reset_parent_tracker();
+    }
+    assert(has_parent_tracker() ? (is_parent_valid()) : true);
   }
 
-  void set_child_ptracker(FixedKVNode *child) {
-    if (!my_tracker) {
-      my_tracker = new parent_tracker_t(this);
+  void set_child_ptracker(ChildableCachedExtent *child) {
+    if (!this->my_tracker) {
+      this->my_tracker = new parent_tracker_t(this);
     }
-    child->parent_tracker.reset(my_tracker);
+    child->reset_parent_tracker(this->my_tracker);
   }
 
   void on_clean_read() final {
@@ -564,6 +562,10 @@ struct FixedKVInternalNode
     : FixedKVNode<NODE_KEY>(rhs),
       node_layout_t(this->get_bptr().c_str()) {}
 
+  bool is_leaf_and_has_children() const final {
+    return false;
+  }
+
   uint16_t get_node_split_pivot() final {
     return this->get_split_pivot().get_offset();
   }
@@ -617,9 +619,8 @@ struct FixedKVInternalNode
 	ceph_assert(this->root_block);
 	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
       } else {
-	ceph_assert(this->parent_tracker);
-	auto &parent = this->parent_tracker->parent;
-	ceph_assert(parent);
+	ceph_assert(this->is_parent_valid());
+	auto parent = this->template get_parent_node<FixedKVNode<NODE_KEY>>();
 	auto off = parent->lower_bound_offset(this->get_meta().begin);
 	assert(parent->get_key_from_idx(off) == this->get_meta().begin);
 	assert(parent->children[off] == this);
@@ -853,17 +854,13 @@ struct FixedKVInternalNode
     }
   }
 
-  std::ostream &print_detail(std::ostream &out) const
+  std::ostream &_print_detail(std::ostream &out) const
   {
     out << ", size=" << this->get_size()
 	<< ", meta=" << this->get_meta()
-	<< ", parent_tracker=" << (void*)this->parent_tracker.get();
-    if (this->parent_tracker) {
-      out << ", parent=" << (void*)this->parent_tracker->parent.get();
-    }
-    out << ", my_tracker=" << (void*)this->my_tracker;
+	<< ", my_tracker=" << (void*)this->my_tracker;
     if (this->my_tracker) {
-      out << ", my_tracker->parent=" << (void*)this->my_tracker->parent.get();
+      out << ", my_tracker->parent=" << (void*)this->my_tracker->get_parent().get();
     }
     return out << ", root_block=" << (void*)this->root_block.get();
   }
@@ -936,8 +933,18 @@ struct FixedKVLeafNode
       VAL,
       VAL_LE>;
   using internal_const_iterator_t = typename node_layout_t::const_iterator;
+  using this_type_t = FixedKVLeafNode<
+    CAPACITY,
+    NODE_KEY,
+    NODE_KEY_LE,
+    VAL,
+    VAL_LE,
+    node_size,
+    node_type_t,
+    has_children>;
+  using base_t = FixedKVNode<NODE_KEY>;
   FixedKVLeafNode(ceph::bufferptr &&ptr)
-    : FixedKVNode<NODE_KEY>(0, std::move(ptr)),
+    : FixedKVNode<NODE_KEY>(has_children ? CAPACITY : 0, std::move(ptr)),
       node_layout_t(this->get_bptr().c_str()) {}
   FixedKVLeafNode(const FixedKVLeafNode &rhs)
     : FixedKVNode<NODE_KEY>(rhs),
@@ -945,11 +952,15 @@ struct FixedKVLeafNode
 
   static constexpr bool do_has_children = has_children;
 
+  bool is_leaf_and_has_children() const final {
+    return has_children;
+  }
+
   uint16_t get_node_split_pivot() final {
     return this->get_split_pivot().get_offset();
   }
 
-  bool validate_stable_children() final {
+  bool validate_stable_children() override {
     return true;
   }
 
@@ -959,9 +970,8 @@ struct FixedKVLeafNode
 	ceph_assert(this->root_block);
 	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
       } else {
-	ceph_assert(this->parent_tracker);
-	auto &parent = this->parent_tracker->parent;
-	ceph_assert(parent);
+	ceph_assert(this->is_parent_valid());
+	auto parent = this->template get_parent_node<FixedKVNode<NODE_KEY>>();
 	auto off = parent->lower_bound_offset(this->get_meta().begin);
 	assert(parent->get_key_from_idx(off) == this->get_meta().begin);
 	assert(parent->children[off] == this);
@@ -970,9 +980,49 @@ struct FixedKVLeafNode
     }
   }
 
-  void on_replace_prior(Transaction &t) final {
-    this->set_parent_tracker();
-    assert(this->mutate_state.empty());
+  void prepare_write() final {
+    if constexpr (has_children) {
+      if (this->is_initial_pending()) {
+	if (this->is_rewrite()) {
+	  this->set_children_from_prior_instance();
+	}
+	this->copy_children_from_stable_sources(
+	  [this](base_t &node, uint16_t pos) {
+	    ceph_assert(node.get_type() == this->get_type());
+	    auto &n = static_cast<this_type_t&>(node);
+	    return n.iter_idx(pos);
+	  }
+	);
+	if (this->is_rewrite()) {
+	  this->reset_prior_instance();
+	} else {
+	  this->adjust_ptracker_for_children();
+	}
+	assert(this->validate_stable_children());
+	this->copy_sources.clear();
+      }
+    }
+    assert(this->is_initial_pending()
+      ? this->copy_sources.empty():
+      true);
+  }
+
+  void on_replace_prior(Transaction&) final {
+    ceph_assert(!this->is_rewrite());
+    if constexpr (has_children) {
+      this->set_children_from_prior_instance();
+      auto &prior = (this_type_t&)(*this->get_prior_instance());
+      auto copied = this->copy_children_from_stable_source(
+	prior,
+	prior.begin(),
+	prior.end(),
+	this->begin());
+      ceph_assert(copied <= get_node_size());
+      assert(this->validate_stable_children());
+      this->set_parent_tracker_from_prior_instance();
+    } else {
+      this->set_parent_tracker_from_prior_instance();
+    }
   }
 
   uint16_t lower_bound_offset(NODE_KEY key) const final {
@@ -1011,11 +1061,13 @@ struct FixedKVLeafNode
 
   virtual void update(
     internal_const_iterator_t iter,
-    VAL val) = 0;
+    VAL val,
+    LogicalCachedExtent* nextent) = 0;
   virtual internal_const_iterator_t insert(
     internal_const_iterator_t iter,
     NODE_KEY addr,
-    VAL val) = 0;
+    VAL val,
+    LogicalCachedExtent* nextent) = 0;
   virtual void remove(internal_const_iterator_t iter) = 0;
 
   std::tuple<Ref, Ref, NODE_KEY>
@@ -1024,6 +1076,9 @@ struct FixedKVLeafNode
       c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto right = c.cache.template alloc_new_extent<node_type_t>(
       c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
+    if constexpr (has_children) {
+      this->split_child_ptrs(*left, *right);
+    }
     auto pivot = this->split_into(*left, *right);
     left->pin.set_range(left->get_meta());
     right->pin.set_range(right->get_meta());
@@ -1038,6 +1093,9 @@ struct FixedKVLeafNode
     Ref &right) {
     auto replacement = c.cache.template alloc_new_extent<node_type_t>(
       c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
+    if constexpr (has_children) {
+      replacement->merge_child_ptrs(*this, *right);
+    }
     replacement->merge_from(*this, *right->template cast<node_type_t>());
     replacement->pin.set_range(replacement->get_meta());
     return replacement;
@@ -1061,6 +1119,14 @@ struct FixedKVLeafNode
       prefer_left,
       *replacement_left,
       *replacement_right);
+    if constexpr (has_children) {
+      this->balance_child_ptrs(
+	*this,
+	right,
+	prefer_left,
+	*replacement_left,
+	*replacement_right);
+    }
 
     replacement_left->pin.set_range(replacement_left->get_meta());
     replacement_right->pin.set_range(replacement_right->get_meta());
@@ -1090,15 +1156,10 @@ struct FixedKVLeafNode
     this->resolve_relative_addrs(base);
   }
 
-  std::ostream &print_detail(std::ostream &out) const
+  std::ostream &_print_detail(std::ostream &out) const
   {
-    out << ", size=" << this->get_size()
-	<< ", meta=" << this->get_meta()
-	<< ", parent_tracker=" << (void*)this->parent_tracker.get();
-    if (this->parent_tracker) {
-      out << ", parent=" << (void*)this->parent_tracker->parent.get();
-    }
-    return out;
+    return out << ", size=" << this->get_size()
+	       << ", meta=" << this->get_meta();
   }
 
   constexpr static size_t get_min_capacity() {

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -18,6 +18,7 @@
 
 #include "crimson/os/seastore/btree/btree_range_pin.h"
 #include "crimson/os/seastore/btree/fixed_kv_btree.h"
+#include "crimson/os/seastore/root_block.h"
 
 namespace crimson::os::seastore {
 
@@ -102,6 +103,7 @@ struct FixedKVNode : CachedExtent {
   uint16_t capacity = 0;
   parent_tracker_t* my_tracker = nullptr;
   parent_tracker_ref parent_tracker;
+  RootBlockRef root_block;
 
   FixedKVNode(uint16_t capacity, ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)),
@@ -345,11 +347,16 @@ struct FixedKVNode : CachedExtent {
   }
 
   void set_parent_tracker_from_prior_instance() {
-    if (pin.is_root()) {
-      return;
-    }
     assert(is_mutation_pending());
     auto &prior = (FixedKVNode&)(*get_prior_instance());
+    if (pin.is_root()) {
+      ceph_assert(prior.root_block);
+      ceph_assert(pending_for_transaction);
+      root_block = prior.root_block;
+      link_phy_tree_root_node(root_block, this);
+      return;
+    }
+    ceph_assert(!root_block);
     parent_tracker = prior.parent_tracker;
     auto &parent = parent_tracker->parent;
     assert(parent);
@@ -605,16 +612,19 @@ struct FixedKVInternalNode
   }
 
   virtual ~FixedKVInternalNode() {
-    if (!this->pin.is_root()
-	&& this->is_valid()
-	&& !this->is_pending()) {
-      ceph_assert(this->parent_tracker);
-      auto &parent = this->parent_tracker->parent;
-      ceph_assert(parent);
-      auto off = parent->lower_bound_offset(this->get_meta().begin);
-      assert(parent->get_key_from_idx(off) == get_node_meta().begin);
-      assert(parent->children[off] == this);
-      parent->children[off] = nullptr;
+    if (this->is_valid() && !this->is_pending()) {
+      if (this->pin.is_root()) {
+	ceph_assert(this->root_block);
+	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
+      } else {
+	ceph_assert(this->parent_tracker);
+	auto &parent = this->parent_tracker->parent;
+	ceph_assert(parent);
+	auto off = parent->lower_bound_offset(this->get_meta().begin);
+	assert(parent->get_key_from_idx(off) == this->get_meta().begin);
+	assert(parent->children[off] == this);
+	parent->children[off] = nullptr;
+      }
     }
   }
 
@@ -855,7 +865,7 @@ struct FixedKVInternalNode
     if (this->my_tracker) {
       out << ", my_tracker->parent=" << (void*)this->my_tracker->parent.get();
     }
-    return out;
+    return out << ", root_block=" << (void*)this->root_block.get();
   }
 
   ceph::bufferlist get_delta() {
@@ -941,16 +951,19 @@ struct FixedKVLeafNode
   }
 
   virtual ~FixedKVLeafNode() {
-    if (!this->pin.is_root()
-	&& this->is_valid()
-	&& !this->is_pending()) {
-      ceph_assert(this->parent_tracker);
-      auto &parent = this->parent_tracker->parent;
-      ceph_assert(parent);
-      auto off = parent->lower_bound_offset(this->get_meta().begin);
-      assert(parent->get_key_from_idx(off) == get_node_meta().begin);
-      assert(parent->children[off] == this);
-      parent->children[off] = nullptr;
+    if (this->is_valid() && !this->is_pending()) {
+      if (this->pin.is_root()) {
+	ceph_assert(this->root_block);
+	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
+      } else {
+	ceph_assert(this->parent_tracker);
+	auto &parent = this->parent_tracker->parent;
+	ceph_assert(parent);
+	auto off = parent->lower_bound_offset(this->get_meta().begin);
+	assert(parent->get_key_from_idx(off) == this->get_meta().begin);
+	assert(parent->children[off] == this);
+	parent->children[off] = nullptr;
+      }
     }
   }
 

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -30,22 +30,22 @@ namespace crimson::os::seastore {
 template <typename node_key_t>
 struct FixedKVNode : ChildableCachedExtent {
   using FixedKVNodeRef = TCachedExtentRef<FixedKVNode>;
-  btree_range_pin_t<node_key_t> pin;
+  fixed_kv_node_meta_t<node_key_t> range;
 
   struct copy_source_cmp_t {
     using is_transparent = node_key_t;
     bool operator()(const FixedKVNodeRef &l, const FixedKVNodeRef &r) const {
-      assert(l->pin.range.end <= r->pin.range.begin
-	|| r->pin.range.end <= l->pin.range.begin
-	|| (l->pin.range.begin == r->pin.range.begin
-	    && l->pin.range.end == r->pin.range.end));
-      return l->pin.range.begin < r->pin.range.begin;
+      assert(l->range.end <= r->range.begin
+	|| r->range.end <= l->range.begin
+	|| (l->range.begin == r->range.begin
+	    && l->range.end == r->range.end));
+      return l->range.begin < r->range.begin;
     }
     bool operator()(const node_key_t &l, const FixedKVNodeRef &r) const {
-      return l < r->pin.range.begin;
+      return l < r->range.begin;
     }
     bool operator()(const FixedKVNodeRef &l, const node_key_t &r) const {
-      return l->pin.range.begin < r;
+      return l->range.begin < r;
     }
   };
 
@@ -94,12 +94,11 @@ struct FixedKVNode : ChildableCachedExtent {
 
   FixedKVNode(uint16_t capacity, ceph::bufferptr &&ptr)
     : ChildableCachedExtent(std::move(ptr)),
-      pin(this),
       children(capacity, nullptr),
       capacity(capacity) {}
   FixedKVNode(const FixedKVNode &rhs)
     : ChildableCachedExtent(rhs),
-      pin(rhs.pin, this),
+      range(rhs.range),
       children(rhs.capacity, nullptr),
       capacity(rhs.capacity) {}
 
@@ -344,7 +343,7 @@ struct FixedKVNode : ChildableCachedExtent {
   void set_parent_tracker_from_prior_instance() {
     assert(is_mutation_pending());
     auto &prior = (FixedKVNode&)(*get_prior_instance());
-    if (pin.is_root()) {
+    if (range.is_root()) {
       ceph_assert(prior.root_block);
       ceph_assert(pending_for_transaction);
       root_block = prior.root_block;
@@ -405,7 +404,6 @@ struct FixedKVNode : ChildableCachedExtent {
     // All in-memory relative addrs are necessarily record-relative
     assert(get_prior_instance());
     assert(pending_for_transaction);
-    pin.take_pin(get_prior_instance()->template cast<FixedKVNode>()->pin);
     resolve_relative_addrs(record_block_offset);
   }
 
@@ -489,7 +487,7 @@ struct FixedKVNode : ChildableCachedExtent {
   void on_initial_write() final {
     // All in-memory relative addrs are necessarily block-relative
     resolve_relative_addrs(get_paddr());
-    if (pin.is_root()) {
+    if (range.is_root()) {
       reset_parent_tracker();
     }
     assert(has_parent_tracker() ? (is_parent_valid()) : true);
@@ -617,7 +615,7 @@ struct FixedKVInternalNode
 
   virtual ~FixedKVInternalNode() {
     if (this->is_valid() && !this->is_pending()) {
-      if (this->pin.is_root()) {
+      if (this->range.is_root()) {
 	ceph_assert(this->root_block);
 	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
       } else {
@@ -758,8 +756,8 @@ struct FixedKVInternalNode
       c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     this->split_child_ptrs(*left, *right);
     auto pivot = this->split_into(*left, *right);
-    left->pin.set_range(left->get_meta());
-    right->pin.set_range(right->get_meta());
+    left->range = left->get_meta();
+    right->range = right->get_meta();
     return std::make_tuple(
       left,
       right,
@@ -773,7 +771,7 @@ struct FixedKVInternalNode
       c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     replacement->merge_child_ptrs(*this, *right);
     replacement->merge_from(*this, *right->template cast<node_type_t>());
-    replacement->pin.set_range(replacement->get_meta());
+    replacement->range = replacement->get_meta();
     return replacement;
   }
 
@@ -802,8 +800,8 @@ struct FixedKVInternalNode
       *replacement_left,
       *replacement_right);
 
-    replacement_left->pin.set_range(replacement_left->get_meta());
-    replacement_right->pin.set_range(replacement_right->get_meta());
+    replacement_left->range = replacement_left->get_meta();
+    replacement_right->range = replacement_right->get_meta();
     return std::make_tuple(
       replacement_left,
       replacement_right,
@@ -992,7 +990,7 @@ struct FixedKVLeafNode
 
   virtual ~FixedKVLeafNode() {
     if (this->is_valid() && !this->is_pending()) {
-      if (this->pin.is_root()) {
+      if (this->range.is_root()) {
 	ceph_assert(this->root_block);
 	unlink_phy_tree_root_node<NODE_KEY>(this->root_block);
       } else {
@@ -1106,8 +1104,8 @@ struct FixedKVLeafNode
       this->split_child_ptrs(*left, *right);
     }
     auto pivot = this->split_into(*left, *right);
-    left->pin.set_range(left->get_meta());
-    right->pin.set_range(right->get_meta());
+    left->range = left->get_meta();
+    right->range = right->get_meta();
     return std::make_tuple(
       left,
       right,
@@ -1123,7 +1121,7 @@ struct FixedKVLeafNode
       replacement->merge_child_ptrs(*this, *right);
     }
     replacement->merge_from(*this, *right->template cast<node_type_t>());
-    replacement->pin.set_range(replacement->get_meta());
+    replacement->range = replacement->get_meta();
     return replacement;
   }
 
@@ -1154,8 +1152,8 @@ struct FixedKVLeafNode
 	*replacement_right);
     }
 
-    replacement_left->pin.set_range(replacement_left->get_meta());
-    replacement_right->pin.set_range(replacement_right->get_meta());
+    replacement_left->range = replacement_left->get_meta();
+    replacement_right->range = replacement_right->get_meta();
     return std::make_tuple(
       replacement_left,
       replacement_right,

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1480,7 +1480,10 @@ void Cache::complete_commit(
 	  i->get_type(),
 	  start_seq));
     } else if (is_backref_node(i->get_type())) {
-      add_backref_extent(i->get_paddr(), i->get_type());
+	add_backref_extent(
+	  i->get_paddr(),
+	  i->cast<backref::BackrefNode>()->get_node_meta().begin,
+	  i->get_type());
     } else {
       ERRORT("{}", t, *i);
       ceph_abort("not possible");

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1018,6 +1018,8 @@ CachedExtentRef Cache::duplicate_for_write(
   ret->prior_instance = i;
   // duplicate_for_write won't occur after ool write finished
   assert(!i->prior_poffset);
+  auto [iter, inserted] = i->mutation_pendings.insert(*ret);
+  ceph_assert(inserted);
   t.add_mutated_extent(ret);
   if (ret->get_type() == extent_types_t::ROOT) {
     t.root = ret->cast<RootBlock>();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1012,7 +1012,7 @@ CachedExtentRef Cache::duplicate_for_write(
     return i;
   }
 
-  auto ret = i->duplicate_for_write();
+  auto ret = i->duplicate_for_write(t);
   ret->pending_for_transaction = t.get_trans_id();
   ret->prior_instance = i;
   // duplicate_for_write won't occur after ool write finished

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -812,7 +812,7 @@ void Cache::invalidate_extent(
 {
   if (!extent.may_conflict()) {
     assert(extent.transactions.empty());
-    extent.state = CachedExtent::extent_state_t::INVALID;
+    extent.set_invalid(t);
     return;
   }
 
@@ -829,7 +829,7 @@ void Cache::invalidate_extent(
       mark_transaction_conflicted(*i.t, extent);
     }
   }
-  extent.state = CachedExtent::extent_state_t::INVALID;
+  extent.set_invalid(t);
 }
 
 void Cache::mark_transaction_conflicted(

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1196,7 +1196,7 @@ record_t Cache::prepare_record(
     fresh_stat.increment(i->get_length());
     get_by_ext(efforts.fresh_inline_by_ext,
                i->get_type()).increment(i->get_length());
-    assert(i->is_inline());
+    assert(i->is_inline() || i->get_paddr().is_fake());
 
     bufferlist bl;
     i->prepare_write();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -802,6 +802,7 @@ void Cache::commit_replace_extent(
     add_to_dirty(next);
   }
 
+  next->on_replace_prior(t);
   invalidate_extent(t, *prev);
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -98,7 +98,8 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
     ext->init(CachedExtent::extent_state_t::CLEAN,
               addr,
               PLACEMENT_HINT_NULL,
-              NULL_GENERATION);
+              NULL_GENERATION,
+	      TRANS_ID_NULL);
     DEBUGT("retire {}~{} as placeholder, add extent -- {}",
            t, addr, length, *ext);
     const auto t_src = t.get_src();
@@ -1012,6 +1013,7 @@ CachedExtentRef Cache::duplicate_for_write(
   }
 
   auto ret = i->duplicate_for_write();
+  ret->pending_for_transaction = t.get_trans_id();
   ret->prior_instance = i;
   // duplicate_for_write won't occur after ool write finished
   assert(!i->prior_poffset);
@@ -1448,6 +1450,7 @@ void Cache::complete_commit(
       i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     }
     i->last_committed_crc = i->get_crc32c();
+    i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
 
     i->state = CachedExtent::extent_state_t::CLEAN;
@@ -1489,6 +1492,7 @@ void Cache::complete_commit(
     assert(i->is_exist_mutation_pending() ||
 	   i->prior_instance);
     i->on_delta_write(final_block_start);
+    i->pending_for_transaction = TRANS_ID_NULL;
     i->prior_instance = CachedExtentRef();
     i->state = CachedExtent::extent_state_t::DIRTY;
     assert(i->version > 0);
@@ -1593,7 +1597,8 @@ void Cache::init()
   root->init(CachedExtent::extent_state_t::CLEAN,
              P_ADDR_ROOT,
              PLACEMENT_HINT_NULL,
-             NULL_GENERATION);
+             NULL_GENERATION,
+	     TRANS_ID_NULL);
   INFO("init root -- {}", *root);
   extents.insert(*root);
 }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -146,6 +146,7 @@ void Cache::register_metrics()
     {extent_types_t::ROOT,                sm::label_instance("ext", "ROOT")},
     {extent_types_t::LADDR_INTERNAL,      sm::label_instance("ext", "LADDR_INTERNAL")},
     {extent_types_t::LADDR_LEAF,          sm::label_instance("ext", "LADDR_LEAF")},
+    {extent_types_t::DINK_LADDR_LEAF,     sm::label_instance("ext", "DINK_LADDR_LEAF")},
     {extent_types_t::OMAP_INNER,          sm::label_instance("ext", "OMAP_INNER")},
     {extent_types_t::OMAP_LEAF,           sm::label_instance("ext", "OMAP_LEAF")},
     {extent_types_t::ONODE_BLOCK_STAGED,  sm::label_instance("ext", "ONODE_BLOCK_STAGED")},
@@ -969,7 +970,8 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
   case extent_types_t::LADDR_INTERNAL:
     return alloc_new_extent<lba_manager::btree::LBAInternalNode>(t, length, hint, gen);
   case extent_types_t::LADDR_LEAF:
-    return alloc_new_extent<lba_manager::btree::LBALeafNode>(t, length, hint, gen);
+    return alloc_new_extent<lba_manager::btree::LBALeafNode>(
+      t, length, hint, gen);
   case extent_types_t::ONODE_BLOCK_STAGED:
     return alloc_new_extent<onode::SeastoreNodeExtent>(t, length, hint, gen);
   case extent_types_t::OMAP_INNER:

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -350,6 +350,7 @@ public:
       [](T &){}, [](T &) {});
   }
 
+
   /**
    * get_extent_if_cached
    *

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -815,6 +815,7 @@ public:
           if (!is_alive) {
             SUBDEBUGT(seastore_cache, "extent is not alive, remove extent -- {}", t, *e);
             remove_extent(e);
+	    e->set_invalid(t);
           } else {
             SUBDEBUGT(seastore_cache, "extent is alive -- {}", t, *e);
           }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1119,6 +1119,8 @@ public:
     switch (type) {
     case extent_types_t::LADDR_INTERNAL:
       [[fallthrough]];
+    case extent_types_t::DINK_LADDR_LEAF:
+      [[fallthrough]];
     case extent_types_t::LADDR_LEAF:
       stats.lba_tree_extents_num += delta;
       ceph_assert(stats.lba_tree_extents_num >= 0);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -205,7 +205,8 @@ public:
       last_commit,
       [this](Transaction& t) {
         return on_transaction_destruct(t);
-      }
+      },
+      ++next_id
     );
     SUBDEBUGT(seastore_t, "created name={}, source={}, is_weak={}",
              *ret, name, src, is_weak);
@@ -284,7 +285,8 @@ public:
       ret->init(CachedExtent::extent_state_t::CLEAN_PENDING,
                 offset,
                 PLACEMENT_HINT_NULL,
-                NULL_GENERATION);
+                NULL_GENERATION,
+		TRANS_ID_NULL);
       SUBDEBUG(seastore_cache,
           "{} {}~{} is absent, add extent and reading ... -- {}",
           T::TYPE, offset, length, *ret);
@@ -303,7 +305,8 @@ public:
       ret->init(CachedExtent::extent_state_t::CLEAN_PENDING,
                 offset,
                 PLACEMENT_HINT_NULL,
-                NULL_GENERATION);
+                NULL_GENERATION,
+		TRANS_ID_NULL);
       SUBDEBUG(seastore_cache,
           "{} {}~{} is absent(placeholder), reading ... -- {}",
           T::TYPE, offset, length, *ret);
@@ -648,7 +651,8 @@ public:
     ret->init(CachedExtent::extent_state_t::INITIAL_WRITE_PENDING,
               result.paddr,
               hint,
-              result.gen);
+              result.gen,
+	      t.get_trans_id());
     t.add_fresh_extent(ret);
     SUBDEBUGT(seastore_cache,
               "allocated {} {}B extent at {}, hint={}, gen={} -- {}",
@@ -989,6 +993,8 @@ private:
 
   // FIXME: This is specific to the segmented implementation
   std::vector<SegmentProvider*> segment_providers_by_device_id;
+
+  transaction_id_t next_id = 0;
 
   /**
    * dirty

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1106,6 +1106,14 @@ public:
   /// Dump live extents
   void dump_contents();
 
+  /**
+   * backref_extent_entry_t
+   *
+   * All the backref extent entries have to be indexed by paddr in memory,
+   * so they can be retrived by range during cleaning.
+   *
+   * See BtreeBackrefManager::retrieve_backref_extents_in_range()
+   */
   struct backref_extent_entry_t {
     backref_extent_entry_t(
       paddr_t paddr,

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -985,6 +985,19 @@ public:
   uint64_t get_omap_tree_depth() {
     return stats.omap_tree_depth;
   }
+
+  /// Update lru for access to ref
+  void touch_extent(
+      CachedExtent &ext,
+      const Transaction::src_t* p_src=nullptr)
+  {
+    if (p_src && is_background_transaction(*p_src))
+      return;
+    if (ext.is_clean() && !ext.is_placeholder()) {
+      lru.move_to_top(ext);
+    }
+  }
+
 private:
   ExtentPlacementManager& epm;
   RootBlockRef root;               ///< ref to current root
@@ -1266,18 +1279,6 @@ private:
       buffer::create_page_aligned(size));
     bp.zero();
     return bp;
-  }
-
-  /// Update lru for access to ref
-  void touch_extent(
-      CachedExtent &ext,
-      const Transaction::src_t* p_src=nullptr)
-  {
-    if (p_src && is_background_transaction(*p_src))
-      return;
-    if (ext.is_clean() && !ext.is_placeholder()) {
-      lru.move_to_top(ext);
-    }
   }
 
   void backref_batch_update(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1061,9 +1061,11 @@ public:
   struct backref_extent_entry_t {
     backref_extent_entry_t(
       paddr_t paddr,
+      paddr_t key,
       extent_types_t type)
-      : paddr(paddr), type(type) {}
+      : paddr(paddr), key(key), type(type) {}
     paddr_t paddr = P_ADDR_NULL;
+    paddr_t key = P_ADDR_NULL;
     extent_types_t type = extent_types_t::ROOT;
     struct cmp_t {
       using is_transparent = paddr_t;
@@ -1155,9 +1157,12 @@ private:
       backref_extent_entry_t::cmp_t>;
   backref_extent_entry_query_set_t backref_extents;
 
-  void add_backref_extent(paddr_t paddr, extent_types_t type) {
+  void add_backref_extent(
+    paddr_t paddr,
+    paddr_t key,
+    extent_types_t type) {
     assert(!paddr.is_relative());
-    auto [iter, inserted] = backref_extents.emplace(paddr, type);
+    auto [iter, inserted] = backref_extents.emplace(paddr, key, type);
     boost::ignore_unused(inserted);
     assert(inserted);
   }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -25,6 +25,15 @@ class BtreeBackrefManager;
 
 namespace crimson::os::seastore {
 
+template <
+  typename node_key_t,
+  typename node_val_t,
+  typename internal_node_t,
+  typename leaf_node_t,
+  typename pin_t,
+  size_t node_size,
+  bool leaf_has_children>
+class FixedKVBtree;
 class BackrefManager;
 class SegmentProvider;
 
@@ -1540,6 +1549,15 @@ private:
     }
   }
 
+  template <
+    typename node_key_t,
+    typename node_val_t,
+    typename internal_node_t,
+    typename leaf_node_t,
+    typename pin_t,
+    size_t node_size,
+    bool leaf_has_children>
+  friend class FixedKVBtree;
 };
 using CacheRef = std::unique_ptr<Cache>;
 

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "crimson/os/seastore/cached_extent.h"
+#include "crimson/os/seastore/transaction.h"
 
 #include "crimson/common/log.h"
 

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -79,6 +79,17 @@ CachedExtent::~CachedExtent()
   }
 }
 
+CachedExtent* CachedExtent::get_transactional_view(Transaction &t) {
+  auto it = mutation_pendings.find(
+    t.get_trans_id(),
+    trans_spec_view_t::cmp_t());
+  if (it != mutation_pendings.end()) {
+    return (CachedExtent*)&(*it);
+  } else {
+    return this;
+  }
+}
+
 std::ostream &LogicalCachedExtent::print_detail(std::ostream &out) const
 {
   out << ", laddr=" << laddr;

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -90,6 +90,14 @@ std::ostream &LogicalCachedExtent::print_detail(std::ostream &out) const
   return print_detail_l(out);
 }
 
+void CachedExtent::set_invalid(Transaction &t) {
+  state = extent_state_t::INVALID;
+  if (trans_view_hook.is_linked()) {
+    trans_view_hook.unlink();
+  }
+  on_invalidated(t);
+}
+
 std::ostream &operator<<(std::ostream &out, const LBAPin &rhs)
 {
   return out << "LBAPin(" << rhs.get_key() << "~" << rhs.get_length()

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -78,11 +78,12 @@ CachedExtent::~CachedExtent()
     parent_index->erase(*this);
   }
 }
-
 CachedExtent* CachedExtent::get_transactional_view(Transaction &t) {
-  auto it = mutation_pendings.find(
-    t.get_trans_id(),
-    trans_spec_view_t::cmp_t());
+  return get_transactional_view(t.get_trans_id());
+}
+
+CachedExtent* CachedExtent::get_transactional_view(transaction_id_t tid) {
+  auto it = mutation_pendings.find(tid, trans_spec_view_t::cmp_t());
   if (it != mutation_pendings.end()) {
     return (CachedExtent*)&(*it);
   } else {

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -119,6 +119,10 @@ std::ostream &LogicalCachedExtent::_print_detail(std::ostream &out) const
   return print_detail_l(out);
 }
 
+void child_pos_t::link_child(ChildableCachedExtent *c) {
+  get_parent<FixedKVNode<laddr_t>>()->link_child(c, pos);
+}
+
 void CachedExtent::set_invalid(Transaction &t) {
   state = extent_state_t::INVALID;
   if (trans_view_hook.is_linked()) {

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -111,11 +111,6 @@ std::ostream &ChildableCachedExtent::print_detail(std::ostream &out) const {
 std::ostream &LogicalCachedExtent::_print_detail(std::ostream &out) const
 {
   out << ", laddr=" << laddr;
-  if (pin) {
-    out << ", pin=" << *pin;
-  } else {
-    out << ", pin=empty";
-  }
   return print_detail_l(out);
 }
 
@@ -161,9 +156,9 @@ parent_tracker_t::~parent_tracker_t() {
   }
 }
 
-std::ostream &operator<<(std::ostream &out, const LBAPin &rhs)
+std::ostream &operator<<(std::ostream &out, const LBAMapping &rhs)
 {
-  return out << "LBAPin(" << rhs.get_key() << "~" << rhs.get_length()
+  return out << "LBAMapping(" << rhs.get_key() << "~" << rhs.get_length()
 	     << "->" << rhs.get_val();
 }
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1139,16 +1139,6 @@ protected:
 
 private:
   laddr_t laddr = L_ADDR_NULL;
-
-  template <
-    typename node_key_t,
-    typename node_val_t,
-    typename internal_node_t,
-    typename leaf_node_t,
-    typename pin_t,
-    size_t node_size,
-    bool leaf_has_children>
-  friend class FixedKVBtree;
 };
 
 using LogicalCachedExtentRef = TCachedExtentRef<LogicalCachedExtent>;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -501,6 +501,10 @@ public:
 
   void set_invalid(Transaction &t);
 
+  CachedExtentRef get_prior_instance() {
+    return prior_instance;
+  }
+
 private:
   template <typename T>
   friend class read_set_item_t;
@@ -585,6 +589,8 @@ private:
   rewrite_gen_t rewrite_generation = NULL_GENERATION;
 
 protected:
+  trans_view_set_t mutation_pendings;
+
   CachedExtent(CachedExtent &&other) = delete;
   CachedExtent(ceph::bufferptr &&ptr) : ptr(std::move(ptr)) {}
   CachedExtent(const CachedExtent &other)
@@ -605,6 +611,8 @@ protected:
   struct retired_placeholder_t{};
   CachedExtent(retired_placeholder_t) : state(extent_state_t::INVALID) {}
 
+  CachedExtent& get_transactional_view(Transaction &t);
+
   friend class Cache;
   template <typename T, typename... Args>
   static TCachedExtentRef<T> make_cached_extent_ref(
@@ -612,8 +620,8 @@ protected:
     return new T(std::forward<Args>(args)...);
   }
 
-  CachedExtentRef get_prior_instance() {
-    return prior_instance;
+  void reset_prior_instance() {
+    prior_instance.reset();
   }
 
   /// Sets last_committed_crc

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -30,7 +30,8 @@ template <
   typename internal_node_t,
   typename leaf_node_t,
   typename pin_t,
-  size_t node_size>
+  size_t node_size,
+  bool leaf_has_children>
 class FixedKVBtree;
 
 // #define DEBUG_CACHED_EXTENT_REF
@@ -189,7 +190,8 @@ class CachedExtent
     typename internal_node_t,
     typename leaf_node_t,
     typename pin_t,
-    size_t node_size>
+    size_t node_size,
+    bool leaf_has_children>
   friend class FixedKVBtree;
   uint32_t last_committed_crc = 0;
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -233,6 +233,16 @@ public:
   virtual void on_delta_write(paddr_t record_block_offset) {}
 
   /**
+   * on_replace_prior
+   *
+   * Called after the extent has replaced a previous one. State
+   * of the extent must be MUTATION_PENDING. Implementation
+   * may use this call to synchronize states that must be synchronized
+   * with the states of Cache and can't wait till transaction
+   * completes.
+   */
+  virtual void on_replace_prior(Transaction &t) {}
+  /**
    * get_type
    *
    * Returns concrete type.

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -242,6 +242,16 @@ public:
    * completes.
    */
   virtual void on_replace_prior(Transaction &t) {}
+
+  /**
+   * on_invalidated
+   *
+   * Called after the extent is invalidated, either by Cache::invalidate_extent
+   * or Transaction::add_to_retired_set. Implementation may use this
+   * call to adjust states that must be changed immediately once
+   * invalidated.
+   */
+  virtual void on_invalidated(Transaction &t) {}
   /**
    * get_type
    *
@@ -488,6 +498,8 @@ public:
     prior_poffset.reset();
     return ret;
   }
+
+  void set_invalid(Transaction &t);
 
 private:
   template <typename T>

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -626,6 +626,7 @@ private:
   }
 
   CachedExtent* get_transactional_view(Transaction &t);
+  CachedExtent* get_transactional_view(transaction_id_t tid);
 
   read_set_item_t<Transaction>::trans_set_t transactions;
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -402,7 +402,7 @@ public:
 
   /// Returns true if extent or prior_instance has been invalidated
   bool has_been_invalidated() const {
-    return !is_valid() || (prior_instance && !prior_instance->is_valid());
+    return !is_valid() || (is_mutation_pending() && !prior_instance->is_valid());
   }
 
   /// Returns true if extent is a plcaeholder

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -192,7 +192,7 @@ public:
    * structure which defers updating the actual buffer until
    * on_delta_write().
    */
-  virtual CachedExtentRef duplicate_for_write() = 0;
+  virtual CachedExtentRef duplicate_for_write(Transaction &t) = 0;
 
   /**
    * prepare_write
@@ -846,7 +846,7 @@ public:
 
   extent_len_t get_length() const final { return length; }
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     ceph_assert(0 == "Should never happen for a placeholder");
     return CachedExtentRef();
   }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -16,6 +16,8 @@
 #include "crimson/common/interruptible_future.h"
 #include "crimson/os/seastore/seastore_types.h"
 
+struct btree_lba_manager_test;
+
 namespace crimson::os::seastore {
 
 class Transaction;

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -105,7 +105,7 @@ struct CollectionNode
   coll_map_t decoded;
   delta_buffer_t delta_buffer;
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     assert(delta_buffer.empty());
     return CachedExtentRef(new CollectionNode(*this));
   }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -246,7 +246,12 @@ public:
     extent_types_t type,
     extent_len_t length,
     placement_hint_t hint,
+#ifdef UNIT_TESTS_BUILT
+    rewrite_gen_t gen,
+    std::optional<paddr_t> external_paddr = std::nullopt
+#else
     rewrite_gen_t gen
+#endif
   ) {
     assert(hint < placement_hint_t::NUM_HINTS);
     assert(is_target_rewrite_generation(gen));
@@ -261,7 +266,14 @@ public:
       buffer::create_page_aligned(length));
     bp.zero();
     paddr_t addr;
+#ifdef UNIT_TESTS_BUILT
+    if (unlikely(external_paddr.has_value())) {
+      assert(external_paddr->is_fake());
+      addr = *external_paddr;
+    } else if (gen == INLINE_GENERATION) {
+#else
     if (gen == INLINE_GENERATION) {
+#endif
       addr = make_record_relative_paddr(0);
     } else if (category == data_category_t::DATA) {
       assert(data_writers_by_gen[generation_to_writer(gen)]);

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -17,17 +17,15 @@ LBAManager::update_mappings(
       t,
       extent->get_laddr(),
       extent->get_prior_paddr_and_reset(),
-      extent->get_paddr()
+      extent->get_paddr(),
+      nullptr	// all the extents should have already been
+		// added to the fixed_kv_btree
     );
   });
 }
 
-template <bool leaf_has_children>
 LBAManagerRef lba_manager::create_lba_manager(Cache &cache) {
-  return LBAManagerRef(new btree::BtreeLBAManager<leaf_has_children>(cache));
+  return LBAManagerRef(new btree::BtreeLBAManager(cache));
 }
-
-template  LBAManagerRef lba_manager::create_lba_manager<true>(Cache &cache);
-template  LBAManagerRef lba_manager::create_lba_manager<false>(Cache &cache);
 
 }

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -22,8 +22,12 @@ LBAManager::update_mappings(
   });
 }
 
+template <bool leaf_has_children>
 LBAManagerRef lba_manager::create_lba_manager(Cache &cache) {
-  return LBAManagerRef(new btree::BtreeLBAManager(cache));
+  return LBAManagerRef(new btree::BtreeLBAManager<leaf_has_children>(cache));
 }
+
+template  LBAManagerRef lba_manager::create_lba_manager<true>(Cache &cache);
+template  LBAManagerRef lba_manager::create_lba_manager<false>(Cache &cache);
 
 }

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -206,6 +206,7 @@ using LBAManagerRef = std::unique_ptr<LBAManager>;
 
 class Cache;
 namespace lba_manager {
+template <bool leaf_has_children>
 LBAManagerRef create_lba_manager(Cache &cache);
 }
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -124,6 +124,9 @@ public:
     Transaction &t,
     CachedExtentRef e) = 0;
 
+  using check_child_trackers_ret = base_iertr::future<>;
+  virtual check_child_trackers_ret check_child_trackers(Transaction &t) = 0;
+
   /**
    * Calls f for each mapping in [begin, end)
    */

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -62,7 +62,7 @@ public:
    */
   using get_mapping_iertr = base_iertr::extend<
     crimson::ct_error::enoent>;
-  using get_mapping_ret = get_mapping_iertr::future<LBAPinRef>;
+  using get_mapping_ret = get_mapping_iertr::future<LBAMappingRef>;
   virtual get_mapping_ret get_mapping(
     Transaction &t,
     laddr_t offset) = 0;
@@ -72,10 +72,10 @@ public:
    *
    * Offset will be relative to the block offset of the record
    * This mapping will block from transaction submission until set_paddr
-   * is called on the LBAPin.
+   * is called on the LBAMapping.
    */
   using alloc_extent_iertr = base_iertr;
-  using alloc_extent_ret = alloc_extent_iertr::future<LBAPinRef>;
+  using alloc_extent_ret = alloc_extent_iertr::future<LBAMappingRef>;
   virtual alloc_extent_ret alloc_extent(
     Transaction &t,
     laddr_t hint,
@@ -110,17 +110,9 @@ public:
     Transaction &t,
     laddr_t addr) = 0;
 
-  virtual void complete_transaction(
-    Transaction &t,
-    std::vector<CachedExtentRef> &to_clear,	///< extents whose pins are to be cleared,
-						//   as the results of their retirements
-    std::vector<CachedExtentRef> &to_link	///< fresh extents whose pins are to be inserted
-						//   into backref manager's pin set
-  ) = 0;
-
   /**
    * Should be called after replay on each cached extent.
-   * Implementation must initialize the LBAPin on any
+   * Implementation must initialize the LBAMapping on any
    * LogicalCachedExtent's and may also read in any dependent
    * structures, etc.
    *
@@ -199,8 +191,6 @@ public:
     paddr_t addr,
     laddr_t laddr,
     extent_len_t len) = 0;
-
-  virtual void add_pin(LBAPin &pin) = 0;
 
   virtual ~LBAManager() {}
 };

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -80,7 +80,8 @@ public:
     Transaction &t,
     laddr_t hint,
     extent_len_t len,
-    paddr_t addr) = 0;
+    paddr_t addr,
+    LogicalCachedExtent *nextent) = 0;
 
   struct ref_update_result_t {
     unsigned refcount = 0;
@@ -166,7 +167,8 @@ public:
     Transaction& t,
     laddr_t laddr,
     paddr_t prev_addr,
-    paddr_t paddr) = 0;
+    paddr_t paddr,
+    LogicalCachedExtent *nextent) = 0;
 
   /**
    * update_mappings
@@ -206,7 +208,6 @@ using LBAManagerRef = std::unique_ptr<LBAManager>;
 
 class Cache;
 namespace lba_manager {
-template <bool leaf_has_children>
 LBAManagerRef create_lba_manager(Cache &cache);
 }
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -351,6 +351,17 @@ BtreeLBAManager::init_cached_extent(
   });
 }
 
+BtreeLBAManager::check_child_trackers_ret
+BtreeLBAManager::check_child_trackers(
+  Transaction &t) {
+  auto c = get_context(t);
+  return with_btree<LBABtree>(
+    cache, c,
+    [c](auto &btree) {
+    return btree.check_child_trackers(c);
+  });
+}
+
 BtreeLBAManager::scan_mappings_ret
 BtreeLBAManager::scan_mappings(
   Transaction &t,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -27,13 +27,16 @@ namespace crimson::os::seastore::lba_manager::btree {
 
 class BtreeLBAPin : public BtreeNodePin<laddr_t, paddr_t> {
 public:
-  BtreeLBAPin() = default;
+  BtreeLBAPin(op_context_t<laddr_t> ctx)
+    : BtreeNodePin(ctx) {}
   BtreeLBAPin(
+    op_context_t<laddr_t> c,
     CachedExtentRef parent,
     uint16_t pos,
     lba_map_val_t &val,
     lba_node_meta_t &&meta)
     : BtreeNodePin(
+	c,
 	parent,
 	pos,
 	val.paddr,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -120,6 +120,8 @@ public:
     Transaction &t,
     CachedExtentRef e) final;
 
+  check_child_trackers_ret check_child_trackers(Transaction &t) final;
+
   scan_mappings_ret scan_mappings(
     Transaction &t,
     laddr_t begin,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -30,10 +30,12 @@ public:
   BtreeLBAPin() = default;
   BtreeLBAPin(
     CachedExtentRef parent,
+    uint16_t pos,
     lba_map_val_t &val,
     lba_node_meta_t &&meta)
     : BtreeNodePin(
 	parent,
+	pos,
 	val.paddr,
 	val.len,
 	std::forward<lba_node_meta_t>(meta))
@@ -88,7 +90,8 @@ public:
     Transaction &t,
     laddr_t hint,
     extent_len_t len,
-    paddr_t addr) final;
+    paddr_t addr,
+    LogicalCachedExtent*) final;
 
   ref_ret decref_extent(
     Transaction &t,
@@ -133,7 +136,8 @@ public:
     Transaction& t,
     laddr_t laddr,
     paddr_t prev_addr,
-    paddr_t paddr) final;
+    paddr_t paddr,
+    LogicalCachedExtent*) final;
 
   get_physical_extent_if_live_ret get_physical_extent_if_live(
     Transaction &t,
@@ -198,7 +202,8 @@ private:
   _update_mapping_ret _update_mapping(
     Transaction &t,
     laddr_t addr,
-    update_func_t &&f);
+    update_func_t &&f,
+    LogicalCachedExtent*);
 };
 using BtreeLBAManagerRef = std::unique_ptr<BtreeLBAManager>;
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -29,8 +29,13 @@ std::ostream& operator<<(std::ostream& out, const lba_map_val_t& v)
 
 std::ostream &LBALeafNode::print_detail(std::ostream &out) const
 {
-  return out << ", size=" << get_size()
-	     << ", meta=" << get_meta();
+  out << ", size=" << get_size()
+      << ", meta=" << get_meta()
+      << ", parent_tracker=" << (void*)parent_tracker.get();
+  if (parent_tracker) {
+    return out << ", parent=" << (void*)parent_tracker->parent.get();
+  }
+  return out;
 }
 
 void LBALeafNode::resolve_relative_addrs(paddr_t base)

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -35,7 +35,7 @@ std::ostream &LBALeafNode::print_detail(std::ostream &out) const
   if (parent_tracker) {
     return out << ", parent=" << (void*)parent_tracker->parent.get();
   }
-  return out;
+  return out << ", root_block=" << (void*)root_block.get();
 }
 
 void LBALeafNode::resolve_relative_addrs(paddr_t base)

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -27,15 +27,15 @@ std::ostream& operator<<(std::ostream& out, const lba_map_val_t& v)
              << ")";
 }
 
-std::ostream &LBALeafNode::print_detail(std::ostream &out) const
+std::ostream &LBALeafNode::_print_detail(std::ostream &out) const
 {
-  out << ", size=" << get_size()
-      << ", meta=" << get_meta()
-      << ", parent_tracker=" << (void*)parent_tracker.get();
-  if (parent_tracker) {
-    return out << ", parent=" << (void*)parent_tracker->parent.get();
+  out << ", size=" << this->get_size()
+      << ", meta=" << this->get_meta()
+      << ", my_tracker=" << (void*)this->my_tracker;
+  if (this->my_tracker) {
+    out << ", my_tracker->parent=" << (void*)this->my_tracker->get_parent().get();
   }
-  return out << ", root_block=" << (void*)root_block.get();
+  return out << ", root_block=" << (void*)this->root_block.get();
 }
 
 void LBALeafNode::resolve_relative_addrs(paddr_t base)

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -219,6 +219,7 @@ using LBALeafNodeRef = TCachedExtentRef<LBALeafNode>;
 }
 
 #if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::lba_manager::btree::lba_node_meta_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba_manager::btree::lba_map_val_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba_manager::btree::LBAInternalNode> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::lba_manager::btree::LBALeafNode> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -145,64 +145,125 @@ struct LBALeafNode
       LBALeafNode,
       true> {
   using Ref = TCachedExtentRef<LBALeafNode>;
-  using internal_iterator_t = const_iterator;
+  using parent_type_t = FixedKVLeafNode<
+			  LEAF_NODE_CAPACITY,
+			  laddr_t, laddr_le_t,
+			  lba_map_val_t, lba_map_val_le_t,
+			  LBA_BLOCK_SIZE,
+			  LBALeafNode,
+			  true>;
+  using internal_const_iterator_t =
+    typename parent_type_t::node_layout_t::const_iterator;
+  using internal_iterator_t =
+    typename parent_type_t::node_layout_t::iterator;
   template <typename... T>
   LBALeafNode(T&&... t) :
-    FixedKVLeafNode(std::forward<T>(t)...) {}
+    parent_type_t(std::forward<T>(t)...) {}
 
   static constexpr extent_types_t TYPE = extent_types_t::LADDR_LEAF;
 
-  void update(
-    const_iterator iter,
-    lba_map_val_t val) final {
-    val.paddr = maybe_generate_relative(val.paddr);
-    return journal_update(
-      iter,
-      val,
-      maybe_get_delta_buffer());
+  bool validate_stable_children() final {
+    LOG_PREFIX(LBALeafNode::validate_stable_children);
+    if (this->children.empty()) {
+      return false;
+    }
+
+    for (auto i : *this) {
+      auto child = (LogicalCachedExtent*)this->children[i.get_offset()];
+      if (is_valid_child_ptr(child) && child->get_laddr() != i.get_key()) {
+	SUBERROR(seastore_fixedkv_tree,
+	  "stable child not valid: child {}, key {}",
+	  *child,
+	  i.get_key());
+	ceph_abort();
+	return false;
+      }
+    }
+    return true;
   }
 
-  const_iterator insert(
-    const_iterator iter,
+  void update(
+    internal_const_iterator_t iter,
+    lba_map_val_t val,
+    LogicalCachedExtent* nextent) final {
+    LOG_PREFIX(LBALeafNode::update);
+    if (nextent) {
+      SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, {}",
+	this->pending_for_transaction,
+	iter.get_offset(),
+	*nextent);
+      // child-ptr may already be correct, see LBAManager::update_mappings()
+      this->update_child_ptr(iter, nextent);
+    }
+    val.paddr = this->maybe_generate_relative(val.paddr);
+    return this->journal_update(
+      iter,
+      val,
+      this->maybe_get_delta_buffer());
+  }
+
+  internal_const_iterator_t insert(
+    internal_const_iterator_t iter,
     laddr_t addr,
-    lba_map_val_t val) final {
-    val.paddr = maybe_generate_relative(val.paddr);
-    journal_insert(
+    lba_map_val_t val,
+    LogicalCachedExtent* nextent) final {
+    LOG_PREFIX(LBALeafNode::insert);
+    SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, key {}, extent {}",
+      this->pending_for_transaction,
+      iter.get_offset(),
+      addr,
+      (void*)nextent);
+    this->insert_child_ptr(iter, nextent);
+    val.paddr = this->maybe_generate_relative(val.paddr);
+    this->journal_insert(
       iter,
       addr,
       val,
-      maybe_get_delta_buffer());
+      this->maybe_get_delta_buffer());
     return iter;
   }
 
-  void remove(const_iterator iter) final {
-    return journal_remove(
+  void remove(internal_const_iterator_t iter) final {
+    LOG_PREFIX(LBALeafNode::remove);
+    SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, key {}",
+      this->pending_for_transaction,
+      iter.get_offset(),
+      iter.get_key());
+    assert(iter != this->end());
+    this->remove_child_ptr(iter);
+    return this->journal_remove(
       iter,
-      maybe_get_delta_buffer());
+      this->maybe_get_delta_buffer());
   }
 
   // See LBAInternalNode, same concept
   void resolve_relative_addrs(paddr_t base);
-  void node_resolve_vals(iterator from, iterator to) const final {
-    if (is_initial_pending()) {
+  void node_resolve_vals(
+    internal_iterator_t from,
+    internal_iterator_t to) const final
+  {
+    if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	auto val = i->get_val();
 	if (val.paddr.is_relative()) {
 	  assert(val.paddr.is_block_relative());
-	  val.paddr = get_paddr().add_relative(val.paddr);
+	  val.paddr = this->get_paddr().add_relative(val.paddr);
 	  i->set_val(val);
 	}
       }
     }
   }
-  void node_unresolve_vals(iterator from, iterator to) const final {
-    if (is_initial_pending()) {
+  void node_unresolve_vals(
+    internal_iterator_t from,
+    internal_iterator_t to) const final
+  {
+    if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	auto val = i->get_val();
 	if (val.paddr.is_relative()) {
 	  auto val = i->get_val();
 	  assert(val.paddr.is_record_relative());
-	  val.paddr = val.paddr.block_relative_to(get_paddr());
+	  val.paddr = val.paddr.block_relative_to(this->get_paddr());
 	  i->set_val(val);
 	}
       }
@@ -213,7 +274,7 @@ struct LBALeafNode
     return TYPE;
   }
 
-  std::ostream &print_detail(std::ostream &out) const final;
+  std::ostream &_print_detail(std::ostream &out) const final;
 };
 using LBALeafNodeRef = TCachedExtentRef<LBALeafNode>;
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -142,7 +142,8 @@ struct LBALeafNode
       laddr_t, laddr_le_t,
       lba_map_val_t, lba_map_val_le_t,
       LBA_BLOCK_SIZE,
-      LBALeafNode> {
+      LBALeafNode,
+      true> {
   using Ref = TCachedExtentRef<LBALeafNode>;
   using internal_iterator_t = const_iterator;
   template <typename... T>

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -8,9 +8,11 @@
 #include "crimson/common/log.h"
 
 #define LOGT(level_, MSG, t, ...) \
-  LOCAL_LOGGER.log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
+  LOCAL_LOGGER.log(level_, "{} trans.{} {}: " MSG, (void*)&t, \
+    (t).get_trans_id(), FNAME , ##__VA_ARGS__)
 #define SUBLOGT(subname_, level_, MSG, t, ...) \
-  LOGGER(subname_).log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
+  LOGGER(subname_).log(level_, "{} trans.{} {}: " MSG, (void*)&t, \
+    (t).get_trans_id(), FNAME , ##__VA_ARGS__)
 
 #define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)
 #define SUBTRACET(subname_, ...) SUBLOGT(subname_, seastar::log_level::trace, __VA_ARGS__)

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -476,7 +476,7 @@ using operate_ret_bare = std::pair<
   std::optional<extent_to_write_t>,
   std::optional<bufferptr>>;
 using operate_ret = get_iertr::future<operate_ret_bare>;
-operate_ret operate_left(context_t ctx, LBAPinRef &pin, const overwrite_plan_t &overwrite_plan)
+operate_ret operate_left(context_t ctx, LBAMappingRef &pin, const overwrite_plan_t &overwrite_plan)
 {
   if (overwrite_plan.get_left_size() == 0) {
     return get_iertr::make_ready_future<operate_ret_bare>(
@@ -555,7 +555,7 @@ operate_ret operate_left(context_t ctx, LBAPinRef &pin, const overwrite_plan_t &
  *
  * Proceed overwrite_plan.right_operation.
  */
-operate_ret operate_right(context_t ctx, LBAPinRef &pin, const overwrite_plan_t &overwrite_plan)
+operate_ret operate_right(context_t ctx, LBAMappingRef &pin, const overwrite_plan_t &overwrite_plan)
 {
   if (overwrite_plan.get_right_size() == 0) {
     return get_iertr::make_ready_future<operate_ret_bare>(

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -22,18 +22,6 @@ namespace crimson::os::seastore {
 using context_t = ObjectDataHandler::context_t;
 using get_iertr = ObjectDataHandler::write_iertr;
 
-auto read_pin(
-  context_t ctx,
-  LBAPinRef pin) {
-  return ctx.tm.pin_to_extent<ObjectDataBlock>(
-    ctx.t,
-    std::move(pin)
-  ).handle_error_interruptible(
-    get_iertr::pass_further{},
-    crimson::ct_error::assert_all{ "read_pin: invalid error" }
-  );
-}
-
 /**
  * extent_to_write_t
  *
@@ -518,7 +506,8 @@ operate_ret operate_left(context_t ctx, LBAPinRef &pin, const overwrite_plan_t &
         std::nullopt,
         std::nullopt);
     } else {
-      return read_pin(ctx, pin->duplicate()
+      return ctx.tm.read_pin<ObjectDataBlock>(
+	ctx.t, pin->duplicate()
       ).si_then([prepend_len](auto left_extent) {
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::nullopt,
@@ -545,7 +534,8 @@ operate_ret operate_left(context_t ctx, LBAPinRef &pin, const overwrite_plan_t &
         left_to_write_extent,
         std::nullopt);
     } else {
-      return read_pin(ctx, pin->duplicate()
+      return ctx.tm.read_pin<ObjectDataBlock>(
+	ctx.t, pin->duplicate()
       ).si_then([prepend_offset=extent_len, prepend_len,
                  left_to_write_extent=std::move(left_to_write_extent)]
                 (auto left_extent) mutable {
@@ -598,7 +588,8 @@ operate_ret operate_right(context_t ctx, LBAPinRef &pin, const overwrite_plan_t 
         std::nullopt);
     } else {
       auto append_offset = overwrite_plan.data_end - right_pin_begin;
-      return read_pin(ctx, pin->duplicate()
+      return ctx.tm.read_pin<ObjectDataBlock>(
+	ctx.t, pin->duplicate()
       ).si_then([append_offset, append_len](auto right_extent) {
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::nullopt,
@@ -626,7 +617,8 @@ operate_ret operate_right(context_t ctx, LBAPinRef &pin, const overwrite_plan_t 
         std::nullopt);
     } else {
       auto append_offset = overwrite_plan.data_end - right_pin_begin;
-      return read_pin(ctx, pin->duplicate()
+      return ctx.tm.read_pin<ObjectDataBlock>(
+	ctx.t, pin->duplicate()
       ).si_then([append_offset, append_len,
                  right_to_write_extent=std::move(right_to_write_extent)]
                 (auto right_extent) mutable {
@@ -731,8 +723,8 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
 	} else {
 	  /* First pin overlaps the boundary and has data, read in extent
 	   * and rewrite portion prior to size */
-	  return read_pin(
-	    ctx,
+	  return ctx.tm.read_pin<ObjectDataBlock>(
+	    ctx.t,
 	    pin.duplicate()
 	  ).si_then([ctx, size, pin_offset, &pin, &object_data, &to_write](
 		     auto extent) {
@@ -1069,7 +1061,7 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
 		      current = end;
 		      return seastar::now();
 		    } else {
-		      return ctx.tm.pin_to_extent<ObjectDataBlock>(
+		      return ctx.tm.read_pin<ObjectDataBlock>(
 			ctx.t,
 			std::move(pin)
 		      ).si_then([&ret, &current, end](auto extent) {

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -24,7 +24,7 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
   ObjectDataBlock(const ObjectDataBlock &other)
     : LogicalCachedExtent(other) {}
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new ObjectDataBlock(*this));
   };
 

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -46,7 +46,7 @@ struct OMapInnerNode
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     assert(delta_buffer.empty());
     return CachedExtentRef(new OMapInnerNode(*this));
   }
@@ -164,7 +164,7 @@ struct OMapLeafNode
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     assert(delta_buffer.empty());
     return CachedExtentRef(new OMapLeafNode(*this));
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -55,7 +55,7 @@ class DummyNodeExtent final: public NodeExtent {
     ceph_abort("impossible path"); }
   DeltaRecorder* get_recorder() const override {
     return nullptr; }
-  CachedExtentRef duplicate_for_write() override {
+  CachedExtentRef duplicate_for_write(Transaction&) override {
     ceph_abort("impossible path"); }
   extent_types_t get_type() const override {
     return extent_types_t::TEST_BLOCK; }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -59,7 +59,7 @@ class SeastoreNodeExtent final: public NodeExtent {
     return recorder.get();
   }
 
-  CachedExtentRef duplicate_for_write() override {
+  CachedExtentRef duplicate_for_write(Transaction&) override {
     return CachedExtentRef(new SeastoreNodeExtent(*this));
   }
   ceph::bufferlist get_delta() override {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
@@ -47,7 +47,7 @@ class TestReplayExtent final: public NodeExtent {
     ceph_abort("impossible path"); }
   DeltaRecorder* get_recorder() const override {
     ceph_abort("impossible path"); }
-  CachedExtentRef duplicate_for_write() override {
+  CachedExtentRef duplicate_for_write(Transaction&) override {
     ceph_abort("impossible path"); }
   extent_types_t get_type() const override {
     return extent_types_t::TEST_BLOCK; }

--- a/src/crimson/os/seastore/root_block.cc
+++ b/src/crimson/os/seastore/root_block.cc
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/root_block.h"
+#include "crimson/os/seastore/lba_manager/btree/lba_btree_node.h"
+#include "crimson/os/seastore/backref/backref_tree_node.h"
+
+namespace crimson::os::seastore {
+
+void RootBlock::on_replace_prior(Transaction &t) {
+  if (!lba_root_node) {
+    auto &prior = static_cast<RootBlock&>(*get_prior_instance());
+    lba_root_node = prior.lba_root_node;
+    if (lba_root_node) {
+      ((lba_manager::btree::LBANode*)lba_root_node)->root_block = this;
+    }
+  }
+  if (!backref_root_node) {
+    auto &prior = static_cast<RootBlock&>(*get_prior_instance());
+    backref_root_node = prior.backref_root_node;
+    if (backref_root_node) {
+      ((backref::BackrefNode*)backref_root_node)->root_block = this;
+    }
+  }
+}
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -38,9 +38,17 @@ struct RootBlock : CachedExtent {
 
   root_t root;
 
+  CachedExtent* lba_root_node = nullptr;
+  CachedExtent* backref_root_node = nullptr;
+
   RootBlock() : CachedExtent(0) {}
 
-  RootBlock(const RootBlock &rhs) = default;
+  RootBlock(const RootBlock &rhs)
+    : CachedExtent(rhs),
+      root(rhs.root),
+      lba_root_node(nullptr),
+      backref_root_node(nullptr)
+  {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new RootBlock(*this));
@@ -50,6 +58,8 @@ struct RootBlock : CachedExtent {
   extent_types_t get_type() const final {
     return extent_types_t::ROOT;
   }
+
+  void on_replace_prior(Transaction &t) final;
 
   /// dumps root as delta
   ceph::bufferlist get_delta() final {
@@ -84,6 +94,11 @@ struct RootBlock : CachedExtent {
 
   root_t &get_root() { return root; }
 
+  std::ostream &print_detail(std::ostream &out) const final {
+    return out << ", root_block(lba_root_node=" << (void*)lba_root_node
+	       << ", backref_root_node=" << (void*)backref_root_node
+	       << ")";
+  }
 };
 using RootBlockRef = RootBlock::Ref;
 

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -42,7 +42,7 @@ struct RootBlock : CachedExtent {
 
   RootBlock(const RootBlock &rhs) = default;
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new RootBlock(*this));
   };
 

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -219,6 +219,8 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
     return out << "LADDR_INTERNAL";
   case extent_types_t::LADDR_LEAF:
     return out << "LADDR_LEAF";
+  case extent_types_t::DINK_LADDR_LEAF:
+    return out << "LADDR_LEAF";
   case extent_types_t::ONODE_BLOCK_STAGED:
     return out << "ONODE_BLOCK_STAGED";
   case extent_types_t::OMAP_INNER:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -24,6 +24,9 @@ namespace crimson::os::seastore {
 /* using a special xattr key "omap_header" to store omap header */
   const std::string OMAP_HEADER_XATTR_KEY = "omap_header";
 
+using transaction_id_t = uint64_t;
+constexpr transaction_id_t TRANS_ID_NULL = 0;
+
 /*
  * Note: NULL value is usually the default and max value.
  */

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -625,6 +625,10 @@ public:
     return get_addr_type() != paddr_types_t::RESERVED;
   }
 
+  bool is_fake() const {
+    return get_device_id() == DEVICE_ID_FAKE;
+  }
+
   auto operator<=>(const paddr_t &) const = default;
 
   DENC(paddr_t, v, p) {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1062,7 +1062,7 @@ enum class extent_types_t : uint8_t {
   ROOT = 0,
   LADDR_INTERNAL = 1,
   LADDR_LEAF = 2,
-  DINK_LADDR_LEAF = 3,
+  DINK_LADDR_LEAF = 3, // should only be used for unitttests
   OMAP_INNER = 4,
   OMAP_LEAF = 5,
   ONODE_BLOCK_STAGED = 6,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1062,23 +1062,24 @@ enum class extent_types_t : uint8_t {
   ROOT = 0,
   LADDR_INTERNAL = 1,
   LADDR_LEAF = 2,
-  OMAP_INNER = 3,
-  OMAP_LEAF = 4,
-  ONODE_BLOCK_STAGED = 5,
-  COLL_BLOCK = 6,
-  OBJECT_DATA_BLOCK = 7,
-  RETIRED_PLACEHOLDER = 8,
+  DINK_LADDR_LEAF = 3,
+  OMAP_INNER = 4,
+  OMAP_LEAF = 5,
+  ONODE_BLOCK_STAGED = 6,
+  COLL_BLOCK = 7,
+  OBJECT_DATA_BLOCK = 8,
+  RETIRED_PLACEHOLDER = 9,
   // the following two types are not extent types,
   // they are just used to indicates paddr allocation deltas
-  ALLOC_INFO = 9,
-  JOURNAL_TAIL = 10,
+  ALLOC_INFO = 10,
+  JOURNAL_TAIL = 11,
   // Test Block Types
-  TEST_BLOCK = 11,
-  TEST_BLOCK_PHYSICAL = 12,
-  BACKREF_INTERNAL = 13,
-  BACKREF_LEAF = 14,
+  TEST_BLOCK = 12,
+  TEST_BLOCK_PHYSICAL = 13,
+  BACKREF_INTERNAL = 14,
+  BACKREF_LEAF = 15,
   // None and the number of valid extent_types_t
-  NONE = 15,
+  NONE = 16,
 };
 using extent_types_le_t = uint8_t;
 constexpr auto EXTENT_TYPES_MAX = static_cast<uint8_t>(extent_types_t::NONE);
@@ -1108,7 +1109,8 @@ constexpr bool is_retired_placeholder(extent_types_t type)
 constexpr bool is_lba_node(extent_types_t type)
 {
   return type == extent_types_t::LADDR_INTERNAL ||
-    type == extent_types_t::LADDR_LEAF;
+    type == extent_types_t::LADDR_LEAF ||
+    type == extent_types_t::DINK_LADDR_LEAF;
 }
 
 constexpr bool is_backref_node(extent_types_t type)

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -117,13 +117,13 @@ public:
     if (ref->is_exist_clean() ||
 	ref->is_exist_mutation_pending()) {
       existing_block_stats.dec(ref);
-      ref->state = CachedExtent::extent_state_t::INVALID;
+      ref->set_invalid(*this);
       write_set.erase(*ref);
     } else if (ref->is_initial_pending()) {
-      ref->state = CachedExtent::extent_state_t::INVALID;
+      ref->set_invalid(*this);
       write_set.erase(*ref);
     } else if (ref->is_mutation_pending()) {
-      ref->state = CachedExtent::extent_state_t::INVALID;
+      ref->set_invalid(*this);
       write_set.erase(*ref);
       assert(ref->prior_instance);
       retired_set.insert(ref->prior_instance);
@@ -348,7 +348,7 @@ public:
 
   void invalidate_clear_write_set() {
     for (auto &&i: write_set) {
-      i.state = CachedExtent::extent_state_t::INVALID;
+      i.set_invalid(*this);
     }
     write_set.clear();
   }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -169,8 +169,11 @@ public:
       pre_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
       fresh_block_stats.increment(ref->get_length());
     } else {
-      assert(ref->get_paddr() == make_record_relative_paddr(0));
-      ref->set_paddr(make_record_relative_paddr(offset));
+      if (likely(ref->get_paddr() == make_record_relative_paddr(0))) {
+	ref->set_paddr(make_record_relative_paddr(offset));
+      } else {
+	ceph_assert(ref->get_paddr().is_fake());
+      }
       offset += ref->get_length();
       inline_block_list.push_back(ref);
       fresh_block_stats.increment(ref->get_length());

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -486,7 +486,8 @@ TransactionManager::rewrite_logical_extent(
     t,
     lextent->get_laddr(),
     lextent->get_paddr(),
-    nlextent->get_paddr());
+    nlextent->get_paddr(),
+    nlextent.get());
 }
 
 TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -125,18 +125,22 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
           t,
           [this](
             paddr_t paddr,
+	    paddr_t backref_key,
             extent_len_t len,
             extent_types_t type,
             laddr_t laddr) {
           if (is_backref_node(type)) {
             assert(laddr == L_ADDR_NULL);
-            backref_manager->cache_new_backref_extent(paddr, type);
+	    assert(backref_key != P_ADDR_NULL);
+            backref_manager->cache_new_backref_extent(paddr, backref_key, type);
             cache->update_tree_extents_num(type, 1);
             epm->mark_space_used(paddr, len);
           } else if (laddr == L_ADDR_NULL) {
+	    assert(backref_key == P_ADDR_NULL);
             cache->update_tree_extents_num(type, -1);
             epm->mark_space_free(paddr, len);
           } else {
+	    assert(backref_key == P_ADDR_NULL);
             cache->update_tree_extents_num(type, 1);
             epm->mark_space_used(paddr, len);
           }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -593,7 +593,7 @@ TransactionManager::get_extents_if_live(
             // Only extent split can happen during the lookup
             ceph_assert(pin_seg_paddr >= paddr &&
                         pin_seg_paddr.add_offset(pin_len) <= paddr.add_offset(len));
-            return pin_to_extent_by_type(t, std::move(pin), type
+            return read_pin_by_type(t, std::move(pin), type
             ).si_then([&list](auto ret) {
               list.emplace_back(std::move(ret));
               return seastar::now();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -371,7 +371,8 @@ public:
     ext->init(CachedExtent::extent_state_t::EXIST_CLEAN,
 	      existing_paddr,
 	      PLACEMENT_HINT_NULL,
-	      NULL_GENERATION);
+	      NULL_GENERATION,
+	      t.get_trans_id());
 
     t.add_fresh_extent(ext);
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -142,6 +142,7 @@ public:
 	assert(!extent.has_pin());
 	assert(!extent.has_been_invalidated());
 	assert(!pin->has_been_invalidated());
+	assert(pin->get_parent());
 	extent.set_pin(std::move(pin));
 	lba_manager->add_pin(extent.get_pin());
       }
@@ -325,7 +326,8 @@ public:
       t,
       laddr_hint,
       len,
-      ext->get_paddr()
+      ext->get_paddr(),
+      ext.get()
     ).si_then([ext=std::move(ext), laddr_hint, &t, FNAME](auto &&ref) mutable {
       ext->set_pin(std::move(ref));
       SUBDEBUGT(seastore_tm, "new extent: {}, laddr_hint: {}", t, *ext, laddr_hint);
@@ -380,7 +382,8 @@ public:
       t,
       laddr_hint,
       length,
-      existing_paddr
+      existing_paddr,
+      ext.get()
     ).si_then([ext=std::move(ext), laddr_hint, this](auto &&ref) {
       ceph_assert(laddr_hint == ref->get_key());
       ext->set_pin(std::move(ref));
@@ -409,7 +412,8 @@ public:
       t,
       hint,
       len,
-      P_ADDR_ZERO);
+      P_ADDR_ZERO,
+      nullptr);
   }
 
   /* alloc_extents

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -134,7 +134,7 @@ public:
     static_assert(is_logical_type(T::TYPE));
     using ret = pin_to_extent_ret<T>;
     auto &pref = *pin;
-    return cache->get_extent<T>(
+    return cache->get_absent_extent<T>(
       t,
       pref.get_val(),
       pref.get_length(),
@@ -168,7 +168,7 @@ public:
     SUBTRACET(seastore_tm, "getting extent {} type {}", t, *pin, type);
     assert(is_logical_type(type));
     auto &pref = *pin;
-    return cache->get_extent_by_type(
+    return cache->get_absent_extent_by_type(
       t,
       type,
       pref.get_val(),

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -71,7 +71,7 @@ TMDriver::read_extents_ret TMDriver::read_extents(
 	      "read_extents: get_extent {}~{}",
 	      pin->get_val(),
 	      pin->get_length());
-	    return tm->pin_to_extent<TestBlock>(
+	    return tm->read_pin<TestBlock>(
 	      t,
 	      std::move(pin)
 	    ).si_then([&ret](auto ref) mutable {

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -54,7 +54,7 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
   TestBlock(const TestBlock &other)
     : LogicalCachedExtent(other) {}
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new TestBlock(*this));
   };
 
@@ -93,7 +93,7 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
   TestBlockPhysical(const TestBlockPhysical &other)
     : CachedExtent(other) {}
 
-  CachedExtentRef duplicate_for_write() final {
+  CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new TestBlockPhysical(*this));
   };
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -328,23 +328,7 @@ struct btree_lba_manager_test : btree_test_base {
 
   btree_lba_manager_test() = default;
 
-  void complete_commit(Transaction &t) final {
-    std::vector<CachedExtentRef> lba_to_clear;
-    lba_to_clear.reserve(t.get_retired_set().size());
-    for (auto &e: t.get_retired_set()) {
-      if (e->is_logical() || is_lba_node(e->get_type()))
-	lba_to_clear.push_back(e);
-    }
-    std::vector<CachedExtentRef> lba_to_link;
-    lba_to_link.reserve(t.get_fresh_block_stats().num);
-    t.for_each_fresh_block([&](auto &e) {
-      if (e->is_valid() &&
-	  (is_lba_node(e->get_type()) || e->is_logical()))
-	  lba_to_link.push_back(e);
-    });
-
-    lba_manager->complete_transaction(t, lba_to_clear, lba_to_link);
-  }
+  void complete_commit(Transaction &t) final {}
 
   LBAManager::mkfs_ret test_structure_setup(Transaction &t) final {
     lba_manager.reset(new BtreeLBAManager(*cache));

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -257,7 +257,7 @@ struct lba_btree_test : btree_test_base {
     check.emplace(addr, get_map_val(len));
     lba_btree_update([=, this](auto &btree, auto &t) {
       return btree.insert(
-	get_op_context(t), addr, get_map_val(len)
+	get_op_context(t), addr, get_map_val(len), nullptr
       ).si_then([](auto){});
     });
   }
@@ -324,7 +324,7 @@ TEST_F(lba_btree_test, basic)
 }
 
 struct btree_lba_manager_test : btree_test_base {
-  BtreeLBAManagerRef<false> lba_manager;
+  BtreeLBAManagerRef lba_manager;
 
   btree_lba_manager_test() = default;
 
@@ -426,7 +426,7 @@ struct btree_lba_manager_test : btree_test_base {
     auto ret = with_trans_intr(
       *t.t,
       [=, this](auto &t) {
-	return lba_manager->alloc_extent(t, hint, len, paddr);
+	return lba_manager->alloc_extent(t, hint, len, paddr, nullptr);
       }).unsafe_get0();
     logger().debug("alloc'd: {}", *ret);
     EXPECT_EQ(len, ret->get_length());

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -198,17 +198,9 @@ struct lba_btree_test : btree_test_base {
       auto mut_croot = cache->duplicate_for_write(
 	t, croot
       )->cast<RootBlock>();
-      mut_croot->root.lba_root = LBABtree::mkfs(get_op_context(t));
+      mut_croot->root.lba_root =
+	LBABtree::mkfs(mut_croot, get_op_context(t));
     });
-  }
-
-  void update_if_dirty(Transaction &t, LBABtree &btree, RootBlockRef croot) {
-    if (btree.is_root_dirty()) {
-      auto mut_croot = cache->duplicate_for_write(
-	t, croot
-      )->cast<RootBlock>();
-      mut_croot->root.lba_root = btree.get_root_undirty();
-    }
   }
 
   template <typename F>
@@ -221,16 +213,13 @@ struct lba_btree_test : btree_test_base {
       [this, tref=std::move(tref), f=std::forward<F>(f)](auto &t) mutable {
 	return cache->get_root(
 	  t
-	).si_then([this, f=std::move(f), &t](RootBlockRef croot) {
+	).si_then([f=std::move(f), &t](RootBlockRef croot) {
 	  return seastar::do_with(
-	    LBABtree(croot->root.lba_root),
-	    [this, croot, f=std::move(f), &t](auto &btree) mutable {
+	    LBABtree(croot),
+	    [f=std::move(f), &t](auto &btree) mutable {
 	      return std::invoke(
 		std::move(f), btree, t
-	      ).si_then([this, croot, &t, &btree] {
-		update_if_dirty(t, btree, croot);
-		return seastar::now();
-	      });
+	      );
 	    });
 	}).si_then([this, tref=std::move(tref)]() mutable {
 	  return submit_transaction(std::move(tref));
@@ -249,7 +238,7 @@ struct lba_btree_test : btree_test_base {
 	  t
 	).si_then([f=std::move(f), &t](RootBlockRef croot) mutable {
 	  return seastar::do_with(
-	    LBABtree(croot->root.lba_root),
+	    LBABtree(croot),
 	    [f=std::move(f), &t](auto &btree) mutable {
 	      return std::invoke(
 		std::move(f), btree, t

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -324,7 +324,7 @@ TEST_F(lba_btree_test, basic)
 }
 
 struct btree_lba_manager_test : btree_test_base {
-  BtreeLBAManagerRef lba_manager;
+  BtreeLBAManagerRef<false> lba_manager;
 
   btree_lba_manager_test() = default;
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -499,6 +499,11 @@ struct btree_lba_manager_test : btree_test_base {
   }
 
   void check_mappings(test_transaction_t &t) {
+    (void)with_trans_intr(
+      *t.t,
+      [=, this](auto &t) {
+	return lba_manager->check_child_trackers(t);
+      }).unsafe_get0();
     for (auto &&i: t.mappings) {
       auto laddr = i.first;
       auto len = i.second.len;

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -135,7 +135,7 @@ struct object_data_handler_test_t:
       }
     }
   }
-  std::list<LBAPinRef> get_mappings(objaddr_t offset, extent_len_t length) {
+  std::list<LBAMappingRef> get_mappings(objaddr_t offset, extent_len_t length) {
     auto t = create_mutate_transaction();
     auto ret = with_trans_intr(*t, [&](auto &t) {
       return tm->get_pins(t, offset, length);

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -561,6 +561,11 @@ struct transaction_manager_test_t :
 	    ++iter;
 	  });
       }).unsafe_get0();
+    (void)with_trans_intr(
+      *t.t,
+      [=, this](auto &t) {
+	return lba_manager->check_child_trackers(t);
+      }).unsafe_get0();
   }
 
   bool try_submit_transaction(test_transaction_t t) {


### PR DESCRIPTION
After this optimization, total cpu time spent in FixedKVBtree::lower_bound drops from 23.4% to 15.1%:

Before:
![image](https://user-images.githubusercontent.com/3112624/186080788-55772f72-b906-45fe-8cdd-e896870a8ace.png)
After:
![image](https://user-images.githubusercontent.com/3112624/186080847-2aa0f3e0-efb9-48d4-b22f-14163d955009.png)


Total cpu time spent doing FixedKVBtree related operations drops from 27.4 % to 20.5%

Before:
![image](https://user-images.githubusercontent.com/3112624/186081194-3bfd3df9-36b5-4fbb-a39a-bd354031a857.png)
After:
![image](https://user-images.githubusercontent.com/3112624/186081265-f87d1f79-ee81-4968-8eae-00c0e93ef5f2.png)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
