### PR TITLE
mgr/telemetry: handle daemons with complex ids

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -493,7 +493,7 @@ class Module(MgrModule):
 
         # Grab output from the "daemon.x heap stats" command
         for daemon in daemons:
-            daemon_type, daemon_id = daemon.split('.')
+            daemon_type, daemon_id = daemon.split('.', 1)
             heap_stats = self.parse_heap_stats(daemon_type, daemon_id)
             if heap_stats:
                 if (daemon_type != 'osd'):
@@ -568,7 +568,7 @@ class Module(MgrModule):
 
         # Grab output from the "dump_mempools" command
         for daemon in daemons:
-            daemon_type, daemon_id = daemon.split('.')
+            daemon_type, daemon_id = daemon.split('.', 1)
             cmd_dict = {
                 'prefix': 'dump_mempools',
                 'format': 'json'


### PR DESCRIPTION
Treating daemons as `<daemon_type>.x` caused a crash in the Telemetry module since the current method does not cover a case where a daemon id is more complex, i.e. `<daemon_type>.x.y`.

When we parse the daemon type and daemon id, we should split it into a maximum of two pieces rather than splitting it by every `.` character. Specifying `1` in the Python .split() function will limit the split to a maximum of two items.

I tested this on a vstart cluster by simulating a complex daemon id in the vstart.sh script:
```diff
diff --git a/src/vstart.sh b/src/vstart.sh
index 7aab8c5a1d6..8e60e5164da 100755
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -878,7 +878,7 @@ init_logrotate() {
 start_mon() {
     local MONS=""
     local count=0
-    for f in a b c d e f g h i j k l m n o p q r s t u v w x y z
+    for f in a.reesi003.ewoftc b.reesi003.ewoftc c.reesi003.ewoftc d e f g h i j k l m n o p q r s t u v w x y z
     do
         [ $count -eq $CEPH_NUM_MON ] && break;
         count=$(($count + 1))
```
Fixes: https://tracker.ceph.com/issues/57700
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
