### PR TITLE
quincy: qa/tasks/kubeadm: set up tigera resources via kubectl create

### DIFF
--- a/qa/tasks/kubeadm.py
+++ b/qa/tasks/kubeadm.py
@@ -404,7 +404,7 @@ def pod_network(ctx, config):
 
     elif pnet == 'calico':
         _kubectl(ctx, config, [
-            'apply', '-f',
+            'create', '-f',
             'https://docs.projectcalico.org/manifests/tigera-operator.yaml'
         ])
         cr = {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57504

---

backport of https://github.com/ceph/ceph/pull/47854
parent tracker: https://tracker.ceph.com/issues/57268

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh