### PR TITLE
install-deps.sh: check for missing boost packages on arm64

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -149,10 +149,9 @@ function install_boost_on_ubuntu {
                               cut -d' ' -f2 |
                               cut -d'.' -f1,2)
     if test -n "$installed_ver"; then
-        if echo "$installed_ver" | grep -q "^$ver"; then
-            return
-        else
-            $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove "ceph-libboost.*${installed_ver}.*"
+        local correct_version_installed=$(echo "$installed_ver" | grep -q "^$ver")
+        if ! $correct_version_installed; then
+	    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove "ceph-libboost.*${installed_ver}.*"
             $SUDO rm -f /etc/apt/sources.list.d/ceph-libboost${installed_ver}.list
         fi
     fi


### PR DESCRIPTION
We were skipping boost package installation on arm64 since
we had a partial list of correct packages:

```
ceph-libboost-atomic1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-chrono1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-container1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-context1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-coroutine1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-date-time1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-filesystem1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-regex1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-serialization1.79-dev/stable,now 1.79.0-1.1 arm64 [installed,automatic]
ceph-libboost-system1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost-thread1.79-dev/stable,now 1.79.0-1.1 arm64 [installed]
ceph-libboost1.79-dev/stable,now 1.79.0-1.1 arm64 [installed,automatic]
```

The current script spot checks `ceph-libboost*-dev` packages for the
correct version, but we do not account for a partial list of correct
packages. In this case, the above list contains correct packages, but
we still need to install `ceph-libboost-random` and a few others.

Fixes: https://tracker.ceph.com/issues/57228
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
