### PR TITLE
qa/suites/crimson-rados: add CRIMSON_COMPAT to workunit env

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -1,0 +1,4 @@
+overrides:
+  workunit:
+    env:
+      CRIMSON_COMPAT: '1'

--- a/qa/suites/crimson-rados/basic/crimson_qa_overrides.yaml
+++ b/qa/suites/crimson-rados/basic/crimson_qa_overrides.yaml
@@ -1,0 +1,1 @@
+.qa/config/crimson_qa_overrides.yaml

--- a/qa/suites/crimson-rados/rbd/crimson_qa_overrides.yaml
+++ b/qa/suites/crimson-rados/rbd/crimson_qa_overrides.yaml
@@ -1,0 +1,1 @@
+.qa/config/crimson_qa_overrides.yaml

--- a/qa/suites/crimson-rados/seastore/basic/crimson_qa_overrides.yaml
+++ b/qa/suites/crimson-rados/seastore/basic/crimson_qa_overrides.yaml
@@ -1,0 +1,1 @@
+.qa/config/crimson_qa_overrides.yaml

--- a/qa/suites/crimson-rados/thrash/crimson_qa_overrides.yaml
+++ b/qa/suites/crimson-rados/thrash/crimson_qa_overrides.yaml
@@ -1,0 +1,1 @@
+.qa/config/crimson_qa_overrides.yaml


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/57798
Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
