### PR TITLE
Wip quincy revert pr 47901

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1220,7 +1220,7 @@ void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
   if (was_min) {
     auto old_ru = readable_until;
     recalc_readable_until();
-    if (now >= old_ru) {
+    if (now < old_ru) {
       pl->recheck_readable();
     }
   }

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1213,8 +1213,8 @@ void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
 	  was_min = true;
 	}
 	acting_readable_until_ub[i] = a.readable_until_ub;
+	break;
       }
-      break;
     }
   }
   if (was_min) {


### PR DESCRIPTION
When testing the Quincy RC for 17.2.4, we discovered this failure:

_Description: rados/thrash-erasure-code/{ceph clusters/{fixed-2 openstack} fast/fast mon_election/classic msgr-failures/osd-delay objectstore/bluestore-comp-zstd rados recovery-overrides/{more-async-partial-recovery} supported-random-distro$/{rhel_8} thrashers/default thrashosds-health workloads/ec-rados-plugin=clay-k=4-m=2}_

_Dead job: http://pulpito.front.sepia.ceph.com/yuriw-2022-09-10_14:05:53-rados-quincy-release-distro-default-smithi/7024541/_

The failure is intermittent, which iexplains why it did not show up in https://github.com/ceph/ceph/pull/47901#issuecomment-1238937342, nor in the rerun of @yuriw's validation run.

We found that running the affected test 50 times is a reliable reproducer, as seen by:
http://pulpito.front.sepia.ceph.com/lflores-2022-09-14_15:11:39-rados-quincy-release-distro-default-smithi/

We suspected https://github.com/ceph/ceph/pull/47901 to be the culprit, so we reran the reproducer with those two commits reverted:
http://pulpito.front.sepia.ceph.com/lflores-2022-09-14_17:02:02-rados-wip-lflores-testing-quincy-release-distro-default-smithi/

All 50 tests passed with the commits from https://github.com/ceph/ceph/pull/47901 reverted.

So far, this bug has only been observed in Quincy (and once on Pacific, but the affected test branch included https://github.com/ceph/ceph/pull/47899, which hasn't been merged yet). It's possible that this bug exists in main since https://github.com/ceph/ceph/pull/44499 has merged.

Fixes: https://tracker.ceph.com/issues/57546
Signed-off-by: Laura Flores <lflores@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
