### PR TITLE
qa: set CRIMSON_COMPAT in crimson's rados API tests

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_api_tests.yaml
@@ -22,6 +22,8 @@ overrides:
         osd blocked scrub grace period: 3600
 tasks:
 - workunit:
+    env:
+      CRIMSON_COMPAT: "true"
     clients:
       client.0:
         - rados/test.sh


### PR DESCRIPTION
We don't have it which leads to failures like the following ones:

### http://pulpito.front.sepia.ceph.com/rzarzynski-2022-08-17_15:35:28-crimson-rados-main-distro-default-smithi/6977150/
*
```
2022-08-17T15:53:00.823 INFO:tasks.workunit.client.0.smithi096.stdout:                   api_io: [  FAILED  ] LibRadosIoEC.RoundTrip (40 ms)
```
* 
```
2022-08-17T15:53:00.825 INFO:tasks.workunit.client.0.smithi096.stdout:                   api_io: [  FAILED  ] LibRadosIoEC.OverlappingWriteRoundTrip (9 ms)
```
* many more `LibRadosLockEC.*`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
