### PR TITLE
quincy: doc: Fix disaster recovery doc

### DIFF
--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -300,9 +300,8 @@ Ensure you have an MDS running and issue:
 
 .. note::
 
-   Symbolic links are recovered as empty regular files. `Symbolic link recovery
-   <https://tracker.ceph.com/issues/46166>`_ is scheduled to be supported in
-   Pacific.
+   The `Symbolic link recovery <https://tracker.ceph.com/issues/46166>`_ is supported from Quincy.
+   Symbolic links were recovered as empty regular files before.
 
 It is recommended to migrate any data from the recovery file system as soon as
 possible. Do not restore the old file system while the recovery file system is


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57747

---

backport of https://github.com/ceph/ceph/pull/48292
parent tracker: https://tracker.ceph.com/issues/57734

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh