### PR TITLE
quincy: mgr/rook: fix error when trying to get the list of nfs services

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -351,8 +351,10 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             all_nfs = self.rook_cluster.get_resource("cephnfses")
             nfs_pods = self.rook_cluster.describe_pods('nfs', None, None)
             for nfs in all_nfs:
-                if nfs['spec']['rados']['pool'] != NFS_POOL_NAME:
-                    continue
+                # Starting with V.17.2.0, the 'rados' spec part in 'cephnfs' resources does not contain the 'pool' item
+                if 'pool' in nfs['spec']['rados']:
+                    if nfs['spec']['rados']['pool'] != NFS_POOL_NAME:
+                        continue
                 nfs_name = nfs['metadata']['name']
                 svc = 'nfs.' + nfs_name
                 if svc in spec:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57601

---

backport of https://github.com/ceph/ceph/pull/46321
parent tracker: https://tracker.ceph.com/issues/55605

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh