### PR TITLE
doc/mgr: edit orchestrator.rst

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -5,14 +5,18 @@
 Orchestrator CLI
 ================
 
-This module provides a command line interface (CLI) to orchestrator
-modules (``ceph-mgr`` modules which interface with external orchestration services).
+This module provides a command line interface (CLI) for orchestrator modules.
+Orchestrator modules are ``ceph-mgr`` plugins that interface with external
+orchestration services.
 
-As the orchestrator CLI unifies multiple external orchestrators, a common nomenclature
-for the orchestrator module is needed.
+Definition of Terms
+===================
+
+The orchestrator CLI unifies multiple external orchestrators, so we need a
+common nomenclature for the orchestrator module: 
 
 +--------------------------------------+---------------------------------------+
-| *host*                               | hostname (not DNS name) of the        |
+| *host*                               | hostname (not the DNS name) of the    |
 |                                      | physical host. Not the podname,       |
 |                                      | container name, or hostname inside    |
 |                                      | the container.                        |
@@ -20,7 +24,7 @@ for the orchestrator module is needed.
 | *service type*                       | The type of the service. e.g., nfs,   |
 |                                      | mds, osd, mon, rgw, mgr, iscsi        |
 +--------------------------------------+---------------------------------------+
-| *service*                            | A logical service, Typically          |
+| *service*                            | A logical service. Typically          |
 |                                      | comprised of multiple service         |
 |                                      | instances on multiple hosts for HA    |
 |                                      |                                       |
@@ -34,29 +38,28 @@ for the orchestrator module is needed.
 |                                      | like LIO or knfsd or whatever)        |
 |                                      |                                       |
 |                                      | This identifier should                |
-|                                      | uniquely identify the instance        |
+|                                      | uniquely identify the instance.       |
 +--------------------------------------+---------------------------------------+
 
-The relation between the names is the following:
+Here is how the names relate: 
 
-* A *service* has a specific *service type*
-* A *daemon* is a physical instance of a *service type*
-
+* A *service* has a specific *service type*.
+* A *daemon* is a physical instance of a *service type*.
 
 .. note::
 
-    Orchestrator modules may only implement a subset of the commands listed below.
-    Also, the implementation of the commands may differ between modules.
+    Orchestrator modules might implement only a subset of the commands listed
+    below. The implementation of the commands may differ between modules.
 
 Status
 ======
 
-::
+.. prompt:: bash $
 
-    ceph orch status [--detail]
+   ceph orch status [--detail]
 
-Show current orchestrator mode and high-level status (whether the orchestrator
-plugin is available and operational)
+This command shows the current orchestrator mode and its high-level status
+(whether the orchestrator plugin is available and operational).
 
 
 ..
@@ -92,15 +95,20 @@ plugin is available and operational)
 Stateless services (MDS/RGW/NFS/rbd-mirror/iSCSI)
 =================================================
 
-(Please note: The orchestrator will not configure the services. Please look into the corresponding
-documentation for service configuration details.)
+.. note::
 
-The ``name`` parameter is an identifier of the group of instances:
+   The orchestrator will not configure the services. See the relevant
+   documentation for details about how to configure particular services. 
 
-* a CephFS file system for a group of MDS daemons,
-* a zone name for a group of RGWs
+The ``name`` parameter identifies the kind of the group of instances. The
+following short list explains the meaning of the ``name`` parameter:
 
-Creating/growing/shrinking/removing services::
+* A CephFS file system identifies a group of MDS daemons.
+* A zone name identifies a group of RGWs.
+
+Creating/growing/shrinking/removing services:
+
+.. prompt:: bash $
 
     ceph orch apply mds <fs_name> [--placement=<placement>] [--dry-run]
     ceph orch apply rgw <name> [--realm=<realm>] [--zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
@@ -111,11 +119,13 @@ where ``placement`` is a :ref:`orchestrator-cli-placement-spec`.
 
 e.g., ``ceph orch apply mds myfs --placement="3 host1 host2 host3"``
 
-Service Commands::
+Service Commands:
+
+.. prompt:: bash $
 
     ceph orch <start|stop|restart|redeploy|reconfig> <service_name>
 
-   .. note:: these commands applies to cephadm containerized daemons only.
+.. note:: These commands apply only to cephadm containerized daemons.
 
 Options
 =======
@@ -148,24 +158,34 @@ Options
 Configuring the Orchestrator CLI
 ================================
 
-To enable the orchestrator, select the orchestrator module to use
-with the ``set backend`` command::
+Enable the orchestrator by using the ``set backend`` command to select the orchestrator module that will be used:
+
+.. prompt:: bash $
 
     ceph orch set backend <module>
 
-For example, to enable the Rook orchestrator module and use it with the CLI::
+Example - Configuring the Orchestrator CLI
+------------------------------------------
+
+For example, to enable the Rook orchestrator module and use it with the CLI:
+
+.. prompt:: bash $
 
     ceph mgr module enable rook
     ceph orch set backend rook
 
-Check the backend is properly configured::
+Confirm that the backend is properly configured:
+
+.. prompt:: bash $
 
     ceph orch status
 
 Disable the Orchestrator
 ------------------------
 
-To disable the orchestrator, use the empty string ``""``::
+To disable the orchestrator, use the empty string ``""``:
+
+.. prompt:: bash $
 
     ceph orch set backend ""
     ceph mgr module disable rook


### PR DESCRIPTION
This PR improves the English language in the "Orchestrator CLI"
section of the MGR documentation. It adds a couple of section
headers in order to signpost the information in the document
a bit more than had already been done, but it makes no major
structural changes to the presentation of the information here.

This PR was motivated by feedback from the 2022 Ceph User Survey
in which one of the respondents wrote "better ceph orch documen-
tation".

The final section on this page, "Current Implementation Status",
must be verified by someone who is familiar with the current state
of "ceph orch" and a date stamp should be applied to the top of
the section so that the word "current" has a meaningful referent.

Signed-off-by: Zac Dover <zac.dover@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
