### PR TITLE
mgr/rook: Device inventory

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -510,7 +510,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                 "On": "On",
                 "Off": "Off",
                 True: "Yes",
-                False: "",
+                False: "No",
             }
 
             out = []


### PR DESCRIPTION
Recovered device inventory list for host clusters

With this modification we recover the possibility to have information about physical devices in rook host clusters uisng the command "ceph orch device ls" 
Documentation in the Rook project will be added  to inform that to show devices information in this type of clusters it is needed to enable the "discovery daemon" in the Operator CRD and also possibly adapt the refresh of the discovery daemon (by default 60m).

Now  the information displayed using CLI (rook tool box):
```
bash-4.4$ ceph orch device ls
HOST                              PATH       TYPE  DEVICE ID   SIZE  AVAILABLE  REFRESHED  REJECT REASONS                                    
mykube1-master-0.karmalabs.local  /dev/vda1  hdd   None       32.2G  No         0s ago     device data coming from ceph-volume not provided  
mykube1-master-0.karmalabs.local  /dev/vdb   hdd   None       10.7G  No         0s ago     Has BlueStore device label                        
mykube1-master-0.karmalabs.local  /dev/vdc   hdd   None       10.7G  Yes        0s ago                                                       
mykube1-worker-0.karmalabs.local  /dev/vda1  hdd   None       32.2G  No         0s ago     device data coming from ceph-volume not provided  
mykube1-worker-0.karmalabs.local  /dev/vdb   hdd   None       10.7G  No         0s ago     Has BlueStore device label                        
mykube1-worker-0.karmalabs.local  /dev/vdc   hdd   None       10.7G  Yes        0s ago                                                       
mykube1-worker-1.karmalabs.local  /dev/vda1  hdd   None       32.2G  No         0s ago     device data coming from ceph-volume not provided  
mykube1-worker-1.karmalabs.local  /dev/vdb   hdd   None       10.7G  No         0s ago     Has BlueStore device label                        
mykube1-worker-1.karmalabs.local  /dev/vdc   hdd   None       10.7G  Yes        0s ago    
```
Using the dashboard:
![image](https://user-images.githubusercontent.com/1820049/194273531-c1f9a170-7a31-4c22-bb15-7837907c2b2a.png)



Fixes: https://github.com/rook/rook/issues/10703

- Component impact
  - [ x ] Affects [Dashboard]
  - [ x ] Affects [Orchestrator]


Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>
