### PR TITLE
crimson/os/seastore: move AsyncCleaner::GCProcess to EPM::BackgroundProcess

### DIFF
--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -89,6 +89,7 @@ SUBSYS(seastore_omap, 0, 5)
 SUBSYS(seastore_tm, 0, 5)    // logs below seastore tm
 SUBSYS(seastore_t, 0, 5)
 SUBSYS(seastore_cleaner, 0, 5)
+SUBSYS(seastore_epm, 0, 5)
 SUBSYS(seastore_lba, 0, 5)
 SUBSYS(seastore_fixedkv_tree, 0, 5)
 SUBSYS(seastore_cache, 0, 5)

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -557,7 +557,7 @@ JournalTrimmerImpl::trim_alloc()
   assert(background_callback->is_ready());
   return repeat_eagain([this, FNAME] {
     return extent_callback->with_transaction_intr(
-      Transaction::src_t::CLEANER_TRIM_ALLOC,
+      Transaction::src_t::TRIM_ALLOC,
       "trim_alloc",
       [this, FNAME](auto &t)
     {
@@ -591,7 +591,7 @@ JournalTrimmerImpl::trim_dirty()
   assert(background_callback->is_ready());
   return repeat_eagain([this, FNAME] {
     return extent_callback->with_transaction_intr(
-      Transaction::src_t::CLEANER_TRIM_DIRTY,
+      Transaction::src_t::TRIM_DIRTY,
       "trim_dirty",
       [this, FNAME](auto &t)
     {
@@ -1023,7 +1023,7 @@ SegmentCleaner::do_reclaim_space(
     reclaimed = 0;
     runs++;
     return extent_callback->with_transaction_intr(
-      Transaction::src_t::CLEANER_RECLAIM,
+      Transaction::src_t::CLEANER,
       "clean_reclaim_space",
       [this, &backref_extents, &pin_list, &reclaimed](auto &t)
     {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1223,12 +1223,12 @@ private:
     // should be consistent with trans_srcs_invalidated in register_metrics()
     assert(!(src1 == Transaction::src_t::READ &&
              src2 == Transaction::src_t::READ));
-    assert(!(src1 == Transaction::src_t::CLEANER_TRIM_DIRTY &&
-             src2 == Transaction::src_t::CLEANER_TRIM_DIRTY));
-    assert(!(src1 == Transaction::src_t::CLEANER_RECLAIM &&
-             src2 == Transaction::src_t::CLEANER_RECLAIM));
-    assert(!(src1 == Transaction::src_t::CLEANER_TRIM_ALLOC &&
-             src2 == Transaction::src_t::CLEANER_TRIM_ALLOC));
+    assert(!(src1 == Transaction::src_t::TRIM_DIRTY &&
+             src2 == Transaction::src_t::TRIM_DIRTY));
+    assert(!(src1 == Transaction::src_t::CLEANER &&
+             src2 == Transaction::src_t::CLEANER));
+    assert(!(src1 == Transaction::src_t::TRIM_ALLOC &&
+             src2 == Transaction::src_t::TRIM_ALLOC));
 
     auto src1_value = static_cast<std::size_t>(src1);
     auto src2_value = static_cast<std::size_t>(src2);
@@ -1256,7 +1256,7 @@ private:
       CachedExtent &ext,
       const Transaction::src_t* p_src=nullptr)
   {
-    if (p_src && is_cleaner_transaction(*p_src))
+    if (p_src && is_background_transaction(*p_src))
       return;
     if (ext.is_clean() && !ext.is_placeholder()) {
       lru.move_to_top(ext);

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -403,15 +403,15 @@ private:
 
     bool background_should_run() const {
       assert(is_ready());
-      return cleaner->should_reclaim_space()
+      return cleaner->should_clean_space()
         || trimmer->should_trim_dirty()
         || trimmer->should_trim_alloc();
     }
 
     bool should_block_io() const {
       assert(is_ready());
-      return trimmer->should_block_on_trim() ||
-             cleaner->should_block_on_reclaim();
+      return trimmer->should_block_io_on_trim() ||
+             cleaner->should_block_io_on_clean();
     }
 
     seastar::future<> do_background_cycle();
@@ -423,7 +423,7 @@ private:
       uint64_t io_count = 0;
       uint64_t io_blocked_count = 0;
       uint64_t io_blocked_count_trim = 0;
-      uint64_t io_blocked_count_reclaim = 0;
+      uint64_t io_blocked_count_clean = 0;
       uint64_t io_blocked_sum = 0;
     } stats;
     seastar::metrics::metric_group metrics;

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -181,7 +181,7 @@ SegmentedJournal::scan_last_segment(
       }
       for (auto &record_header : *maybe_headers) {
         ceph_assert(is_valid_transaction(record_header.type));
-        if (is_cleaner_transaction(record_header.type)) {
+        if (is_background_transaction(record_header.type)) {
           has_tail_delta = true;
         }
       }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -397,12 +397,12 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
     return os << "MUTATE";
   case transaction_type_t::READ:
     return os << "READ";
-  case transaction_type_t::CLEANER_TRIM_DIRTY:
-    return os << "CLEANER_TRIM_DIRTY";
-  case transaction_type_t::CLEANER_TRIM_ALLOC:
-    return os << "CLEANER_TRIM_ALLOC";
-  case transaction_type_t::CLEANER_RECLAIM:
-    return os << "CLEANER_RECLAIM";
+  case transaction_type_t::TRIM_DIRTY:
+    return os << "TRIM_DIRTY";
+  case transaction_type_t::TRIM_ALLOC:
+    return os << "TRIM_ALLOC";
+  case transaction_type_t::CLEANER:
+    return os << "CLEANER";
   case transaction_type_t::MAX:
     return os << "TRANS_TYPE_NULL";
   default:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1662,9 +1662,9 @@ std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail);
 enum class transaction_type_t : uint8_t {
   MUTATE = 0,
   READ, // including weak and non-weak read transactions
-  CLEANER_TRIM_DIRTY,
-  CLEANER_TRIM_ALLOC,
-  CLEANER_RECLAIM,
+  TRIM_DIRTY,
+  TRIM_ALLOC,
+  CLEANER,
   MAX
 };
 
@@ -1679,14 +1679,14 @@ constexpr bool is_valid_transaction(transaction_type_t type) {
   return type < transaction_type_t::MAX;
 }
 
-constexpr bool is_cleaner_transaction(transaction_type_t type) {
-  return (type >= transaction_type_t::CLEANER_TRIM_DIRTY &&
+constexpr bool is_background_transaction(transaction_type_t type) {
+  return (type >= transaction_type_t::TRIM_DIRTY &&
           type < transaction_type_t::MAX);
 }
 
 constexpr bool is_trim_transaction(transaction_type_t type) {
-  return (type == transaction_type_t::CLEANER_TRIM_DIRTY ||
-      type == transaction_type_t::CLEANER_TRIM_ALLOC);
+  return (type == transaction_type_t::TRIM_DIRTY ||
+      type == transaction_type_t::TRIM_ALLOC);
 }
 
 struct record_size_t {

--- a/src/crimson/os/seastore/segment_seq_allocator.h
+++ b/src/crimson/os/seastore/segment_seq_allocator.h
@@ -41,7 +41,7 @@ private:
   segment_seq_t next_segment_seq = 0;
   segment_type_t type = segment_type_t::NULL_SEG;
   friend class journal::SegmentedJournal;
-  friend class AsyncCleaner;
+  friend class SegmentCleaner;
 };
 
 using SegmentSeqAllocatorRef =

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -689,6 +689,7 @@ TransactionManagerRef make_transaction_manager(
 
   if (journal_type == journal_type_t::SEGMENTED) {
     cache->set_segment_provider(*async_cleaner);
+    async_cleaner->set_journal_trimmer(journal_trimmer);
   }
 
   JournalRef journal;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -661,16 +661,16 @@ TransactionManagerRef make_transaction_manager(
   ceph_assert(roll_start % primary_device->get_block_size() == 0);
 
   bool cleaner_is_detailed;
-  AsyncCleaner::config_t cleaner_config;
+  SegmentCleaner::config_t cleaner_config;
   JournalTrimmerImpl::config_t trimmer_config;
   if (is_test) {
     cleaner_is_detailed = true;
-    cleaner_config = AsyncCleaner::config_t::get_test();
+    cleaner_config = SegmentCleaner::config_t::get_test();
     trimmer_config = JournalTrimmerImpl::config_t::get_test(
         roll_size, journal_type);
   } else {
     cleaner_is_detailed = false;
-    cleaner_config = AsyncCleaner::config_t::get_default();
+    cleaner_config = SegmentCleaner::config_t::get_default();
     trimmer_config = JournalTrimmerImpl::config_t::get_default(
         roll_size, journal_type);
   }
@@ -679,21 +679,21 @@ TransactionManagerRef make_transaction_manager(
       *backref_manager, trimmer_config,
       journal_type, roll_start, roll_size);
 
-  auto async_cleaner = std::make_unique<AsyncCleaner>(
+  auto segment_cleaner = SegmentCleaner::create(
     cleaner_config,
     std::move(sms),
     *backref_manager,
     cleaner_is_detailed);
 
   if (journal_type == journal_type_t::SEGMENTED) {
-    cache->set_segment_provider(*async_cleaner);
-    async_cleaner->set_journal_trimmer(*journal_trimmer);
+    cache->set_segment_provider(*segment_cleaner);
+    segment_cleaner->set_journal_trimmer(*journal_trimmer);
   }
 
   JournalRef journal;
   if (journal_type == journal_type_t::SEGMENTED) {
     journal = journal::make_segmented(
-      *async_cleaner,
+      *segment_cleaner,
       *journal_trimmer);
   } else {
     journal = journal::make_circularbounded(
@@ -702,7 +702,7 @@ TransactionManagerRef make_transaction_manager(
       "");
   }
 
-  epm->init(std::move(journal_trimmer), std::move(async_cleaner));
+  epm->init(std::move(journal_trimmer), std::move(segment_cleaner));
   epm->set_primary_device(primary_device);
 
   return std::make_unique<TransactionManager>(

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -146,7 +146,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
   }).safe_then([this] {
     return epm->open_for_write();
   }).safe_then([FNAME, this] {
-    epm->start_gc();
+    epm->start_background();
     INFO("completed");
   }).handle_error(
     mount_ertr::pass_further{},
@@ -160,7 +160,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
 TransactionManager::close_ertr::future<> TransactionManager::close() {
   LOG_PREFIX(TransactionManager::close);
   INFO("enter");
-  return epm->stop_gc(
+  return epm->stop_background(
   ).then([this] {
     return cache->close();
   }).safe_then([this] {
@@ -675,36 +675,34 @@ TransactionManagerRef make_transaction_manager(
         roll_size, journal_type);
   }
 
-  auto ref_journal_trimmer = JournalTrimmerImpl::create(
+  auto journal_trimmer = JournalTrimmerImpl::create(
       *backref_manager, trimmer_config,
       journal_type, roll_start, roll_size);
-  JournalTrimmer &journal_trimmer = *ref_journal_trimmer;
 
   auto async_cleaner = std::make_unique<AsyncCleaner>(
     cleaner_config,
     std::move(sms),
     *backref_manager,
-    cleaner_is_detailed,
-    std::move(ref_journal_trimmer));
+    cleaner_is_detailed);
 
   if (journal_type == journal_type_t::SEGMENTED) {
     cache->set_segment_provider(*async_cleaner);
-    async_cleaner->set_journal_trimmer(journal_trimmer);
+    async_cleaner->set_journal_trimmer(*journal_trimmer);
   }
 
   JournalRef journal;
   if (journal_type == journal_type_t::SEGMENTED) {
     journal = journal::make_segmented(
       *async_cleaner,
-      journal_trimmer);
+      *journal_trimmer);
   } else {
     journal = journal::make_circularbounded(
-      journal_trimmer,
+      *journal_trimmer,
       static_cast<random_block_device::RBMDevice*>(primary_device),
       "");
   }
 
-  epm->set_async_cleaner(std::move(async_cleaner));
+  epm->init(std::move(journal_trimmer), std::move(async_cleaner));
   epm->set_primary_device(primary_device);
 
   return std::make_unique<TransactionManager>(

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -206,7 +206,7 @@ protected:
     ).handle_error(
       crimson::ct_error::assert_all{"Error in mount"}
     ).then([this] {
-      return epm->stop_gc();
+      return epm->stop_background();
     }).then([this] {
       return epm->run_background_work_until_halt();
     });


### PR DESCRIPTION
* Further decouple trimmer and cleaner with `AsyncCleaner::GCProcess`.
   * The only dependency left is that `SegmentCleaner` needs to query `JournalTrimmer` to avoid reclaimming closed in-journal segments.
* Move `AsyncCleaner::GCProcess` to `EPM::BackgroundProcess`.
* Rename the implementation to `SegmentCleaner` and introduce the initial `AsyncCleaner` interface.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
