### PR TITLE
quincy: doc/glossary.rst: remove duplicates

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -59,7 +59,7 @@ service interfaces built on top of ``librados``.
 Storing Data
 ------------
 
-The Ceph Storage Cluster receives data from :term:`Ceph Clients`--whether it
+The Ceph Storage Cluster receives data from :term:`Ceph Client`\s--whether it
 comes through a :term:`Ceph Block Device`, :term:`Ceph Object Storage`, the
 :term:`Ceph File System` or a custom implementation you create using
 ``librados``-- which is stored as RADOS objects. Each object is stored on an
@@ -80,7 +80,7 @@ stored in a monolithic database-like fashion.
 Ceph OSD Daemons store data as objects in a flat namespace (e.g., no
 hierarchy of directories). An object has an identifier, binary data, and
 metadata consisting of a set of name/value pairs. The semantics are completely
-up to :term:`Ceph Clients`. For example, CephFS uses metadata to store file
+up to :term:`Ceph Client`\s. For example, CephFS uses metadata to store file
 attributes such as the file owner, created date, last modified date, and so
 forth.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -37,12 +37,12 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
                 The collection of libraries that can be used to interact with
                 components of the Ceph System.
 
-	Ceph Clients
 	Ceph Cluster Map
 	Ceph Dashboard
 	Ceph File System
+                See :term:`CephFS`
+
 	CephFS
-	Ceph FS
                 The POSIX filesystem components of Ceph. Refer :ref:`CephFS
                 Architecture <arch-cephfs>` and :ref:`ceph-file-system` for
                 more details.

--- a/doc/rados/api/index.rst
+++ b/doc/rados/api/index.rst
@@ -6,7 +6,7 @@
 
 The :term:`Ceph Storage Cluster` has a messaging layer protocol that enables
 clients to interact with a :term:`Ceph Monitor` and a :term:`Ceph OSD Daemon`.
-``librados`` provides this functionality to :term:`Ceph Clients` in the form of
+``librados`` provides this functionality to :term:`Ceph Client`\s in the form of
 a library.  All Ceph Clients either use ``librados`` or the same functionality
 encapsulated in ``librados`` to interact with the object store.  For example,
 ``librbd`` and ``libcephfs`` leverage this functionality. You may use


### PR DESCRIPTION
This commit removes similar but distinct entries for the following:
   * CephFS
   * Ceph Client

Removal of a glossary term that is referred to in the body of the documentation suite requires the alteration of the text string that refers to the glossary term. Alterations of this kind have been made to doc/architecture.rst and doc/rados/api/index.rst.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 0692b223540143cdb4a60b54595a7069284b5481)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
