### PR TITLE
mds: fix client isn't responding to mclientcaps(revoke)

### DIFF
--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -183,24 +183,6 @@ public:
     return last_sent;
   }
   int confirm_receipt(ceph_seq_t seq, unsigned caps);
-  // we may get a release racing with revocations, which means our revokes will be ignored
-  // by the client.  clean them out of our _revokes history so we don't wait on them.
-  void clean_revoke_from(ceph_seq_t li) {
-    bool changed = false;
-    while (!_revokes.empty() && _revokes.front().last_issue <= li) {
-      _revokes.pop_front();
-      changed = true;
-    }
-    if (changed) {
-      bool was_revoking = (_issued & ~_pending);
-      calc_issued();
-      if (was_revoking && _issued == _pending) {
-	item_revoking_caps.remove_myself();
-	item_client_revoking_caps.remove_myself();
-	maybe_clear_notable();
-      }
-    }
-  }
   ceph_seq_t get_mseq() const { return mseq; }
   void inc_mseq() { mseq++; }
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4066,13 +4066,6 @@ void Locker::_do_cap_release(client_t client, inodeno_t ino, uint64_t cap_id,
                   new C_Locker_RetryCapRelease(this, client, ino, cap_id, mseq, seq));
     return;
   }
-  if (seq != cap->get_last_issue()) {
-    dout(7) << " issue_seq " << seq << " != " << cap->get_last_issue() << dendl;
-    // clean out any old revoke history
-    cap->clean_revoke_from(seq);
-    eval_cap_gather(in);
-    return;
-  }
   remove_client_cap(in, cap);
 }
 

--- a/src/test/libcephfs/multiclient.cc
+++ b/src/test/libcephfs/multiclient.cc
@@ -15,12 +15,13 @@
 #include "gtest/gtest.h"
 #include "include/compat.h"
 #include "include/cephfs/libcephfs.h"
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <dirent.h>
+#include <thread>
 #ifdef __linux__
 #include <sys/xattr.h>
 #endif
@@ -97,4 +98,83 @@ TEST(LibCephFS, MulticlientHoleEOF) {
 
   ceph_shutdown(ca);
   ceph_shutdown(cb);
+}
+
+static void write_func(bool *stop)
+{
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  char name[20];
+  snprintf(name, sizeof(name), "foo.%d", getpid());
+  int fd = ceph_open(cmount, name, O_CREAT|O_RDWR, 0644);
+  ASSERT_LE(0, fd);
+
+  int buf_size = 4096;
+  char *buf = (char *)malloc(buf_size);
+  if (!buf) {
+    *stop = true;
+    printf("write_func failed to allocate buffer!");
+    return;
+  }
+  memset(buf, 1, buf_size);
+
+  while (!(*stop)) {
+    int i;
+
+    // truncate the file size to 4096 will set the max_size to 4MB.
+    ASSERT_EQ(0, ceph_ftruncate(cmount, fd, 4096));
+
+    // write 4MB + extra 64KB data will make client to trigger to
+    // call check_cap() to report new size. And if MDS is revoking
+    // the Fsxrw caps and we are still holding the Fw caps and will
+    // trigger tracker#57244.
+    for (i = 0; i < 1040; i++) {
+      ASSERT_EQ(ceph_write(cmount, fd, buf, buf_size, 0), buf_size);
+    }
+  }
+
+  ceph_shutdown(cmount);
+}
+
+static void setattr_func(bool *stop)
+{
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  char name[20];
+  snprintf(name, sizeof(name), "foo.%d", getpid());
+  int fd = ceph_open(cmount, name, O_CREAT|O_RDWR, 0644);
+  ASSERT_LE(0, fd);
+
+  while (!(*stop)) {
+    // setattr will make the MDS to acquire xlock for the filelock and
+    // force to revoke caps from clients
+    struct ceph_statx stx = {.stx_size = 0};
+    ASSERT_EQ(ceph_fsetattrx(cmount, fd, &stx, CEPH_SETATTR_SIZE), 0);
+  }
+
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, MulticlientRevokeCaps) {
+  std::thread thread1, thread2;
+  bool stop = false;
+  int wait = 60; // in second
+
+  thread1 = std::thread(write_func, &stop);
+  thread2 = std::thread(setattr_func, &stop);
+
+  printf(" Will run test for %d seconds!\n", wait);
+  sleep(wait);
+  stop = true;
+
+  thread1.join();
+  thread2.join();
 }


### PR DESCRIPTION
When revoking caps from clients and if the clients could release
some of the caps references and the clients still could send cap
update request back to MDS, while the confirm_receipt() will clear
the _revokes list anyway. But this cap will still be kept in revoking_caps
list.

Fixes: https://tracker.ceph.com/issues/57244
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
