### PR TITLE
rgw/reshard: fix hold reshard lock collisions

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6949,6 +6949,16 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
 	ldpp_dout(dpp, 20) << __func__ <<
 	  " ERROR: failed to take reshard lock for bucket " <<
 	  bucket_id << "; expected if resharding underway" << dendl;
+
+        // the reshard may have finished, so refresh bucket_obj to avoid
+        // acquiring reshard lock conflicts
+        ret = fetch_new_bucket_info("trying_to_refresh_bucket_info");
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << __func__ <<
+            " ERROR: failed to refresh bucket_obj for bucket " <<
+            bs->bucket.name << dendl;
+          continue; // try again
+        }
       } else {
 	ldpp_dout(dpp, 10) << __func__ <<
 	  " INFO: was able to take reshard lock for bucket " <<

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6916,11 +6916,11 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
     if (!entry.resharding_in_progress()) {
       ret = fetch_new_bucket_info("get_bucket_resharding_succeeded");
       if (ret < 0) {
-	ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-	  " failed to refresh bucket info after reshard when get bucket "
-	  "resharding succeeded, error: " << cpp_strerror(-ret) << dendl;
-	return ret;
+        ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+          " failed to refresh bucket info after reshard when get bucket "
+          "resharding succeeded, error: " << cpp_strerror(-ret) << dendl;
       }
+      return ret;
     }
 
     ldpp_dout(dpp, 20) << __func__ << " NOTICE: reshard still in progress; " <<
@@ -6957,7 +6957,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
           ldpp_dout(dpp, 0) << __func__ <<
             " ERROR: failed to refresh bucket_obj for bucket " <<
             bs->bucket.name << dendl;
-          continue; // try again
+          return ret;
         }
       } else {
 	ldpp_dout(dpp, 10) << __func__ <<


### PR DESCRIPTION
Now, the old reshard oids retain in-progress state after resharding succeed, as a result, all operations blocked by reshard will gain reshard_lock to get new bucket info. This will lead to mass collisions, then parts of operations fail to hold lock in the loop. To solve it, update the newest bucket_obj after accqure lock failed, then redo the operations with new bucket info.

The collision easy be recurred when resharding bucket with large omap that old shards will cost a long time to clean. It also can be mocked by annotating clean_index in commit_reshard.

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>