### PR TITLE
crimson/seastore: add max allocate size threshold

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -70,6 +70,11 @@ options:
   level: dev
   desc: default logical address space reservation for seastore objects' metadata
   default: 16777216
+- name: seastore_max_allocate_size
+  type: uint
+  level: dev
+  desc: maximum size in bytes of data block allocated to write, 0 for unlimited.
+  default: 65536 
 - name: seastore_cache_lru_size
   type: size
   level: advanced


### PR DESCRIPTION
This PR introduces a threshold which limits the size of allocating extent in insertions to reduce read amplification in certain scenarios.

It is observed that when reading in 4KiB size, if the existing content is large, such as 4MiB or greater, then there will be serious performance regression. To avoid this situation, spilt the new extent when doing insertions if it is greater than the threshold.


### Benchmark data

Prefill a new rbd image with 16GiB data with different block size(0 represents no prefill, do read test after write test). Then do random read and random write test.

<details>
<summary>prefill fio config</summary>

```
[global]
ioengine=rbd
clientname=admin
pool=_benchtest_
rbdname=rbd_image
size=16384M
invalidate=0
[prefill]
rw=write
bs=4M
numjobs=1
iodepth=32
```

</details>

<details>
<summary>test fio config</summary>

```
[global]
ioengine=rbd
clientname=admin
pool=_benchtest_
rbdname=rbd_image
direct=1
sync=1
time_based=1
runtime=300
[randread]
rw=randread
bs=4K
numjobs=1
iodepth=128
[randwrite]
rw=randwrite
bs=4K
numjobs=1
iodepth=128

```

</details>

**Random Read/Write IOPS**
block size of prefill  | 0 | 4KiB | 64KiB | 4MiB
-- | -- | -- | -- | -- |
4KiB Random Read | 15394 | 5334 | 3378 | 459
4KiB Random Write | 3261 | 2478 | 2542 | 1912


Signed-off-by: Jianxin Li <jianxin1.li@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
