### PR TITLE
mgr/dashboard: use service call instead of form component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
@@ -346,17 +346,4 @@ export class SilenceFormComponent {
     }
     return `${action} ${this.resource} for ${msg.slice(0, -1)}`;
   }
-
-  createSilenceFromNotification(data: any) {
-    this.isNavigate = false;
-    this.setMatcher({
-      name: 'alertname',
-      value: data['title'].split(' ')[0],
-      isRegex: false
-    });
-    this.createForm();
-    this.form.get('comment').setValue('Silence created from the alert notification');
-    this.setupDates();
-    this.submit(data);
-  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
@@ -13,11 +13,14 @@ import _ from 'lodash';
 import moment from 'moment';
 import { Subscription } from 'rxjs';
 
-import { SilenceFormComponent } from '~/app/ceph/cluster/prometheus/silence-form/silence-form.component';
 import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { SucceededActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import {
+  AlertmanagerSilence,
+  AlertmanagerSilenceMatcher
+} from '~/app/shared/models/alertmanager-silence';
 import { CdNotification } from '~/app/shared/models/cd-notification';
 import { ExecutingTask } from '~/app/shared/models/executing-task';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -29,7 +32,6 @@ import { SummaryService } from '~/app/shared/services/summary.service';
 import { TaskMessageService } from '~/app/shared/services/task-message.service';
 
 @Component({
-  providers: [SilenceFormComponent],
   selector: 'cd-notifications-sidebar',
   templateUrl: './notifications-sidebar.component.html',
   styleUrls: ['./notifications-sidebar.component.scss'],
@@ -65,7 +67,6 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
     private authStorageService: AuthStorageService,
     private prometheusAlertService: PrometheusAlertService,
     private prometheusService: PrometheusService,
-    private silenceFormComponent: SilenceFormComponent,
     private ngZone: NgZone,
     private cdRef: ChangeDetectorRef
   ) {
@@ -174,8 +175,37 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
   }
 
   silence(data: CdNotification) {
+    const datetimeFormat = 'YYYY-MM-DD HH:mm';
+    const resource = $localize`silence`;
+    const matcher: AlertmanagerSilenceMatcher = {
+      name: 'alertname',
+      value: data['title'].split(' ')[0],
+      isRegex: false
+    };
+    const silencePayload: AlertmanagerSilence = {
+      matchers: [matcher],
+      startsAt: moment(moment().format(datetimeFormat)).toISOString(),
+      endsAt: moment(moment().add(2, 'hours').format(datetimeFormat)).toISOString(),
+      createdBy: this.authStorageService.getUsername(),
+      comment: 'Silence created from the alert notification'
+    };
+    let msg = '';
+
     data.alertSilenced = true;
-    this.silenceFormComponent.createSilenceFromNotification(data);
+    msg = msg.concat(` ${matcher.name} - ${matcher.value},`);
+    const title = `${this.succeededLabels.CREATED} ${resource} for ${msg.slice(0, -1)}`;
+    this.prometheusService.setSilence(silencePayload).subscribe((resp) => {
+      if (data) {
+        data.silenceId = resp.body['silenceId'];
+      }
+      this.notificationService.show(
+        NotificationType.success,
+        title,
+        undefined,
+        undefined,
+        'Prometheus'
+      );
+    });
   }
 
   expire(data: CdNotification) {


### PR DESCRIPTION
For creating the silence from the notification sidebar, instead of using the silence form which will require initializing the whole component on the landing page, we can just call the prometheus service and pass on the required data to the service call. This will fix showing the `Prometheus not configured` error everytime we visit the landing page when the prometheus is not configured

This also fixes the accessibility error in e2e. https://jenkins.ceph.com/job/ceph-api-nightly-main-e2e/114/consoleFull#-1979990252850dcd63-8003-466d-a467-63e6a2b699b9

Fixes: https://tracker.ceph.com/issues/57576
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
