### PR TITLE
pacific: qa/cephadm: remove fsid dir before bootstrap in test_cephadm.sh

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -180,6 +180,14 @@ $CEPHADM shell --fsid $FSID -e FOO=BAR -- printenv | grep FOO=BAR
 # test stdin
 echo foo | $CEPHADM shell -- cat | grep -q foo
 
+# the shell commands a bit above this seems to cause the
+# /var/lib/ceph/<fsid> directory to be made. Since we now
+# check in bootstrap that there are no clusters with the same
+# fsid based on the directory existing, we need to make sure
+# this directory is gone before bootstrapping. We can
+# accomplish this with another rm-cluster
+$CEPHADM rm-cluster --fsid $FSID --force
+
 ## bootstrap
 ORIG_CONFIG=`mktemp -p $TMPDIR`
 CONFIG=`mktemp -p $TMPDIR`


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57398

---

backport of https://github.com/ceph/ceph/pull/47796
parent tracker: https://tracker.ceph.com/issues/57290

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh