### PR TITLE
[DNM] pacific: osd/PeeringState: fix missed recheck_readable from laggy

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1243,8 +1243,8 @@ void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
 	  was_min = true;
 	}
 	acting_readable_until_ub[i] = a.readable_until_ub;
-	break;
       }
+      break;
     }
   }
   if (was_min) {

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1250,7 +1250,7 @@ void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
   if (was_min) {
     auto old_ru = readable_until;
     recalc_readable_until();
-    if (now < old_ru) {
+    if (now >= old_ru) {
       pl->recheck_readable();
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56734

---

backport of https://github.com/ceph/ceph/pull/44499
parent tracker: https://tracker.ceph.com/issues/53806

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh