### PR TITLE
 crimson/osd: simplify and inform OSDMapGate about each new OSDMap epoch 

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -137,7 +137,7 @@ seastar::future<> ClientRequest::with_pg_int(
 	      std::move(trigger),
 	      m->get_min_epoch());
 	  });
-      }).then_interruptible([this, this_instance_id, &pg](auto map) {
+      }).then_interruptible([this, this_instance_id, &pg] {
 	logger().debug("{}.{}: after wait_for_map", *this, this_instance_id);
 	return enter_stage<interruptor>(pp(pg).wait_for_active);
       }).then_interruptible([this, this_instance_id, &pg]() {

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -74,7 +74,7 @@ seastar::future<> PeeringEvent<T>::with_pg(
 	  return pg->osdmap_gate.wait_for_map(
 	    std::move(trigger), evt.get_epoch_sent());
 	});
-    }).then_interruptible([this, pg](auto) {
+    }).then_interruptible([this, pg] {
       return this->template enter_stage<interruptor>(pp(*pg).process);
     }).then_interruptible([this, pg] {
       // TODO: likely we should synchronize also with the pg log-based

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -54,6 +54,7 @@ seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
 
 template <OSDMapGateType OSDMapGateTypeV>
 void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
+  logger().debug("{}: epoch({}), current({})", __func__, epoch, current);
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -41,7 +41,7 @@ public:
     OSDMapBlocker &operator=(const OSDMapBlocker &) = delete;
     OSDMapBlocker &operator=(OSDMapBlocker &&) = delete;
 
-    seastar::shared_promise<epoch_t> promise;
+    seastar::shared_promise<> promise;
 
     void dump_detail(Formatter *f) const final;
   };
@@ -63,10 +63,10 @@ public:
   /**
    * wait_for_map
    *
-   * Wait for an osdmap whose epoch is greater or equal to given epoch.
+   * Wait for an osdmap whose epoch is equal to given epoch.
    * If shard_services is non-null, request map if not present.
    */
-  seastar::future<epoch_t>
+  seastar::future<>
   wait_for_map(
     typename OSDMapBlocker::BlockingEvent::TriggerI&& trigger,
     epoch_t epoch,

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -126,8 +126,8 @@ public:
 	    opref.get_epoch(),
 	    &shard_services);
 	});
-    }).then([&logger, &opref](auto epoch) {
-      logger.debug("{}: got map {}, entering get_pg", opref, epoch);
+    }).then([&logger, &opref] {
+      logger.debug("{}: got map {}, entering get_pg", opref, opref.get_epoch());
       return opref.template enter_stage<>(
 	opref.get_connection_pipeline().get_pg);
     }).then([this, &logger, &opref] {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -636,10 +636,11 @@ seastar::future<> CoreState::broadcast_map_to_pgs(
     [=, &shard_manager, &shard_services](auto& pg) {
       return shard_services.start_operation<PGAdvanceMap>(
 	shard_manager, pg.second, pg.second->get_osdmap_epoch(), epoch,
-	PeeringCtx{}, false).second;
-    }).then([epoch, this] {
-      osdmap_gate.got_map(epoch);
-      return seastar::make_ready_future();
+	PeeringCtx{}, false
+      ).second.then([epoch, this] {
+        osdmap_gate.got_map(epoch);
+        return seastar::now();
+      });
     });
 }
 

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -633,7 +633,7 @@ seastar::future<> CoreState::broadcast_map_to_pgs(
   auto &pgs = pg_map.get_pgs();
   return seastar::parallel_for_each(
     pgs.begin(), pgs.end(),
-    [=, &shard_manager, &shard_services](auto& pg) {
+    [=, &shard_manager, &shard_services, this](auto& pg) {
       return shard_services.start_operation<PGAdvanceMap>(
 	shard_manager, pg.second, pg.second->get_osdmap_epoch(), epoch,
 	PeeringCtx{}, false


### PR DESCRIPTION
crimson/osd: inform OSDMapGate about each new OSDMap epoch

The goal is to let `OSDMapGate` unblock waiters waiting on
particular map epoch. Without this patch it was possible that
a waiter for `OSDMap` epoch x+1 gets unblocked even if somebody
is waiting for epoch x.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
