### PR TITLE
dokan: switch to Dokany v2

### DIFF
--- a/README.windows.rst
+++ b/README.windows.rst
@@ -103,8 +103,7 @@ In order to mount Ceph filesystems, you will have to install Dokany.
 You may fetch the installer as well as the source code from the Dokany
 Github repository: https://github.com/dokan-dev/dokany/releases
 
-The minimum supported Dokany version is 1.3.1. At the time of the writing,
-Dokany 2.0 is in Beta stage and is unsupported.
+Make sure to install Dokany 2.0.5 or later.
 
 In order to map RBD images, the ``WNBD`` driver must be installed. Please
 check out this page for more details about ``WNBD`` and the install process:

--- a/doc/install/windows-install.rst
+++ b/doc/install/windows-install.rst
@@ -34,8 +34,7 @@ In order to mount Ceph filesystems, ``ceph-dokan`` requires Dokany to be
 installed. You may fetch the installer as well as the source code from the
 Dokany GitHub repository: https://github.com/dokan-dev/dokany/releases
 
-The minimum supported Dokany version is 1.3.1. At the time of the writing,
-Dokany 2.0 is in Beta stage and is unsupported.
+Make sure to install Dokany 2.0.5 or later.
 
 Unlike ``WNBD``, Dokany isn't included in the Ceph MSI installer.
 

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -953,6 +953,8 @@ int do_map() {
   dout(0) << "Mounted cephfs directory: " << g_cfg->root_path.c_str()
           <<". Mountpoint: " << to_string(g_cfg->mountpoint) << dendl;
 
+  DokanInit();
+
   DWORD status = DokanMain(dokan_options, dokan_operations);
   switch (static_cast<int>(status)) {
   case DOKAN_SUCCESS:
@@ -980,6 +982,8 @@ int do_map() {
     derr << "Unknown Dokan error: " << status << dendl;
     break;
   }
+
+  DokanShutdown();
 
   free(dokan_options);
   free(dokan_operations);

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #define CEPH_DOKAN_IO_DEFAULT_TIMEOUT 60 * 5 // Seconds
-#define CEPH_DOKAN_DEFAULT_THREAD_COUNT 10
 
 // Avoid conflicting COM types, exposed when using C++.
 #define _OLE2_H_
@@ -28,7 +27,6 @@ struct Config {
   bool dokan_stderr = false;
 
   int operation_timeout = CEPH_DOKAN_IO_DEFAULT_TIMEOUT;
-  int thread_count = CEPH_DOKAN_DEFAULT_THREAD_COUNT;
 
   std::wstring mountpoint = L"";
   std::string root_path = "/";

--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -29,7 +29,6 @@ Map options:
   -l [ --mountpoint ] arg     mountpoint (path or drive letter) (e.g -l x)
   -x [ --root-path ] arg      mount a Ceph filesystem subdirectory
 
-  -t [ --thread-count] arg    thread count
   --operation-timeout arg     Dokan operation timeout. Default: 120s.
 
   --debug                     enable debug output
@@ -85,6 +84,8 @@ int parse_args(
   std::string mountpoint;
   std::string win_vol_name;
 
+  int thread_count;
+
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
       *command = Command::Help;
@@ -111,16 +112,10 @@ int parse_args(
       cfg->win_vol_name = to_wstring(win_vol_name);
     } else if (ceph_argparse_flag(args, i, "--current-session-only", (char *)NULL)) {
       cfg->current_session_only = true;
-    } else if (ceph_argparse_witharg(args, i, (int*)&cfg->thread_count,
+    } else if (ceph_argparse_witharg(args, i, &thread_count,
                                      err, "--thread-count", "-t", (char *)NULL)) {
-      if (!err.str().empty()) {
-        *err_msg << "ceph-dokan: " << err.str();
-        return -EINVAL;
-      }
-      if (cfg->thread_count < 0) {
-        *err_msg << "ceph-dokan: Invalid argument for thread-count";
-        return -EINVAL;
-      }
+      std::cerr << "ceph-dokan: the thread count parameter is not supported by Dokany v2 "
+                << "and has been deprecated." << std::endl;
     } else if (ceph_argparse_witharg(args, i, (int*)&cfg->operation_timeout,
                                      err, "--operation-timeout", (char *)NULL)) {
       if (!err.str().empty()) {
@@ -187,7 +182,6 @@ int parse_args(
 int set_dokan_options(Config *cfg, PDOKAN_OPTIONS dokan_options) {
   ZeroMemory(dokan_options, sizeof(DOKAN_OPTIONS));
   dokan_options->Version = DOKAN_VERSION;
-  dokan_options->ThreadCount = cfg->thread_count;
   dokan_options->MountPoint = cfg->mountpoint.c_str();
   dokan_options->Timeout = cfg->operation_timeout * 1000;
 

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -43,7 +43,7 @@ wnbdSrcDir="${depsSrcDir}/wnbd"
 wnbdLibDir="${depsToolsetDir}/wnbd/lib"
 
 dokanUrl="https://github.com/dokan-dev/dokany"
-dokanTag="v1.3.1.1000"
+dokanTag="v2.0.5.1000"
 dokanSrcDir="${depsSrcDir}/dokany"
 dokanLibDir="${depsToolsetDir}/dokany/lib"
 


### PR DESCRIPTION
dokan: switch to Dokany v2
    
The stable version of Dokany v2 has been released. It introduces new
features and performance improvements, plus v1 is likely going
to be deprecated eventually.

As per this document[1], there are very few changes that we need to
make in order to use Dokany v2.

That being said, we're now bumping the Dokany requirement to
2.0.5.1000 (latest).

[1] https://github.com/dokan-dev/dokany/wiki/Update-Dokan-1.1.0-application-to-Dokany-2.0.0

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
