### PR TITLE
examples/librados: Compile with c++20 on Ubuntu

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,6 +1,6 @@
 
 CXX?=g++
-CXX_FLAGS?=-std=c++11 -Wno-unused-parameter -Wall -Wextra -Werror -g
+CXX_FLAGS+=-Wno-unused-parameter -Wall -Wextra -Werror -g
 CXX_LIBS?=-lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)

--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -28,9 +28,21 @@ function distro_version() {
 }
 
 function install() {
+    if [ $(distro_id) = "ubuntu" ]; then
+        sudo apt-get purge -y gcc
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    fi
     for package in "$@" ; do
         install_one $package
     done
+    if [ $(distro_id) = "ubuntu" ]; then
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 11
+        sudo update-alternatives --set cc /usr/bin/gcc
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 11
+        sudo update-alternatives --set c++ /usr/bin/g++
+    fi
 }
 
 function install_one() {

--- a/qa/workunits/rados/test_librados_build.sh
+++ b/qa/workunits/rados/test_librados_build.sh
@@ -71,7 +71,10 @@ pushd $DESTDIR
 case $(distro_id) in
     centos|fedora|rhel|opensuse*|suse|sles)
         install gcc-c++ make libradospp-devel librados-devel;;
-    ubuntu|debian|devuan|softiron)
+    ubuntu)
+        install gcc-11 g++-11 make libradospp-dev librados-dev
+        export CXX_FLAGS="-std=c++20";;
+    debian|devuan|softiron)
         install g++ make libradospp-dev librados-dev;;
     *)
         echo "$(distro_id) is unknown, $@ will have to be installed manually."


### PR DESCRIPTION
Kudos to @jdurgin 

Fixes: https://tracker.ceph.com/issues/57163

Verified fix on Ubuntu, CentOS and RHEL.

https://pulpito.ceph.com/matan-2022-09-05_08:24:48-rados:singleton-nomsgr-main-distro-default-smithi/
Tested against fork: https://github.com/Matan-B/ceph/commit/dc9cb4a9995476c5269a546fcc618a1c23ab055b

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
