### PR TITLE
mgr/dashboard: fix weird data in osd details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -8,7 +8,9 @@
       <a ngbNavLink
          i18n>Devices</a>
       <ng-template ngbNavContent>
-        <cd-device-list [osdId]="osd?.id"></cd-device-list>
+        <cd-device-list [osdId]="osd?.id"
+                        [hostname]="selection?.host.name"
+                        [osdList]="true"></cd-device-list>
       </ng-template>
     </ng-container>
     <ng-container ngbNavItem="attributes">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
@@ -8,8 +8,35 @@
 
 <ng-template #deviceLocation
              let-value="value">
-  <span *ngFor="let location of value">{{location.dev}}</span>
+  <ng-container *ngFor="let location of value">
+    <cd-label *ngIf="location.host === hostname"
+              [value]="location.dev"></cd-label>
+  </ng-container>
 </ng-template>
+
+<ng-template #daemonName
+             let-value="value">
+  <ng-container [ngTemplateOutlet]="osdId !== null ? osdIdDaemon : readableDaemons"
+                [ngTemplateOutletContext]="{daemons: value}">
+  </ng-container>
+</ng-template>
+
+<ng-template #osdIdDaemon
+             let-daemons="daemons">
+  <ng-container *ngFor="let daemon of daemons">
+    <cd-label *ngIf="daemon.includes(osdId)"
+              [value]="daemon"></cd-label>
+  </ng-container>
+</ng-template>
+
+<ng-template #readableDaemons
+             let-daemons="daemons">
+  <ng-container *ngFor="let daemon of daemons">
+    <cd-label class="mr-1"
+              [value]="daemon"></cd-label>
+  </ng-container>
+</ng-template>
+
 
 <ng-template #lifeExpectancy
              let-value="value">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.ts
@@ -18,8 +18,13 @@ export class DeviceListComponent implements OnChanges, OnInit {
   @Input()
   osdId: number = null;
 
+  @Input()
+  osdList = false;
+
   @ViewChild('deviceLocation', { static: true })
   locationTemplate: TemplateRef<any>;
+  @ViewChild('daemonName', { static: true })
+  daemonNameTemplate: TemplateRef<any>;
   @ViewChild('lifeExpectancy', { static: true })
   lifeExpectancyTemplate: TemplateRef<any>;
   @ViewChild('lifeExpectancyTimestamp', { static: true })
@@ -69,16 +74,16 @@ export class DeviceListComponent implements OnChanges, OnInit {
         isHidden: true
       },
       { prop: 'location', name: $localize`Device Name`, cellTemplate: this.locationTemplate },
-      { prop: 'readableDaemons', name: $localize`Daemons` }
+      { prop: 'daemons', name: $localize`Daemons`, cellTemplate: this.daemonNameTemplate }
     ];
   }
 
   ngOnChanges() {
     const updateDevicesFn = (devices: CdDevice[]) => (this.devices = devices);
-    if (this.hostname) {
-      this.hostService.getDevices(this.hostname).subscribe(updateDevicesFn);
-    } else if (this.osdId !== null) {
+    if (this.osdList && this.osdId !== null) {
       this.osdService.getDevices(this.osdId).subscribe(updateDevicesFn);
+    } else if (this.hostname) {
+      this.hostService.getDevices(this.hostname).subscribe(updateDevicesFn);
     }
   }
 }


### PR DESCRIPTION
The devices section in the OSD Details and Host Details shows more than one daemon and device path in the column when you view the details of a single osd details/host details. This is because more than one osd is created on a device with same `deviceid`. I am not sure if this will happen in the real environment but its mostly reproducible in environments with QEMU emulated devices.

For generating badges I used the newly added `cd-labels` component.


FYI, Showing multiple OSD daemons in host detail is not fixable (at least without writing a messier code) in the host component. Because the backend returns like this

```
DEVICE                 DEV  DAEMONS            EXPECTED FAILURE
QEMU_HARDDISK_QM00005  sda  osd.0 osd.2 osd.4                  
QEMU_HARDDISK_QM00007  sdb  osd.1 osd.3 osd.5                  
```

**BEFORE**
![weird](https://user-images.githubusercontent.com/71764184/194805154-90793fbb-4c2f-4470-b315-bf0dd09eab69.png)

**AFTER**
![Screenshot from 2022-10-10 11-01-14](https://user-images.githubusercontent.com/71764184/194805162-13650e31-ef03-460d-a21d-a2d39250321b.png)
![Screenshot from 2022-10-10 11-00-54](https://user-images.githubusercontent.com/71764184/194805165-1c7146e3-ee63-4479-b42e-81e1a7e22ad7.png)


Fixes: https://tracker.ceph.com/issues/57803
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
