### PR TITLE
mgr/orchestrator/tests: don't match exact whitespace in table output

### DIFF
--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -191,11 +191,15 @@ def test_orch_ps(_describe_service):
     }
     m = OrchestratorCli('orchestrator', 0, 0)
     r = m._handle_command(None, cmd)
-    out = 'NAME    HOST       PORTS  STATUS   REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID   \n'\
-          'osd.1   <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  \n'\
-          'osd.2   <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  \n'\
-          'osd.10  <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  '
-    assert r == HandleCommandResult(retval=0, stdout=out, stderr='')
+    expected_out = 'NAME    HOST       PORTS  STATUS   REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID   \n'\
+                   'osd.1   <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  \n'\
+                   'osd.2   <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  \n'\
+                   'osd.10  <unknown>         unknown          -    -        -        -  <unknown>  <unknown>  '
+    expected_out = [c for c in expected_out if c.isalpha()]
+    actual_out = [c for c in r.stdout if c.isalpha()]
+    assert r.retval == 0
+    assert expected_out == actual_out
+    assert r.stderr == ''
 
 
 hlist = OrchResult([HostSpec("ceph-node-1"), HostSpec("ceph-node-2"), HostSpec("ceph-node-10")])
@@ -210,12 +214,16 @@ def test_orch_host_ls(_describe_service):
     }
     m = OrchestratorCli('orchestrator', 0, 0)
     r = m._handle_command(None, cmd)
-    out = 'HOST          ADDR          LABELS  STATUS  \n'\
-        'ceph-node-1   ceph-node-1                   \n'\
-        'ceph-node-2   ceph-node-2                   \n'\
-        'ceph-node-10  ceph-node-10                  \n'\
-        '3 hosts in cluster'
-    assert r == HandleCommandResult(retval=0, stdout=out, stderr='')
+    expected_out = 'HOST          ADDR          LABELS  STATUS  \n'\
+                   'ceph-node-1   ceph-node-1                   \n'\
+                   'ceph-node-2   ceph-node-2                   \n'\
+                   'ceph-node-10  ceph-node-10                  \n'\
+                   '3 hosts in cluster'
+    expected_out = [c for c in expected_out if c.isalpha()]
+    actual_out = [c for c in r.stdout if c.isalpha()]
+    assert r.retval == 0
+    assert expected_out == actual_out
+    assert r.stderr == ''
 
 
 def test_orch_device_ls():
@@ -230,11 +238,15 @@ def test_orch_device_ls():
         }
         m = OrchestratorCli('orchestrator', 0, 0)
         r = m._handle_command(None, cmd)
-        out = 'HOST          PATH      TYPE     DEVICE ID   SIZE  AVAILABLE  REFRESHED  REJECT REASONS  \n'\
-              'ceph-node-1   /dev/vdb  unknown  None          0   Yes        0s ago                     \n'\
-              'ceph-node-2   /dev/vdb  unknown  None          0   Yes        0s ago                     \n'\
-              'ceph-node-10  /dev/vdb  unknown  None          0   Yes        0s ago                     '
-        assert r == HandleCommandResult(retval=0, stdout=out, stderr='')
+        expected_out = 'HOST          PATH      TYPE     DEVICE ID   SIZE  AVAILABLE  REFRESHED  REJECT REASONS  \n'\
+                       'ceph-node-1   /dev/vdb  unknown  None          0   Yes        0s ago                     \n'\
+                       'ceph-node-2   /dev/vdb  unknown  None          0   Yes        0s ago                     \n'\
+                       'ceph-node-10  /dev/vdb  unknown  None          0   Yes        0s ago                     '
+        expected_out = [c for c in expected_out if c.isalpha()]
+        actual_out = [c for c in r.stdout if c.isalpha()]
+        assert r.retval == 0
+        assert expected_out == actual_out
+        assert r.stderr == ''
 
 
 def test_preview_table_osd_smoke():


### PR DESCRIPTION
It seems that the exact spacing may differ a bit between
python versions. Currently seeing py3 (which cooresponds to py 3.6
on my system) passing these tests and py37 (which is python 3.7
obviously) failing. I think verifying against the exact whitespace
is unnecessary anyhow. As long as it isn't egregious, we don't
really need to worry about exactly what the spacing is.

Signed-off-by: Adam King <adking@redhat.com>

I'm hoping this fixes the tox-mgr failures I'm seeing on make check



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
