### PR TITLE
mon: disable snap id allocation for fsmap pools

### DIFF
--- a/doc/dev/cephfs-snapshots.rst
+++ b/doc/dev/cephfs-snapshots.rst
@@ -131,3 +131,8 @@ sharing a single pool (via namespaces), their snapshots *will* collide and
 deleting one will result in missing file data for others. (This may even be
 invisible, not throwing errors to the user.) If each FS gets its own
 pool things probably work, but this isn't tested and may not be true.
+
+.. Note:: To avoid snap id collision between mon-managed snapshots and file system
+   snapshots, pools with mon-managed snapshots are not allowed to be attached
+   to a file system. Also, mon-managed snapshots can't be created in pools
+   already attached to a file system either.

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -534,3 +534,62 @@ class TestSnapshots(CephFSTestCase):
             # after reducing limit we expect the new snapshot creation to fail
             pass
         self.delete_dir_and_snaps("accounts", new_limit + 1)
+
+
+class TestMonSnapsAndFsPools(CephFSTestCase):
+    MDSS_REQUIRED = 3
+
+    def test_disallow_monitor_managed_snaps_for_fs_pools(self):
+        """
+        Test that creation of monitor managed snaps fails for pools attached
+        to any file-system
+        """
+        with self.assertRaises(CommandFailedError):
+            self.fs.rados(["mksnap", "snap1"], pool=self.fs.get_data_pool_name())
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.rados(["mksnap", "snap2"], pool=self.fs.get_metadata_pool_name())
+
+    def test_attaching_pools_with_snaps_to_fs_fails(self):
+        """
+        Test that attempt to attach pool with snapshots to an fs fails
+        """
+        test_pool_name = 'snap-test-pool'
+        base_cmd = f'osd pool create {test_pool_name}'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        self.assertEqual(ret, 0)
+
+        self.fs.rados(["mksnap", "snap3"], pool=test_pool_name)
+
+        base_cmd = f'fs add_data_pool {self.fs.name} {test_pool_name}'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        self.assertEqual(ret, errno.EOPNOTSUPP)
+
+        # cleanup
+        self.fs.rados(["rmsnap", "snap3"], pool=test_pool_name)
+        base_cmd = f'osd pool delete {test_pool_name}'
+        ret = self.run_cluster_cmd_result(base_cmd)
+
+    def test_using_pool_with_snap_fails_fs_creation(self):
+        """
+        Test that using a pool with snaps for fs creation fails
+        """
+        base_cmd = 'osd pool create test_data_pool'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        self.assertEqual(ret, 0)
+        base_cmd = 'osd pool create test_metadata_pool'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        self.assertEqual(ret, 0)
+
+        self.fs.rados(["mksnap", "snap4"], pool='test_data_pool')
+
+        base_cmd = 'fs new testfs test_metadata_pool test_data_pool'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        self.assertEqual(ret, errno.EOPNOTSUPP)
+
+        # cleanup
+        self.fs.rados(["rmsnap", "snap4"], pool='test_data_pool')
+        base_cmd = 'osd pool delete test_data_pool'
+        ret = self.run_cluster_cmd_result(base_cmd)
+        base_cmd = 'osd pool delete test_metadata_pool'
+        ret = self.run_cluster_cmd_result(base_cmd)

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1545,6 +1545,12 @@ int FileSystemCommandHandler::_check_pool(
     return -ENOENT;
   }
 
+  if (pool->has_snaps()) {
+    *ss << "pool(" << pool_id <<") already has mon-managed snaps; "
+	   "can't attach pool to fs";
+    return -EOPNOTSUPP;
+  }
+
   const string& pool_name = osd_map.get_pool_name(pool_id);
   auto app_map = pool->application_metadata;
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14052,6 +14052,16 @@ bool OSDMonitor::prepare_pool_op(MonOpRequestRef op)
 
   const pg_pool_t *pool = osdmap.get_pg_pool(m->pool);
 
+  if (m->op == POOL_OP_CREATE_SNAP ||
+      m->op == POOL_OP_CREATE_UNMANAGED_SNAP) {
+    if (const auto& fsmap = mon.mdsmon()->get_fsmap(); fsmap.pool_in_use(m->pool)) {
+      dout(20) << "monitor-managed snapshots have been disabled for pools "
+		  " attached to an fs - pool:" << m->pool << dendl;
+      _pool_op_reply(op, -EOPNOTSUPP, osdmap.get_epoch());
+      return false;
+    }
+  }
+
   switch (m->op) {
     case POOL_OP_CREATE_SNAP:
       if (pool->is_tier()) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1495,6 +1495,10 @@ public:
     grade_table.resize(0);
   }
 
+  bool has_snaps() const {
+    return snaps.size() > 0;
+  }
+
   bool is_stretch_pool() const {
     return peering_crush_bucket_count != 0;
   }


### PR DESCRIPTION
* disallow monitor managed snaps to be created for pools attached to cephfs filesystems
* disallow pools with snaps to be used in dir and file layouts
* disallow pools with snaps to be used for fs creation

Fixes: https://tracker.ceph.com/issues/16745
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
