### PR TITLE
rgw: fix d3n crash in StoreManager::get_config()

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -304,8 +304,8 @@ StoreManager::Config StoreManager::get_config(bool admin, CephContext* cct)
     /* Check to see if d3n is configured, but only for non-admin */
     const auto& d3n = g_conf().get_val<bool>("rgw_d3n_l1_local_datacache_enabled");
     if (!admin && d3n) {
-      if (g_conf().get_val<size_t>("rgw_max_chunk_size") !=
-	  g_conf().get_val<size_t>("rgw_obj_stripe_size")) {
+      if (g_conf().get_val<Option::size_t>("rgw_max_chunk_size") !=
+	  g_conf().get_val<Option::size_t>("rgw_obj_stripe_size")) {
 	lsubdout(cct, rgw_datacache, 0) << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires that the chunk_size equals stripe_size)" << dendl;
       } else if (!g_conf().get_val<bool>("rgw_beast_enable_async")) {
 	lsubdout(cct, rgw_datacache, 0) << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires yield context - rgw_beast_enable_async=true)" << dendl;


### PR DESCRIPTION
config options with `type: size` are not actually `size_t` but `uint64_t`, so accessing them with `get_val<size_t>()` leads to a `bad_variant_access` exception. use the `Option::size_t` type instead

Fixes: https://tracker.ceph.com/issues/57195

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
