### PR TITLE
pacific: cephadm: add `ip_nonlocal_bind` to haproxy deployment

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -912,8 +912,9 @@ class HAproxy(object):
     @staticmethod
     def get_sysctl_settings() -> List[str]:
         return [
-            '# IP forwarding',
+            '# IP forwarding and non-local bind',
             'net.ipv4.ip_forward = 1',
+            'net.ipv4.ip_nonlocal_bind = 1',
         ]
 
 ##################################


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57644

---

backport of https://github.com/ceph/ceph/pull/48120
parent tracker: https://tracker.ceph.com/issues/57563

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh