### PR TITLE
quincy: doc/monitoring: add min vers of apps in mon stack

### DIFF
--- a/monitoring/ceph-mixin/README.md
+++ b/monitoring/ceph-mixin/README.md
@@ -15,7 +15,13 @@ In `dashboards_out` you can find a collection of
 These dashboards are based on metrics collected
 from [prometheus](https://prometheus.io/) scraping the [prometheus mgr
 plugin](http://docs.ceph.com/en/latest/mgr/prometheus/) and the
-[node_exporter](https://github.com/prometheus/node_exporter).
+[node_exporter (0.17.0)](https://github.com/prometheus/node_exporter).
+
+
+##### Recommended versions: 
+-grafana 8.3.5
+    -grafana-piechart-panel 1.6.2
+    -grafana-status-panel 1.0.11
 
 #### Requirements
 
@@ -40,12 +46,19 @@ showMultiCluster: true,
 clusterLabel: '<your cluster label>',
 ```
 
+##### Recommended versions: 
+-prometheus v2.33.4
+
 #### SNMP
-Ceph provides a MIB (CEPH-PROMETHEUS-ALERT-MIB.txt) to support sending Prometheus
-alerts through to an SNMP management platform. The translation from Prometheus
-alert to SNMP trap requires the Prometheus alert to contain an OID that maps to
-a definition within the MIB. When making changes to the Prometheus alert rules
-file, developers should include any necessary changes to the MIB.
+Ceph provides a MIB (CEPH-PROMETHEUS-ALERT-MIB.txt) to support sending
+Prometheus alerts to an SNMP management platform. The translation from
+Prometheus alert to SNMP trap requires the Prometheus alert to contain an OID
+that maps to a definition within the MIB. When making changes to the Prometheus
+alert rules file, developers should include any necessary changes to the MIB.
+
+
+##### Recommended: 
+-alertmanager 0.16.2
 
 ### Building from Jsonnet
 
@@ -59,3 +72,5 @@ To rebuild all the generated files, you can run `tox -egrafonnet-fix`.
 The jsonnet code located in this directory depends on some Jsonnet third party
 libraries. To update those libraries you can run `jb update` and then update
 the generated files using `tox -egrafonnet-fix`.
+
+##### Any upgrade or downgrade to different major versions of the recommended tools mentioned above is not supported.


### PR DESCRIPTION
https://tracker.ceph.com/issues/45447

This PR adds recommended versions of grafana and
prometheus and alert manager.

This PR is a second attempt at getting the information in the following PR into the docs:
https://github.com/ceph/ceph/pull/46000/files

Himadri Maheshwari deserves the credit for the work in this commit.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
Signed-off-by: Himadri Maheshwari <himadri.maheshwari7915@gmail.com>
(cherry picked from commit 367695f5b09f75ee723d53116e2f4a6e45dd795d)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
