### PR TITLE
quincy: qa/tasks/rbd_fio: bump default to fio 3.32

### DIFF
--- a/qa/tasks/rbd_fio.py
+++ b/qa/tasks/rbd_fio.py
@@ -123,7 +123,7 @@ def run_fio(remote, config, rbd_test_dir):
 
     formats=[1,2]
     features=[['layering'],['striping'],['exclusive-lock','object-map']]
-    fio_version='3.16'
+    fio_version='3.32'
     if config.get('formats'):
         formats=config['formats']
     if config.get('features'):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57779

---

backport of https://github.com/ceph/ceph/pull/48372
parent tracker: https://tracker.ceph.com/issues/57766