### PR TITLE
quincy: cephadm/mgr: adding logic to handle --no-overwrite for tuned profiles

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -267,7 +267,7 @@ Then apply the tuning profile with::
 This profile will then be written to ``/etc/sysctl.d/`` on each host matching the
 given placement and `sysctl --system` will be run on the host.
 
-.. note:: 
+.. note::
 
   The exact filename the profile will be written to is within ``/etc/sysctl.d/`` is
   ``<profile-name>-cephadm-tuned-profile.conf`` where <profile-name>
@@ -280,6 +280,11 @@ given placement and `sysctl --system` will be run on the host.
 
   These settings are applied only at the host level, and are not specific
   to any certain daemon or container
+
+.. note::
+
+  Applying tuned profiles is idempotent when the ``--no-overwrite`` option is passed.
+  In this case existing profiles with the same name are not overwritten.
 
 
 Viewing Profiles

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -425,6 +425,9 @@ class TunedProfileStore():
             self.profiles[k] = TunedProfileSpec.from_json(v)
             self.profiles[k]._last_updated = datetime_to_str(datetime_now())
 
+    def exists(self, profile_name: str) -> bool:
+        return profile_name in self.profiles
+
     def save(self) -> None:
         profiles_json = {k: v.to_json() for k, v in self.profiles.items()}
         self.mgr.set_store('tuned_profiles', json.dumps(profiles_json))

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2475,11 +2475,14 @@ Then run the following:
         return self._apply_service_spec(cast(ServiceSpec, spec))
 
     @handle_orch_error
-    def apply_tuned_profiles(self, specs: List[TunedProfileSpec]) -> str:
+    def apply_tuned_profiles(self, specs: List[TunedProfileSpec], no_overwrite: bool = False) -> str:
         outs = []
         for spec in specs:
-            self.tuned_profiles.add_profile(spec)
-            outs.append(f'Saved tuned profile {spec.profile_name}')
+            if no_overwrite and self.tuned_profiles.exists(spec.profile_name):
+                outs.append(f"Tuned profile '{spec.profile_name}' already exists (--no-overwrite was passed)")
+            else:
+                self.tuned_profiles.add_profile(spec)
+                outs.append(f'Saved tuned profile {spec.profile_name}')
         self._kick_serve_loop()
         return '\n'.join(outs)
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -679,7 +679,7 @@ class Orchestrator(object):
         """Update an existing snmp gateway service"""
         raise NotImplementedError()
 
-    def apply_tuned_profiles(self, specs: List[TunedProfileSpec]) -> OrchResult[str]:
+    def apply_tuned_profiles(self, specs: List[TunedProfileSpec], no_overwrite: bool) -> OrchResult[str]:
         """Add or update an existing tuned profile"""
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1401,7 +1401,7 @@ Usage:
             tuned_profile_spec = TunedProfileSpec(
                 profile_name=profile_name, placement=placement_spec, settings=settings_dict)
             specs = [tuned_profile_spec]
-        completion = self.apply_tuned_profiles(specs)
+        completion = self.apply_tuned_profiles(specs, no_overwrite)
         res = raise_if_exception(completion)
         return HandleCommandResult(stdout=res)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57426

---

backport of https://github.com/ceph/ceph/pull/47815
parent tracker: https://tracker.ceph.com/issues/57032

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh