### PR TITLE
crimson/osd: fix handling of recovery kickback

### DIFF
--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -74,6 +74,10 @@ struct InterruptibleOperation : Operation {
   using interruptible_future =
     ::crimson::interruptible::interruptible_future<
       ::crimson::osd::IOInterruptCondition, ValuesT>;
+  template <typename ErroratorT, typename ValuesT = void>
+  using interruptible_errorated_future =
+    ::crimson::interruptible::interruptible_errorated_future<
+      ::crimson::osd::IOInterruptCondition, ErroratorT, ValuesT>;
   using interruptor =
     ::crimson::interruptible::interruptor<
       ::crimson::osd::IOInterruptCondition>;

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -6,12 +6,16 @@
 #include "crimson/common/operation.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operation.h"
+#include "osd/osd_op_util.h"
 
 namespace crimson::osd {
 
+using kickback_recovery_ertr = crimson::errorator<
+  crimson::ct_error::eagain>;
+
 struct CommonClientRequest {
-  static InterruptibleOperation::template interruptible_future<>
-  do_recover_missing(Ref<PG>& pg, const hobject_t& soid);
+  static InterruptibleOperation::template interruptible_errorated_future<kickback_recovery_ertr>
+  do_recover_missing(Ref<PG>& pg, const hobject_t& soid, const OpInfo& op_info);
 
   static bool should_abort_request(
     const crimson::Operation& op, std::exception_ptr eptr);

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -65,45 +65,42 @@ seastar::future<> InternalClientRequest::start()
           return enter_stage<interruptor>(
             pp().recover_missing
           ).then_interruptible([this] {
-            return do_recover_missing(pg, get_target_oid());
-          }).then_interruptible([this] {
+            osd_ops = create_osd_ops();
+            [[maybe_unused]] const int ret = op_info.set_from_op(
+              std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());
+            assert(ret == 0);
+            return do_recover_missing(pg, get_target_oid(), op_info);
+          }).safe_then_interruptible([this] {
             return enter_stage<interruptor>(
               pp().get_obc
             ).then_interruptible([this] () -> PG::load_obc_iertr::future<> {
               logger().debug("{}: getting obc lock", *this);
-              return seastar::do_with(create_osd_ops(),
-                [this](auto& osd_ops) mutable {
-                logger().debug("InternalClientRequest: got {} OSDOps to execute",
-                               std::size(osd_ops));
-                [[maybe_unused]] const int ret = op_info.set_from_op(
-                  std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());
-                assert(ret == 0);
-                return pg->with_locked_obc(get_target_oid(), op_info,
-                  [&osd_ops, this](auto obc) {
-                  return enter_stage<interruptor>(pp().process).then_interruptible(
-                    [obc=std::move(obc), &osd_ops, this] {
-                    return pg->do_osd_ops(
-                      std::move(obc),
-                      osd_ops,
-                      std::as_const(op_info),
-                      get_do_osd_ops_params(),
-                      [] {
-                        return PG::do_osd_ops_iertr::now();
-                      },
-                      [] (const std::error_code& e) {
-                        return PG::do_osd_ops_iertr::now();
-                      }
-                    ).safe_then_unpack_interruptible(
-                      [](auto submitted, auto all_completed) {
-                        return all_completed.handle_error_interruptible(
-                          crimson::ct_error::eagain::handle([] {
-                            return seastar::now();
-                          }));
-                      }, crimson::ct_error::eagain::handle([] {
-                        return interruptor::now();
-                      })
-                    );
-                  });
+              return pg->with_locked_obc(get_target_oid(), op_info,
+                [this](auto obc) {
+                return enter_stage<interruptor>(pp().process).then_interruptible(
+                  [obc=std::move(obc), this] {
+                  logger().debug("{}: executing {} OSDOps", *this, std::size(osd_ops));
+                  return pg->do_osd_ops(
+                    std::move(obc),
+                    osd_ops,
+                    std::as_const(op_info),
+                    get_do_osd_ops_params(),
+                    [] {
+                      return PG::do_osd_ops_iertr::now();
+                    },
+                    [] (const std::error_code& e) {
+                      return PG::do_osd_ops_iertr::now();
+                    }
+                  ).safe_then_unpack_interruptible(
+                    [](auto submitted, auto all_completed) {
+                      return all_completed.handle_error_interruptible(
+                        crimson::ct_error::eagain::handle([] {
+                          return seastar::now();
+                        }));
+                    }, crimson::ct_error::eagain::handle([] {
+                      return interruptor::now();
+                    })
+                  );
                 });
               });
             }).handle_error_interruptible(PG::load_obc_ertr::all_same_way([] {
@@ -111,7 +108,8 @@ seastar::future<> InternalClientRequest::start()
             })).then_interruptible([] {
               return seastar::stop_iteration::yes;
             });
-          });
+          }, crimson::ct_error::eagain::handle([this]() mutable {
+          }));
         });
       }, [this](std::exception_ptr eptr) {
         if (should_abort_request(*this, std::move(eptr))) {

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -14,6 +14,8 @@ namespace crimson::osd {
 
 class InternalClientRequest : public PhasedOperationT<InternalClientRequest>,
                               private CommonClientRequest {
+  std::vector<OSDOp> osd_ops;
+
 public:
   explicit InternalClientRequest(Ref<PG> pg);
   ~InternalClientRequest();

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -255,8 +255,18 @@ void PG::on_activate(interval_set<snapid_t>)
   projected_last_update = peering_state.get_info().last_update;
 }
 
+// replicas
+void PG::on_activate_committed()
+{
+  logger().info("PG {} {} {}", pgid, __func__, get_acting_recovery_backfill());
+  wait_for_active_blocker.unblock();
+}
+
+// primary
 void PG::on_activate_complete()
 {
+  logger().info("PG {} {} {}", pgid, __func__, get_acting_recovery_backfill());
+  ceph_assert(!get_acting_recovery_backfill().empty());
   wait_for_active_blocker.unblock();
 
   if (peering_state.needs_recovery()) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -323,9 +323,7 @@ public:
     // Not needed yet (will be needed for IO unblocking)
     return nullptr;
   }
-  void on_activate_committed() final {
-    // Not needed yet (will be needed for IO unblocking)
-  }
+  void on_activate_committed() final;
   void on_active_exit() final {
     // Not needed yet
   }


### PR DESCRIPTION
We were calling `is_degraded_or_backfilling_object()` not only on primary but on replicas as well.

```
DEBUG 2022-09-01 08:04:13,689 [shard 0] osd - do_recover_missing check for recovery, 3:b49b5c5c:::rbd_data.10558297efa9.0000000000000007:head
ERROR 2022-09-01 08:04:13,689 [shard 0] none - /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-14585-g9f053b1c/rpm/el8/BUILD/ceph-17.0.0-14585-g9f053b1c/src/crimson/osd/pg.cc:1434 : In function 'bool crimson::osd::PG::is_degraded_or_backfilling_object(const hobject_t&) const', ceph_assert(%s)
```

```
!get_acting_recovery_backfill().empty()
2022-09-01T08:03:15.575 INFO:tasks.ceph.osd.2.smithi146.stderr: 0# gsignal in /lib64/libc.so.6
2022-09-01T08:03:15.576 INFO:tasks.ceph.osd.2.smithi146.stderr: 1# abort in /lib64/libc.so.6
2022-09-01T08:03:15.576 INFO:tasks.ceph.osd.2.smithi146.stderr: 2# ceph::__ceph_assert_fail(char const*, char const*, int, char const*) in ceph-osd
2022-09-01T08:03:15.577 INFO:tasks.ceph.osd.2.smithi146.stderr: 3# crimson::osd::PG::is_degraded_or_backfilling_object(hobject_t const&) const in ceph-osd
2022-09-01T08:03:15.577 INFO:tasks.ceph.osd.2.smithi146.stderr: 4# crimson::osd::CommonClientRequest::do_recover_missing(boost::intrusive_ptr<crimson::osd::PG>&, hobject_t const&) in ceph-osd
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
