### PR TITLE
pacific: doc/cephadm/services: fix example for specifying rgw placement

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -431,7 +431,7 @@ Cephadm supports the deployment of multiple daemons on the same host:
     service_type: rgw
     placement:
       label: rgw
-      count-per-host: 2
+      count_per_host: 2
 
 The main reason for deploying multiple daemons per host is an additional
 performance benefit for running multiple RGW and MDS daemons on the same host.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57412

---

backport of https://github.com/ceph/ceph/pull/47921
parent tracker: https://tracker.ceph.com/issues/56953

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh