### PR TITLE
quincy: PendingReleaseNotes: Note the fix for high CPU utilization during recovery

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,6 +5,9 @@
   'AT_STATX_DONT_SYNC' macro. The 'AT_NO_ATTR_SYNC' macro will be removed in
   the future.
 
+* OSD: The issue of high CPU utilization during recovery/backfill operations
+  has been fixed. For more details, see: https://tracker.ceph.com/issues/56530.
+
 >=17.2.1
 
 * The "BlueStore zero block detection" feature (first introduced to Quincy in


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57461

---

backport of https://github.com/ceph/ceph/pull/47630
parent tracker: https://tracker.ceph.com/issues/57448

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh