### PR TITLE
mon: dissociate app from pools on pool remove

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1035,6 +1035,10 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
       mon->osdmon()->propose_pending(); /* maybe new blocklists */
     }
 
+    mon->osdmon()->do_application_disable(-1, // for all pools
+					  pg_pool_t::APPLICATION_NAME_CEPHFS,
+					  fs_name);
+
     fsmap.erase_filesystem(fs->fscid);
 
     return 0;
@@ -1235,6 +1239,9 @@ class RemoveDataPoolHandler : public FileSystemCommandHandler
       // It was already removed, succeed in silence
       return 0;
     } else if (r == 0) {
+      mon->osdmon()->do_application_disable(poolid,
+					    pg_pool_t::APPLICATION_NAME_CEPHFS,
+					    fs_name);
       // We removed it, succeed
       ss << "removed data pool " << poolid << " from fsmap";
       return 0;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4892,6 +4892,27 @@ void OSDMonitor::check_pg_creates_sub(Subscription *sub)
   }
 }
 
+void OSDMonitor::do_application_disable(int64_t pool_id,
+                                        const std::string &app_name,
+				        const std::string &app_value)
+{
+  for (auto& [_pool_id, _pg_pool] : osdmap.get_pools()) {
+    if (pool_id == -1 || _pool_id == pool_id) {
+      auto it = _pg_pool.application_metadata[app_name].cbegin();
+      while (it != _pg_pool.application_metadata[app_name].cend()) {
+	auto value = it->second;
+	if (value == app_value) { // for this fs
+	  auto curr = it;
+	  ++it;
+	  _pg_pool.application_metadata[app_name].erase(curr);
+	} else {
+	  ++it;
+	}
+      }
+    }
+  }
+}
+
 void OSDMonitor::do_application_enable(int64_t pool_id,
                                        const std::string &app_name,
 				       const std::string &app_key,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -763,6 +763,12 @@ public:
   void check_osdmap_sub(Subscription *sub);
   void check_pg_creates_sub(Subscription *sub);
 
+  // dissociate application from pools
+  // if pool_id == -1: then dissociate all pools
+  // if pool_id != -1: then dissociate specific pool
+  void do_application_disable(int64_t pool_id,
+                              const std::string &app_name,
+			      const std::string &app_value);
   void do_application_enable(int64_t pool_id, const std::string &app_name,
 			     const std::string &app_key="",
 			     const std::string &app_value="",


### PR DESCRIPTION
Problem:
Application is not dissociated from a pool when fs is deleted or when a
pool is removed from a fs.

Solution:
This commit now ensures that the application is dissociated from the
pool when it is removed from a fs or when the entire fs is deleted.

Fixes: https://tracker.ceph.com/issues/57285
Signed-off-by: Milind Changire <mchangir@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
