### PR TITLE
quincy: osd: add scrub duration for scrubs after recovery

### DIFF
--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -104,6 +104,14 @@ sc::result NotActive::react(const StartScrub&)
   return transit<ReservingReplicas>();
 }
 
+sc::result NotActive::react(const AfterRepairScrub&)
+{
+  dout(10) << "NotActive::react(const AfterRepairScrub&)" << dendl;
+  DECLARE_LOCALS;
+  scrbr->set_scrub_begin_time();
+  return transit<ReservingReplicas>();
+}
+
 // ----------------------- ReservingReplicas ---------------------------------
 
 ReservingReplicas::ReservingReplicas(my_context ctx) : my_base(ctx)

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -154,12 +154,12 @@ struct NotActive : sc::state<NotActive, ScrubMachine> {
   explicit NotActive(my_context ctx);
 
   using reactions = mpl::list<sc::custom_reaction<StartScrub>,
-			      // a scrubbing that was initiated at recovery completion,
-			      // and requires no resource reservations:
-			      sc::transition<AfterRepairScrub, ReservingReplicas>,
+			      // a scrubbing that was initiated at recovery completion
+			      sc::custom_reaction<AfterRepairScrub>,
 			      sc::transition<StartReplica, ReplicaWaitUpdates>,
 			      sc::transition<StartReplicaNoWait, ActiveReplica>>;
   sc::result react(const StartScrub&);
+  sc::result react(const AfterRepairScrub&);
 };
 
 struct ReservingReplicas : sc::state<ReservingReplicas, ScrubMachine> {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55282

---

backport of https://github.com/ceph/ceph/pull/45599
parent tracker: https://tracker.ceph.com/issues/54994

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh