### PR TITLE
quincy: ceph-dencoder: Add erasure_code to denc-mod-osd's target_link_libraries

### DIFF
--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -49,7 +49,8 @@ add_denc_mod(denc-mod-osd
 target_link_libraries(denc-mod-osd
   os
   osd
-  mon)
+  mon
+  erasure_code)
 
 if(WITH_RADOSGW)
   add_denc_mod(denc-mod-rgw

--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -50,7 +50,8 @@ target_link_libraries(denc-mod-osd
   os
   osd
   mon
-  erasure_code)
+  erasure_code
+  global)
 
 if(WITH_RADOSGW)
   add_denc_mod(denc-mod-rgw


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57391

---

backport of https://github.com/ceph/ceph/pull/47919
parent tracker: https://tracker.ceph.com/issues/57390

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh