### PR TITLE
Revert "rgw: add coroutine drain callback capture_error()"

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -53,16 +53,6 @@ static const string bucket_full_status_oid_prefix = "bucket.full-sync-status";
 static const string bucket_status_oid_prefix = "bucket.sync-status";
 static const string object_status_oid_prefix = "bucket.sync-status";
 
-// returns a lambda that captures negative error codes into the given int&
-static auto capture_error(int& retcode) {
-  return [&retcode] (uint64_t stack_id, int ret) {
-    if (ret < 0) {
-      retcode = ret;
-    }
-    return ret;
-  };
-}
-
 void rgw_datalog_info::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("num_objects", num_shards, obj);
 }
@@ -1471,16 +1461,20 @@ public:
           yield_spawn_window(rgw::error_repo::write_cr(sync_env->store->svc()->rados, error_repo,
                             rgw::error_repo::encode_key(bs, each->gen),
                             timestamp), cct->_conf->rgw_data_sync_spawn_window,
-                            capture_error(retcode));
-          if (retcode < 0) {
-            return set_cr_error(retcode);
-          }
+                            [&](uint64_t stack_id, int ret) {
+                              if (ret < 0) {
+                                retcode = ret;
+                              }
+                              return 0;
+                            });
         }
       }
-      drain_all_cb(capture_error(retcode));
-      if (retcode < 0) {
-        return set_cr_error(retcode);
-      }
+      drain_all_cb([&](uint64_t stack_id, int ret) {
+                   if (ret < 0) {
+                     tn->log(10, SSTR("writing to error repo returned error: " << ret));
+                   }
+                   return ret;
+                 });
 
       // once everything succeeds, remove the full sync obligation from the error repo
       yield call(rgw::error_repo::remove_cr(sync_env->store->svc()->rados, error_repo,
@@ -1602,11 +1596,21 @@ public:
             first_shard = false;
           } else {
             yield_spawn_window(shard_cr, cct->_conf->rgw_data_sync_spawn_window,
-                               capture_error(retcode));
+                              [&](uint64_t stack_id, int ret) {
+                                if (ret < 0) {
+                                  retcode = ret;
+                                }
+                                return retcode;
+                                });
             }
           }
         }
-        drain_all_cb(capture_error(retcode));
+        drain_all_cb([&](uint64_t stack_id, int ret) {
+                if (ret < 0) {
+                  retcode = ret;
+                }
+                return retcode;
+              });
       }
 
       yield call(marker_tracker->finish(key));
@@ -4353,14 +4357,25 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
                       false);
         }
         drain_with_cb(cct->_conf->rgw_bucket_sync_spawn_window,
-                      capture_error(sync_result));
+                      [&](uint64_t stack_id, int ret) {
+                if (ret < 0) {
+                  tn->log(10, "a sync operation returned error");
+                  sync_result = ret;
+                }
+                return 0;
+              });
       }
     } while (list_result.is_truncated && sync_result == 0);
     set_status("done iterating over all objects");
 
     /* wait for all operations to complete */
-    drain_all_cb(capture_error(sync_result));
-
+    drain_all_cb([&](uint64_t stack_id, int ret) {
+      if (ret < 0) {
+        tn->log(10, "a sync operation returned error");
+        sync_result = ret;
+      }
+      return 0;
+    });
     tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
     if (lease_cr && !lease_cr->is_locked()) {
       tn->log(1, "no lease or lease is lost, abort");
@@ -4736,12 +4751,24 @@ int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
           }
         // }
         drain_with_cb(cct->_conf->rgw_bucket_sync_spawn_window,
-                      capture_error(sync_status));
+                      [&](uint64_t stack_id, int ret) {
+                if (ret < 0) {
+                  tn->log(10, "a sync operation returned error");
+                  sync_status = ret;
+                }
+                return 0;
+              });
       }
 
     } while (!list_result.empty() && sync_status == 0 && !syncstopped);
 
-    drain_all_cb(capture_error(sync_status));
+    drain_all_cb([&](uint64_t stack_id, int ret) {
+      if (ret < 0) {
+        tn->log(10, "a sync operation returned error");
+        sync_status = ret;
+      }
+      return 0;
+    });
     tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
 
     if (syncstopped) {


### PR DESCRIPTION
fixes a regression from https://github.com/ceph/ceph/commit/d75ea8757d96a82df692a9476ed40b3206cba47e which changed the callback's return code

Fixes: https://tracker.ceph.com/issues/57400

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
