### PR TITLE
crimson: allow pg creation to be canceled if pool is removed

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -93,11 +93,6 @@ class error_t {
     return ConcreteErrorT::exception_ptr_type_info();
   }
 
-  std::exception_ptr to_exception_ptr() const {
-    const auto* concrete_error = static_cast<const ConcreteErrorT*>(this);
-    return concrete_error->to_exception_ptr();
-  }
-
   decltype(auto) static from_exception_ptr(std::exception_ptr ep) {
     return ConcreteErrorT::from_exception_ptr(std::move(ep));
   }
@@ -107,6 +102,12 @@ class error_t {
 
   template <class ErrorVisitorT, class FuturatorT>
   friend class maybe_handle_error_t;
+
+protected:
+  std::exception_ptr to_exception_ptr() const {
+    const auto* concrete_error = static_cast<const ConcreteErrorT*>(this);
+    return concrete_error->to_exception_ptr();
+  }
 
 public:
   template <class Func>
@@ -125,6 +126,10 @@ struct unthrowable_wrapper : error_t<unthrowable_wrapper<ErrorT, ErrorV>> {
   [[nodiscard]] static const auto& make() {
     static constexpr unthrowable_wrapper instance{};
     return instance;
+  }
+
+  static auto exception_ptr() {
+    return make().to_exception_ptr();
   }
 
   template<class Func>

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -64,10 +64,11 @@ void PGMap::pg_created(spg_t pgid, Ref<PG> pg)
   ceph_assert(!pgs.count(pgid));
   pgs.emplace(pgid, pg);
 
-  auto state = pgs_creating.find(pgid);
-  ceph_assert(state != pgs_creating.end());
-  state->second.promise.set_value(pg);
-  pgs_creating.erase(pgid);
+  auto creating_iter = pgs_creating.find(pgid);
+  ceph_assert(creating_iter != pgs_creating.end());
+  auto promise = std::move(creating_iter->second.promise);
+  pgs_creating.erase(creating_iter);
+  promise.set_value(pg);
 }
 
 void PGMap::pg_loaded(spg_t pgid, Ref<PG> pg)

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -25,17 +25,19 @@ void PGMap::PGCreationState::dump_detail(Formatter *f) const
   f->dump_bool("creating", creating);
 }
 
-std::pair<seastar::future<Ref<PG>>, bool>
+PGMap::wait_for_pg_ret
 PGMap::wait_for_pg(PGCreationBlockingEvent::TriggerI&& trigger, spg_t pgid)
 {
   if (auto pg = get_pg(pgid)) {
-    return make_pair(seastar::make_ready_future<Ref<PG>>(pg), true);
+    return make_pair(
+      wait_for_pg_fut(wait_for_pg_ertr::ready_future_marker{}, pg),
+      true);
   } else {
     auto &state = pgs_creating.emplace(pgid, pgid).first->second;
     return make_pair(
-      // TODO: add to blocker Trigger-taking make_blocking_future
-      trigger.maybe_record_blocking(state.promise.get_shared_future(), state),
-      state.creating);
+      wait_for_pg_fut(
+	trigger.maybe_record_blocking(state.promise.get_shared_future(), state)
+      ), state.creating);
   }
 }
 
@@ -75,6 +77,20 @@ void PGMap::pg_loaded(spg_t pgid, Ref<PG> pg)
 {
   ceph_assert(!pgs.count(pgid));
   pgs.emplace(pgid, pg);
+}
+
+void PGMap::pg_creation_canceled(spg_t pgid)
+{
+  logger().debug("PGMap::pg_creation_canceled: {}", pgid);
+  ceph_assert(!pgs.count(pgid));
+
+  auto creating_iter = pgs_creating.find(pgid);
+  ceph_assert(creating_iter != pgs_creating.end());
+  auto promise = std::move(creating_iter->second.promise);
+  pgs_creating.erase(creating_iter);
+  promise.set_exception(
+    crimson::ct_error::ecanceled::exception_ptr()
+  );
 }
 
 PGMap::~PGMap() {}

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -123,8 +123,11 @@ public:
    * Get future for pg with a bool indicating whether it's already being
    * created.
    */
-  std::pair<seastar::future<Ref<PG>>, bool>
-  wait_for_pg(PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
+  using wait_for_pg_ertr = crimson::errorator<
+    crimson::ct_error::ecanceled>;
+  using wait_for_pg_fut = wait_for_pg_ertr::future<Ref<PG>>;
+  using wait_for_pg_ret = std::pair<wait_for_pg_fut, bool>;
+  wait_for_pg_ret wait_for_pg(PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
 
   /**
    * get PG in non-blocking manner
@@ -145,6 +148,11 @@ public:
    * Add newly loaded pg
    */
   void pg_loaded(spg_t pgid, Ref<PG> pg);
+
+  /**
+   * Cancel pending creation of pgid.
+   */
+  void pg_creation_canceled(spg_t pgid);
 
   pgs_t& get_pgs() { return pgs; }
   const pgs_t& get_pgs() const { return pgs; }

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -375,12 +375,18 @@ public:
     bool do_create);
   seastar::future<Ref<PG>> handle_pg_create_info(
     std::unique_ptr<PGCreateInfo> info);
-  seastar::future<Ref<PG>> get_or_create_pg(
+
+  using get_or_create_pg_ertr = PGMap::wait_for_pg_ertr;
+  using get_or_create_pg_ret = get_or_create_pg_ertr::future<Ref<PG>>;
+  get_or_create_pg_ret get_or_create_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&,
     spg_t pgid,
     epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
-  seastar::future<Ref<PG>> wait_for_pg(
+
+  using wait_for_pg_ertr = PGMap::wait_for_pg_ertr;
+  using wait_for_pg_ret = wait_for_pg_ertr::future<Ref<PG>>;
+  wait_for_pg_ret wait_for_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
   seastar::future<Ref<PG>> load_pg(spg_t pgid);
 


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
