### PR TITLE
quincy: mgr/snap_schedule: remove subvol interface

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -49,10 +49,9 @@ The following time periods are recognized: `h(our), d(ay), w(eek), m(onth),
 y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
 the last 10 snapshots regardless of timing,
 
-All subcommands take optional `fs` and `subvol` arguments to specify paths in
+All subcommands take optional `fs` argument to specify paths in
 multi-fs setups and :doc:`/cephfs/fs-volumes` managed setups. If not
-passed `fs` defaults to the first file system listed in the fs_map, `subvolume`
-defaults to nothing.
+passed `fs` defaults to the first file system listed in the fs_map.
 When using :doc:`/cephfs/fs-volumes` the argument `fs` is equivalent to a
 `volume`.
 
@@ -66,15 +65,20 @@ When no subcommand is supplied a synopsis is printed::
 
   #> ceph fs snap-schedule
   no valid command found; 8 closest matches:
-  fs snap-schedule status [<path>] [<subvol>] [<fs>] [<format>]
-  fs snap-schedule list <path> [<subvol>] [--recursive] [<fs>] [<format>]
-  fs snap-schedule add <path> <snap_schedule> [<start>] [<fs>] [<subvol>]
-  fs snap-schedule remove <path> [<repeat>] [<start>] [<subvol>] [<fs>]
-  fs snap-schedule retention add <path> <retention_spec_or_period> [<retention_count>] [<fs>] [<subvol>]
-  fs snap-schedule retention remove <path> <retention_spec_or_period> [<retention_count>] [<fs>] [<subvol>]
-  fs snap-schedule activate <path> [<repeat>] [<start>] [<subvol>] [<fs>]
-  fs snap-schedule deactivate <path> [<repeat>] [<start>] [<subvol>] [<fs>]
+  fs snap-schedule status [<path>] [<fs>] [<format>]
+  fs snap-schedule list <path> [--recursive] [<fs>] [<format>]
+  fs snap-schedule add <path> <snap_schedule> [<start>] [<fs>]
+  fs snap-schedule remove <path> [<repeat>] [<start>] [<fs>]
+  fs snap-schedule retention add <path> <retention_spec_or_period> [<retention_count>] [<fs>]
+  fs snap-schedule retention remove <path> <retention_spec_or_period> [<retention_count>] [<fs>]
+  fs snap-schedule activate <path> [<repeat>] [<start>] [<fs>]
+  fs snap-schedule deactivate <path> [<repeat>] [<start>] [<fs>]
   Error EINVAL: invalid command
+
+Note:
+^^^^^
+A `subvolume` argument is no longer accepted by the commands.
+
 
 Inspect snapshot schedules
 --------------------------

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -363,7 +363,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         log.debug(f'snapshots: {snapshots}')
 
         result = self.fs_snap_schedule_cmd('status', path=dir_path,
-                                           snap_schedule='1M', format='json')
+                                           format='json')
         json_res = json.loads(result)[0]
         db_count = int(json_res['created_count'])
         log.debug(f'json_res: {json_res}')

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -37,17 +37,6 @@ class Module(MgrModule):
         self._initialized = Event()
         self.client = SnapSchedClient(self)
 
-    def resolve_subvolume_path(self, fs: str, subvol: Optional[str], path: str) -> str:
-        if not subvol:
-            return path
-
-        rc, subvol_path, err = self.remote('fs', 'subvolume', 'getpath',
-                                           fs, subvol)
-        if rc != 0:
-            # TODO custom exception?
-            raise Exception(f'Could not resolve {path} in {fs}, {subvol}')
-        return subvol_path + path
-
     @property
     def default_fs(self) -> str:
         fs_map = self.get('fs_map')
@@ -71,7 +60,6 @@ class Module(MgrModule):
     @CLIReadCommand('fs snap-schedule status')
     def snap_schedule_get(self,
                           path: str = '/',
-                          subvol: Optional[str] = None,
                           fs: Optional[str] = None,
                           format: Optional[str] = 'plain') -> Tuple[int, str, str]:
         '''
@@ -91,7 +79,6 @@ class Module(MgrModule):
 
     @CLIReadCommand('fs snap-schedule list')
     def snap_schedule_list(self, path: str,
-                           subvol: Optional[str] = None,
                            recursive: bool = False,
                            fs: Optional[str] = None,
                            format: Optional[str] = 'plain') -> Tuple[int, str, str]:
@@ -124,8 +111,7 @@ class Module(MgrModule):
                           path: str,
                           snap_schedule: str,
                           start: Optional[str] = None,
-                          fs: Optional[str] = None,
-                          subvol: Optional[str] = None) -> Tuple[int, str, str]:
+                          fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Set a snapshot schedule for <path>
         '''
@@ -133,7 +119,8 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
+            subvol = None
             self.client.store_snap_schedule(use_fs,
                                             abs_path,
                                             (abs_path, snap_schedule,
@@ -156,7 +143,6 @@ class Module(MgrModule):
                          path: str,
                          repeat: Optional[str] = None,
                          start: Optional[str] = None,
-                         subvol: Optional[str] = None,
                          fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Remove a snapshot schedule for <path>
@@ -165,7 +151,7 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
             self.client.rm_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:
             return e.to_tuple()
@@ -178,8 +164,7 @@ class Module(MgrModule):
                                     path: str,
                                     retention_spec_or_period: str,
                                     retention_count: Optional[str] = None,
-                                    fs: Optional[str] = None,
-                                    subvol: Optional[str] = None) -> Tuple[int, str, str]:
+                                    fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Set a retention specification for <path>
         '''
@@ -187,7 +172,7 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
             self.client.add_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
                                           retention_count)
@@ -202,8 +187,7 @@ class Module(MgrModule):
                                    path: str,
                                    retention_spec_or_period: str,
                                    retention_count: Optional[str] = None,
-                                   fs: Optional[str] = None,
-                                   subvol: Optional[str] = None) -> Tuple[int, str, str]:
+                                   fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Remove a retention specification for <path>
         '''
@@ -211,7 +195,7 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
             self.client.rm_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
                                           retention_count)
@@ -226,7 +210,6 @@ class Module(MgrModule):
                                path: str,
                                repeat: Optional[str] = None,
                                start: Optional[str] = None,
-                               subvol: Optional[str] = None,
                                fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Activate a snapshot schedule for <path>
@@ -235,7 +218,7 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
             self.client.activate_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:
             return e.to_tuple()
@@ -248,7 +231,6 @@ class Module(MgrModule):
                                  path: str,
                                  repeat: Optional[str] = None,
                                  start: Optional[str] = None,
-                                 subvol: Optional[str] = None,
                                  fs: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Deactivate a snapshot schedule for <path>
@@ -257,7 +239,7 @@ class Module(MgrModule):
             use_fs = fs if fs else self.default_fs
             if not self.has_fs(use_fs):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
+            abs_path = path
             self.client.deactivate_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:
             return e.to_tuple()

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -58,6 +58,9 @@ class Module(MgrModule):
             raise CephfsConnectionException(
                 -errno.ENOENT, "no filesystem found")
 
+    def has_fs(self, fs_name: str) -> bool:
+        return fs_name in self.client.get_all_filesystems()
+
     def serve(self) -> None:
         self._initialized.set()
 
@@ -75,6 +78,8 @@ class Module(MgrModule):
         List current snapshot schedules
         '''
         use_fs = fs if fs else self.default_fs
+        if not self.has_fs(use_fs):
+            return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
         try:
             ret_scheds = self.client.get_snap_schedules(use_fs, path)
         except CephfsConnectionException as e:
@@ -95,6 +100,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             scheds = self.client.list_snap_schedules(use_fs, path, recursive)
             self.log.debug(f'recursive is {recursive}')
         except CephfsConnectionException as e:
@@ -124,6 +131,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.store_snap_schedule(use_fs,
                                             abs_path,
@@ -154,6 +163,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.rm_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:
@@ -174,6 +185,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.add_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
@@ -196,6 +209,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.rm_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
@@ -218,6 +233,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.activate_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:
@@ -238,6 +255,8 @@ class Module(MgrModule):
         '''
         try:
             use_fs = fs if fs else self.default_fs
+            if not self.has_fs(use_fs):
+                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = self.resolve_subvolume_path(use_fs, subvol, path)
             self.client.deactivate_snap_schedule(use_fs, abs_path, repeat, start)
         except CephfsConnectionException as e:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55749
backport tracker: https://tracker.ceph.com/issues/55579

---

backport of https://github.com/ceph/ceph/pull/46034
parent tracker: https://tracker.ceph.com/issues/55148

backport of https://github.com/ceph/ceph/pull/45732
parent tracker: https://tracker.ceph.com/issues/54560

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh