### PR TITLE
os/bluestore: Provide backup and restore for bluestore db

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -391,6 +391,10 @@ public:
 			     const std::string& start, const std::string& end) {}
   virtual void compact_range_async(const std::string& prefix,
 				   const std::string& start, const std::string& end) {}
+  /// backup db
+  virtual bool db_backup(const std::string& dst_dir) { return false; }
+  /// restore db
+  virtual bool db_restore(const std::string& backup_dir) { return false; }
 
   // See RocksDB merge operator definition, we support the basic
   // associative merge only right now.

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -2097,6 +2097,52 @@ void RocksDBStore::compact_range(const string& start, const string& end)
   }
 }
 
+bool RocksDBStore::db_backup(const string& dst_dir)
+{
+  rocksdb::Status s;
+  rocksdb::BackupableDBOptions engine_options(dst_dir, rocksdb::Env::Default());
+  rocksdb::BackupEngine *backup_engine;
+  std::unique_ptr<rocksdb::BackupEngine> backup_engine_;
+
+  s = rocksdb::BackupEngine::Open(env, engine_options, &backup_engine);
+  if (!s.ok()) {
+    derr << s.ToString() << dendl;
+    return s.ok();
+  }
+  backup_engine_.reset(backup_engine);
+  s = backup_engine_->CreateNewBackup(db);
+  if (!s.ok()) {
+    derr << s.ToString() << dendl;
+    return s.ok();
+  }
+  backup_engine_.reset();
+
+  return s.ok();
+}
+
+bool RocksDBStore::db_restore(const string& backup_dir)
+{
+  rocksdb::Status s;
+  rocksdb::BackupableDBOptions engine_options(backup_dir, rocksdb::Env::Default());
+  rocksdb::BackupEngineReadOnly *backup_engine_ro;
+  std::unique_ptr<rocksdb::BackupEngineReadOnly> backup_engine_ro_;
+
+  s = rocksdb::BackupEngineReadOnly::Open(env, engine_options, &backup_engine_ro);
+  if (!s.ok()) {
+    derr << s.ToString() << dendl;
+    return s.ok();
+  }
+  backup_engine_ro_.reset(backup_engine_ro);
+  s = backup_engine_ro->RestoreDBFromLatestBackup(path, path+".wal");
+  if (!s.ok()) {
+    derr << s.ToString() << dendl;
+    return s.ok();
+  }
+  backup_engine_ro_.reset();
+
+  return s.ok();
+}
+
 RocksDBStore::RocksDBWholeSpaceIteratorImpl::~RocksDBWholeSpaceIteratorImpl()
 {
   delete dbiter;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -17,6 +17,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/table.h"
 #include "rocksdb/db.h"
+#include "rocksdb/utilities/backupable_db.h"
 #include "kv/rocksdb_cache/BinnedLRUCache.h"
 #include <errno.h>
 #include "common/errno.h"
@@ -56,10 +57,13 @@ namespace rocksdb{
   class Iterator;
   class Logger;
   class ColumnFamilyHandle;
+  class BackupEngine;
+  class BackupEngineReadOnly;
   struct Options;
   struct BlockBasedTableOptions;
   struct DBOptions;
   struct ColumnFamilyOptions;
+  struct BackupableDBOptions;
 }
 
 extern rocksdb::Logger *create_rocksdb_ceph_logger();
@@ -230,6 +234,10 @@ public:
 			   const std::string& end) override {
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
+  /// backup rocksdb
+  bool db_backup(const std::string& dst_dir) override;
+  /// restore rocksdb
+  bool db_restore(const std::string& backup_dir) override;
 
   RocksDBStore(CephContext *c, const std::string &path, std::map<std::string,std::string> opt, void *p) :
     cct(c),

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -781,6 +781,7 @@ public:
   virtual bool has_builtin_csum() const {
     return false;
   }
+  virtual bool db_backup(const std::string& dst_dir) { return false; }
 };
 
 #endif

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3242,6 +3242,12 @@ public:
     double lat_threshold,
     std::function<std::string (const ceph::timespan& lat)> fn) const;
 
+  bool db_backup(const std::string& dst_dir) override {
+    ceph_assert(db);
+    bool ret = db->db_backup(dst_dir);
+    return ret;
+  }
+
 private:
   bool _debug_data_eio(const ghobject_t& o) {
     if (!cct->_conf->bluestore_debug_inject_read_err) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3156,6 +3156,25 @@ will start to track new ops received afterwards.";
       st.dump(f);
       f->close_section();
     }
+  } else if (prefix == "db_backup") {
+    string dst_dir;
+    if (!(cmd_getval(cmdmap, "dst_dir", dst_dir))) {
+      ss << "Error db backup: no dst dir provided";
+      ret = -EINVAL;
+      goto out;
+    }
+    dout(1) << "triggering manual db backup" << dendl;
+    auto start = ceph::coarse_mono_clock::now();
+    bool ret = store->db_backup(dst_dir);
+    auto end = ceph::coarse_mono_clock::now();
+    double duration = std::chrono::duration<double>(end-start).count();
+    if(!ret) {
+      ss << "db backup failed";
+    } else {
+      dout(1) << "finished db backup in "
+              << duration
+              << " seconds" << dendl;
+    }
   } else {
     ceph_abort_msg("broken asok registration");
   }
@@ -3989,6 +4008,12 @@ void OSD::final_init()
 				     asok_hook,
 				     "Commpact object store's omap."
                                      " WARNING: Compaction probably slows your requests");
+  ceph_assert(r == 0);
+
+  r = admin_socket->register_command("db_backup " \
+                                     "name=dst_dir,type=CephString",
+                                     asok_hook,
+                                     "Backup rocksdb to other filesystem, and then you can use it to restore db");
   ceph_assert(r == 0);
 
   r = admin_socket->register_command("get_mapped_pools",

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -20,4 +20,5 @@
     destructive-repair  (use only as last resort! may corrupt healthy data)
     stats
     histogram [prefix]
+    db-restore <backup_dir>
   

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -51,6 +51,7 @@ void usage(const char *pname)
     << "  destructive-repair  (use only as last resort! may corrupt healthy data)\n"
     << "  stats\n"
     << "  histogram [prefix]\n"
+    << "  db-restore <backup_dir>\n"
     << std::endl;
 }
 
@@ -99,7 +100,7 @@ int main(int argc, const char *argv[])
     return 1;
   }
 
-  bool to_repair = (cmd == "destructive-repair");
+  bool to_repair = (cmd == "destructive-repair" || cmd == "db-restore");
   bool need_stats = (cmd == "stats");
   StoreTool st(type, path, to_repair, need_stats);
 
@@ -354,6 +355,18 @@ int main(int argc, const char *argv[])
     if (argc > 4)
       prefix = url_unescape(argv[4]);
     st.build_size_histogram(prefix);
+  } else if (cmd == "db-restore") {
+    if (argc < 3)  {
+      usage(argv[0]);
+      return 1;
+    }
+    string backup_dir = args[3];
+    std::cout << "manul triggering osd db restore" << std::endl;
+    bool ret = st.db_restore(backup_dir);
+    if(ret)
+      std::cout << "finished osd db restore" << std::endl;
+    else
+      std::cout << "failed osd db restore" << std::endl;
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     return 1;

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -25,6 +25,9 @@ StoreTool::StoreTool(const string& type,
     g_conf()->rocksdb_perf = true;
     g_conf()->rocksdb_collect_compaction_stats = true;
   }
+  if (to_repair) {
+    g_conf()->bluefs_min_flush_size = 0;
+  }
 
   if (type == "bluestore-kv") {
 #ifdef WITH_BLUESTORE
@@ -377,4 +380,9 @@ void StoreTool::compact_range(const string& prefix,
 int StoreTool::destructive_repair()
 {
   return db->repair(std::cout);
+}
+
+bool StoreTool::db_restore(const string& backup_dir)
+{
+  return db->db_restore(backup_dir);
 }

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -78,4 +78,5 @@ public:
 
   int print_stats() const;
   int build_size_histogram(const std::string& prefix) const;
+  bool db_restore(const std::string& backup_dir);
 };


### PR DESCRIPTION
If have a function what we can backup rocksdb of bluetore, and then we can use backup db to restore db when db damage. At now, osd block device disk is a 16TB HDD, if have one of db happend damage, we have to destroyed and redeployed osd, and then have a 16TB data need to backfill, but block device is intact. If we can restore db by backup, we don't need to redeployed osd, just backfill a little data.

Signed-off-by: Yite Gu <ess_gyt@qq.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
