### PR TITLE
pacific: mon/Elector: Added sanity check when pinging a peer monitor 

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
@@ -1,0 +1,45 @@
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - mon.a
+  - mgr.a
+  - client.0
+- - host.b
+  - osd.3
+  - osd.4
+  - osd.5
+  - mon.b
+  - mgr.b
+  - client.1
+- - host.c
+  - osd.6
+  - osd.7
+  - osd.8
+  - mon.c
+  - mgr.c
+  - client.2
+- - host.d
+  - osd.9
+  - osd.10
+  - osd.11
+  - mon.d
+  - mgr.d
+  - client.3
+- - host.e
+  - osd.12
+  - osd.13
+  - osd.14
+  - mon.e
+  - mgr.e
+  - client.4
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - ceph orch apply mds a
+- cephfs_test_runner:
+    modules:
+      - tasks.cephadm_cases.test_cli_mon

--- a/qa/tasks/cephadm_cases/test_cli_mon.py
+++ b/qa/tasks/cephadm_cases/test_cli_mon.py
@@ -1,0 +1,71 @@
+import json
+import logging
+
+from tasks.mgr.mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestCephadmCLI(MgrTestCase):
+
+    APPLY_MON_PERIOD = 60
+
+    def _cmd(self, *args) -> str:
+        assert self.mgr_cluster is not None
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
+
+    def _orch_cmd(self, *args) -> str:
+        return self._cmd("orch", *args)
+
+    def setUp(self):
+        super(TestCephadmCLI, self).setUp()
+
+    def _create_and_write_pool(self, pool_name):
+        # Create new pool and write to it, simulating a small workload.
+        self.mgr_cluster.mon_manager.create_pool(pool_name)
+        args = [
+            "rados", "-p", pool_name, "bench", "30", "write", "-t", "16"]
+        self.mgr_cluster.admin_remote.run(args=args, wait=True)
+    
+    def _get_quorum_size(self) -> int:
+        # Evaluate if the quorum size of the cluster is correct.
+        # log the quorum_status before reducing the monitors
+        retstr = self._cmd('quorum_status')
+        log.info("test_apply_mon._check_quorum_size: %s" % json.dumps(retstr, indent=2))
+        quorum_size = len(json.loads(retstr)['quorum']) # get quorum size
+        return quorum_size
+
+    def _check_no_crashes(self):
+        # Evaluate if there are no crashes
+        # log the crash
+        retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'crash', 'ls',
+        )
+        log.info("test_apply_mon._check_no_crashes: %s" % retstr)
+        self.assertEqual(0, len(retstr)) # check if there are no crashes
+
+    def test_apply_mon_three(self):
+        # Evaluating the process of reducing the number of 
+        # monitors from 5 to 3 and increasing the number of
+        # monitors from 3 to 5, using the `ceph orch apply mon <num>` command.
+
+        self.wait_until_equal(lambda : self._get_quorum_size(), 5,
+                      timeout=self.APPLY_MON_PERIOD, period=10)
+
+        self._orch_cmd('apply', 'mon', '3') # reduce the monitors from 5 -> 3
+
+        self._create_and_write_pool('test_pool1')
+
+        self.wait_until_equal(lambda : self._get_quorum_size(), 3,
+                      timeout=self.APPLY_MON_PERIOD, period=10)
+
+        self._check_no_crashes()
+
+        self._orch_cmd('apply', 'mon', '5') # increase the monitors from 3 -> 5
+
+        self._create_and_write_pool('test_pool2')
+
+        self.wait_until_equal(lambda : self._get_quorum_size(), 5,
+                      timeout=self.APPLY_MON_PERIOD, period=10)
+
+        self._check_no_crashes()

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -491,6 +491,15 @@ void Elector::send_peer_ping(int peer, const utime_t *n)
 void Elector::ping_check(int peer)
 {
   dout(20) << __func__ << " to peer " << peer << dendl;
+
+  if (peer >= mon->monmap->ranks.size()) {
+    // Monitor no longer exists in the monmap,
+    // therefore, we shouldn't ping this monitor
+    // since we cannot lookup the address!
+    dout(20) << __func__ << "peer >= ranks_size" << dendl;
+    live_pinging.erase(peer);
+    return;
+  }
   if (!live_pinging.count(peer) &&
       !dead_pinging.count(peer)) {
     dout(20) << __func__ << peer << " is no longer marked for pinging" << dendl;
@@ -518,6 +527,7 @@ void Elector::ping_check(int peer)
 
 void Elector::begin_dead_ping(int peer)
 {
+  dout(20) << __func__ << " to peer " << peer << dendl;  
   if (dead_pinging.count(peer)) {
     return;
   }


### PR DESCRIPTION
This PR prevents a crash in the monitor
when the monitor gets removed out
of the cluster before getting shut down.

The motivation behind this PR is that
at this time, cephadm is actually removing
monitor before shutting it down, which leads
to problems in the Elector code, which assumes
that Monitors will be unreachable (stopped) before
it is removed and this should be fixed in #45511.
However, even if the user somehow manually
removed the monitor before shutting it down by accident,
we should prevent the Ceph from ultimately crashing.

- Added a check: 
   if ``peer >= ranks_size``, then we
  remove the peer from ``live_pinging`` set,  incase
  the peer was already removed from the quorum
  but for some reason, the Elector code didn't
  get to update ``live_pinging`` and ``dead_pinging`` sets
  in time with when ranks.size() of monmap is changed.
  This is to prevent going into assertion error later at
  MonMap.h:get_addrs(). This case usually occurs when
  the Monitor is removed out of the cluster before it is shut down,
  causing rank to be reduced before the monitor gets inserted to
 ``dead_pinging``.

- Added a test where we have 5 MONs on
  5 different hosts and try to reduce
  the number of MONs from 5 to 3 using
  the command ``ceph orch apply mon 3``.
  Also,increasing the number of MONs from
   3 to 5 using the command:
  ``ceph orch apply mon 5``.
  Evaluating the correctness of the commands
  and inspecting if there are crashes.

Fixes:  https://tracker.ceph.com/issues/50089

Backporting relevant commits from the main PR:

https://github.com/ceph/ceph/pull/44993

Backport Tracker: https://tracker.ceph.com/issues/57705

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
