### PR TITLE
quincy: test/{librbd, rgw}: increase delay between and number of bind attempts

### DIFF
--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -86,7 +86,7 @@ public:
 
   // if we have a racing where another thread manages to bind and listen the
   // port picked by this acceptor, try again.
-  static constexpr int MAX_BIND_RETRIES = 42;
+  static constexpr int MAX_BIND_RETRIES = 60;
 
   void create_acceptor(bool reuse) {
     for (int retries = 0;; retries++) {
@@ -105,7 +105,7 @@ public:
 	}
       }
       // backoff a little bit
-      usleep(retries * 10'000);
+      sleep(1);
     }
     m_server_port = m_acceptor->local_endpoint().port();
   }

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -29,7 +29,7 @@ namespace {
 
   // if we have a racing where another thread manages to bind and listen the
   // port picked by this acceptor, try again.
-  static constexpr int MAX_BIND_RETRIES = 42;
+  static constexpr int MAX_BIND_RETRIES = 60;
 
   tcp::acceptor try_bind(boost::asio::io_context& ioctx) {
     using tcp = boost::asio::ip::tcp;
@@ -50,7 +50,7 @@ namespace {
 	}
       }
       // backoff a little bit
-      usleep(retries * 10'000);
+      sleep(1);
     }
     return acceptor;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57478

---

backport of https://github.com/ceph/ceph/pull/48014 (https://github.com/ceph/ceph/pull/47962 already backported)
parent tracker: https://tracker.ceph.com/issues/57116