### PR TITLE
pacific: mgr/dashboard: Add details to the modal which displays the `safe-to-d…

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -63,13 +63,50 @@
 <ng-template #criticalConfirmationTpl
              let-safeToPerform="safeToPerform"
              let-message="message"
+             let-active="active"
+             let-missingStats="missingStats"
+             let-storedPgs="storedPgs"
              let-actionDescription="actionDescription"
              let-osdIds="osdIds">
   <div *ngIf="!safeToPerform"
-       class="danger">
-    <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, true {OSD is} other {OSDs are}} not safe to be
-      {{ actionDescription }}! {{ message }}</cd-alert-panel>
+       class="danger mb-3">
+    <cd-alert-panel type="warning">
+      <span i18n>
+        The {selection.hasSingleSelection, select, true {OSD is} other {OSDs are}} not safe to be
+        {{ actionDescription }}!
+      </span>
+      <br>
+      <ul class="mb-0 pl-4">
+        <li *ngIf="active.length > 0"
+             i18n>
+          {selection.hasSingleSelection, select, true {} other {{{ active | join }} : }}
+          Some PGs are currently mapped to
+          {active.length === 1, select, true {it} other {them}}.
+        </li>
+        <li *ngIf="missingStats.length > 0"
+             i18n>
+          {selection.hasSingleSelection, select, true {} other {{{ missingStats | join }} : }}
+          There are no reported stats and not all PGs are active and clean.
+        </li>
+        <li *ngIf="storedPgs.length > 0"
+             i18n>
+          {selection.hasSingleSelection, select, true {OSD} other {{{ storedPgs | join }} : OSDs }}
+          still store some PG data and not all PGs are active and clean.
+        </li>
+        <li *ngIf="message">
+          {{ message }}
+        </li>
+      </ul>
+    </cd-alert-panel>
+  </div>
+  <div *ngIf="safeToPerform"
+       class="danger mb-3">
+    <cd-alert-panel type="info">
+      <span i18n>
+        The {selection.hasSingleSelection, select, true {OSD is} other {OSDs are}}
+        safe to destroy without reducing data durability.
+      </span>
+    </cd-alert-panel>
   </div>
   <ng-container i18n><strong>OSD {{ osdIds | join }}</strong> will be
   <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -580,6 +580,9 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
         bodyContext: {
           safeToPerform: result[checkKey],
           message: result.message,
+          active: result.active,
+          missingStats: result.missing_stats,
+          storedPgs: result.stored_pgs,
           actionDescription: templateItemDescription,
           osdIds: this.getSelectedOsdIds()
         },

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -165,6 +165,9 @@ export class OsdService {
 
   safeToDestroy(ids: string) {
     interface SafeToDestroyResponse {
+      active: number[];
+      missing_stats: number[];
+      stored_pgs: number[];
       is_safe_to_destroy: boolean;
       message?: string;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57584

---

backport of https://github.com/ceph/ceph/pull/47849
parent tracker: https://tracker.ceph.com/issues/37327

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh