### PR TITLE
msg: change to allow separate port ranges for MDS and OSD

### DIFF
--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -314,6 +314,10 @@ addresses.
 
 .. confval:: ms_bind_port_min
 .. confval:: ms_bind_port_max
+.. confval:: ms_bind_port_min_osd
+.. confval:: ms_bind_port_max_osd
+.. confval:: ms_bind_port_min_mds
+.. confval:: ms_bind_port_max_mds
 .. confval:: ms_bind_ipv4
 .. confval:: ms_bind_ipv6
 .. confval:: public_bind_addr

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1189,6 +1189,34 @@ options:
   fmt_desc: The maximum port number to which an OSD or MDS daemon will bind.
   default: 7568
   with_legacy: true
+- name: ms_bind_port_min_osd
+  type: int
+  level: advanced
+  desc: Lowest port number to bind OSD daemon(s) to
+  fmt_desc: The minimum port number to which an OSD daemon will bind.
+  default: 0
+  with_legacy: true
+- name: ms_bind_port_max_osd
+  type: int
+  level: advanced
+  desc: Highest port number to bind OSD daemon(s) to
+  fmt_desc: The maximum port number to which an OSD daemon will bind.
+  default: 0
+  with_legacy: true
+- name: ms_bind_port_min_mds
+  type: int
+  level: advanced
+  desc: Lowest port number to bind MDS daemon(s) to
+  fmt_desc: The minimum port number to which an MDS daemon will bind.
+  default: 0
+  with_legacy: true
+- name: ms_bind_port_max_mds
+  type: int
+  level: advanced
+  desc: Highest port number to bind MDS daemon(s) to
+  fmt_desc: The maximum port number to which an MDS daemon will bind.
+  default: 0
+  with_legacy: true
 # FreeBSD does not use SO_REAUSEADDR so allow for a bit more time per default
 - name: ms_bind_retry_count
   type: int


### PR DESCRIPTION
The messenger is assigned a random port through ms_bind_port_min and ms_bind_port_max. This makes it impossible for clients to use the policy to differentiate between OSD and MDS via port. This patch uses the _osd and _mds additional options to allow changing the range of each.

Fixes: https://tracker.ceph.com/issues/54978
Signed-off-by: Kim Minjong <caffeinism@puzzle-ai.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
