### PR TITLE
libcephfs: Nonblocking io

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -15511,6 +15511,19 @@ int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int
   return _preadv_pwritev_locked(fh, iov, iovcnt, off, false, false);
 }
 
+int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
+                                  int iovcnt, int64_t offset, bool write,
+                                  Context *onfinish, bufferlist *bl)
+{
+    RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
+    if (!mref_reader.is_state_satisfied())
+      return -CEPHFS_ENOTCONN;
+
+    std::scoped_lock cl(client_lock);
+    return _preadv_pwritev_locked(fh, iov, iovcnt, offset, write, true,
+    				  onfinish, bl);
+}
+
 int Client::ll_flush(Fh *fh)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11027,7 +11027,8 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     r = objectcacher->file_write(&in->oset, &in->layout,
 				 in->snaprealm->get_snap_context(),
 				 offset, size, bl, ceph::real_clock::now(),
-				 0);
+				 0, nullptr,
+				 objectcacher->CFG_block_writes_upfront());
     put_cap_ref(in, CEPH_CAP_FILE_BUFFER);
 
     if (r < 0)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3586,7 +3586,8 @@ void Client::put_cap_ref(Inode *in, int cap)
 	ldout(cct, 10) << __func__ << " finishing pending cap_snap on " << *in << dendl;
 	in->cap_snaps.rbegin()->second.writing = 0;
 	finish_cap_snap(in, in->cap_snaps.rbegin()->second, get_caps_used(in));
-	signal_context_list(in->waitfor_caps);  // wake up blocked sync writers
+	ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+	signal_caps_inode(in);  // wake up blocked sync writers
       }
       if (last & CEPH_CAP_FILE_BUFFER) {
 	for (auto &p : in->cap_snaps)
@@ -4236,6 +4237,24 @@ void Client::signal_context_list(list<Context*>& ls)
   }
 }
 
+void Client::signal_caps_inode(Inode *in)
+{
+  // Process the waitfor_caps list
+  while (!in->waitfor_caps.empty()) {
+    in->waitfor_caps.front()->complete(0);
+    in->waitfor_caps.pop_front();
+  }
+
+  // New items may have been added to the pending list, move them onto the
+  // waitfor_caps list
+  while (!in->waitfor_caps_pending.empty()) {
+    Context *ctx = in->waitfor_caps_pending.front();
+
+    in->waitfor_caps_pending.pop_front();
+    in->waitfor_caps.push_back(ctx);
+  }
+}
+
 void Client::wake_up_session_caps(MetaSession *s, bool reconnect)
 {
   for (const auto &cap : s->caps) {
@@ -4252,7 +4271,8 @@ void Client::wake_up_session_caps(MetaSession *s, bool reconnect)
 	  in.flags |= I_CAP_DROPPED;
       }
     }
-    signal_context_list(in.waitfor_caps);
+    ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+    signal_caps_inode(&in);
   }
 }
 
@@ -4506,8 +4526,10 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
     }
   }
 
-  if (issued & ~old_caps)
-    signal_context_list(in->waitfor_caps);
+  if (issued & ~old_caps) {
+    ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+    signal_caps_inode(in);
+  }
 }
 
 void Client::remove_cap(Cap *cap, bool queue_release)
@@ -4599,7 +4621,8 @@ void Client::remove_session_caps(MetaSession *s, int err)
       _schedule_invalidate_callback(in.get(), 0, 0);
     }
 
-    signal_context_list(in->waitfor_caps);
+    ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+    signal_caps_inode(in.get());
   }
   s->flushing_caps_tids.clear();
   sync_cond.notify_all();
@@ -4810,8 +4833,10 @@ void Client::force_session_readonly(MetaSession *s)
   s->readonly = true;
   for (xlist<Cap*>::iterator p = s->caps.begin(); !p.end(); ++p) {
     auto &in = (*p)->inode;
-    if (in.caps_wanted() & CEPH_CAP_FILE_WR)
-      signal_context_list(in.waitfor_caps);
+    if (in.caps_wanted() & CEPH_CAP_FILE_WR) {
+      ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+      signal_caps_inode(&in);
+    }
   }
 }
 
@@ -5532,13 +5557,6 @@ void Client::handle_cap_flush_ack(MetaSession *session, Inode *in, Cap *cap, con
 	  << " cleaned " << ccap_string(cleaned) << " on " << *in
 	  << " with " << ccap_string(dirty) << dendl;
 
-  if (flushed) {
-    signal_context_list(in->waitfor_caps);
-    if (session->flushing_caps_tids.empty() ||
-	*session->flushing_caps_tids.begin() > flush_ack_tid)
-      sync_cond.notify_all();
-  }
-
   if (!dirty) {
     in->cap_dirtier_uid = -1;
     in->cap_dirtier_gid = -1;
@@ -5557,9 +5575,19 @@ void Client::handle_cap_flush_ack(MetaSession *session, Inode *in, Cap *cap, con
        if (in->flushing_cap_tids.empty())
 	  in->flushing_cap_item.remove_myself();
       }
-      if (!in->caps_dirty())
-	put_inode(in);
     }
+  }
+
+  if (flushed) {
+    ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+    signal_caps_inode(in);
+    if (session->flushing_caps_tids.empty() ||
+	*session->flushing_caps_tids.begin() > flush_ack_tid)
+      sync_cond.notify_all();
+  }
+
+  if (cleaned && !in->caps_dirty()) {
+    put_inode(in);
   }
 }
 
@@ -5585,7 +5613,8 @@ void Client::handle_cap_flushsnap_ack(MetaSession *session, Inode *in, const MCo
 	in->flushing_cap_item.remove_myself();
       in->cap_snaps.erase(it);
 
-      signal_context_list(in->waitfor_caps);
+      ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+      signal_caps_inode(in);
       if (session->flushing_caps_tids.empty() ||
 	  *session->flushing_caps_tids.begin() > flush_ack_tid)
 	sync_cond.notify_all();
@@ -5847,8 +5876,10 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
     check_caps(in, flags);
 
   // wake up waiters
-  if (new_caps)
-    signal_context_list(in->waitfor_caps);
+  if (new_caps) {
+    ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+    signal_caps_inode(in);
+  }
 
   // may drop inode's last ref
   if (deleted_inode)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2784,7 +2784,7 @@ void Client::handle_client_reply(const MConstRef<MClientReply>& reply)
       request->unsafe_item.remove_myself();
       request->unsafe_dir_item.remove_myself();
       request->unsafe_target_item.remove_myself();
-      signal_cond_list(request->waitfor_safe);
+      signal_context_list(request->waitfor_safe);
     }
     request->item.remove_myself();
     unregister_request(request);
@@ -3277,7 +3277,7 @@ void Client::wait_unsafe_requests()
        ++p) {
     MetaRequest *req = *p;
     if (req->unsafe_item.is_on_list())
-      wait_on_list(req->waitfor_safe);
+      wait_on_context_list(req->waitfor_safe);
     put_request(req);
   }
 }
@@ -3313,7 +3313,7 @@ void Client::kick_requests_closed(MetaSession *session)
 		     <<  in->ino  << " " << req->get_tid() << dendl;
 	  req->unsafe_target_item.remove_myself();
 	}
-	signal_cond_list(req->waitfor_safe);
+	signal_context_list(req->waitfor_safe);
 	unregister_request(req);
       }
     }
@@ -3586,12 +3586,12 @@ void Client::put_cap_ref(Inode *in, int cap)
 	ldout(cct, 10) << __func__ << " finishing pending cap_snap on " << *in << dendl;
 	in->cap_snaps.rbegin()->second.writing = 0;
 	finish_cap_snap(in, in->cap_snaps.rbegin()->second, get_caps_used(in));
-	signal_cond_list(in->waitfor_caps);  // wake up blocked sync writers
+	signal_context_list(in->waitfor_caps);  // wake up blocked sync writers
       }
       if (last & CEPH_CAP_FILE_BUFFER) {
 	for (auto &p : in->cap_snaps)
 	  p.second.dirty_data = 0;
-	signal_cond_list(in->waitfor_commit);
+	signal_context_list(in->waitfor_commit);
 	ldout(cct, 5) << __func__ << " dropped last FILE_BUFFER ref on " << *in << dendl;
 	++put_nref;
 
@@ -3716,9 +3716,9 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
     }
 
     if (waitfor_caps)
-      wait_on_list(in->waitfor_caps);
+      wait_on_context_list(in->waitfor_caps);
     else if (waitfor_commit)
-      wait_on_list(in->waitfor_commit);
+      wait_on_context_list(in->waitfor_commit);
   }
 }
 
@@ -4252,7 +4252,7 @@ void Client::wake_up_session_caps(MetaSession *s, bool reconnect)
 	  in.flags |= I_CAP_DROPPED;
       }
     }
-    signal_cond_list(in.waitfor_caps);
+    signal_context_list(in.waitfor_caps);
   }
 }
 
@@ -4507,7 +4507,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
   }
 
   if (issued & ~old_caps)
-    signal_cond_list(in->waitfor_caps);
+    signal_context_list(in->waitfor_caps);
 }
 
 void Client::remove_cap(Cap *cap, bool queue_release)
@@ -4599,7 +4599,7 @@ void Client::remove_session_caps(MetaSession *s, int err)
       _schedule_invalidate_callback(in.get(), 0, 0);
     }
 
-    signal_cond_list(in->waitfor_caps);
+    signal_context_list(in->waitfor_caps);
   }
   s->flushing_caps_tids.clear();
   sync_cond.notify_all();
@@ -4811,7 +4811,7 @@ void Client::force_session_readonly(MetaSession *s)
   for (xlist<Cap*>::iterator p = s->caps.begin(); !p.end(); ++p) {
     auto &in = (*p)->inode;
     if (in.caps_wanted() & CEPH_CAP_FILE_WR)
-      signal_cond_list(in.waitfor_caps);
+      signal_context_list(in.waitfor_caps);
   }
 }
 
@@ -4894,7 +4894,7 @@ void Client::wait_sync_caps(Inode *in, ceph_tid_t want)
     ldout(cct, 10) << __func__ << " on " << *in << " flushing "
 		   << ccap_string(it->second) << " want " << want
 		   << " last " << it->first << dendl;
-    wait_on_list(in->waitfor_caps);
+    wait_on_context_list(in->waitfor_caps);
   }
 }
 
@@ -5533,7 +5533,7 @@ void Client::handle_cap_flush_ack(MetaSession *session, Inode *in, Cap *cap, con
 	  << " with " << ccap_string(dirty) << dendl;
 
   if (flushed) {
-    signal_cond_list(in->waitfor_caps);
+    signal_context_list(in->waitfor_caps);
     if (session->flushing_caps_tids.empty() ||
 	*session->flushing_caps_tids.begin() > flush_ack_tid)
       sync_cond.notify_all();
@@ -5585,7 +5585,7 @@ void Client::handle_cap_flushsnap_ack(MetaSession *session, Inode *in, const MCo
 	in->flushing_cap_item.remove_myself();
       in->cap_snaps.erase(it);
 
-      signal_cond_list(in->waitfor_caps);
+      signal_context_list(in->waitfor_caps);
       if (session->flushing_caps_tids.empty() ||
 	  *session->flushing_caps_tids.begin() > flush_ack_tid)
 	sync_cond.notify_all();
@@ -5848,7 +5848,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 
   // wake up waiters
   if (new_caps)
-    signal_cond_list(in->waitfor_caps);
+    signal_context_list(in->waitfor_caps);
 
   // may drop inode's last ref
   if (deleted_inode)
@@ -10528,6 +10528,7 @@ void Client::C_Read_Finisher::finish_io(int r)
   if (have_caps) {
     clnt->put_cap_ref(in, CEPH_CAP_FILE_RD);
   }
+
   if (movepos) {
     clnt->unlock_fh_pos(f);
   }
@@ -11603,7 +11604,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
     ldout(cct, 15) << "waiting on unsafe requests, last tid " << req->get_tid() <<  dendl;
 
     req->get();
-    wait_on_list(req->waitfor_safe);
+    wait_on_context_list(req->waitfor_safe);
     put_request(req);
   }
 
@@ -11618,7 +11619,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
     while (in->cap_refs[CEPH_CAP_FILE_BUFFER] > 0) {
       ldout(cct, 10) << "ino " << in->ino << " has " << in->cap_refs[CEPH_CAP_FILE_BUFFER]
 		     << " uncommitted, waiting" << dendl;
-      wait_on_list(in->waitfor_commit);
+      wait_on_context_list(in->waitfor_commit);
     }
   }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1028,6 +1028,7 @@ protected:
   }
   void wait_on_context_list(std::list<Context*>& ls);
   void signal_context_list(std::list<Context*>& ls);
+  void signal_caps_inode(Inode *in);
 
   // -- metadata cache stuff
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -646,6 +646,10 @@ public:
   int ll_write(Fh *fh, loff_t off, loff_t len, const char *data);
   int64_t ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off);
   int64_t ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off);
+  int64_t ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov, int iovcnt,
+                            int64_t offset, bool write,
+                            Context *onfinish = nullptr,
+                            bufferlist *blp = nullptr);
   loff_t ll_lseek(Fh *fh, loff_t offset, int whence);
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -649,7 +649,8 @@ public:
   int64_t ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov, int iovcnt,
                             int64_t offset, bool write,
                             Context *onfinish = nullptr,
-                            bufferlist *blp = nullptr);
+                            bufferlist *blp = nullptr,
+                            bool do_fsync = false, bool syncdataonly = false);
   loff_t ll_lseek(Fh *fh, loff_t offset, int whence);
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);
@@ -1381,17 +1382,21 @@ private:
   public:
     void finish_io(int r);
     void finish_onuninline(int r);
+    void finish_fsync(int r);
 
     C_Write_Finisher(Client *clnt, Context *onfinish, bool dont_need_uninline,
                      bool is_file_write, utime_t start, Fh *f, Inode *in,
-                     uint64_t fpos, int64_t offset, uint64_t size)
+                     uint64_t fpos, int64_t offset, uint64_t size,
+                     bool do_fsync, bool syncdataonly)
       : clnt(clnt), onfinish(onfinish),
         is_file_write(is_file_write), start(start), f(f), in(in), fpos(fpos),
-        offset(offset), size(size) {
+        offset(offset), size(size), syncdataonly(syncdataonly) {
       iofinished_r = 0;
       onuninlinefinished_r = 0;
+      fsync_r = 0;
       iofinished = false;
       onuninlinefinished = dont_need_uninline;
+      fsync_finished = !do_fsync;
     }
 
     void finish(int r) override {
@@ -1408,10 +1413,13 @@ private:
     uint64_t fpos;
     int64_t offset;
     uint64_t size;
+    bool syncdataonly;
     int64_t iofinished_r;
     int64_t onuninlinefinished_r;
+    int64_t fsync_r;
     bool iofinished;
     bool onuninlinefinished;
+    bool fsync_finished;
     bool try_complete();
   };
 
@@ -1423,6 +1431,17 @@ private:
 
     void finish(int r) override {
       CWF->finish_io(r);
+    }
+  };
+
+  struct CWF_fsync_finish : public Context {
+    C_Write_Finisher *CWF;
+
+    CWF_fsync_finish(C_Write_Finisher *CWF)
+      : CWF(CWF) {}
+
+    void finish(int r) override {
+      CWF->finish_fsync(r);
     }
   };
 
@@ -1460,12 +1479,7 @@ private:
 
     void advance();
 
-    void complete_flush(int r) {
-      flush_completed = true;
-      result = r;
-      if (progress == 2)
-        advance();
-    }
+    void complete_flush(int r);
   };
 
   struct C_nonblocking_fsync_state_advancer : Context {
@@ -1476,11 +1490,7 @@ private:
       : clnt(clnt), state(state) {
     }
 
-    void finish(int r) override {
-      clnt->client_lock.lock();
-      state->advance();
-      clnt->client_lock.unlock();
-    }
+    void finish(int r) override;
   };
 
   struct C_nonblocking_fsync_flush_finisher : Context {
@@ -1492,9 +1502,8 @@ private:
     }
 
     void finish(int r) override {
-      clnt->client_lock.lock();
+      ceph_assert(ceph_mutex_is_locked_by_me(clnt->client_lock));
       state->complete_flush(r);
-      clnt->client_lock.unlock();
     }
   };
 
@@ -1659,12 +1668,14 @@ private:
   int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
           int64_t offset, uint64_t size, Inode *in);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
-          const struct iovec *iov, int iovcnt, Context *onfinish = nullptr);
+          const struct iovec *iov, int iovcnt, Context *onfinish = nullptr,
+          bool do_fsync = false, bool syncdataonly = false);
   int64_t _preadv_pwritev_locked(Fh *fh, const struct iovec *iov,
                                  unsigned iovcnt, int64_t offset,
                                  bool write, bool clamp_to_int,
                                  Context *onfinish = nullptr,
-                                 bufferlist *blp = nullptr);
+                                 bufferlist *blp = nullptr,
+                                 bool do_fsync = false, bool syncdataonly = false);
   int _preadv_pwritev(int fd, const struct iovec *iov, unsigned iovcnt,
                       int64_t offset, bool write, Context *onfinish = nullptr,
                       bufferlist *blp = nullptr);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1400,6 +1400,9 @@ private:
 
   loff_t _lseek(Fh *fh, loff_t offset, int whence);
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
+  void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
+  int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
+          int64_t offset, uint64_t size, Inode *in);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt);
   int64_t _preadv_pwritev_locked(Fh *fh, const struct iovec *iov,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1023,6 +1023,9 @@ protected:
   // helpers
   void wake_up_session_caps(MetaSession *s, bool reconnect);
 
+  void add_nonblocking_onfinish_to_context_list(std::list<Context*>& ls, Context *onfinish) {
+    ls.push_back(onfinish);
+  }
   void wait_on_context_list(std::list<Context*>& ls);
   void signal_context_list(std::list<Context*>& ls);
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -242,6 +242,7 @@ struct Inode : RefCountedObject {
   std::map<frag_t, std::vector<mds_rank_t>> frag_repmap; // non-auth mds mappings
 
   std::list<Context*> waitfor_caps;
+  std::list<Context*> waitfor_caps_pending;
   std::list<Context*> waitfor_commit;
   std::list<ceph::condition_variable*> waitfor_deleg;
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -241,8 +241,8 @@ struct Inode : RefCountedObject {
   std::map<frag_t,int> fragmap;  // known frag -> mds mappings
   std::map<frag_t, std::vector<mds_rank_t>> frag_repmap; // non-auth mds mappings
 
-  std::list<ceph::condition_variable*> waitfor_caps;
-  std::list<ceph::condition_variable*> waitfor_commit;
+  std::list<Context*> waitfor_caps;
+  std::list<Context*> waitfor_commit;
   std::list<ceph::condition_variable*> waitfor_deleg;
 
   Dentry *get_first_parent() {

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -70,7 +70,7 @@ public:
 
   ceph::condition_variable *caller_cond = NULL;   // who to take up
   ceph::condition_variable *dispatch_cond = NULL; // who to kick back
-  std::list<ceph::condition_variable*> waitfor_safe;
+  std::list<Context*> waitfor_safe;
 
   InodeRef target;
   UserPerm perms;

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -127,6 +127,8 @@ struct ceph_ll_io_info {
   int64_t off;
   int64_t result;
   bool write;
+  bool fsync;
+  bool syncdataonly;
 };
 
 /* setattr mask bits (up to an int in size) */

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -118,6 +118,17 @@ struct ceph_snapdiff_entry_t {
   uint64_t snapid; //should be snapid_t but prefer not to exposure it
 };
 
+struct ceph_ll_io_info {
+  void (*callback) (struct ceph_ll_io_info *cb_info);
+  void *priv; // private for caller
+  struct Fh *fh;
+  const struct iovec *iov;
+  int iovcnt;
+  int64_t off;
+  int64_t result;
+  bool write;
+};
+
 /* setattr mask bits (up to an int in size) */
 #ifndef CEPH_SETATTR_MODE
 #define CEPH_SETATTR_MODE		(1 << 0)
@@ -1934,6 +1945,8 @@ int64_t ceph_ll_readv(struct ceph_mount_info *cmount, struct Fh *fh,
 		      const struct iovec *iov, int iovcnt, int64_t off);
 int64_t ceph_ll_writev(struct ceph_mount_info *cmount, struct Fh *fh,
 		       const struct iovec *iov, int iovcnt, int64_t off);
+int64_t ceph_ll_nonblocking_readv_writev(struct ceph_mount_info *cmount,
+					 struct ceph_ll_io_info *io_info);
 int ceph_ll_close(struct ceph_mount_info *cmount, struct Fh* filehandle);
 int ceph_ll_iclose(struct ceph_mount_info *cmount, struct Inode *in, int mode);
 /**

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2042,7 +2042,8 @@ extern "C" int64_t ceph_ll_nonblocking_readv_writev(class ceph_mount_info *cmoun
 
   return (cmount->get_client()->ll_preadv_pwritev(
 			io_info->fh, io_info->iov, io_info->iovcnt,
-			io_info->off, io_info->write, onfinish, &onfinish->bl));
+			io_info->off, io_info->write, onfinish, &onfinish->bl,
+			io_info->fsync, io_info->syncdataonly));
 }
 
 extern "C" int ceph_ll_close(class ceph_mount_info *cmount, Fh* fh)

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <string>
 
+#include "include/Context.h"
 #include "auth/Crypto.h"
 #include "client/Client.h"
 #include "client/Inode.h"
@@ -2016,6 +2017,32 @@ extern "C" int64_t ceph_ll_writev(class ceph_mount_info *cmount,
 				  int iovcnt, int64_t off)
 {
   return (cmount->get_client()->ll_writev(fh, iov, iovcnt, off));
+}
+
+class LL_Onfinish : public Context {
+public:
+  LL_Onfinish(struct ceph_ll_io_info *io_info)
+    : io_info(io_info) {}
+  bufferlist bl;
+private:
+  struct ceph_ll_io_info *io_info;
+  void finish(int r) override {
+    if (!io_info->write && r > 0) {
+      copy_bufferlist_to_iovec(io_info->iov, io_info->iovcnt, &bl, r);
+    }
+    io_info->result = r;
+    io_info->callback(io_info);
+  }
+};
+
+extern "C" int64_t ceph_ll_nonblocking_readv_writev(class ceph_mount_info *cmount,
+						    struct ceph_ll_io_info *io_info)
+{
+  LL_Onfinish *onfinish = new LL_Onfinish(io_info);
+
+  return (cmount->get_client()->ll_preadv_pwritev(
+			io_info->fh, io_info->iov, io_info->iovcnt,
+			io_info->off, io_info->write, onfinish, &onfinish->bl));
 }
 
 extern "C" int ceph_ll_close(class ceph_mount_info *cmount, Fh* fh)

--- a/src/test/client/CMakeLists.txt
+++ b/src/test/client/CMakeLists.txt
@@ -3,11 +3,13 @@ if(${WITH_CEPHFS})
     main.cc
     alternate_name.cc
     ops.cc
+    nonblocking.cc
     )
   target_link_libraries(ceph_test_client
     client
     global
     ceph-common
+    cephfs
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -1,0 +1,86 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <errno.h>
+
+#include <iostream>
+#include <string>
+
+#include <fmt/format.h>
+
+#include "test/client/TestClient.h"
+
+TEST_F(TestClient, LlreadvLlwritev) {
+  int mypid = getpid();
+  char filename[256];
+
+  client->unmount();
+  TearDown();
+  SetUp();
+
+  sprintf(filename, "test_llreadvllwritevfile%u", mypid);
+
+  Inode *root, *file;
+  root = client->get_root();
+  ASSERT_NE(root, (Inode *)NULL);
+
+  Fh *fh;
+  struct ceph_statx stx;
+
+  ASSERT_EQ(0, client->ll_createx(root, filename, 0666,
+				  O_RDWR | O_CREAT | O_TRUNC,
+				  &file, &fh, &stx, 0, 0, myperm));
+
+  /* Reopen read-only */
+  char out0[] = "hello ";
+  char out1[] = "world\n";
+  struct iovec iov_out[2] = {
+	{out0, sizeof(out0)},
+	{out1, sizeof(out1)},
+  };
+  char in0[sizeof(out0)];
+  char in1[sizeof(out1)];
+  struct iovec iov_in[2] = {
+	{in0, sizeof(in0)},
+	{in1, sizeof(in1)},
+  };
+
+  ssize_t nwritten = iov_out[0].iov_len + iov_out[1].iov_len;
+
+  std::unique_ptr<C_SaferCond> writefinish = nullptr;
+  std::unique_ptr<C_SaferCond> readfinish = nullptr;
+
+  writefinish.reset(new C_SaferCond("test-nonblocking"));
+  readfinish.reset(new C_SaferCond("test-nonblocking"));
+
+  int64_t rc;
+  bufferlist bl;
+  rc = client->ll_preadv_pwritev(fh, iov_out, 2, 0, true, writefinish.get(), nullptr);
+  ASSERT_EQ(0, rc);
+  rc = writefinish->wait();
+  ASSERT_EQ(nwritten, rc);
+
+  rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(), &bl);
+  ASSERT_EQ(0, rc);
+  rc = readfinish.get()->wait();
+  ASSERT_EQ(nwritten, rc);
+  copy_bufferlist_to_iovec(iov_in, 2, &bl, rc);
+
+  ASSERT_EQ(0, strncmp((const char*)iov_in[0].iov_base, (const char*)iov_out[0].iov_base, iov_out[0].iov_len));
+  ASSERT_EQ(0, strncmp((const char*)iov_in[1].iov_base, (const char*)iov_out[1].iov_base, iov_out[1].iov_len));
+
+  client->ll_release(fh);
+  ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
+}
+

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -56,16 +56,43 @@ TEST_F(TestClient, LlreadvLlwritev) {
 	{in1, sizeof(in1)},
   };
 
+  char out_a_0[] = "hello ";
+  char out_a_1[] = "world a is longer\n";
+  struct iovec iov_out_a[2] = {
+	{out_a_0, sizeof(out_a_0)},
+	{out_a_1, sizeof(out_a_1)},
+  };
+  char in_a_0[sizeof(out_a_0)];
+  char in_a_1[sizeof(out_a_1)];
+  struct iovec iov_in_a[2] = {
+	{in_a_0, sizeof(in_a_0)},
+	{in_a_1, sizeof(in_a_1)},
+  };
+
+  char out_b_0[] = "hello ";
+  char out_b_1[] = "world b is much longer\n";
+  struct iovec iov_out_b[2] = {
+	{out_b_0, sizeof(out_b_0)},
+	{out_b_1, sizeof(out_b_1)},
+  };
+  char in_b_0[sizeof(out_b_0)];
+  char in_b_1[sizeof(out_b_1)];
+  struct iovec iov_in_b[2] = {
+	{in_b_0, sizeof(in_b_0)},
+	{in_b_1, sizeof(in_b_1)},
+  };
+
   ssize_t nwritten = iov_out[0].iov_len + iov_out[1].iov_len;
 
   std::unique_ptr<C_SaferCond> writefinish = nullptr;
   std::unique_ptr<C_SaferCond> readfinish = nullptr;
 
-  writefinish.reset(new C_SaferCond("test-nonblocking"));
-  readfinish.reset(new C_SaferCond("test-nonblocking"));
+  writefinish.reset(new C_SaferCond("test-nonblocking-writefinish"));
+  readfinish.reset(new C_SaferCond("test-nonblocking-readfinish"));
 
   int64_t rc;
   bufferlist bl;
+
   rc = client->ll_preadv_pwritev(fh, iov_out, 2, 0, true, writefinish.get(), nullptr);
   ASSERT_EQ(0, rc);
   rc = writefinish->wait();
@@ -79,6 +106,44 @@ TEST_F(TestClient, LlreadvLlwritev) {
 
   ASSERT_EQ(0, strncmp((const char*)iov_in[0].iov_base, (const char*)iov_out[0].iov_base, iov_out[0].iov_len));
   ASSERT_EQ(0, strncmp((const char*)iov_in[1].iov_base, (const char*)iov_out[1].iov_base, iov_out[1].iov_len));
+
+  // need new condition variables...
+  writefinish.reset(new C_SaferCond("test-nonblocking-writefinish"));
+  readfinish.reset(new C_SaferCond("test-nonblocking-readfinish"));
+  ssize_t nwritten_a = iov_out_a[0].iov_len + iov_out_a[1].iov_len;
+
+  rc = client->ll_preadv_pwritev(fh, iov_out_a, 2, 100, true, writefinish.get(), nullptr);
+  ASSERT_EQ(0, rc);
+  rc = writefinish->wait();
+  ASSERT_EQ(nwritten_a, rc);
+
+  rc = client->ll_preadv_pwritev(fh, iov_in_a, 2, 100, false, readfinish.get(), &bl);
+  ASSERT_EQ(0, rc);
+  rc = readfinish.get()->wait();
+  ASSERT_EQ(nwritten_a, rc);
+  copy_bufferlist_to_iovec(iov_in_a, 2, &bl, rc);
+
+  ASSERT_EQ(0, strncmp((const char*)iov_in_a[0].iov_base, (const char*)iov_out_a[0].iov_base, iov_out_a[0].iov_len));
+  ASSERT_EQ(0, strncmp((const char*)iov_in_a[1].iov_base, (const char*)iov_out_a[1].iov_base, iov_out_a[1].iov_len));
+
+  // need new condition variables...
+  writefinish.reset(new C_SaferCond("test-nonblocking-writefinish"));
+  readfinish.reset(new C_SaferCond("test-nonblocking-readfinish"));
+  ssize_t nwritten_b = iov_out_b[0].iov_len + iov_out_b[1].iov_len;
+
+  rc = client->ll_preadv_pwritev(fh, iov_out_b, 2, 1000, true, writefinish.get(), nullptr, true, false);
+  ASSERT_EQ(0, rc);
+  rc = writefinish->wait();
+  ASSERT_EQ(nwritten_b, rc);
+
+  rc = client->ll_preadv_pwritev(fh, iov_in_b, 2, 1000, false, readfinish.get(), &bl);
+  ASSERT_EQ(0, rc);
+  rc = readfinish.get()->wait();
+  ASSERT_EQ(nwritten_b, rc);
+  copy_bufferlist_to_iovec(iov_in_b, 2, &bl, rc);
+
+  ASSERT_EQ(0, strncmp((const char*)iov_in_b[0].iov_base, (const char*)iov_out_b[0].iov_base, iov_out_b[0].iov_len));
+  ASSERT_EQ(0, strncmp((const char*)iov_in_b[1].iov_base, (const char*)iov_out_b[1].iov_base, iov_out_b[1].iov_len));
 
   client->ll_release(fh);
   ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));


### PR DESCRIPTION
This replaces https://github.com/ceph/ceph/pull/44991 (async I/O).

This tests as working with Ganesha. I renamed to nonblocking I/O because there was some confusion with Read_Sync_Async that looks a lot better as Read_Sync_Nonblocking. A unit test is included.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
