### PR TITLE
quincy: test/lazy-omap-stats: Various enhancements

### DIFF
--- a/src/test/lazy-omap-stats/CMakeLists.txt
+++ b/src/test/lazy-omap-stats/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(ceph_test_lazy_omap_stats
   main.cc
   lazy_omap_stats_test.cc)
 target_link_libraries(ceph_test_lazy_omap_stats
-  librados Boost::system ${UNITTEST_LIBS})
+  librados Boost::system ceph-common ${UNITTEST_LIBS})
 install(TARGETS
   ceph_test_lazy_omap_stats
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.h
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.h
@@ -39,9 +39,15 @@ class LazyOmapStatsTest
     unsigned keys = 2000;
     unsigned how_many = 50;
     std::string pool_name = "lazy_omap_test_pool";
+    std::string pool_id;
     unsigned total_bytes = 0;
     unsigned total_keys = 0;
   } conf;
+
+  typedef enum {
+    TARGET_MON,
+    TARGET_MGR
+  } CommandTarget;
 
   LazyOmapStatsTest(LazyOmapStatsTest&) = delete;
   void operator=(LazyOmapStatsTest) = delete;
@@ -51,7 +57,7 @@ class LazyOmapStatsTest
   const std::string get_name() const;
   void create_payload();
   void write_many(const unsigned how_many);
-  void scrub() const;
+  void scrub();
   const int find_matches(std::string& output, std::regex& reg) const;
   void check_one();
   const int find_index(std::string& haystack, std::regex& needle,
@@ -61,7 +67,6 @@ class LazyOmapStatsTest
   void check_column(const int index, const std::string& table,
                     const std::string& type, bool header = true) const;
   index_t get_indexes(std::regex& reg, std::string& output) const;
-  const std::string get_pool_id(std::string& pool);
   void check_pg_dump();
   void check_pg_dump_summary();
   void check_pg_dump_pgs();
@@ -69,7 +74,10 @@ class LazyOmapStatsTest
   void check_pg_ls();
   const std::string get_output(
       const std::string command = R"({"prefix": "pg dump"})",
-      const bool silent = false);
+      const bool silent = false,
+      const CommandTarget target = CommandTarget::TARGET_MGR);
+  void get_pool_id(const std::string& pool);
+  std::map<std::string, std::string> get_scrub_stamps();
   void wait_for_active_clean();
 
  public:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57209

---

backport of https://github.com/ceph/ceph/pull/39980
parent tracker: https://tracker.ceph.com/issues/49727

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh