### PR TITLE
pacific: mgr/cephadm: Adding logic to store grafana cert/key per node

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -41,8 +41,10 @@ class GrafanaService(CephadmService):
         grafana_data_sources = self.mgr.template.render(
             'services/grafana/ceph-dashboard.yml.j2', {'hosts': prom_services})
 
-        cert = self.mgr.get_store('grafana_crt')
-        pkey = self.mgr.get_store('grafana_key')
+        cert_path = f'{daemon_spec.host}/grafana_crt'
+        key_path = f'{daemon_spec.host}/grafana_key'
+        cert = self.mgr.get_store(cert_path)
+        pkey = self.mgr.get_store(key_path)
         if cert and pkey:
             try:
                 verify_tls(cert, pkey)
@@ -50,9 +52,9 @@ class GrafanaService(CephadmService):
                 logger.warning('Provided grafana TLS certificates invalid: %s', str(e))
                 cert, pkey = None, None
         if not (cert and pkey):
-            cert, pkey = create_self_signed_cert('Ceph', 'cephadm')
-            self.mgr.set_store('grafana_crt', cert)
-            self.mgr.set_store('grafana_key', pkey)
+            cert, pkey = create_self_signed_cert('Ceph', daemon_spec.host)
+            self.mgr.set_store(cert_path, cert)
+            self.mgr.set_store(key_path, pkey)
             if 'dashboard' in self.mgr.get('mgr_map')['modules']:
                 self.mgr.check_mon_command({
                     'prefix': 'dashboard set-grafana-api-ssl-verify',
@@ -102,6 +104,17 @@ class GrafanaService(CephadmService):
             'dashboard set-grafana-api-url',
             service_url
         )
+
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        """
+        Called before grafana daemon is removed.
+        """
+        if daemon.hostname is not None:
+            # delete cert/key entires for this grafana daemon
+            cert_path = f'{daemon.hostname}/grafana_crt'
+            key_path = f'{daemon.hostname}/grafana_key'
+            self.mgr.set_store(cert_path, None)
+            self.mgr.set_store(key_path, None)
 
     def ok_to_stop(self,
                    daemon_ids: List[str],

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -435,8 +435,8 @@ class TestMonitoring:
         _run_cephadm.return_value = ('{}', '', 0)
 
         with with_host(cephadm_module, 'test'):
-            cephadm_module.set_store('grafana_crt', 'c')
-            cephadm_module.set_store('grafana_key', 'k')
+            cephadm_module.set_store('test/grafana_crt', 'c')
+            cephadm_module.set_store('test/grafana_key', 'k')
             with with_service(cephadm_module, MonitoringSpec('prometheus')) as _, \
                     with_service(cephadm_module, GrafanaSpec('grafana')) as _:
                 files = {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57384

---

backport of https://github.com/ceph/ceph/pull/47098
parent tracker: https://tracker.ceph.com/issues/56508

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh