### PR TITLE
cmake: add fixture for setting ip-local-port-range 

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -599,12 +599,10 @@ endif()
 if(WITH_RBD)
   # Run rbd-unit-tests separate so they an run in parallel
   # For values see: src/include/rbd/features.h
-  add_ceph_test(run-rbd-unit-tests-N.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh N)
-  add_ceph_test(run-rbd-unit-tests-0.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 0)
-  add_ceph_test(run-rbd-unit-tests-1.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 1)
-  add_ceph_test(run-rbd-unit-tests-61.sh  ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 61)
-  add_ceph_test(run-rbd-unit-tests-109.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 109)
-  add_ceph_test(run-rbd-unit-tests-127.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 127)
+  foreach(features N 0 1 61 109 127)
+    add_ceph_test(run-rbd-unit-tests-${features}.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh ${features})
+  endforeach()
   if(FREEBSD)
     add_ceph_test(rbd-ggate.sh ${CMAKE_CURRENT_SOURCE_DIR}/rbd-ggate.sh)
   endif(FREEBSD)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -599,9 +599,19 @@ endif()
 if(WITH_RBD)
   # Run rbd-unit-tests separate so they an run in parallel
   # For values see: src/include/rbd/features.h
+  add_test(NAME increase-local-port-range
+    COMMAND sudo sysctl -w net.ipv4.ip_local_port_range="1024 65535")
+  set_property(TEST increase-local-port-range PROPERTY
+    FIXTURES_SETUP more-local-ports)
+  add_test(NAME restore-local-port-range
+    COMMAND sudo sysctl -w net.ipv4.ip_local_port_range="32768 60999")
+  set_property(TEST restore-local-port-range PROPERTY
+    FIXTURES_CLEANUP more-local-ports)
   foreach(features N 0 1 61 109 127)
     add_ceph_test(run-rbd-unit-tests-${features}.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh ${features})
+    set_property(TEST run-rbd-unit-tests-${features}.sh PROPERTY
+      FIXTURES_REQUIRED more-local-ports)
   endforeach()
   if(FREEBSD)
     add_ceph_test(rbd-ggate.sh ${CMAKE_CURRENT_SOURCE_DIR}/rbd-ggate.sh)


### PR DESCRIPTION
in case we are running out of available ports while performing tests.

Fixes: https://tracker.ceph.com/issues/57116
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
