### PR TITLE
rgw: remove dout_subsys defs from header files

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -73,7 +73,6 @@ extern "C" {
 #include "services/svc_zone.h"
 
 #define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_rgw
 
 #define SECRET_KEY_LEN 40
 #define PUBLIC_ID_LEN 20
@@ -81,6 +80,8 @@ extern "C" {
 using namespace std;
 
 static rgw::sal::Store* store = NULL;
+static constexpr auto dout_subsys = ceph_subsys_rgw;
+
 
 static const DoutPrefixProvider* dpp() {
   struct GlobalPrefix : public DoutPrefixProvider {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -36,7 +36,8 @@
 #include <sstream>
 
 #define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_rgw
+
+static constexpr auto dout_subsys = ceph_subsys_rgw;
 
 using rgw::ARN;
 using rgw::IAM::Effect;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -18,8 +18,6 @@
 #include "services/svc_sys_obj.h"
 #include "services/svc_bucket.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 struct rgw_http_param_pair;
 class RGWRESTConn;
 

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -18,8 +18,6 @@
 #include "services/svc_zone_utils.h"
 #include "include/ceph_assert.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 class OpsLogSink;
 
 namespace rgw {
@@ -47,7 +45,7 @@ namespace rgw {
     rgw::LDAPHelper* get_ldh() { return ldh; }
 
     CephContext *get_cct() const override { return cct.get(); }
-    unsigned get_subsys() const { return dout_subsys; }
+    unsigned get_subsys() const { return ceph_subsys_rgw; }
     std::ostream& gen_prefix(std::ostream& out) const { return out << "lib rgw: "; }
 
     int init();

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -11,8 +11,6 @@
 #include <fstream>
 #include "rgw_sal_fwd.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 struct rgw_log_entry {
 
   using headers_map = boost::container::flat_map<std::string, std::string>;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -64,9 +64,9 @@
 #include <sys/prctl.h>
 #endif
 
-#define dout_subsys ceph_subsys_rgw
-
 using namespace std;
+
+static constexpr auto dout_subsys = ceph_subsys_rgw;
 
 namespace {
 TracepointProvider::Traits rgw_op_tracepoint_traits("librgw_op_tp.so",

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -21,8 +21,6 @@
 
 #include "rgw_sal_rados.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 #define RGW_ORPHAN_INDEX_OID "orphan.index"
 #define RGW_ORPHAN_INDEX_PREFIX "orphan.scan"
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -18,11 +18,6 @@
 
 #include <atomic>
 
-#if !defined(dout_subsys)
-#define dout_subsys ceph_subsys_rgw
-#define def_dout_subsys
-#endif
-
 #define dout_context g_ceph_context
 
 extern void signal_shutdown();
@@ -198,10 +193,6 @@ extern int rgw_process_authenticated(RGWHandler_REST* handler,
                                      rgw::sal::Store* store,
                                      bool skip_retarget = false);
 
-#if defined(def_dout_subsys)
-#undef def_dout_subsys
-#undef dout_subsys
-#endif
 #undef dout_context
 
 #endif /* RGW_PROCESS_H */

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -13,10 +13,12 @@
 #include "rgw_rados.h"
 #include "rgw_worker.h"
 
-
 #define dout_context g_ceph_context
 
+static constexpr auto dout_subsys = ceph_subsys_rgw;
+
 using namespace std;
+
 
 RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, uint64_t _handle,
                                    const RGWSyncTraceNodeRef& _parent,

--- a/src/rgw/rgw_worker.h
+++ b/src/rgw/rgw_worker.h
@@ -1,5 +1,3 @@
-
-
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
@@ -23,8 +21,6 @@
 #include "common/Thread.h"
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"
-
-#define dout_subsys ceph_subsys_rgw
 
 class RGWRados;
 
@@ -54,7 +50,7 @@ class RGWRadosThread {
     }
 
   CephContext *get_cct() const { return cct; }
-  unsigned get_subsys() const { return dout_subsys; }
+  unsigned get_subsys() const { return ceph_subsys_rgw; }
   std::ostream& gen_prefix(std::ostream& out) const { return out << "rgw rados thread: "; }
 
   };

--- a/src/rgw/store/dbstore/common/dbstore_log.h
+++ b/src/rgw/store/dbstore/common/dbstore_log.h
@@ -12,7 +12,6 @@
 #include <fstream>
 #include "common/dout.h"
 
-#define dout_subsys ceph_subsys_rgw
 #undef dout_prefix
 #define dout_prefix *_dout << "rgw dbstore: "
 

--- a/src/rgw/store/dbstore/dbstore_mgr.cc
+++ b/src/rgw/store/dbstore/dbstore_mgr.cc
@@ -6,7 +6,10 @@
 
 #include <filesystem>
 
+static constexpr auto dout_subsys = ceph_subsys_rgw;
+
 using namespace std;
+
 
 /* Given a tenant, find and return the DBStore handle.
  * If not found and 'create' set to true, create one


### PR DESCRIPTION
Each compilation unit should be able to define its own dout_subsys
without generating a redefinition warning. When dout_subsys is defined
in header files, it complicates this matter. This commit removes
definitions and header files and makes sure definitions are added to
.cc files as needed.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
