### PR TITLE
[Bluestore] Fix legacy bluestore_bluefs_env_mirror option

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -597,3 +597,138 @@ rocksdb::Status BlueRocksEnv::GetTestDirectory(std::string* path)
   *path = "temp_" + stringify(++foo);
   return rocksdb::Status::OK();
 }
+
+
+
+rocksdb::Status NoRocksEnv::NewSequentialFile(
+  const std::string& fname,
+  std::unique_ptr<rocksdb::SequentialFile>* result,
+  const rocksdb::EnvOptions& options)
+{
+  return EnvWrapper::NewSequentialFile(base + fname, result, options);
+}
+rocksdb::Status NoRocksEnv::NewRandomAccessFile(
+  const std::string& fname,
+  std::unique_ptr<rocksdb::RandomAccessFile>* result,
+  const rocksdb::EnvOptions& options)
+{
+  return EnvWrapper::NewRandomAccessFile(base + fname, result, options);
+}
+
+rocksdb::Status NoRocksEnv::NewWritableFile(
+  const std::string& fname,
+  std::unique_ptr<rocksdb::WritableFile>* result,
+  const rocksdb::EnvOptions& options)
+{
+  return EnvWrapper::NewWritableFile(base + fname, result, options);
+}
+
+rocksdb::Status NoRocksEnv::ReuseWritableFile(
+  const std::string& fname,
+  const std::string& old_fname,
+  std::unique_ptr<rocksdb::WritableFile>* result,
+  const rocksdb::EnvOptions& options)
+{
+  return EnvWrapper::ReuseWritableFile(base + fname, base + old_fname, result, options);
+}
+
+rocksdb::Status NoRocksEnv::NewDirectory(
+  const std::string& name,
+  std::unique_ptr<rocksdb::Directory>* result)
+{
+  return EnvWrapper::NewDirectory(base + name, result);
+}
+
+rocksdb::Status NoRocksEnv::FileExists(const std::string& fname)
+{
+  return EnvWrapper::FileExists(base + fname);
+}
+
+rocksdb::Status NoRocksEnv::GetChildren(const std::string& dir,
+					std::vector<std::string>* result)
+{
+  return EnvWrapper::GetChildren(base + dir, result);
+}
+
+rocksdb::Status NoRocksEnv::DeleteFile(const std::string& fname)
+{
+  return EnvWrapper::DeleteFile(base + fname);
+}
+
+rocksdb::Status NoRocksEnv::CreateDir(const std::string& dirname)
+{
+  return EnvWrapper::CreateDir(base + dirname);
+}
+
+rocksdb::Status NoRocksEnv::CreateDirIfMissing(const std::string& dirname)
+{
+  return EnvWrapper::CreateDirIfMissing(base + dirname);
+}
+
+rocksdb::Status NoRocksEnv::DeleteDir(const std::string& dirname)
+{
+  return EnvWrapper::DeleteDir(base + dirname);
+}
+
+rocksdb::Status NoRocksEnv::GetFileSize(const std::string& fname, uint64_t* file_size)
+{
+  return EnvWrapper::GetFileSize(base + fname, file_size);
+}
+
+rocksdb::Status NoRocksEnv::GetFileModificationTime(const std::string& fname,
+					uint64_t* file_mtime)
+{
+  return EnvWrapper::GetFileModificationTime(base + fname, file_mtime);
+}
+
+rocksdb::Status NoRocksEnv::RenameFile(const std::string& src,
+			   const std::string& target)
+{
+  return EnvWrapper::RenameFile(base + src, base + target);
+}
+
+rocksdb::Status NoRocksEnv::LinkFile(const std::string& src, const std::string& target)
+{
+  return EnvWrapper::LinkFile(base + src, base + target);
+}
+
+rocksdb::Status NoRocksEnv::AreFilesSame(const std::string& first,
+			     const std::string& second, bool* res)
+{
+  return EnvWrapper::AreFilesSame(base + first, base + second, res);
+}
+
+rocksdb::Status NoRocksEnv::LockFile(const std::string& fname, rocksdb::FileLock** lock)
+{
+  return EnvWrapper::LockFile(base + fname, lock);
+}
+
+rocksdb::Status NoRocksEnv::GetTestDirectory(std::string* path)
+{
+  rocksdb::Status s = EnvWrapper::GetTestDirectory(path);
+  if (path->find(base) == 0) {
+    *path = path->substr(base.length());
+  }
+  return s;
+}
+
+rocksdb::Status NoRocksEnv::NewLogger(
+  const std::string& fname,
+  std::shared_ptr<rocksdb::Logger>* result)
+{
+  return EnvWrapper::NewLogger(base + fname, result);
+}
+
+rocksdb::Status NoRocksEnv::GetAbsolutePath(const std::string& db_path,
+				std::string* output_path)
+{
+  return EnvWrapper::GetAbsolutePath(db_path, output_path);
+}
+
+NoRocksEnv::NoRocksEnv(const std::string& base)
+  : EnvWrapper(Env::Default())
+  , base(base)
+{
+  if (base.length() == 0 || *base.rbegin() != '/')
+    this->base = base + "/";
+}

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -363,7 +363,9 @@ rocksdb::Status BlueRocksEnv::NewSequentialFile(
   BlueFS::FileReader *h;
   int r = fs->open_for_read(dir, file, &h, false);
   if (r < 0)
-    return err_to_status(r);
+    // Degrade error handling to synchronize error with rocksdb posix env.
+    // Without it, we cannot use rocksdb::EnvMirror.
+    return err_to_status(-EIO);
   result->reset(new BlueRocksSequentialFile(fs, h));
   return rocksdb::Status::OK();
 }

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -153,4 +153,73 @@ private:
   BlueFS *fs;
 };
 
+class NoRocksEnv : public rocksdb::EnvWrapper {
+public:
+  rocksdb::Status NewSequentialFile(
+    const std::string& fname,
+    std::unique_ptr<rocksdb::SequentialFile>* result,
+    const rocksdb::EnvOptions& options) override;
+
+  rocksdb::Status NewRandomAccessFile(
+    const std::string& fname,
+    std::unique_ptr<rocksdb::RandomAccessFile>* result,
+    const rocksdb::EnvOptions& options) override;
+
+  rocksdb::Status NewWritableFile(
+    const std::string& fname,
+    std::unique_ptr<rocksdb::WritableFile>* result,
+    const rocksdb::EnvOptions& options) override;
+
+  rocksdb::Status ReuseWritableFile(
+    const std::string& fname,
+    const std::string& old_fname,
+    std::unique_ptr<rocksdb::WritableFile>* result,
+    const rocksdb::EnvOptions& options) override;
+
+  rocksdb::Status NewDirectory(
+    const std::string& name,
+    std::unique_ptr<rocksdb::Directory>* result) override;
+
+  rocksdb::Status FileExists(const std::string& fname) override;
+
+  rocksdb::Status GetChildren(const std::string& dir,
+                             std::vector<std::string>* result) override;
+
+  rocksdb::Status DeleteFile(const std::string& fname) override;
+
+  rocksdb::Status CreateDir(const std::string& dirname) override;
+
+  rocksdb::Status CreateDirIfMissing(const std::string& dirname) override;
+
+  rocksdb::Status DeleteDir(const std::string& dirname) override;
+
+  rocksdb::Status GetFileSize(const std::string& fname, uint64_t* file_size) override;
+
+  rocksdb::Status GetFileModificationTime(const std::string& fname,
+                                         uint64_t* file_mtime) override;
+
+  rocksdb::Status RenameFile(const std::string& src,
+                            const std::string& target) override;
+
+  rocksdb::Status LinkFile(const std::string& src, const std::string& target) override;
+
+  rocksdb::Status AreFilesSame(const std::string& first,
+			       const std::string& second, bool* res) override;
+
+  rocksdb::Status LockFile(const std::string& fname, rocksdb::FileLock** lock) override;
+
+  rocksdb::Status GetTestDirectory(std::string* path) override;
+
+  rocksdb::Status NewLogger(
+    const std::string& fname,
+    std::shared_ptr<rocksdb::Logger>* result) override;
+
+  rocksdb::Status GetAbsolutePath(const std::string& db_path,
+      std::string* output_path) override;
+
+  explicit NoRocksEnv(const std::string& base);
+private:
+  std::string base;
+};
+
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6484,8 +6484,8 @@ int BlueStore::_prepare_db_environment(bool create, bool read_only,
   ceph_assert(!db);
   std::string& fn=*_fn;
   std::string& kv_backend=*_kv_backend;
-  fn = path + "/db";
-  std::shared_ptr<Int64ArrayMergeOperator> merge_op(new Int64ArrayMergeOperator);
+  // simplify the dir names, too, as "seen" by rocksdb
+  fn = "db";
 
   if (create) {
     kv_backend = cct->_conf->bluestore_kvbackend;
@@ -6505,9 +6505,7 @@ int BlueStore::_prepare_db_environment(bool create, bool read_only,
   }
   dout(10) << __func__ << " do_bluefs = " << do_bluefs << dendl;
 
-  map<string,string> kv_options;
   // force separate wal dir for all new deployments.
-  kv_options["separate_wal_dir"] = 1;
   rocksdb::Env *env = NULL;
   if (do_bluefs) {
     dout(10) << __func__ << " initializing bluefs" << dendl;
@@ -6523,24 +6521,31 @@ int BlueStore::_prepare_db_environment(bool create, bool read_only,
 
     if (cct->_conf->bluestore_bluefs_env_mirror) {
       rocksdb::Env* a = new BlueRocksEnv(bluefs);
-      rocksdb::Env* b = rocksdb::Env::Default();
+      rocksdb::Env* b = new NoRocksEnv(path + "/mirror");
       if (create) {
-        string cmd = "rm -rf " + path + "/db " +
-          path + "/db.slow " +
-          path + "/db.wal";
+        string cmd = "rm -rf " + path + "/mirror";
         int r = system(cmd.c_str());
         (void)r;
+	cmd = "mkdir -p " + path + "/mirror";
+        r = system(cmd.c_str());
+        (void)r;
       }
-      env = new rocksdb::EnvMirror(b, a, false, true);
+      env = new rocksdb::EnvMirror(b, a, true, true);
     } else {
       env = new BlueRocksEnv(bluefs);
-
-      // simplify the dir names, too, as "seen" by rocksdb
-      fn = "db";
     }
-    BlueFSVolumeSelector::paths paths;
-    bluefs->get_vselector_paths(fn, paths);
+  } else {
+    // In this case env is ersatz to unify file operations
+    // We need env that is contained to specific dir,
+    // i.e. "db/00038.sst" must be equally accessible for
+    // both BlueRocksEnv and our ersatz env
+    env = new NoRocksEnv(path);
+  }
 
+  map<string,string> kv_options;
+  BlueFSVolumeSelector::paths paths;
+  if (do_bluefs) {
+    bluefs->get_vselector_paths(fn, paths);
     {
       ostringstream db_paths;
       bool first = true;
@@ -6555,53 +6560,23 @@ int BlueStore::_prepare_db_environment(bool create, bool read_only,
       kv_options["db_paths"] = db_paths.str();
       dout(1) << __func__ << " set db_paths to " << db_paths.str() << dendl;
     }
-
-    if (create) {
-      for (auto& p : paths) {
-        env->CreateDir(p.first);
-      }
-      // Selectors don't provide wal path so far hence create explicitly
-      env->CreateDir(fn + ".wal");
-    } else {
-      std::vector<std::string> res;
-      // check for dir presence
-      auto r = env->GetChildren(fn+".wal", &res);
-      if (r.IsNotFound()) {
-	kv_options.erase("separate_wal_dir");
-      }
-    }
   } else {
-    string walfn = path + "/db.wal";
-
-    if (create) {
-      int r = ::mkdir(fn.c_str(), 0755);
-      if (r < 0)
-	r = -errno;
-      if (r < 0 && r != -EEXIST) {
-	derr << __func__ << " failed to create " << fn << ": " << cpp_strerror(r)
-	     << dendl;
-	return r;
-      }
-
-      // wal_dir, too!
-      r = ::mkdir(walfn.c_str(), 0755);
-      if (r < 0)
-	r = -errno;
-      if (r < 0 && r != -EEXIST) {
-	derr << __func__ << " failed to create " << walfn
-	  << ": " << cpp_strerror(r)
-	  << dendl;
-	return r;
-      }
-    } else {
-      struct stat st;
-      r = ::stat(walfn.c_str(), &st);
-      if (r < 0 && errno == ENOENT) {
-	kv_options.erase("separate_wal_dir");
-      }
+    paths.emplace_back(fn, 0);
+  }
+  if (create) {
+    for (auto& p : paths) {
+      env->CreateDir(p.first);
     }
+    // Selectors don't provide wal path so far hence create explicitly
+    env->CreateDir(fn + ".wal");
   }
 
+  std::vector<std::string> res;
+  // check for dir presence
+  auto rr = env->GetChildren(fn+".wal", &res);
+  if (!rr.IsNotFound()) {
+    kv_options["separate_wal_dir"] = 1;
+  }
 
   db = KeyValueDB::create(cct,
 			  kv_backend,
@@ -6620,6 +6595,7 @@ int BlueStore::_prepare_db_environment(bool create, bool read_only,
     return -EIO;
   }
 
+  std::shared_ptr<Int64ArrayMergeOperator> merge_op(new Int64ArrayMergeOperator);
   FreelistManager::setup_merge_operators(db, freelist_type);
   db->set_merge_operator(PREFIX_STAT, merge_op);
   db->set_cache_size(cache_kv_ratio * cache_size);


### PR DESCRIPTION
Now options:
1) bluestore_bluefs=false 
and 
2) bluestore_bluefs_env_mirror=true
work back.
Note bluestore_allocation_from_file=true writes to bluefs directly, 
so it is incompatible bluestore_bluefs=false.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
