### PR TITLE
pacific: cephadm: consider stdout to get container version

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -524,10 +524,11 @@ class Monitoring(object):
         cmd = daemon_type.replace('-', '_')
         code = -1
         err = ''
+        out = ''
         version = ''
         if daemon_type == 'alertmanager':
             for cmd in ['alertmanager', 'prometheus-alertmanager']:
-                _, err, code = call(ctx, [
+                out, err, code = call(ctx, [
                     ctx.container_engine.path, 'exec', container_id, cmd,
                     '--version'
                 ], verbosity=CallVerbosity.DEBUG)
@@ -535,12 +536,14 @@ class Monitoring(object):
                     break
             cmd = 'alertmanager'  # reset cmd for version extraction
         else:
-            _, err, code = call(ctx, [
+            out, err, code = call(ctx, [
                 ctx.container_engine.path, 'exec', container_id, cmd, '--version'
             ], verbosity=CallVerbosity.DEBUG)
-        if code == 0 and \
-                err.startswith('%s, version ' % cmd):
-            version = err.split(' ')[2]
+        if code == 0:
+            if err.startswith('%s, version ' % cmd):
+                version = err.split(' ')[2]
+            elif out.startswith('%s, version ' % cmd):
+                version = out.split(' ')[2]
         return version
 
 ##################################


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57639

---

backport of https://github.com/ceph/ceph/pull/48118
parent tracker: https://tracker.ceph.com/issues/57558

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh