### PR TITLE
crimson: create buffer from temporary_buffer with foreign-ptr by default

### DIFF
--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -38,12 +38,12 @@ class raw_seastar_local_ptr : public raw {
 
 inline namespace v15_2_0 {
 
-ceph::unique_leakable_ptr<buffer::raw> create_foreign(temporary_buffer&& buf) {
+ceph::unique_leakable_ptr<buffer::raw> create(temporary_buffer&& buf) {
   return ceph::unique_leakable_ptr<buffer::raw>(
     new raw_seastar_foreign_ptr(std::move(buf)));
 }
 
-ceph::unique_leakable_ptr<buffer::raw> create(temporary_buffer&& buf) {
+ceph::unique_leakable_ptr<buffer::raw> create_local(temporary_buffer&& buf) {
   return ceph::unique_leakable_ptr<buffer::raw>(
     new raw_seastar_local_ptr(std::move(buf)));
 }

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -36,7 +36,7 @@ struct bufferlist_consumer {
     if (remaining >= data.size()) {
       // consume the whole buffer
       remaining -= data.size();
-      bl.append(buffer::create_foreign(std::move(data)));
+      bl.append(buffer::create(std::move(data)));
       if (remaining > 0) {
         // return none to request more segments
         return seastar::make_ready_future<consumption_result_type>(
@@ -49,7 +49,7 @@ struct bufferlist_consumer {
     }
     if (remaining > 0) {
       // consume the front
-      bl.append(buffer::create_foreign(data.share(0, remaining)));
+      bl.append(buffer::create(data.share(0, remaining)));
       data.trim_front(remaining);
       remaining = 0;
     }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -153,11 +153,11 @@ struct error_code;
 #ifdef HAVE_SEASTAR
   /// create a raw buffer to wrap seastar cpu-local memory, using foreign_ptr to
   /// make it safe to share between cpus
-  ceph::unique_leakable_ptr<buffer::raw> create_foreign(seastar::temporary_buffer<char>&& buf);
+  ceph::unique_leakable_ptr<buffer::raw> create(seastar::temporary_buffer<char>&& buf);
   /// create a raw buffer to wrap seastar cpu-local memory, without the safety
   /// of foreign_ptr. the caller must otherwise guarantee that the buffer ptr is
   /// destructed on this cpu
-  ceph::unique_leakable_ptr<buffer::raw> create(seastar::temporary_buffer<char>&& buf);
+  ceph::unique_leakable_ptr<buffer::raw> create_local(seastar::temporary_buffer<char>&& buf);
 #endif
 
   /*


### PR DESCRIPTION
temporary_buffer is internally shareable with a thread-unsafe ref-counter, we need to make sure it is released in the same core where it is constructed.

Users that need the extra efficiency can swap to create_local as needed.

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
