### PR TITLE
include: fix IS_ERR on Windows

### DIFF
--- a/src/include/err.h
+++ b/src/include/err.h
@@ -5,10 +5,11 @@
  * adapted from linux 2.6.24 include/linux/err.h
  */
 #define MAX_ERRNO 4095
-#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+#define IS_ERR_VALUE(x) ((x) >= (uintptr_t)-MAX_ERRNO)
 
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* this generates a warning in c++; caller can do the cast manually
 static inline void *ERR_PTR(long error)
@@ -17,12 +18,12 @@ static inline void *ERR_PTR(long error)
 }
 */
 
-static inline long PTR_ERR(const void *ptr)
+static inline intptr_t PTR_ERR(const void *ptr)
 {
-  return (uintptr_t) ptr;
+  return (intptr_t) ptr;
 }
 
-static inline long IS_ERR(const void *ptr)
+static inline bool IS_ERR(const void *ptr)
 {
   return IS_ERR_VALUE((uintptr_t)ptr);
 }


### PR DESCRIPTION
include: fix IS_ERR on Windows

The "long" type uses 32b on x64 Windows platforms, which means
it's not large enough to store a pointer. intptr_t or uintptr_t
should be used instead.

This change fixes include/err.h, using the right types. There was
a previous patch on this topic but unfortunately it didn't address
all the type casts.

This issue was brought up by the unittest_crush test, which recently
started to fail as the CrushWrapper methods use IS_ERR.

Fixes: https://tracker.ceph.com/issues/57308
Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
