### PR TITLE
crimson/.../replicated_request,logmissing_request: retain reference to req

### DIFF
--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -61,7 +61,7 @@ seastar::future<> LogMissingRequest::with_pg(
 
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
-    return pg->do_update_log_missing(std::move(req));
+    return pg->do_update_log_missing(req);
   }, [ref](std::exception_ptr) { return seastar::now(); }, pg);
 }
 

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -61,7 +61,7 @@ seastar::future<> RepRequest::with_pg(
 
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
-    return pg->handle_rep_op(std::move(req));
+    return pg->handle_rep_op(req);
   }, [ref](std::exception_ptr) { return seastar::now(); }, pg);
 }
 


### PR DESCRIPTION
Otherwise, operator<< and dump_detail would need to accessing req after the call to handle_rep_op.

Fixes: https://tracker.ceph.com/issues/57739
Signed-off-by: Samuel Just <sjust@redhat.com>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
