### PR TITLE
quincy: ceph-volume: fix inventory with device arg

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -215,7 +215,7 @@ def disable_kernel_queries(monkeypatch):
     '''
     This speeds up calls to Device and Disk
     '''
-    monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: {})
+    monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda device='': {})
     monkeypatch.setattr("ceph_volume.util.disk.udevadm_property", lambda *a, **kw: {})
 
 
@@ -297,7 +297,7 @@ def device_info(monkeypatch, patch_bluestore_label):
         udevadm = udevadm if udevadm else {}
         lv = Factory(**lv) if lv else None
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
-        monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
+        monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda device='': devices)
         if not devices:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_single_lv", lambda filters: lv)
         else:

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -111,7 +111,10 @@ class Device(object):
             if "dm-" not in real_path:
                 self.path = real_path
         if not sys_info.devices:
-            sys_info.devices = disk.get_devices()
+            if self.path:
+                sys_info.devices = disk.get_devices(device=self.path)
+            else:
+                sys_info.devices = disk.get_devices()
         if sys_info.devices.get(self.path, {}):
             self.device_nodes = sys_info.devices[self.path]['device_nodes']
         self.sys_api = sys_info.devices.get(self.path, {})

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -768,7 +768,7 @@ class AllowLoopDevices(object):
 allow_loop_devices = AllowLoopDevices()
 
 
-def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block'):
+def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block', device=''):
     def holder_inner_loop():
         for holder in holders:
             # /sys/block/sdy/holders/dm-8/dm/uuid
@@ -778,7 +778,10 @@ def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys
 
     # First, get devices that are _not_ partitions
     result = list()
-    dev_names = os.listdir(_sys_block_path)
+    if not device:
+        dev_names = os.listdir(_sys_block_path)
+    else:
+        dev_names = [device]
     for dev in dev_names:
         name = kname = os.path.join("/dev", dev)
         if not os.path.exists(name):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57567

---

backport of https://github.com/ceph/ceph/pull/48037
parent tracker: https://tracker.ceph.com/issues/57085

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh