### PR TITLE
mgr: Fix prettytable pinning to restore python3.6

### DIFF
--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -5,7 +5,7 @@ cryptography
 jsonpatch
 Jinja2
 pecan
-prettytable==3.3.0
+prettytable<3.4.0
 pyfakefs
 pyOpenSSL
 pytest-cov==2.7.1


### PR DESCRIPTION
prettytable 3.3.0 requires python3.7; we still support 3.6, so change the pinning to simply keep us under 3.4.0

Signed-off-by: Zack Cerza <zack@redhat.com>