### PR TITLE
quincy: pybind/mgr: object_format.py decorator updates & docs

### DIFF
--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -108,9 +108,13 @@ following commands::
 Exposing commands
 -----------------
 
-There are two approaches for exposing a command. The first one is to
-use the ``@CLICommand`` decorator to decorate the method which handles
-the command. like this
+There are two approaches for exposing a command. The first method involves using
+the ``@CLICommand`` decorator to decorate the methods needed to handle a command.
+The second method uses a ``COMMANDS`` attribute defined for the module class.
+
+
+The CLICommand approach
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
@@ -164,7 +168,11 @@ In addition to ``@CLICommand``, you could also use ``@CLIReadCommand`` or
 ``@CLIWriteCommand`` if your command only requires read permissions or
 write permissions respectively.
 
-The second one is to set the ``COMMANDS`` class attribute of your module to
+
+The COMMANDS Approach
+~~~~~~~~~~~~~~~~~~~~~
+
+This method uses the ``COMMANDS`` class attribute of your module to define
 a list of dicts like this::
 
     COMMANDS = [

--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -135,7 +135,7 @@ The CLICommand approach
        else:
            location = blackhole
        self.send_object_to(obj, location)
-       return HandleCommandResult(stdout=f'the black hole swallowed '{oid}'")
+       return HandleCommandResult(stdout=f"the black hole swallowed '{oid}'")
 
 The first parameter passed to ``CLICommand`` is the "name" of the command.
 Since there are lots of commands in Ceph, we tend to group related commands

--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -205,6 +205,192 @@ when they are sent:
 .. py:currentmodule:: mgr_module
 .. automethod:: MgrModule.handle_command
 
+
+Responses and Formatting
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Functions that handle manager commands are expected to return a three element
+tuple with the type signature ``Tuple[int, str, str]``. The first element is a
+return value/error code, where zero indicates no error and a negative `errno`_
+is typically used for error conditions.  The second element corresponds to the
+command's "output". The third element corresponds to the command's "error
+output" (akin to stderr) and is frequently used to report textual error details
+when the return code is non-zero. The ``mgr_module.HandleCommandResult`` type
+can also be used in lieu of a response tuple.
+
+.. _`errno`: https://man7.org/linux/man-pages/man3/errno.3.html
+
+When the implementation of a command raises an exception one of two possible
+approaches to handling the exception exist. First, the command function can do
+nothing and let the exception bubble up to the manager.  When this happens the
+manager will automatically set a return code to -EINVAL and record a trace-back
+in the error output. This trace-back can be very long in some cases. The second
+approach is to handle an exception within a try-except block and convert the
+exception to an error code that better fits the exception (converting a
+KeyError to -ENOENT, for example).  In this case the error output may also be
+set to something more specific and actionable by the one calling the command.
+
+In many cases, especially in more recent versions of Ceph, manager commands are
+designed to return structured output to the caller. Structured output includes
+machine-parsable data such as JSON, YAML, XML, etc. JSON is the most common
+structured output format returned by manager commands. As of Ceph Reef, there
+are a number of new decorators available from the ``object_format`` module that
+help manage formatting output and handling exceptions automatically.  The
+intent is that most of the implementation of a manager command can be written in
+an idiomatic (aka "Pythonic") style and the decorators will take care of most of
+the work needed to format the output and return manager response tuples.
+
+In most cases, net new code should use the ``Responder`` decorator. Example:
+
+.. code:: python
+
+   @CLICommand('antigravity list wormholes', perm='r')
+   @Responder()
+   def list_wormholes(self, oid: str, details: bool = False) -> List[Dict[str, Any]]:
+       '''List wormholes associated with the supplied oid.
+       '''
+       with self.open_wormhole_db() as db:
+           wormholes = db.query(oid=oid)
+       if not details:
+           return [{'name': wh.name} for wh in wormholes]
+       return [{'name': wh.name, 'age': wh.get_age(), 'destination': wh.dest}
+               for wh in wormholes]
+
+Formatting
+++++++++++
+
+The ``Responder`` decorator automatically takes care of converting Python
+objects into a response tuple with formatted output. By default, this decorator
+can automatically return JSON and YAML. When invoked from the command line the
+``--format`` flag can be used to select the response format. If left
+unspecified, JSON will be returned. The automatic formatting can be applied to
+any basic Python type: lists, dicts, str, int, etc. Other objects can be
+formatted automatically if they meet the ``SimpleDataProvider`` protocol - they
+provide a ``to_simplified`` method. The ``to_simplified`` function must return
+a simplified representation of the object made out of basic types.
+
+.. code:: python
+
+   class MyCleverObject:
+       def to_simplified(self) -> Dict[str, int]:
+           # returns a python object(s) made up from basic types
+           return {"gravitons": 999, "tachyons": 404}
+
+   @CLICommand('antigravity list wormholes', perm='r')
+   @Responder()
+   def list_wormholes(self, oid: str, details: bool = False) -> MyCleverObject:
+       '''List wormholes associated with the supplied oid.
+       '''
+       ...
+
+The behavior of the automatic output formatting can be customized and extednted
+to other types of formatting (XML, Plain Text, etc). As this is a complex
+topic, please refer to the module documentation for the ``object_format``
+module.
+
+
+
+Error Handling
+++++++++++++++
+
+Additionally, the ``Responder`` decorator can automatically handle converting
+some  exceptions into response tuples. Any raised exception inheriting from
+``ErrorResponseBase`` will be automatically converted into a response tuple.
+The common approach will be to use ``ErrorResponse``, an exception type that
+can be used directly and has arguments for the error output and return value or
+it can be constructed from an existing exception using the ``wrap``
+classmethod. The wrap classmethod will automatically use the exception text and
+if available the ``errno`` property of other exceptions.
+
+Converting our previous example to use this exception handling approach:
+
+.. code:: python
+
+   @CLICommand('antigravity list wormholes', perm='r')
+   @Responder()
+   def list_wormholes(self, oid: str, details: bool = False) -> List[Dict[str, Any]]:
+       '''List wormholes associated with the supplied oid.
+       '''
+       try:
+           with self.open_wormhole_db() as db:
+               wormholes = db.query(oid=oid)
+       except UnknownOIDError:
+            raise ErrorResponse(f"Unknown oid: {oid}", return_value=-errno.ENOENT)
+       except WormholeDBError as err:
+           raise ErrorResponse.wrap(err)
+       if not details:
+           return [{'name': wh.name} for wh in wormholes]
+       return [{'name': wh.name, 'age': wh.get_age(), 'destination': wh.dest}
+               for wh in wormholes]
+
+
+.. note:: Because the decorator can not determine the difference between a
+   programming mistake and an expected error condition it does not try to
+   catch all exceptions.
+
+
+
+Additional Decorators
++++++++++++++++++++++
+
+The ``object_format`` module provides additional decorators to complement
+``Responder`` but for cases where ``Responder`` is insufficient or too "heavy
+weight".
+
+The ``ErrorResponseHandler`` decorator exists for cases where you *must* still
+return a manager response tuple but want to handle errors as exceptions (as in
+typical Python code). In short, it works like ``Responder`` but only with
+regards to exceptions. Just like ``Responder`` it handles exceptions that
+inherit from ``ErrorResponseBase``. This can be useful in cases where you need
+to return raw data in the output. Example:
+
+.. code:: python
+
+   @CLICommand('antigravity dump config', perm='r')
+   @ErrorResponseHandler()
+   def dump_config(self, oid: str) -> Tuple[int, str, str]:
+       '''Dump configuration
+       '''
+       # we have no control over what data is inside the blob!
+       try:
+            blob = self.fetch_raw_config_blob(oid)
+            return 0, blob, ''
+       except KeyError:
+            raise ErrorResponse("Blob does not exist", return_value=-errno.ENOENT)
+
+
+The ``EmptyResponder`` decorator exists for cases where, on a success
+condition, no output should be generated at all. If you used ``Responder`` and
+default JSON formatting you may always see outputs like ``{}`` or ``[]`` if the
+command completes without error. Instead, ``EmptyResponder`` helps you create
+manager commands that obey the `Rule of Silence`_ when the command has no
+interesting output to emit on success. The functions that ``EmptyResponder``
+decorate should always return ``None``. Like both ``Responder`` and
+``ErrorResponseHandler`` exceptions that inhert from ``ErrorResponseBase`` will
+be automatically processed. Example:
+
+.. code:: python
+
+   @CLICommand('antigravity create wormhole', perm='rw')
+   @EmptyResponder()
+   def create_wormhole(self, oid: str, name: str) -> None:
+       '''Create a new wormhole.
+       '''
+       try:
+           with self.open_wormhole_db() as db:
+               wh = Wormhole(name)
+               db.insert(oid=oid, wormhole=wh)
+       except UnknownOIDError:
+           raise ErrorResponse(f"Unknown oid: {oid}", return_value=-errno.ENOENT)
+       except InvalidWormholeError as err:
+           raise ErrorResponse.wrap(err)
+       except WormholeDBError as err:
+           raise ErrorResponse.wrap(err)
+
+
+.. _`Rule of Silence`: http://www.linfo.org/rule_of_silence.html
+
+
 Configuration options
 ---------------------
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -404,7 +404,7 @@ class CLICommand(object):
                 continue
             arg_spec[argname] = argtype
             args.append(CephArgtype.to_argdesc(
-                argtype, dict(name=arg), has_default=True, positional=False
+                argtype, dict(name=argname), has_default=True, positional=False
             ))
         return desc, arg_spec, first_default, ' '.join(args)
 

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -190,12 +190,6 @@ class Format(str, enum.Enum):
 SimpleData = Any
 
 
-ObjectResponseFuncType = Union[
-    Callable[..., Dict[Any, Any]],
-    Callable[..., List[Any]],
-]
-
-
 class SimpleDataProvider(Protocol):
     def to_simplified(self) -> SimpleData:
         """Return a simplified representation of the current object.
@@ -441,6 +435,16 @@ class ErrorResponse(ErrorResponseBase):
         err = cls(str(exc), return_value=return_value)
         setattr(err, "__cause__", exc)
         return err
+
+
+ObjectResponseFuncType = Union[
+    Callable[..., Dict[Any, Any]],
+    Callable[..., List[Any]],
+    Callable[..., SimpleDataProvider],
+    Callable[..., JSONDataProvider],
+    Callable[..., YAMLDataProvider],
+    Callable[..., ReturnValueProvider],
+]
 
 
 def _get_requested_format(f: ObjectResponseFuncType, kw: Dict[str, Any]) -> str:

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -426,10 +426,14 @@ class ErrorResponse(ErrorResponseBase):
     @classmethod
     def wrap(
         cls: Type[E], exc: Exception, return_value: Optional[int] = None
-    ) -> E:
+    ) -> ErrorResponseBase:
+        if isinstance(exc, ErrorResponseBase):
+            return exc
         if return_value is None:
             try:
-                return_value = -int(getattr(exc, "errno"))
+                return_value = int(getattr(exc, "errno"))
+                if return_value > 0:
+                    return_value = -return_value
             except (AttributeError, ValueError):
                 pass
         err = cls(str(exc), return_value=return_value)

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -529,3 +529,76 @@ class Responder:
         # on the ceph cli/api
         setattr(_format_response, "extra_args", {"format": str})
         return _format_response
+
+
+class ErrorResponseHandler:
+    """ErrorResponseHandler is a very simple decorator that handles functions that
+    raise exceptions inheriting from ErrorResponseBase. If such an exception
+    is raised that exception can and will be converted to a mgr response tuple.
+    This is similar to Responder but error handling is all this decorator does.
+    """
+
+    def __call__(self, f: Callable[..., Tuple[int, str, str]]) -> HandlerFuncType:
+        """Wrap a python function so that if the function raises an exception inheriting
+        ErrorResponderBase the error is correctly converted to a mgr response.
+        """
+
+        @wraps(f)
+        def _format_response(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
+            try:
+                retval, body, sts = f(*args, **kwargs)
+            except ErrorResponseBase as e:
+                return e.format_response()
+            return retval, body, sts
+
+        return _format_response
+
+
+class ConstantResponderBase:
+    """The constant responder base assumes that a wrapped function should not
+    be passing data back to the manager. It only responds with the default
+    (constant) values provided. The process_response function allows a subclass
+    to handle/log/validate any values that were returned from the wrapped
+    function.
+
+    This class can be used a building block for special decorators that
+    do not normally emit response data.
+    """
+
+    def mgr_return_value(self) -> int:
+        return 0
+
+    def mgr_body_value(self) -> str:
+        return ""
+
+    def mgr_status_value(self) -> str:
+        return ""
+
+    def process_response(self, result: Any) -> None:
+        return None
+
+    def __call__(self, f: Callable) -> HandlerFuncType:
+        """Wrap a python function so that if the function raises an exception
+        inheriting ErrorResponderBase the error is correctly converted to a mgr
+        response. Otherwise, it returns a default set of constant values.
+        """
+
+        @wraps(f)
+        def _format_response(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
+            try:
+                self.process_response(f(*args, **kwargs))
+            except ErrorResponseBase as e:
+                return e.format_response()
+            return self.mgr_return_value(), self.mgr_body_value(), self.mgr_status_value()
+        return _format_response
+
+
+class EmptyResponder(ConstantResponderBase):
+    """Always respond with an empty (string) body. Checks that the wrapped function
+    returned None in order to ensure it is not being used on functions that
+    return data objects.
+    """
+
+    def process_response(self, result: Any) -> None:
+        if result is not None:
+            raise ValueError("EmptyResponder expects None from wrapped functions")

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -287,10 +287,11 @@ class DecoDemo:
 
 
 @pytest.mark.parametrize(
-    "prefix, args, response",
+    "prefix, can_format, args, response",
     [
         (
             "alpha one",
+            True,
             {"name": "moonbase"},
             (
                 0,
@@ -301,6 +302,7 @@ class DecoDemo:
         # ---
         (
             "alpha one",
+            True,
             {"name": "moonbase2", "format": "yaml"},
             (
                 0,
@@ -311,6 +313,7 @@ class DecoDemo:
         # ---
         (
             "alpha one",
+            True,
             {"name": "moonbase2", "format": "chocolate"},
             (
                 -22,
@@ -321,6 +324,7 @@ class DecoDemo:
         # ---
         (
             "beta two",
+            True,
             {"name": "blocker"},
             (
                 0,
@@ -331,6 +335,7 @@ class DecoDemo:
         # ---
         (
             "beta two",
+            True,
             {"name": "test", "format": "yaml"},
             (
                 0,
@@ -341,6 +346,7 @@ class DecoDemo:
         # ---
         (
             "beta two",
+            True,
             {"name": "test", "format": "plain"},
             (
                 -22,
@@ -351,6 +357,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {},
             (
                 0,
@@ -361,6 +368,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {"size": 1, "format": "json"},
             (
                 0,
@@ -371,6 +379,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {"size": 1, "format": "plain"},
             (
                 0,
@@ -381,6 +390,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {"size": 2, "format": "plain"},
             (
                 0,
@@ -391,6 +401,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {"size": 2, "format": "xml"},
             (
                 0,
@@ -401,6 +412,7 @@ class DecoDemo:
         # ---
         (
             "gamma three",
+            True,
             {"size": 2, "format": "toml"},
             (
                 -22,
@@ -411,6 +423,7 @@ class DecoDemo:
         # ---
         (
             "z_err",
+            False,
             {"name": "foobar"},
             (
                 0,
@@ -421,6 +434,7 @@ class DecoDemo:
         # ---
         (
             "z_err",
+            False,
             {"name": "zamboni"},
             (
                 -22,
@@ -431,6 +445,7 @@ class DecoDemo:
         # ---
         (
             "empty one",
+            False,
             {"name": "zucchini"},
             (
                 0,
@@ -441,6 +456,7 @@ class DecoDemo:
         # ---
         (
             "empty one",
+            False,
             {"name": "pow"},
             (
                 -5,
@@ -450,9 +466,14 @@ class DecoDemo:
         ),
     ],
 )
-def test_cli_with_decorators(prefix, args, response):
+def test_cli_with_decorators(prefix, can_format, args, response):
     dd = DecoDemo()
-    assert CLICommand.COMMANDS[prefix].call(dd, args, None) == response
+    cmd = CLICommand.COMMANDS[prefix]
+    assert cmd.call(dd, args, None) == response
+    # slighly hacky way to check that the CLI "knows" about a --format option
+    # checking the extra_args feature of the Decorators that provide them (Responder)
+    if can_format:
+        assert 'name=format,' in cmd.args
 
 
 def test_error_response():

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -263,6 +263,13 @@ class DecoDemo:
     def gamma_three(self, size: int = 0) -> Dict[str, Any]:
         return {"name": "funnystuff", "size": size}
 
+    @CLICommand("z_err", perm="rw")
+    @object_format.ErrorResponseHandler()
+    def z_err(self, name: str = "default") -> Tuple[int, str, str]:
+        if "z" in name:
+            raise object_format.ErrorResponse(f"{name} bad")
+        return 0, name, ""
+
 
 @pytest.mark.parametrize(
     "prefix, args, response",
@@ -386,9 +393,29 @@ class DecoDemo:
                 "Unknown format name: toml",
             ),
         ),
+        # ---
+        (
+            "z_err",
+            {"name": "foobar"},
+            (
+                0,
+                "foobar",
+                "",
+            ),
+        ),
+        # ---
+        (
+            "z_err",
+            {"name": "zamboni"},
+            (
+                -22,
+                "",
+                "zamboni bad",
+            ),
+        ),
     ],
 )
-def test_cli_command_responder(prefix, args, response):
+def test_cli_with_decorators(prefix, args, response):
     dd = DecoDemo()
     assert CLICommand.COMMANDS[prefix].call(dd, args, None) == response
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/47763


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
