### PR TITLE
test/{librbd, rgw}: increase delay between and number of bind attempts

### DIFF
--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -86,7 +86,7 @@ public:
 
   // if we have a racing where another thread manages to bind and listen the
   // port picked by this acceptor, try again.
-  static constexpr int MAX_BIND_RETRIES = 42;
+  static constexpr int MAX_BIND_RETRIES = 60;
 
   void create_acceptor(bool reuse) {
     for (int retries = 0;; retries++) {
@@ -105,7 +105,7 @@ public:
 	}
       }
       // backoff a little bit
-      usleep(retries * 10'000);
+      sleep(1);
     }
     m_server_port = m_acceptor->local_endpoint().port();
   }

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -29,7 +29,7 @@ namespace {
 
   // if we have a racing where another thread manages to bind and listen the
   // port picked by this acceptor, try again.
-  static constexpr int MAX_BIND_RETRIES = 42;
+  static constexpr int MAX_BIND_RETRIES = 60;
 
   tcp::acceptor try_bind(boost::asio::io_context& ioctx) {
     using tcp = boost::asio::ip::tcp;
@@ -50,7 +50,7 @@ namespace {
 	}
       }
       // backoff a little bit
-      usleep(retries * 10'000);
+      sleep(1);
     }
     return acceptor;
   }


### PR DESCRIPTION
Commit aa7885f7cc41 ("test/{librbd, rgw}: retry when bind fail with port 0") reduced the frequency of sporadic unit test failures caused by EADDRINUSE a lot, but not entirely.

Currently, it yields a cumulative sleep of ~9 seconds.  Let's increase that to 1 minute.

Fixes: https://tracker.ceph.com/issues/57116
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
