### PR TITLE
quincy: mgr/dashboard: Add text to empty life expectancy column

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -482,8 +482,18 @@ class Osd(RESTController):
 
     @RESTController.Resource('GET')
     def devices(self, svc_id):
-        # (str) -> dict
-        return CephService.send_command('mon', 'device ls-by-daemon', who='osd.{}'.format(svc_id))
+        # type: (str) -> Union[list, str]
+        devices: Union[list, str] = CephService.send_command(
+            'mon', 'device ls-by-daemon', who='osd.{}'.format(svc_id))
+        mgr_map = mgr.get('mgr_map')
+        available_modules = [m['name'] for m in mgr_map['available_modules']]
+
+        life_expectancy_enabled = any(
+            item.startswith('diskprediction_') for item in available_modules)
+        for device in devices:
+            device['life_expectancy_enabled'] = life_expectancy_enabled
+
+        return devices
 
 
 @UIRouter('/osd', Scope.OSD)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
@@ -13,6 +13,8 @@
 
 <ng-template #lifeExpectancy
              let-value="value">
+  <span *ngIf="!value.life_expectancy_enabled"
+        i18n>{{ "" | notAvailable }}</span>
   <span *ngIf="value.min && !value.max">&gt; {{value.min | i18nPlural: translationMapping}}</span>
   <span *ngIf="value.max && !value.min">&lt; {{value.max | i18nPlural: translationMapping}}</span>
   <span *ngIf="value.max && value.min">{{value.min}} to {{value.max | i18nPlural: translationMapping}}</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/devices.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/devices.ts
@@ -8,6 +8,7 @@ export interface CephDevice {
   life_expectancy_min?: string;
   life_expectancy_max?: string;
   life_expectancy_stamp?: string;
+  life_expectancy_enabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57680

---

backport of https://github.com/ceph/ceph/pull/47876
parent tracker: https://tracker.ceph.com/issues/43116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh