### PR TITLE
quincy: python-common: Add 'KB' to supported suffixes in SizeMatcher

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/matchers.py
+++ b/src/python-common/ceph/deployment/drive_selection/matchers.py
@@ -175,9 +175,9 @@ class SizeMatcher(Matcher):
     """
 
     SUFFIXES = (
-        ["MB", "GB", "TB"],
-        ["M", "G", "T"],
-        [1e+6, 1e+9, 1e+12]
+        ["KB", "MB", "GB", "TB"],
+        ["K", "M", "G", "T"],
+        [1e+3, 1e+6, 1e+9, 1e+12]
     )
 
     supported_suffixes = SUFFIXES[0] + SUFFIXES[1]

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -122,6 +122,12 @@ class TestSizeMatcher(object):
         assert matcher.low[0] == '50'
         assert matcher.low[1] == 'GB'
 
+    def test_to_byte_KB(self):
+        """ I doubt anyone ever thought we'd need to understand KB """
+
+        ret = drive_selection.SizeMatcher('size', '4K').to_byte(('4', 'KB'))
+        assert ret == 4 * 1e+3
+
     def test_to_byte_GB(self):
         """ Pretty nonesense test.."""
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57637

---

backport of https://github.com/ceph/ceph/pull/48184
parent tracker: https://tracker.ceph.com/issues/57609

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh