### PR TITLE
mgr/nfs: add sectype option

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -262,7 +262,7 @@ Create CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>]
+    $ ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>] [--sectype <value>...]
 
 This creates export RADOS objects containing the export block, where
 
@@ -289,6 +289,18 @@ for permissible values.
 value is `no_root_squash`. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
 
+``<sectype>`` specifies which authentication methods will be used when
+connecting to the export. Valid values include "krb5p", "krb5i", "krb5", "sys",
+and "none". More than one value can be supplied. The flag may be specified
+multiple times (example: ``--sectype=krb5p --sectype=krb5i``) or multiple
+values may be separated by a comma (example: ``--sectype krb5p,krb5i``). The
+server will negotatiate a supported security type with the client preferring
+the supplied methods left-to-right.
+
+.. note:: Specifying values for sectype that require Kerberos will only function on servers
+          that are configured to support Kerberos. Setting up NFS-Ganesha to support Kerberos
+          is outside the scope of this document.
+
 .. note:: Export creation is supported only for NFS Ganesha clusters deployed using nfs interface.
 
 Create RGW Export
@@ -308,7 +320,7 @@ To export a *bucket*:
 
 .. code::
 
-   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>]
+   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>] [--sectype <value>...]
 
 For example, to export *mybucket* via NFS cluster *mynfs* at the pseudo-path */bucketdata* to any host in the ``192.168.10.0/24`` network
 
@@ -338,6 +350,18 @@ for permissible values.
 ``<squash>`` defines the kind of user id squashing to be performed. The default
 value is `no_root_squash`. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
+
+``<sectype>`` specifies which authentication methods will be used when
+connecting to the export. Valid values include "krb5p", "krb5i", "krb5", "sys",
+and "none". More than one value can be supplied. The flag may be specified
+multiple times (example: ``--sectype=krb5p --sectype=krb5i``) or multiple
+values may be separated by a comma (example: ``--sectype krb5p,krb5i``). The
+server will negotatiate a supported security type with the client preferring
+the supplied methods left-to-right.
+
+.. note:: Specifying values for sectype that require Kerberos will only function on servers
+          that are configured to support Kerberos. Setting up NFS-Ganesha to support Kerberos
+          is outside the scope of this document.
 
 RGW user export
 ^^^^^^^^^^^^^^^

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -635,7 +635,8 @@ class ExportMgr:
                              path: str,
                              squash: str,
                              access_type: str,
-                             clients: list = []) -> Tuple[int, str, str]:
+                             clients: list = [],
+                             sectype: Optional[List[str]] = None) -> Tuple[int, str, str]:
         pseudo_path = normalize_path(pseudo_path)
 
         if not self._fetch_export(cluster_id, pseudo_path):
@@ -652,6 +653,7 @@ class ExportMgr:
                         "fs_name": fs_name,
                     },
                     "clients": clients,
+                    "sectype": sectype,
                 }
             )
             log.debug("creating cephfs export %s", export)
@@ -675,7 +677,8 @@ class ExportMgr:
                           squash: str,
                           bucket: Optional[str] = None,
                           user_id: Optional[str] = None,
-                          clients: list = []) -> Tuple[int, str, str]:
+                          clients: list = [],
+                          sectype: Optional[List[str]] = None) -> Tuple[int, str, str]:
         pseudo_path = normalize_path(pseudo_path)
 
         if not bucket and not user_id:
@@ -695,6 +698,7 @@ class ExportMgr:
                         "user_id": user_id,
                     },
                     "clients": clients,
+                    "sectype": sectype,
                 }
             )
             log.debug("creating rgw export %s", export)

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -46,6 +46,13 @@ def _validate_access_type(access_type: str) -> None:
         )
 
 
+def _validate_sec_type(sec_type: str) -> None:
+    valid_sec_types = ["none", "sys", "krb5", "krb5i", "krb5p"]
+    if not isinstance(sec_type, str) or sec_type not in valid_sec_types:
+        raise NFSInvalidOperation(
+            f"SecType {sec_type} invalid, valid types are {valid_sec_types}")
+
+
 class RawBlock():
     def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
         if not values:  # workaround mutable default argument
@@ -355,7 +362,8 @@ class Export:
             protocols: List[int],
             transports: List[str],
             fsal: FSAL,
-            clients: Optional[List[Client]] = None) -> None:
+            clients: Optional[List[Client]] = None,
+            sectype: Optional[List[str]] = None) -> None:
         self.export_id = export_id
         self.path = path
         self.fsal = fsal
@@ -368,6 +376,7 @@ class Export:
         self.protocols = protocols
         self.transports = transports
         self.clients: List[Client] = clients or []
+        self.sectype = sectype
 
     @classmethod
     def from_export_block(cls, export_block: RawBlock, cluster_id: str) -> 'Export':
@@ -387,6 +396,11 @@ class Export:
         elif not transports:
             transports = []
 
+        # if this module wrote the ganesha conf the param is camelcase
+        # "SecType".  but for compatiblity with manually edited ganesha confs,
+        # accept "sectype" too.
+        sectype = (export_block.values.get("SecType")
+                   or export_block.values.get("sectype") or None)
         return cls(export_block.values['export_id'],
                    export_block.values['path'],
                    cluster_id,
@@ -398,10 +412,11 @@ class Export:
                    transports,
                    FSAL.from_fsal_block(fsal_blocks[0]),
                    [Client.from_client_block(client)
-                    for client in client_blocks])
+                    for client in client_blocks],
+                   sectype=sectype)
 
     def to_export_block(self) -> RawBlock:
-        result = RawBlock('EXPORT', values={
+        values = {
             'export_id': self.export_id,
             'path': self.path,
             'pseudo': self.pseudo,
@@ -411,7 +426,10 @@ class Export:
             'security_label': self.security_label,
             'protocols': self.protocols,
             'transports': self.transports,
-        })
+        }
+        if self.sectype:
+            values['SecType'] = self.sectype
+        result = RawBlock("EXPORT", values=values)
         result.blocks = [
             self.fsal.to_fsal_block()
         ] + [
@@ -432,10 +450,11 @@ class Export:
                    ex_dict.get('protocols', [4]),
                    ex_dict.get('transports', ['TCP']),
                    FSAL.from_dict(ex_dict.get('fsal', {})),
-                   [Client.from_dict(client) for client in ex_dict.get('clients', [])])
+                   [Client.from_dict(client) for client in ex_dict.get('clients', [])],
+                   sectype=ex_dict.get("sectype"))
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        values = {
             'export_id': self.export_id,
             'path': self.path,
             'cluster_id': self.cluster_id,
@@ -448,6 +467,9 @@ class Export:
             'fsal': self.fsal.to_dict(),
             'clients': [client.to_dict() for client in self.clients]
         }
+        if self.sectype:
+            values['sectype'] = self.sectype
+        return values
 
     def validate(self, mgr: 'Module') -> None:
         if not isabs(self.pseudo) or self.pseudo == "/":
@@ -486,6 +508,9 @@ class Export:
             pass
         else:
             raise NFSInvalidOperation('FSAL {self.fsal.name} not supported')
+
+        for st in (self.sectype or []):
+            _validate_sec_type(st)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Export):

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -34,6 +34,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             readonly: Optional[bool] = False,
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',
+            sectype: Optional[List[str]] = None,
     ) -> Tuple[int, str, str]:
         """Create a CephFS export"""
         return self.export_mgr.create_export(
@@ -45,6 +46,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             path=path,
             squash=squash,
             addr=client_addr,
+            sectype=sectype,
         )
 
     @CLICommand('nfs export create rgw', perm='rw')
@@ -57,6 +59,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             readonly: Optional[bool] = False,
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',
+            sectype: Optional[List[str]] = None,
     ) -> Tuple[int, str, str]:
         """Create an RGW export"""
         return self.export_mgr.create_export(
@@ -68,6 +71,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             read_only=readonly,
             squash=squash,
             addr=client_addr,
+            sectype=sectype,
         )
 
     @CLICommand('nfs export rm', perm='rw')

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -36,10 +36,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash: str = 'none',
     ) -> Tuple[int, str, str]:
         """Create a CephFS export"""
-        return self.export_mgr.create_export(fsal_type='cephfs', fs_name=fsname,
-                                             cluster_id=cluster_id, pseudo_path=pseudo_path,
-                                             read_only=readonly, path=path,
-                                             squash=squash, addr=client_addr)
+        return self.export_mgr.create_export(
+            fsal_type='cephfs',
+            fs_name=fsname,
+            cluster_id=cluster_id,
+            pseudo_path=pseudo_path,
+            read_only=readonly,
+            path=path,
+            squash=squash,
+            addr=client_addr,
+        )
 
     @CLICommand('nfs export create rgw', perm='rw')
     def _cmd_nfs_export_create_rgw(
@@ -53,11 +59,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash: str = 'none',
     ) -> Tuple[int, str, str]:
         """Create an RGW export"""
-        return self.export_mgr.create_export(fsal_type='rgw', bucket=bucket,
-                                             user_id=user_id,
-                                             cluster_id=cluster_id, pseudo_path=pseudo_path,
-                                             read_only=readonly, squash=squash,
-                                             addr=client_addr)
+        return self.export_mgr.create_export(
+            fsal_type='rgw',
+            bucket=bucket,
+            user_id=user_id,
+            cluster_id=cluster_id,
+            pseudo_path=pseudo_path,
+            read_only=readonly,
+            squash=squash,
+            addr=client_addr,
+        )
 
     @CLICommand('nfs export rm', perm='rw')
     def _cmd_nfs_export_rm(self, cluster_id: str, pseudo_path: str) -> Tuple[int, str, str]:


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/57404



Add the sectype argument, also for use as a CLI option, to the functions
that create nfs exports. NFS Ganesha can use the sectype configuration
option to decide what kind of security will be applied/required for
connection to an export.

The NFS-Ganesha option may be used to select kerberos integration in the
nfs client connection. If the option is not present in the configuration
dict, the option will not be present in the ganesha config blocks, just
as it was before.

NOTE: This option is only useful when Ganesha is configured along with
LDAP/Kerberos integration. Configuration of that integration is outside
the scope of these patches.


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
