### PR TITLE
denc: support non-c++20 compliant C++ standard library

### DIFF
--- a/src/include/cpp_lib_backport.h
+++ b/src/include/cpp_lib_backport.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstring>
+#include <type_traits>
+
+namespace std {
+
+#ifndef __cpp_lib_bit_cast
+#define __cpp_lib_bit_cast 201806L
+
+/// Create a value of type `To` from the bits of `from`.
+template<typename To, typename From>
+requires (sizeof(To) == sizeof(From)) &&
+         std::is_trivially_copyable_v<From> &&
+         std::is_trivially_copyable_v<To>
+[[nodiscard]] constexpr To
+bit_cast(const From& from) noexcept {
+#if __has_builtin(__builtin_bit_cast)
+  return __builtin_bit_cast(To, from);
+#else
+  static_assert(std::is_trivially_constructible_v<To>);
+  To to;
+  std::memcpy(&to, &from, sizeof(To));
+  return to;
+#endif
+}
+
+#endif // __cpp_lib_bit_cast
+
+} // namespace std

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -41,6 +41,7 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/optional.hpp>
 
+#include "include/cpp_lib_backport.h"
 #include "include/compat.h"
 #include "include/int_types.h"
 #include "include/scope_guard.h"


### PR DESCRIPTION
when compiling with the standard library comes with GCC-10, we have
FTBFS like:

```
src/include/denc.h:517:49: error: 'bit_cast' is not a member of 'std';
did you mean 'bad_cast'?
  517 |   unsigned lowznib = v ?
      (std::countr_zero(std::bit_cast<uint64_t>(v)) / 4) : 0u;
      |                                                 ^~~~~~~~
      |                                                 bad_cast
```

to address this issue, an implementation of std::bit_cast<> is defined
if it is not available. in the long run, we should use a better C++
compiler for compiling the tree.

Fixes: https://tracker.ceph.com/issues/57355
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
