### PR TITLE
quincy: common/ceph_context: leak some memory fail to show in valgrind

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -502,6 +502,14 @@ int CephContext::do_command(std::string_view command, const cmdmap_t& cmdmap,
   }
 }
 
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+static void leak_some_memory() {
+  volatile char *foo = new char[1234];
+  (void)foo;
+}
+#pragma GCC pop_options
+
 int CephContext::_do_command(
   std::string_view command, const cmdmap_t& cmdmap,
   Formatter *f,
@@ -520,8 +528,7 @@ int CephContext::_do_command(
     }
   }
   if (command == "leak_some_memory") {
-    char *foo = new char[1234];
-    (void)foo;
+    leak_some_memory();
   }
   else if (command == "perfcounters_dump" || command == "1" ||
       command == "perf dump") {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57346

---

backport of https://github.com/ceph/ceph/pull/47802
parent tracker: https://tracker.ceph.com/issues/57165

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh