### PR TITLE
crimson/os/seastore: introduce (64-8)-bit signed device_off_t and 32-bit signed segment_off_t

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -61,7 +61,7 @@ void segment_info_t::set_closed()
 void segment_info_t::init_closed(
     segment_seq_t _seq, segment_type_t _type,
     data_category_t _category, reclaim_gen_t _generation,
-    std::size_t seg_size)
+    segment_off_t seg_size)
 {
   ceph_assert(_seq != NULL_SEG_SEQ);
   ceph_assert(_type != segment_type_t::NULL_SEG);
@@ -144,7 +144,7 @@ void segments_info_t::add_segment_manager(
     ceph_assert(ssize > 0);
     segment_size = ssize;
   } else {
-    ceph_assert(segment_size == (std::size_t)ssize);
+    ceph_assert(segment_size == ssize);
   }
 
   // NOTE: by default the segments are empty
@@ -279,7 +279,7 @@ void segments_info_t::mark_closed(
   }
   ceph_assert(get_segment_size() >= segment_info.written_to);
   auto seg_avail_bytes = get_segment_size() - segment_info.written_to;
-  ceph_assert(avail_bytes_in_open >= seg_avail_bytes);
+  ceph_assert(avail_bytes_in_open >= (std::size_t)seg_avail_bytes);
   avail_bytes_in_open -= seg_avail_bytes;
 
   if (segment_info.modify_time != NULL_TIME) {
@@ -304,7 +304,7 @@ void segments_info_t::update_written_to(
     ceph_abort();
   }
 
-  auto new_written_to = static_cast<std::size_t>(saddr.get_segment_off());
+  auto new_written_to = saddr.get_segment_off();
   ceph_assert(new_written_to <= get_segment_size());
   if (segment_info.written_to > new_written_to) {
     ERROR("written_to should not decrease! type={}, offset={}, {}",
@@ -315,7 +315,7 @@ void segments_info_t::update_written_to(
   DEBUG("type={}, offset={}, {}", type, offset, segment_info);
   ceph_assert(type == segment_info.type);
   auto avail_deduction = new_written_to - segment_info.written_to;
-  ceph_assert(avail_bytes_in_open >= avail_deduction);
+  ceph_assert(avail_bytes_in_open >= (std::size_t)avail_deduction);
   avail_bytes_in_open -= avail_deduction;
   segment_info.written_to = new_written_to;
 }
@@ -687,7 +687,7 @@ bool SpaceTrackerSimple::equals(const SpaceTrackerI &_other) const
 
 int64_t SpaceTrackerDetailed::SegmentMap::allocate(
   device_segment_id_t segment,
-  seastore_off_t offset,
+  segment_off_t offset,
   extent_len_t len,
   const extent_len_t block_size)
 {
@@ -714,7 +714,7 @@ int64_t SpaceTrackerDetailed::SegmentMap::allocate(
 
 int64_t SpaceTrackerDetailed::SegmentMap::release(
   device_segment_id_t segment,
-  seastore_off_t offset,
+  segment_off_t offset,
   extent_len_t len,
   const extent_len_t block_size)
 {

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -404,8 +404,8 @@ JournalTrimmerImpl::JournalTrimmerImpl(
   BackrefManager &backref_manager,
   config_t config,
   journal_type_t type,
-  seastore_off_t roll_start,
-  seastore_off_t roll_size)
+  device_off_t roll_start,
+  device_off_t roll_size)
   : backref_manager(backref_manager),
     config(config),
     journal_type(type),

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -339,7 +339,7 @@ std::ostream &operator<<(std::ostream &os, const segments_info_t &infos)
 
 void JournalTrimmerImpl::config_t::validate() const
 {
-  ceph_assert(max_journal_bytes <= MAX_SEG_OFF);
+  ceph_assert(max_journal_bytes <= DEVICE_OFF_MAX);
   ceph_assert(max_journal_bytes > target_journal_dirty_bytes);
   ceph_assert(max_journal_bytes > target_journal_alloc_bytes);
   ceph_assert(rewrite_dirty_bytes_per_cycle > 0);
@@ -494,7 +494,7 @@ journal_seq_t JournalTrimmerImpl::get_tail_limit() const
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       journal_type,
-      -static_cast<seastore_off_t>(config.max_journal_bytes),
+      -static_cast<device_off_t>(config.max_journal_bytes),
       roll_start,
       roll_size);
   return ret;
@@ -505,7 +505,7 @@ journal_seq_t JournalTrimmerImpl::get_dirty_tail_target() const
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       journal_type,
-      -static_cast<seastore_off_t>(config.target_journal_dirty_bytes),
+      -static_cast<device_off_t>(config.target_journal_dirty_bytes),
       roll_start,
       roll_size);
   return ret;
@@ -516,7 +516,7 @@ journal_seq_t JournalTrimmerImpl::get_alloc_tail_target() const
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       journal_type,
-      -static_cast<seastore_off_t>(config.target_journal_alloc_bytes),
+      -static_cast<device_off_t>(config.target_journal_alloc_bytes),
       roll_start,
       roll_size);
   return ret;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -44,7 +44,7 @@ struct segment_info_t {
 
   std::size_t num_extents = 0;
 
-  std::size_t written_to = 0;
+  segment_off_t written_to = 0;
 
   bool is_in_journal(journal_seq_t tail_committed) const {
     return type == segment_type_t::JOURNAL &&
@@ -65,7 +65,7 @@ struct segment_info_t {
 
   void init_closed(segment_seq_t, segment_type_t,
                    data_category_t, reclaim_gen_t,
-                   std::size_t);
+                   segment_off_t);
 
   void set_open(segment_seq_t, segment_type_t,
                 data_category_t, reclaim_gen_t);
@@ -118,7 +118,7 @@ public:
     assert(segments.size() > 0);
     return segments.size();
   }
-  std::size_t get_segment_size() const {
+  segment_off_t get_segment_size() const {
     assert(segment_size > 0);
     return segment_size;
   }
@@ -239,7 +239,7 @@ private:
   // See reset() for member initialization
   segment_map_t<segment_info_t> segments;
 
-  std::size_t segment_size;
+  segment_off_t segment_size;
 
   segment_id_t journal_segment_id;
   std::size_t num_in_journal_open;
@@ -615,12 +615,12 @@ class SpaceTrackerI {
 public:
   virtual int64_t allocate(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) = 0;
 
   virtual int64_t release(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) = 0;
 
   virtual int64_t get_usage(
@@ -643,7 +643,7 @@ using SpaceTrackerIRef = std::unique_ptr<SpaceTrackerI>;
 class SpaceTrackerSimple : public SpaceTrackerI {
   struct segment_bytes_t {
     int64_t live_bytes = 0;
-    seastore_off_t total_bytes = 0;
+    segment_off_t total_bytes = 0;
   };
   // Tracks live space for each segment
   segment_map_t<segment_bytes_t> live_bytes_by_segment;
@@ -666,14 +666,14 @@ public:
 
   int64_t allocate(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) final {
     return update_usage(segment, len);
   }
 
   int64_t release(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) final {
     return update_usage(segment, -(int64_t)len);
   }
@@ -707,13 +707,13 @@ public:
 class SpaceTrackerDetailed : public SpaceTrackerI {
   class SegmentMap {
     int64_t used = 0;
-    seastore_off_t total_bytes = 0;
+    segment_off_t total_bytes = 0;
     std::vector<bool> bitmap;
 
   public:
     SegmentMap(
       size_t blocks,
-      seastore_off_t total_bytes)
+      segment_off_t total_bytes)
     : total_bytes(total_bytes),
       bitmap(blocks, false) {}
 
@@ -724,13 +724,13 @@ class SpaceTrackerDetailed : public SpaceTrackerI {
 
     int64_t allocate(
       device_segment_id_t segment,
-      seastore_off_t offset,
+      segment_off_t offset,
       extent_len_t len,
       const extent_len_t block_size);
 
     int64_t release(
       device_segment_id_t segment,
-      seastore_off_t offset,
+      segment_off_t offset,
       extent_len_t len,
       const extent_len_t block_size);
 
@@ -774,7 +774,7 @@ public:
 
   int64_t allocate(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) final {
     return segment_usage[segment].allocate(
       segment.device_segment_id(),
@@ -785,7 +785,7 @@ public:
 
   int64_t release(
     segment_id_t segment,
-    seastore_off_t offset,
+    segment_off_t offset,
     extent_len_t len) final {
     return segment_usage[segment].release(
       segment.device_segment_id(),
@@ -1077,14 +1077,14 @@ private:
   struct reclaim_state_t {
     reclaim_gen_t generation;
     reclaim_gen_t target_generation;
-    std::size_t segment_size;
+    segment_off_t segment_size;
     paddr_t start_pos;
     paddr_t end_pos;
 
     static reclaim_state_t create(
         segment_id_t segment_id,
         reclaim_gen_t generation,
-        std::size_t segment_size) {
+        segment_off_t segment_size) {
       ceph_assert(generation < RECLAIM_GENERATIONS);
       return {generation,
               (reclaim_gen_t)(generation == RECLAIM_GENERATIONS - 1 ?
@@ -1099,7 +1099,7 @@ private:
     }
 
     bool is_complete() const {
-      return (std::size_t)end_pos.as_seg_paddr().get_segment_off() >= segment_size;
+      return end_pos.as_seg_paddr().get_segment_off() >= segment_size;
     }
 
     void advance(std::size_t bytes) {
@@ -1107,7 +1107,7 @@ private:
       start_pos = end_pos;
       auto &end_seg_paddr = end_pos.as_seg_paddr();
       auto next_off = end_seg_paddr.get_segment_off() + bytes;
-      if (next_off > segment_size) {
+      if (next_off > (std::size_t)segment_size) {
         end_seg_paddr.set_segment_off(segment_size);
       } else {
         end_seg_paddr.set_segment_off(next_off);

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -348,7 +348,7 @@ public:
     extent_types_t type,
     paddr_t addr,
     laddr_t laddr,
-    seastore_off_t len) = 0;
+    extent_len_t len) = 0;
 
   /**
    * submit_transaction_direct

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -483,8 +483,8 @@ public:
     BackrefManager &backref_manager,
     config_t config,
     journal_type_t type,
-    seastore_off_t roll_start,
-    seastore_off_t roll_size);
+    device_off_t roll_start,
+    device_off_t roll_size);
 
   ~JournalTrimmerImpl() = default;
 
@@ -549,8 +549,8 @@ public:
       BackrefManager &backref_manager,
       config_t config,
       journal_type_t type,
-      seastore_off_t roll_start,
-      seastore_off_t roll_size) {
+      device_off_t roll_start,
+      device_off_t roll_size) {
     return std::make_unique<JournalTrimmerImpl>(
         backref_manager, config, type, roll_start, roll_size);
   }
@@ -575,8 +575,8 @@ private:
 
   config_t config;
   journal_type_t journal_type;
-  seastore_off_t roll_start;
-  seastore_off_t roll_size;
+  device_off_t roll_start;
+  device_off_t roll_size;
 
   journal_seq_t journal_head;
   journal_seq_t journal_dirty_tail;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -125,7 +125,7 @@ BtreeBackrefManager::new_mapping(
     is_aligned(
       key.get_addr_type() == paddr_types_t::SEGMENT ?
 	key.as_seg_paddr().get_segment_off() :
-	key.as_blk_paddr().get_block_off(),
+	key.as_blk_paddr().get_device_off(),
       cache.get_block_size()));
   struct state_t {
     paddr_t last_end;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -126,7 +126,7 @@ BtreeBackrefManager::new_mapping(
       key.get_addr_type() == paddr_types_t::SEGMENT ?
 	key.as_seg_paddr().get_segment_off() :
 	key.as_blk_paddr().get_block_off(),
-      (uint64_t)cache.get_block_size()));
+      cache.get_block_size()));
   struct state_t {
     paddr_t last_end;
 
@@ -322,7 +322,7 @@ BtreeBackrefManager::scan_mapped_space(
           c,
           btree.lower_bound(
             c,
-            paddr_t::make_seg_paddr(segment_id_t{0, 0}, 0),
+            P_ADDR_MIN,
             &tree_visitor),
           [c, &scan_visitor, block_size, FNAME](auto &pos) {
             if (pos.is_end()) {

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -722,7 +722,7 @@ public:
     op_context_t<node_key_t> c,
     paddr_t addr,
     node_key_t laddr,
-    seastore_off_t len)
+    extent_len_t len)
   {
     LOG_PREFIX(FixedKVBtree::get_leaf_if_live);
     return lower_bound(
@@ -760,7 +760,7 @@ public:
     op_context_t<node_key_t> c,
     paddr_t addr,
     node_key_t laddr,
-    seastore_off_t len)
+    extent_len_t len)
   {
     LOG_PREFIX(FixedKVBtree::get_internal_if_live);
     return lower_bound(

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -942,7 +942,7 @@ void Cache::on_transaction_destruct(Transaction& t)
 CachedExtentRef Cache::alloc_new_extent_by_type(
   Transaction &t,        ///< [in, out] current transaction
   extent_types_t type,   ///< [in] type tag
-  seastore_off_t length, ///< [in] length
+  extent_len_t length,   ///< [in] length
   placement_hint_t hint, ///< [in] user hint
   reclaim_gen_t gen      ///< [in] reclaim generation
 )
@@ -1123,7 +1123,7 @@ record_t Cache::prepare_record(
 	   : L_ADDR_NULL),
 	  i->last_committed_crc,
 	  final_crc,
-	  (seastore_off_t)i->get_length(),
+	  i->get_length(),
 	  i->get_version() - 1,
 	  sseq,
 	  stype,
@@ -1897,7 +1897,7 @@ Cache::get_extent_ertr::future<CachedExtentRef> Cache::_get_extent_by_type(
   extent_types_t type,
   paddr_t offset,
   laddr_t laddr,
-  seastore_off_t length,
+  extent_len_t length,
   const Transaction::src_t* p_src,
   extent_init_func_t &&extent_init_func,
   extent_init_func_t &&on_cache)

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -271,8 +271,8 @@ public:
   template <typename T, typename Func, typename OnCache>
   get_extent_ret<T> get_extent(
     paddr_t offset,                ///< [in] starting addr
-    seastore_off_t length,          ///< [in] length
-    const src_ext_t* p_src_ext, ///< [in] cache query metric key
+    extent_len_t length,           ///< [in] length
+    const src_ext_t* p_src_ext,    ///< [in] cache query metric key
     Func &&extent_init_func,       ///< [in] init func for extent
     OnCache &&on_cache
   ) {
@@ -339,7 +339,7 @@ public:
   template <typename T>
   get_extent_ret<T> get_extent(
     paddr_t offset,                ///< [in] starting addr
-    seastore_off_t length,          ///< [in] length
+    extent_len_t length,           ///< [in] length
     const src_ext_t* p_metric_key  ///< [in] cache query metric key
   ) {
     return get_extent<T>(
@@ -414,7 +414,7 @@ public:
   get_extent_iertr::future<TCachedExtentRef<T>> get_extent(
     Transaction &t,
     paddr_t offset,
-    seastore_off_t length,
+    extent_len_t length,
     Func &&extent_init_func) {
     CachedExtentRef ret;
     LOG_PREFIX(Cache::get_extent);
@@ -451,11 +451,11 @@ public:
   get_extent_iertr::future<TCachedExtentRef<T>> get_extent(
     Transaction &t,
     paddr_t offset,
-    seastore_off_t length) {
+    extent_len_t length) {
     return get_extent<T>(t, offset, length, [](T &){});
   }
 
-  seastore_off_t get_block_size() const {
+  extent_len_t get_block_size() const {
     return epm.get_block_size();
   }
 
@@ -490,7 +490,7 @@ private:
     extent_types_t type,
     paddr_t offset,
     laddr_t laddr,
-    seastore_off_t length,
+    extent_len_t length,
     const Transaction::src_t* p_src,
     extent_init_func_t &&extent_init_func,
     extent_init_func_t &&on_cache
@@ -504,7 +504,7 @@ private:
     extent_types_t type,
     paddr_t offset,
     laddr_t laddr,
-    seastore_off_t length,
+    extent_len_t length,
     extent_init_func_t &&extent_init_func
   ) {
     LOG_PREFIX(Cache::get_extent_by_type);
@@ -580,7 +580,7 @@ public:
     extent_types_t type,    ///< [in] type tag
     paddr_t offset,         ///< [in] starting addr
     laddr_t laddr,          ///< [in] logical address if logical
-    seastore_off_t length,   ///< [in] length
+    extent_len_t length,    ///< [in] length
     Func &&extent_init_func ///< [in] extent init func
   ) {
     return _get_extent_by_type(
@@ -596,7 +596,7 @@ public:
     extent_types_t type,
     paddr_t offset,
     laddr_t laddr,
-    seastore_off_t length
+    extent_len_t length
   ) {
     return get_extent_by_type(
       t, type, offset, laddr, length, [](CachedExtent &) {});
@@ -627,7 +627,7 @@ public:
   template <typename T>
   TCachedExtentRef<T> alloc_new_extent(
     Transaction &t,         ///< [in, out] current transaction
-    seastore_off_t length,  ///< [in] length
+    extent_len_t length,    ///< [in] length
     placement_hint_t hint,  ///< [in] user hint
     reclaim_gen_t gen       ///< [in] reclaim generation
   ) {
@@ -656,7 +656,7 @@ public:
   CachedExtentRef alloc_new_extent_by_type(
     Transaction &t,        ///< [in, out] current transaction
     extent_types_t type,   ///< [in] type tag
-    seastore_off_t length, ///< [in] length
+    extent_len_t length,   ///< [in] length
     placement_hint_t hint, ///< [in] user hint
     reclaim_gen_t gen      ///< [in] reclaim generation
     );

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -619,7 +619,7 @@ class ExtentIndex {
   friend class Cache;
   CachedExtent::index extent_index;
 public:
-  auto get_overlap(paddr_t addr, seastore_off_t len) {
+  auto get_overlap(paddr_t addr, extent_len_t len) {
     auto bottom = extent_index.upper_bound(addr, paddr_cmp());
     if (bottom != extent_index.begin())
       --bottom;

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -18,8 +18,8 @@ namespace {
 
 namespace crimson::os::seastore::collection_manager {
 
-constexpr static seastore_off_t MIN_FLAT_BLOCK_SIZE = 4<<10;
-[[maybe_unused]] constexpr static seastore_off_t MAX_FLAT_BLOCK_SIZE = 4<<20;
+constexpr static extent_len_t MIN_FLAT_BLOCK_SIZE = 4<<10;
+[[maybe_unused]] constexpr static extent_len_t MAX_FLAT_BLOCK_SIZE = 4<<20;
 
 FlatCollectionManager::FlatCollectionManager(
   TransactionManager &tm)

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -71,7 +71,7 @@ public:
 
   virtual const seastore_meta_t &get_meta() const = 0;
 
-  virtual seastore_off_t get_block_size() const = 0;
+  virtual extent_len_t get_block_size() const = 0;
 
   virtual std::size_t get_available_size() const = 0;
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -100,7 +100,7 @@ public:
     return background_process.get_journal_type();
   }
 
-  seastore_off_t get_block_size() const {
+  extent_len_t get_block_size() const {
     assert(primary_device != nullptr);
     // assume all the devices have the same block size
     return primary_device->get_block_size();
@@ -141,7 +141,7 @@ public:
   alloc_result_t alloc_new_extent(
     Transaction& t,
     extent_types_t type,
-    seastore_off_t length,
+    extent_len_t length,
     placement_hint_t hint,
     reclaim_gen_t gen
   ) {

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -36,8 +36,7 @@ CircularBoundedJournal::mkfs(const mkfs_config_t& config)
 {
   LOG_PREFIX(CircularBoundedJournal::mkfs);
   assert(device);
-  assert(static_cast<seastore_off_t>(config.block_size) ==
-    device->get_block_size());
+  assert(config.block_size == device->get_block_size());
   ceph::bufferlist bl;
   CircularBoundedJournal::cbj_header_t head;
   head.block_size = config.block_size;
@@ -168,7 +167,7 @@ CircularBoundedJournal::submit_record_ret CircularBoundedJournal::submit_record(
 
   auto write_result = write_result_t{
     j_seq,
-    (seastore_off_t)encoded_size
+    encoded_size
   };
   auto write_fut = device_write_bl(target, to_write);
   return handle.enter(write_pipeline->device_submission
@@ -320,7 +319,7 @@ Journal::replay_ret CircularBoundedJournal::replay(
 	  DEBUG("{} at {}", r_header, cursor_addr);
 	  auto write_result = write_result_t{
 	    r_header.committed_to,
-	    (seastore_off_t)bl.length()
+	    bl.length()
 	  };
 	  if (expected_seq == NULL_SEG_SEQ) {
 	    expected_seq = r_header.committed_to.segment_seq;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -291,7 +291,7 @@ public:
   device_id_t get_device_id() const {
     return header.device_id;
   }
-  size_t get_block_size() const {
+  extent_len_t get_block_size() const {
     return header.block_size;
   }
   rbm_abs_addr get_journal_end() const {

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -174,7 +174,7 @@ SegmentAllocator::write(ceph::bufferlist&& to_write)
 
   auto write_result = write_result_t{
     write_start_seq,
-    static_cast<seastore_off_t>(write_length)
+    write_length
   };
   written_to += write_length;
   segment_provider.update_segment_avail_bytes(
@@ -331,7 +331,7 @@ RecordBatch::encode_batch(
   submitting_mdlength = gsize.get_mdlength();
   auto bl = encode_records(pending, committed_to, segment_nonce);
   // Note: pending is cleared here
-  assert(bl.length() == (std::size_t)submitting_length);
+  assert(bl.length() == submitting_length);
   return std::make_pair(bl, gsize);
 }
 

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -69,7 +69,7 @@ class SegmentAllocator {
     return current_segment_nonce;
   }
 
-  seastore_off_t get_written_to() const {
+  segment_off_t get_written_to() const {
     assert(can_write());
     return written_to;
   }
@@ -126,7 +126,7 @@ class SegmentAllocator {
   SegmentProvider &segment_provider;
   SegmentManagerGroup &sm_group;
   SegmentRef current_segment;
-  seastore_off_t written_to;
+  segment_off_t written_to;
   SegmentSeqAllocator &segment_seq_allocator;
   segment_nonce_t current_segment_nonce;
   JournalTrimmer *trimmer;

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -45,7 +45,7 @@ class SegmentAllocator {
     return segment_provider;
   }
 
-  seastore_off_t get_block_size() const {
+  extent_len_t get_block_size() const {
     return sm_group.get_block_size();
   }
 
@@ -265,12 +265,12 @@ private:
 
   record_group_t pending;
   std::size_t submitting_size = 0;
-  seastore_off_t submitting_length = 0;
-  seastore_off_t submitting_mdlength = 0;
+  extent_len_t submitting_length = 0;
+  extent_len_t submitting_mdlength = 0;
 
   struct promise_result_t {
     write_result_t write_result;
-    seastore_off_t mdlength;
+    extent_len_t mdlength;
   };
   using maybe_promise_result_t = std::optional<promise_result_t>;
   std::optional<seastar::shared_promise<maybe_promise_result_t> > io_promise;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -197,7 +197,7 @@ public:
     extent_types_t type,
     paddr_t addr,
     laddr_t laddr,
-    seastore_off_t len) = 0;
+    extent_len_t len) = 0;
 
   virtual void add_pin(LBAPin &pin) = 0;
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -435,7 +435,7 @@ BtreeLBAManager::get_physical_extent_if_live(
   extent_types_t type,
   paddr_t addr,
   laddr_t laddr,
-  seastore_off_t len)
+  extent_len_t len)
 {
   LOG_PREFIX(BtreeLBAManager::get_physical_extent_if_live);
   DEBUGT("{}, laddr={}, paddr={}, length={}",

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -136,7 +136,7 @@ public:
     extent_types_t type,
     paddr_t addr,
     laddr_t laddr,
-    seastore_off_t len) final;
+    extent_len_t len) final;
 
   void add_pin(LBAPin &pin) final {
     auto *bpin = reinterpret_cast<BtreeLBAPin*>(&pin);

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -92,7 +92,7 @@ public:
   virtual write_ertr::future<> complete_allocation(Transaction &t) = 0;
 
   virtual size_t get_size() const = 0;
-  virtual size_t get_block_size() const = 0;
+  virtual extent_len_t get_block_size() const = 0;
   virtual uint64_t get_free_blocks() const = 0;
   virtual device_id_t get_device_id() const = 0;
   virtual ~RandomBlockManager() {}

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -103,7 +103,7 @@ using rbm_abs_addr = uint64_t;
 
 inline rbm_abs_addr convert_paddr_to_abs_addr(const paddr_t& paddr) {
   const blk_paddr_t& blk_addr = paddr.as_blk_paddr();
-  return blk_addr.get_block_off();
+  return blk_addr.get_device_off();
 }
 
 inline paddr_t convert_abs_addr_to_paddr(rbm_abs_addr addr, device_id_t d_id) {

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -221,7 +221,7 @@ public:
   write_ertr::future<> write_rbm_header();
 
   size_t get_size() const final { return super.size; };
-  size_t get_block_size() const final { return super.block_size; }
+  extent_len_t get_block_size() const final { return super.block_size; }
 
   // max block number a block can represent using bitmap
   uint64_t max_block_by_bitmap_block() {

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -119,8 +119,8 @@ public:
   secondary_device_set_t& get_secondary_devices() final {
     return devices;
   }
-  std::size_t get_available_size() const { return size; }
-  seastore_off_t get_block_size() const { return block_size; }
+  std::size_t get_available_size() const final { return size; }
+  extent_len_t get_block_size() const final { return block_size; }
 
   virtual read_ertr::future<> read(
     uint64_t offset,

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -33,7 +33,7 @@ namespace crimson::os::seastore {
  * mutation which changes the journal trim bound.
  */
 struct RootBlock : CachedExtent {
-  constexpr static seastore_off_t SIZE = 4<<10;
+  constexpr static extent_len_t SIZE = 4<<10;
   using Ref = TCachedExtentRef<RootBlock>;
 
   root_t root;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -66,15 +66,6 @@ std::ostream &operator<<(std::ostream &out, const segment_id_t &segment)
   }
 }
 
-std::ostream &operator<<(std::ostream &out, const seastore_off_printer_t &off)
-{
-  if (off.off == NULL_SEG_OFF) {
-    return out << "NULL_OFF";
-  } else {
-    return out << off.off;
-  }
-}
-
 std::ostream& operator<<(std::ostream& out, segment_type_t t)
 {
   switch(t) {
@@ -147,7 +138,6 @@ journal_seq_t journal_seq_t::add_offset(
   } else {
     assert(type == journal_type_t::RANDOM_BLOCK);
     auto boff = offset.as_blk_paddr().get_device_off();
-    assert(boff <= MAX_SEG_OFF);
     joff = boff;
   }
   auto roll_end = roll_start + roll_size;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -117,7 +117,7 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
     auto &s = rhs.as_seg_paddr();
     out << s.get_segment_id()
         << ","
-        << seastore_off_printer_t{s.get_segment_off()};
+        << s.get_segment_off();
   } else if (rhs.get_addr_type() == paddr_types_t::RANDOM_BLOCK) {
     auto &s = rhs.as_blk_paddr();
     out << device_id_printer_t{s.get_device_id()}

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1204,7 +1204,7 @@ struct delta_info_t {
   laddr_t laddr = L_ADDR_NULL;                 ///< logical address
   uint32_t prev_crc = 0;
   uint32_t final_crc = 0;
-  seastore_off_t length = NULL_SEG_OFF;         ///< extent length
+  extent_len_t length = NULL_SEG_OFF;          ///< extent length
   extent_version_t pversion;                   ///< prior version
   segment_seq_t ext_seq;		       ///< seq of the extent's segment
   segment_type_t seg_type;
@@ -1482,7 +1482,7 @@ class __attribute__((packed)) coll_root_le_t {
 public:
   coll_root_le_t() = default;
   
-  coll_root_le_t(laddr_t laddr, seastore_off_t size)
+  coll_root_le_t(laddr_t laddr, extent_len_t size)
     : addr(laddr), size(init_extent_len_le(size)) {}
 
 
@@ -1971,7 +1971,7 @@ try_decode_deltas(
 
 struct write_result_t {
   journal_seq_t start_seq;
-  seastore_off_t length;
+  extent_len_t length;
 
   journal_seq_t get_end_seq() const {
     return journal_seq_t{

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -454,6 +454,19 @@ using internal_paddr_t = uint64_t;
 constexpr auto PADDR_BITS = std::numeric_limits<internal_paddr_t>::digits;
 static_assert(PADDR_BITS == SEGMENT_ID_BITS + SEGMENT_OFF_BITS);
 
+/**
+ * device_off_t
+ *
+ * Offset within a device, may be negative for relative offsets.
+ *
+ * TODO: replace block_off_t
+ */
+using device_off_t = int64_t;
+constexpr auto DEVICE_OFF_BITS = PADDR_BITS - DEVICE_ID_BITS;
+constexpr auto DEVICE_OFF_MAX =
+    std::numeric_limits<device_off_t>::max() >> DEVICE_ID_BITS;
+constexpr auto DEVICE_OFF_MIN = -(DEVICE_OFF_MAX + 1);
+
 using block_off_t = internal_paddr_t;
 constexpr auto BLOCK_OFF_BITS = PADDR_BITS - DEVICE_ID_BITS;
 constexpr auto BLOCK_OFF_MAX =
@@ -909,11 +922,11 @@ struct journal_seq_t {
   // produces a pseudo journal_seq_t relative to this by offset
   journal_seq_t add_offset(
       journal_type_t type,
-      seastore_off_t off,
+      device_off_t off,
       seastore_off_t roll_start,
       seastore_off_t roll_size) const;
 
-  seastore_off_t relative_to(
+  device_off_t relative_to(
       journal_type_t type,
       const journal_seq_t& r,
       seastore_off_t roll_start,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -92,7 +92,7 @@ constexpr paddr_types_t device_id_to_paddr_type(device_id_t id) {
   }
 }
 
-constexpr bool has_seastore_off(device_id_t id) {
+constexpr bool has_device_off(device_id_t id) {
   return id == DEVICE_ID_RECORD_RELATIVE ||
          id == DEVICE_ID_BLOCK_RELATIVE ||
          id == DEVICE_ID_DELAYED ||
@@ -462,6 +462,7 @@ static_assert(PADDR_BITS == SEGMENT_ID_BITS + SEGMENT_OFF_BITS);
  * TODO: replace block_off_t
  */
 using device_off_t = int64_t;
+using u_device_off_t = uint64_t;
 constexpr auto DEVICE_OFF_BITS = PADDR_BITS - DEVICE_ID_BITS;
 constexpr auto DEVICE_OFF_MAX =
     std::numeric_limits<device_off_t>::max() >> DEVICE_ID_BITS;
@@ -483,14 +484,26 @@ using segment_off_t = int32_t;
 using u_segment_off_t = uint32_t;
 
 constexpr auto DEVICE_ID_MASK =
-  ((internal_paddr_t(1) << DEVICE_ID_BITS) - 1) << BLOCK_OFF_BITS;
-constexpr auto BLOCK_OFF_MASK =
-  static_cast<internal_paddr_t>(BLOCK_OFF_MAX);
+  ((internal_paddr_t(1) << DEVICE_ID_BITS) - 1) << DEVICE_OFF_BITS;
+constexpr auto DEVICE_OFF_MASK =
+  std::numeric_limits<u_device_off_t>::max() >> DEVICE_ID_BITS;
 constexpr auto SEGMENT_ID_MASK =
   ((internal_paddr_t(1) << SEGMENT_ID_BITS) - 1) << SEGMENT_OFF_BITS;
 constexpr auto SEGMENT_OFF_MASK =
   (internal_paddr_t(1) << SEGMENT_OFF_BITS) - 1;
 constexpr auto SEASTORE_OFF_MASK = SEGMENT_OFF_MASK;
+
+constexpr internal_paddr_t encode_device_off(device_off_t off) {
+  return static_cast<internal_paddr_t>(off) & DEVICE_OFF_MASK;
+}
+
+constexpr device_off_t decode_device_off(internal_paddr_t addr) {
+  if (addr & (1ull << (DEVICE_OFF_BITS - 1))) {
+    return static_cast<device_off_t>(addr | DEVICE_ID_MASK);
+  } else {
+    return static_cast<device_off_t>(addr & DEVICE_OFF_MASK);
+  }
+}
 
 struct seg_paddr_t;
 struct blk_paddr_t;
@@ -498,7 +511,7 @@ struct res_paddr_t;
 struct paddr_t {
 public:
   // P_ADDR_MAX == P_ADDR_NULL == paddr_t{}
-  paddr_t() : paddr_t(DEVICE_ID_MAX, seastore_off_t(0)) {}
+  paddr_t() : paddr_t(DEVICE_ID_MAX, device_off_t(0)) {}
 
   static paddr_t make_seg_paddr(
     segment_id_t seg,
@@ -515,13 +528,15 @@ public:
 
   static paddr_t make_blk_paddr(
     device_id_t device,
-    block_off_t offset) {
+    device_off_t offset) {
+    assert(device_id_to_paddr_type(device) == paddr_types_t::RANDOM_BLOCK);
     return paddr_t(device, offset);
   }
 
   static paddr_t make_res_paddr(
     device_id_t device,
-    seastore_off_t offset) {
+    device_off_t offset) {
+    assert(device_id_to_paddr_type(device) == paddr_types_t::RESERVED);
     return paddr_t(device, offset);
   }
 
@@ -530,14 +545,14 @@ public:
   }
 
   device_id_t get_device_id() const {
-    return static_cast<device_id_t>(internal_paddr >> BLOCK_OFF_BITS);
+    return static_cast<device_id_t>(internal_paddr >> DEVICE_OFF_BITS);
   }
 
   paddr_types_t get_addr_type() const {
     return device_id_to_paddr_type(get_device_id());
   }
 
-  paddr_t add_offset(seastore_off_t o) const;
+  paddr_t add_offset(device_off_t o) const;
 
   paddr_t add_relative(paddr_t o) const;
 
@@ -579,7 +594,7 @@ public:
   paddr_t block_relative_to(paddr_t rhs) const;
 
   // To be compatible with laddr_t operator+
-  paddr_t operator+(seastore_off_t o) const {
+  paddr_t operator+(device_off_t o) const {
     return add_offset(o);
   }
 
@@ -627,7 +642,7 @@ public:
   }
 
   bool is_absolute() const {
-    return device_id_to_paddr_type(get_device_id()) != paddr_types_t::RESERVED;
+    return get_addr_type() != paddr_types_t::RESERVED;
   }
 
   auto operator<=>(const paddr_t &) const = default;
@@ -639,8 +654,8 @@ public:
   }
 
   constexpr static paddr_t create_const(
-      device_id_t d_id, device_segment_id_t s_id, seastore_off_t offset) {
-    return paddr_t(d_id, s_id, offset);
+      device_id_t d_id, device_off_t offset) {
+    return paddr_t(d_id, offset, const_construct_t());
   }
 
 protected:
@@ -652,27 +667,21 @@ private:
     : paddr_t((static_cast<internal_paddr_t>(seg.segment) << SEGMENT_OFF_BITS) |
               static_cast<u_segment_off_t>(offset)) {}
 
-  // as blk
-  paddr_t(device_id_t d_id, block_off_t offset)
-    : paddr_t((static_cast<internal_paddr_t>(d_id) << BLOCK_OFF_BITS) |
-              (offset & BLOCK_OFF_MASK)) {
-    assert(device_id_to_paddr_type(get_device_id()) == paddr_types_t::RANDOM_BLOCK);
-    assert(offset <= BLOCK_OFF_MAX);
-  }
-
-  // as res
-  paddr_t(device_id_t d_id, seastore_off_t offset)
-    : paddr_t((static_cast<internal_paddr_t>(d_id) << BLOCK_OFF_BITS) |
-              static_cast<u_seastore_off_t>(offset)) {
-    assert(device_id_to_paddr_type(get_device_id()) == paddr_types_t::RESERVED);
+  // as blk or res
+  paddr_t(device_id_t d_id, device_off_t offset)
+    : paddr_t((static_cast<internal_paddr_t>(d_id) << DEVICE_OFF_BITS) |
+              encode_device_off(offset)) {
+    assert(offset >= DEVICE_OFF_MIN);
+    assert(offset <= DEVICE_OFF_MAX);
+    assert(get_addr_type() != paddr_types_t::SEGMENT);
   }
 
   paddr_t(internal_paddr_t val);
 
-  constexpr paddr_t(device_id_t d_id, device_segment_id_t s_id, seastore_off_t offset)
+  struct const_construct_t {};
+  constexpr paddr_t(device_id_t d_id, device_off_t offset, const_construct_t)
     : internal_paddr((static_cast<internal_paddr_t>(d_id) << BLOCK_OFF_BITS) |
-                     (static_cast<internal_paddr_t>(s_id) << SEGMENT_OFF_BITS) |
-                     static_cast<u_seastore_off_t>(offset)) {}
+                     static_cast<u_device_off_t>(offset)) {}
 
   friend struct paddr_le_t;
 };
@@ -700,7 +709,7 @@ struct seg_paddr_t : public paddr_t {
     internal_paddr |= static_cast<u_segment_off_t>(off);
   }
 
-  paddr_t add_offset(seastore_off_t o) const {
+  paddr_t add_offset(device_off_t o) const {
     device_off_t off = get_segment_off() + o;
     assert(off >= 0);
     assert(off <= MAX_SEG_OFF);
@@ -715,19 +724,21 @@ struct blk_paddr_t : public paddr_t {
   blk_paddr_t& operator=(const blk_paddr_t&) = delete;
   blk_paddr_t& operator=(blk_paddr_t&) = delete;
 
-  block_off_t get_block_off() const {
-    return block_off_t(internal_paddr & BLOCK_OFF_MASK);
+  device_off_t get_device_off() const {
+    return decode_device_off(internal_paddr);
   }
 
-  void set_block_off(block_off_t off) {
-    assert(off <= BLOCK_OFF_MAX);
+  void set_device_off(device_off_t off) {
+    assert(off >= 0);
+    assert(off <= DEVICE_OFF_MAX);
     internal_paddr = (internal_paddr & DEVICE_ID_MASK);
-    internal_paddr |= (off & BLOCK_OFF_MASK);
+    internal_paddr |= encode_device_off(off);
   }
 
-  paddr_t add_offset(seastore_off_t o) const {
-    auto off = get_block_off() + o;
-    assert(o >= 0 ? off >= get_block_off() : off < get_block_off());
+  paddr_t add_offset(device_off_t o) const {
+    assert(o >= DEVICE_OFF_MIN);
+    assert(o <= DEVICE_OFF_MAX);
+    auto off = get_device_off() + o;
     return paddr_t::make_blk_paddr(get_device_id(), off);
   }
 };
@@ -738,49 +749,50 @@ struct res_paddr_t : public paddr_t {
   res_paddr_t& operator=(const res_paddr_t&) = delete;
   res_paddr_t& operator=(res_paddr_t&) = delete;
 
-  seastore_off_t get_seastore_off() const {
-    return seastore_off_t(internal_paddr & SEASTORE_OFF_MASK);
+  device_off_t get_device_off() const {
+    return decode_device_off(internal_paddr);
   }
 
-  void set_seastore_off(seastore_off_t off) {
-    assert(has_seastore_off(get_device_id()));
+  void set_device_off(device_off_t off) {
+    assert(has_device_off(get_device_id()));
+    assert(off >= DEVICE_OFF_MIN);
+    assert(off <= DEVICE_OFF_MAX);
     internal_paddr = (internal_paddr & DEVICE_ID_MASK);
-    internal_paddr |= static_cast<u_seastore_off_t>(off);
+    internal_paddr |= encode_device_off(off);
   }
 
-  paddr_t add_offset(seastore_off_t o) const {
-    assert(has_seastore_off(get_device_id()));
-    auto off = get_seastore_off() + o;
-    assert(o >= 0 ? off >= get_seastore_off() : off < get_seastore_off());
+  paddr_t add_offset(device_off_t o) const {
+    assert(has_device_off(get_device_id()));
+    assert(o >= DEVICE_OFF_MIN);
+    assert(o <= DEVICE_OFF_MAX);
+    auto off = get_device_off() + o;
     return paddr_t::make_res_paddr(get_device_id(), off);
   }
 
   paddr_t block_relative_to(const res_paddr_t &rhs) const {
     assert(rhs.is_record_relative() && is_record_relative());
-    auto off = get_seastore_off() - rhs.get_seastore_off();
-    assert(rhs.get_seastore_off() >= 0 ?
-           off <= get_seastore_off() : off > get_seastore_off());
+    auto off = get_device_off() - rhs.get_device_off();
     return paddr_t::make_res_paddr(DEVICE_ID_BLOCK_RELATIVE, off);
   }
 };
 
-constexpr paddr_t P_ADDR_MIN = paddr_t::create_const(0, 0, 0);
+constexpr paddr_t P_ADDR_MIN = paddr_t::create_const(0, 0);
 // P_ADDR_MAX == P_ADDR_NULL == paddr_t{}
-constexpr paddr_t P_ADDR_MAX = paddr_t::create_const(DEVICE_ID_MAX, 0, 0);
+constexpr paddr_t P_ADDR_MAX = paddr_t::create_const(DEVICE_ID_MAX, 0);
 constexpr paddr_t P_ADDR_NULL = P_ADDR_MAX;
-constexpr paddr_t P_ADDR_ZERO = paddr_t::create_const(DEVICE_ID_ZERO, 0, 0);
-constexpr paddr_t P_ADDR_ROOT = paddr_t::create_const(DEVICE_ID_ROOT, 0, 0);
+constexpr paddr_t P_ADDR_ZERO = paddr_t::create_const(DEVICE_ID_ZERO, 0);
+constexpr paddr_t P_ADDR_ROOT = paddr_t::create_const(DEVICE_ID_ROOT, 0);
 
-inline paddr_t make_record_relative_paddr(seastore_off_t off) {
+inline paddr_t make_record_relative_paddr(device_off_t off) {
   return paddr_t::make_res_paddr(DEVICE_ID_RECORD_RELATIVE, off);
 }
-inline paddr_t make_block_relative_paddr(seastore_off_t off) {
+inline paddr_t make_block_relative_paddr(device_off_t off) {
   return paddr_t::make_res_paddr(DEVICE_ID_BLOCK_RELATIVE, off);
 }
-inline paddr_t make_fake_paddr(seastore_off_t off) {
+inline paddr_t make_fake_paddr(device_off_t off) {
   return paddr_t::make_res_paddr(DEVICE_ID_FAKE, off);
 }
-inline paddr_t make_delayed_temp_paddr(seastore_off_t off) {
+inline paddr_t make_delayed_temp_paddr(device_off_t off) {
   return paddr_t::make_res_paddr(DEVICE_ID_DELAYED, off);
 }
 
@@ -816,15 +828,15 @@ inline res_paddr_t& paddr_t::as_res_paddr() {
 
 inline paddr_t::paddr_t(internal_paddr_t val) : internal_paddr(val) {
 #ifndef NDEBUG
-  auto type = device_id_to_paddr_type(get_device_id());
+  auto type = get_addr_type();
   if (type == paddr_types_t::SEGMENT) {
     assert(as_seg_paddr().get_segment_off() >= 0);
   } else if (type == paddr_types_t::RANDOM_BLOCK) {
-    // nothing to check
+    assert(as_blk_paddr().get_device_off() >= 0);
   } else {
     assert(type == paddr_types_t::RESERVED);
-    if (!has_seastore_off(get_device_id())) {
-      assert((internal_paddr & SEASTORE_OFF_MASK) == 0);
+    if (!has_device_off(get_device_id())) {
+      assert(as_res_paddr().get_device_off() == 0);
     }
   }
 #endif
@@ -835,7 +847,7 @@ inline paddr_t::paddr_t(internal_paddr_t val) : internal_paddr(val) {
     return static_cast<const base*>(this)->func;   \
   }
 
-inline paddr_t paddr_t::add_offset(seastore_off_t o) const {
+inline paddr_t paddr_t::add_offset(device_off_t o) const {
   PADDR_OPERATION(paddr_types_t::SEGMENT, seg_paddr_t, add_offset(o))
   PADDR_OPERATION(paddr_types_t::RANDOM_BLOCK, blk_paddr_t, add_offset(o))
   PADDR_OPERATION(paddr_types_t::RESERVED, res_paddr_t, add_offset(o))
@@ -846,7 +858,7 @@ inline paddr_t paddr_t::add_offset(seastore_off_t o) const {
 inline paddr_t paddr_t::add_relative(paddr_t o) const {
   assert(o.is_relative());
   auto &res_o = o.as_res_paddr();
-  return add_offset(res_o.get_seastore_off());
+  return add_offset(res_o.get_device_off());
 }
 
 inline paddr_t paddr_t::block_relative_to(paddr_t rhs) const {
@@ -935,14 +947,14 @@ struct journal_seq_t {
   journal_seq_t add_offset(
       journal_type_t type,
       device_off_t off,
-      seastore_off_t roll_start,
-      seastore_off_t roll_size) const;
+      device_off_t roll_start,
+      device_off_t roll_size) const;
 
   device_off_t relative_to(
       journal_type_t type,
       const journal_seq_t& r,
-      seastore_off_t roll_start,
-      seastore_off_t roll_size) const;
+      device_off_t roll_start,
+      device_off_t roll_size) const;
 
   DENC(journal_seq_t, v, p) {
     DENC_START(1, 1, p);
@@ -965,17 +977,17 @@ private:
     } else if (segment_seq < other.segment_seq) {
       return -1;
     }
-    using ret_t = std::pair<int64_t, segment_id_t>;
+    using ret_t = std::pair<device_off_t, segment_id_t>;
     auto to_pair = [](const paddr_t &addr) -> ret_t {
       if (addr.get_addr_type() == paddr_types_t::SEGMENT) {
 	auto &seg_addr = addr.as_seg_paddr();
 	return ret_t(seg_addr.get_segment_off(), seg_addr.get_segment_id());
       } else if (addr.get_addr_type() == paddr_types_t::RANDOM_BLOCK) {
 	auto &blk_addr = addr.as_blk_paddr();
-	return ret_t(blk_addr.get_block_off(), MAX_SEG_ID);
+	return ret_t(blk_addr.get_device_off(), MAX_SEG_ID);
       } else if (addr.get_addr_type() == paddr_types_t::RESERVED) {
         auto &res_addr = addr.as_res_paddr();
-        return ret_t(res_addr.get_seastore_off(), MAX_SEG_ID);
+        return ret_t(res_addr.get_device_off(), MAX_SEG_ID);
       } else {
 	assert(0 == "impossible");
 	return ret_t(0, MAX_SEG_ID);

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -47,7 +47,7 @@ struct block_sm_superblock_t {
     ceph_assert(block_size > 0);
     ceph_assert(segment_size > 0 &&
                 segment_size % block_size == 0);
-    ceph_assert_always(segment_size <= MAX_SEG_OFF);
+    ceph_assert_always(segment_size <= SEGMENT_OFF_MAX);
     ceph_assert(size > segment_size &&
                 size % block_size == 0);
     ceph_assert_always(size <= DEVICE_OFF_MAX);

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -47,9 +47,12 @@ struct block_sm_superblock_t {
     ceph_assert(block_size > 0);
     ceph_assert(segment_size > 0 &&
                 segment_size % block_size == 0);
+    ceph_assert_always(segment_size <= MAX_SEG_OFF);
     ceph_assert(size > segment_size &&
                 size % block_size == 0);
+    ceph_assert_always(size <= DEVICE_OFF_MAX);
     ceph_assert(segments > 0);
+    ceph_assert_always(segments <= DEVICE_SEGMENT_ID_MAX);
     ceph_assert(tracker_offset > 0 &&
                 tracker_offset % block_size == 0);
     ceph_assert(first_segment_offset > tracker_offset &&

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -95,12 +95,12 @@ public:
   /**
    * min next write location
    */
-  virtual seastore_off_t get_write_ptr() const = 0;
+  virtual segment_off_t get_write_ptr() const = 0;
 
   /**
    * max capacity
    */
-  virtual seastore_off_t get_write_capacity() const = 0;
+  virtual segment_off_t get_write_capacity() const = 0;
 
   /**
    * close
@@ -129,7 +129,7 @@ public:
     crimson::ct_error::enospc              // write exceeds segment size
     >;
   virtual write_ertr::future<> write(
-    seastore_off_t offset, ceph::bufferlist bl) = 0;
+    segment_off_t offset, ceph::bufferlist bl) = 0;
 
   /**
    * advance_wp
@@ -139,7 +139,7 @@ public:
    * @param offset: advance write pointer till the given offset
    */
   virtual write_ertr::future<> advance_wp(
-    seastore_off_t offset) = 0;
+    segment_off_t offset) = 0;
 
   virtual ~Segment() {}
 };
@@ -175,7 +175,7 @@ public:
   virtual release_ertr::future<> release(segment_id_t id) = 0;
 
   /* Methods for discovering device geometry, segmentid set, etc */
-  virtual seastore_off_t get_segment_size() const = 0;
+  virtual segment_off_t get_segment_size() const = 0;
   virtual device_segment_id_t get_num_segments() const {
     ceph_assert(get_available_size() % get_segment_size() == 0);
     return ((device_segment_id_t)(get_available_size() / get_segment_size()));

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -386,7 +386,7 @@ BlockSegment::BlockSegment(
   BlockSegmentManager &manager, segment_id_t id)
   : manager(manager), id(id) {}
 
-seastore_off_t BlockSegment::get_write_capacity() const
+segment_off_t BlockSegment::get_write_capacity() const
 {
   return manager.get_segment_size();
 }
@@ -397,7 +397,7 @@ Segment::close_ertr::future<> BlockSegment::close()
 }
 
 Segment::write_ertr::future<> BlockSegment::write(
-  seastore_off_t offset, ceph::bufferlist bl)
+  segment_off_t offset, ceph::bufferlist bl)
 {
   LOG_PREFIX(BlockSegment::write);
   auto paddr = paddr_t::make_seg_paddr(id, offset);
@@ -424,12 +424,12 @@ Segment::write_ertr::future<> BlockSegment::write(
 }
 
 Segment::write_ertr::future<> BlockSegment::advance_wp(
-  seastore_off_t offset) {
+  segment_off_t offset) {
   return write_ertr::now();
 }
 
 Segment::close_ertr::future<> BlockSegmentManager::segment_close(
-    segment_id_t id, seastore_off_t write_pointer)
+    segment_id_t id, segment_off_t write_pointer)
 {
   LOG_PREFIX(BlockSegmentManager::segment_close);
   auto s_id = id.device_segment_id();

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -88,16 +88,16 @@ class BlockSegment final : public Segment {
   friend class BlockSegmentManager;
   BlockSegmentManager &manager;
   const segment_id_t id;
-  seastore_off_t write_pointer = 0;
+  segment_off_t write_pointer = 0;
 public:
   BlockSegment(BlockSegmentManager &manager, segment_id_t id);
 
   segment_id_t get_segment_id() const final { return id; }
-  seastore_off_t get_write_capacity() const final;
-  seastore_off_t get_write_ptr() const final { return write_pointer; }
+  segment_off_t get_write_capacity() const final;
+  segment_off_t get_write_ptr() const final { return write_pointer; }
   close_ertr::future<> close() final;
-  write_ertr::future<> write(seastore_off_t offset, ceph::bufferlist bl) final;
-  write_ertr::future<> advance_wp(seastore_off_t offset) final;
+  write_ertr::future<> write(segment_off_t offset, ceph::bufferlist bl) final;
+  write_ertr::future<> advance_wp(segment_off_t offset) final;
 
   ~BlockSegment() {}
 };
@@ -138,7 +138,7 @@ public:
   extent_len_t get_block_size() const {
     return superblock.block_size;
   }
-  seastore_off_t get_segment_size() const {
+  segment_off_t get_segment_size() const {
     return superblock.segment_size;
   }
 
@@ -225,7 +225,7 @@ private:
   char *buffer = nullptr;
 
   Segment::close_ertr::future<> segment_close(
-      segment_id_t id, seastore_off_t write_pointer);
+      segment_id_t id, segment_off_t write_pointer);
 };
 
 }

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -135,7 +135,7 @@ public:
   size_t get_available_size() const final {
     return superblock.size;
   }
-  seastore_off_t get_block_size() const {
+  extent_len_t get_block_size() const {
     return superblock.block_size;
   }
   seastore_off_t get_segment_size() const {

--- a/src/crimson/os/seastore/segment_manager/ephemeral.cc
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.cc
@@ -63,7 +63,7 @@ EphemeralSegment::EphemeralSegment(
   EphemeralSegmentManager &manager, segment_id_t id)
   : manager(manager), id(id) {}
 
-seastore_off_t EphemeralSegment::get_write_capacity() const
+segment_off_t EphemeralSegment::get_write_capacity() const
 {
   return manager.get_segment_size();
 }
@@ -76,7 +76,7 @@ Segment::close_ertr::future<> EphemeralSegment::close()
 }
 
 Segment::write_ertr::future<> EphemeralSegment::write(
-  seastore_off_t offset, ceph::bufferlist bl)
+  segment_off_t offset, ceph::bufferlist bl)
 {
   if (offset < write_pointer || offset % manager.config.block_size != 0)
     return crimson::ct_error::invarg::make();
@@ -88,7 +88,7 @@ Segment::write_ertr::future<> EphemeralSegment::write(
 }
 
 Segment::write_ertr::future<> EphemeralSegment::advance_wp(
-  seastore_off_t offset)
+  segment_off_t offset)
 {
   return write_ertr::now();
 }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -25,7 +25,7 @@ struct ephemeral_config_t {
     ceph_assert_always(size > 0);
     ceph_assert_always(size <= DEVICE_OFF_MAX);
     ceph_assert_always(segment_size > 0);
-    ceph_assert_always(segment_size <= MAX_SEG_OFF);
+    ceph_assert_always(segment_size <= SEGMENT_OFF_MAX);
     ceph_assert_always(size / segment_size > 0);
     ceph_assert_always(size / segment_size <= DEVICE_SEGMENT_ID_MAX);
   }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -117,7 +117,7 @@ public:
   size_t get_available_size() const final {
     return config.size;
   }
-  seastore_off_t get_block_size() const final {
+  extent_len_t get_block_size() const final {
     return config.block_size;
   }
   seastore_off_t get_segment_size() const final {

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -20,6 +20,15 @@ struct ephemeral_config_t {
   size_t size = 0;
   size_t block_size = 0;
   size_t segment_size = 0;
+
+  void validate() const {
+    ceph_assert_always(size > 0);
+    ceph_assert_always(size <= DEVICE_OFF_MAX);
+    ceph_assert_always(segment_size > 0);
+    ceph_assert_always(segment_size <= MAX_SEG_OFF);
+    ceph_assert_always(size / segment_size > 0);
+    ceph_assert_always(size / segment_size <= DEVICE_SEGMENT_ID_MAX);
+  }
 };
 
 constexpr ephemeral_config_t DEFAULT_TEST_EPHEMERAL = {
@@ -75,7 +84,10 @@ class EphemeralSegmentManager final : public SegmentManager {
 public:
   EphemeralSegmentManager(
     ephemeral_config_t config)
-    : config(config) {}
+    : config(config) {
+    config.validate();
+  }
+
   ~EphemeralSegmentManager();
 
   close_ertr::future<> close() final {

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -48,16 +48,16 @@ class EphemeralSegment final : public Segment {
   friend class EphemeralSegmentManager;
   EphemeralSegmentManager &manager;
   const segment_id_t id;
-  seastore_off_t write_pointer = 0;
+  segment_off_t write_pointer = 0;
 public:
   EphemeralSegment(EphemeralSegmentManager &manager, segment_id_t id);
 
   segment_id_t get_segment_id() const final { return id; }
-  seastore_off_t get_write_capacity() const final;
-  seastore_off_t get_write_ptr() const final { return write_pointer; }
+  segment_off_t get_write_capacity() const final;
+  segment_off_t get_write_ptr() const final { return write_pointer; }
   close_ertr::future<> close() final;
-  write_ertr::future<> write(seastore_off_t offset, ceph::bufferlist bl) final;
-  write_ertr::future<> advance_wp(seastore_off_t offset) final;
+  write_ertr::future<> write(segment_off_t offset, ceph::bufferlist bl) final;
+  write_ertr::future<> advance_wp(segment_off_t offset) final;
 
   ~EphemeralSegment() {}
 };
@@ -120,7 +120,7 @@ public:
   extent_len_t get_block_size() const final {
     return config.block_size;
   }
-  seastore_off_t get_segment_size() const final {
+  segment_off_t get_segment_size() const final {
     return config.segment_size;
   }
 

--- a/src/crimson/os/seastore/segment_manager/zns.cc
+++ b/src/crimson/os/seastore/segment_manager/zns.cc
@@ -92,6 +92,7 @@ static zns_sm_metadata_t make_metadata(
     zone_size,
     zone_size * RESERVED_ZONES,
     meta};
+  ret.validate();
   return ret;
 }
 
@@ -298,6 +299,7 @@ read_metadata(seastar::file &device, seastar::stat_data sd)
 	zns_sm_metadata_t ret;
 	auto bliter = bl.cbegin();
 	decode(ret, bliter);
+        ret.validate();
 	return ZNSSegmentManager::access_ertr::future<zns_sm_metadata_t>(
 	  ZNSSegmentManager::access_ertr::ready_future_marker{},
 	  ret);

--- a/src/crimson/os/seastore/segment_manager/zns.cc
+++ b/src/crimson/os/seastore/segment_manager/zns.cc
@@ -573,7 +573,7 @@ SegmentManager::read_ertr::future<> ZNSSegmentManager::read(
 }
 
 Segment::close_ertr::future<> ZNSSegmentManager::segment_close(
-  segment_id_t id, seastore_off_t write_pointer)
+  segment_id_t id, segment_off_t write_pointer)
 {
   LOG_PREFIX(ZNSSegmentManager::segment_close);
   return seastar::do_with(
@@ -631,7 +631,7 @@ magic_t ZNSSegmentManager::get_magic() const
   return metadata.magic;
 };
 
-seastore_off_t ZNSSegment::get_write_capacity() const
+segment_off_t ZNSSegment::get_write_capacity() const
 {
   return manager.get_segment_size();
 }
@@ -650,7 +650,7 @@ Segment::close_ertr::future<> ZNSSegment::close()
 }
 
 Segment::write_ertr::future<> ZNSSegment::write(
-  seastore_off_t offset, ceph::bufferlist bl)
+  segment_off_t offset, ceph::bufferlist bl)
 {
   LOG_PREFIX(ZNSSegment::write);
   if (offset != write_pointer || offset % manager.metadata.block_size != 0) {
@@ -699,7 +699,7 @@ Segment::write_ertr::future<> ZNSSegment::write_padding_bytes(
 
 // Advance write pointer, to given offset.
 Segment::write_ertr::future<> ZNSSegment::advance_wp(
-  seastore_off_t offset)
+  segment_off_t offset)
 {
   LOG_PREFIX(ZNSSegment::advance_wp);
 

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -58,6 +58,15 @@ namespace crimson::os::seastore::segment_manager::zns {
       }
       DENC_FINISH(p);
     }
+
+    void validate() const {
+      ceph_assert_always(size > 0);
+      ceph_assert_always(size <= DEVICE_OFF_MAX);
+      ceph_assert_always(segment_capacity > 0);
+      ceph_assert_always(segment_capacity <= MAX_SEG_OFF);
+      ceph_assert_always(segments > 0);
+      ceph_assert_always(segments <= DEVICE_SEGMENT_ID_MAX);
+    }
   };
 
   using write_ertr = crimson::errorator<crimson::ct_error::input_output_error>;

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -63,7 +63,7 @@ namespace crimson::os::seastore::segment_manager::zns {
       ceph_assert_always(size > 0);
       ceph_assert_always(size <= DEVICE_OFF_MAX);
       ceph_assert_always(segment_capacity > 0);
-      ceph_assert_always(segment_capacity <= MAX_SEG_OFF);
+      ceph_assert_always(segment_capacity <= SEGMENT_OFF_MAX);
       ceph_assert_always(segments > 0);
       ceph_assert_always(segments <= DEVICE_SEGMENT_ID_MAX);
     }

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -112,7 +112,7 @@ namespace crimson::os::seastore::segment_manager::zns {
       return metadata.size;
     };
 
-    seastore_off_t get_block_size() const final {
+    extent_len_t get_block_size() const final {
       return metadata.block_size;
     };
 

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -79,18 +79,18 @@ namespace crimson::os::seastore::segment_manager::zns {
     ZNSSegment(ZNSSegmentManager &man, segment_id_t i) : manager(man), id(i){};
 
     segment_id_t get_segment_id() const final { return id; }
-    seastore_off_t get_write_capacity() const final;
-    seastore_off_t get_write_ptr() const final { return write_pointer; }
+    segment_off_t get_write_capacity() const final;
+    segment_off_t get_write_ptr() const final { return write_pointer; }
     close_ertr::future<> close() final;
-    write_ertr::future<> write(seastore_off_t offset, ceph::bufferlist bl) final;
-    write_ertr::future<> advance_wp(seastore_off_t offset) final;
+    write_ertr::future<> write(segment_off_t offset, ceph::bufferlist bl) final;
+    write_ertr::future<> advance_wp(segment_off_t offset) final;
 
     ~ZNSSegment() {}
   private:
     friend class ZNSSegmentManager;
     ZNSSegmentManager &manager;
     const segment_id_t id;
-    seastore_off_t write_pointer = 0;
+    segment_off_t write_pointer = 0;
     write_ertr::future<> write_padding_bytes(size_t padding_bytes);
   };
 
@@ -116,7 +116,7 @@ namespace crimson::os::seastore::segment_manager::zns {
       return metadata.block_size;
     };
 
-    seastore_off_t get_segment_size() const final {
+    segment_off_t get_segment_size() const final {
       return metadata.segment_capacity;
     };
 
@@ -173,7 +173,7 @@ namespace crimson::os::seastore::segment_manager::zns {
     seastar::metrics::metric_group metrics;
 
     Segment::close_ertr::future<> segment_close(
-      segment_id_t id, seastore_off_t write_pointer);
+      segment_id_t id, segment_off_t write_pointer);
 
     uint64_t get_offset(paddr_t addr) {
       auto& seg_addr = addr.as_seg_paddr();

--- a/src/crimson/os/seastore/segment_manager_group.cc
+++ b/src/crimson/os/seastore/segment_manager_group.cc
@@ -214,8 +214,7 @@ SegmentManagerGroup::read_validate_record_metadata(
   return segment_manager.read(start, block_size
   ).safe_then([=, &segment_manager](bufferptr bptr) mutable
               -> read_validate_record_metadata_ret {
-    auto block_size = static_cast<extent_len_t>(
-        segment_manager.get_block_size());
+    auto block_size = segment_manager.get_block_size();
     bufferlist bl;
     bl.append(bptr);
     auto maybe_header = try_decode_records_header(bl, nonce);
@@ -244,7 +243,7 @@ SegmentManagerGroup::read_validate_record_metadata(
 
     auto rest_start = paddr_t::make_seg_paddr(
         seg_addr.get_segment_id(),
-        seg_addr.get_segment_off() + (seastore_off_t)block_size
+        seg_addr.get_segment_off() + block_size
     );
     auto rest_len = header.mdlength - block_size;
     TRACE("reading record group header rest {}~{}", rest_start, rest_len);
@@ -307,7 +306,7 @@ SegmentManagerGroup::consume_next_records(
         cursor.seq.segment_seq,
         next.offset
       },
-      static_cast<seastore_off_t>(total_length)
+      total_length
     }
   };
   DEBUG("processing {} at {}, budget_used={}",

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -50,7 +50,7 @@ public:
    *
    * Assume all segment managers share the same following information.
    */
-  seastore_off_t get_block_size() const {
+  extent_len_t get_block_size() const {
     assert(device_ids.size());
     return segment_managers[*device_ids.begin()]->get_block_size();
   }

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -55,7 +55,7 @@ public:
     return segment_managers[*device_ids.begin()]->get_block_size();
   }
 
-  seastore_off_t get_segment_size() const {
+  segment_off_t get_segment_size() const {
     assert(device_ids.size());
     return segment_managers[*device_ids.begin()]->get_segment_size();
   }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -451,8 +451,8 @@ private:
 
   RootBlockRef root;        ///< ref to root if read or written by transaction
 
-  seastore_off_t offset = 0; ///< relative offset of next block
-  seastore_off_t delayed_temp_offset = 0;
+  device_off_t offset = 0; ///< relative offset of next block
+  device_off_t delayed_temp_offset = 0;
 
   /**
    * read_set

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -527,7 +527,7 @@ TransactionManager::get_extents_if_live(
   extent_types_t type,
   paddr_t paddr,
   laddr_t laddr,
-  seastore_off_t len)
+  extent_len_t len)
 {
   LOG_PREFIX(TransactionManager::get_extent_if_live);
   TRACET("{} {}~{} {}", t, type, laddr, len, paddr);
@@ -539,7 +539,7 @@ TransactionManager::get_extents_if_live(
   return cache->get_extent_if_cached(t, paddr, type
   ).si_then([=, this, &t](auto extent)
 	    -> get_extents_if_live_ret {
-    if (extent && extent->get_length() == (extent_len_t)len) {
+    if (extent && extent->get_length() == len) {
       DEBUGT("{} {}~{} {} is live in cache -- {}",
              t, type, laddr, len, paddr, *extent);
       std::list<CachedExtentRef> res;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -642,8 +642,8 @@ TransactionManagerRef make_transaction_manager(
   }
 
   auto journal_type = p_backend_type;
-  seastore_off_t roll_size;
-  seastore_off_t roll_start;
+  device_off_t roll_size;
+  device_off_t roll_start;
   if (journal_type == journal_type_t::SEGMENTED) {
     roll_size = static_cast<SegmentManager*>(primary_device)->get_segment_size();
     roll_start = 0;
@@ -654,6 +654,9 @@ TransactionManagerRef make_transaction_manager(
     // see CircularBoundedJournal::get_start_addr()
     roll_start = journal::CBJOURNAL_START_ADDRESS +
                  primary_device->get_block_size();
+    ceph_assert_always(roll_size <= DEVICE_OFF_MAX);
+    ceph_assert_always((std::size_t)roll_size + roll_start <=
+                       primary_device->get_available_size());
   }
   ceph_assert(roll_size % primary_device->get_block_size() == 0);
   ceph_assert(roll_start % primary_device->get_block_size() == 0);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -315,7 +315,7 @@ public:
     LOG_PREFIX(TransactionManager::alloc_extent);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    ceph_assert(is_aligned(laddr_hint, (uint64_t)epm->get_block_size()));
+    ceph_assert(is_aligned(laddr_hint, epm->get_block_size()));
     auto ext = cache->alloc_new_extent<T>(
       t,
       len,
@@ -402,7 +402,7 @@ public:
     extent_len_t len) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}", t, len, hint);
-    ceph_assert(is_aligned(hint, (uint64_t)epm->get_block_size()));
+    ceph_assert(is_aligned(hint, epm->get_block_size()));
     return lba_manager->alloc_extent(
       t,
       hint,
@@ -495,7 +495,7 @@ public:
     extent_types_t type,
     paddr_t paddr,
     laddr_t laddr,
-    seastore_off_t len) final;
+    extent_len_t len) final;
 
   /**
    * read_root_meta

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -19,7 +19,7 @@ seastar::future<> TMDriver::write(
 {
   logger().debug("Writing offset {}", offset);
   assert(offset % device->get_block_size() == 0);
-  assert((ptr.length() % (size_t)device->get_block_size()) == 0);
+  assert((ptr.length() % device->get_block_size()) == 0);
   return seastar::do_with(ptr, [this, offset](auto& ptr) {
     return repeat_eagain([this, offset, &ptr] {
       return tm->with_transaction_intr(
@@ -94,7 +94,7 @@ seastar::future<bufferlist> TMDriver::read(
 {
   logger().debug("Reading offset {}", offset);
   assert(offset % device->get_block_size() == 0);
-  assert(size % (size_t)device->get_block_size() == 0);
+  assert(size % device->get_block_size() == 0);
   auto blptrret = std::make_unique<bufferlist>();
   auto &blret = *blptrret;
   return repeat_eagain([=, &blret, this] {

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -44,7 +44,7 @@ inline std::ostream &operator<<(
 }
 
 struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
-  constexpr static seastore_off_t SIZE = 4<<10;
+  constexpr static extent_len_t SIZE = 4<<10;
   using Ref = TCachedExtentRef<TestBlock>;
 
   std::vector<test_block_delta_t> delta = {};
@@ -83,7 +83,7 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
 using TestBlockRef = TCachedExtentRef<TestBlock>;
 
 struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
-  constexpr static seastore_off_t SIZE = 4<<10;
+  constexpr static extent_len_t SIZE = 4<<10;
   using Ref = TCachedExtentRef<TestBlockPhysical>;
 
   std::vector<test_block_delta_t> delta = {};

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -415,7 +415,7 @@ struct btree_lba_manager_test : btree_test_base {
     );
   }
 
-  seastore_off_t next_off = 0;
+  device_off_t next_off = 0;
   paddr_t get_paddr() {
     next_off += block_size;
     return make_fake_paddr(next_off);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -37,9 +37,9 @@ struct cache_test_t : public seastar_test_suite_t {
       bl.append(block.bl);
     }
 
-    ceph_assert((seastore_off_t)bl.length() <
+    ceph_assert((segment_off_t)bl.length() <
 		segment_manager->get_segment_size());
-    if (current.as_seg_paddr().get_segment_off() + (seastore_off_t)bl.length() >
+    if (current.as_seg_paddr().get_segment_off() + (segment_off_t)bl.length() >
 	segment_manager->get_segment_size())
       current = paddr_t::make_seg_paddr(
 	segment_id_t(

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -72,7 +72,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
 
   std::default_random_engine generator;
 
-  seastore_off_t block_size;
+  extent_len_t block_size;
 
   SegmentManagerGroupRef sms;
 

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -325,7 +325,7 @@ public:
   }
 
   size_t get_available_size() const final { return sm.get_available_size(); }
-  seastore_off_t get_block_size() const final { return sm.get_block_size(); }
+  extent_len_t get_block_size() const final { return sm.get_block_size(); }
   seastore_off_t get_segment_size() const final {
     return sm.get_segment_size();
   }

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -326,7 +326,7 @@ public:
 
   size_t get_available_size() const final { return sm.get_available_size(); }
   extent_len_t get_block_size() const final { return sm.get_block_size(); }
-  seastore_off_t get_segment_size() const final {
+  segment_off_t get_segment_size() const final {
     return sm.get_segment_size();
   }
   const seastore_meta_t &get_meta() const final {

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -118,7 +118,8 @@ protected:
   {
     auto config =
       journal::CircularBoundedJournal::mkfs_config_t::get_default();
-    rb_device.reset(new random_block_device::TestMemory(config.total_size));
+    rb_device.reset(new random_block_device::TestMemory(
+          config.total_size + config.block_size));
     rb_device->set_device_id(
       1 << (std::numeric_limits<device_id_t>::digits - 1));
     return rb_device->mount().handle_error(crimson::ct_error::assert_all{}


### PR DESCRIPTION
They relaces the original 64-bit unsigned `block_off_t` and 32-bit signed `seastore_off_t` for the following considerations:
* The offset for `blk_paddr_t` should not be 32-bit `seastore_off_t`, following up https://github.com/ceph/ceph/pull/47698#discussion_r951039417
* Extend the offset type of `res_paddr_t` for the same reason.
* Fix `extent_len_t` usages for extent length and block size.
* The size/offset for both circular/segmented journal should not be limited by 32-bit `seastore_off_t`.
* Re-introduce `segment_off_t` to represent the 32-bit segment offset field from `seg_paddr_t`.

Does it address the issue you see @aravind-wdc ?

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
