### PR TITLE
Libfmt9 fixes

### DIFF
--- a/src/test/cls_fifo/bench_cls_fifo.cc
+++ b/src/test/cls_fifo/bench_cls_fifo.cc
@@ -177,6 +177,34 @@ void clean(R::RADOS& r, const R::IOContext& ioc, RCf::FIFO& f,
 }
 }
 
+#if FMT_VERSION >= 90000
+
+template <>
+struct fmt::formatter<bpo::options_description> :
+       fmt::ostream_formatter {};
+
+template <>
+struct fmt::formatter<rados::cls::fifo::part_header> :
+       fmt::ostream_formatter {};
+
+template <>
+struct fmt::formatter<rados::cls::fifo::info> :
+       fmt::ostream_formatter {};
+
+template <typename Clock, typename Duration>
+std::ostream& operator<< (std::ostream& ostr,
+                          const sc::time_point<Clock, Duration>& tp)
+{
+  auto tse = tp.time_since_epoch ();
+  return ostr << tse.count ();
+}
+
+template <typename Clock, typename Duration>
+struct fmt::formatter<sc::time_point<Clock, Duration>> :
+       fmt::ostream_formatter {};
+
+#endif
+
 int main(int argc, char* argv[])
 {
   const std::string_view prog(argv[0]);

--- a/src/tools/neorados.cc
+++ b/src/tools/neorados.cc
@@ -44,6 +44,17 @@ namespace bs = boost::system;
 namespace R = neorados;
 namespace s = spawn;
 
+#if FMT_VERSION >= 90000
+
+template <>
+struct fmt::formatter<R::Entry> : fmt::ostream_formatter {};
+
+template <>
+struct fmt::formatter<boost::program_options::options_description> :
+       fmt::ostream_formatter {};
+
+#endif
+
 std::string verstr(const std::tuple<uint32_t, uint32_t, uint32_t>& v)
 {
   const auto [maj, min, p] = v;


### PR DESCRIPTION
Starting with libfmt 9, custom types don't use iostream operators to perform formatting. Instead, one must define the formatters manually. There is a compatibility mode for libfmt, but the docs state that it will be deprecated soon. As such, this PR fixes this issues for versions >= 9.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
