### PR TITLE
selinux: prepare for anon inode controls enablement

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -75,6 +75,9 @@ manage_lnk_files_pattern(ceph_t, ceph_var_run_t, ceph_var_run_t)
 
 kernel_read_system_state(ceph_t)
 kernel_read_network_state(ceph_t)
+ifdef(`kernel_io_uring_use',`
+	kernel_io_uring_use(ceph_t)
+')
 allow ceph_t kernel_t:system module_request;
 
 corenet_all_recvfrom_unlabeled(ceph_t)


### PR DESCRIPTION
We plan to start labeling anon inodes (userfaultfd and io_uring file
descriptors) properly in selinux-policy, which means that domains using
these will need new rules.

See: https://github.com/fedora-selinux/selinux-policy/pull/1351

Since ceph may optionally use io_uring, this patch adds the necessary
interface call to its policy to avoid a regression. As the new interface
call is put under a conditional, the policy package will be buildable
against selinux-policy with or without the above PR merged, but it will
need to be rebuilt against the updated selinux-policy to actually pick
up the new rules.

I tested this on a minimal ceph cluster with 'bdev_ioring = true' added
to ceph.conf. I got io_uring denials without this patch + with
selinux-policy with PR#1351 and no denials with ceph rebuilt with this
patch.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>