### PR TITLE
quincy: mgr/dashboard: fix rgw connect when using ssl

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -84,7 +84,7 @@ def _determine_rgw_addr(daemon_info: Dict[str, Any]) -> RgwDaemon:
     Parse RGW daemon info to determine the configured host (IP address) and port.
     """
     daemon = RgwDaemon()
-    daemon.host = _parse_addr(daemon_info['addr'])
+    daemon.host = daemon_info['metadata']['hostname']
     daemon.port, daemon.ssl = _parse_frontend_config(daemon_info['metadata']['frontend_config#0'])
 
     return daemon

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -290,7 +290,8 @@ class RgwStub(Stub):
                     'id': 'daemon1',
                     'realm_name': 'realm1',
                     'zonegroup_name': 'zonegroup1',
-                    'zone_name': 'zone1'
+                    'zone_name': 'zone1',
+                    'hostname': 'daemon1.server.lan'
                 }
             },
             '5398': {
@@ -300,7 +301,8 @@ class RgwStub(Stub):
                     'id': 'daemon2',
                     'realm_name': 'realm2',
                     'zonegroup_name': 'zonegroup2',
-                    'zone_name': 'zone2'
+                    'zone_name': 'zone2',
+                    'hostname': 'daemon2.server.lan'
                 }
             }
         }}}})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57223

---

backport of https://github.com/ceph/ceph/pull/47207
parent tracker: https://tracker.ceph.com/issues/56970

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh