### PR TITLE
vstart.sh: add hostname to daemon name

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -493,7 +493,7 @@ class Module(MgrModule):
 
         # Grab output from the "daemon.x heap stats" command
         for daemon in daemons:
-            daemon_type, daemon_id = daemon.split('.', 1)
+            daemon_type, daemon_id = daemon.split('.')
             heap_stats = self.parse_heap_stats(daemon_type, daemon_id)
             if heap_stats:
                 if (daemon_type != 'osd'):
@@ -568,7 +568,7 @@ class Module(MgrModule):
 
         # Grab output from the "dump_mempools" command
         for daemon in daemons:
-            daemon_type, daemon_id = daemon.split('.', 1)
+            daemon_type, daemon_id = daemon.split('.')
             cmd_dict = {
                 'prefix': 'dump_mempools',
                 'format': 'json'

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -880,6 +880,7 @@ start_mon() {
     local count=0
     for f in a b c d e f g h i j k l m n o p q r s t u v w x y z
     do
+        f=$HOSTNAME.$f
         [ $count -eq $CEPH_NUM_MON ] && break;
         count=$(($count + 1))
         if [ -z "$MONS" ]; then
@@ -1085,6 +1086,7 @@ start_mgr() {
     PROMETHEUS_PORT=9283
     for name in x y z a b c d e f g h i j k l m n o p
     do
+        name=$HOSTNAME.$name
         [ $mgr -eq $CEPH_NUM_MGR ] && break
         mgr=$(($mgr + 1))
         if [ "$new" -eq 1 ]; then
@@ -1174,6 +1176,7 @@ start_mds() {
     local mds=0
     for name in a b c d e f g h i j k l m n o p
     do
+        name=$HOSTNAME.$name
         [ $mds -eq $CEPH_NUM_MDS ] && break
         mds=$(($mds + 1))
 
@@ -1526,6 +1529,7 @@ fi
 fs=0
 for name in a b c d e f g h i j k l m n o p
 do
+    name=$HOSTNAME.$name
     [ $fs -eq $CEPH_NUM_FS ] && break
     fs=$(($fs + 1))
     if [ "$CEPH_MAX_MDS" -gt 1 ]; then


### PR DESCRIPTION
This is more realistic to how actual clusters are set up, instead of something simple like `mon.a`. Adding the hostname to daemon names can help detect bugs like https://tracker.ceph.com/issues/57700 earlier on in development.

Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
