### PR TITLE
quincy: cephadm: return nonzero exit code when applying spec fails in bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5427,6 +5427,8 @@ def save_cluster_config(ctx: CephadmContext, uid: int, gid: int, fsid: str) -> N
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
 
+    ctx.error_code = 0
+
     if not ctx.output_config:
         ctx.output_config = os.path.join(ctx.output_dir, CEPH_CONF)
     if not ctx.output_keyring:
@@ -5645,6 +5647,7 @@ def command_bootstrap(ctx):
             out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
             logger.info(out)
         except Exception:
+            ctx.error_code = -errno.EINVAL
             logger.info('\nApplying %s to cluster failed!\n' % ctx.apply_spec)
 
     save_cluster_config(ctx, uid, gid, fsid)
@@ -5670,7 +5673,7 @@ def command_bootstrap(ctx):
                 'For more information see:\n\n'
                 '\thttps://docs.ceph.com/docs/master/mgr/telemetry/\n')
     logger.info('Bootstrap complete.')
-    return 0
+    return ctx.error_code
 
 ##################################
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57378

---

backport of https://github.com/ceph/ceph/pull/47665
parent tracker: https://tracker.ceph.com/issues/57173

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh