### PR TITLE
pacific: mgr/dashboard: handle the cephfs permission issue in nfs exports

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -13,7 +13,8 @@ from mgr_module import NFS_GANESHA_SUPPORTED_FSALS
 from .. import mgr
 from ..security import Scope
 from ..services.cephfs import CephFS
-from ..services.exception import DashboardException, serialize_dashboard_exception
+from ..services.exception import DashboardException, handle_cephfs_error, \
+    serialize_dashboard_exception
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
     ReadPermission, RESTController, Task, UIRouter
 from ._version import APIVersion
@@ -118,6 +119,7 @@ class NFSGaneshaExports(RESTController):
 
         return exports
 
+    @handle_cephfs_error()
     @NfsTask('create', {'path': '{path}', 'fsal': '{fsal.name}',
                         'cluster_id': '{cluster_id}'}, 2.0)
     @EndpointDoc("Creates a new NFS-Ganesha export",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57691

---

backport of https://github.com/ceph/ceph/pull/48267
parent tracker: https://tracker.ceph.com/issues/48686

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh