### PR TITLE
quincy: test/encoding: verify that e.what() starts with expected str

### DIFF
--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -1,6 +1,7 @@
 #include "include/buffer.h"
 #include "include/encoding.h"
 
+#include <fmt/format.h>
 #include "gtest/gtest.h"
 
 using namespace std;
@@ -319,26 +320,27 @@ TEST(EncodingRoundTrip, Integers) {
   }
 }
 
-const char* expected_what[] = {
-  "void lame_decoder(int) no longer understand old encoding version 100 < 200: Malformed input",
-  "void lame_decoder(int) decode past end of struct encoding: Malformed input"
-};
-
-void lame_decoder(int which) {
-  switch (which) {
-  case 0:
-    throw buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, 100, 200));
-  case 1:
-    throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__));
-  }
-}
-
 TEST(EncodingException, Macros) {
-  for (unsigned i = 0; i < std::size(expected_what); i++) {
+  const struct {
+    buffer::malformed_input exc;
+    std::string expected_what;
+  } tests[] = {
+    {
+      DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, 100, 200),
+      fmt::format("{} no longer understand old encoding version 100 < 200: Malformed input",
+                  __PRETTY_FUNCTION__)
+    },
+    {
+      DECODE_ERR_PAST(__PRETTY_FUNCTION__),
+      fmt::format("{} decode past end of struct encoding: Malformed input",
+                  __PRETTY_FUNCTION__)
+    }
+  };
+  for (auto& [exec, expected_what] : tests) {
     try {
-      lame_decoder(i);
+      throw exec;
     } catch (const exception& e) {
-      ASSERT_NE(string(e.what()).find(expected_what[i]), string::npos);
+      ASSERT_NE(string(e.what()).find(expected_what), string::npos);
     }
   }
 }

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -334,11 +334,11 @@ void lame_decoder(int which) {
 }
 
 TEST(EncodingException, Macros) {
-  for (unsigned i = 0; i < sizeof(expected_what)/sizeof(expected_what[0]); i++) {
+  for (unsigned i = 0; i < std::size(expected_what); i++) {
     try {
       lame_decoder(i);
     } catch (const exception& e) {
-      ASSERT_EQ(string(expected_what[i]), string(e.what()));
+      ASSERT_NE(string(e.what()).find(expected_what[i]), string::npos);
     }
   }
 }


### PR DESCRIPTION
backport of #47217


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
