### PR TITLE
crimson/osd: Generalize loading obc for head/clone

### DIFF
--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -104,10 +104,9 @@ public:
     ssc = std::move(_ssc);
   }
 
-  void set_clone_state(ObjectState &&_obs, Ref &&_head) {
+  void set_clone_state(ObjectState &&_obs) {
     ceph_assert(!is_head());
     obs = std::move(_obs);
-    head = _head;
   }
 
   /// pass the provided exception to any waiting consumers of this ObjectContext

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1029,7 +1029,7 @@ PG::with_head_obc(ObjectContextRef obc, bool existed, with_obc_func_t&& func)
     } else {
       logger().debug("with_head_obc: cache miss on {}", obc->get_oid());
       loaded = obc->with_promoted_lock<State, IOInterruptCondition>([this, obc] {
-        return load_head_obc(obc);
+        return load_obc(obc);
       });
     }
     return loaded.safe_then_interruptible([func = std::move(func)](auto obc) {
@@ -1085,16 +1085,12 @@ PG::with_clone_obc(hobject_t oid, with_obc_func_t&& func)
         logger().debug("with_clone_obc: found {} in cache", clone->get_oid());
       } else {
         logger().debug("with_clone_obc: cache miss on {}", clone->get_oid());
-        //TODO: generalize load_head_obc -> load_obc (support head/clone obc)
         loaded = clone->template with_promoted_lock<State, IOInterruptCondition>(
-          [clone, head, this] {
-          return backend->load_metadata(clone->get_oid()).safe_then_interruptible(
-            [clone=std::move(clone), head=std::move(head)](auto md) mutable {
-            clone->set_clone_state(std::move(md->os), std::move(head));
-            return clone;
-          });
+          [clone, this] {
+          return load_obc(clone);
         });
       }
+      clone->head = head;
       return loaded.safe_then_interruptible([func = std::move(func)](auto clone) {
         return std::move(func)(std::move(clone));
       });
@@ -1124,23 +1120,26 @@ PG::with_existing_clone_obc(ObjectContextRef clone, with_obc_func_t&& func)
 }
 
 PG::load_obc_iertr::future<crimson::osd::ObjectContextRef>
-PG::load_head_obc(ObjectContextRef obc)
+PG::load_obc(ObjectContextRef obc)
 {
   return backend->load_metadata(obc->get_oid()).safe_then_interruptible(
     [obc=std::move(obc)](auto md)
     -> load_obc_ertr::future<crimson::osd::ObjectContextRef> {
     const hobject_t& oid = md->os.oi.soid;
     logger().debug(
-      "load_head_obc: loaded obs {} for {}", md->os.oi, oid);
-    if (!md->ssc) {
-      logger().error(
-        "load_head_obc: oid {} missing snapsetcontext", oid);
-      return crimson::ct_error::object_corrupted::make();
-
+      "load_obc: loaded obs {} for {}", md->os.oi, oid);
+    if (oid.is_head()) {
+      if (!md->ssc) {
+        logger().error(
+          "load_obc: oid {} missing snapsetcontext", oid);
+        return crimson::ct_error::object_corrupted::make();
+      }
+      obc->set_head_state(std::move(md->os), std::move(md->ssc));
+    } else {
+      obc->set_clone_state(std::move(md->os));
     }
-    obc->set_head_state(std::move(md->os), std::move(md->ssc));
     logger().debug(
-      "load_head_obc: returning obc {} for {}",
+      "load_obc: returning obc {} for {}",
       obc->obs.oi, obc->obs.oi.soid);
     return load_obc_ertr::make_ready_future<
       crimson::osd::ObjectContextRef>(obc);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -527,7 +527,7 @@ public:
   get_or_load_head_obc(hobject_t oid);
 
   load_obc_iertr::future<crimson::osd::ObjectContextRef>
-  load_head_obc(ObjectContextRef obc);
+  load_obc(ObjectContextRef obc);
 
   load_obc_iertr::future<>
   reload_obc(crimson::osd::ObjectContext& obc) const;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -517,14 +517,11 @@ public:
       load_obc_ertr>;
   using interruptor = ::crimson::interruptible::interruptor<
     ::crimson::osd::IOInterruptCondition>;
-  load_obc_iertr::future<
-    std::pair<crimson::osd::ObjectContextRef, bool>>
-  get_or_load_clone_obc(
-    hobject_t oid, crimson::osd::ObjectContextRef head_obc);
 
-  load_obc_iertr::future<
-    std::pair<crimson::osd::ObjectContextRef, bool>>
-  get_or_load_head_obc(hobject_t oid);
+  template<RWState::State State>
+  load_obc_iertr::future<crimson::osd::ObjectContextRef>
+  get_or_load_obc(
+    crimson::osd::ObjectContextRef head_obc, bool existed);
 
   load_obc_iertr::future<crimson::osd::ObjectContextRef>
   load_obc(ObjectContextRef obc);


### PR DESCRIPTION
* `load_head_obc` is changed to `load_obc` and can be used to load clone obc's as well.
* `get_or_load_obc` is introduced  and used both by `with_head/clone_obc` avoiding boilerplates.

 (This change will also be useful for `CEPH_OSD_OP_ROLLBACK` implementation).

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
