### PR TITLE
test/osd/RadosModel: Improve error debugging

### DIFF
--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1232,7 +1232,8 @@ public:
 
       context->update_object_version(oid, version);
       ceph_assert(rcompletion->is_complete());
-      ceph_assert(rcompletion->get_return_value() == 1);
+      int r = rcompletion->get_return_value();
+      assertf(r >= 0, "r = %d", r);
       if (rcompletion->get_version64() != version) {
 	std::cerr << "Error: racing read on " << oid << " returned version "
 		  << rcompletion->get_version64() << " rather than version "

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1243,6 +1243,8 @@ public:
           std::cout << "oid " << oid << "version " << version
                     << "is already newer than " << (*i)->get_version64() << std::endl;
         }
+	(*i)->release();
+	waiting.erase(i++);
       }
 
       context->update_object_version(oid, version);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1052,8 +1052,14 @@ public:
 	  std::cerr << "Error: oid " << oid << " write returned error code "
 		    << err << std::endl;
 	}
-	if ((*i)->get_version64() > version)
+	if ((*i)->get_version64() > version) {
+          std::cout << num << ":  oid " << oid << " updating version " << version
+                    << " to " << (*i)->get_version64() << std::endl;
 	  version = (*i)->get_version64();
+        } else {
+          std::cout << num << ":  oid " << oid << " version " << version
+                    << " is already newer than " << (*i)->get_version64() << std::endl;
+        }
 	(*i)->release();
 	waiting.erase(i++);
       }
@@ -1227,10 +1233,14 @@ public:
 	  std::cerr << "Error: oid " << oid << " writesame returned error code "
 	       << err << std::endl;
 	}
-	if ((*i)->get_version64() > version)
+	if ((*i)->get_version64() > version) {
+          std::cout << "oid " << oid << "updating version " << version
+                    << "to " << (*i)->get_version64() << std::endl;
 	  version = (*i)->get_version64();
-	(*i)->release();
-	waiting.erase(i++);
+        } else {
+          std::cout << "oid " << oid << "version " << version
+                    << "is already newer than " << (*i)->get_version64() << std::endl;
+        }
       }
 
       context->update_object_version(oid, version);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1051,6 +1051,7 @@ public:
 	if (int err = (*i)->get_return_value()) {
 	  std::cerr << "Error: oid " << oid << " write returned error code "
 		    << err << std::endl;
+          ceph_abort();
 	}
 	if ((*i)->get_version64() > version) {
           std::cout << num << ":  oid " << oid << " updating version " << version
@@ -1232,6 +1233,7 @@ public:
 	if (int err = (*i)->get_return_value()) {
 	  std::cerr << "Error: oid " << oid << " writesame returned error code "
 	       << err << std::endl;
+          ceph_abort();
 	}
 	if ((*i)->get_version64() > version) {
           std::cout << "oid " << oid << "updating version " << version


### PR DESCRIPTION
* `WriteSameOp`: fixed assertion, we should except a non-negative return value. Otherwise, when testing `writesame` ops:
   ```
   257:  finishing writesame tid 6 to folio03576882-188
   update_object_version oid 188 v 149 (ObjNum 256 snap 0 seq_num 256) dirty exists
   ../src/test/osd/RadosModel.h: In function 'virtual void WriteSameOp::_finish(TestOp::CallbackInfo*)' thread 7fea1a517700 time 
   2022-08-31T14:08:14.309528+0000
   ../src/test/osd/RadosModel.h: 1237: FAILED ceph_assert(rcompletion->get_return_value() == 1)
   ```
   Intoduced: 8dd6d9151dd8b83626e415e2004de5ef00eac20b

* `WriteOp`: In similarity to `writesame` asserts, this change could allow us to have a better understanding on why read got a wrong version.

* Abort on returned error codes.

* Add verbosity to track version updates:
  ```
  998:  finishing write tid 3 to folio031439332-140
  998:  finishing write tid 4 to folio031439332-140
  998:  finishing write tid 5 to folio031439332-140
  998:  oid 140 updating version 0 to 283
  998:  oid 140 version 283 is already newer than 281
  998:  oid 140 version 283 is already newer than 282
  998:  oid 140 version 283 is already newer than 280
  ```

* `WriteSameOp`: fixed infinite loop, iterating through `waiting` without erasing elements.
 

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
