### PR TITLE
mgr/cephadm: write client files after applying services

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -187,12 +187,6 @@ class CephadmServe:
         self.log.debug('_refresh_hosts_and_daemons')
         bad_hosts = []
         failures = []
-
-        if self.mgr.manage_etc_ceph_ceph_conf or self.mgr.keys.keys:
-            client_files = self._calc_client_files()
-        else:
-            client_files = {}
-
         agents_down: List[str] = []
 
         @forall_hosts
@@ -268,9 +262,9 @@ class CephadmServe:
                 self.log.debug(f"autotuning memory for {host}")
                 self._autotune_host_memory(host)
 
-            self._write_client_files(client_files, host)
-
         refresh(self.mgr.cache.get_hosts())
+
+        self._write_all_client_files()
 
         self.mgr.agent_helpers._update_agent_down_healthcheck(agents_down)
 
@@ -1063,6 +1057,18 @@ class CephadmServe:
                 self.log.warning(
                     f'unable to calc client keyring {ks.entity} placement {ks.placement}: {e}')
         return client_files
+
+    def _write_all_client_files(self) -> None:
+        if self.mgr.manage_etc_ceph_ceph_conf or self.mgr.keys.keys:
+            client_files = self._calc_client_files()
+        else:
+            client_files = {}
+
+        @forall_hosts
+        def _write_files(host: str) -> None:
+            self._write_client_files(client_files, host)
+
+        _write_files(self.mgr.cache.get_hosts())
 
     def _write_client_files(self,
                             client_files: Dict[str, Dict[str, Tuple[int, int, int, bytes, str]]],

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1741,7 +1741,7 @@ class TestCephadm(object):
             cephadm_module.config_notify()
             assert cephadm_module.manage_etc_ceph_ceph_conf is True
 
-            CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+            CephadmServe(cephadm_module)._write_all_client_files()
             # Make sure both ceph conf locations (default and per fsid) are called
             _write_file.assert_has_calls([mock.call('test', '/etc/ceph/ceph.conf', b'',
                                           0o644, 0, 0, None),
@@ -1755,7 +1755,7 @@ class TestCephadm(object):
 
             # set extra config and expect that we deploy another ceph.conf
             cephadm_module._set_extra_ceph_conf('[mon]\nk=v')
-            CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+            CephadmServe(cephadm_module)._write_all_client_files()
             _write_file.assert_has_calls([mock.call('test',
                                                     '/etc/ceph/ceph.conf',
                                                     b'\n\n[mon]\nk=v\n', 0o644, 0, 0, None),
@@ -1777,7 +1777,7 @@ class TestCephadm(object):
             f2_before_digest = cephadm_module.cache.get_host_client_files(
                 'test')['/var/lib/ceph/fsid/config/ceph.conf'][0]
             cephadm_module._set_extra_ceph_conf('[mon]\nk2=v2')
-            CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+            CephadmServe(cephadm_module)._write_all_client_files()
             f1_after_digest = cephadm_module.cache.get_host_client_files('test')[
                 '/etc/ceph/ceph.conf'][0]
             f2_after_digest = cephadm_module.cache.get_host_client_files(


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/56696
Fixes: https://tracker.ceph.com/issues/57462
Fixes: https://tracker.ceph.com/issues/57449

There is a bug described in the linked trackers where client files are being removed for seemingly no reason. In the cases of the trackers it's the client keyring or ceph.conf being removed and it's causing failures in the test scenarios. After giving the relevant code a thorough look, I couldn't come up with any potential causes. Since one of the failures was occurring with some regularity (maybe 1/5 times) in a teuthology test, I just added a bunch of extra logging and ran through the tests. That logging included
```
if self.mgr.manage_etc_ceph_ceph_conf or self.mgr.keys.keys:
  client_files = self._calc_client_files()
  self.log.error(f'ADMK - all client files {client_files}')
else:
  self.log.error('ADMK - no calcing client files')
  client_files = {}
```
around the part of the code that actually figured out what the client files should be (that code is being removed in this commit). In theory, this should tell me what client files were calculated for that iteration or that no client files were calculated at all. Additionally, there was logging to say when we were actually writing or removing a client file (all prepended with "ADMK" to help with searching through the logs). There was more logging around scheduling, multiple parts of _calc_client_files etc. You can see an example run with the logging at
http://qa-proxy.ceph.com/teuthology/adking-2022-09-13_11:46:25-fs:workload-wip-adk-removal-debugging2-distro-default-smithi/7030534/teuthology.log where searching for "ADMK" will show all the new log statements and can look at the two last commits in
https://github.com/adk3798/ceph/tree/wip-adk-removal-debugging2 to see what all the logging statement that were added are. As expected, this logigng eventually gave a message about it removing the relevant files and additionally stated that the client_files calculated were "{}" as in, no files were calculated. Given that, I expected to see "ADMK - all client files {}" or "ADMK - no calcing client files" in the logs not far above that. But they weren't there.I could not find a single instance within 30 minutes of the removal of it actually calculating that there should be no client files (the only instances of that were very early in the test before things had been setup). In fact, directly leading up to when the files were removed, the most recent instance of either of the logging statements in the posted code snippet was about 20 seconds earlier and had correctly calculated that there should be a number of client files. Somehow it is deciding that client_files is an empty dict but I simply cannot find any instance anywhere of it actually doing so (outside of early on before the client files are setup where it is correct to say that). The solution proposed in this commit is simply to calculate the client files right before writing them in the hope that this consolidation of the functionality will maybe prevent whatever was setting client_files to an empty dict from doing so or at least make the debugging process easier. The plan is to basically, unless someone has a good idea, to run this through testing we know causes the issue and see if it still happens. If not, I'll consider it "fixed". Otherwise, hopefully the consolidation makes debugging easier. Keep in mind so far this issue has only been seen in long running tests and, as mentioned earlier when talking about the teuthology a that produces this, doesn't happen every time.

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
