### PR TITLE
SimpleRADOSStriper: Avoid moving bufferlists by using deque in read()

### DIFF
--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -488,7 +488,10 @@ ssize_t SimpleRADOSStriper::read(void* data, size_t len, uint64_t off)
   }
 
   size_t r = 0;
-  std::vector<std::pair<bufferlist, aiocompletionptr>> reads;
+  // Don't use std::vector to store bufferlists (e.g for parallelizing aio_reads),
+  // as they are being moved whenever the vector resizes
+  // and will cause invalidated references.
+  std::deque<std::pair<bufferlist, aiocompletionptr>> reads;
   while ((len-r) > 0) {
     auto ext = get_next_extent(off+r, len-r);
     auto& [bl, aiocp] = reads.emplace_back();


### PR DESCRIPTION
#### From the tracker's core dump:

```
(gdb) thread 3
..
#5  librados::AioCompletionImpl::wait_for_complete (this=0x55d397944720) at ./src/librados/AioCompletionImpl.h:63
#6  librados::v14_2_0::AioCompletion::wait_for_complete (this=<optimized out>) at ./src/librados/librados_cxx.cc:1050
#7  0x00007fc1bae649c0 in SimpleRADOSStriper::read (this=0x55d3974e6c70, data=data@entry=0x55d3974eee38, len=len@entry=65536, off=off@entry=4129788)
    at /usr/include/c++/9/bits/unique_ptr.h:360
```
```
[Current thread is 1 ..
(gdb) bt
#0  0x00007fc1bacfac5b in ceph::buffer::v15_2_0::list::buffers_t::clear_and_dispose (this=0x55d3974d3ed0) at ./src/include/buffer.h:599
#1  ceph::buffer::v15_2_0::list::buffers_t::operator= (other=..., this=0x55d3974d3ed0) at ./src/include/buffer.h:505
#2  ceph::buffer::v15_2_0::list::operator= (this=0x55d3974d3ed0, other=...) at ./src/include/buffer.h:970
#3  0x00007fc1bad35606 in Message::claim_data (bl=..., this=0x7fc1a001b680) at ./src/msg/Message.h:431
#4  Objecter::handle_osd_op_reply (this=0x55d397435b90, m=0x7fc1a001b680) at ./src/osdc/Objecter.cc:3509
```

#### Reproduced by attempting to make multithreaded aio requests similarly to `SimpleRADOSStriper`:
```
std::vector<std::pair<librados::bufferlist, std::unique_ptr<librados::AioCompletion>>> reads;
  for (i = 0; i < 5; i++) {
    auto& [bl_ok, aiocp] = reads.emplace_back();
    aiocp = std::unique_ptr<librados::AioCompletion>(librados::Rados::aio_create_completion());
    ret = io_ctx.aio_read(object_name, aiocp.get(), &bl_ok, read_len, 0);
  }
  for (auto& [bl, aiocp] : reads) {
    if (int rc = aiocp->wait_for_complete(); rc < 0) {
      return rc;
    }
  }
```

Same segfault:
```
(gdb) bt 5
#0  ceph::buffer::v15_2_0::list::buffers_t::clear_and_dispose (this=0x7b0c000200a0) at ../src/include/buffer.h:599
#1  ceph::buffer::v15_2_0::list::buffers_t::operator= (other=..., this=0x7b0c000200a0) at ../src/include/buffer.h:505
#2  ceph::buffer::v15_2_0::list::operator= (this=0x7b0c000200a0, other=...) at ../src/include/buffer.h:972
#3  0x00007ffff7f12ff7 in Message::claim_data (bl=..., this=0x7b540000ff00) at ../src/msg/Message.h:434
#4  Objecter::handle_osd_op_reply (this=this@entry=0x7b6c00000700, m=m@entry=0x7b540000ff00) at ../src/osdc/Objecter.cc:3513
```

#### Assumptions
It looks like we are deallocating the bufferlist before all requests using it are finished.
When using ~`unique_ptr<librados::bufferlist>`~`std::deque` instead of `vector` to avoid moves with significantly more requests, the test passes succefully.

* Test added: 
  ```
   [----------] 30 tests from LibRadosAio
   [ RUN      ] LibRadosAio.MultiReads
   [       OK ] LibRadosAio.MultiReads (2251 ms)
  ```
  Same test using `std::vector` (not included in the commit)
  ```
  [----------] 30 tests from LibRadosAio
  [ RUN      ] LibRadosAio.MultiReadsVector
  [1]    662753 segmentation fault (core dumped)  ceph_test_rados_api_aio_pp
  ```

Fixes: https://tracker.ceph.com/issues/57152

Signed-off-by: Matan Breizman <mbreizma@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
