### PR TITLE
pacific: doc/mgr: update prompts in dboard.rst includes

### DIFF
--- a/doc/mgr/dashboard_plugins/debug.inc.rst
+++ b/doc/mgr/dashboard_plugins/debug.inc.rst
@@ -4,13 +4,30 @@ Debug
 ^^^^^
 
 This plugin allows to customize the behaviour of the dashboard according to the
-debug mode. It can be enabled, disabled or checked with the following command::
+debug mode. It can be enabled, disabled or checked with the following command:
 
-  $ ceph dashboard debug status
+.. prompt:: bash $
+
+   ceph dashboard debug status
+
+::
+
   Debug: 'disabled'
-  $ ceph dashboard debug enable
+
+.. prompt:: bash $
+
+   ceph dashboard debug enable
+
+::
+
   Debug: 'enabled'
-  $ ceph dashboard debug disable
+
+.. prompt:: bash $
+
+   ceph dashboard debug disable
+
+::
+
   Debug: 'disabled'
 
 By default, it's disabled. This is the recommended setting for production

--- a/doc/mgr/dashboard_plugins/feature_toggles.inc.rst
+++ b/doc/mgr/dashboard_plugins/feature_toggles.inc.rst
@@ -25,9 +25,14 @@ The list of features that can be enabled/disabled is:
 
 By default all features come enabled.
 
-To retrieve a list of features and their current statuses::
+To retrieve a list of features and their current statuses:
 
-  $ ceph dashboard feature status
+.. prompt:: bash $
+
+   ceph dashboard feature status
+
+::
+
   Feature 'cephfs': 'enabled'
   Feature 'iscsi': 'enabled'
   Feature 'mirroring': 'enabled'
@@ -35,9 +40,14 @@ To retrieve a list of features and their current statuses::
   Feature 'rgw': 'enabled'
   Feature 'nfs': 'enabled'
 
-To enable or disable the status of a single or multiple features::
+To enable or disable the status of a single or multiple features:
 
-  $ ceph dashboard feature disable iscsi mirroring
+.. prompt:: bash $
+
+   ceph dashboard feature disable iscsi mirroring
+
+:: 
+
   Feature 'iscsi': disabled
   Feature 'mirroring': disabled
 

--- a/doc/mgr/dashboard_plugins/motd.inc.rst
+++ b/doc/mgr/dashboard_plugins/motd.inc.rst
@@ -12,17 +12,23 @@ syntax to specify the expiration time: `Ns|m|h|d|w` for seconds, minutes,
 hours, days and weeks. If the MOTD should expire after 2 hours, use `2h`
 or `5w` for 5 weeks. Use `0` to configure a MOTD that does not expire.
 
-To configure a MOTD, run the following command::
+To configure a MOTD, run the following command:
 
-  $ ceph dashboard motd set <severity:info|warning|danger> <expires> <message>
+.. prompt:: bash $
 
-To show the configured MOTD::
+   ceph dashboard motd set <severity:info|warning|danger> <expires> <message>
 
-  $ ceph dashboard motd get
+To show the configured MOTD:
 
-To clear the configured MOTD run::
+.. prompt:: bash $
 
-  $ ceph dashboard motd clear
+   ceph dashboard motd get
+
+To clear the configured MOTD run:
+
+.. prompt:: bash $
+
+   ceph dashboard motd clear
 
 A MOTD with a `info` or `warning` severity can be closed by the user. The
 `info` MOTD is not displayed anymore until the local storage cookies are


### PR DESCRIPTION
This PR adds unselectable prompts to three files that are
transcluded in the doc/mgr/dashboard.rst file. These three
files are:

 1. debug.inc.rst
 2. feature_toggles.inc.rst
 3. motd.inc.rst

The addition of unselectable prompts to these three files
completes the work begun in PR#47810 (d8064b4), which sought
to bring dashboard.rst into line with the unselectable prompt
standard introduced by Kefu Chai in 2020.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit fc70ccde758cb1f7c03f208115b88a4ef325aed7)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
