### PR TITLE
crimson/test: Add skip test for pool EIO flag

### DIFF
--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -2284,6 +2284,7 @@ void pool_io_callback(completion_t cb, void *arg /* Actually AioCompletion* */)
 }
 
 TEST(LibRadosAio, PoolEIOFlag) {
+  SKIP_IF_CRIMSON();
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
 


### PR DESCRIPTION
EIO flag not yet supported, it will cause the test to hang.

Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
