### PR TITLE
[Copy-Object API] : (IAM policy) Added checks for tagging permissions in verify permission.

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1485,6 +1485,29 @@ public:
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
+enum class TaggingPermission : short {
+NO_TAGGING_PERM,
+PUT_TAGGING_PERM,
+GET_TAGGING_PERM
+};
+
+enum class TaggingDirective {
+NO_TAGGING_DIRECTIVE,
+COPY_TAGGING_DIRECTIVE,
+REPLACE_TAGGING_DIRECTIVE
+};
+
+constexpr TaggingPermission& operator|=(TaggingPermission& lhs, TaggingPermission rhs) {
+    using TaggingPermissionType = std::underlying_type<TaggingPermission>::type;
+    return lhs = TaggingPermission( static_cast<TaggingPermissionType>(lhs) | static_cast<TaggingPermissionType>(rhs));
+}
+
+constexpr TaggingPermission operator|(TaggingPermission lhs, TaggingPermission rhs) {
+    TaggingPermission tg;
+    using TaggingPermissionType = std::underlying_type<TaggingPermission>::type;
+    return  tg = TaggingPermission( static_cast<TaggingPermissionType>(lhs) | static_cast<TaggingPermissionType>(rhs));
+}
+
 class RGWCopyObj : public RGWOp {
 protected:
   RGWAccessControlPolicy dest_policy;


### PR DESCRIPTION
Problem : Tagging permissions are not handled while checking IAM policy for Copy object API

Solution : Handled tagging permissions while checking IAM policy in RGWCopyObj::verify_permission() function.

Signed-off-by: shraddhaghatol <shraddha.j.ghatol@seagate.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
