### PR TITLE
quincy: rgw: fix data corruption due to network jitter

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -330,6 +330,11 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
 
   r = obj_op.write_meta(dpp, actual_size, accounted_size, attrs, y);
   if (r < 0) {
+    if (r == -ETIMEDOUT) {
+      // The head object write may eventually succeed, clear the set of objects for deletion. if it
+      // doesn't ever succeed, we'll orphan any tail objects as if we'd crashed before that write
+      writer.clear_written();
+    }
     return r;
   }
   if (!obj_op.meta.canceled) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57559

---

backport of https://github.com/ceph/ceph/pull/47667
parent tracker: https://tracker.ceph.com/issues/57519

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh