### PR TITLE
win32: remove libcurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,8 +399,10 @@ else()
   set(EXE_LINKER_USE_PIE ${ENABLE_SHARED})
 endif()
 
-# require libcurl with good curl_multi_wait(), see https://tracker.ceph.com/issues/15915
-find_package(CURL 7.32 REQUIRED)
+if(NOT WIN32)
+  # require libcurl with good curl_multi_wait(), see https://tracker.ceph.com/issues/15915
+  find_package(CURL 7.32 REQUIRED)
+endif()
 
 find_package(OpenSSL REQUIRED)
 set(CRYPTO_LIBS OpenSSL::Crypto)

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -82,7 +82,6 @@ depsToolsetDir="$DEPS_DIR/mingw"
 cmakeGenerator="Ninja"
 lz4Dir="${depsToolsetDir}/lz4"
 sslDir="${depsToolsetDir}/openssl"
-curlDir="${depsToolsetDir}/curl"
 boostDir="${depsToolsetDir}/boost"
 zlibDir="${depsToolsetDir}/zlib"
 backtraceDir="${depsToolsetDir}/libbacktrace"
@@ -93,7 +92,7 @@ wnbdLibDir="${depsToolsetDir}/wnbd/lib"
 dokanSrcDir="${depsSrcDir}/dokany"
 dokanLibDir="${depsToolsetDir}/dokany/lib"
 
-depsDirs="$lz4Dir;$curlDir;$sslDir;$boostDir;$zlibDir;$backtraceDir;$snappyDir"
+depsDirs="$lz4Dir;$sslDir;$boostDir;$zlibDir;$backtraceDir;$snappyDir"
 depsDirs+=";$winLibDir"
 
 # Cmake recommends using CMAKE_PREFIX_PATH instead of link_directories.
@@ -104,8 +103,6 @@ linkDirs="$zlibDir/lib"
 
 lz4Lib="${lz4Dir}/lib/dll/liblz4-1.dll"
 lz4Include="${lz4Dir}/lib"
-curlLib="${curlDir}/lib/libcurl.dll.a"
-curlInclude="${curlDir}/include"
 
 if [[ -n $CLEAN_BUILD ]]; then
     echo "Cleaning up build dir: $BUILD_DIR"

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -19,10 +19,6 @@ sslTag="OpenSSL_1_1_1c"
 sslDir="${depsToolsetDir}/openssl"
 sslSrcDir="${depsSrcDir}/openssl"
 
-curlTag="curl-7_84_0"
-curlSrcDir="${depsSrcDir}/curl"
-curlDir="${depsToolsetDir}/curl"
-
 # For now, we'll keep the version number within the file path when not using git.
 boostUrl="https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz"
 boostSrcDir="${depsSrcDir}/boost_1_79_0"
@@ -127,20 +123,6 @@ CROSS_COMPILE="${MINGW_PREFIX}" ./Configure \
 _make depend
 _make
 _make install
-
-echo "Building libcurl."
-cd $depsSrcDir
-if [[ ! -d $curlSrcDir ]]; then
-    git clone --branch $curlTag --depth 1 https://github.com/curl/curl
-    cd $curlSrcDir
-fi
-cd $curlSrcDir
-./buildconf
-./configure --prefix=$curlDir --with-ssl=$sslDir --with-zlib=$zlibDir \
-            --host=${MINGW_BASE} --libdir="$curlDir/lib"
-_make
-_make install
-
 
 echo "Building boost."
 cd $depsSrcDir


### PR DESCRIPTION
The Windows client does not use libcurl for anything. Remove it to simplify the build process.

Note, if we ever add libcurl back on Windows, we should disable unused protocols to harden the build:

```
--disable-ftp --disable-ldap --disable-ldaps --disable-rtsp \
--disable-dict --disable-telnet --disable-tftp --disable-pop3 \
--disable-imap --disable-smb --disable-smtp --disable-gopher \
--disable-mqtt --disable-manual --disable-ntlm
```