### PR TITLE
quincy: qa/cephadm: specify using container host distros for workunits

### DIFF
--- a/qa/suites/orch/cephadm/workunits/0-distro
+++ b/qa/suites/orch/cephadm/workunits/0-distro
@@ -1,0 +1,1 @@
+.qa/distros/container-hosts


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57314

---

backport of https://github.com/ceph/ceph/pull/47674
parent tracker: https://tracker.ceph.com/issues/57303

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh