### PR TITLE
qa/workunits/rados: test_env_librados_rocksdb CXX20

### DIFF
--- a/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
+++ b/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
@@ -10,6 +10,13 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
 tasks:
 - install:
+    extra_packages:
+      deb:
+        - librados-dev
+        - libradospp-dev
+      rpm:
+        - librados-devel
+        - libradospp-devel
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -19,8 +19,12 @@ CURRENT_PATH=`pwd`
 # install prerequisites
 # for rocksdb
 case $(distro_id) in
-	ubuntu|debian|devuan|softiron)
+	debian|devuan|softiron)
 		install git g++ libsnappy-dev zlib1g-dev libbz2-dev libradospp-dev cmake
+		;;
+	ubuntu)
+		install git g++-11 libsnappy-dev zlib1g-dev libbz2-dev libradospp-dev cmake
+		export CXX_FLAGS="-std=c++20"
 		;;
 	centos|fedora|rhel)
         case $(distro_id) in
@@ -70,8 +74,12 @@ else
     CMAKE=cmake
 fi
 
+if [ $(distro_id) = "ubuntu" ]; then
+	STANDARD='-DCMAKE_CXX_STANDARD=20'
+fi
+
 [ -z "$BUILD_DIR" ] && BUILD_DIR=build
-mkdir ${BUILD_DIR} && cd ${BUILD_DIR} && ${CMAKE} -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=ON -DWITH_LIBRADOS=ON -DWITH_SNAPPY=ON -DWITH_GFLAGS=OFF -DFAIL_ON_WARNINGS=OFF ..
+mkdir ${BUILD_DIR} && cd ${BUILD_DIR} && ${CMAKE} ${STANDARD} -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=ON -DWITH_LIBRADOS=ON -DWITH_SNAPPY=ON -DWITH_GFLAGS=OFF -DFAIL_ON_WARNINGS=OFF ..
 make rocksdb_env_librados_test -j8
 
 echo "Copy ceph.conf"


### PR DESCRIPTION
~DNM until https://github.com/ceph/rocksdb/pull/43 is mergerd.~
Compile with CXX20 on Ubuntu to avoid invalid pointer failure.
Fixes: https://tracker.ceph.com/issues/57632

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
