### PR TITLE
mgr/telemetry: add `basic_pool_options_bluestore` collection

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -183,17 +183,18 @@ List all collections with::
 
   ceph telemetry collection ls
 
-  NAME                  STATUS                                               DESC
-  basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
-  basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
-  basic_pool_usage      NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics
-  basic_usage_by_class  NOT REPORTING: NOT OPTED-IN                          Default device class usage statistics
-  crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
-  device_base           REPORTING                                            Information about device health metrics
-  ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster
-  perf_memory_metrics   NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Heap stats and mempools for mon and mds
-  perf_perf             NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Information about performance counters of the cluster
-
+  NAME                            STATUS                                               DESC
+  basic_base                      NOT REPORTING: NOT OPTED-IN                          Basic information about the cluster (capacity, number and type of daemons, version, etc.)
+  basic_mds_metadata              NOT REPORTING: NOT OPTED-IN                          MDS metadata
+  basic_pool_options_bluestore    NOT REPORTING: NOT OPTED-IN                          Per-pool bluestore config options
+  basic_pool_usage                NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics
+  basic_rook_v01                  NOT REPORTING: NOT OPTED-IN                          Basic Rook deployment data
+  basic_usage_by_class            NOT REPORTING: NOT OPTED-IN                          Default device class usage statistics
+  crash_base                      NOT REPORTING: NOT OPTED-IN                          Information about daemon crashes (daemon type and version, backtrace, etc.)
+  device_base                     NOT REPORTING: NOT OPTED-IN                          Information about device health metrics
+  ident_base                      NOT REPORTING: NOT OPTED-IN, CHANNEL ident IS OFF    User-provided identifying information about the cluster
+  perf_memory_metrics             NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Heap stats and mempools for mon and mds
+  perf_perf                       NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Information about performance counters of the cluster
 
 Where:
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -70,6 +70,7 @@ class Collection(str, enum.Enum):
     basic_usage_by_class = 'basic_usage_by_class'
     basic_rook_v01 = 'basic_rook_v01'
     perf_memory_metrics = 'perf_memory_metrics'
+    basic_pool_options_bluestore = 'basic_pool_options_bluestore'
 
 MODULE_COLLECTION : List[Dict] = [
     {
@@ -130,6 +131,12 @@ MODULE_COLLECTION : List[Dict] = [
         "name": Collection.perf_memory_metrics,
         "description": "Heap stats and mempools for mon and mds",
         "channel": "perf",
+        "nag": False
+    },
+    {
+        "name": Collection.basic_pool_options_bluestore,
+        "description": "Per-pool bluestore config options",
+        "channel": "basic",
         "nag": False
     },
 ]
@@ -1086,7 +1093,17 @@ class Module(MgrModule):
                                             'wr': pool_stats['wr'],
                                             'wr_bytes': pool_stats['wr_bytes']
                         }
-
+                    pool_data['options'] = {}
+                    # basic_pool_options_bluestore collection
+                    if self.is_enabled_collection(Collection.basic_pool_options_bluestore):
+                        bluestore_options = ['compression_algorithm',
+                                             'compression_mode',
+                                             'compression_required_ratio',
+                                             'compression_min_blob_size',
+                                             'compression_max_blob_size']
+                        for option in bluestore_options:
+                            if option in pool['options']:
+                                pool_data['options'][option] = pool['options'][option]
                 cast(List[Dict[str, Any]], report['pools']).append(pool_data)
                 if 'rbd' in pool['application_metadata']:
                     rbd_num_pools += 1


### PR DESCRIPTION
Collects per-pool bluestore options, such as `bluestore_compression_mode`.

See https://docs.ceph.com/en/latest/rados/configuration/bluestore-config-ref/#inline-compression for
where the per-pool bluestore options are documented.

Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
