### PR TITLE
mgr/dashboard: fix openapi-check

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -33,7 +33,7 @@ class Docs(BaseController):
                     list_of_ctrl.add(endpoint.ctrl)
 
         tag_map: Dict[str, str] = {}
-        for ctrl in list_of_ctrl:
+        for ctrl in sorted(list_of_ctrl, key=lambda ctrl: ctrl.__name__):
             tag_name = ctrl.__name__
             tag_descr = ""
             if hasattr(ctrl, 'doc_info'):

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -30,6 +30,7 @@ deps =
     -rrequirements-lint.txt
 
 [testenv]
+basepython=python3
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -47,7 +48,6 @@ commands =
     pytest {posargs}
 
 [testenv:run]
-basepython=python3
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -99,7 +99,6 @@ commands =
     rstcheck --report info --debug -- {[rstlint]dirs}
 
 [testenv:lint]
-basepython=python3
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -112,13 +111,11 @@ commands =
     {[base-rst]commands}
 
 [testenv:flake8]
-basepython = python3
 deps = {[base-lint]deps}
 commands =
     flake8 --config=tox.ini {posargs}
 
 [testenv:pylint]
-basepython = python3
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -126,7 +123,6 @@ commands =
     pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
 
 [testenv:rst]
-basepython = python3
 deps = {[base-lint]deps}
 commands =
     rstcheck --report info --debug -- {posargs:{[rstlint]dirs}}
@@ -142,7 +138,6 @@ addopts =
 #    --aggressive
 
 [testenv:fix]
-basepython=python3
 deps =
     {[base-lint]deps}
 commands =
@@ -156,7 +151,6 @@ commands =
     python ci/check_grafana_dashboards.py frontend/src/app ../../../../monitoring/ceph-mixin/dashboards_out
 
 [testenv:openapi-{check,fix}]
-basepython = python3
 allowlist_externals = diff
 description =
     check: Ensure that auto-generated OpenAPI Specification matches the current version


### PR DESCRIPTION
When generating tags the order of endpoints wasn't taken into account.
Two endpoints with the same url prefix, for example `/api/cluster/` and
`/api/cluster/user`, have different docs and the tags is generated from
a doc of one of these two, and since the order of these endpoints might
vary it is imperative to sort them to have a deterministic output.

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>
Fixes: https://tracker.ceph.com/issues/57345


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
