### PR TITLE
crimson/osd: don't clone non-existing objects

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -807,15 +807,14 @@ void OpsExecuter::make_writeable(std::vector<pg_log_entry_t>& log_entries)
     osd_op_params->at_version.version++;
 
     // TODO: update most recent clone_overlap and usage stats
-
-    if (snapc.seq > obc->ssc->snapset.seq) {
-       // update snapset with latest snap context
-       obc->ssc->snapset.seq = snapc.seq;
-       obc->ssc->snapset.snaps.clear();
-    }
-    logger().debug("{} {} done, snapset={}",
-      __func__, soid, obc->ssc->snapset);
   }
+  if (snapc.seq > obc->ssc->snapset.seq) {
+     // update snapset with latest snap context
+     obc->ssc->snapset.seq = snapc.seq;
+     obc->ssc->snapset.snaps.clear();
+  }
+  logger().debug("{} {} done, snapset={}",
+    __func__, soid, obc->ssc->snapset);
 }
 
 const object_info_t OpsExecuter::prepare_clone(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -748,9 +748,9 @@ void OpsExecuter::make_writeable(std::vector<pg_log_entry_t>& log_entries)
                  obc->ssc->snapset, snapc);
 
   // clone?
-  if (head_os.exists &&                          // old obs.exists
-      snapc.snaps.size() &&                      // there are snaps
-      snapc.snaps[0] > obc->ssc->snapset.seq) {  // existing obj is old
+  if (initial_os.existed && !initial_os.is_whiteout &&  // old obs.exists
+      snapc.snaps.size() &&                             // there are snaps
+      snapc.snaps[0] > obc->ssc->snapset.seq) {         // existing obj is old
 
     // clone object, the snap field is set to the seq of the SnapContext
     // at its creation.

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -166,6 +166,15 @@ private:
   };
 
   Ref<PG> pg; // for the sake of object class
+  const struct initial_os_t {
+    bool existed;
+    bool is_whiteout;
+
+    initial_os_t(const ObjectContext& obc)
+      : existed(obc.obs.exists),
+        is_whiteout(obc.obs.oi.is_whiteout()) {
+    }
+  } initial_os;
   ObjectContextRef obc;
   ObjectContextRef clone_obc; // if we create a clone
   ObjectState head_os;
@@ -259,6 +268,7 @@ public:
               const MsgT& msg,
               const SnapContext& snapc)
     : pg(std::move(pg)),
+      initial_os(*obc),
       obc(std::move(obc)),
       op_info(op_info),
       msg(std::in_place_type_t<ExecutableMessagePimpl<MsgT>>{}, &msg),


### PR DESCRIPTION
The differences
============
crimson
-------
```
DEBUG 2022-10-04 20:10:24,710 [shard 0] osd - client_request(id=37, detail=m=[osd_op(client.4117.0:40 1.6 1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:head {set-alloc-hint object_size 4194304 write_size 4194304, write 0~80 in=80b} snapc 4={4} ondisk+write+known_if_redirected+supports_pool_eio e9) v8]).0: after await_map stage
...
DEBUG 2022-10-04 20:10:24,710 [shard 0] osd - cloning v 0'0 to 1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:4 v 9'2 snaps= {4} snapset=0={}:{4={4}}
DEBUG 2022-10-04 20:10:24,710 [shard 0] osd - make_writeable 1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:head done, snapset=4={}:{4={4}}
...
DEBUG 2022-10-04 20:10:24,711 [shard 0] osd - final snapset 4={}:{4={4}} in 1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:head
TRACE 2022-10-04 20:10:24,712 [shard 0] bluestore - _dump_transaction transaction dump:
{
    "ops": [
// ...
        {
            "op_num": 1,
            "op_name": "clone",
            "collection": "1.6_head",
            "src_oid": "#1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:head#",
            "dst_oid": "#1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:4#"
        },
// ...
        {
            "op_num": 6,
            "op_name": "touch",
            "collection": "1.6_head",
            "oid": "#1:65e2c3d8:::rbd_data.1015fc34d4d2.0000000000000000:head#"
        },
// ...
    ]
}
```

The classical OSD
-----------------
```
2022-09-26T09:46:53.502+0000 7f74c1e7b700 20 osd.0 pg_epoch: 11 pg[1.0( v 11'7 (0'0,11'7] local-lis/les=7/8 n=4 ec=7/7 lis/c=7/7 les/c/f=8/8/0 sis=7) [0] r=0 lpr=7 crt=11'7 lcod 10'6 mlcod 10'6 active+clean ps=[2~1]] do_op: op osd_op(client.4117.0:40 1.0 1:2f0692fe:::rbd_data.10152970f466.0000000000000000:head [set-alloc-hint object_size 4194304 write_size 4194304,write 0~80 in=80b] snapc 4=[4] ondisk+write+known_if_redirected+supports_pool_eio e11) v8
...
2022-09-26T09:46:53.502+0000 7f74c1e7b700 20 osd.0 pg_epoch: 11 pg[1.0( v 11'7 (0'0,11'7] local-lis/les=7/8 n=4 ec=7/7 lis/c=7/7 les/c/f=8/8/0 sis=7) [0] r=0 lpr=7 crt=11'7 lcod 10'6 mlcod 10'6 active+clean ps=[2~1]] make_writeable 1:2f0692fe:::rbd_data.10152970f466.0000000000000000:head snapset=0=[]:{}  snapc=4=[4]
2022-09-26T09:46:53.502+0000 7f74c1e7b700 20 osd.0 pg_epoch: 11 pg[1.0( v 11'7 (0'0,11'7] local-lis/les=7/8 n=4 ec=7/7 lis/c=7/7 les/c/f=8/8/0 sis=7) [0] r=0 lpr=7 crt=11'7 lcod 10'6 mlcod 10'6 active+clean ps=[2~1]]  setting DIRTY flag
2022-09-26T09:46:53.502+0000 7f74c1e7b700 20 osd.0 pg_epoch: 11 pg[1.0( v 11'7 (0'0,11'7] local-lis/les=7/8 n=4 ec=7/7 lis/c=7/7 les/c/f=8/8/0 sis=7) [0] r=0 lpr=7 crt=11'7 lcod 10'6 mlcod 10'6 active+clean ps=[2~1]] make_writeable 1:2f0692fe:::rbd_data.10152970f466.0000000000000000:head done, snapset=4=[]:{}
...
2022-09-26T09:46:53.502+0000 7f74c1e7b700 10 osd.0 pg_epoch: 11 pg[1.0( v 11'7 (0'0,11'7] local-lis/les=7/8 n=4 ec=7/7 lis/c=7/7 les/c/f=8/8/0 sis=7) [0] r=0 lpr=7 crt=11'7 lcod 10'6 mlcod 10'6 active+clean ps=[2~1]]  final snapset 4=[]:{} in 1:2f0692fe:::rbd_data.10152970f466.0000000000000000:head
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
