### PR TITLE
quincy: mgr/cephadm: allow binding to loopback for rgw daemons

### DIFF
--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -1,3 +1,4 @@
+import ipaddress
 import hashlib
 import logging
 import random
@@ -359,6 +360,13 @@ class HostAssignment(object):
     def find_ip_on_host(self, hostname: str, subnets: List[str]) -> Optional[str]:
         for subnet in subnets:
             ips: List[str] = []
+            # following is to allow loopback interfaces for both ipv4 and ipv6. Since we
+            # only have the subnet (and no IP) we assume default loopback IP address.
+            if ipaddress.ip_network(subnet).is_loopback:
+                if ipaddress.ip_network(subnet).version == 4:
+                    ips.append('127.0.0.1')
+                else:
+                    ips.append('::1')
             for iface, iface_ips in self.networks.get(hostname, {}).get(subnet, {}).items():
                 ips.extend(iface_ips)
             if ips:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57382

---

backport of https://github.com/ceph/ceph/pull/47817
parent tracker: https://tracker.ceph.com/issues/57304

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh