### PR TITLE
quincy: os/bluestore: fix no metadata update on truncate+fsync

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3660,6 +3660,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
   std::lock_guard ll(log.lock);
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
   h->file->fnode.size = offset;
+  h->file->is_dirty = true;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
   log.t.op_file_update_inc(h->file->fnode);
   return 0;
@@ -3671,7 +3672,8 @@ int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
   std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
   {
-    dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
+    dout(10) << __func__ << " " << h << " " << h->file->fnode
+             << " dirty " << h->file->is_dirty << dendl;
     int r = _flush_F(h, true);
     if (r < 0)
       return r;

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1303,6 +1303,65 @@ TEST(BlueFS, test_concurrent_dir_link_and_compact_log_56210) {
   }
 }
 
+TEST(BlueFS, truncate_fsync) {
+  uint64_t bdev_size = 128 * 1048576;
+  uint64_t block_size = 4096;
+  uint64_t reserved = 1048576;
+  TempBdev bdev{bdev_size};
+  uuid_d fsid;
+  const char* DIR_NAME="dir";
+  const char* FILE_NAME="file1";
+
+  size_t sizes[] = {3, 1024, 4096, 1024 * 4096};
+  for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    const size_t content_size= sizes[i];
+    const size_t read_size = p2roundup(content_size, size_t(block_size));
+    const std::string content(content_size, 'x');
+    {
+      BlueFS fs(g_ceph_context);
+      ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false, reserved));
+      ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+      ASSERT_EQ(0, fs.mount());
+      ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+      {
+        BlueFS::FileWriter *h;
+        ASSERT_EQ(0, fs.mkdir("dir"));
+        ASSERT_EQ(0, fs.open_for_write(DIR_NAME, FILE_NAME, &h, false));
+        h->append(content.c_str(), content.length());
+        fs.fsync(h);
+        fs.close_writer(h);
+      }
+      {
+        BlueFS::FileReader *h;
+        ASSERT_EQ(0, fs.open_for_read(DIR_NAME, FILE_NAME, &h));
+        bufferlist bl;
+        ASSERT_EQ(content.length(), fs.read(h, 0, read_size, &bl, NULL));
+        ASSERT_EQ(0, strncmp(content.c_str(), bl.c_str(), content.length()));
+        delete h;
+      }
+      {
+        BlueFS::FileWriter *h;
+        ASSERT_EQ(0, fs.open_for_write(DIR_NAME, FILE_NAME, &h, true));
+        fs.truncate(h, 0);
+        fs.fsync(h);
+        fs.close_writer(h);
+      }
+    }
+    {
+      //this was broken due to https://tracker.ceph.com/issues/55307
+      BlueFS fs(g_ceph_context);
+      ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev.path, false, reserved));
+      ASSERT_EQ(0, fs.mount());
+      BlueFS::FileReader *h;
+      ASSERT_EQ(0, fs.open_for_read(DIR_NAME, FILE_NAME, &h));
+      bufferlist bl;
+      ASSERT_EQ(0, fs.read(h, 0, read_size, &bl, NULL));
+      delete h;
+      fs.umount();
+    }
+  }
+}
+
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);
   map<string,string> defaults = {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/57458
Signed-off-by: Igor Fedotov <ifedotov@croit.io>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
