### PR TITLE
pacific: log: Make log_max_recent have an effect again.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -597,6 +597,7 @@ std::vector<Option> get_global_options() {
     Option("log_max_recent", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(500)
     .set_daemon_default(10000)
+    .set_min(1)
     .set_description("recent log entries to keep in memory to dump in the event of a crash")
     .set_long_description("The purpose of this option is to log at a higher debug level only to the in-memory buffer, and write out the detailed log messages only if there is a crash.  Only log entries below the lower log level will be written unconditionally to the log.  For example, debug_osd=1/5 will write everything <= 1 to the log unconditionally but keep entries at levels 2-5 in memory.  If there is a seg fault or assertion failure, all entries will be dumped to the log."),
 

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -90,7 +90,7 @@ public:
     str.assign(strv.begin(), strv.end());
     return *this;
   }
-  ConcreteEntry(ConcreteEntry&& e) : Entry(e), str(std::move(e.str)) {}
+  ConcreteEntry(ConcreteEntry&& e) noexcept : Entry(e), str(std::move(e.str)) {}
   ConcreteEntry& operator=(ConcreteEntry&& e) {
     Entry::operator=(e);
     str = std::move(e.str);

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -132,7 +132,7 @@ void Log::set_max_new(std::size_t n)
 void Log::set_max_recent(std::size_t n)
 {
   std::scoped_lock lock(m_flush_mutex);
-  m_max_recent = n;
+  m_recent.set_capacity(n);
 }
 
 void Log::set_log_file(std::string_view fn)
@@ -490,8 +490,8 @@ void Log::dump_recent()
 			     tid_to_int(pthread_id), pthread_name), true);
   }
 
-  _log_message(fmt::format("  max_recent {:9}", m_max_recent), true);
-  _log_message(fmt::format("  max_new    {:9}", m_max_recent), true);
+  _log_message(fmt::format("  max_recent {:9}", m_recent.capacity()), true);
+  _log_message(fmt::format("  max_new    {:9}", m_max_new), true);
   _log_message(fmt::format("  log_file {}", m_log_file), true);
 
   _log_message("--- end dump of recent events ---", true);

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -116,7 +116,6 @@ private:
   bool m_stop = false;
 
   std::size_t m_max_new = DEFAULT_MAX_NEW;
-  std::size_t m_max_recent = DEFAULT_MAX_RECENT;
 
   bool m_inject_segv = false;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56635

---

backport of https://github.com/ceph/ceph/pull/46736
parent tracker: https://tracker.ceph.com/issues/56093

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh