### PR TITLE
crimson/osd: got map dont need to update current for old map

### DIFF
--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -54,6 +54,11 @@ seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
 
 template <OSDMapGateType OSDMapGateTypeV>
 void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
+  if (epoch < current) {
+    logger().info("got_map({}) < current({}), ignoring", epoch, current);
+    return;
+  }
+  assert(epoch == current + 1);
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);


### PR DESCRIPTION
When we updating current map in got_map with older epoch, we will cause wait_for_map to re-subscrib and wait for map that we already got.

Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>




<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
