### PR TITLE
crimson/osd/replicated_backend: block _submit_transaction on sending the messages

### DIFF
--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -81,6 +81,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
     return seastar::make_ready_future<crimson::osd::acked_peers_t>(std::move(acked_peers));
   });
 
+  auto sends = std::make_unique<std::vector<seastar::future<>>>();
   for (auto pg_shard : pg_shards) {
     if (pg_shard != whoami) {
       auto m = crimson::make_message<MOSDRepOp>(
@@ -100,10 +101,13 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
       m->min_last_complete_ondisk = osd_op_p.min_last_complete_ondisk;
       m->set_rollback_to(osd_op_p.at_version);
       // TODO: set more stuff. e.g., pg_states
-      (void) shard_services.send_to_osd(pg_shard.osd, std::move(m), map_epoch);
+      sends->emplace_back(shard_services.send_to_osd(pg_shard.osd, std::move(m), map_epoch));
     }
   }
-  return {seastar::now(), std::move(all_completed)};
+  auto sends_complete = seastar::when_all_succeed(
+    sends->begin(), sends->end()
+  ).finally([sends=std::move(sends)] {});
+  return {std::move(sends_complete), std::move(all_completed)};
 }
 
 void ReplicatedBackend::on_actingset_changed(peering_info_t pi)


### PR DESCRIPTION
Otherwise, the send operations can reorder.

Fixes: https://tracker.ceph.com/issues/57738
Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
