### PR TITLE
rgw: rados service shuts down rados client on shutdown()

### DIFF
--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -272,7 +272,24 @@ void RGWServices_Def::shutdown()
     return;
   }
 
+  role_rados->shutdown();
   datalog_rados.reset();
+  user_rados->shutdown();
+  sync_modules->shutdown();
+  otp->shutdown();
+  notify->shutdown();
+  meta_be_otp->shutdown();
+  meta_be_sobj->shutdown();
+  meta->shutdown();
+  mdlog->shutdown();
+  config_key_rados->shutdown();
+  cls->shutdown();
+  bilog_rados->shutdown();
+  bi_rados->shutdown();
+  bucket_sync_sobj->shutdown();
+  bucket_sobj->shutdown();
+  finisher->shutdown();
+
   sysobj->shutdown();
   sysobj_core->shutdown();
   notify->shutdown();

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -272,6 +272,7 @@ void RGWServices_Def::shutdown()
     return;
   }
 
+  datalog_rados.reset();
   sysobj->shutdown();
   sysobj_core->shutdown();
   notify->shutdown();

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -45,6 +45,7 @@ void RGWSI_RADOS::shutdown()
   if (async_processor) {
     async_processor->stop();
   }
+  rados.shutdown();
 }
 
 void RGWSI_RADOS::stop_processor()


### PR DESCRIPTION
if we leave the rados client running, it will keep delivering AioCompletions while we're shutting other things down

this resolves a valgrind use-after-free where rgw::notify::Manager gets completions after its destruction

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
