### PR TITLE
Windows tests follow-up (librados_asio error category, disable some tests)

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -490,6 +490,8 @@ install(TARGETS
   ceph_test_stress_watch
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# limited Windows signal support, skipped for now
+if(NOT WIN32)
 add_executable(ceph_test_c2c
   test_c2c.cc
   )
@@ -503,6 +505,7 @@ target_link_libraries(ceph_test_c2c
 install(TARGETS
   ceph_test_c2c
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif(NOT WIN32)
 
 if(WITH_FUSE)
   add_executable(ceph_test_cfuse_cache_invalidate

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -36,17 +36,20 @@ if(WITH_LIBCEPHFS)
   install(TARGETS ceph_test_libcephfs_newops
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-  add_executable(ceph_test_libcephfs_reclaim
-    reclaim.cc
-  )
-  target_link_libraries(ceph_test_libcephfs_reclaim
-    cephfs
-    ${UNITTEST_LIBS}
-    ${EXTRALIBS}
-    ${CMAKE_DL_LIBS}
+  # uses fork, not available on Windows
+  if(NOT WIN32)
+    add_executable(ceph_test_libcephfs_reclaim
+      reclaim.cc
     )
-  install(TARGETS ceph_test_libcephfs_reclaim
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+    target_link_libraries(ceph_test_libcephfs_reclaim
+      cephfs
+      ${UNITTEST_LIBS}
+      ${EXTRALIBS}
+      ${CMAKE_DL_LIBS}
+      )
+    install(TARGETS ceph_test_libcephfs_reclaim
+      DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif(NOT WIN32)
 
   add_executable(ceph_test_libcephfs_lazyio
     lazyio.cc

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -17,6 +17,7 @@
 #include "include/buffer.h"
 #include "include/stringify.h"
 #include "include/cephfs/libcephfs.h"
+#include "include/fs_types.h"
 #include "include/rados/librados.h"
 #include <errno.h>
 #include <fcntl.h>

--- a/src/test/libcephfs/lazyio.cc
+++ b/src/test/libcephfs/lazyio.cc
@@ -13,6 +13,7 @@
  */
 
 #include "gtest/gtest.h"
+#include "include/compat.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/rados/librados.h"
 #include <errno.h>

--- a/src/test/libcephfs/reclaim.cc
+++ b/src/test/libcephfs/reclaim.cc
@@ -7,6 +7,7 @@
  */
 
 #include "gtest/gtest.h"
+#include "include/compat.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/fs_types.h"
 #include "include/stat.h"

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -197,7 +197,8 @@ if [[ -z $SKIP_BUILD ]]; then
     # TODO: do we actually need the ceph compression libs?
     ninja_targets+=" compressor ceph_lz4 ceph_snappy ceph_zlib ceph_zstd"
     if [[ -z $SKIP_TESTS ]]; then
-      ninja_targets+=" tests ceph_radosacl ceph_scratchtool"
+      ninja_targets+=" tests ceph_radosacl ceph_scratchtool "
+      ninja_targets+=`ninja -t targets | grep ceph_test | cut -d ":" -f 1 | grep -v exe`
     fi
 
     ninja -v $ninja_targets 2>&1 | tee "${BUILD_DIR}/build.log"


### PR DESCRIPTION
Windows tests follow-up

This is mostly a follow-up to the PR that ported the libcephfs tests to Windows (https://github.com/ceph/ceph/pull/48053).

We'll update the ``win32_build.sh`` script to actually build the ``ceph_test_`` tests and fix a few other unrelated tests (e.g. the librados ones, which aren't currently executed by the Windows pipeline).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
