### PR TITLE
rgw: Don't go through 'system object' subsystem for what should be simple RADOS operations

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -131,21 +131,39 @@ RGWAsyncGetSystemObj::RGWAsyncGetSystemObj(const DoutPrefixProvider *_dpp, RGWCo
 
 int RGWSimpleRadosReadAttrsCR::send_request(const DoutPrefixProvider *dpp)
 {
-  req = new RGWAsyncGetSystemObj(dpp, this, stack->create_completion_notifier(),
-			         svc, objv_tracker, obj, true, raw_attrs);
-  async_rados->queue(req);
-  return 0;
+  int r = store->getRados()->get_raw_obj_ref(dpp, obj, &ref);
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << "ERROR: failed to get ref for (" << obj << ") ret="
+			 << r << dendl;
+    return r;
+  }
+
+  set_status() << "sending request";
+
+  librados::ObjectReadOperation op;
+  if (objv_tracker) {
+    objv_tracker->prepare_op_for_read(&op);
+  }
+
+  if (raw_attrs && pattrs) {
+    op.getxattrs(pattrs, nullptr);
+  } else {
+    op.getxattrs(&unfiltered_attrs, nullptr);
+  }
+
+  cn = stack->create_completion_notifier();
+  return ref.pool.ioctx().aio_operate(ref.obj.oid, cn->completion(), &op,
+				      nullptr);
 }
 
 int RGWSimpleRadosReadAttrsCR::request_complete()
 {
-  if (pattrs) {
-    *pattrs = std::move(req->attrs);
+  int ret = cn->completion()->get_return_value();
+  set_status() << "request complete; ret=" << ret;
+  if (!raw_attrs && pattrs) {
+    rgw_filter_attrset(unfiltered_attrs, RGW_ATTR_PREFIX, pattrs);
   }
-  if (objv_tracker) {
-    *objv_tracker = req->objv_tracker;
-  }
-  return req->get_ret_status();
+  return ret;
 }
 
 int RGWAsyncPutSystemObj::_send_request(const DoutPrefixProvider *dpp)

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -571,51 +571,69 @@ public:
 };
 
 class RGWSimpleRadosWriteAttrsCR : public RGWSimpleCoroutine {
-  const DoutPrefixProvider *dpp;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWSI_SysObj *svc;
-  RGWObjVersionTracker *objv_tracker;
-
+  const DoutPrefixProvider* dpp;
+  rgw::sal::RadosStore* const store;
+  RGWObjVersionTracker* objv_tracker;
   rgw_raw_obj obj;
   std::map<std::string, bufferlist> attrs;
   bool exclusive;
-  RGWAsyncPutSystemObjAttrs *req = nullptr;
+
+  rgw_rados_ref ref;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+
 
 public:
-  RGWSimpleRadosWriteAttrsCR(const DoutPrefixProvider *_dpp,
-                             RGWAsyncRadosProcessor *_async_rados,
-                             RGWSI_SysObj *_svc, const rgw_raw_obj& _obj,
-                             std::map<std::string, bufferlist> _attrs,
-                             RGWObjVersionTracker *objv_tracker = nullptr,
+  RGWSimpleRadosWriteAttrsCR(const DoutPrefixProvider* dpp,
+			     rgw::sal::RadosStore* const store,
+                             rgw_raw_obj obj,
+                             std::map<std::string, bufferlist> attrs,
+                             RGWObjVersionTracker* objv_tracker = nullptr,
                              bool exclusive = false)
-			     : RGWSimpleCoroutine(_svc->ctx()), dpp(_dpp), async_rados(_async_rados),
-      svc(_svc), objv_tracker(objv_tracker), obj(_obj),
-      attrs(std::move(_attrs)), exclusive(exclusive) {
-  }
-  ~RGWSimpleRadosWriteAttrsCR() override {
-    request_cleanup();
-  }
-
-  void request_cleanup() override {
-    if (req) {
-      req->finish();
-      req = NULL;
-    }
-  }
+			     : RGWSimpleCoroutine(store->ctx()), dpp(dpp),
+			       store(store), objv_tracker(objv_tracker),
+			       obj(std::move(obj)), attrs(std::move(attrs)),
+			       exclusive(exclusive) {}
 
   int send_request(const DoutPrefixProvider *dpp) override {
-    req = new RGWAsyncPutSystemObjAttrs(dpp, this, stack->create_completion_notifier(),
-			           svc, objv_tracker, obj, std::move(attrs),
-                                   exclusive);
-    async_rados->queue(req);
-    return 0;
+    int r = store->getRados()->get_raw_obj_ref(dpp, obj, &ref);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << "ERROR: failed to get ref for (" << obj << ") ret="
+			 << r << dendl;
+      return r;
+    }
+
+    set_status() << "sending request";
+
+    librados::ObjectWriteOperation op;
+    if (exclusive) {
+      op.create(true);
+    }
+    if (objv_tracker) {
+      objv_tracker->prepare_op_for_write(&op);
+    }
+
+    for (const auto& [name, bl] : attrs) {
+      if (!bl.length())
+	continue;
+      op.setxattr(name.c_str(), bl);
+    }
+
+    cn = stack->create_completion_notifier();
+    if (!op.size()) {
+      cn->cb();
+      return 0;
+    }
+
+    return ref.pool.ioctx().aio_operate(ref.obj.oid, cn->completion(), &op);
   }
 
   int request_complete() override {
-    if (objv_tracker) { // copy the updated version
-      *objv_tracker = req->objv_tracker;
+    int ret = cn->completion()->get_return_value();
+    set_status() << "request complete; ret=" << ret;
+    if (ret >= 0 && objv_tracker) {
+      objv_tracker->apply_write();
     }
-    return req->get_ret_status();
+    return ret;
   }
 };
 

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -514,49 +514,59 @@ public:
 
 template <class T>
 class RGWSimpleRadosWriteCR : public RGWSimpleCoroutine {
-  const DoutPrefixProvider *dpp;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWSI_SysObj *svc;
-  bufferlist bl;
+  const DoutPrefixProvider* dpp;
+  rgw::sal::RadosStore* const store;
   rgw_raw_obj obj;
-  RGWObjVersionTracker *objv_tracker;
+  RGWObjVersionTracker* objv_tracker;
   bool exclusive;
-  RGWAsyncPutSystemObj *req{nullptr};
+
+  bufferlist bl;
+  rgw_rados_ref ref;
+  std::map<std::string, bufferlist> unfiltered_attrs;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+
 
 public:
-  RGWSimpleRadosWriteCR(const DoutPrefixProvider *_dpp, 
-			RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
-			const rgw_raw_obj& _obj, const T& _data,
-			RGWObjVersionTracker *objv_tracker = nullptr,
+  RGWSimpleRadosWriteCR(const DoutPrefixProvider* dpp,
+			rgw::sal::RadosStore* const store,
+			rgw_raw_obj obj, const T& data,
+			RGWObjVersionTracker* objv_tracker = nullptr,
 			bool exclusive = false)
-    : RGWSimpleCoroutine(_svc->ctx()), dpp(_dpp), async_rados(_async_rados),
-      svc(_svc), obj(_obj), objv_tracker(objv_tracker), exclusive(exclusive) {
-    encode(_data, bl);
-  }
-
-  ~RGWSimpleRadosWriteCR() override {
-    request_cleanup();
-  }
-
-  void request_cleanup() override {
-    if (req) {
-      req->finish();
-      req = NULL;
-    }
+    : RGWSimpleCoroutine(store->ctx()), dpp(dpp), store(store),
+      obj(std::move(obj)), objv_tracker(objv_tracker), exclusive(exclusive) {
+    encode(data, bl);
   }
 
   int send_request(const DoutPrefixProvider *dpp) override {
-    req = new RGWAsyncPutSystemObj(dpp, this, stack->create_completion_notifier(),
-			           svc, objv_tracker, obj, exclusive, std::move(bl));
-    async_rados->queue(req);
-    return 0;
+    int r = store->getRados()->get_raw_obj_ref(dpp, obj, &ref);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << "ERROR: failed to get ref for (" << obj << ") ret="
+			 << r << dendl;
+      return r;
+    }
+
+    set_status() << "sending request";
+
+    librados::ObjectWriteOperation op;
+    if (exclusive) {
+      op.create(true);
+    }
+    if (objv_tracker) {
+      objv_tracker->prepare_op_for_write(&op);
+    }
+    op.write_full(bl);
+
+    cn = stack->create_completion_notifier();
+    return ref.pool.ioctx().aio_operate(ref.obj.oid, cn->completion(), &op);
   }
 
   int request_complete() override {
-    if (objv_tracker) { // copy the updated version
-      *objv_tracker = req->objv_tracker;
+    int ret = cn->completion()->get_return_value();
+    set_status() << "request complete; ret=" << ret;
+    if (ret >= 0 && objv_tracker) {
+      objv_tracker->apply_write();
     }
-    return req->get_ret_status();
+    return ret;
   }
 };
 

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -17,8 +17,6 @@
 #include "services/svc_sys_obj.h"
 #include "services/svc_bucket.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 struct rgw_http_param_pair;
 class RGWRESTConn;
 
@@ -485,38 +483,28 @@ int RGWSimpleRadosReadCR<T>::request_complete()
 }
 
 class RGWSimpleRadosReadAttrsCR : public RGWSimpleCoroutine {
-  const DoutPrefixProvider *dpp;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWSI_SysObj *svc;
+  const DoutPrefixProvider* dpp;
+  rgw::sal::RadosStore* const store;
 
-  rgw_raw_obj obj;
-  std::map<std::string, bufferlist> *pattrs;
-  bool raw_attrs;
-  RGWObjVersionTracker* objv_tracker;
-  RGWAsyncGetSystemObj *req = nullptr;
+  const rgw_raw_obj obj;
+  std::map<std::string, bufferlist>* const pattrs;
+  const bool raw_attrs;
+  RGWObjVersionTracker* const objv_tracker;
+
+  rgw_rados_ref ref;
+  std::map<std::string, bufferlist> unfiltered_attrs;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWSimpleRadosReadAttrsCR(const DoutPrefixProvider *_dpp, RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
-                            const rgw_raw_obj& _obj, std::map<std::string, bufferlist> *_pattrs,
-                            bool _raw_attrs, RGWObjVersionTracker* objv_tracker = nullptr)
-    : RGWSimpleCoroutine(_svc->ctx()),
-      dpp(_dpp),
-      async_rados(_async_rados), svc(_svc),
-      obj(_obj),
-      pattrs(_pattrs),
-      raw_attrs(_raw_attrs),
-      objv_tracker(objv_tracker)
-  {}
-  ~RGWSimpleRadosReadAttrsCR() override {
-    request_cleanup();
-  }
-                                                         
-  void request_cleanup() override {
-    if (req) {
-      req->finish();
-      req = NULL;
-    }
-  }
+  RGWSimpleRadosReadAttrsCR(const DoutPrefixProvider* dpp,
+			    rgw::sal::RadosStore* store,
+                            rgw_raw_obj obj,
+			    std::map<std::string, bufferlist>* pattrs,
+                            bool raw_attrs,
+			    RGWObjVersionTracker* objv_tracker = nullptr)
+    : RGWSimpleCoroutine(store->ctx()), dpp(dpp), store(store),
+      obj(std::move(obj)), pattrs(pattrs), raw_attrs(raw_attrs),
+      objv_tracker(objv_tracker) {}
 
   int send_request(const DoutPrefixProvider *dpp) override;
   int request_complete() override;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -401,86 +401,88 @@ public:
 
 template <class T>
 class RGWSimpleRadosReadCR : public RGWSimpleCoroutine {
-  const DoutPrefixProvider *dpp;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWSI_SysObj *svc;
-
+  const DoutPrefixProvider* dpp;
+  rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
-  T *result;
+  T* result;
   /// on ENOENT, call handle_data() with an empty object instead of failing
   const bool empty_on_enoent;
-  RGWObjVersionTracker *objv_tracker;
-  RGWAsyncGetSystemObj *req{nullptr};
+  RGWObjVersionTracker* objv_tracker;
+
+  T val;
+  rgw_rados_ref ref;
+  ceph::buffer::list bl;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWSimpleRadosReadCR(const DoutPrefixProvider *_dpp, 
-                      RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
-		      const rgw_raw_obj& _obj,
-		      T *_result, bool empty_on_enoent = true,
-		      RGWObjVersionTracker *objv_tracker = nullptr)
-    : RGWSimpleCoroutine(_svc->ctx()), dpp(_dpp), async_rados(_async_rados), svc(_svc),
-      obj(_obj), result(_result),
-      empty_on_enoent(empty_on_enoent), objv_tracker(objv_tracker) {}
-  ~RGWSimpleRadosReadCR() override {
-    request_cleanup();
-  }
-
-  void request_cleanup() override {
-    if (req) {
-      req->finish();
-      req = NULL;
+  RGWSimpleRadosReadCR(const DoutPrefixProvider* dpp,
+		       rgw::sal::RadosStore* store,
+		       const rgw_raw_obj& obj,
+		       T* result, bool empty_on_enoent = true,
+		       RGWObjVersionTracker* objv_tracker = nullptr)
+    : RGWSimpleCoroutine(store->ctx()), dpp(dpp), store(store),
+      obj(obj), result(result), empty_on_enoent(empty_on_enoent),
+      objv_tracker(objv_tracker) {
+    if (!result) {
+      result = &val;
     }
   }
 
-  int send_request(const DoutPrefixProvider *dpp) override;
-  int request_complete() override;
+  int send_request(const DoutPrefixProvider *dpp) {
+    int r = store->getRados()->get_raw_obj_ref(dpp, obj, &ref);
+    if (r < 0) {
+      ldpp_dout(dpp, -1) << "ERROR: failed to get ref for (" << obj << ") ret="
+			 << r << dendl;
+      return r;
+    }
+
+    set_status() << "sending request";
+
+    librados::ObjectReadOperation op;
+    if (objv_tracker) {
+      objv_tracker->prepare_op_for_read(&op);
+    }
+
+    op.read(0, -1, &bl, nullptr);
+
+    cn = stack->create_completion_notifier();
+    return ref.pool.ioctx().aio_operate(ref.obj.oid, cn->completion(), &op,
+					nullptr);
+  }
+
+  int request_complete() {
+    int ret = cn->completion()->get_return_value();
+    set_status() << "request complete; ret=" << ret;
+
+    if (ret == -ENOENT && empty_on_enoent) {
+      *result = T();
+    } else {
+      if (ret < 0) {
+	return ret;
+      }
+      try {
+	auto iter = bl.cbegin();
+	if (iter.end()) {
+	  // allow successful reads with empty buffers. ReadSyncStatus coroutines
+	  // depend on this to be able to read without locking, because the
+	  // cls lock from InitSyncStatus will create an empty object if it didn't
+	  // exist
+	  *result = T();
+	} else {
+	  decode(*result, iter);
+	}
+      } catch (buffer::error& err) {
+	return -EIO;
+      }
+    }
+
+    return handle_data(*result);
+  }
 
   virtual int handle_data(T& data) {
     return 0;
   }
 };
-
-template <class T>
-int RGWSimpleRadosReadCR<T>::send_request(const DoutPrefixProvider *dpp)
-{
-  req = new RGWAsyncGetSystemObj(dpp, this, stack->create_completion_notifier(), svc,
-			         objv_tracker, obj, false, false);
-  async_rados->queue(req);
-  return 0;
-}
-
-template <class T>
-int RGWSimpleRadosReadCR<T>::request_complete()
-{
-  int ret = req->get_ret_status();
-  retcode = ret;
-  if (ret == -ENOENT && empty_on_enoent) {
-    *result = T();
-  } else {
-    if (ret < 0) {
-      return ret;
-    }
-    if (objv_tracker) { // copy the updated version
-      *objv_tracker = req->objv_tracker;
-    }
-    try {
-      auto iter = req->bl.cbegin();
-      if (iter.end()) {
-        // allow successful reads with empty buffers. ReadSyncStatus coroutines
-        // depend on this to be able to read without locking, because the
-        // cls lock from InitSyncStatus will create an empty object if it didn't
-        // exist
-        *result = T();
-      } else {
-        decode(*result, iter);
-      }
-    } catch (buffer::error& err) {
-      return -EIO;
-    }
-  }
-
-  return handle_data(*result);
-}
 
 class RGWSimpleRadosReadAttrsCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider* dpp;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -127,7 +127,7 @@ bool RGWReadDataSyncStatusMarkersCR::spawn_next()
     return false;
   }
   using CR = RGWSimpleRadosReadCR<rgw_data_sync_marker>;
-  spawn(new CR(env->dpp, env->async_rados, env->svc->sysobj,
+  spawn(new CR(env->dpp, env->store,
                rgw_raw_obj(env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::shard_obj_name(sc->source_zone, shard_id)),
                &markers[shard_id]),
         false);
@@ -202,7 +202,7 @@ int RGWReadDataSyncStatusCoroutine::operate(const DoutPrefixProvider *dpp)
     using ReadInfoCR = RGWSimpleRadosReadCR<rgw_data_sync_info>;
     yield {
       bool empty_on_enoent = false; // fail on ENOENT
-      call(new ReadInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+      call(new ReadInfoCR(dpp, sync_env->store,
                           rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::sync_status_oid(sc->source_zone)),
                           &sync_status->sync_info, empty_on_enoent));
     }
@@ -2114,7 +2114,7 @@ public:
   }
 
   RGWCoroutine *alloc_finisher_cr() override {
-    return new RGWSimpleRadosReadCR<rgw_data_sync_marker>(sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
+    return new RGWSimpleRadosReadCR<rgw_data_sync_marker>(sync_env->dpp, sync_env->store,
                                                           rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::shard_obj_name(sc->source_zone, shard_id)),
                                                           &sync_marker);
   }
@@ -3589,7 +3589,7 @@ int RGWReadPendingBucketShardsCoroutine::operate(const DoutPrefixProvider *dpp)
   reenter(this){
     //read sync status marker
     using CR = RGWSimpleRadosReadCR<rgw_data_sync_marker>;
-    yield call(new CR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+    yield call(new CR(dpp, sync_env->store,
                       rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, status_oid),
                       sync_marker));
     if (retcode < 0) {
@@ -4418,7 +4418,7 @@ public:
         // read bucket sync status
         objv_tracker.clear();
         using ReadCR = RGWSimpleRadosReadCR<rgw_bucket_sync_status>;
-        yield call(new ReadCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+        yield call(new ReadCR(dpp, sync_env->store,
                               bucket_status_obj, &bucket_status, false, &objv_tracker));
         if (retcode < 0) {
           ldpp_dout(dpp, 20) << "failed to read bucket shard status: "
@@ -5433,7 +5433,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
     using ReadCR = RGWSimpleRadosReadCR<rgw_bucket_sync_status>;
     using WriteCR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
 
-    yield call(new ReadCR(dpp, env->async_rados, env->svc->sysobj,
+    yield call(new ReadCR(dpp, env->store,
                           status_obj, &bucket_status, false, &objv));
     if (retcode == -ENOENT) {
       // use exclusive create to set state=Init
@@ -5444,7 +5444,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
       if (retcode == -EEXIST) {
         // raced with another create, read its status
         tn->log(20, "raced with another create, read its status");
-        yield call(new ReadCR(dpp, env->async_rados, env->svc->sysobj,
+        yield call(new ReadCR(dpp, env->store,
                               status_obj, &bucket_status, false, &objv));
       }
     }
@@ -5493,8 +5493,8 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
           }
 
           // check if local state is "stopped"
-          yield call(new ReadCR(dpp, env->async_rados, env->svc->sysobj,
-                status_obj, &bucket_status, false, &objv));
+          yield call(new ReadCR(dpp, env->store,
+				status_obj, &bucket_status, false, &objv));
           if (retcode < 0) {
             tn->log(20, SSTR("ERROR: failed to read status before writing 'stopped'. error: " << retcode));
             RELEASE_LOCK(bucket_lease_cr);
@@ -5541,8 +5541,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
         }
 
         // reread the status after acquiring the lock
-        yield call(new ReadCR(dpp, env->async_rados, env->svc->sysobj,
-                            status_obj, &bucket_status, false, &objv));
+        yield call(new ReadCR(dpp, env->store, status_obj, &bucket_status, false, &objv));
         if (retcode < 0) {
           RELEASE_LOCK(bucket_lease_cr);
           tn->log(20, SSTR("ERROR: reading the status after acquiring the lock failed. error: " << retcode));
@@ -5965,8 +5964,7 @@ public:
       // Get the source's status. In incremental sync, this gives us
       // the generation and shard count that is next needed to be run.
       yield call(new RGWSimpleRadosReadCR<rgw_bucket_sync_status>(
-		   dpp, sc.env->async_rados, sc.env->svc->sysobj,
-		   status_obj, &status));
+		   dpp, sc.env->store, status_obj, &status));
       if (retcode < 0) {
 	ldpp_dout(dpp, -1) << "ERROR: Unable to fetch status for zone="
 			   << sc.source_zone << " retcode="
@@ -6029,8 +6027,7 @@ public:
 	pretty_print(sc.env, "Completed.\n");
 
 	yield call(new RGWSimpleRadosReadCR<rgw_bucket_sync_status>(
-		     dpp, sc.env->async_rados, sc.env->svc->sysobj,
-		     status_obj, &status));
+		     dpp, sc.env->store, status_obj, &status));
 	if (retcode < 0) {
 	  ldpp_dout(dpp, -1) << "ERROR: Unable to fetch status for zone="
 			     << sc.source_zone << " retcode="

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -577,7 +577,7 @@ public:
         return set_cr_error(retcode);
       }
       using WriteInfoCR = RGWSimpleRadosWriteCR<rgw_data_sync_info>;
-      yield call(new WriteInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+      yield call(new WriteInfoCR(dpp, store,
                                  rgw_raw_obj{pool, sync_status_oid},
                                  status->sync_info));
       if (retcode < 0) {
@@ -622,7 +622,7 @@ public:
           marker.timestamp = info.last_update;
           const auto& oid = RGWDataSyncStatusManager::shard_obj_name(sc->source_zone, i);
           using WriteMarkerCR = RGWSimpleRadosWriteCR<rgw_data_sync_marker>;
-          spawn(new WriteMarkerCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+          spawn(new WriteMarkerCR(dpp, sync_env->store,
                                   rgw_raw_obj{pool, oid}, marker), true);
         }
       }
@@ -635,7 +635,7 @@ public:
       }
 
       status->sync_info.state = rgw_data_sync_info::StateBuildingFullSyncMaps;
-      yield call(new WriteInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+      yield call(new WriteInfoCR(dpp, sync_env->store,
                                  rgw_raw_obj{pool, sync_status_oid},
                                  status->sync_info));
       if (retcode < 0) {
@@ -982,7 +982,7 @@ public:
           rgw_data_sync_marker& marker = iter->second;
           marker.total_entries = entries_index->get_total_entries(shard_id);
           spawn(new RGWSimpleRadosWriteCR<rgw_data_sync_marker>(
-		  dpp, sync_env->async_rados, sync_env->svc->sysobj,
+		  dpp, sync_env->store,
 		  rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool,
 			      RGWDataSyncStatusManager::shard_obj_name(
 				sc->source_zone, shard_id)),
@@ -1040,7 +1040,7 @@ public:
 
     tn->log(20, SSTR("updating marker marker_oid=" << marker_oid << " marker=" << new_marker));
 
-    return new RGWSimpleRadosWriteCR<rgw_data_sync_marker>(sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
+    return new RGWSimpleRadosWriteCR<rgw_data_sync_marker>(sync_env->dpp, sync_env->store,
                                                            rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, marker_oid),
                                                            sync_marker);
   }
@@ -1739,7 +1739,7 @@ public:
       sync_marker.marker = sync_marker.next_step_marker;
       sync_marker.next_step_marker.clear();
       yield call(new RGWSimpleRadosWriteCR<rgw_data_sync_marker>(
-             sc->env->dpp,sc->env->async_rados, sc->env->svc->sysobj,
+             sc->env->dpp, sc->env->store,
              rgw_raw_obj(pool, status_oid), sync_marker));
       if (retcode < 0) {
         tn->log(0, SSTR("ERROR: failed to set sync marker: retcode=" << retcode));
@@ -2247,7 +2247,7 @@ public:
   }
 
   RGWCoroutine *set_sync_info_cr() {
-    return new RGWSimpleRadosWriteCR<rgw_data_sync_info>(sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
+    return new RGWSimpleRadosWriteCR<rgw_data_sync_info>(sync_env->dpp, sync_env->store,
                                                          rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::sync_status_oid(sc->source_zone)),
                                                          sync_status.sync_info);
   }
@@ -3470,7 +3470,7 @@ public:
 
       // write bucket sync status
       using CR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
-      yield call(new CR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+      yield call(new CR(dpp, sync_env->store,
 			status_obj, status, &objv, false));
       if (retcode < 0) {
         ldout(cct, 20) << "failed to write bucket shard status: "
@@ -3876,7 +3876,7 @@ public:
 
     tn->log(20, SSTR("updating marker oid=" << status_obj.oid << " marker=" << new_marker));
     return new RGWSimpleRadosWriteCR<rgw_bucket_sync_status>(
-        sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
+        sync_env->dpp, sync_env->store,
 	status_obj, sync_status, &objv_tracker);
   }
 
@@ -4371,8 +4371,7 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
       sync_status.state = BucketSyncState::Incremental;
       tn->log(5, SSTR("set bucket state=" << sync_status.state));
       yield call(new RGWSimpleRadosWriteCR<rgw_bucket_sync_status>(
-	      dpp, sync_env->async_rados, sync_env->svc->sysobj,
-              status_obj, sync_status, &objv));
+	      dpp, sync_env->store, status_obj, sync_status, &objv));
       tn->log(5, SSTR("bucket status objv=" << objv));
     } else {
       tn->log(10, SSTR("backing out with sync_status=" << sync_result));
@@ -4455,7 +4454,7 @@ public:
           }
           ldpp_dout(dpp, 20) << "bucket status incremental gen is " << bucket_status.incremental_gen << dendl;
           using WriteCR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
-          call(new WriteCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+          call(new WriteCR(dpp, sync_env->store,
                             bucket_status_obj, bucket_status, &objv_tracker, false));
         }
         if (retcode < 0 && retcode != -ECANCELED) {
@@ -5438,8 +5437,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
     if (retcode == -ENOENT) {
       // use exclusive create to set state=Init
       objv.generate_new_write_ver(cct);
-      yield call(new WriteCR(dpp, env->async_rados, env->svc->sysobj,
-                             status_obj, bucket_status, &objv, true));
+      yield call(new WriteCR(dpp, env->store, status_obj, bucket_status, &objv, true));
       tn->log(20, "bucket status object does not exist, create a new one");
       if (retcode == -EEXIST) {
         // raced with another create, read its status
@@ -5503,8 +5501,8 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
           if (bucket_status.state != BucketSyncState::Stopped) {
             // make sure that state is changed to stopped localy
             bucket_status.state = BucketSyncState::Stopped;
-            yield call(new WriteCR(dpp, env->async_rados, env->svc->sysobj,
-                  status_obj, bucket_status, &objv, false));
+            yield call(new WriteCR(dpp, env->store, status_obj, bucket_status,
+				   &objv, false));
             if (retcode < 0) {
               tn->log(20, SSTR("ERROR: failed to write 'stopped' status. error: " << retcode));
               RELEASE_LOCK(bucket_lease_cr);
@@ -5745,7 +5743,7 @@ int RGWBucketPipeSyncStatusManager::init_sync_status(
     pretty_print(source.sc.env, "Initializing sync state of bucket {} with zone {}.\n",
 		 source.info.bucket.name, source.zone_name);
     stack->call(new RGWSimpleRadosWriteCR<rgw_bucket_sync_status>(
-		  dpp, source.sc.env->async_rados, source.sc.env->svc->sysobj,
+		  dpp, source.sc.env->store,
 		  {sync_env.svc->zone->get_zone_params().log_pool,
                    full_status_oid(source.sc.source_zone,
 				   source.info.bucket,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3054,7 +3054,7 @@ public:
 
         map<string, bufferlist> attrs;
         status.encode_all_attrs(attrs);
-        call(new RGWSimpleRadosWriteAttrsCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+        call(new RGWSimpleRadosWriteAttrsCR(dpp, sync_env->store,
                                             obj, attrs, &objv_tracker, exclusive));
       }
 
@@ -3907,7 +3907,7 @@ class RGWWriteBucketShardIncSyncStatus : public RGWCoroutine {
     reenter(this) {
       sync_marker.encode_attr(attrs);
 
-      yield call(new RGWSimpleRadosWriteAttrsCR(sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
+      yield call(new RGWSimpleRadosWriteAttrsCR(sync_env->dpp, sync_env->store,
                                                 obj, attrs, &objv_tracker));
       if (retcode < 0) {
         return set_cr_error(retcode);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3148,7 +3148,7 @@ public:
 int RGWReadBucketPipeSyncStatusCoroutine::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
-    yield call(new RGWSimpleRadosReadAttrsCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+    yield call(new RGWSimpleRadosReadAttrsCR(dpp, sync_env->store,
                                              rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, oid),
                                              &attrs, true, objv_tracker));
     if (retcode == -ENOENT) {

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -11,8 +11,6 @@
 #include <fstream>
 #include "rgw_sal_fwd.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 struct rgw_log_entry {
 
   using headers_map = boost::container::flat_map<std::string, std::string>;

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -21,8 +21,6 @@
 
 #include "rgw_sal_rados.h"
 
-#define dout_subsys ceph_subsys_rgw
-
 #define RGW_ORPHAN_INDEX_OID "orphan.index"
 #define RGW_ORPHAN_INDEX_PREFIX "orphan.scan"
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -784,7 +784,7 @@ bool RGWReadSyncStatusMarkersCR::spawn_next()
   using CR = RGWSimpleRadosReadCR<rgw_meta_sync_marker>;
   rgw_raw_obj obj{env->store->svc()->zone->get_zone_params().log_pool,
                   env->shard_obj_name(shard_id)};
-  spawn(new CR(env->dpp, env->async_rados, env->store->svc()->sysobj, obj, &markers[shard_id]), false);
+  spawn(new CR(env->dpp, env->store, obj, &markers[shard_id]), false);
   shard_id++;
   return true;
 }
@@ -810,7 +810,7 @@ int RGWReadSyncStatusCoroutine::operate(const DoutPrefixProvider *dpp)
       bool empty_on_enoent = false; // fail on ENOENT
       rgw_raw_obj obj{sync_env->store->svc()->zone->get_zone_params().log_pool,
                       sync_env->status_oid()};
-      call(new ReadInfoCR(dpp, sync_env->async_rados, sync_env->store->svc()->sysobj, obj,
+      call(new ReadInfoCR(dpp, sync_env->store, obj,
                           &sync_status->sync_info, empty_on_enoent));
     }
     if (retcode < 0) {
@@ -1939,7 +1939,7 @@ public:
 
   RGWCoroutine *alloc_finisher_cr() override {
     rgw::sal::RadosStore* store = sync_env->store;
-    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->dpp, sync_env->async_rados, store->svc()->sysobj,
+    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->dpp, store,
                                                           rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                           &sync_marker);
   }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -689,7 +689,7 @@ public:
       yield {
         set_status("writing sync status");
 	rgw::sal::RadosStore* store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, sync_env->async_rados, store->svc()->sysobj,
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, store,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
       }
@@ -720,8 +720,7 @@ public:
 	  marker.timestamp = info.last_update;
 	  rgw::sal::RadosStore* store = sync_env->store;
           spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(dpp,
-                                                                sync_env->async_rados,
-                                                                store->svc()->sysobj,
+                                                                store,
                                                                 rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
                                                                 marker), true);
         }
@@ -730,7 +729,7 @@ public:
         set_status("changing sync state: build full sync maps");
 	status.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
 	rgw::sal::RadosStore* store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, sync_env->async_rados, store->svc()->sysobj,
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, store,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
       }
@@ -1007,7 +1006,7 @@ public:
           int shard_id = (int)iter->first;
           rgw_meta_sync_marker& marker = iter->second;
           marker.total_entries = entries_index->get_total_entries(shard_id);
-          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(dpp, sync_env->async_rados, sync_env->store->svc()->sysobj,
+          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(dpp, sync_env->store,
                                                                 rgw_raw_obj(sync_env->store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(shard_id)),
                                                                 marker), true);
         }
@@ -1268,8 +1267,7 @@ public:
     ldpp_dout(sync_env->dpp, 20) << __func__ << "(): updating marker marker_oid=" << marker_oid << " marker=" << new_marker << " realm_epoch=" << sync_marker.realm_epoch << dendl;
     tn->log(20, SSTR("new marker=" << new_marker));
     rgw::sal::RadosStore* store = sync_env->store;
-    return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->dpp, sync_env->async_rados,
-                                                           store->svc()->sysobj,
+    return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->dpp, store,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, marker_oid),
                                                            sync_marker);
   }
@@ -1685,7 +1683,7 @@ public:
 	  ldpp_dout(sync_env->dpp, 4) << *this << ": saving marker pos=" << temp_marker->marker << " realm_epoch=" << realm_epoch << dendl;
 
 	  using WriteMarkerCR = RGWSimpleRadosWriteCR<rgw_meta_sync_marker>;
-	  yield call(new WriteMarkerCR(sync_env->dpp, sync_env->async_rados, sync_env->store->svc()->sysobj,
+	  yield call(new WriteMarkerCR(sync_env->dpp, sync_env->store,
 				       rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
 				       *temp_marker));
         }
@@ -2052,8 +2050,7 @@ public:
         // write the updated sync info
         sync_status.sync_info.period = cursor.get_period().get_id();
         sync_status.sync_info.realm_epoch = cursor.get_epoch();
-        yield call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, sync_env->async_rados,
-                                                                 sync_env->store->svc()->sysobj,
+        yield call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, sync_env->store,
                                                                  rgw_raw_obj(pool, sync_env->status_oid()),
                                                                  sync_status.sync_info));
       }
@@ -2130,9 +2127,9 @@ int RGWRemoteMetaLog::init_sync_status(const DoutPrefixProvider *dpp)
 int RGWRemoteMetaLog::store_sync_info(const DoutPrefixProvider *dpp, const rgw_meta_sync_info& sync_info)
 {
   tn->log(20, "store sync info");
-  return run(dpp, new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, async_rados, store->svc()->sysobj,
-                                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env.status_oid()),
-                                                           sync_info));
+  return run(dpp, new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(dpp, store,
+								rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env.status_oid()),
+								sync_info));
 }
 
 // return a cursor to the period at our sync position

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -1452,8 +1452,8 @@ public:
 
   int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
-      yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(dpp, sync_env->async_rados, sync_env->svc->sysobj,
-                                                                 status_obj, &status, false));
+      yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(
+		   dpp, sync_env->store, status_obj, &status, false));
 
       if (retcode < 0 && retcode != -ENOENT) {
         ldpp_dout(dpp, 0) << "ERROR: failed to read sync status of object " << src_obj << " retcode=" << retcode << dendl;

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -1515,7 +1515,7 @@ public:
           return set_cr_error(ret_err);
         }
 
-        yield call(new RGWSimpleRadosWriteCR<rgw_sync_aws_multipart_upload_info>(dpp, sync_env->async_rados, sync_env->svc->sysobj, status_obj, status));
+        yield call(new RGWSimpleRadosWriteCR<rgw_sync_aws_multipart_upload_info>(dpp, sync_env->store, status_obj, status));
         if (retcode < 0) {
           ldpp_dout(dpp, 0) << "ERROR: failed to store multipart upload state, retcode=" << retcode << dendl;
           /* continue with upload anyway */

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -779,7 +779,8 @@ class PSManager
             rgw_raw_obj obj;
             ps.get_sub_meta_obj(sub_name, &obj);
             bool empty_on_enoent = false;
-            call(new ReadInfoCR(dpp, sync_env->async_rados, sync_env->store->svc()->sysobj,
+            call(new ReadInfoCR(dpp,
+				sync_env->store,
                                 obj,
                                 &user_sub_conf, empty_on_enoent));
           }
@@ -970,7 +971,7 @@ public:
       using ReadInfoCR = RGWSimpleRadosReadCR<rgw_pubsub_bucket_topics>;
       yield {
         bool empty_on_enoent = true;
-        call(new ReadInfoCR(dpp, sync_env->async_rados, sync_env->store->svc()->sysobj,
+        call(new ReadInfoCR(dpp, sync_env->store,
                             bucket_obj,
                             &bucket_topics, empty_on_enoent));
       }
@@ -984,8 +985,7 @@ public:
 	using ReadUserTopicsInfoCR = RGWSimpleRadosReadCR<rgw_pubsub_topics>;
 	yield {
 	  bool empty_on_enoent = true;
-	  call(new ReadUserTopicsInfoCR(dpp, sync_env->async_rados, sync_env->store->svc()->sysobj,
-					user_obj,
+	  call(new ReadUserTopicsInfoCR(dpp, sync_env->store, user_obj,
 					&user_topics, empty_on_enoent));
 	}
 	if (retcode < 0 && retcode != -ENOENT) {

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -1096,8 +1096,7 @@ int BucketTrimCR::operate(const DoutPrefixProvider *dpp)
       // read BucketTrimStatus for marker position
       set_status("reading trim status");
       using ReadStatus = RGWSimpleRadosReadCR<BucketTrimStatus>;
-      yield call(new ReadStatus(dpp, store->svc()->rados->get_async_processor(), store->svc()->sysobj, obj,
-                                &status, true, &objv));
+      yield call(new ReadStatus(dpp, store, obj, &status, true, &objv));
       if (retcode < 0) {
         ldpp_dout(dpp, 10) << "failed to read bilog trim status: "
             << cpp_strerror(retcode) << dendl;

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -1154,8 +1154,7 @@ int BucketTrimCR::operate(const DoutPrefixProvider *dpp)
       status.marker = std::move(last_cold_marker);
       ldpp_dout(dpp, 20) << "writing bucket trim marker=" << status.marker << dendl;
       using WriteStatus = RGWSimpleRadosWriteCR<BucketTrimStatus>;
-      yield call(new WriteStatus(dpp, store->svc()->rados->get_async_processor(), store->svc()->sysobj, obj,
-                                 status, &objv));
+      yield call(new WriteStatus(dpp, store, obj, status, &objv));
       if (retcode < 0) {
         ldpp_dout(dpp, 4) << "failed to write updated trim status: "
             << cpp_strerror(retcode) << dendl;

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -110,6 +110,83 @@ namespace mdlog {
 
 using Cursor = RGWPeriodHistory::Cursor;
 
+namespace {
+template <class T>
+class SysObjReadCR : public RGWSimpleCoroutine {
+  const DoutPrefixProvider *dpp;
+  RGWAsyncRadosProcessor *async_rados;
+  RGWSI_SysObj *svc;
+
+  rgw_raw_obj obj;
+  T *result;
+  /// on ENOENT, call handle_data() with an empty object instead of failing
+  const bool empty_on_enoent;
+  RGWObjVersionTracker *objv_tracker;
+  RGWAsyncGetSystemObj *req{nullptr};
+
+public:
+  SysObjReadCR(const DoutPrefixProvider *_dpp, 
+	       RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
+	       const rgw_raw_obj& _obj,
+	       T *_result, bool empty_on_enoent = true,
+	       RGWObjVersionTracker *objv_tracker = nullptr)
+    : RGWSimpleCoroutine(_svc->ctx()), dpp(_dpp), async_rados(_async_rados), svc(_svc),
+      obj(_obj), result(_result),
+      empty_on_enoent(empty_on_enoent), objv_tracker(objv_tracker) {}
+  ~SysObjReadCR() override {
+    request_cleanup();
+  }
+
+  void request_cleanup() override {
+    if (req) {
+      req->finish();
+      req = NULL;
+    }
+  }
+
+  int send_request(const DoutPrefixProvider *dpp) {
+    req = new RGWAsyncGetSystemObj(dpp, this, stack->create_completion_notifier(), svc,
+				   objv_tracker, obj, false, false);
+    async_rados->queue(req);
+    return 0;
+  }
+
+  int request_complete() {
+    int ret = req->get_ret_status();
+    retcode = ret;
+    if (ret == -ENOENT && empty_on_enoent) {
+      *result = T();
+    } else {
+      if (ret < 0) {
+	return ret;
+      }
+      if (objv_tracker) { // copy the updated version
+	*objv_tracker = req->objv_tracker;
+      }
+      try {
+	auto iter = req->bl.cbegin();
+	if (iter.end()) {
+	  // allow successful reads with empty buffers. ReadSyncStatus
+	  // coroutines depend on this to be able to read without
+	  // locking, because the cls lock from InitSyncStatus will
+	  // create an empty object if it didn't exist
+	  *result = T();
+	} else {
+	  decode(*result, iter);
+	}
+      } catch (buffer::error& err) {
+	return -EIO;
+      }
+    }
+    return handle_data(*result);
+  }
+
+  virtual int handle_data(T& data) {
+    return 0;
+  }
+};
+}
+
 /// read the mdlog history and use it to initialize the given cursor
 class ReadHistoryCR : public RGWCoroutine {
   const DoutPrefixProvider *dpp;
@@ -137,7 +214,7 @@ class ReadHistoryCR : public RGWCoroutine {
                         RGWMetadataLogHistory::oid};
         constexpr bool empty_on_enoent = false;
 
-        using ReadCR = RGWSimpleRadosReadCR<RGWMetadataLogHistory>;
+        using ReadCR = SysObjReadCR<RGWMetadataLogHistory>;
         call(new ReadCR(dpp, async_processor, svc.sysobj, obj,
                         &state, empty_on_enoent, objv_tracker));
       }

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -241,3 +241,12 @@ add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)
 target_link_libraries(unittest_rgw_lua ${rgw_libs})
 
+add_executable(radosgw-cr-test rgw_cr_test.cc)
+target_link_libraries(radosgw-cr-test ${rgw_libs} librados
+  cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
+  cls_log_client cls_timeindex_client neorados_cls_fifo
+  cls_version_client cls_user_client
+  global ${LIB_RESOLV}
+  OATH::OATH
+  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
+  GTest::GTest)

--- a/src/test/rgw/rgw_cr_test.cc
+++ b/src/test/rgw/rgw_cr_test.cc
@@ -1,0 +1,182 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include <cerrno>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
+#include "include/rados/librados.hpp"
+
+#include "common/common_init.h"
+#include "common/config.h"
+#include "common/ceph_argparse.h"
+#include "common/debug.h"
+
+#include "rgw_coroutine.h"
+#include "rgw_cr_rados.h"
+#include "rgw_sal.h"
+#include "rgw_sal_rados.h"
+
+#include "gtest/gtest.h"
+
+using namespace std::literals;
+
+static constexpr auto dout_subsys = ceph_subsys_rgw;
+
+static rgw::sal::RadosStore* store = nullptr;
+
+static const DoutPrefixProvider* dpp() {
+  struct GlobalPrefix : public DoutPrefixProvider {
+    CephContext *get_cct() const override { return g_ceph_context; }
+    unsigned get_subsys() const override { return dout_subsys; }
+    std::ostream& gen_prefix(std::ostream& out) const override { return out; }
+  };
+  static GlobalPrefix global_dpp;
+  return &global_dpp;
+}
+
+class StoreDestructor {
+  rgw::sal::Store* store;
+public:
+  explicit StoreDestructor(rgw::sal::RadosStore* _s) : store(_s) {}
+  ~StoreDestructor() {
+    StoreManager::close_storage(store);
+  }
+};
+
+struct TempPool {
+  inline static uint64_t num = 0;
+  std::string name =
+    fmt::format("{}-{}-{}", ::time(nullptr), ::getpid(),num++);
+
+  TempPool() {
+    auto r = store->getRados()->get_rados_handle()->pool_create(name.c_str());
+    assert(r == 0);
+  }
+
+  ~TempPool() {
+    auto r = store->getRados()->get_rados_handle()->pool_delete(name.c_str());
+    assert(r == 0);
+  }
+
+  operator rgw_pool() {
+    return { name };
+  }
+
+  operator librados::IoCtx() {
+    librados::IoCtx ioctx;
+    auto r = store->getRados()->get_rados_handle()->ioctx_create(name.c_str(),
+								 ioctx);
+    assert(r == 0);
+    return ioctx;
+  }
+};
+
+int run(RGWCoroutine* cr) {
+  RGWCoroutinesManager cr_mgr{store->ctx(),
+                              store->getRados()->get_cr_registry()};
+  std::list<RGWCoroutinesStack *> stacks;
+  auto stack = new RGWCoroutinesStack(store->ctx(), &cr_mgr);
+  stack->call(cr);
+  stacks.push_back(stack);
+  return cr_mgr.run(dpp(), stacks);
+}
+
+TEST(ReadAttrs, Unfiltered) {
+  TempPool pool;
+  ceph::bufferlist bl;
+  auto dummy = "Dummy attribute value"s;
+  encode(dummy, bl);
+  const std::map<std::string, ceph::bufferlist> ref_attrs{
+    { "foo"s, bl }, { "bar"s, bl }, { "baz"s, bl }
+  };
+  auto oid = "object"s;
+  {
+    librados::IoCtx ioctx(pool);
+    librados::ObjectWriteOperation op;
+    op.setxattr("foo", bl);
+    op.setxattr("bar", bl);
+    op.setxattr("baz", bl);
+    auto r = ioctx.operate(oid, &op);
+    ASSERT_EQ(0, r);
+  }
+  std::map<std::string, ceph::bufferlist> attrs;
+  auto r = run(new RGWSimpleRadosReadAttrsCR(dpp(), store, {pool, oid}, &attrs,
+					     true));
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(ref_attrs, attrs);
+}
+
+TEST(ReadAttrs, Filtered) {
+  TempPool pool;
+  ceph::bufferlist bl;
+  auto dummy = "Dummy attribute value"s;
+  encode(dummy, bl);
+  const std::map<std::string, ceph::bufferlist> ref_attrs{
+    { RGW_ATTR_PREFIX "foo"s, bl },
+    { RGW_ATTR_PREFIX "bar"s, bl },
+    { RGW_ATTR_PREFIX "baz"s, bl }
+  };
+  auto oid = "object"s;
+  {
+    librados::IoCtx ioctx(pool);
+    librados::ObjectWriteOperation op;
+    op.setxattr(RGW_ATTR_PREFIX "foo", bl);
+    op.setxattr(RGW_ATTR_PREFIX "bar", bl);
+    op.setxattr(RGW_ATTR_PREFIX "baz", bl);
+    op.setxattr("oneOfTheseThingsIsNotLikeTheOthers", bl);
+    auto r = ioctx.operate(oid, &op);
+    ASSERT_EQ(0, r);
+  }
+  std::map<std::string, ceph::bufferlist> attrs;
+  auto r = run(new RGWSimpleRadosReadAttrsCR(dpp(), store, {pool, oid}, &attrs,
+					     false));
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(ref_attrs, attrs);
+}
+
+int main(int argc, const char **argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = rgw_global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			     CODE_ENVIRONMENT_UTILITY, 0);
+
+  // for region -> zonegroup conversion (must happen before common_init_finish())
+  if (!g_conf()->rgw_region.empty() && g_conf()->rgw_zonegroup.empty()) {
+    g_conf().set_val_or_die("rgw_zonegroup", g_conf()->rgw_region.c_str());
+  }
+
+  /* common_init_finish needs to be called after g_conf().set_val() */
+  common_init_finish(g_ceph_context);
+
+
+  StoreManager::Config cfg = StoreManager::get_config(true, g_ceph_context);
+
+  store = static_cast<rgw::sal::RadosStore*>(
+    StoreManager::get_storage(dpp(),
+			      g_ceph_context,
+			      cfg,
+			      false,
+			      false,
+			      false,
+			      false,
+			      false,
+			      true,
+			      false));
+  if (!store) {
+    std::cerr << "couldn't init storage provider" << std::endl;
+    return 5; //EIO
+  }
+  StoreDestructor store_destructor(static_cast<rgw::sal::RadosStore*>(store));
+
+  std::string pool{"rgw_cr_test"};
+  store->getRados()->create_pool(dpp(), pool);
+
+  testing::InitGoogleTest();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Motivated by cache coherence problems where some operations are run directly against RADOS and others go through the system object cache.

I had started a more thorough refactor, but since we're not going to need any of this once we get better coroutines, it's not really worth it.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
