### PR TITLE
Neorados CLS version

### DIFF
--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -17,10 +17,12 @@ class JSONObj;
 
 
 struct obj_version {
-  uint64_t ver;
+  uint64_t ver = 0;
   std::string tag;
 
-  obj_version() : ver(0) {}
+  obj_version() = default;
+  obj_version(uint64_t ver, std::string tag)
+    : ver(ver), tag(std::move(tag)) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -4,8 +4,14 @@
 #ifndef CEPH_CLS_VERSION_TYPES_H
 #define CEPH_CLS_VERSION_TYPES_H
 
+#include <cstdint>
+#include <iostream>
+#include <list>
+#include <string>
+
 #include "include/encoding.h"
 #include "include/types.h"
+
 
 class JSONObj;
 
@@ -58,6 +64,10 @@ struct obj_version {
   static void generate_test_instances(std::list<obj_version*>& o);
 };
 WRITE_CLASS_ENCODER(obj_version)
+
+inline std::ostream& operator <<(std::ostream& m, const obj_version& v) {
+  return m << v.tag << ":" << v.ver;
+}
 
 enum VersionCond {
   VER_COND_NONE =      0,

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -187,24 +187,24 @@ class CompletionImpl final : public Completion<void(Args...), T> {
 
   void destroy_defer(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
-    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
     w.second.get_executor().defer(std::move(f), alloc2);
   }
   void destroy_dispatch(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
-    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
     w.second.get_executor().dispatch(std::move(f), alloc2);
   }
   void destroy_post(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
-    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    auto f = bind_and_forward(std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
     w.second.get_executor().post(std::move(f), alloc2);

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -14,28 +14,4 @@ target_link_libraries(libneorados PRIVATE
   osdc ceph-common cls_lock_client fmt::fmt
   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
 
-# if(ENABLE_SHARED)
-#   add_library(libneorados ${CEPH_SHARED}
-#     $<TARGET_OBJECTS:neorados_api_obj>
-#     $<TARGET_OBJECTS:neorados_objs>
-#     $<TARGET_OBJECTS:common_buffer_obj>)
-#   set_target_properties(libneorados PROPERTIES
-#     OUTPUT_NAME RADOS
-#     VERSION 0.0.1
-#     SOVERSION 1
-#     CXX_VISIBILITY_PRESET hidden
-#     VISIBILITY_INLINES_HIDDEN ON)
-#   if(NOT APPLE)
-#     set_property(TARGET libneorados APPEND_STRING PROPERTY
-#       LINK_FLAGS " -Wl,--exclude-libs,ALL")
-#   endif()
-# else(ENABLE_SHARED)
-#   add_library(libneorados STATIC
-#     $<TARGET_OBJECTS:neorados_api_obj>
-#     $<TARGET_OBJECTS:neorados_objs>)
-# endif(ENABLE_SHARED)
-# target_link_libraries(libneorados PRIVATE
-#   osdc ceph-common cls_lock_client
-#   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
-# target_link_libraries(libneorados ${rados_libs})
-# install(TARGETS libneorados DESTINATION ${CMAKE_INSTALL_LIBDIR})
+add_library(neorados_cls_version STATIC cls/version.cc)

--- a/src/neorados/cls/common.h
+++ b/src/neorados/cls/common.h
@@ -1,0 +1,127 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+#include <concepts>
+#include <coroutine>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+/// \file neorados/cls/common.h
+///
+/// \brief Helpers for writing simple CLS clients
+///
+/// For writing functions that call out to the OSD, perform a CLS
+/// call, and return its data in a user friendly way, we need to
+/// coordinate asynchronous operation with decoding and returning the
+/// relevant data.
+///
+/// Ideally, these functions will help.
+
+namespace neorados::cls {
+/// \brief Perform a CLS read operation and return the result
+///
+/// Asynchronously call into the OSD, decode its response and
+/// pass it to a supplied function that extracts the relevant
+/// information.
+///
+/// \tparam Rep The type of the CLS operation's result that will be
+///             passed to `f`
+///
+/// \param r RADOS handle
+/// \param oid Object name
+/// \param ioc IOContext locator
+/// \param cls Name of the object class
+/// \param method Object class method to call
+/// \param req Request (parameters to the class method). Pass nullptr if there
+///            is no request structure.
+/// \param f Function to extract/process call result
+/// \param token Boost.Asio CompletionToken
+///
+/// \return The relevant data in a way appropriate to the completion
+/// token. See Boost.Asio documentation. The signature is the return
+/// type of `f`.
+template<std::default_initializable Rep, typename Req,
+	 std::invocable<Rep&&> F,
+	 std::default_initializable Ret = std::invoke_result_t<F&&, Rep&&>,
+	 boost::asio::completion_token_for<
+	   void(boost::system::error_code, Ret)> CompletionToken>
+auto exec(
+  RADOS& r,
+  Object oid,
+  IOContext ioc,
+  std::string cls,
+  std::string method,
+  const Req& req,
+  F&& f,
+  CompletionToken&& token)
+{
+  namespace asio = boost::asio;
+  namespace buffer = ceph::buffer;
+  using boost::system::error_code;
+  using boost::system::system_error;
+
+  buffer::list in;
+  if (!std::is_same_v<Req, std::nullptr_t>) {
+    encode(req, in);
+  }
+// In this case, the warning is spurious as the 'mismatched' `operator
+// new` calls directly into the matching `operator new`, returning its
+// result.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+  return asio::async_initiate<CompletionToken,
+			      void(error_code, Ret)>
+    (asio::experimental::co_composed<void(error_code, Ret)>
+     ([](auto state, RADOS& r, Object oid, IOContext ioc, std::string cls,
+	 std::string method, buffer::list in, F&& f) -> void {
+       try {
+	 ReadOp op;
+	 buffer::list out;
+	 error_code ec;
+	 op.exec(cls, method, std::move(in), &out, &ec);
+	 co_await r.execute(std::move(oid), std::move(ioc), std::move(op),
+			    nullptr, asio::deferred);
+	 if (ec) {
+	   co_return {ec, Ret{}};
+	 }
+	 Rep rep;
+	 decode(rep, out);
+	 co_return {error_code{},
+	            std::invoke(std::forward<F>(f), std::move(rep))};
+       } catch (const system_error& e) {
+	 co_return {e.code(), Ret{}};
+       }
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid), std::move(ioc), std::move(cls),
+     std::move(method), std::move(in), std::forward<F>(f));
+#pragma GCC diagnostic pop
+}
+} // namespace neorados::cls

--- a/src/neorados/cls/version.cc
+++ b/src/neorados/cls/version.cc
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+#include "version.h"
+
+#include <utility>
+
+#include <boost/system/error_code.hpp>
+
+#include "include/buffer.h"
+
+#include "cls/version/cls_version_ops.h"
+#include "cls/version/cls_version_types.h"
+
+
+namespace neorados::cls::version {
+namespace buffer = ceph::buffer;
+
+using boost::system::error_code;
+
+void set(WriteOp& op, const obj_version& objv)
+{
+  buffer::list in;
+  cls_version_set_op call;
+  call.objv = objv;
+  encode(call, in);
+  op.exec("version", "set", in);
+}
+
+void inc(WriteOp& op)
+{
+  buffer::list in;
+  cls_version_inc_op call;
+  encode(call, in);
+  op.exec("version", "inc", in);
+}
+
+void inc(WriteOp& op, const obj_version& objv, const VersionCond cond)
+{
+  buffer::list in;
+  cls_version_inc_op call;
+  call.objv = objv;
+
+  obj_version_cond c;
+  c.cond = cond;
+  c.ver = objv;
+
+  call.conds.push_back(c);
+
+  encode(call, in);
+  op.exec("version", "inc_conds", in);
+}
+
+void check(Op& op, const obj_version& objv, const VersionCond cond)
+{
+  buffer::list in;
+  cls_version_check_op call;
+  call.objv = objv;
+
+  obj_version_cond c;
+  c.cond = cond;
+  c.ver = objv;
+
+  call.conds.push_back(c);
+
+  encode(call, in);
+  op.exec("version", "check_conds", in);
+}
+
+void read(ReadOp& op, obj_version* const objv)
+{
+  buffer::list inbl;
+  op.exec("version", "read", inbl,
+          [objv](error_code ec,
+                 const buffer::list& bl) {
+            cls_version_read_ret ret;
+            if (!ec) {
+              try {
+                auto iter = bl.cbegin();
+                decode(ret, iter);
+		if (objv)
+		  *objv = std::move(ret.objv);
+              } catch (const ceph::buffer::error& err) {
+                // TODO: Currently there's no good way to propagate
+                // errors back.
+              }
+            }
+          });
+}
+} // namespace neorados::cls::version

--- a/src/neorados/cls/version.h
+++ b/src/neorados/cls/version.h
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+/// \file neorados/cls/version.h
+///
+/// \brief NeoRADOS interface to object versioning class
+///
+/// The `version` object class stores a version in the extended
+/// attributes of an object to help coordinate multiple writers. This
+/// version comprises a byte string and an integer. The integers are
+/// comparable and can be compared with the operators in
+/// `VersionCond`. The byte strings are incomparable. Two versions
+/// with different strings will always conflict.
+
+#include <coroutine>
+#include <string>
+#include <utility>
+
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_ops.h"
+#include "cls/version/cls_version_types.h"
+
+#include "neorados/cls/common.h"
+
+namespace neorados::cls::version {
+/// \brief Set the object version
+///
+/// Append a call to a write operation to set the object's version.
+///
+/// \param op Write operation to modify
+/// \param ver Version to set
+void set(WriteOp& op, const obj_version& ver);
+
+/// \brief Unconditional increment version
+///
+/// Append a call to a write operation to increment the integral
+/// portion of a version.
+///
+/// \param op Write operation to modify
+void inc(WriteOp& op);
+
+/// \brief Conditionally increment version
+///
+/// Append a call to a write operation to increment the object's
+/// version if condition is met. If the condition is not met, the
+/// operation fails with `std::errc::resource_unavailable_try_again`.
+///
+/// \param op Write operation to modify
+/// \param ver Version to compare stored object version against
+/// \param cond Comparison operator
+void inc(WriteOp& op, const obj_version& ver, const VersionCond cond);
+
+/// \brief Assert condition on stored version
+///
+/// Append a call to an operation that verifies the stored version has
+/// the specified relationship to the supplied version. If the
+/// condition is not met, the operation fails with `std::errc::canceled`.
+///
+/// \param op Operation to modify
+/// \param ver Version to compare stored object version against
+/// \param cond Comparison operator
+void check(Op& op, const obj_version& ver, const VersionCond cond);
+
+/// \brief Read the stored object version
+///
+/// Append a call to a read operation that reads the stored version.
+///
+/// \param op Read operation to modify
+/// \param objv Location to store the version
+void read(ReadOp& op, obj_version* const objv);
+
+/// \brief Read the stored object version
+///
+/// Execute an asynchronous operation that reads the stored version.
+///
+/// \param e Executor to use for the operation
+/// \param r RADOS handle
+/// \param o Object to query
+/// \param ioc IOContext determining the object location
+/// \param token Boost.Asio CompletionToken
+///
+/// \return The object version in a way appropriate to the completion
+/// token. See Boost.Asio documentation.
+template<boost::asio::completion_token_for<
+	   void(boost::system::error_code, obj_version)> CompletionToken>
+auto read(RADOS& r, Object o, IOContext ioc,
+	  CompletionToken&& token)
+{
+  using namespace std::literals;
+  return exec<cls_version_read_ret>(
+    r, std::move(o), std::move(ioc),
+    "version"s, "read"s, nullptr,
+    [](cls_version_read_ret&& ret) {
+      return std::move(ret.objv);
+    }, std::forward<CompletionToken>(token));
+}
+} // namespace neorados::cls::version

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -849,12 +849,6 @@ struct RGWObjVersionTracker {
   void generate_new_write_ver(CephContext* cct);
 };
 
-inline std::ostream& operator<<(std::ostream& out, const obj_version &v)
-{
-  out << v.tag << ":" << v.ver;
-  return out;
-}
-
 inline std::ostream& operator<<(std::ostream& out, const RGWObjVersionTracker &ot)
 {
   out << "{r=" << ot.read_version << ",w=" << ot.write_version << "}";

--- a/src/test/cls_version/CMakeLists.txt
+++ b/src/test/cls_version/CMakeLists.txt
@@ -14,3 +14,20 @@ target_link_libraries(ceph_test_cls_version
   radostest-cxx
   )
 
+
+add_executable(ceph_test_neocls_version
+  test_neocls_version.cc
+  )
+target_link_libraries(ceph_test_neocls_version
+  neorados_cls_version
+  libneorados
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_neocls_version
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_version/test_neocls_version.cc
+++ b/src/test/cls_version/test_neocls_version.cc
@@ -1,0 +1,293 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#include "neorados/cls/version.h"
+
+#include <boost/asio/post.hpp>
+#include <coroutine>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/redirect_error.hpp>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_types.h"
+
+#include "test/neorados/common_tests.h"
+
+#include "gtest/gtest.h"
+
+namespace asio = boost::asio;
+namespace version = neorados::cls::version;
+
+using boost::system::error_code;
+using boost::system::errc::operation_canceled;
+
+CORO_TEST_F(neocls_version, test_version_inc_read, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(rados, oid, pool, asio::use_awaitable);
+
+  auto ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  /* inc version */
+  neorados::WriteOp op;
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0u, ver.tag.size());
+
+  op = neorados::WriteOp();
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  auto ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  obj_version ver3;
+
+  neorados::ReadOp rop;
+  version::read(rop, &ver3);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::use_awaitable);
+  EXPECT_EQ(ver2.ver, ver3.ver);
+  EXPECT_EQ(1u, ver2.compare(&ver3));
+  co_return;
+}
+
+
+
+CORO_TEST_F(neocls_version, test_version_set, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(rados, oid, pool, asio::use_awaitable);
+
+  auto ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  ver.ver = 123;
+  ver.tag = "foo";
+
+  /* set version */
+  neorados::WriteOp op;
+  version::set(op, ver);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  auto ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+
+  EXPECT_EQ(ver2.ver, ver.ver);
+  EXPECT_EQ(0, ver2.tag.compare(ver.tag));
+}
+
+CORO_TEST_F(neocls_version, test_version_inc_cond, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(rados, oid, pool, asio::use_awaitable);
+
+  auto ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  /* inc version */
+  neorados::WriteOp op;
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0, ver.tag.size());
+
+  auto cond_ver = ver;
+
+  op = neorados::WriteOp();
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  auto ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  /* now check various condition tests */
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_NONE);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  /* a bunch of conditions that should fail */
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_EQ);
+  error_code ec;
+  co_await rados.execute(oid, pool, std::move(op),
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_LT);
+  co_await rados.execute(oid, pool, std::move(op),
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_LE);
+  co_await rados.execute(oid, pool, std::move(op),
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_TAG_NE);
+  co_await rados.execute(oid, pool, std::move(op),
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  /* a bunch of conditions that should succeed */
+  op = neorados::WriteOp();
+  version::inc(op, ver2, VER_COND_EQ);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_GT);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_GE);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  op = neorados::WriteOp();
+  version::inc(op, cond_ver, VER_COND_TAG_EQ);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+}
+
+CORO_TEST_F(neocls_version, test_version_inc_check, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(rados, oid, pool, asio::use_awaitable);
+
+  auto ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  /* inc version */
+  neorados::WriteOp op;
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  ver = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0u, ver.tag.size());
+
+  obj_version cond_ver = ver;
+
+  /* a bunch of conditions that should succeed */
+  neorados::ReadOp rop;
+  version::check(rop, cond_ver, VER_COND_EQ);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::use_awaitable);
+
+  rop = neorados::ReadOp();
+  version::check(rop, cond_ver, VER_COND_GE);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::use_awaitable);
+
+  rop = neorados::ReadOp();
+  version::check(rop, cond_ver, VER_COND_LE);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::use_awaitable);
+
+  rop = neorados::ReadOp();
+  version::check(rop, cond_ver, VER_COND_TAG_EQ);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::use_awaitable);
+
+  op = neorados::WriteOp();
+  version::inc(op);
+  co_await rados.execute(oid, pool, std::move(op), asio::use_awaitable);
+
+  auto ver2 = co_await version::read(rados, oid, pool, asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0, ver2.tag.compare(ver.tag));
+
+  /* a bunch of conditions that should fail */
+  rop = neorados::ReadOp();
+  error_code ec;
+  version::check(rop, ver, VER_COND_LT);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  rop = neorados::ReadOp();
+  version::check(rop, ver, VER_COND_LE);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+
+  rop = neorados::ReadOp();
+  version::check(rop, ver, VER_COND_TAG_NE);
+  co_await rados.execute(oid, pool, std::move(rop), nullptr,
+			 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(operation_canceled, ec);
+}
+
+TEST(neocls_version_bare, lambdata)
+{
+  asio::io_context c;
+
+  std::string_view oid = "obj";
+
+  obj_version iver{123, "foo"};
+  obj_version ever;
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  neorados::RADOS::Builder{}.build(c, [&](error_code ec, neorados::RADOS r_) {
+    ASSERT_FALSE(ec);
+    rados = std::move(r_);
+    create_pool(*rados, get_temp_pool_name(),
+		[&](error_code ec, int64_t poolid) {
+		  ASSERT_FALSE(ec);
+		  pool.pool(poolid);
+		  neorados::WriteOp op;
+		  op.create(true);
+		  version::set(op, iver);
+		  rados->execute(oid, pool, std::move(op), [&](error_code ec) {
+		    ASSERT_FALSE(ec);
+		    version::read(*rados, oid, pool,
+				  [&](error_code ec, obj_version over) {
+				    ASSERT_FALSE(ec);
+				    ASSERT_EQ(iver, over);
+				    ever = over;
+				  });
+		  });
+		});
+  });
+  c.run();
+  ASSERT_EQ(iver, ever);
+}

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(ceph_test_neorados_op_speed
 
 add_library(neoradostest-support STATIC common_tests.cc)
 target_link_libraries(neoradostest-support
-  libneorados fmt::fmt)
+  libneorados fmt::fmt GTest::GTest)
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool

--- a/src/test/neorados/common_tests.cc
+++ b/src/test/neorados/common_tests.cc
@@ -12,7 +12,6 @@
  * Foundation.  See file COPYING.
  */
 
-#include <cstring>
 #include <string>
 #include <string_view>
 
@@ -23,12 +22,11 @@
 #include "common_tests.h"
 #include "include/neorados/RADOS.hpp"
 
-namespace ba = boost::asio;
-namespace R = neorados;
+namespace asio = boost::asio;
 
 std::string get_temp_pool_name(std::string_view prefix)
 {
-  static auto hostname = ba::ip::host_name();
+  static auto hostname = asio::ip::host_name();
   static auto num = 1ull;
   return fmt::format("{}{}-{}-{}", prefix, hostname, getpid(), num++);
 }

--- a/src/test/neorados/common_tests.h
+++ b/src/test/neorados/common_tests.h
@@ -12,30 +12,288 @@
  * Foundation.  See file COPYING.
  */
 
+#pragma once
+
+#include <coroutine>
+#include <cstddef>
+#include <exception>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 
 #include "include/neorados/RADOS.hpp"
 
+#include "gtest/gtest.h"
+
+/// \file test/neorados/common_tests.h
+///
+/// \brief Tools for testing neorados code
+///
+/// This is a set of utilities for testing code using the neorados
+/// library, as well as for tests using C++20 Coroutines more generally.
+
+/// \brief Get a random, unique pool name
+///
+/// Return a uniquified pool name specific to the host on which we are running.
+///
+/// \param prefix A prefix for the returned pool name
+///
+/// \return A unique pool name
 std::string get_temp_pool_name(std::string_view prefix = {});
 
-template<typename CompletionToken>
-auto create_pool(neorados::RADOS& r, std::string pname,
+/// \brief Create a RADOS pool
+///
+/// Create a RADOS pool, returning its ID on success.
+///
+/// \param r RADOS handle
+/// \param pname Pool name
+/// \param token Boost.Asio completion token
+///
+/// \return The ID of the newly created pool
+template<boost::asio::completion_token_for<
+	   void(boost::system::error_code, int64_t)> CompletionToken>
+auto create_pool(neorados::RADOS& r,
+		 std::string pname,
 		 CompletionToken&& token)
 {
-  boost::asio::async_completion<CompletionToken,
-				void(boost::system::error_code,
-				     std::int64_t)> init(token);
-  r.create_pool(pname, std::nullopt,
-		[&r, pname = std::string(pname),
-		 h = std::move(init.completion_handler)]
-		(boost::system::error_code ec) mutable {
-		  r.lookup_pool(
-		    pname,
-		    [h = std::move(h)]
-		    (boost::system::error_code ec, std::int64_t pool) mutable {
-		      std::move(h)(ec, pool);
-		    });
-		});
-  return init.result.get();
+  namespace asio = boost::asio;
+  using boost::system::error_code;
+  using boost::system::system_error;
+
+// In this case, the warning is spurious as the 'mismatched' `operator
+// new` calls directly into the matching `operator new`, returning its
+// result.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+  return asio::async_initiate<CompletionToken, void(error_code, int64_t)>
+    (asio::experimental::co_composed<void(error_code, int64_t)>
+     ([](auto state, neorados::RADOS& r, std::string pname) -> void {
+       try {
+	 co_await r.create_pool(pname, std::nullopt, asio::deferred);
+	 auto pool = co_await r.lookup_pool(pname, asio::deferred);
+	 co_return {error_code{}, pool};
+       } catch (const system_error& e) {
+	 co_return {e.code(), int64_t{}};
+       }
+     }, r.get_executor()),
+     token, std::ref(r), std::move(pname));
+#pragma GCC diagnostic pop
 }
+
+/// \brief Create a new, empty RADOS object
+///
+/// \param r RADOS handle
+/// \param oid Object name
+/// \param ioc Locator
+/// \param token Boost.Asio completion token
+template<boost::asio::completion_token_for<
+  void(boost::system::error_code)> CompletionToken>
+auto create_obj(neorados::RADOS& r, std::string_view oid,
+		const neorados::IOContext& ioc,
+		CompletionToken&& token)
+{
+  neorados::WriteOp op;
+  op.create(true);
+  return r.execute(oid, ioc, std::move(op),
+		   std::forward<CompletionToken>(token));
+}
+
+/// \brief Test harness for C++20 Coroutines
+///
+/// C++20 coroutines are better than what we had before, but don't
+/// play well with RAII. There's no good way to run a coroutine from a
+/// destructor, especially in a single-threaded, non-blocking
+/// program.
+///
+/// To be fair to C++20, this is difficult and even rust doesn't have
+/// async drop yet.
+///
+/// GTest has explicit SetUp and TearDown methods, however they're
+/// just regular functions. So we get Coroutine analogues of SetUp and
+/// TearDown that we then call from our custom TestBody. The user
+/// writes their tests in CoTestBody.
+class CoroTest : public testing::Test {
+private:
+  std::exception_ptr eptr;
+protected:
+  boost::asio::io_context asio_context; ///< The context on which the
+					///  coroutine runs.
+public:
+  /// Final override that does nothing. Actual setup code should go in CoSetUp
+  void SetUp() override final { };
+  /// Final override that does nothing. Actual teardown code should go
+  /// in CotearDown.
+  void TearDown() override final { };
+
+  /// \brief SetUp coroutine
+  ///
+  /// Called before the test body. Indicate failure by throwing
+  /// an exception. If an exception is thrown, neither the test body
+  /// nor teardown code are run.
+  virtual boost::asio::awaitable<void> CoSetUp() {
+    co_return;
+  }
+
+  /// \brief TearDown coroutine
+  ///
+  /// Called after the test body exits.
+  ///
+  /// \note This function is not run if CoSetup fails
+  virtual boost::asio::awaitable<void> CoTearDown() {
+    co_return;
+  }
+
+  /// \brief TestBody coroutine
+  ///
+  /// Run after setup.
+  virtual boost::asio::awaitable<void> CoTestBody() = 0;
+
+  /// \brief Run our coroutines
+  ///
+  /// This is marked final, since the actual test body belongs in
+  /// CoTestBody.
+  ///
+  /// Run CoSetUp and, if CoSetUp succeeded, CoTestBody and
+  /// CoTearDown.
+  ///
+  /// Error reporting of failures in CoSetUp and CoTearDown leaves
+  /// something to be desired as GTest thinks everything is the test
+  /// proper.
+  void TestBody() override final {
+    boost::asio::co_spawn(
+      asio_context,
+      [](CoroTest* t) -> boost::asio::awaitable<void> {
+	co_await t->CoSetUp();
+	try {
+	  co_await t->CoTestBody();
+	} catch (...) {
+	  t->eptr = std::current_exception();
+	}
+	co_await t->CoTearDown();
+	if (t->eptr) {
+	  std::rethrow_exception(t->eptr);
+	}
+	co_return;
+      }(this),
+      [](std::exception_ptr e) {
+	if (e) std::rethrow_exception(e);
+      });
+    asio_context.run();
+  }
+};
+
+/// \brief C++20 coroutine test harness for NeoRados
+///
+/// CoTestBody has access to `rados`, a `neorados::RADOS` handle, and
+/// `pool`, a `neorados::IOContext` representing a pool that will be
+/// destroyed when the test exits.
+class NeoRadosTest : public CoroTest {
+private:
+  /// Workaround so we don't have to use an optional or allocate or
+  /// something.
+  alignas(neorados::RADOS) std::byte rspace[sizeof(neorados::RADOS)];
+protected:
+  neorados::RADOS& rados =
+    *reinterpret_cast<neorados::RADOS*>(rspace);
+  neorados::IOContext pool; ///< The pool usable by this test.
+public:
+
+  /// \brief Create RADOS handle and pool for the test
+  boost::asio::awaitable<void> CoSetUp() override {
+    auto r = co_await neorados::RADOS::Builder{}
+      .build(asio_context, boost::asio::use_awaitable);
+    new (&rados) neorados::RADOS(std::move(r));
+    pool.pool(co_await create_pool(rados, get_temp_pool_name(
+				     testing::UnitTest::GetInstance()
+				     ->current_test_info()->name()),
+				   boost::asio::use_awaitable));
+    co_return;
+  }
+
+  ~NeoRadosTest() override {
+    rados.~RADOS();
+  }
+
+  /// \brief Delete pool used for testing
+  boost::asio::awaitable<void> CoTearDown() override {
+    co_await rados.delete_pool(pool.pool(),
+				boost::asio::use_awaitable);
+    co_return;
+  }
+};
+
+/// \brief Helper macro for defining coroutine tests with a fixture
+///
+/// Defines a test using a coroutine fixture for
+/// SetUp/TearDown. Fixtures must be descendants of `CoroTest`.
+///
+/// \note Uses more of GTest's internals that I would like.
+///
+/// \warning Use `EXPECT_*` only, not `ASSERT_*`. `ASSERT_` macros
+/// return from the calling function and will not work in a
+/// coroutine.
+///
+/// \param test_suite_name Name of the test suite
+/// \param test_name Name of the test
+/// \param fixture Fixture class to use (descendent of CoroTest)
+#define CORO_TEST_F(test_suite_name, test_name, fixture)                       \
+  static_assert(sizeof(GTEST_STRINGIFY_(test_suite_name)) > 1,                 \
+		"test_suite_name must not be empty");                          \
+  static_assert(sizeof(GTEST_STRINGIFY_(test_name)) > 1,                       \
+		"test_name must not be empty");                                \
+  class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) : public fixture {  \
+  public:                                                                      \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() = default;            \
+    ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override = default;  \
+    GTEST_DISALLOW_COPY_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,    \
+							   test_name));        \
+    GTEST_DISALLOW_MOVE_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,    \
+							   test_name));        \
+									       \
+  private:                                                                     \
+    boost::asio::awaitable<void> CoTestBody() override;                        \
+    static ::testing::TestInfo *const test_info_ GTEST_ATTRIBUTE_UNUSED_;      \
+  };                                                                           \
+									       \
+  ::testing::TestInfo *const GTEST_TEST_CLASS_NAME_(test_suite_name,           \
+						    test_name)::test_info_ =   \
+      ::testing::internal::MakeAndRegisterTestInfo(                            \
+	  #test_suite_name, #test_name, nullptr, nullptr,                      \
+	  ::testing::internal::CodeLocation(__FILE__, __LINE__),               \
+	  (::testing::internal::GetTypeId<fixture>()),                         \
+	  ::testing::internal::SuiteApiResolver<fixture>::GetSetUpCaseOrSuite( \
+	      __FILE__, __LINE__),                                             \
+	  ::testing::internal::SuiteApiResolver<                               \
+	      fixture>::GetTearDownCaseOrSuite(__FILE__, __LINE__),            \
+	  new ::testing::internal::TestFactoryImpl<GTEST_TEST_CLASS_NAME_(     \
+	      test_suite_name, test_name)>);                                   \
+  boost::asio::awaitable<void> GTEST_TEST_CLASS_NAME_(test_suite_name,         \
+						      test_name)::CoTestBody()
+
+/// \brief Helper macro for defining coroutine tests
+///
+/// Tests created this way are direct descendants of `CoroTest`.
+///
+/// The Boost.Asio IO Context is `io_context`.
+///
+/// \warning Use `EXPECT_*` only, not `ASSERT_*`. `ASSERT_` macros
+/// return from the calling function and will not work in a
+/// coroutine.
+///
+/// \param test_suite_name Name of the test suite
+/// \param test_name Name of the test
+#define CORO_TEST(test_suite_name, test_name)                                  \
+  CORO_TEST_F(test_suite_name, test_name, CoroTest)


### PR DESCRIPTION
CLS Version for neorados

(Also getting some experience with `async_compose` and writing unit tests for C++20 coroutines.)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
