### PR TITLE
cmake: allow building against BoringSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ endif()
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 option(WITH_RADOSGW_BEAST_OPENSSL "Rados Gateway's Beast frontend uses OpenSSL" ON)
+option(WITH_RADOSGW_KMIP "Rados Gateway's server side encryption supports KMIP" ON)
 option(WITH_RADOSGW_AMQP_ENDPOINT "Rados Gateway's pubsub support for AMQP push endpoint" ON)
 option(WITH_RADOSGW_KAFKA_ENDPOINT "Rados Gateway's pubsub support for Kafka push endpoint" ON)
 option(WITH_RADOSGW_LUA_PACKAGES "Rados Gateway's support for dynamically adding lua packagess" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -686,7 +686,7 @@ set(ceph_osd_srcs
 
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global-static common
+target_link_libraries(ceph-osd osd os global-static
   ${ALLOC_LIBS}
   ${BLKID_LIBRARIES})
 if(WITH_FUSE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -183,7 +183,7 @@ add_library(common-common-objs OBJECT
 # Let's not rely on the default system headers and point Cmake to the
 # retrieved OpenSSL location. This is especially important when cross
 # compiling (e.g. targeting Windows).
-target_include_directories(common-common-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
+target_include_directories(common-common-objs PUBLIC ${OPENSSL_INCLUDE_DIR})
 # for options.cc
 target_compile_definitions(common-common-objs PRIVATE
   "CMAKE_INSTALL_LIBDIR=\"${CMAKE_INSTALL_LIBDIR}\""

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -26,6 +26,9 @@
 #  include <openssl/engine.h>
 #  include <openssl/err.h>
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+#ifdef OPENSSL_IS_BORINGSSL
+#  include <openssl/mem.h> // for OPENSSL_cleanse
+#endif
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -88,7 +88,8 @@ namespace TOPNSPC::crypto {
     };
 
 
-# if OPENSSL_VERSION_NUMBER < 0x10100000L
+  // boringssl doesn't have HMAC_CTX_get_md()
+# if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(OPENSSL_IS_BORINGSSL)
   class HMAC {
   private:
     HMAC_CTX mContext;

--- a/src/common/openssl_opts_handler.cc
+++ b/src/common/openssl_opts_handler.cc
@@ -30,6 +30,12 @@ using std::string;
 using std::ostream;
 using std::vector;
 
+#ifdef OPENSSL_IS_BORINGSSL
+void ceph::crypto::init_openssl_engine_once()
+{
+  // no CONF_modules_load() in boringssl
+}
+#else
 // -----------------------------------------------------------------------------
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_common
@@ -144,3 +150,4 @@ void ceph::crypto::init_openssl_engine_once()
   static std::once_flag flag;
   std::call_once(flag, init_engine);
 }
+#endif

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -52,7 +52,7 @@ if(HAS_VTA)
 endif()
 add_library(osd STATIC ${osd_srcs})
 target_link_libraries(osd
-  PUBLIC dmclock::dmclock Boost::MPL
+  PUBLIC dmclock::dmclock Boost::MPL common
   PRIVATE os heap_profiler cpu_profiler fmt::fmt ${CMAKE_DL_LIBS})
 if(WITH_LTTNG)
   add_dependencies(osd osd-tp pg-tp)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -160,7 +160,6 @@ set(librgw_common_srcs
   rgw_rest_iam.cc
   rgw_object_lock.cc
   rgw_kms.cc
-  rgw_kmip_client.cc
   rgw_url.cc
   rgw_oidc_provider.cc
   rgw_datalog.cc
@@ -186,6 +185,9 @@ list(APPEND librgw_common_srcs
   store/rados/config/zone.cc
   store/rados/config/zonegroup.cc)
 
+if (WITH_RADOSGW_KMIP)
+  list(APPEND librgw_common_srcs rgw_kmip_client.cc)
+endif()
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
 endif()
@@ -247,6 +249,11 @@ target_include_directories(rgw_common
   PUBLIC "services"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${LUA_INCLUDE_DIR}")
+if (WITH_RADOSGW_KMIP)
+  target_link_libraries(rgw_common PUBLIC kmip)
+  target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/libkmip")
+  target_compile_definitions(rgw_common PUBLIC "HAVE_KMIP")
+endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   # used by rgw_kafka.cc
   target_link_libraries(rgw_common
@@ -307,7 +314,6 @@ set(rgw_a_srcs
   rgw_file.cc
   rgw_frontend.cc
   rgw_http_client_curl.cc
-  rgw_kmip_client_impl.cc
   rgw_lib.cc
   rgw_loadgen.cc
   rgw_loadgen_process.cc
@@ -334,6 +340,10 @@ set(rgw_a_srcs
   rgw_usage.cc
   rgw_sts.cc)
 
+if (WITH_RADOSGW_KMIP)
+  list(APPEND rgw_a_srcs rgw_kmip_client_impl.cc)
+endif()
+
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf
   rgw_iam_policy_keywords.frag.cc)
 set_source_files_properties(rgw_iam_policy.cc PROPERTIES
@@ -346,7 +356,6 @@ add_library(rgw_a STATIC
 
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw_a PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
-target_include_directories(rgw_a PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip")
 target_include_directories(rgw_a SYSTEM PUBLIC "../rapidjson/include")
 target_include_directories(rgw_a PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
 
@@ -391,13 +400,12 @@ add_executable(radosgw ${radosgw_srcs})
 target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PRIVATE "${LUA_INCLUDE_DIR}")
 
 target_include_directories(radosgw SYSTEM PUBLIC "../rapidjson/include")
 
-target_link_libraries(radosgw PRIVATE ${rgw_libs} rgw_schedulers kmip)
+target_link_libraries(radosgw PRIVATE ${rgw_libs} rgw_schedulers)
 if(WITH_RADOSGW_BEAST_OPENSSL)
   # used by rgw_asio_frontend.cc
   target_link_libraries(radosgw PRIVATE OpenSSL::SSL)
@@ -454,7 +462,6 @@ add_library(rgw SHARED ${librgw_srcs})
 target_compile_definitions(rgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PRIVATE "${LUA_INCLUDE_DIR}")
 
@@ -464,7 +471,6 @@ target_link_libraries(rgw
   PRIVATE
   ${rgw_libs}
   rgw_schedulers
-  kmip
   librados
   cls_rgw_client
   cls_otp_client

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -52,8 +52,10 @@
 #include "rgw_process.h"
 #include "rgw_frontend.h"
 #include "rgw_http_client_curl.h"
+#ifdef HAVE_KMIP
 #include "rgw_kmip_client.h"
 #include "rgw_kmip_client_impl.h"
+#endif
 #include "rgw_perf_counters.h"
 #include "rgw_signal.h"
 #ifdef WITH_RADOSGW_AMQP_ENDPOINT
@@ -233,7 +235,9 @@ void rgw::AppMain::init_http_clients()
   rgw_init_resolver();
   rgw::curl::setup_curl(fe_map);
   rgw_http_client_init(dpp->get_cct());
+#ifdef HAVE_KMIP
   rgw_kmip_client_init(*new RGWKMIPManagerImpl(dpp->get_cct()));
+#endif
 } /* init_http_clients */
 
 void rgw::AppMain::cond_init_apis() 
@@ -583,7 +587,9 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
   rgw_tools_cleanup();
   rgw_shutdown_resolver();
   rgw_http_client_cleanup();
+#ifdef HAVE_KMIP
   rgw_kmip_client_cleanup();
+#endif
   rgw::curl::cleanup_curl();
   g_conf().remove_observer(implicit_tenant_context.get());
   implicit_tenant_context.reset(); // deletes

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -12,7 +12,9 @@
 #include "rgw/rgw_keystone.h"
 #include "rgw/rgw_b64.h"
 #include "rgw/rgw_kms.h"
+#ifdef HAVE_KMIP
 #include "rgw/rgw_kmip_client.h"
+#endif
 #include <rapidjson/allocators.h>
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
@@ -761,6 +763,7 @@ public:
 
 };
 
+#ifdef HAVE_KMIP
 class KmipSecretEngine;
 class KmipGetTheKey {
 private:
@@ -859,6 +862,7 @@ public:
 	return r;
   }
 };
+#endif
 
 static int get_actual_key_from_conf(const DoutPrefixProvider* dpp,
                                     CephContext *cct,
@@ -1053,7 +1057,7 @@ static int reconstitute_actual_key_from_vault(const DoutPrefixProvider *dpp,
     return get_actual_key_from_vault(dpp, cct, kctx, attrs, actual_key, false);
 }
 
-
+#ifdef HAVE_KMIP
 static int get_actual_key_from_kmip(const DoutPrefixProvider *dpp,
                                      CephContext *cct,
                                      std::string_view key_id,
@@ -1070,6 +1074,8 @@ static int get_actual_key_from_kmip(const DoutPrefixProvider *dpp,
     return -EINVAL;
   }
 }
+#endif
+
 class KMSContext : public SSEContext {
   CephContext *cct;
 public:
@@ -1169,11 +1175,11 @@ int reconstitute_actual_key_from_kms(const DoutPrefixProvider *dpp, CephContext 
   if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend) {
     return reconstitute_actual_key_from_vault(dpp, cct, kctx, attrs, actual_key);
   }
-
+#ifdef HAVE_KMIP
   if (RGW_SSE_KMS_BACKEND_KMIP == kms_backend) {
     return get_actual_key_from_kmip(dpp, cct, key_id, actual_key);
   }
-
+#endif
   if (RGW_SSE_KMS_BACKEND_TESTING == kms_backend) {
     std::string key_selector = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYSEL);
     return get_actual_key_from_conf(dpp, cct, key_id, key_selector, actual_key);


### PR DESCRIPTION
OpenSSL doesn't support quic, so many quic libraries depend on BoringSSL. to start experimenting with quic integration, we need the ability to build in this configuration

this doesn't add BoringSSL as a ceph dependency, it only works around some build/link failures when our `find_package(OpenSSL)` is pointed at a boringssl build. this was tested against the master branch of https://github.com/google/boringssl:
> cmake -DOPENSSL_SSL_LIBRARY=\~/boringssl/ssl/libssl.so
-DOPENSSL_CRYPTO_LIBRARY=\~/boringssl/crypto/libcrypto.so
-DOPENSSL_INCLUDE_DIR=\~/boringssl/include

these were several compilation failures due to api differences:
* common/ceph_crypto.h: `HMAC_CTX_get_md()` not found in openssl/hmac.h with older boringssl versions (added very recently in https://github.com/google/boringssl/commit/d45d8933e61ccd8bd50fcf58f33a604627e6552c)
* common/ceph_crypto.cc: `OPENSSL_cleanse()` not found in openssl/crypto.h, boringssl has it in openssl/mem.h
* common/openssl_opts_handler.cc: `CONF_modules_load()` not found in openssl/conf.h, boringssl only has `CONF_modules_load_file()`
* rgw/rgw_kmip_client_impl.cc: `BIO_new_ssl_connect()` not found in openssl/ssl.h

there were also linker errors because some sources were still including the default /usr/include/openssl headers. all sources that depend on openssl need to use our overridden include directory, so OPENSSL_INCLUDE_DIR was made a PUBLIC part of the common-common-objs target

we're still using the system libcurl library which links against openssl, so rgw's RGWHTTPManager crashes on startup in `curl_easy_init()`

the boost::asio::ssl wrappers used by rbd and rgw already support boringssl

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
