### PR TITLE
pacific: SimpleRADOSStriper: Avoid moving bufferlists by using deque in read()

### DIFF
--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -488,7 +488,10 @@ ssize_t SimpleRADOSStriper::read(void* data, size_t len, uint64_t off)
   }
 
   size_t r = 0;
-  std::vector<std::pair<bufferlist, aiocompletionptr>> reads;
+  // Don't use std::vector to store bufferlists (e.g for parallelizing aio_reads),
+  // as they are being moved whenever the vector resizes
+  // and will cause invalidated references.
+  std::deque<std::pair<bufferlist, aiocompletionptr>> reads;
   while ((len-r) > 0) {
     auto ext = get_next_extent(off+r, len-r);
     auto& [bl, aiocp] = reads.emplace_back();

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -2231,3 +2231,47 @@ TEST(LibRadosAio, RoundTripCmpExtPP2)
   ioctx.remove("test_obj");
   destroy_one_pool_pp(pool_name, cluster);
 }
+
+// This test case reproduces https://tracker.ceph.com/issues/57152
+TEST(LibRadosAio, MultiReads) {
+
+  // here we test multithreaded aio reads
+
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+  auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+  ASSERT_TRUE(my_completion);
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl1;
+  bl1.append(buf, sizeof(buf));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+                                           bl1, sizeof(buf), 0));
+  {
+    TestAlarm alarm;
+    ASSERT_EQ(0, my_completion->wait_for_complete());
+  }
+  ASSERT_EQ(0, my_completion->get_return_value());
+
+  // Don't use std::vector to store bufferlists (e.g for parallelizing aio_reads),
+  // as they are being moved whenever the vector resizes
+  // and will cause invalidated references.
+  std::deque<std::pair<bufferlist, std::unique_ptr<AioCompletion>>> reads;
+  for (int i = 0; i < 100; i++) {
+    // std::deque is appropriate here as emplace_back() is obliged to
+    // preserve the referenced inserted element. (Unlike insert() or erase())
+    auto& [bl, aiocp] = reads.emplace_back();
+    aiocp = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+    ASSERT_TRUE(aiocp);
+    ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", aiocp.get(),
+                                            &bl, sizeof(buf), 0));
+  }
+  for (auto& [bl, aiocp] : reads) {
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, aiocp->wait_for_complete());
+    }
+    ASSERT_EQ((int)sizeof(buf), aiocp->get_return_value());
+    ASSERT_EQ(0, memcmp(buf, bl.c_str(), sizeof(buf)));
+  }
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57373

---

backport of https://github.com/ceph/ceph/pull/47841
parent tracker: https://tracker.ceph.com/issues/57152

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh