### PR TITLE
blk/KernelDevice: Modify the rotational and discard check log message

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -266,7 +266,7 @@ int KernelDevice::open(const string& p)
 	  << byte_u_t(size) << ")"
 	  << " block_size " << block_size
 	  << " (" << byte_u_t(block_size) << ")"
-	  << " " << (rotational ? "rotational" : "non-rotational")
+	  << " " << (rotational ? "rotational device," : "non-rotational device,")
       << " discard " << (support_discard ? "supported" : "not supported")
 	  << dendl;
   return 0;


### PR DESCRIPTION
blk/KernelDevice: Modify the rotational and discard check log message
Fixes: https://tracker.ceph.com/issues/57271

Signed-off-by: Vikhyat Umrao <vikhyat@redhat.com>

