### PR TITLE
compressor: fix rpmbuild on RHEL-8

### DIFF
--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -12,6 +12,7 @@ if(HAVE_QATZIP AND HAVE_QATDRV)
                         qatzip::qatzip
                        )
 endif()
+add_dependencies(compressor_objs legacy-option-headers)
 
 ## compressor plugins
 


### PR DESCRIPTION
Merge of #48287 to Quincy.

When building rpms on latest RHEL-8.6:

    [  0%] Building CXX object src/compressor/CMakeFiles/compressor_objs.dir/Compressor.cc.o
    In file included from /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/common/config_values.h:59,
                     from /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/common/config.h:27,
                     from /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/common/config_proxy.h:6,
                     from /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/common/ceph_context.h:41,
                     from /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/compressor/Compressor.cc:23:
    /d/ceph-build/ceph-17.2.3-0-dff484dfc9e/src/common/options/legacy_config_opts.h:1:10: fatal error: global_legacy_options.h: No such file or directory
        1 | #include "global_legacy_options.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    make[2]: *** [src/compressor/CMakeFiles/compressor_objs.dir/build.make:76: src/compressor/CMakeFiles/compressor_objs.dir/Compressor.cc.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:7964: src/compressor/CMakeFiles/compressor_objs.dir/all] Error 2
    make: *** [Makefile:146: all] Error 2
    error: Bad exit status from /var/tmp/rpm-tmp.1CBUsC (%build)

    RPM build errors:
        Bad exit status from /var/tmp/rpm-tmp.1CBUsC (%build)

Solution: add legacy-option-headers dependency to compressor_objs.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
(cherry picked from commit 3b3da64d741960e2ecb217c1990142f4a88f2fa3)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
