### PR TITLE
mgr/dashboard: refactor dashboard cephadm e2e tests

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -46,5 +46,12 @@ while [[ $PROMETHEUS_RUNNING_COUNT -lt 1 ]]; do
     PROMETHEUS_RUNNING_COUNT=$(kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch ls --service_name=prometheus --format=json"' | jq -r '.[] | .status.running')
 done
 
+# grafana ip address is set to the fqdn by default.
+# kcli is not working with that, so setting the IP manually.
+kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-api-host http://192.168.100.100:9093"'
+kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'
+kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'
+kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2'"'
+
 cypress_run ["orchestrator/workflow/*.feature, orchestrator/workflow/*-spec.ts"]
 cypress_run "orchestrator/grafana/*.feature"

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -8,6 +8,8 @@ cleanup() {
         echo "Starting cleanup..."
         kcli delete plan -y ceph || true
         kcli delete network ceph-dashboard -y
+        kcli delete pool ceph-dashboard -y
+        rm -rf ${HOME}/.kcli
         docker container prune -f
         echo "Cleanup completed."
     fi

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
@@ -18,7 +18,7 @@ export class MirroringPageHelper extends PageHelper {
    */
   @PageHelper.restrictTo(pages.index.url)
   editMirror(name: string, option: string) {
-    // Select the pool in the table
+    // Clicks the pool in the table
     this.getFirstTableCell(name).click();
 
     // Clicks the Edit Mode button
@@ -33,9 +33,6 @@ export class MirroringPageHelper extends PageHelper {
     cy.contains('.modal-dialog', 'Edit pool mirror mode').should('not.exist');
     const val = option.toLowerCase(); // used since entries in table are lower case
     this.getFirstTableCell(val).should('be.visible');
-
-    // unselect the pool in the table
-    this.getFirstTableCell(name).click();
   }
 
   @PageHelper.restrictTo(pages.index.url)

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -106,8 +106,8 @@ export class HostsPageHelper extends PageHelper {
   @PageHelper.restrictTo(pages.index.url)
   maintenance(hostname: string, exit = false, force = false) {
     this.clearTableSearchInput();
-    this.getTableCell(this.columnIndex.hostname, hostname).click();
     if (force) {
+      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       cy.get('cd-modal').within(() => {
@@ -124,6 +124,7 @@ export class HostsPageHelper extends PageHelper {
     }
     if (exit) {
       this.getTableCell(this.columnIndex.hostname, hostname)
+        .click()
         .parent()
         .find(`datatable-body-cell:nth-child(${this.columnIndex.status})`)
         .then(($ele) => {
@@ -141,6 +142,7 @@ export class HostsPageHelper extends PageHelper {
           expect(status).to.not.include('maintenance');
         });
     } else {
+      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       this.getTableCell(this.columnIndex.hostname, hostname)

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -159,10 +159,6 @@ export class HostsPageHelper extends PageHelper {
     this.clickActionButton('start-drain');
     this.checkLabelExists(hostname, ['_no_schedule'], true);
 
-    // unselect it to avoid colliding with any other selection
-    // in different steps
-    this.getTableCell(this.columnIndex.hostname, hostname).click();
-
     this.clickTab('cd-host-details', hostname, 'Daemons');
     cy.get('cd-host-details').within(() => {
       cy.wait(20000);

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -195,10 +195,6 @@ export class ServicesPageHelper extends PageHelper {
     cy.get('cd-service-daemon-list').within(() => {
       this.getTableRow(daemon).click();
       this.clickActionButton(action);
-
-      // unselect it to avoid colliding with any other selection
-      // in different steps
-      this.getTableRow(daemon).click();
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -39,7 +39,7 @@ export class ServicesPageHelper extends PageHelper {
   addService(
     serviceType: string,
     exist?: boolean,
-    count = '1',
+    count = 1,
     snmpVersion?: string,
     snmpPrivProtocol?: boolean,
     unmanaged = false
@@ -49,7 +49,7 @@ export class ServicesPageHelper extends PageHelper {
       switch (serviceType) {
         case 'rgw':
           cy.get('#service_id').type('foo');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(count);
+          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
           break;
 
         case 'ingress':
@@ -65,7 +65,7 @@ export class ServicesPageHelper extends PageHelper {
 
         case 'nfs':
           cy.get('#service_id').type('testnfs');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(count);
+          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
           break;
 
         case 'snmp-gateway':
@@ -89,7 +89,7 @@ export class ServicesPageHelper extends PageHelper {
 
         default:
           cy.get('#service_id').type('test');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(count);
+          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
           break;
       }
       if (serviceType === 'snmp-gateway') {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/common/01-global.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/common/01-global.feature.po.ts
@@ -158,7 +158,7 @@ And('I should see row {string} does not have {string}', (row: string, options: s
 
 And('I go to the {string} tab', (names: string) => {
   for (const name of names.split(', ')) {
-    cy.contains('.nav.nav-tabs li', name).click();
+    cy.contains('.nav.nav-tabs a', name).click();
   }
 });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/02-create-cluster-add-host.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/02-create-cluster-add-host.feature
@@ -14,8 +14,9 @@ Feature: Cluster expansion host addition
         When I click on "Add" button
         And enter "hostname" "<hostname>"
         And select options "<labels>"
-        And I click on submit button
-        Then I should see a row with "<hostname>"
+        And I click on "Add Host" button
+        Then I should not see the modal
+        And I should see a row with "<hostname>"
         And I should see row "<hostname>" have "<labels>"
 
         Examples:
@@ -43,8 +44,9 @@ Feature: Cluster expansion host addition
         Given I am on the "Add Hosts" section
         When I click on "Add" button
         And enter "hostname" "ceph-node-[01-02]"
-        And I click on submit button
-        Then I should see rows with following entries
+        And I click on "Add Host" button
+        Then I should not see the modal
+        And I should see rows with following entries
             | hostname |
             | ceph-node-01 |
             | ceph-node-02 |
@@ -61,12 +63,12 @@ Feature: Cluster expansion host addition
         When I select a row "<hostname>"
         And I click on "Edit" button from the table actions
         And "add" option "<labels>"
-        And I click on submit button
+        And I click on "Edit Host" button
         Then I should see row "<hostname>" have "<labels>"
         When I select a row "<hostname>"
         And I click on "Edit" button from the table actions
         And "remove" option "<labels>"
-        And I click on submit button
+        And I click on "Edit Host" button
         Then I should see row "<hostname>" does not have "<labels>"
 
         Examples:

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('Create cluster create services page', () => {
   const createCluster = new CreateClusterWizardHelper();
   const createClusterServicePage = new CreateClusterServicePageHelper();
 
-  const createService = (serviceType: string, serviceName: string, count = '1') => {
+  const createService = (serviceType: string, serviceName: string, count = 1) => {
     cy.get('[aria-label=Create]').first().click();
     createClusterServicePage.addService(serviceType, false, count);
     createClusterServicePage.checkExist(serviceName, true);
@@ -31,7 +31,7 @@ describe('Create cluster create services page', () => {
     const serviceName = 'mds.test';
 
     it('should create an mds service', () => {
-      createService('mds', serviceName, '1');
+      createService('mds', serviceName);
     });
 
     it('should edit a service', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/04-create-cluster-create-osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/04-create-cluster-create-osds.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Create cluster create osds page', () => {
 
   describe('when Orchestrator is available', () => {
     it('should create OSDs', () => {
-      const hostnames = ['ceph-node-00', 'ceph-node-01', 'ceph-node-02'];
+      const hostnames = ['ceph-node-00', 'ceph-node-01'];
       for (const hostname of hostnames) {
         osds.create('hdd', hostname, true);
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/06-cluster-check.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/06-cluster-check.e2e-spec.ts
@@ -1,5 +1,4 @@
 /* tslint:disable*/
-import { Input, ManagerModulesPageHelper } from '../../cluster/mgr-modules.po';
 import { CreateClusterWizardHelper } from '../../cluster/create-cluster.po';
 import { HostsPageHelper } from '../../cluster/hosts.po';
 import { ServicesPageHelper } from '../../cluster/services.po';
@@ -9,7 +8,6 @@ describe('when cluster creation is completed', () => {
   const createCluster = new CreateClusterWizardHelper();
   const services = new ServicesPageHelper();
   const hosts = new HostsPageHelper();
-  const mgrmodules = new ManagerModulesPageHelper();
 
   const hostnames = ['ceph-node-00', 'ceph-node-01', 'ceph-node-02', 'ceph-node-03'];
 
@@ -32,33 +30,10 @@ describe('when cluster creation is completed', () => {
       hosts.navigateTo();
     });
 
-    // grafana ip address is set to the fqdn by default.
-    // kcli is not working with that, so setting the IP manually.
-    it('should change ip address of grafana, prometheus and alertmanager', () => {
-      const dashboardArr: Input[] = [
-        {
-          id: 'GRAFANA_API_URL',
-          newValue: 'https://192.168.100.100:3000',
-          oldValue: ''
-        },
-        {
-          id: 'PROMETHEUS_API_HOST',
-          newValue: 'http://192.168.100.100:9095',
-          oldValue: ''
-        },
-        {
-          id: 'ALERTMANAGER_API_HOST',
-          newValue: 'http://192.168.100.100:9093',
-          oldValue: ''
-        }
-      ];
-      mgrmodules.editMgrModule('dashboard', dashboardArr);
-    });
-
-    // avoid creating node-exporter on the newly added host
-    // to favour the host draining process
-    it('should reduce the count for node-exporter', { retries: 2 }, () => {
-      services.editService('node-exporter', '3');
+    it('should add one more host', () => {
+      hosts.navigateTo('add');
+      hosts.add(hostnames[3]);
+      hosts.checkExist(hostnames[3], true);
     });
 
     it('should check if monitoring stacks are running on the root host', { retries: 2 }, () => {
@@ -69,12 +44,6 @@ describe('when cluster creation is completed', () => {
           services.checkServiceStatus(daemon);
         });
       }
-    });
-
-    it('should add one more host', () => {
-      hosts.navigateTo('add');
-      hosts.add(hostnames[3]);
-      hosts.checkExist(hostnames[3], true);
     });
 
     it('should have removed "_no_schedule" label', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/08-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/08-hosts.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Host Page', () => {
   // rgw is needed for testing the force maintenance
   it('should create rgw services', () => {
     services.navigateTo('create');
-    services.addService('rgw', false, '4');
+    services.addService('rgw', false, 4);
     services.checkExist('rgw.foo', true);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/09-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/09-services.e2e-spec.ts
@@ -67,7 +67,7 @@ describe('Services page', () => {
 
   it('should create and delete snmp-gateway service with version V2c', () => {
     services.navigateTo('create');
-    services.addService('snmp-gateway', false, '1', 'V2c');
+    services.addService('snmp-gateway', false, 1, 'V2c');
     services.checkExist('snmp-gateway', true);
 
     services.clickServiceTab('snmp-gateway', 'Details');
@@ -80,7 +80,7 @@ describe('Services page', () => {
 
   it('should create and delete snmp-gateway service with version V3', () => {
     services.navigateTo('create');
-    services.addService('snmp-gateway', false, '1', 'V3', true);
+    services.addService('snmp-gateway', false, 1, 'V3', true);
     services.checkExist('snmp-gateway', true);
 
     services.clickServiceTab('snmp-gateway', 'Details');
@@ -93,7 +93,7 @@ describe('Services page', () => {
 
   it('should create and delete snmp-gateway service with version V3 and w/o privacy protocol', () => {
     services.navigateTo('create');
-    services.addService('snmp-gateway', false, '1', 'V3', false);
+    services.addService('snmp-gateway', false, 1, 'V3', false);
     services.checkExist('snmp-gateway', true);
 
     services.clickServiceTab('snmp-gateway', 'Details');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   Input,
   OnChanges,
@@ -97,7 +98,8 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
     public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private daemonService: DaemonService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private cdRef: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
@@ -214,6 +216,10 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
     this.columns = this.columns.filter((col: any) => {
       return !this.hiddenColumns.includes(col.prop);
     });
+
+    setTimeout(() => {
+      this.cdRef.detectChanges();
+    }, 1000);
   }
 
   ngOnChanges() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -569,30 +569,12 @@ describe('TableComponent', () => {
       expect(executingElement.nativeElement.textContent.trim()).toBe(`(${state})`);
     };
 
-    it('should display executing template', () => {
+    it.only('should display executing template', () => {
       testExecutingTemplate();
     });
 
-    it('should display executing template with custom classes', () => {
+    it.only('should display executing template with custom classes', () => {
       testExecutingTemplate({ valueClass: 'a b', executingClass: 'c d' });
-    });
-  });
-
-  describe('test unselect functionality of rows', () => {
-    beforeEach(() => {
-      component.autoReload = -1;
-      component.selectionType = 'single';
-      fixture.detectChanges();
-    });
-
-    it('should unselect row on clicking on it again', () => {
-      const rowCellDebugElement = fixture.debugElement.query(By.css('datatable-body-cell'));
-
-      rowCellDebugElement.triggerEventHandler('click', null);
-      expect(component.selection.selected.length).toEqual(1);
-
-      rowCellDebugElement.triggerEventHandler('click', null);
-      expect(component.selection.selected.length).toEqual(0);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -333,10 +333,6 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     } else {
       this.useData();
     }
-
-    if (this.selectionType === 'single') {
-      this.table.selectCheck = this.singleSelectCheck.bind(this);
-    }
   }
 
   initUserConfig() {
@@ -770,10 +766,6 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       this.selection.selected = $event['selected'];
     }
     this.updateSelection.emit(_.clone(this.selection));
-  }
-
-  private singleSelectCheck(row: any) {
-    return this.selection.selected.indexOf(row) === -1;
   }
 
   toggleColumn(column: CdTableColumn) {


### PR DESCRIPTION
I'll be reverting the PR to select/unselect datatables: https://github.com/ceph/ceph/pull/45313

I moved the code for changing the alertmanager_api_host, prometheus_api_host and grafana_api_url from the tests to the script to reduce the complexity of the tests. We are not actually testing anything there just making sure the environment is ready and the urls are okay. Because by default, these urls are set with fqdn and kcli env has issues with the fqdns. 
Also by doing this it reduces some 404 errors coming from the node-exporter and prometheus so that the tests won't be affected by it.

In addition to this I reduced the count of node-exporter to 2 before starting the test. Its because, if we try to drain a host that has  a node-exporter in it, that will cause a 404 error momentarily and that will cause the cypress to fail again. By positioning it into the script itself, this issue won't be there.

There used to appear an [ExpressionChangedAfterChecked](https://angular.io/errors/NG0100) error in the service-daemon-list component because of the relativeDate pipe. And I did some searching and its a known issue with the [date pipes ](https://github.com/AndrewPoyntz/time-ago-pipe/issues/6). The good thing is that this will only happen in the developer environment. The easiest and proper way to catch this is to manually do the changeDetection which I done using a timeout.

There are some minor cleanups too where I do a proper cleanup by deleting the pool as well as the `.kcli` folder. Its to prevent errors like `fedora36 image not found and it causes the vms to not start` and that will make the test to hang there. The downside of doing this is that everytime the test needs to run in an environment it'll need to download the fedora36 image, but it'll make the test a bit more foolproof.

Fixes: https://tracker.ceph.com/issues/57511
Fixes: https://tracker.ceph.com/issues/57386
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
