### PR TITLE
 mon: remove empty list entries from ceph versions

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3940,29 +3940,35 @@ void Monitor::handle_command(MonOpRequestRef op)
     }
     f->close_section();
 
-    mgrmon()->count_metadata("ceph_version", &mgr);
-    f->open_object_section("mgr");
-    for (auto& p : mgr) {
-      f->dump_int(p.first.c_str(), p.second);
-      overall[p.first] += p.second;
+    if (!mgr.empty()) {
+      mgrmon()->count_metadata("ceph_version", &mgr);
+      f->open_object_section("mgr");
+      for (auto& p : mgr) {
+        f->dump_int(p.first.c_str(), p.second);
+        overall[p.first] += p.second;
+      }
+      f->close_section();
     }
-    f->close_section();
 
-    osdmon()->count_metadata("ceph_version", &osd);
-    f->open_object_section("osd");
-    for (auto& p : osd) {
-      f->dump_int(p.first.c_str(), p.second);
-      overall[p.first] += p.second;
+    if (!osd.empty()) {
+      osdmon()->count_metadata("ceph_version", &osd);
+      f->open_object_section("osd");
+      for (auto& p : osd) {
+        f->dump_int(p.first.c_str(), p.second);
+        overall[p.first] += p.second;
+      }
+      f->close_section();
     }
-    f->close_section();
 
-    mdsmon()->count_metadata("ceph_version", &mds);
-    f->open_object_section("mds");
-    for (auto& p : mds) {
-      f->dump_int(p.first.c_str(), p.second);
-      overall[p.first] += p.second;
+    if (!mds.empty()) {
+      mdsmon()->count_metadata("ceph_version", &mds);
+      f->open_object_section("mds");
+      for (auto& p : mds) {
+        f->dump_int(p.first.c_str(), p.second);
+        overall[p.first] += p.second;
+      }
+      f->close_section();
     }
-    f->close_section();
 
     for (auto& p : mgrstatmon()->get_service_map().services) {
       auto &service = p.first;


### PR DESCRIPTION
In ceph versions command output, empty list gets printed for
mds. If there are no rgw/rbd-mirror daemon deployed, the
ceph versions command doesn't display version information
(empty list) for those daemons. Similar issue has been observed
for mgr and osd daemons. The ceph versions should only show
version information for daemons which are deployed in the cluster.

Fixes: https://tracker.ceph.com/issues/57585

Signed-off-by: shreyanshjain7174 <ssanchet@redhat.com>