### PR TITLE
quincy: include: fix IS_ERR on Windows

### DIFF
--- a/src/include/err.h
+++ b/src/include/err.h
@@ -5,10 +5,11 @@
  * adapted from linux 2.6.24 include/linux/err.h
  */
 #define MAX_ERRNO 4095
-#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+#define IS_ERR_VALUE(x) ((x) >= (uintptr_t)-MAX_ERRNO)
 
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* this generates a warning in c++; caller can do the cast manually
 static inline void *ERR_PTR(long error)
@@ -17,12 +18,12 @@ static inline void *ERR_PTR(long error)
 }
 */
 
-static inline long PTR_ERR(const void *ptr)
+static inline intptr_t PTR_ERR(const void *ptr)
 {
-  return (uintptr_t) ptr;
+  return (intptr_t) ptr;
 }
 
-static inline long IS_ERR(const void *ptr)
+static inline bool IS_ERR(const void *ptr)
 {
   return IS_ERR_VALUE((uintptr_t)ptr);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57402

---

backport of https://github.com/ceph/ceph/pull/47818
parent tracker: https://tracker.ceph.com/issues/57308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh