### PR TITLE
quincy: common/win32,dokan: include bcrypt.h for NTSTATUS

### DIFF
--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -954,7 +954,7 @@ int do_map() {
           <<". Mountpoint: " << to_string(g_cfg->mountpoint) << dendl;
 
   DWORD status = DokanMain(dokan_options, dokan_operations);
-  switch (status) {
+  switch (static_cast<int>(status)) {
   case DOKAN_SUCCESS:
     dout(2) << "Dokan has returned successfully" << dendl;
     break;

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -13,10 +13,10 @@
 #define CEPH_DOKAN_IO_DEFAULT_TIMEOUT 60 * 5 // Seconds
 #define CEPH_DOKAN_DEFAULT_THREAD_COUNT 10
 
-typedef DWORD NTSTATUS;
 // Avoid conflicting COM types, exposed when using C++.
 #define _OLE2_H_
 
+#include <bcrypt.h>  // for typedef of NTSTATUS
 #include <dokan.h>
 
 struct Config {

--- a/src/dokan/dbg.cc
+++ b/src/dokan/dbg.cc
@@ -139,7 +139,7 @@ void print_open_params(
   check_flag(o, FlagsAndAttributes, SECURITY_EFFECTIVE_ONLY);
   check_flag(o, FlagsAndAttributes, SECURITY_SQOS_PRESENT);
 
-  o << "\n\tIsDirectory: " << (DokanFileInfo->IsDirectory != NULL);
+  o << "\n\tIsDirectory: " << static_cast<bool>(DokanFileInfo->IsDirectory);
 
   o << "\n\tCreateOptions: " << hex << CreateOptions << " ";
   check_flag(o, CreateOptions, FILE_DIRECTORY_FILE);

--- a/src/include/err.h
+++ b/src/include/err.h
@@ -5,10 +5,11 @@
  * adapted from linux 2.6.24 include/linux/err.h
  */
 #define MAX_ERRNO 4095
-#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+#define IS_ERR_VALUE(x) ((x) >= (uintptr_t)-MAX_ERRNO)
 
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* this generates a warning in c++; caller can do the cast manually
 static inline void *ERR_PTR(long error)
@@ -17,12 +18,12 @@ static inline void *ERR_PTR(long error)
 }
 */
 
-static inline long PTR_ERR(const void *ptr)
+static inline intptr_t PTR_ERR(const void *ptr)
 {
-  return (uintptr_t) ptr;
+  return (intptr_t) ptr;
 }
 
-static inline long IS_ERR(const void *ptr)
+static inline bool IS_ERR(const void *ptr)
 {
   return IS_ERR_VALUE((uintptr_t)ptr);
 }

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -1,6 +1,7 @@
 #include "include/buffer.h"
 #include "include/encoding.h"
 
+#include <fmt/format.h>
 #include "gtest/gtest.h"
 
 using namespace std;
@@ -319,26 +320,27 @@ TEST(EncodingRoundTrip, Integers) {
   }
 }
 
-const char* expected_what[] = {
-  "void lame_decoder(int) no longer understand old encoding version 100 < 200: Malformed input",
-  "void lame_decoder(int) decode past end of struct encoding: Malformed input"
-};
-
-void lame_decoder(int which) {
-  switch (which) {
-  case 0:
-    throw buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, 100, 200));
-  case 1:
-    throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__));
-  }
-}
-
 TEST(EncodingException, Macros) {
-  for (unsigned i = 0; i < std::size(expected_what); i++) {
+  const struct {
+    buffer::malformed_input exc;
+    std::string expected_what;
+  } tests[] = {
+    {
+      DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, 100, 200),
+      fmt::format("{} no longer understand old encoding version 100 < 200: Malformed input",
+                  __PRETTY_FUNCTION__)
+    },
+    {
+      DECODE_ERR_PAST(__PRETTY_FUNCTION__),
+      fmt::format("{} decode past end of struct encoding: Malformed input",
+                  __PRETTY_FUNCTION__)
+    }
+  };
+  for (auto& [exec, expected_what] : tests) {
     try {
-      lame_decoder(i);
+      throw exec;
     } catch (const exception& e) {
-      ASSERT_NE(string(e.what()).find(expected_what[i]), string::npos);
+      ASSERT_NE(string(e.what()).find(expected_what), string::npos);
     }
   }
 }

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -334,11 +334,11 @@ void lame_decoder(int which) {
 }
 
 TEST(EncodingException, Macros) {
-  for (unsigned i = 0; i < sizeof(expected_what)/sizeof(expected_what[0]); i++) {
+  for (unsigned i = 0; i < std::size(expected_what); i++) {
     try {
       lame_decoder(i);
     } catch (const exception& e) {
-      ASSERT_EQ(string(expected_what[i]), string(e.what()));
+      ASSERT_NE(string(e.what()).find(expected_what[i]), string::npos);
     }
   }
 }

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -19,7 +19,7 @@ sslTag="OpenSSL_1_1_1c"
 sslDir="${depsToolsetDir}/openssl"
 sslSrcDir="${depsSrcDir}/openssl"
 
-curlTag="curl-7_66_0"
+curlTag="curl-7_84_0"
 curlSrcDir="${depsSrcDir}/curl"
 curlDir="${depsToolsetDir}/curl"
 


### PR DESCRIPTION
Even though https://github.com/ceph/ceph/pull/46554 wasn't (yet?) backported to quincy, Jenkins ends up building against Boost 1.79 anyway because the build environments aren't separated.  This exposes quincy to test failures and also potential build failures that were addressed in main as part of enabling Boost 1.79, e.g.:

```
[ RUN      ] EncodingException.Macros
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/encoding.cc:341: Failure
Expected equality of these values:
  string(expected_what[i])
    Which is: "void lame_decoder(int) no longer understand old encoding version 100 < 200: Malformed input"
  string(e.what())
    Which is: "void lame_decoder(int) no longer understand old encoding version 100 < 200: Malformed input [buffer:3]"
[  FAILED  ] EncodingException.Macros (0 ms)
```

Backport https://github.com/ceph/ceph/pull/47217, https://github.com/ceph/ceph/pull/47461, https://github.com/ceph/ceph/pull/47470 and https://github.com/ceph/ceph/pull/47818 to quincy to address some of that.