### PR TITLE
qa/suites/rados: add deduplication test with rgw s3 workload

### DIFF
--- a/qa/suites/rados/thrash/workloads/rgw_dedup.yaml
+++ b/qa/suites/rados/thrash/workloads/rgw_dedup.yaml
@@ -1,0 +1,35 @@
+tasks:
+- rgw: [client.0]
+- s3tests:
+    client.0:
+      force-branch: ceph-master
+      rgw_server: client.0
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- deduplication:
+    clients: [client.0]
+    op: 'sample-dedup'
+    pool: 'default.rgw.buckets.data'
+    chunk_pool: 'low_tier'
+    chunk_size: 131072
+    chunk_algorithm: 'fastcdc'
+    fingerprint_algorithm: 'sha1'
+    chunk_dedup_threshold: 1
+    max_thread: 2
+    wakeup_period: 15
+    sampling_ratio: 100
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw lc debug interval: 10
+        rgw crypt s3 kms backend: testing
+        rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl: false
+  thrashosds:
+    op_delay: 30
+    chance_test_min_size: 0
+    ceph_objectstore_tool: false
+  rgw:
+    frontend: beast

--- a/qa/tasks/deduplication.py
+++ b/qa/tasks/deduplication.py
@@ -109,7 +109,7 @@ def task(ctx, config):
                 log.info('proc stdout ', proc.stdout.getvalue())
                 return proc.stdout.getvalue().strip()
             tries += 1
-            if tries > 30:
+            if tries > 120:
                 raise Exception('timed out getting correct exitstatus')
             time.sleep(30)
 


### PR DESCRIPTION
prerequisite: https://github.com/ceph/ceph/pull/48223 should be merged first.
see: https://github.com/ceph/ceph/pull/45369

test results: 
1) https://pulpito.ceph.com/myoungwon-2022-09-18_22:34:57-rados:thrash-wip-samplededup-20220919-distro-default-smithi/
2) rerun ->  https://pulpito.ceph.com/myoungwon-2022-10-04_06:48:50-rados:thrash-wip-rgw-dedup-2022-10-03-distro-default-smithi/

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
