### PR TITLE
pacific: qa: Fix test_subvolume_snapshot_info_if_orphan_clone

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -5688,7 +5688,7 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
 
         # insert delay at the beginning of snapshot clone
-        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 5)
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 10)
 
         # schedule a clones
         for clone in clone_list:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57723

---

backport of https://github.com/ceph/ceph/pull/47991
parent tracker: https://tracker.ceph.com/issues/57446

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh