### PR TITLE
pacific: mgr/dashboard: fix openapi-check

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -35,7 +35,7 @@ class Docs(BaseController):
                     list_of_ctrl.add(endpoint.ctrl)
 
         tag_map: Dict[str, str] = {}
-        for ctrl in list_of_ctrl:
+        for ctrl in sorted(list_of_ctrl, key=lambda ctrl: ctrl.__name__):
             tag_name = ctrl.__name__
             tag_descr = ""
             if hasattr(ctrl, 'doc_info'):

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -30,6 +30,7 @@ deps =
     -rrequirements-lint.txt
 
 [testenv]
+basepython=python3
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -47,7 +48,6 @@ commands =
     pytest {posargs}
 
 [testenv:run]
-basepython=python3
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -99,7 +99,6 @@ commands =
     rstcheck --report info --debug -- {[rstlint]dirs}
 
 [testenv:lint]
-basepython=python3
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -112,13 +111,11 @@ commands =
     {[base-rst]commands}
 
 [testenv:flake8]
-basepython = python3
 deps = {[base-lint]deps}
 commands =
     flake8 --config=tox.ini {posargs}
 
 [testenv:pylint]
-basepython = python3
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -126,7 +123,6 @@ commands =
     pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
 
 [testenv:rst]
-basepython = python3
 deps = {[base-lint]deps}
 commands =
     rstcheck --report info --debug -- {posargs:{[rstlint]dirs}}
@@ -142,7 +138,6 @@ addopts =
 #    --aggressive
 
 [testenv:fix]
-basepython=python3
 deps =
     {[base-lint]deps}
 commands =
@@ -156,7 +151,6 @@ commands =
     python ci/check_grafana_dashboards.py frontend/src/app ../../../../monitoring/ceph-mixin/dashboards_out
 
 [testenv:openapi-{check,fix}]
-basepython = python3
 allowlist_externals = diff
 description =
     check: Ensure that auto-generated OpenAPI Specification matches the current version


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57493

---

backport of https://github.com/ceph/ceph/pull/48032
parent tracker: https://tracker.ceph.com/issues/57345

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh