### PR TITLE
quincy: librbd: retry ENOENT in V2_REFRESH_PARENT as well

### DIFF
--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -805,8 +805,8 @@ Context *RefreshRequest<I>::handle_v2_get_snapshots(int *result) {
     }
   }
 
-  if (*result == -ENOENT) {
-    ldout(cct, 10) << "out-of-sync snapshot state detected" << dendl;
+  if (*result == -ENOENT && m_enoent_retries++ < MAX_ENOENT_RETRIES) {
+    ldout(cct, 10) << "out-of-sync snapshot state detected, retrying" << dendl;
     send_v2_get_mutable_metadata();
     return nullptr;
   } else if (m_legacy_snapshot == LEGACY_SNAPSHOT_DISABLED &&

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -95,7 +95,7 @@ Context *RefreshRequest<I>::handle_get_migration_header(int *result) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
 
-  if (*result == 0) {
+  if (*result >= 0) {
     auto it = m_out_bl.cbegin();
     *result = cls_client::migration_get_finish(&it, &m_migration_spec);
   } else if (*result == -ENOENT) {
@@ -252,7 +252,7 @@ Context *RefreshRequest<I>::handle_v1_get_snapshots(int *result) {
 
   std::vector<std::string> snap_names;
   std::vector<uint64_t> snap_sizes;
-  if (*result == 0) {
+  if (*result >= 0) {
     auto it = m_out_bl.cbegin();
     *result = cls_client::old_snapshot_list_finish(&it, &snap_names,
                                                    &snap_sizes, &m_snapc);
@@ -305,15 +305,16 @@ Context *RefreshRequest<I>::handle_v1_get_locks(int *result) {
   ldout(cct, 10) << this << " " << __func__ << ": "
                  << "r=" << *result << dendl;
 
-  if (*result == 0) {
+  if (*result >= 0) {
     auto it = m_out_bl.cbegin();
     ClsLockType lock_type;
     *result = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
                                                      &lock_type, &m_lock_tag);
-    if (*result == 0) {
+    if (*result >= 0) {
       m_exclusive_locked = (lock_type == ClsLockType::EXCLUSIVE);
     }
   }
+
   if (*result < 0) {
     lderr(cct) << "failed to retrieve locks: " << cpp_strerror(*result)
                << dendl;
@@ -405,10 +406,10 @@ Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
   }
 
   if (*result >= 0) {
-    ClsLockType lock_type = ClsLockType::NONE;
+    ClsLockType lock_type;
     *result = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
                                                      &lock_type, &m_lock_tag);
-    if (*result == 0) {
+    if (*result >= 0) {
       m_exclusive_locked = (lock_type == ClsLockType::EXCLUSIVE);
     }
   }
@@ -488,20 +489,20 @@ Context *RefreshRequest<I>::handle_v2_get_parent(int *result) {
 
   auto it = m_out_bl.cbegin();
   if (!m_legacy_parent) {
-    if (*result == 0) {
+    if (*result >= 0) {
       *result = cls_client::parent_get_finish(&it, &m_parent_md.spec);
     }
 
     std::optional<uint64_t> parent_overlap;
-    if (*result == 0) {
+    if (*result >= 0) {
       *result = cls_client::parent_overlap_get_finish(&it, &parent_overlap);
     }
 
-    if (*result == 0 && parent_overlap) {
+    if (*result >= 0 && parent_overlap) {
       m_parent_md.overlap = *parent_overlap;
       m_head_parent_overlap = true;
     }
-  } else if (*result == 0) {
+  } else if (*result >= 0) {
     *result = cls_client::get_parent_finish(&it, &m_parent_md.spec,
                                             &m_parent_md.overlap);
     m_head_parent_overlap = true;
@@ -512,7 +513,7 @@ Context *RefreshRequest<I>::handle_v2_get_parent(int *result) {
     m_legacy_parent = true;
     send_v2_get_parent();
     return nullptr;
-  } if (*result < 0) {
+  } else if (*result < 0) {
     lderr(cct) << "failed to retrieve parent: " << cpp_strerror(*result)
                << dendl;
     return m_on_finish;
@@ -618,10 +619,12 @@ Context *RefreshRequest<I>::handle_v2_get_op_features(int *result) {
 
   // -EOPNOTSUPP handler not required since feature bit implies OSD
   // supports the method
-  if (*result == 0) {
+  if (*result >= 0) {
     auto it = m_out_bl.cbegin();
-    cls_client::op_features_get_finish(&it, &m_op_features);
-  } else if (*result < 0) {
+    *result = cls_client::op_features_get_finish(&it, &m_op_features);
+  }
+
+  if (*result < 0) {
     lderr(cct) << "failed to retrieve op features: " << cpp_strerror(*result)
                << dendl;
     return m_on_finish;
@@ -655,10 +658,11 @@ Context *RefreshRequest<I>::handle_v2_get_group(int *result) {
   ldout(cct, 10) << this << " " << __func__ << ": "
                  << "r=" << *result << dendl;
 
-  if (*result == 0) {
+  if (*result >= 0) {
     auto it = m_out_bl.cbegin();
-    cls_client::image_group_get_finish(&it, &m_group_spec);
+    *result = cls_client::image_group_get_finish(&it, &m_group_spec);
   }
+
   if (*result < 0 && *result != -EOPNOTSUPP) {
     lderr(cct) << "failed to retrieve group: " << cpp_strerror(*result)
                << dendl;
@@ -754,14 +758,14 @@ Context *RefreshRequest<I>::handle_v2_get_snapshots(int *result) {
       *result = cls_client::snapshot_get_finish(&it, &m_snap_infos[i]);
     }
 
-    if (*result == 0) {
+    if (*result >= 0) {
       if (m_legacy_parent) {
         *result = cls_client::get_parent_finish(&it, &m_snap_parents[i].spec,
                                                 &m_snap_parents[i].overlap);
       } else {
         std::optional<uint64_t> parent_overlap;
         *result = cls_client::parent_overlap_get_finish(&it, &parent_overlap);
-        if (*result == 0 && parent_overlap && m_parent_md.spec.pool_id > -1) {
+        if (*result >= 0 && parent_overlap && m_parent_md.spec.pool_id > -1) {
           m_snap_parents[i].spec = m_parent_md.spec;
           m_snap_parents[i].overlap = *parent_overlap;
         }

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -50,34 +50,34 @@ private:
    *  * |                                                     |     migrating)
    *  * | (v2)                                                v
    *  * \-----> V2_GET_MUTABLE_METADATA                   V1_GET_SNAPSHOTS
-   *  *             |                                         |
-   *  *             |     -EOPNOTSUPP                         v
-   *  *             |  * * *                              V1_GET_LOCKS
-   *  *             |  *   *                                  |
-   *  *             v  v   *                                  v
-   *  *         V2_GET_PARENT                              <apply>
-   *  *             |                                         |
+   *  *    *        |                                         |
+   *  *    *        |     -EOPNOTSUPP                         v
+   *  *    *        |  * * *                              V1_GET_LOCKS
+   *  *    *        |  *   *                                  |
+   *  *    *        v  v   *                                  v
+   *  *    *    V2_GET_PARENT                              <apply>
+   *  *    *        |                                         |
    *  *             v                                         |
    *  * * * * * GET_MIGRATION_HEADER (skip if not             |
    *  (ENOENT)      |                 migrating)              |
    *                v                                         |
-   *            V2_GET_METADATA                               |
-   *                |                                         |
-   *                v                                         |
-   *            V2_GET_POOL_METADATA                          |
-   *                |                                         |
-   *                v (skip if not enabled)                   |
-   *            V2_GET_OP_FEATURES                            |
-   *                |                                         |
-   *                v                                         |
-   *            V2_GET_GROUP                                  |
-   *                |                                         |
-   *                |     -EOPNOTSUPP                         |
-   *                |   * * * *                               |
-   *                |   *     *                               |
-   *                v   v     *                               |
-   *            V2_GET_SNAPSHOTS (skip if no snaps)           |
-   *                |                                         |
+   *       *    V2_GET_METADATA                               |
+   *       *        |                                         |
+   *       *        v                                         |
+   *       *    V2_GET_POOL_METADATA                          |
+   *       *        |                                         |
+   *       *        v (skip if not enabled)                   |
+   *       *    V2_GET_OP_FEATURES                            |
+   *       *        |                                         |
+   *       *        v                                         |
+   *       *    V2_GET_GROUP                                  |
+   *       *        |                                         |
+   *       *        |        -EOPNOTSUPP                      |
+   *       *        |     * * *                               |
+   *       *        |     *   *                               |
+   *       *        v     v   *                               |
+   *        * * V2_GET_SNAPSHOTS (skip if no snaps)           |
+   *     (ENOENT)   |                                         |
    *                v                                         |
    *            V2_REFRESH_PARENT (skip if no parent or       |
    *                |              refresh not needed)        |

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -80,9 +80,9 @@ private:
    *       *        v     v   *                               |
    *        * * V2_GET_SNAPSHOTS (skip if no snaps)           |
    *     (ENOENT)   |                                         |
-   *                v                                         |
-   *            V2_REFRESH_PARENT (skip if no parent or       |
-   *                |              refresh not needed)        |
+   *       *        v                                         |
+   *        * * V2_REFRESH_PARENT (skip if no parent or       |
+   *     (ENOENT)   |              refresh not needed)        |
    *                v                                         |
    *            V2_INIT_EXCLUSIVE_LOCK (skip if lock          |
    *                |                   active or disabled)   |

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -27,6 +27,8 @@ template<typename> class RefreshParentRequest;
 template<typename ImageCtxT = ImageCtx>
 class RefreshRequest {
 public:
+  static constexpr int MAX_ENOENT_RETRIES = 10;
+
   static RefreshRequest *create(ImageCtxT &image_ctx, bool acquiring_lock,
                                 bool skip_open_parent, Context *on_finish) {
     return new RefreshRequest(image_ctx, acquiring_lock, skip_open_parent,
@@ -143,6 +145,8 @@ private:
 
   bool m_legacy_parent = false;
   LegacySnapshot m_legacy_snapshot = LEGACY_SNAPSHOT_DISABLED;
+
+  int m_enoent_retries = 0;
 
   uint8_t m_order = 0;
   uint64_t m_size = 0;

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -834,8 +834,10 @@ TEST_F(TestMockImageRefreshRequest, SuccessChild) {
   expect_op_work_queue(mock_image_ctx);
   expect_test_features(mock_image_ctx);
 
+  mock_image_ctx.features &= ~RBD_FEATURE_OPERATIONS;
+
   InSequence seq;
-  expect_get_mutable_metadata(mock_image_ctx, ictx2->features, 0);
+  expect_get_mutable_metadata(mock_image_ctx, mock_image_ctx.features, 0);
   expect_get_parent(mock_image_ctx, 0);
   MockGetMetadataRequest mock_get_metadata_request;
   expect_get_metadata(mock_image_ctx, mock_get_metadata_request,
@@ -843,7 +845,6 @@ TEST_F(TestMockImageRefreshRequest, SuccessChild) {
   expect_get_metadata(mock_image_ctx, mock_get_metadata_request, RBD_INFO, {},
                       0);
   expect_apply_metadata(mock_image_ctx, 0);
-  expect_get_op_features(mock_image_ctx, RBD_OPERATION_FEATURE_CLONE_CHILD, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(*mock_refresh_parent_request, true);
   expect_refresh_parent_send(mock_image_ctx, *mock_refresh_parent_request, 0);
@@ -892,8 +893,10 @@ TEST_F(TestMockImageRefreshRequest, SuccessChildDontOpenParent) {
   expect_op_work_queue(mock_image_ctx);
   expect_test_features(mock_image_ctx);
 
+  mock_image_ctx.features &= ~RBD_FEATURE_OPERATIONS;
+
   InSequence seq;
-  expect_get_mutable_metadata(mock_image_ctx, ictx2->features, 0);
+  expect_get_mutable_metadata(mock_image_ctx, mock_image_ctx.features, 0);
   expect_get_parent(mock_image_ctx, 0);
   MockGetMetadataRequest mock_get_metadata_request;
   expect_get_metadata(mock_image_ctx, mock_get_metadata_request,
@@ -901,7 +904,6 @@ TEST_F(TestMockImageRefreshRequest, SuccessChildDontOpenParent) {
   expect_get_metadata(mock_image_ctx, mock_get_metadata_request, RBD_INFO, {},
                       0);
   expect_apply_metadata(mock_image_ctx, 0);
-  expect_get_op_features(mock_image_ctx, RBD_OPERATION_FEATURE_CLONE_CHILD, 0);
   expect_get_group(mock_image_ctx, 0);
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -20,7 +20,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <arpa/inet.h>
-#include <list>
+#include <queue>
 #include <boost/scope_exit.hpp>
 
 namespace librbd {
@@ -69,26 +69,32 @@ struct GetMetadataRequest<MockRefreshImageCtx> {
 
 template <>
 struct RefreshParentRequest<MockRefreshImageCtx> {
-  static RefreshParentRequest* s_instance;
+  static std::queue<RefreshParentRequest*> s_instances;
   static RefreshParentRequest* create(MockRefreshImageCtx &mock_image_ctx,
                                       const ParentImageInfo &parent_md,
                                       const MigrationInfo &migration_info,
                                       Context *on_finish) {
-    ceph_assert(s_instance != nullptr);
-    s_instance->on_finish = on_finish;
-    return s_instance;
+    ceph_assert(!s_instances.empty());
+    auto instance = s_instances.front();
+    instance->on_finish = on_finish;
+    return instance;
   }
   static bool is_refresh_required(MockRefreshImageCtx &mock_image_ctx,
                                   const ParentImageInfo& parent_md,
                                   const MigrationInfo &migration_info) {
-    ceph_assert(s_instance != nullptr);
-    return s_instance->is_refresh_required();
+    ceph_assert(!s_instances.empty());
+    return s_instances.front()->is_refresh_required();
   }
 
   Context *on_finish = nullptr;
 
   RefreshParentRequest() {
-    s_instance = this;
+    s_instances.push(this);
+  }
+
+  ~RefreshParentRequest() {
+    ceph_assert(this == s_instances.front());
+    s_instances.pop();
   }
 
   MOCK_CONST_METHOD0(is_refresh_required, bool());
@@ -98,7 +104,7 @@ struct RefreshParentRequest<MockRefreshImageCtx> {
 };
 
 GetMetadataRequest<MockRefreshImageCtx>* GetMetadataRequest<MockRefreshImageCtx>::s_instance = nullptr;
-RefreshParentRequest<MockRefreshImageCtx>* RefreshParentRequest<MockRefreshImageCtx>::s_instance = nullptr;
+std::queue<RefreshParentRequest<MockRefreshImageCtx>*> RefreshParentRequest<MockRefreshImageCtx>::s_instances;
 
 } // namespace image
 
@@ -907,6 +913,141 @@ TEST_F(TestMockImageRefreshRequest, SuccessChildDontOpenParent) {
   req->send();
 
   ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageRefreshRequest, SuccessChildBeingFlattened) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  librbd::ImageCtx *ictx2 = nullptr;
+  std::string clone_name = get_temp_image_name();
+
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_EQ(0, snap_create(*ictx, "snap"));
+  ASSERT_EQ(0, snap_protect(*ictx, "snap"));
+  BOOST_SCOPE_EXIT_ALL((&)) {
+    if (ictx2 != nullptr) {
+      close_image(ictx2);
+    }
+
+    librbd::NoOpProgressContext no_op;
+    ASSERT_EQ(0, librbd::api::Image<>::remove(m_ioctx, clone_name, no_op));
+    ASSERT_EQ(0, ictx->operations->snap_unprotect(
+        cls::rbd::UserSnapshotNamespace(), "snap"));
+  };
+
+  int order = ictx->order;
+  ASSERT_EQ(0, librbd::clone(m_ioctx, m_image_name.c_str(), "snap", m_ioctx,
+                             clone_name.c_str(), ictx->features, &order, 0, 0));
+
+  ASSERT_EQ(0, open_image(clone_name, &ictx2));
+
+  MockRefreshImageCtx mock_image_ctx(*ictx2);
+  auto mock_refresh_parent_request = new MockRefreshParentRequest();
+  MockRefreshParentRequest mock_refresh_parent_request_ext;
+  MockExclusiveLock mock_exclusive_lock;
+  expect_op_work_queue(mock_image_ctx);
+  expect_test_features(mock_image_ctx);
+
+  mock_image_ctx.features &= ~RBD_FEATURE_OPERATIONS;
+
+  InSequence seq;
+  expect_get_mutable_metadata(mock_image_ctx, mock_image_ctx.features, 0);
+  expect_get_parent(mock_image_ctx, 0);
+  MockGetMetadataRequest mock_get_metadata_request;
+  expect_get_metadata(mock_image_ctx, mock_get_metadata_request,
+                      mock_image_ctx.header_oid, {}, 0);
+  expect_get_metadata(mock_image_ctx, mock_get_metadata_request, RBD_INFO, {},
+                      0);
+  expect_apply_metadata(mock_image_ctx, 0);
+  expect_get_group(mock_image_ctx, 0);
+  expect_refresh_parent_is_required(*mock_refresh_parent_request, true);
+  expect_refresh_parent_send(mock_image_ctx, *mock_refresh_parent_request,
+                             -ENOENT);
+  expect_get_mutable_metadata(mock_image_ctx, mock_image_ctx.features, 0);
+  expect_get_parent(mock_image_ctx, 0);
+  expect_get_metadata(mock_image_ctx, mock_get_metadata_request,
+                      mock_image_ctx.header_oid, {}, 0);
+  expect_get_metadata(mock_image_ctx, mock_get_metadata_request, RBD_INFO, {},
+                      0);
+  expect_apply_metadata(mock_image_ctx, 0);
+  expect_get_group(mock_image_ctx, 0);
+  expect_refresh_parent_is_required(mock_refresh_parent_request_ext, false);
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
+  }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
+
+  C_SaferCond ctx;
+  auto req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageRefreshRequest, ChildEnoentRetriesLimit) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  librbd::ImageCtx *ictx2 = nullptr;
+  std::string clone_name = get_temp_image_name();
+
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_EQ(0, snap_create(*ictx, "snap"));
+  ASSERT_EQ(0, snap_protect(*ictx, "snap"));
+  BOOST_SCOPE_EXIT_ALL((&)) {
+    if (ictx2 != nullptr) {
+      close_image(ictx2);
+    }
+
+    librbd::NoOpProgressContext no_op;
+    ASSERT_EQ(0, librbd::api::Image<>::remove(m_ioctx, clone_name, no_op));
+    ASSERT_EQ(0, ictx->operations->snap_unprotect(
+        cls::rbd::UserSnapshotNamespace(), "snap"));
+  };
+
+  int order = ictx->order;
+  ASSERT_EQ(0, librbd::clone(m_ioctx, m_image_name.c_str(), "snap", m_ioctx,
+                             clone_name.c_str(), ictx->features, &order, 0, 0));
+
+  ASSERT_EQ(0, open_image(clone_name, &ictx2));
+
+  MockRefreshImageCtx mock_image_ctx(*ictx2);
+  constexpr int num_tries = RefreshRequest<>::MAX_ENOENT_RETRIES + 1;
+  MockRefreshParentRequest* mock_refresh_parent_requests[num_tries];
+  for (auto& mock_refresh_parent_request : mock_refresh_parent_requests) {
+    mock_refresh_parent_request = new MockRefreshParentRequest();
+  }
+  MockGetMetadataRequest mock_get_metadata_request;
+  expect_op_work_queue(mock_image_ctx);
+  expect_test_features(mock_image_ctx);
+
+  mock_image_ctx.features &= ~RBD_FEATURE_OPERATIONS;
+
+  InSequence seq;
+  for (auto mock_refresh_parent_request : mock_refresh_parent_requests) {
+    expect_get_mutable_metadata(mock_image_ctx, mock_image_ctx.features, 0);
+    expect_get_parent(mock_image_ctx, 0);
+    expect_get_metadata(mock_image_ctx, mock_get_metadata_request,
+                        mock_image_ctx.header_oid, {}, 0);
+    expect_get_metadata(mock_image_ctx, mock_get_metadata_request, RBD_INFO, {},
+                        0);
+    expect_apply_metadata(mock_image_ctx, 0);
+    expect_get_group(mock_image_ctx, 0);
+    expect_refresh_parent_is_required(*mock_refresh_parent_request, true);
+    expect_refresh_parent_send(mock_image_ctx, *mock_refresh_parent_request,
+                               -ENOENT);
+  }
+  expect_refresh_parent_apply(*mock_refresh_parent_requests[num_tries - 1]);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
+  expect_refresh_parent_finalize(
+      mock_image_ctx, *mock_refresh_parent_requests[num_tries - 1], 0);
+
+  C_SaferCond ctx;
+  auto req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
+  req->send();
+
+  ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
 TEST_F(TestMockImageRefreshRequest, SuccessOpFeatures) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57453

---

backport of https://github.com/ceph/ceph/pull/47987
parent tracker: https://tracker.ceph.com/issues/52810