### PR TITLE
pacific: mgr/dashboard: fix Expected to find element: `cd-modal .badge but never found it

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -88,6 +88,7 @@ export class HostsPageHelper extends PageHelper {
     // Verify labels are added or removed from Labels column
     // First find row with hostname, then find labels in the row
     this.getTableCell(this.columnIndex.hostname, hostname)
+      .click()
       .parent()
       .find(`datatable-body-cell:nth-child(${this.columnIndex.labels}) .badge`)
       .should(($ele) => {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57582

---

backport of https://github.com/ceph/ceph/pull/47958
parent tracker: https://tracker.ceph.com/issues/57207

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh