### PR TITLE
quincy: mgr/cephadm: don't try to write client/os tuning profiles to known offline hosts

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1057,6 +1057,8 @@ class CephadmServe:
                             client_files: Dict[str, Dict[str, Tuple[int, int, int, bytes, str]]],
                             host: str) -> None:
         updated_files = False
+        if host in self.mgr.offline_hosts:
+            return
         old_files = self.mgr.cache.get_host_client_files(host).copy()
         for path, m in client_files.get(host, {}).items():
             mode, uid, gid, content, digest = m

--- a/src/pybind/mgr/cephadm/tests/test_tuned_profiles.py
+++ b/src/pybind/mgr/cephadm/tests/test_tuned_profiles.py
@@ -52,6 +52,7 @@ class FakeMgr:
         self.tuned_profiles = TunedProfileStore(self)
         self.tuned_profiles.profiles = profiles
         self.ssh = SSHManager(self)
+        self.offline_hosts = []
 
     def set_store(self, what: str, value: str):
         raise SaveError(f'{what}: {value}')

--- a/src/pybind/mgr/cephadm/tuned_profiles.py
+++ b/src/pybind/mgr/cephadm/tuned_profiles.py
@@ -46,6 +46,8 @@ class TunedProfileUtils():
             self._write_tuned_profiles(host, profiles)
 
     def _remove_stray_tuned_profiles(self, host: str, profiles: List[Dict[str, str]]) -> None:
+        if host in self.mgr.offline_hosts:
+            return
         cmd = ['ls', SYSCTL_DIR]
         found_files = self.mgr.ssh.check_execute_command(host, cmd).split('\n')
         found_files = [s.strip() for s in found_files]
@@ -62,6 +64,8 @@ class TunedProfileUtils():
             self.mgr.ssh.check_execute_command(host, ['sysctl', '--system'])
 
     def _write_tuned_profiles(self, host: str, profiles: List[Dict[str, str]]) -> None:
+        if host in self.mgr.offline_hosts:
+            return
         updated = False
         for p in profiles:
             for profile_name, content in p.items():


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57377

---

backport of https://github.com/ceph/ceph/pull/47666
parent tracker: https://tracker.ceph.com/issues/57175

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh