### PR TITLE
win32: skip installing openssl man pages

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -126,7 +126,7 @@ CROSS_COMPILE="${MINGW_PREFIX}" ./Configure \
     mingw64 shared --prefix=$sslDir --libdir="$sslDir/lib"
 _make depend
 _make
-_make install
+_make install_sw
 
 echo "Building libcurl."
 cd $depsSrcDir


### PR DESCRIPTION
This speeds up the build a bit and makes the logs easier to read.