### PR TITLE
quincy: exporter: avoid stoi for empty pid_str

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -114,7 +114,9 @@ void DaemonMetricCollector::dump_asok_metrics() {
     if (!pid_path.size()) {
       continue;
     }
-    daemon_pids.push_back({daemon_name, std::stoi(pid_str)});
+    if (!pid_str.empty()) {
+      daemon_pids.push_back({daemon_name, std::stoi(pid_str)});
+    }
     json_object dump = boost::json::parse(perf_dump_response).as_object();
     json_object schema = boost::json::parse(perf_schema_response).as_object();
     for (auto &perf : schema) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57633

---

backport of https://github.com/ceph/ceph/pull/48193
parent tracker: https://tracker.ceph.com/issues/57619

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh