### PR TITLE
crimson/osd: populate version/user_version in reply for duplicate ops

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -723,7 +723,14 @@ public:
 	return &it->second;
     }
   }
-  interruptible_future<std::tuple<bool, int>> already_complete(const osd_reqid_t& reqid);
+
+  struct complete_op_t {
+    const version_t user_version;
+    const eversion_t version;
+    const int err;
+  };
+  interruptible_future<std::optional<complete_op_t>>
+  already_complete(const osd_reqid_t& reqid);
   int get_recovery_op_priority() const {
     int64_t pri = 0;
     get_pgpool().info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);


### PR DESCRIPTION
Otherwise, we get ceph_test_rados errors that look like:

...
2022-09-20T01:04:19.432 INFO:tasks.rados.rados.0.smithi182.stdout:74:  oid 74 version 0 is already newer than 0 2022-09-20T01:04:19.432 INFO:tasks.rados.rados.0.smithi182.stdout:74:  oid 74 updating version 0 to 19 2022-09-20T01:04:19.432 INFO:tasks.rados.rados.0.smithi182.stdout:74:  oid 74 version 19 is already newer than 0 2022-09-20T01:04:19.432 INFO:tasks.rados.rados.0.smithi182.stdout:74:  oid 74 version 19 is already newer than 0 2022-09-20T01:04:19.432 INFO:tasks.rados.rados.0.smithi182.stdout:update_object_version oid 74 v 19 (ObjNum 73 snap 0 seq_num 73) dirty exists 2022-09-20T01:04:19.433 INFO:tasks.rados.rados.0.smithi182.stderr:Error: racing read on 74 returned version 22 rather than version 19 ...

Note the "already newer than 0" bit -- the MOSDOpReply message we send when we detect a duplicate op has a field that should contain the user_version recorded in the pg log where we found the duplicate, but it's not being populated.

Fixes: https://tracker.ceph.com/issues/57617
Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
