### PR TITLE
mgr/dashboard: fix snapshot creation with duplicate name

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 from collections import defaultdict
 
@@ -18,6 +19,8 @@ GET_QUOTAS_SCHEMA = {
     'max_bytes': (int, ''),
     'max_files': (int, '')
 }
+
+logger = logging.getLogger("controllers.rgw")
 
 
 @APIRouter('/cephfs', Scope.CEPHFS)
@@ -470,6 +473,14 @@ class CephFS(RESTController):
         :rtype: str
         """
         cfs = self._cephfs_instance(fs_id)
+        list_snaps = cfs.ls_snapshots(path)
+        for snap in list_snaps:
+            if name == snap['name']:
+                raise DashboardException(code='Snapshot name already in use',
+                                         msg='Snapshot name {} is already in use.'
+                                         'Please use another name'.format(name),
+                                         component='cephfs')
+
         return cfs.mk_snapshot(path, name)
 
     @RESTController.Resource('DELETE', path='/snapshot')


### PR DESCRIPTION
Snapshot creation with same name on UI throwing 500 Internal Error, This PR intends to fix this issue.

Fixes: https://tracker.ceph.com/issues/57456
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

![Screenshot from 2022-09-05 17-28-04](https://user-images.githubusercontent.com/66050535/188444873-025bd790-ff27-4994-9766-c86d9424b878.png)

![Screenshot from 2022-09-06 10-57-37](https://user-images.githubusercontent.com/66050535/188555346-7fcb7139-0203-4885-bc86-c601c7896deb.png)







<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
