### PR TITLE
pacific: doc: Fix disaster recovery doc

### DIFF
--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -301,8 +301,7 @@ Ensure you have an MDS running and issue:
 .. note::
 
    Symbolic links are recovered as empty regular files. `Symbolic link recovery
-   <https://tracker.ceph.com/issues/46166>`_ is scheduled to be supported in
-   Pacific.
+   <https://tracker.ceph.com/issues/46166>`_ is scheduled to be supported in Quincy.
 
 It is recommended to migrate any data from the recovery file system as soon as
 possible. Do not restore the old file system while the recovery file system is


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57748

---

backport of https://github.com/ceph/ceph/pull/48292
parent tracker: https://tracker.ceph.com/issues/57734

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh