### PR TITLE
Crypto: Add queue mode for batch when object size < 64KB

### DIFF
--- a/src/crypto/crypto_accel.h
+++ b/src/crypto/crypto_accel.h
@@ -23,6 +23,7 @@ typedef std::shared_ptr<CryptoAccel> CryptoAccelRef;
 class CryptoAccel {
  public:
   CryptoAccel() {}
+  CryptoAccel(const size_t chunk_size) {}
   virtual ~CryptoAccel() {}
 
   static const int AES_256_IVSIZE = 128/8;
@@ -32,6 +33,12 @@ class CryptoAccel {
                    const unsigned char (&key)[AES_256_KEYSIZE]) = 0;
   virtual bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                    const unsigned char (&iv)[AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) = 0;
+  virtual bool cbc_encrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) = 0;
+  virtual bool cbc_decrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
                    const unsigned char (&key)[AES_256_KEYSIZE]) = 0;
 };
 #endif

--- a/src/crypto/crypto_plugin.h
+++ b/src/crypto/crypto_plugin.h
@@ -31,6 +31,7 @@ public:
   ~CryptoPlugin()
   {}
   virtual int factory(CryptoAccelRef *cs,
-                      std::ostream *ss) = 0;
+                      std::ostream *ss,
+                      const size_t chunk_size) = 0;
 };
 #endif

--- a/src/crypto/isa-l/isal_crypto_accel.cc
+++ b/src/crypto/isa-l/isal_crypto_accel.cc
@@ -20,7 +20,7 @@ bool ISALCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, s
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
 {
-  if ((size % AES_256_IVSIZE) != 0) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
   alignas(16) struct cbc_key_data keys_blk;
@@ -33,7 +33,7 @@ bool ISALCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, s
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
 {
-  if ((size % AES_256_IVSIZE) != 0) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
   alignas(16) struct cbc_key_data keys_blk;

--- a/src/crypto/isa-l/isal_crypto_accel.h
+++ b/src/crypto/isa-l/isal_crypto_accel.h
@@ -27,5 +27,11 @@ class ISALCryptoAccel : public CryptoAccel {
   bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                    const unsigned char (&iv)[AES_256_IVSIZE],
                    const unsigned char (&key)[AES_256_KEYSIZE]) override;
+  bool cbc_encrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
+  bool cbc_decrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
 };
 #endif

--- a/src/crypto/isa-l/isal_crypto_plugin.h
+++ b/src/crypto/isa-l/isal_crypto_plugin.h
@@ -31,7 +31,8 @@ public:
   ~ISALCryptoPlugin()
   {}
   virtual int factory(CryptoAccelRef *cs,
-                      std::ostream *ss)
+                      std::ostream *ss,
+                      const size_t chunk_size)
   {
     if (cryptoaccel == nullptr)
     {

--- a/src/crypto/openssl/openssl_crypto_accel.cc
+++ b/src/crypto/openssl/openssl_crypto_accel.cc
@@ -79,7 +79,7 @@ bool OpenSSLCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
 {
-  if ((size % AES_256_IVSIZE) != 0) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
 
@@ -93,7 +93,7 @@ bool OpenSSLCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
 {
-  if ((size % AES_256_IVSIZE) != 0) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
 

--- a/src/crypto/openssl/openssl_crypto_accel.h
+++ b/src/crypto/openssl/openssl_crypto_accel.h
@@ -28,5 +28,11 @@ class OpenSSLCryptoAccel : public CryptoAccel {
   bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                    const unsigned char (&iv)[AES_256_IVSIZE],
                    const unsigned char (&key)[AES_256_KEYSIZE]) override;
+  bool cbc_encrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
+  bool cbc_decrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char iv[][AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
 };
 #endif

--- a/src/crypto/openssl/openssl_crypto_plugin.h
+++ b/src/crypto/openssl/openssl_crypto_plugin.h
@@ -25,7 +25,9 @@ class OpenSSLCryptoPlugin : public CryptoPlugin {
 public:
   explicit OpenSSLCryptoPlugin(CephContext* cct) : CryptoPlugin(cct)
   {}
-  int factory(CryptoAccelRef *cs, std::ostream *ss) override {
+  int factory(CryptoAccelRef *cs,
+              std::ostream *ss,
+              const size_t chunk_size) override {
     if (cryptoaccel == nullptr)
       cryptoaccel = CryptoAccelRef(new OpenSSLCryptoAccel);
 

--- a/src/crypto/qat/qat_crypto_accel.cc
+++ b/src/crypto/qat/qat_crypto_accel.cc
@@ -15,28 +15,28 @@
 
 #include "crypto/qat/qat_crypto_accel.h"
 
-bool QccCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
-    const unsigned char (&iv)[AES_256_IVSIZE],
-    const unsigned char (&key)[AES_256_KEYSIZE])
-{
-  if ((size % AES_256_IVSIZE) != 0) {
+bool QccCryptoAccel::cbc_encrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+        const unsigned char iv[][AES_256_IVSIZE],
+        const unsigned char (&key)[AES_256_KEYSIZE]) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
 
-  return qcccrypto.perform_op(out, in, size,
-      const_cast<unsigned char *>(&iv[0]),
-      const_cast<unsigned char *>(&key[0]), CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT);
+  return qcccrypto.perform_op_batch(out, in, size,
+      const_cast<unsigned char *>(&iv[0][0]),
+      const_cast<unsigned char *>(&key[0]),
+      CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT);
 }
 
-bool QccCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
-    const unsigned char (&iv)[AES_256_IVSIZE],
-    const unsigned char (&key)[AES_256_KEYSIZE])
-{
-  if ((size % AES_256_IVSIZE) != 0) {
+bool QccCryptoAccel::cbc_decrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+        const unsigned char iv[][AES_256_IVSIZE],
+        const unsigned char (&key)[AES_256_KEYSIZE]) {
+  if (unlikely((size % AES_256_IVSIZE) != 0)) {
     return false;
   }
 
-  return qcccrypto.perform_op(out, in, size,
-      const_cast<unsigned char *>(&iv[0]),
-      const_cast<unsigned char *>(&key[0]), CPA_CY_SYM_CIPHER_DIRECTION_DECRYPT);
+  return qcccrypto.perform_op_batch(out, in, size,
+      const_cast<unsigned char *>(&iv[0][0]),
+      const_cast<unsigned char *>(&key[0]),
+      CPA_CY_SYM_CIPHER_DIRECTION_DECRYPT);
 }

--- a/src/crypto/qat/qat_crypto_accel.h
+++ b/src/crypto/qat/qat_crypto_accel.h
@@ -22,14 +22,20 @@
 class QccCryptoAccel : public CryptoAccel {
   public:
     QccCrypto qcccrypto;
-    QccCryptoAccel() { qcccrypto.init(); };
+    QccCryptoAccel(const size_t chunk_size) { qcccrypto.init(chunk_size); };
     ~QccCryptoAccel() { qcccrypto.destroy(); };
 
     bool cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
         const unsigned char (&iv)[AES_256_IVSIZE],
-        const unsigned char (&key)[AES_256_KEYSIZE]) override;
+        const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
     bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
         const unsigned char (&iv)[AES_256_IVSIZE],
+        const unsigned char (&key)[AES_256_KEYSIZE]) override { return false; }
+    bool cbc_encrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+        const unsigned char iv[][AES_256_IVSIZE],
+        const unsigned char (&key)[AES_256_KEYSIZE]) override;
+    bool cbc_decrypt_batch(unsigned char* out, const unsigned char* in, size_t size,
+        const unsigned char iv[][AES_256_IVSIZE],
         const unsigned char (&key)[AES_256_KEYSIZE]) override;
 };
 #endif

--- a/src/crypto/qat/qat_crypto_plugin.h
+++ b/src/crypto/qat/qat_crypto_plugin.h
@@ -29,11 +29,11 @@ public:
   {}
   ~QccCryptoPlugin()
   {}
-  virtual int factory(CryptoAccelRef *cs, std::ostream *ss)
+  virtual int factory(CryptoAccelRef *cs, std::ostream *ss, const size_t chunk_size)
   {
     std::lock_guard<std::mutex> l(qat_init);
     if (cryptoaccel == nullptr)
-      cryptoaccel = CryptoAccelRef(new QccCryptoAccel);
+      cryptoaccel = CryptoAccelRef(new QccCryptoAccel(chunk_size));
 
     *cs = cryptoaccel;
     return 0;

--- a/src/crypto/qat/qcccrypto.cc
+++ b/src/crypto/qat/qcccrypto.cc
@@ -2,10 +2,12 @@
 #include  <iostream>
 #include "string.h"
 #include <pthread.h>
+#include <condition_variable>
 #include "common/debug.h"
 #include "include/scope_guard.h"
 #include "common/dout.h"
 #include "common/errno.h"
+#include <atomic>
 
 // -----------------------------------------------------------------------------
 #define dout_context g_ceph_context
@@ -19,31 +21,64 @@ static std::ostream& _prefix(std::ostream* _dout)
 }
 // -----------------------------------------------------------------------------
 
+class CompletionHandle
+{
+ public:
+  CompletionHandle(size_t count):count(count) {};
+  CompletionHandle():count(0) {};
+  void wait() {
+    std::unique_lock lock{mutex};
+    cv.wait(lock, [this]{return count == 0;});
+  }
+  void complete() {
+    std::scoped_lock lock{mutex};
+    count--;
+    if (count == 0) {
+      cv.notify_one();
+    }
+  }
+
+  void add_one() {
+    count++;
+  }
+
+ private:
+  std::condition_variable cv;
+  std::mutex mutex;
+  std::atomic<std::size_t> count;
+};
+
 /*
- * Poller thread & functions
-*/
+ * Callback function
+ */
+static void symDpCallback(CpaCySymDpOpData *pOpData,
+                        CpaStatus status,
+                        CpaBoolean verifyResult)
+{
+  if (nullptr != pOpData->pCallbackTag)
+  {
+    auto complete = static_cast<CompletionHandle*>(pOpData->pCallbackTag);
+    complete->complete();
+  }
+}
+
 static std::mutex qcc_alloc_mutex;
 static std::mutex qcc_eng_mutex;
+static std::condition_variable alloc_cv;
 static std::atomic<bool> init_called = { false };
-
-void* QccCrypto::crypt_thread(void *args) {
-  struct qcc_thread_args *thread_args = (struct qcc_thread_args *)args;
-  thread_args->qccinstance->do_crypt(thread_args);
-  return thread_args;
-}
 
 void QccCrypto::QccFreeInstance(int entry) {
   std::lock_guard<std::mutex> freeinst(qcc_alloc_mutex);
   open_instances.push(entry);
+  alloc_cv.notify_one();
 }
 
 int QccCrypto::QccGetFreeInstance() {
   int ret = -1;
-  std::lock_guard<std::mutex> getinst(qcc_alloc_mutex);
-  if (!open_instances.empty()) {
-    ret = open_instances.front();
-    open_instances.pop();
-  }
+  std::unique_lock getinst(qcc_alloc_mutex);
+  alloc_cv.wait(getinst, [this](){return !open_instances.empty();});
+  ret = open_instances.front();
+  open_instances.pop();
   return ret;
 }
 
@@ -51,20 +86,31 @@ void QccCrypto::cleanup() {
   icp_sal_userStop();
   qaeMemDestroy();
   is_init = false;
-  init_stat = stat;
   init_called = false;
   derr << "Failure during QAT init sequence. Quitting" << dendl;
+}
+
+void QccCrypto::poll_instances(void) {
+  while (!thread_stop) {
+    for (int iter = 0; iter < qcc_inst->num_instances; iter++) {
+      if (qcc_inst->is_polled[iter] == CPA_TRUE) {
+        icp_sal_CyPollDpInstance(qcc_inst->cy_inst_handles[iter], 0);
+      }
+    }
+    std::this_thread::yield();
+  }
 }
 
 /*
  * We initialize QAT instance and everything that is common for all ops
 */
-bool QccCrypto::init()
-{
+bool QccCrypto::init(const size_t chunk_size) {
 
   std::lock_guard<std::mutex> l(qcc_eng_mutex);
+  CpaStatus stat = CPA_STATUS_SUCCESS;
+  this->chunk_size = chunk_size;
 
-  if(init_called) {
+  if (init_called) {
     dout(10) << "Init sequence already called. Skipping duplicate call" << dendl;
     return true;
   }
@@ -76,21 +122,21 @@ bool QccCrypto::init()
   // Find if the usermode memory driver is available. We need to this to
   // create contiguous memory needed by QAT.
   stat = qaeMemInit();
-  if(stat != CPA_STATUS_SUCCESS) {
+  if (stat != CPA_STATUS_SUCCESS) {
     derr << "Unable to load memory driver" << dendl;
     this->cleanup();
     return false;
   }
 
   stat = icp_sal_userStart("CEPH");
-  if(stat != CPA_STATUS_SUCCESS) {
+  if (stat != CPA_STATUS_SUCCESS) {
     derr << "Unable to start qat device" << dendl;
     this->cleanup();
     return false;
   }
 
   qcc_os_mem_alloc((void **)&qcc_inst, sizeof(QCCINST));
-  if(qcc_inst == NULL) {
+  if (qcc_inst == NULL) {
     derr << "Unable to alloc mem for instance struct" << dendl;
     this->cleanup();
     return false;
@@ -121,12 +167,13 @@ bool QccCrypto::init()
     this->cleanup();
     return false;
   }
+  dout(1) << "Get instances num: " << qcc_inst->num_instances << dendl;
 
   int iter = 0;
   //Start Instances
-  for(iter = 0; iter < qcc_inst->num_instances; iter++) {
+  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
     stat = cpaCyStartInstance(qcc_inst->cy_inst_handles[iter]);
-    if(stat != CPA_STATUS_SUCCESS) {
+    if (stat != CPA_STATUS_SUCCESS) {
       derr << "Unable to start instance" << dendl;
       this->cleanup();
       return false;
@@ -136,7 +183,7 @@ bool QccCrypto::init()
   qcc_os_mem_alloc((void **)&qcc_inst->is_polled,
       ((int)qcc_inst->num_instances * sizeof(CpaBoolean)));
   CpaInstanceInfo2 info;
-  for(iter = 0; iter < qcc_inst->num_instances; iter++) {
+  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
     qcc_inst->is_polled[iter] = cpaCyInstanceGetInfo2(qcc_inst->cy_inst_handles[iter],
         &info) == CPA_STATUS_SUCCESS ? info.isPolled : CPA_FALSE;
   }
@@ -144,7 +191,7 @@ bool QccCrypto::init()
   // Allocate memory structures for all instances
   qcc_os_mem_alloc((void **)&qcc_sess,
       ((int)qcc_inst->num_instances * sizeof(QCCSESS)));
-  if(qcc_sess == NULL) {
+  if (qcc_sess == NULL) {
     derr << "Unable to allocate memory for session struct" << dendl;
     this->cleanup();
     return false;
@@ -152,53 +199,33 @@ bool QccCrypto::init()
 
   qcc_os_mem_alloc((void **)&qcc_op_mem,
       ((int)qcc_inst->num_instances * sizeof(QCCOPMEM)));
-  if(qcc_sess == NULL) {
+  if (qcc_sess == NULL) {
     derr << "Unable to allocate memory for opmem struct" << dendl;
     this->cleanup();
     return false;
   }
 
-  qcc_os_mem_alloc((void **)&cypollthreads,
-      ((int)qcc_inst->num_instances * sizeof(pthread_t)));
-  if(cypollthreads == NULL) {
-    derr << "Unable to allocate memory for pthreads" << dendl;
-    this->cleanup();
-    return false;
-  }
-
   //At this point we are only doing an user-space version.
-  //To-Do: Maybe a kernel based one
-  for(iter = 0; iter < qcc_inst->num_instances; iter++) {
+  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
     stat = cpaCySetAddressTranslation(qcc_inst->cy_inst_handles[iter],
                                        qaeVirtToPhysNUMA);
-    if(stat == CPA_STATUS_SUCCESS) {
-      // Start HW Polling Thread
-      // To-Do: Enable epoll & interrupt based later?
-      // QccCyStartPoll(iter);
-      // Setup the session structures for crypto operation and populate
-      // whatever we can now. Rest will be filled in when crypto operation
-      // happens.
-      qcc_sess[iter].sess_ctx_sz = 0;
-      qcc_sess[iter].sess_ctx = NULL;
-      qcc_sess[iter].sess_stp_data.sessionPriority = CPA_CY_PRIORITY_NORMAL;
-      qcc_sess[iter].sess_stp_data.symOperation = CPA_CY_SYM_OP_CIPHER;
+    if (stat == CPA_STATUS_SUCCESS) {
       open_instances.push(iter);
       qcc_op_mem[iter].is_mem_alloc = false;
-      qcc_op_mem[iter].op_complete = false;
-      qcc_op_mem[iter].op_result = CPA_STATUS_SUCCESS;
-      qcc_op_mem[iter].sym_op_data = NULL;
-      qcc_op_mem[iter].buff_meta_size = qcc_op_mem[iter].buff_size = 0;
-      qcc_op_mem[iter].src_buff_meta = qcc_op_mem[iter].src_buff
-        = qcc_op_mem[iter].iv_buff = NULL;
-      qcc_op_mem[iter].src_buff_list = NULL;
-      qcc_op_mem[iter].src_buff_flat = NULL;
-      qcc_op_mem[iter].num_buffers = 1;
+
+      stat = cpaCySymDpRegCbFunc(qcc_inst->cy_inst_handles[iter], symDpCallback);
+      if (stat != CPA_STATUS_SUCCESS) {
+        dout(1) << "Unable to register callback function for instance " << iter << " with status = " << stat << dendl;
+        return false;
+      }
     } else {
-      derr << "Unable to find address translations of instance " << iter << dendl;
+      dout(1) << "Unable to find address translations of instance " << iter << dendl;
       this->cleanup();
       return false;
     }
   }
+
+  qat_poll_thread = make_named_thread("qat_poll", &QccCrypto::poll_instances, this);
   is_init = true;
   dout(10) << "Init complete" << dendl;
   return true;
@@ -210,15 +237,15 @@ bool QccCrypto::destroy() {
     return false;
   }
 
-  unsigned int retry = 0;
-  while(retry <= QCC_MAX_RETRIES) {
-    if(open_instances.size() == qcc_inst->num_instances) {
-      break;
-    } else {
-      retry++;
-    }
-    dout(5) << "QAT is still busy and cannot free resources yet" << dendl;
-    return false;
+  {
+    std::unique_lock getinst(qcc_alloc_mutex);
+    // waiting for all instance being free
+    alloc_cv.wait(getinst, [this](){return (open_instances.size() == qcc_inst->num_instances);});
+  }
+
+  thread_stop = true;
+  if (qat_poll_thread.joinable()) {
+    qat_poll_thread.join();
   }
 
   dout(10) << "Destroying QAT crypto & related memory" << dendl;
@@ -226,21 +253,21 @@ bool QccCrypto::destroy() {
 
   // Free up op related memory
   for (iter =0; iter < qcc_inst->num_instances; iter++) {
-    qcc_contig_mem_free((void **)&(qcc_op_mem[iter].src_buff));
-    qcc_contig_mem_free((void **)&(qcc_op_mem[iter].iv_buff));
-    qcc_os_mem_free((void **)&(qcc_op_mem[iter].src_buff_list));
-    qcc_os_mem_free((void **)&(qcc_op_mem[iter].src_buff_flat));
-    qcc_contig_mem_free((void **)&(qcc_op_mem[iter].sym_op_data));
+    for (size_t i = 0; i < MAX_NUM_SYM_REQ_BATCH; i++) {
+      qcc_contig_mem_free((void **)&(qcc_op_mem[iter].src_buff[i]));
+      qcc_contig_mem_free((void **)&(qcc_op_mem[iter].iv_buff[i]));
+      qcc_contig_mem_free((void **)&(qcc_op_mem[iter].sym_op_data[i]));
+    }
   }
 
   // Free up Session memory
-  for(iter = 0; iter < qcc_inst->num_instances; iter++) {
-    cpaCySymRemoveSession(qcc_inst->cy_inst_handles[iter], qcc_sess[iter].sess_ctx);
+  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
+    cpaCySymDpRemoveSession(qcc_inst->cy_inst_handles[iter], qcc_sess[iter].sess_ctx);
     qcc_contig_mem_free((void **)&(qcc_sess[iter].sess_ctx));
   }
 
   // Stop QAT Instances
-  for(iter = 0; iter < qcc_inst->num_instances; iter++) {
+  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
     cpaCyStopInstance(qcc_inst->cy_inst_handles[iter]);
   }
 
@@ -249,7 +276,6 @@ bool QccCrypto::destroy() {
   qcc_os_mem_free((void **)&qcc_sess);
   qcc_os_mem_free((void **)&(qcc_inst->cy_inst_handles));
   qcc_os_mem_free((void **)&(qcc_inst->is_polled));
-  qcc_os_mem_free((void **)&cypollthreads);
   qcc_os_mem_free((void **)&qcc_inst);
 
   //Un-init memory driver and QAT HW
@@ -260,55 +286,30 @@ bool QccCrypto::destroy() {
   return true;
 }
 
-void QccCrypto::do_crypt(qcc_thread_args *thread_args) {
-  auto entry = thread_args->entry;
-  qcc_op_mem[entry].op_result = cpaCySymPerformOp(qcc_inst->cy_inst_handles[entry],
-      NULL,
-      qcc_op_mem[entry].sym_op_data,
-      qcc_op_mem[entry].src_buff_list,
-      qcc_op_mem[entry].src_buff_list,
-      NULL);
-  qcc_op_mem[entry].op_complete = true;
-  free(thread_args);
-}
-
-bool QccCrypto::perform_op(unsigned char* out, const unsigned char* in,
-    size_t size, uint8_t *iv, uint8_t *key, CpaCySymCipherDirection op_type)
+bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, size_t size,
+    Cpa8U *iv,
+    Cpa8U *key,
+    CpaCySymCipherDirection op_type)
 {
   if (!init_called) {
     dout(10) << "QAT not intialized yet. Initializing now..." << dendl;
-    if(!QccCrypto::init()) {
+    if (!QccCrypto::init(chunk_size)) {
       derr << "QAT init failed" << dendl;
       return false;
     }
   }
 
-  if(!is_init)
+  if (!is_init)
   {
-    dout(10) << "QAT not initialized in this instance or init failed with possible error " << (int)init_stat << dendl;
+    dout(10) << "QAT not initialized in this instance or init failed" << dendl;
     return is_init;
   }
-
+  CpaStatus status = CPA_STATUS_SUCCESS;
   int avail_inst = -1;
-  unsigned int retrycount = 0;
-  while(retrycount <= QCC_MAX_RETRIES) {
-    avail_inst = QccGetFreeInstance();
-    if(avail_inst != -1) {
-      break;
-    } else {
-      retrycount++;
-      usleep(qcc_sleep_duration);
-    }
-  }
+  avail_inst = QccGetFreeInstance();
 
-  if(avail_inst == -1) {
-    derr << "Unable to get an QAT instance. Failing request" << dendl;
-    return false;
-  }
+  dout(10) << "Using dp_batch inst " << avail_inst << dendl;
 
-  dout(15) << "Using inst " << avail_inst << dendl;
-  // Start polling threads for this instance
-  //QccCyStartPoll(avail_inst);
 
   auto sg = make_scope_guard([=] {
       //free up the instance irrespective of the op status
@@ -322,150 +323,191 @@ bool QccCrypto::perform_op(unsigned char* out, const unsigned char* in,
    * Hold onto to most of them until destructor is called.
   */
   if (qcc_op_mem[avail_inst].is_mem_alloc == false) {
+    for (size_t i = 0; i < MAX_NUM_SYM_REQ_BATCH; i++) {
+      // Allocate IV memory
+      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].iv_buff[i]), AES_256_IV_LEN, 8);
+      if (status != CPA_STATUS_SUCCESS) {
+        derr << "Unable to allocate iv_buff memory" << dendl;
+        return false;
+      }
 
-    qcc_sess[avail_inst].sess_stp_data.cipherSetupData.cipherAlgorithm =
-                                                     CPA_CY_SYM_CIPHER_AES_CBC;
-    qcc_sess[avail_inst].sess_stp_data.cipherSetupData.cipherKeyLenInBytes =
-                                                              AES_256_KEY_SIZE;
+      // Allocate src memory
+      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff[i]), chunk_size, 8);
+      if (status != CPA_STATUS_SUCCESS) {
+        derr << "Unable to allocate src_buff memory" << dendl;
+        return false;
+      }
 
-    // Allocate contig memory for buffers that are independent of the
-    // input/output
-    stat = cpaCyBufferListGetMetaSize(qcc_inst->cy_inst_handles[avail_inst],
-        qcc_op_mem[avail_inst].num_buffers, &(qcc_op_mem[avail_inst].buff_meta_size));
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to get buff meta size" << dendl;
-      return false;
-    }
-
-    // Allocate Buffer List Private metadata
-    stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff_meta),
-        qcc_op_mem[avail_inst].buff_meta_size, 1);
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to allocate private metadata memory" << dendl;
-      return false;
-    }
-
-    // Allocate Buffer List Memory
-    qcc_os_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff_list), sizeof(CpaBufferList));
-    qcc_os_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff_flat),
-              (qcc_op_mem[avail_inst].num_buffers * sizeof(CpaFlatBuffer)));
-    if(qcc_op_mem[avail_inst].src_buff_list == NULL || qcc_op_mem[avail_inst].src_buff_flat == NULL) {
-      derr << "Unable to allocate bufferlist memory" << dendl;
-      return false;
-    }
-
-    // Allocate IV memory
-    stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].iv_buff), AES_256_IV_LEN);
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to allocate bufferlist memory" << dendl;
-      return false;
-    }
-
-    //Assign src stuff for the operation
-    (qcc_op_mem[avail_inst].src_buff_list)->pBuffers = qcc_op_mem[avail_inst].src_buff_flat;
-    (qcc_op_mem[avail_inst].src_buff_list)->numBuffers = qcc_op_mem[avail_inst].num_buffers;
-    (qcc_op_mem[avail_inst].src_buff_list)->pPrivateMetaData = qcc_op_mem[avail_inst].src_buff_meta;
-
-    //Setup OpData
-    stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].sym_op_data),
-        sizeof(CpaCySymOpData));
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to allocate opdata memory" << dendl;
-      return false;
-    }
-
-    // Assuming op to be encryption for initiation. This will be reset when we
-    // exit this block
-    qcc_sess[avail_inst].sess_stp_data.cipherSetupData.cipherDirection =
-                                            CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT;
-    // Allocate Session memory
-    stat = cpaCySymSessionCtxGetSize(qcc_inst->cy_inst_handles[avail_inst],
-        &(qcc_sess[avail_inst].sess_stp_data), &(qcc_sess[avail_inst].sess_ctx_sz));
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to find session size" << dendl;
-      return false;
-    }
-
-    stat = qcc_contig_mem_alloc((void **)&(qcc_sess[avail_inst].sess_ctx),
-        qcc_sess[avail_inst].sess_ctx_sz);
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to allocate contig memory" << dendl;
-      return false;
+      //Setup OpData
+      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].sym_op_data[i]),
+          sizeof(CpaCySymDpOpData), 8);
+      if (status != CPA_STATUS_SUCCESS) {
+        derr << "Unable to allocate opdata memory" << dendl;
+        return false;
+      }
     }
 
     // Set memalloc flag so that we don't go through this exercise again.
     qcc_op_mem[avail_inst].is_mem_alloc = true;
-    dout(15) << "Instantiation complete for " << avail_inst << dendl;
+
+    status = initSession(qcc_inst->cy_inst_handles[avail_inst],
+                             &(qcc_sess[avail_inst].sess_ctx),
+                             (Cpa8U *)key,
+                             op_type);
+  } else {
+    status = updateSession(qcc_sess[avail_inst].sess_ctx,
+                               (Cpa8U *)key,
+                               op_type);
   }
 
-  // Section that runs on every call
-  // Identify the operation and assign to session
-  qcc_sess[avail_inst].sess_stp_data.cipherSetupData.cipherDirection = op_type;
-  qcc_sess[avail_inst].sess_stp_data.cipherSetupData.pCipherKey = (Cpa8U *)key;
-
-  stat = cpaCySymInitSession(qcc_inst->cy_inst_handles[avail_inst],
-      NULL,
-      &(qcc_sess[avail_inst].sess_stp_data),
-      qcc_sess[avail_inst].sess_ctx);
-  if (stat != CPA_STATUS_SUCCESS) {
-    derr << "Unable to init session" << dendl;
+  if (unlikely(status != CPA_STATUS_SUCCESS)) {
+    derr << "Unable to init session with status =" << status << dendl;
     return false;
   }
 
-  // Allocate actual buffers that will hold data
-  if (qcc_op_mem[avail_inst].buff_size != (Cpa32U)size) {
-    qcc_contig_mem_free((void **)&(qcc_op_mem[avail_inst].src_buff));
-    qcc_op_mem[avail_inst].buff_size = (Cpa32U)size;
-    stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff),
-              qcc_op_mem[avail_inst].buff_size);
-    if(stat != CPA_STATUS_SUCCESS) {
-      derr << "Unable to allocate contig memory" << dendl;
-      return false;
+  return symPerformOp(avail_inst,
+                      qcc_sess[avail_inst].sess_ctx,
+                      in,
+                      out,
+                      size,
+                      reinterpret_cast<Cpa8U*>(iv),
+                      AES_256_IV_LEN);
+}
+
+/*
+ * Perform session update
+ */
+CpaStatus QccCrypto::updateSession(CpaCySymSessionCtx sessionCtx,
+                               Cpa8U *pCipherKey,
+                               CpaCySymCipherDirection cipherDirection) {
+  CpaStatus status = CPA_STATUS_SUCCESS;
+  CpaCySymSessionUpdateData sessionUpdateData = {0};
+
+  sessionUpdateData.flags = CPA_CY_SYM_SESUPD_CIPHER_KEY;
+  sessionUpdateData.flags |= CPA_CY_SYM_SESUPD_CIPHER_DIR;
+  sessionUpdateData.pCipherKey = pCipherKey;
+  sessionUpdateData.cipherDirection = cipherDirection;
+
+  do {
+    status = cpaCySymUpdateSession(sessionCtx, &sessionUpdateData);
+  } while (status == CPA_STATUS_RETRY);
+
+  if (unlikely(status != CPA_STATUS_SUCCESS)) {
+    dout(1) << "cpaCySymUpdateSession failed with status = " << status << dendl;
+  }
+
+  return status;
+}
+
+CpaStatus QccCrypto::initSession(CpaInstanceHandle cyInstHandle,
+                             CpaCySymSessionCtx *sessionCtx,
+                             Cpa8U *pCipherKey,
+                             CpaCySymCipherDirection cipherDirection) {
+  CpaStatus status = CPA_STATUS_SUCCESS;
+  Cpa32U sessionCtxSize = 0;
+  CpaCySymSessionSetupData sessionSetupData;
+  memset(&sessionSetupData, 0, sizeof(sessionSetupData));
+
+  sessionSetupData.sessionPriority = CPA_CY_PRIORITY_NORMAL;
+  sessionSetupData.symOperation = CPA_CY_SYM_OP_CIPHER;
+  sessionSetupData.cipherSetupData.cipherAlgorithm = CPA_CY_SYM_CIPHER_AES_CBC;
+  sessionSetupData.cipherSetupData.cipherKeyLenInBytes = AES_256_KEY_SIZE;
+  sessionSetupData.cipherSetupData.pCipherKey = pCipherKey;
+  sessionSetupData.cipherSetupData.cipherDirection = cipherDirection;
+
+  status = cpaCySymDpSessionCtxGetSize(cyInstHandle, &sessionSetupData, &sessionCtxSize);
+  if (likely(CPA_STATUS_SUCCESS == status)) {
+    status = qcc_contig_mem_alloc((void **)(sessionCtx), sessionCtxSize);
+  } else {
+    dout(1) << "cpaCySymDpSessionCtxGetSize failed with status = " << status << dendl;
+  }
+  if (likely(CPA_STATUS_SUCCESS == status)) {
+    status = cpaCySymDpInitSession(cyInstHandle,
+                                   &sessionSetupData,
+                                   *sessionCtx);
+    if (unlikely(status != CPA_STATUS_SUCCESS)) {
+      dout(1) << "cpaCySymDpInitSession failed with status = " << status << dendl;
+    }
+  } else {
+    dout(1) << "Session alloc failed with status = " << status << dendl;
+  }
+  return status;
+}
+
+bool QccCrypto::symPerformOp(int avail_inst,
+                              CpaCySymSessionCtx sessionCtx,
+                              const Cpa8U *pSrc,
+                              Cpa8U *pDst,
+                              Cpa32U size,
+                              Cpa8U *pIv,
+                              Cpa32U ivLen) {
+  CpaStatus status = CPA_STATUS_SUCCESS;
+  Cpa32U one_batch_size = chunk_size * MAX_NUM_SYM_REQ_BATCH;
+  Cpa32U iv_index = 0;
+  for (Cpa32U off = 0; off < size; off += one_batch_size) {
+    CompletionHandle complete;
+    for (Cpa32U offset = off, i = 0; offset < size && i < MAX_NUM_SYM_REQ_BATCH; offset += chunk_size, i++) {
+      CpaCySymDpOpData *pOpData = qcc_op_mem[avail_inst].sym_op_data[i];
+      Cpa8U *pSrcBuffer = qcc_op_mem[avail_inst].src_buff[i];
+      Cpa8U *pIvBuffer = qcc_op_mem[avail_inst].iv_buff[i];
+      Cpa32U process_size = offset + chunk_size <= size ? chunk_size : size - offset;
+      if (CPA_STATUS_SUCCESS == status) {
+        // copy source into buffer
+        memcpy(pSrcBuffer, pSrc + offset, process_size);
+        // copy IV into buffer
+        memcpy(pIvBuffer, &pIv[iv_index * ivLen], ivLen);
+        iv_index++;
+
+        complete.add_one();
+
+        //pOpData assignment
+        pOpData->thisPhys = qaeVirtToPhysNUMA(pOpData);
+        pOpData->instanceHandle = qcc_inst->cy_inst_handles[avail_inst];
+        pOpData->sessionCtx = sessionCtx;
+        pOpData->pCallbackTag = (void *)&complete;
+        pOpData->cryptoStartSrcOffsetInBytes = 0;
+        pOpData->messageLenToCipherInBytes = process_size;
+        pOpData->iv = qaeVirtToPhysNUMA(pIvBuffer);
+        pOpData->pIv = pIvBuffer;
+        pOpData->ivLenInBytes = ivLen;
+        pOpData->srcBuffer = qaeVirtToPhysNUMA(pSrcBuffer);
+        pOpData->srcBufferLen = process_size;
+        pOpData->dstBuffer = qaeVirtToPhysNUMA(pSrcBuffer);
+        pOpData->dstBufferLen = process_size;
+
+        status = cpaCySymDpEnqueueOp(pOpData, CPA_FALSE);
+        if (unlikely(CPA_STATUS_SUCCESS != status)) {
+          dout(1) << "cpaCySymDpEnqueueOp failed. (status = " << status << ")" << dendl;
+          // submit all request, clean the queue
+          cpaCySymDpPerformOpNow(qcc_inst->cy_inst_handles[avail_inst]);
+          return false;
+        }
+      }
+    }
+
+    if (likely(CPA_STATUS_SUCCESS == status)) {
+      status = cpaCySymDpPerformOpNow(qcc_inst->cy_inst_handles[avail_inst]);
+      if (unlikely(CPA_STATUS_SUCCESS != status)) {
+        dout(1) << "cpaCySymDpPerformOpNow failed. (status = " << status << ")" << dendl;
+        return false;
+      }
+    }
+
+    if (likely(CPA_STATUS_SUCCESS == status)) {
+      complete.wait();
+      // Copy data back to pDst buffer
+      for (Cpa32U offset = off, i = 0; offset < size && i < MAX_NUM_SYM_REQ_BATCH; offset += chunk_size, i++) {
+        Cpa8U *pSrcBuffer = qcc_op_mem[avail_inst].src_buff[i];
+        Cpa32U process_size = offset + chunk_size <= size ? chunk_size : size - offset;
+        memcpy(pDst + offset, pSrcBuffer, process_size);
+      }
     }
   }
 
-  // Copy src & iv into the respective buffers
-  memcpy(qcc_op_mem[avail_inst].src_buff, in, size);
-  memcpy(qcc_op_mem[avail_inst].iv_buff, iv, AES_256_IV_LEN);
-
-  //Assign the reminder of the stuff
-  qcc_op_mem[avail_inst].src_buff_flat->dataLenInBytes = qcc_op_mem[avail_inst].buff_size;
-  qcc_op_mem[avail_inst].src_buff_flat->pData = qcc_op_mem[avail_inst].src_buff;
-
-  //OpData assignment
-  qcc_op_mem[avail_inst].sym_op_data->sessionCtx = qcc_sess[avail_inst].sess_ctx;
-  qcc_op_mem[avail_inst].sym_op_data->packetType = CPA_CY_SYM_PACKET_TYPE_FULL;
-  qcc_op_mem[avail_inst].sym_op_data->pIv = qcc_op_mem[avail_inst].iv_buff;
-  qcc_op_mem[avail_inst].sym_op_data->ivLenInBytes = AES_256_IV_LEN;
-  qcc_op_mem[avail_inst].sym_op_data->cryptoStartSrcOffsetInBytes = 0;
-  qcc_op_mem[avail_inst].sym_op_data->messageLenToCipherInBytes = qcc_op_mem[avail_inst].buff_size;
-
-  // Perform cipher operation in a thread
-  qcc_thread_args* thread_args = new qcc_thread_args();
-  thread_args->qccinstance = this;
-  thread_args->entry = avail_inst;
-
-  if (pthread_create(&cypollthreads[avail_inst], NULL, crypt_thread, (void *)thread_args) != 0) {
-    derr << "Unable to create thread for crypt operation" << dendl;
-    return false;
+  Cpa32U max_used_buffer_num = iv_index > MAX_NUM_SYM_REQ_BATCH ? MAX_NUM_SYM_REQ_BATCH : iv_index;
+  for (Cpa32U i = 0; i < max_used_buffer_num; i++) {
+    memset(qcc_op_mem[avail_inst].src_buff[i], 0, chunk_size);
+    memset(qcc_op_mem[avail_inst].iv_buff[i], 0, ivLen);
   }
-  if (qcc_inst->is_polled[avail_inst] == CPA_TRUE) {
-    while (!qcc_op_mem[avail_inst].op_complete) {
-      icp_sal_CyPollInstance(qcc_inst->cy_inst_handles[avail_inst], 0);
-    }
-  }
-  pthread_join(cypollthreads[avail_inst], NULL);
-
-  if(qcc_op_mem[avail_inst].op_result != CPA_STATUS_SUCCESS) {
-    derr << "Unable to perform crypt operation" << dendl;
-    return false;
-  }
-
-  //Copy data back to out buffer
-  memcpy(out, qcc_op_mem[avail_inst].src_buff, size);
-  //Always cleanup memory holding user-data at the end
-  memset(qcc_op_mem[avail_inst].iv_buff, 0, AES_256_IV_LEN);
-  memset(qcc_op_mem[avail_inst].src_buff, 0, qcc_op_mem[avail_inst].buff_size);
-
-  return true;
+  return (status == CPA_STATUS_SUCCESS);
 }

--- a/src/crypto/qat/qcccrypto.cc
+++ b/src/crypto/qat/qcccrypto.cc
@@ -8,6 +8,8 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include <atomic>
+#include <chrono>
+#include <functional>
 
 // -----------------------------------------------------------------------------
 #define dout_context g_ceph_context
@@ -21,32 +23,77 @@ static std::ostream& _prefix(std::ostream* _dout)
 }
 // -----------------------------------------------------------------------------
 
-class CompletionHandle
-{
+class BaseCompletionHandle {
  public:
-  CompletionHandle(size_t count):count(count) {};
-  CompletionHandle():count(0) {};
+  virtual void operator() () = 0;
+  virtual ~BaseCompletionHandle() {};
+};
+
+class CompletionHandle : public BaseCompletionHandle {
+ public:
+  CompletionHandle(size_t count):count(count) {}
+  CompletionHandle():count(0) {}
+  ~CompletionHandle() {}
   void wait() {
     std::unique_lock lock{mutex};
     cv.wait(lock, [this]{return count == 0;});
   }
-  void complete() {
+
+  void operator() () override {
     std::scoped_lock lock{mutex};
     count--;
     if (count == 0) {
       cv.notify_one();
+      if (free_instance) {
+        free_instance();
+      }
     }
   }
 
   void add_one() {
+    std::lock_guard lock(mutex);
     count++;
+  }
+
+  void add_num(size_t num) {
+    std::lock_guard lock(mutex);
+    count += num;
+  }
+
+  void set_callback(std::function<void()>&& free_instance) {
+    this->free_instance = std::move(free_instance);
   }
 
  private:
   std::condition_variable cv;
   std::mutex mutex;
   std::atomic<std::size_t> count;
+
+  // only for queue mode
+  std::function<void()> free_instance;  // used for free instance
 };
+
+class QueueOneCompletionHandle : public BaseCompletionHandle{
+  std::function<void()> result_back;  // data copy
+  std::shared_ptr<CompletionHandle> completion_handle; // free instance
+  CompletionHandle* one_object_completion_handle;
+ public:
+  QueueOneCompletionHandle(std::function<void()> result_back,
+                           std::shared_ptr<CompletionHandle> completion_handle,
+                           CompletionHandle* one_object_completion_handle) :
+                           result_back(result_back), completion_handle(completion_handle),
+                           one_object_completion_handle(one_object_completion_handle) {}
+  ~QueueOneCompletionHandle() {
+    delete this;
+  }
+  void operator() () override {
+    result_back();
+    (*completion_handle)();
+    (*one_object_completion_handle)();
+  }
+};
+
+
 
 /*
  * Callback function
@@ -57,8 +104,8 @@ static void symDpCallback(CpaCySymDpOpData *pOpData,
 {
   if (nullptr != pOpData->pCallbackTag)
   {
-    auto complete = static_cast<CompletionHandle*>(pOpData->pCallbackTag);
-    complete->complete();
+    auto complete = static_cast<BaseCompletionHandle*>(pOpData->pCallbackTag);
+    (*complete)();
   }
 }
 
@@ -68,7 +115,7 @@ static std::condition_variable alloc_cv;
 static std::atomic<bool> init_called = { false };
 
 void QccCrypto::QccFreeInstance(int entry) {
-  std::lock_guard<std::mutex> freeinst(qcc_alloc_mutex);
+  std::lock_guard freeinst(qcc_alloc_mutex);
   open_instances.push(entry);
   alloc_cv.notify_one();
 }
@@ -101,6 +148,14 @@ void QccCrypto::poll_instances(void) {
   }
 }
 
+void QccCrypto::perform_queue(void) {
+  while (!thread_stop) {
+    int avail_inst = QccGetFreeInstance();
+    doQueuePerformOp(avail_inst);
+    std::this_thread::yield();
+  }
+}
+
 /*
  * We initialize QAT instance and everything that is common for all ops
 */
@@ -109,6 +164,7 @@ bool QccCrypto::init(const size_t chunk_size) {
   std::lock_guard<std::mutex> l(qcc_eng_mutex);
   CpaStatus stat = CPA_STATUS_SUCCESS;
   this->chunk_size = chunk_size;
+  threshold = MAX_NUM_SYM_REQ_BATCH * chunk_size / 2;
 
   if (init_called) {
     dout(10) << "Init sequence already called. Skipping duplicate call" << dendl;
@@ -188,21 +244,43 @@ bool QccCrypto::init(const size_t chunk_size) {
         &info) == CPA_STATUS_SUCCESS ? info.isPolled : CPA_FALSE;
   }
 
-  // Allocate memory structures for all instances
-  qcc_os_mem_alloc((void **)&qcc_sess,
-      ((int)qcc_inst->num_instances * sizeof(QCCSESS)));
-  if (qcc_sess == NULL) {
-    derr << "Unable to allocate memory for session struct" << dendl;
+  qcc_os_mem_alloc((void **)&qcc_op_mem,
+      ((int)qcc_inst->num_instances * sizeof(QCCOPMEM)));
+  if (qcc_op_mem == NULL) {
+    derr << "Unable to allocate memory for opmem struct" << dendl;
     this->cleanup();
     return false;
   }
 
-  qcc_os_mem_alloc((void **)&qcc_op_mem,
-      ((int)qcc_inst->num_instances * sizeof(QCCOPMEM)));
-  if (qcc_sess == NULL) {
-    derr << "Unable to allocate memory for opmem struct" << dendl;
-    this->cleanup();
-    return false;
+  for (iter =0; iter < qcc_inst->num_instances; iter++) {
+    for (size_t i = 0; i < MAX_NUM_SYM_REQ_BATCH; i++) {
+      // Allocate IV memory
+      stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[iter].iv_buff[i]), AES_256_IV_LEN, 8);
+      if (stat != CPA_STATUS_SUCCESS) {
+        dout(1) << "Unable to allocate iv_buff memory" << dendl;
+        this->cleanup();
+        return false;
+      }
+
+      // Allocate src memory
+      stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[iter].src_buff[i]), chunk_size, 8);
+      if (stat != CPA_STATUS_SUCCESS) {
+        dout(1) << "Unable to allocate src_buff memory" << dendl;
+        this->cleanup();
+        return false;
+      }
+
+      //Setup OpData
+      stat = qcc_contig_mem_alloc((void **)&(qcc_op_mem[iter].sym_op_data[i]),
+          sizeof(CpaCySymDpOpData), 8);
+      if (stat != CPA_STATUS_SUCCESS) {
+        dout(1) << "Unable to allocate opdata memory" << dendl;
+        this->cleanup();
+        return false;
+      }
+
+      qcc_op_mem[iter].sess_ctx[i] = nullptr;
+    }
   }
 
   //At this point we are only doing an user-space version.
@@ -211,7 +289,6 @@ bool QccCrypto::init(const size_t chunk_size) {
                                        qaeVirtToPhysNUMA);
     if (stat == CPA_STATUS_SUCCESS) {
       open_instances.push(iter);
-      qcc_op_mem[iter].is_mem_alloc = false;
 
       stat = cpaCySymDpRegCbFunc(qcc_inst->cy_inst_handles[iter], symDpCallback);
       if (stat != CPA_STATUS_SUCCESS) {
@@ -226,6 +303,7 @@ bool QccCrypto::init(const size_t chunk_size) {
   }
 
   qat_poll_thread = make_named_thread("qat_poll", &QccCrypto::poll_instances, this);
+  qat_queue_thread = make_named_thread("qat_queue", &QccCrypto::perform_queue, this);
   is_init = true;
   dout(10) << "Init complete" << dendl;
   return true;
@@ -247,6 +325,9 @@ bool QccCrypto::destroy() {
   if (qat_poll_thread.joinable()) {
     qat_poll_thread.join();
   }
+  if (qat_queue_thread.joinable()) {
+    qat_queue_thread.join();
+  }
 
   dout(10) << "Destroying QAT crypto & related memory" << dendl;
   int iter = 0;
@@ -257,13 +338,9 @@ bool QccCrypto::destroy() {
       qcc_contig_mem_free((void **)&(qcc_op_mem[iter].src_buff[i]));
       qcc_contig_mem_free((void **)&(qcc_op_mem[iter].iv_buff[i]));
       qcc_contig_mem_free((void **)&(qcc_op_mem[iter].sym_op_data[i]));
+      cpaCySymDpRemoveSession(qcc_inst->cy_inst_handles[iter], qcc_op_mem[iter].sess_ctx[i]);
+      qcc_contig_mem_free((void **)&(qcc_op_mem[iter].sess_ctx[i]));
     }
-  }
-
-  // Free up Session memory
-  for (iter = 0; iter < qcc_inst->num_instances; iter++) {
-    cpaCySymDpRemoveSession(qcc_inst->cy_inst_handles[iter], qcc_sess[iter].sess_ctx);
-    qcc_contig_mem_free((void **)&(qcc_sess[iter].sess_ctx));
   }
 
   // Stop QAT Instances
@@ -273,7 +350,6 @@ bool QccCrypto::destroy() {
 
   // Free up the base structures we use
   qcc_os_mem_free((void **)&qcc_op_mem);
-  qcc_os_mem_free((void **)&qcc_sess);
   qcc_os_mem_free((void **)&(qcc_inst->cy_inst_handles));
   qcc_os_mem_free((void **)&(qcc_inst->is_polled));
   qcc_os_mem_free((void **)&qcc_inst);
@@ -304,6 +380,18 @@ bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, si
     dout(10) << "QAT not initialized in this instance or init failed" << dendl;
     return is_init;
   }
+
+  if (size < threshold) {
+    CompletionHandle complete;
+    complete.add_num(size / chunk_size);
+    if (size % chunk_size) {
+      complete.add_one();
+    }
+    request_queue.push(out, in, size, iv, key, op_type, &complete);
+    complete.wait();
+    return true;
+  }
+
   CpaStatus status = CPA_STATUS_SUCCESS;
   int avail_inst = -1;
   avail_inst = QccGetFreeInstance();
@@ -314,7 +402,6 @@ bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, si
   auto sg = make_scope_guard([=] {
       //free up the instance irrespective of the op status
       dout(15) << "Completed task under " << avail_inst << dendl;
-      qcc_op_mem[avail_inst].op_complete = false;
       QccCrypto::QccFreeInstance(avail_inst);
       });
 
@@ -322,40 +409,13 @@ bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, si
    * Allocate buffers for this version of the instance if not already done.
    * Hold onto to most of them until destructor is called.
   */
-  if (qcc_op_mem[avail_inst].is_mem_alloc == false) {
-    for (size_t i = 0; i < MAX_NUM_SYM_REQ_BATCH; i++) {
-      // Allocate IV memory
-      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].iv_buff[i]), AES_256_IV_LEN, 8);
-      if (status != CPA_STATUS_SUCCESS) {
-        derr << "Unable to allocate iv_buff memory" << dendl;
-        return false;
-      }
-
-      // Allocate src memory
-      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].src_buff[i]), chunk_size, 8);
-      if (status != CPA_STATUS_SUCCESS) {
-        derr << "Unable to allocate src_buff memory" << dendl;
-        return false;
-      }
-
-      //Setup OpData
-      status = qcc_contig_mem_alloc((void **)&(qcc_op_mem[avail_inst].sym_op_data[i]),
-          sizeof(CpaCySymDpOpData), 8);
-      if (status != CPA_STATUS_SUCCESS) {
-        derr << "Unable to allocate opdata memory" << dendl;
-        return false;
-      }
-    }
-
-    // Set memalloc flag so that we don't go through this exercise again.
-    qcc_op_mem[avail_inst].is_mem_alloc = true;
-
+  if (qcc_op_mem[avail_inst].sess_ctx[0] == nullptr) {
     status = initSession(qcc_inst->cy_inst_handles[avail_inst],
-                             &(qcc_sess[avail_inst].sess_ctx),
+                             &(qcc_op_mem[avail_inst].sess_ctx[0]),
                              (Cpa8U *)key,
                              op_type);
   } else {
-    status = updateSession(qcc_sess[avail_inst].sess_ctx,
+    status = updateSession(qcc_op_mem[avail_inst].sess_ctx[0],
                                (Cpa8U *)key,
                                op_type);
   }
@@ -366,7 +426,7 @@ bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, si
   }
 
   return symPerformOp(avail_inst,
-                      qcc_sess[avail_inst].sess_ctx,
+                      qcc_op_mem[avail_inst].sess_ctx[0],
                       in,
                       out,
                       size,
@@ -509,5 +569,91 @@ bool QccCrypto::symPerformOp(int avail_inst,
     memset(qcc_op_mem[avail_inst].src_buff[i], 0, chunk_size);
     memset(qcc_op_mem[avail_inst].iv_buff[i], 0, ivLen);
   }
+  return (status == CPA_STATUS_SUCCESS);
+}
+
+
+bool QccCrypto::doQueuePerformOp(int avail_inst) {
+  CpaStatus status = CPA_STATUS_SUCCESS;
+  Cpa32U remain_size = chunk_size * MAX_NUM_SYM_REQ_BATCH;
+  Cpa32U qcc_op_mem_index = 0;
+  Cpa32U request_num = 0;
+  RequestQueue::Node node;
+  bool get_data;
+  std::shared_ptr<CompletionHandle> complete = std::make_shared<CompletionHandle>();
+  complete->set_callback([this, avail_inst]() {
+    QccCrypto::QccFreeInstance(avail_inst);
+  });
+
+  while ((get_data = request_queue.try_get(node, remain_size)) || request_num == 0) {
+    if (get_data) {
+      if (qcc_op_mem[avail_inst].sess_ctx[request_num] == nullptr) {
+        status = initSession(qcc_inst->cy_inst_handles[avail_inst],
+                             &(qcc_op_mem[avail_inst].sess_ctx[request_num]),
+                             node.key,
+                             node.op_type);
+      } else {
+        status = updateSession(qcc_op_mem[avail_inst].sess_ctx[request_num],
+                               node.key,
+                               node.op_type);
+      }
+      for (Cpa32U offset = 0, i = 0; offset < node.size; offset += chunk_size, i++) {
+        CpaCySymDpOpData *pOpData = qcc_op_mem[avail_inst].sym_op_data[qcc_op_mem_index];
+        Cpa8U *pSrcBuffer = qcc_op_mem[avail_inst].src_buff[qcc_op_mem_index];
+        Cpa8U *pIvBuffer = qcc_op_mem[avail_inst].iv_buff[qcc_op_mem_index];
+        Cpa32U process_size = offset + chunk_size <= node.size ? chunk_size : node.size - offset;
+        if (CPA_STATUS_SUCCESS == status) {
+          // copy source into buffer
+          memcpy(pSrcBuffer, node.in + offset, process_size);
+          // copy IV into buffer
+          memcpy(pIvBuffer, &node.iv[i * AES_256_IV_LEN], AES_256_IV_LEN);
+          complete->add_one();
+          QueueOneCompletionHandle *handle = new QueueOneCompletionHandle([this, src = pSrcBuffer,
+                                                         dst = node.out + offset, len = process_size]()mutable{
+            memcpy(dst, src, len);
+            memset(src, 0, len);
+          }, complete, node.completion);
+          //pOpData assignment
+          pOpData->thisPhys = qaeVirtToPhysNUMA(pOpData);
+          pOpData->instanceHandle = qcc_inst->cy_inst_handles[avail_inst];
+          pOpData->sessionCtx = qcc_op_mem[avail_inst].sess_ctx[request_num];
+          pOpData->pCallbackTag = (void *)handle;
+          pOpData->cryptoStartSrcOffsetInBytes = 0;
+          pOpData->messageLenToCipherInBytes = process_size;
+          pOpData->iv = qaeVirtToPhysNUMA(pIvBuffer);
+          pOpData->pIv = pIvBuffer;
+          pOpData->ivLenInBytes = AES_256_IV_LEN;
+          pOpData->srcBuffer = qaeVirtToPhysNUMA(pSrcBuffer);
+          pOpData->srcBufferLen = process_size;
+          pOpData->dstBuffer = qaeVirtToPhysNUMA(pSrcBuffer);
+          pOpData->dstBufferLen = process_size;
+
+          status = cpaCySymDpEnqueueOp(pOpData, CPA_FALSE);
+          if (unlikely(CPA_STATUS_SUCCESS != status)) {
+            dout(1) << "cpaCySymDpEnqueueOp failed. (status = " << status << ")" << dendl;
+            // submit all request, clean the queue
+            cpaCySymDpPerformOpNow(qcc_inst->cy_inst_handles[avail_inst]);
+            return false;
+          }
+        }
+        qcc_op_mem_index++;
+      }
+      request_num++;
+      remain_size = chunk_size * (MAX_NUM_SYM_REQ_BATCH - qcc_op_mem_index);
+      if (qcc_op_mem_index >= MAX_NUM_SYM_REQ_BATCH) {
+          break;
+      }
+    }
+  }
+
+
+  if (likely(CPA_STATUS_SUCCESS == status)) {
+    status = cpaCySymDpPerformOpNow(qcc_inst->cy_inst_handles[avail_inst]);
+    if (unlikely(CPA_STATUS_SUCCESS != status)) {
+      dout(1) << "cpaCySymDpPerformOpNow failed. (status = " << status << ")" << dendl;
+	    return false;
+    }
+  }
+
   return (status == CPA_STATUS_SUCCESS);
 }


### PR DESCRIPTION
QAT is not friendly to the acceleration of object smaller than 32KB. Using queue and batch mode can make the advantages of QAT play out.

Signed-off-by: Feng, Hualong <hualong.feng@intel.com>




## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
