### PR TITLE
pacific: rgw: x-amz-date change breaks certain cases of aws sig v4.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -217,8 +217,9 @@ bool rgw_create_s3_canonical_header(const DoutPrefixProvider *dpp,
 
     if (header_time) {
       struct tm t;
-      if (!parse_rfc2616(req_date, &t)) {
-        ldpp_dout(dpp, 0) << "NOTICE: failed to parse date for auth header" << dendl;
+      uint32_t ns = 0;
+      if (!parse_rfc2616(req_date, &t) && !parse_iso8601(req_date, &t, &ns, false)) {
+        ldpp_dout(dpp, 0) << "NOTICE: failed to parse date <" << req_date << "> for auth header" << dendl;
         return false;
       }
       if (t.tm_year < 70) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57197

---

backport of https://github.com/ceph/ceph/pull/47547
parent tracker: https://tracker.ceph.com/issues/57094

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh