### PR TITLE
qa/run-standalone.sh: add support for crimson-osd

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -52,10 +52,14 @@ export LD_LIBRARY_PATH="$(pwd)/lib"
 
 # TODO: Use getops
 dryrun=false
+ceph_osd=ceph-osd
 while [ $# -ge 1 ]; do
 case $1 in
     --dry-run)
         dryrun=true
+        ;;
+    --crimson)
+        ceph_osd=crimson-osd
         ;;
     *)
         break
@@ -67,6 +71,8 @@ all=false
 if [ "$1" = "" ]; then
    all=true
 fi
+
+export CEPH_OSD=$ceph_osd
 
 select=("$@")
 

--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -52,10 +52,16 @@ export LD_LIBRARY_PATH="$(pwd)/lib"
 
 # TODO: Use getops
 dryrun=false
-if [[ "$1" = "--dry-run" ]]; then
-    dryrun=true
-    shift
-fi
+while [ $# -ge 1 ]; do
+case $1 in
+    --dry-run)
+        dryrun=true
+        ;;
+    *)
+        break
+esac
+shift
+done
 
 all=false
 if [ "$1" = "" ]; then

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -664,7 +664,7 @@ function run_osd() {
     echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $osd_data/new.json
     ceph osd new $uuid -i $osd_data/new.json
     rm $osd_data/new.json
-    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid
+    $CEPH_OSD -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid
 
     local key_fn=$osd_data/keyring
     cat > $key_fn<<EOF
@@ -674,7 +674,7 @@ EOF
     echo adding osd$id key to auth repository
     ceph -i "$key_fn" auth add osd.$id osd "allow *" mon "allow profile osd" mgr "allow profile osd"
     echo start osd.$id
-    ceph-osd -i $id $ceph_args &
+    $CEPH_OSD -i $id $ceph_args &
 
     # If noup is set, then can't wait for this osd
     if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
@@ -719,7 +719,7 @@ function run_osd_filestore() {
     echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $osd_data/new.json
     ceph osd new $uuid -i $osd_data/new.json
     rm $osd_data/new.json
-    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid --osd-objectstore=filestore
+    $CEPH_OSD -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid --osd-objectstore=filestore
 
     local key_fn=$osd_data/keyring
     cat > $key_fn<<EOF
@@ -729,7 +729,7 @@ EOF
     echo adding osd$id key to auth repository
     ceph -i "$key_fn" auth add osd.$id osd "allow *" mon "allow profile osd" mgr "allow profile osd"
     echo start osd.$id
-    ceph-osd -i $id $ceph_args &
+    $CEPH_OSD -i $id $ceph_args &
 
     # If noup is set, then can't wait for this osd
     if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
@@ -879,7 +879,7 @@ function activate_osd() {
     mkdir -p $osd_data
 
     echo start osd.$id
-    ceph-osd -i $id $ceph_args &
+    $CEPH_OSD -i $id $ceph_args &
 
     [ "$id" = "$(cat $osd_data/whoami)" ] || return 1
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
