### PR TITLE
win32: ubuntu platform build fixes

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -72,7 +72,7 @@ case "$OS" in
         sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
             mingw-w64 cmake pkg-config \
             python3-dev python3-pip python3-yaml \
-                autoconf libtool ninja-build zip
+                autoconf libtool ninja-build wget zip
         sudo python3 -m pip install cython
         ;;
     suse)

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -69,7 +69,8 @@ echo "Installing required packages."
 case "$OS" in
     ubuntu)
         sudo apt-get update
-        sudo apt-get -y install mingw-w64 cmake pkg-config \
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
+            mingw-w64 cmake pkg-config \
             python3-dev python3-pip python3-yaml \
                 autoconf libtool ninja-build zip
         sudo python3 -m pip install cython


### PR DESCRIPTION
The build process requires `wget`. Install this on Ubuntu platforms.

Install deps with `DEBIAN_FRONTEND=noninteractive` This simplifies the installation process when I run it in an interactive terminal.