### PR TITLE
qa/suites/crimson-rados/thrash: Adding workloads / Simplifying thrashers

### DIFF
--- a/qa/suites/crimson-rados/thrash/thrashers/default.yaml
+++ b/qa/suites/crimson-rados/thrash/thrashers/default.yaml
@@ -20,6 +20,14 @@ overrides:
         mon osdmap full prune txsize: 2
 tasks:
 - thrashosds:
+    timeout: 2400
     dump_ops_enable: false
     sighup_delay: 0
     min_in: 3
+    noscrub_toggle_delay: 0
+    chance_down: 0
+    chance_thrash_pg_upmap: 0
+    reweight_osd: 0
+    thrash_primary_affinity: false
+    ceph_objectstore_tool: false
+    chance_inject_pause_short: 0

--- a/qa/suites/crimson-rados/thrash/workloads/admin_socket_objecter_requests.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/admin_socket_objecter_requests.yaml
@@ -1,0 +1,13 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        admin socket: /var/run/ceph/ceph-$name.asok
+tasks:
+- radosbench:
+    clients: [client.0]
+    time: 150
+- admin_socket:
+    client.0:
+      objecter_requests:
+        test: "http://git.ceph.com/?p={repo};a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"

--- a/qa/suites/crimson-rados/thrash/workloads/cache-agent-big.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-agent-big.yaml
@@ -1,0 +1,37 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd erasure-code-profile set myprofile crush-failure-domain=osd m=2 k=2
+      - sudo ceph osd pool create base 4 4 erasure myprofile
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool set base min_size 2
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 60
+      - sudo ceph osd pool set cache target_max_objects 5000
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 10000
+    objects: 6600
+    max_seconds: 1200
+    size: 1024
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0

--- a/qa/suites/crimson-rados/thrash/workloads/cache-agent-small.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-agent-small.yaml
@@ -1,0 +1,35 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 60
+      - sudo ceph osd pool set cache target_max_objects 250
+      - sudo ceph osd pool set cache min_read_recency_for_promote 2
+      - sudo ceph osd pool set cache min_write_recency_for_promote 2
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0

--- a/qa/suites/crimson-rados/thrash/workloads/cache-pool-snaps-readproxy.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-pool-snaps-readproxy.yaml.disabled
@@ -1,0 +1,44 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache readproxy
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 3600
+      - sudo ceph osd pool set cache target_max_objects 250
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0
+      # TODO: CEPH_OSD_OP_CACHE_FLUSH
+      cache_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_TRY_FLUSH
+      cache_try_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+      snap_create: 50
+      snap_remove: 0
+      # TODO: CEPH_OSD_OP_ROLLBACK
+      rollback: 0

--- a/qa/suites/crimson-rados/thrash/workloads/cache-pool-snaps.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-pool-snaps.yaml.disabled
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 3600
+      - sudo ceph osd pool set cache target_max_objects 250
+      - sudo ceph osd pool set cache min_read_recency_for_promote 0
+      - sudo ceph osd pool set cache min_write_recency_for_promote 0
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0
+      # TODO: CEPH_OSD_OP_CACHE_FLUSH
+      cache_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_TRY_FLUSH
+      cache_try_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+      snap_create: 50
+      snap_remove: 0
+      # TODO: CEPH_OSD_OP_ROLLBACK
+      rollback: 0
+openstack:
+  - machine:
+      ram: 15000 # MB

--- a/qa/suites/crimson-rados/thrash/workloads/cache-snaps-balanced.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-snaps-balanced.yaml.disabled
@@ -1,0 +1,46 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 3600
+      - sudo ceph osd pool set cache target_max_objects 250
+      - sudo ceph osd pool set cache min_read_recency_for_promote 2
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    balance_reads: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0
+      # TODO: CEPH_OSD_OP_CACHE_FLUSH
+      cache_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_TRY_FLUSH
+      cache_try_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+      snap_create: 50
+      snap_remove: 0
+      # TODO: CEPH_OSD_OP_ROLLBACK
+      rollback: 0
+

--- a/qa/suites/crimson-rados/thrash/workloads/cache-snaps.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/cache-snaps.yaml.disabled
@@ -1,0 +1,45 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 3600
+      - sudo ceph osd pool set cache target_max_objects 250
+      - sudo ceph osd pool set cache min_read_recency_for_promote 2
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0
+      # TODO: CEPH_OSD_OP_CACHE_FLUSH
+      cache_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_TRY_FLUSH
+      cache_try_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+      snap_create: 50
+      snap_remove: 0
+      # TODO: CEPH_OSD_OP_ROLLBACK
+      rollback: 0
+

--- a/qa/suites/crimson-rados/thrash/workloads/cache.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/cache.yaml
@@ -1,0 +1,41 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - must scrub before tier agent can activate
+    conf:
+      osd:
+        # override short_pg_log_entries.yaml (which sets these under [global])
+        osd_min_pg_log_entries: 3000
+        osd_max_pg_log_entries: 3000
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create base 4
+      - sudo ceph osd pool application enable base rados
+      - sudo ceph osd pool create cache 4
+      - sudo ceph osd tier add base cache
+      - sudo ceph osd tier cache-mode cache writeback
+      - sudo ceph osd tier set-overlay base cache
+      - sudo ceph osd pool set cache hit_set_type bloom
+      - sudo ceph osd pool set cache hit_set_count 8
+      - sudo ceph osd pool set cache hit_set_period 3600
+      - sudo ceph osd pool set cache min_read_recency_for_promote 0
+      - sudo ceph osd pool set cache min_write_recency_for_promote 0
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0
+      # TODO: CEPH_OSD_OP_CACHE_FLUSH
+      cache_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_TRY_FLUSH
+      cache_try_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+

--- a/qa/suites/crimson-rados/thrash/workloads/dedup-io-mixed.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/dedup-io-mixed.yaml.disabled
@@ -1,0 +1,24 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 1500
+    objects: 50
+    set_chunk: true
+    enable_dedup: true
+    dedup_chunk_size: '131072'
+    dedup_chunk_algo: 'fastcdc'
+    op_weights:
+      read: 100
+      write: 50
+      # TODO: CEPH_OSD_OP_SET_CHUNK
+      set_chunk: 0
+      # TODO: CEPH_OSD_OP_TIER_PROMOTE
+      tier_promote: 0
+      # TODO: CEPH_OSD_OP_TIER_FLUSH
+      tier_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0

--- a/qa/suites/crimson-rados/thrash/workloads/dedup-io-snaps.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/dedup-io-snaps.yaml.disabled
@@ -1,0 +1,28 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 1500
+    objects: 50
+    set_chunk: true
+    enable_dedup: true
+    dedup_chunk_size: '131072'
+    dedup_chunk_algo: 'fastcdc'
+    op_weights:
+      read: 100
+      write: 50
+      # TODO: CEPH_OSD_OP_SET_CHUNK
+      set_chunk: 0
+      # TODO: CEPH_OSD_OP_TIER_PROMOTE
+      tier_promote: 0
+      # TODO: CEPH_OSD_OP_TIER_FLUSH
+      tier_flush: 0
+      # TODO: CEPH_OSD_OP_CACHE_EVICT
+      cache_evict: 0
+      snap_create: 10
+      snap_remove: 10
+      # TODO: CEPH_OSD_OP_ROLLBACK
+      rollback: 0

--- a/qa/suites/crimson-rados/thrash/workloads/pool-snaps-few-objects.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/pool-snaps-few-objects.yaml.disabled
@@ -1,23 +1,21 @@
-overrides:
-  ceph:
-    crush_tunables: jewel
+override:
+  conf:
+    osd:
+      osd deep scrub update digest min age: 0
 tasks:
 - rados:
     clients: [client.0]
-    ops: 400000
-    max_seconds: 600
-    max_in_flight: 64
-    objects: 1024
-    size: 16384
+    ops: 4000
+    objects: 50
+    pool_snaps: true
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0
       # TODO: CEPH_OSD_OP_COPY_FROM
       copy_from: 0
-      setattr: 25
-      rmattr: 25
+

--- a/qa/suites/crimson-rados/thrash/workloads/rados_api_tests.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/rados_api_tests.yaml.disabled
@@ -1,0 +1,23 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - reached quota
+      - \(POOL_APP_NOT_ENABLED\)
+      - \(PG_AVAILABILITY\)
+    crush_tunables: jewel
+    conf:
+      client:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+      mon:
+        mon warn on pool no app: false
+        debug mgrc: 20
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rados/test.sh

--- a/qa/suites/crimson-rados/thrash/workloads/radosbench-high-concurrency.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/radosbench-high-concurrency.yaml
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90

--- a/qa/suites/crimson-rados/thrash/workloads/radosbench.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/radosbench.yaml
@@ -1,0 +1,24 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90

--- a/qa/suites/crimson-rados/thrash/workloads/redirect.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/redirect.yaml.disabled
@@ -1,0 +1,17 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 4000
+    objects: 500
+    # TODO: CEPH_OSD_OP_SET_REDIRECT
+    set_redirect: false
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0

--- a/qa/suites/crimson-rados/thrash/workloads/redirect_promote_tests.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/redirect_promote_tests.yaml
@@ -1,0 +1,17 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 4000
+    objects: 500
+    # TODO: CEPH_OSD_OP_SET_REDIRECT
+    set_redirect: false
+    op_weights:
+      # TODO: CEPH_OSD_OP_SET_REDIRECT
+      set_redirect: 0
+      read: 50
+      # TODO: CEPH_OSD_OP_TIER_PROMOTE
+      tier_promote: 0

--- a/qa/suites/crimson-rados/thrash/workloads/redirect_promote_tests.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/redirect_promote_tests.yaml.disabled
@@ -1,0 +1,16 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 4000
+    objects: 500
+    set_redirect: true
+    op_weights:
+      # TODO: CEPH_OSD_OP_SET_REDIRECT
+      set_redirect: 0
+      read: 50
+      # TODO: CEPH_OSD_OP_TIER_PROMOTE
+      tier_promote: 0

--- a/qa/suites/crimson-rados/thrash/workloads/redirect_set_object.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/redirect_set_object.yaml.disabled
@@ -1,0 +1,15 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 4000
+    objects: 500
+    set_redirect: true
+    op_weights:
+      # TODO: CEPH_OSD_OP_SET_REDIRECT
+      set_redirect: 0
+      # TODO: CEPH_OSD_OP_COPY_FROM
+      copy_from: 0

--- a/qa/suites/crimson-rados/thrash/workloads/set-chunks-read.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/set-chunks-read.yaml.disabled
@@ -1,0 +1,14 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 4000
+    objects: 300
+    set_chunk: true
+    op_weights:
+      chunk_read: 0
+      # TODO: CEPH_OSD_OP_TIER_PROMOTE
+      tier_promote: 0

--- a/qa/suites/crimson-rados/thrash/workloads/small-objects-balanced.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/small-objects-balanced.yaml.disabled
@@ -9,11 +9,12 @@ tasks:
     max_in_flight: 64
     objects: 1024
     size: 16384
+    balance_reads: true
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0

--- a/qa/suites/crimson-rados/thrash/workloads/small-objects-localized.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/small-objects-localized.yaml.disabled
@@ -9,11 +9,12 @@ tasks:
     max_in_flight: 64
     objects: 1024
     size: 16384
+    localize_reads: true
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0

--- a/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects-balanced.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects-balanced.yaml.disabled
@@ -1,23 +1,16 @@
-overrides:
-  ceph:
-    crush_tunables: jewel
 tasks:
 - rados:
     clients: [client.0]
-    ops: 400000
-    max_seconds: 600
-    max_in_flight: 64
-    objects: 1024
-    size: 16384
+    ops: 4000
+    objects: 50
+    balance_reads: true
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0
       # TODO: CEPH_OSD_OP_COPY_FROM
       copy_from: 0
-      setattr: 25
-      rmattr: 25

--- a/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects-localized.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects-localized.yaml.disabled
@@ -1,23 +1,16 @@
-overrides:
-  ceph:
-    crush_tunables: jewel
 tasks:
 - rados:
     clients: [client.0]
-    ops: 400000
-    max_seconds: 600
-    max_in_flight: 64
-    objects: 1024
-    size: 16384
+    ops: 4000
+    objects: 50
+    localize_reads: true
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0
       # TODO: CEPH_OSD_OP_COPY_FROM
       copy_from: 0
-      setattr: 25
-      rmattr: 25

--- a/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects.yaml.disabled
+++ b/qa/suites/crimson-rados/thrash/workloads/snaps-few-objects.yaml.disabled
@@ -1,23 +1,15 @@
-overrides:
-  ceph:
-    crush_tunables: jewel
 tasks:
 - rados:
     clients: [client.0]
-    ops: 400000
-    max_seconds: 600
-    max_in_flight: 64
-    objects: 1024
-    size: 16384
+    ops: 4000
+    objects: 50
     op_weights:
       read: 100
       write: 100
       delete: 50
-      snap_create: 0
+      snap_create: 50
       snap_remove: 0
       # TODO: CEPH_OSD_OP_ROLLBACK
       rollback: 0
       # TODO: CEPH_OSD_OP_COPY_FROM
       copy_from: 0
-      setattr: 25
-      rmattr: 25

--- a/qa/suites/crimson-rados/thrash/workloads/write_fadvise_dontneed.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/write_fadvise_dontneed.yaml
@@ -1,0 +1,8 @@
+tasks:
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 500
+    write_fadvise_dontneed: true
+    op_weights:
+      write: 100


### PR DESCRIPTION
By simplifying the thrash suite, we can re-enable the opted-out configurations gradually - approaching each issue on its own.

Some workloads were added and marked as disabled for now.

https://pulpito.ceph.com/matan-2022-09-19_06:13:25-crimson-rados:thrash-main-distro-crimson-smithi/

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
