### PR TITLE
rgw: ContinuousLeaseCR uses LOCK_FLAG_MUST_RENEW to detect timeouts and racing lockers

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -930,10 +930,10 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
   }
   reenter(this) {
 
-    last_renew_try_time = ceph::coarse_mono_clock::now();
+    last_renew_try_time = Clock::now();
     while (!going_down) {
       yield call(new RGWSimpleRadosLockCR(async_rados, store, obj, lock));
-      current_time = ceph::coarse_mono_clock::now();
+      current_time = Clock::now();
       if (current_time - last_renew_try_time > interval_tolerance) {
         // renewal should happen between 50%-90% of interval
         ldout(store->ctx(), 1) << *this << ": WARNING: did not renew lock " << obj << ": within 90\% of interval. " <<

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -929,13 +929,14 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
     return set_cr_done();
   }
   reenter(this) {
+
     last_renew_try_time = ceph::coarse_mono_clock::now();
     while (!going_down) {
-      yield call(new RGWSimpleRadosLockCR(async_rados, store, obj, lock_name, cookie, interval));
+      yield call(new RGWSimpleRadosLockCR(async_rados, store, obj, lock));
       current_time = ceph::coarse_mono_clock::now();
       if (current_time - last_renew_try_time > interval_tolerance) {
         // renewal should happen between 50%-90% of interval
-        ldout(store->ctx(), 1) << *this << ": WARNING: did not renew lock " << obj << ":" << lock_name << ": within 90\% of interval. " << 
+        ldout(store->ctx(), 1) << *this << ": WARNING: did not renew lock " << obj << ": within 90\% of interval. " <<
           (current_time - last_renew_try_time) << " > " << interval_tolerance << dendl;
       }
       last_renew_try_time = current_time;
@@ -943,15 +944,16 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
       caller->set_sleeping(false); /* will only be relevant when we return, that's why we can do it early */
       if (retcode < 0) {
         set_locked(false);
-        ldout(store->ctx(), 20) << *this << ": couldn't lock " << obj << ":" << lock_name << ": retcode=" << retcode << dendl;
+        ldout(store->ctx(), 20) << *this << ": couldn't lock " << obj << ": retcode=" << retcode << dendl;
         return set_state(RGWCoroutine_Error, retcode);
       }
-      ldout(store->ctx(), 20) << *this << ": successfully locked " << obj << ":" << lock_name << dendl;
+      ldout(store->ctx(), 20) << *this << ": successfully locked " << obj << dendl;
       set_locked(true);
+
       yield wait(utime_t(interval / 2, 0));
     }
     set_locked(false); /* moot at this point anyway */
-    yield call(new RGWSimpleRadosUnlockCR(async_rados, store, obj, lock_name, cookie));
+    yield call(new RGWSimpleRadosUnlockCR(async_rados, store, obj, lock));
     return set_state(RGWCoroutine_Done);
   }
   return 0;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1416,9 +1416,10 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
   RGWCoroutine *caller;
 
   bool aborted{false};
-  
-  ceph::coarse_mono_time last_renew_try_time;
-  ceph::coarse_mono_time current_time;
+
+  using Clock = ceph::coarse_mono_clock;
+  Clock::time_point last_renew_try_time;
+  Clock::time_point current_time;
 
 public:
   RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
@@ -1439,7 +1440,7 @@ public:
   int operate(const DoutPrefixProvider *dpp) override;
 
   bool is_locked() const {
-    if (ceph::coarse_mono_clock::now() - last_renew_try_time > ts_interval) {
+    if (Clock::now() - last_renew_try_time > ts_interval) {
       return false;
     }
     return locked;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -374,30 +374,25 @@ public:
 class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
   rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
-  std::string lock_name;
-  std::string cookie;
-  uint32_t duration_secs;
-
+  rados::cls::lock::Lock cls_lock;
 protected:
   int _send_request(const DoutPrefixProvider *dpp) override;
 public:
-  RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
-                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-		        const std::string& _name, const std::string& _cookie, uint32_t _duration_secs);
+  RGWAsyncLockSystemObj(RGWCoroutine* caller, RGWAioCompletionNotifier* cn,
+                        rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
+                        const rados::cls::lock::Lock& lock);
 };
 
 class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
   rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
-  std::string lock_name;
-  std::string cookie;
-
+  rados::cls::lock::Lock cls_lock;
 protected:
   int _send_request(const DoutPrefixProvider *dpp) override;
 public:
-  RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
-                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-		        const std::string& _name, const std::string& _cookie);
+  RGWAsyncUnlockSystemObj(RGWCoroutine* caller, RGWAioCompletionNotifier* cn,
+                          rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
+                          const rados::cls::lock::Lock& lock);
 };
 
 template <class T>
@@ -749,20 +744,21 @@ public:
 class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
   rgw::sal::RadosStore* store;
-  std::string lock_name;
-  std::string cookie;
-  uint32_t duration;
-
   rgw_raw_obj obj;
-
-  RGWAsyncLockSystemObj *req;
+  rados::cls::lock::Lock lock;
+  RGWAsyncLockSystemObj* req = nullptr;
 
 public:
-  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
-		      const rgw_raw_obj& _obj,
-                      const std::string& _lock_name,
-		      const std::string& _cookie,
-		      uint32_t _duration);
+  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor* async_rados,
+                       rgw::sal::RadosStore* store,
+                       const rgw_raw_obj& obj,
+                       const rados::cls::lock::Lock& lock);
+  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor* async_rados,
+                       rgw::sal::RadosStore* store,
+                       const rgw_raw_obj& obj,
+                       const std::string& lock_name,
+                       const std::string& cookie,
+                       uint32_t duration);
   ~RGWSimpleRadosLockCR() override {
     request_cleanup();
   }
@@ -780,20 +776,23 @@ public:
 };
 
 class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
-  RGWAsyncRadosProcessor *async_rados;
+  RGWAsyncRadosProcessor* async_rados;
   rgw::sal::RadosStore* store;
-  std::string lock_name;
-  std::string cookie;
-
   rgw_raw_obj obj;
+  rados::cls::lock::Lock lock;
 
-  RGWAsyncUnlockSystemObj *req;
+  RGWAsyncUnlockSystemObj* req = nullptr;
 
 public:
-  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
-		      const rgw_raw_obj& _obj, 
-                      const std::string& _lock_name,
-		      const std::string& _cookie);
+  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor* async_rados,
+                         rgw::sal::RadosStore* store,
+                         const rgw_raw_obj& obj,
+                         const rados::cls::lock::Lock& lock);
+  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor* async_rados,
+                         rgw::sal::RadosStore* store,
+                         const rgw_raw_obj& obj,
+                         const std::string& lock_name,
+                         const std::string& cookie);
   ~RGWSimpleRadosUnlockCR() override {
     request_cleanup();
   }


### PR DESCRIPTION
allow `SimpleRadosLock/UnlockCR`s to take `rados::cls::lock::Lock` directly, so that callers like `ContinuousLeaseCR` can override `set_may_renew()`/`set_must_renew()`. `ContinuousLeaseCR` uses `set_must_renew()` to raise `EBUSY` errors if a renewal request is processed after expiration

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
