### PR TITLE
pacific: qa: ignore disk quota exceeded failure in test

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -6211,7 +6211,11 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "create", self.volname, subvolume,"--mode=777", "--size", str(osize))
 
         # do IO, write 50 files of 1MB each to exceed quota. This mostly succeeds as quota enforcement takes time.
-        self._do_subvolume_io(subvolume, number_of_files=50)
+        try:
+            self._do_subvolume_io(subvolume, number_of_files=50)
+        except CommandFailedError:
+            # ignore quota enforcement error.
+            pass
 
         # snapshot subvolume
         self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57555

---

backport of https://github.com/ceph/ceph/pull/47516
parent tracker: https://tracker.ceph.com/issues/56632

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh