### PR TITLE
osd/scrub: use the actual active set when requesting replicas to scrub

### DIFF
--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -63,6 +63,10 @@ void PrimaryLogScrub::submit_digest_fixes(const digests_fixes_t& fixes)
       num_digest_updates_pending--;
       continue;
     }
+    dout(15) << fmt::format(
+		  "{}: {}, pg[{}] {}/{}", __func__, num_digest_updates_pending,
+		  m_pg_id, obj, dgs)
+	     << dendl;
     if (obc->obs.oi.soid != obj) {
       m_osds->clog->error()
 	<< m_pg_id << " " << m_mode_desc << " " << obj

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -513,7 +513,7 @@ Scrub::schedule_result_t ScrubQueue::select_from_group(
     }
   }
 
-  dout(20) << " returning 'none ready' " << dendl;
+  dout(20) << " returning 'none ready'" << dendl;
   return Scrub::schedule_result_t::none_ready;
 }
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -891,7 +891,7 @@ void PgScrubber::get_replicas_maps(bool replica_can_preempt)
   m_primary_scrubmap_pos.reset();
 
   // ask replicas to scan and send maps
-  for (const auto& i : m_pg->get_acting_recovery_backfill()) {
+  for (const auto& i : m_pg->get_actingset()) {
 
     if (i == m_pg_whoami)
       continue;
@@ -1005,7 +1005,7 @@ void PgScrubber::on_init()
     m_pg_whoami,
     m_is_repair,
     m_is_deep ? scrub_level_t::deep : scrub_level_t::shallow,
-    m_pg->get_acting_recovery_backfill());
+    m_pg->get_actingset());
 
   //  create a new store
   {

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -1062,17 +1062,25 @@ ScrubBackend::auth_and_obj_errs_t ScrubBackend::match_in_shards(
                                                      ho.has_snapset());
 
       dout(20) << fmt::format(
-                    "{}: {} {} {} shards: {} {} {}",
-                    __func__,
-                    (m_repair ? " repair " : " "),
-                    (m_is_replicated ? "replicated " : ""),
-                    (srd == auth_sel.auth_shard ? "auth" : ""),
-                    auth_sel.shard_map.size(),
-                    (auth_sel.digest_match ? " digest_match " : " "),
-                    (auth_sel.shard_map[srd].only_data_digest_mismatch_info()
-                       ? "'info mismatch info'"
-                       : ""))
-               << dendl;
+		    "{}: {}{} <{}:{}> shards: {} {} {}", __func__,
+		    (m_repair ? "repair " : ""),
+		    (m_is_replicated ? "replicated " : ""), srd,
+		    (srd == auth_sel.auth_shard ? "auth" : "-"),
+		    auth_sel.shard_map.size(),
+		    (auth_sel.digest_match ? " digest_match " : " "),
+		    (auth_sel.shard_map[srd].only_data_digest_mismatch_info()
+		       ? "'info mismatch info'"
+		       : ""))
+	       << dendl;
+      if (discrep_found) {
+	dout(10) << fmt::format(
+		      "{}: <{}> auth:{} ({}/{}) vs {} ({}/{}) {}", __func__, ho,
+		      auth_sel.auth_shard, auth_object.omap_digest_present,
+		      auth_object.omap_digest, srd,
+		      smap.objects[ho].omap_digest_present ? true : false,
+		      smap.objects[ho].omap_digest, ss.str())
+		 << dendl;
+      }
 
       // If all replicas match, but they don't match object_info we can
       // repair it by using missing_digest mechanism


### PR DESCRIPTION
Note that get_acting_set() may differ from
get_acting_recovery_backfill() - if we are backfilling or recovering.

Fixes: https://tracker.ceph.com/issues/57698

