### PR TITLE
quincy: mgr/snap_schedule: Use rados.Ioctx.remove_object() instead of remove().

### DIFF
--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -201,7 +201,7 @@ class SnapSchedClient(CephfsClient):
                     size, _mtime = ioctx.stat(SNAP_DB_OBJECT_NAME)
                     dump = ioctx.read(SNAP_DB_OBJECT_NAME, size).decode('utf-8')
                     db.executescript(dump)
-                    ioctx.remove(SNAP_DB_OBJECT_NAME)
+                    ioctx.remove_object(SNAP_DB_OBJECT_NAME)
                 except rados.ObjectNotFound:
                     log.debug(f'No legacy schedule DB found in {fs}')
             db.executescript(Schedule.CREATE_TABLES)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56541

---

backport of https://github.com/ceph/ceph/pull/47006
parent tracker: https://tracker.ceph.com/issues/56269

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh