### PR TITLE
rgw: add bucket chown entrypoint

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1642,6 +1642,85 @@ Special Error Responses
 :Description: Unable to link bucket to specified user.
 :Code: 409 Conflict
 
+Change the Owner of a Bucket
+============================
+
+Change the bucket's owner.
+By changing the bucket's owner to a specified user, the owner
+is changed for all objects held by the bucket.
+
+:caps: buckets=write
+
+Syntax
+~~~~~~
+
+::
+
+	PUT /{admin}/bucket?owner&format=json HTTP/1.1
+	Host: {fqdn}
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``bucket``
+
+:Description: The name of the bucket whose owner is to be changed.
+:Type: String
+:Example: ``foo_bucket``
+:Required: Yes
+
+``uid``
+
+:Description: The user ID of the bucket's new owner.
+:Type: String
+:Example: ``foo_user``
+:Required: Yes
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+``new_user_id``
+
+:Description: The user ID of the bucket's new owner.
+:Type: String
+
+``old_user_id``
+
+:Description: The user ID of the bucket's old owner.
+:Type: String
+
+``processed_objects``
+
+:Description: The total number of objects processed in this bucket.
+:Type: Integer
+
+``object_progression``
+
+:Description: Progress of the on-going operation.
+              Every entry in the array represents a block of 100 processed objects.
+:Type: Container
+
+``processed_objects``
+
+:Description: The number of objects processed so far.
+:Type: Integer
+:Parent: ``object_progression``
+
+``processing_object``
+
+:Description: The name of the object currently being processed.
+:Type: Integer
+:Parent: ``object_progression``
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``NoSuchKey``
+
+:Description: Specified bucket does not exist.
+:Code: 404 Not Found
+
 Remove Object
 =============
 

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -349,8 +349,13 @@ public:
           std::map<RGWObjCategory, RGWStorageStats>& calculated_stats,
           std::string *err_msg = NULL);
 
-  int chown(RGWBucketAdminOpState& op_state, const std::string& marker,
-            optional_yield y, const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
+  int chown(RGWBucketAdminOpState& op_state,
+            const std::string& marker,
+            RGWFormatterFlusher& flusher,
+            optional_yield y,
+            const DoutPrefixProvider *dpp,
+            std::string *err_msg = NULL);
+
   int set_quota(RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
 
   int remove_object(const DoutPrefixProvider *dpp, RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
@@ -374,7 +379,7 @@ public:
 
   static int unlink(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
   static int link(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
-  static int chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, const std::string& marker, const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
+  static int chown(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, const std::string& marker, const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
 
   static int check_index(rgw::sal::Driver* driver, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
@@ -688,9 +693,15 @@ public:
                     const DoutPrefixProvider *dpp,
                     bool update_entrypoint = true);
 
-  int chown(rgw::sal::Driver* driver, rgw::sal::Bucket* bucket,
-            const rgw_user& user_id, const std::string& display_name,
-            const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp);
+  int chown(rgw::sal::Driver* driver,
+            rgw::sal::Bucket* bucket,
+            const rgw_user& user_id,
+            const std::string& display_name,
+            const std::string& marker,
+            RGWFormatterFlusher* flusher,
+            int &processed_object_count,
+            optional_yield y,
+            const DoutPrefixProvider *dpp);
 
   int read_buckets_stats(std::map<std::string, RGWBucketEnt>& m,
                          optional_yield y,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -582,7 +582,12 @@ class RadosBucket : public StoreBucket {
     virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual int update_container_stats(const DoutPrefixProvider* dpp) override;
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp) override;
-    virtual int chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
+    virtual int chown(const DoutPrefixProvider* dpp,
+                      User* new_user,
+                      User* old_user,
+                      optional_yield y,
+                      const std::string* marker = nullptr,
+                      RGWFormatterFlusher* flusher = nullptr) override;
     virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime) override;
     virtual bool is_owner(User* user) override;
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7286,7 +7286,7 @@ int main(int argc, const char **argv)
     bucket_op.set_new_bucket_name(new_bucket_name);
     string err;
 
-    int r = RGWBucketAdminOp::chown(driver, bucket_op, marker, dpp(), &err);
+    int r = RGWBucketAdminOp::chown(driver, bucket_op, stream_flusher, marker, dpp(), &err);
     if (r < 0) {
       cerr << "failure: " << cpp_strerror(-r) << ": " << err << std::endl;
       return -r;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -942,7 +942,8 @@ void RGWHTTPArgs::append(const string& name, const string& val)
               (name.compare("quota") == 0) ||
               (name.compare("list") == 0) ||
               (name.compare("object") == 0) ||
-              (name.compare("sync") == 0)) {
+              (name.compare("sync") == 0) ||
+              (name.compare("owner") == 0)) {
     if (!admin_subresource_added) {
       sub_resources[name] = "";
       admin_subresource_added = true;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -681,7 +681,12 @@ class Bucket {
     /** Check if this bucket needs resharding, and schedule it if it does */
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp) = 0;
     /** Change the owner of this bucket in the backing store */
-    virtual int chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) = 0;
+    virtual int chown(const DoutPrefixProvider* dpp,
+                      User* new_user,
+                      User* old_user,
+                      optional_yield y,
+                      const std::string* marker = nullptr,
+                      RGWFormatterFlusher* flusher = nullptr) = 0;
     /** Store the cached bucket info into the backing store */
     virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime) = 0;
     /** Check to see if the given user is the owner of this bucket */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -321,7 +321,12 @@ namespace rgw::sal {
     return 0;
   }
 
-  int DBBucket::chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
+  int DBBucket::chown(const DoutPrefixProvider* dpp,
+                      User* new_user,
+                      User* old_user,
+                      optional_yield y,
+                      const std::string* marker,
+                      RGWFormatterFlusher* flusher)
   {
     int ret;
 

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -202,7 +202,12 @@ protected:
       virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
       virtual int update_container_stats(const DoutPrefixProvider *dpp) override;
       virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
-      virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
+      virtual int chown(const DoutPrefixProvider* dpp,
+                        User* new_user,
+                        User* old_user,
+                        optional_yield y,
+                        const std::string* marker = nullptr,
+                        RGWFormatterFlusher* flusher = nullptr) override;
       virtual int put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) override;
       virtual bool is_owner(User* user) override;
       virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -741,11 +741,14 @@ int FilterBucket::check_bucket_shards(const DoutPrefixProvider* dpp)
   return next->check_bucket_shards(dpp);
 }
 
-int FilterBucket::chown(const DoutPrefixProvider* dpp, User* new_user,
-			User* old_user, optional_yield y,
-			const std::string* marker)
+int FilterBucket::chown(const DoutPrefixProvider* dpp,
+                        User* new_user,
+			                  User* old_user,
+                        optional_yield y,
+			                  const std::string* marker,
+                        RGWFormatterFlusher* flusher)
 {
-  return next->chown(dpp, new_user, old_user, y, marker);
+  return next->chown(dpp, new_user, old_user, y, marker, flusher);
 }
 
 int FilterBucket::put_info(const DoutPrefixProvider* dpp, bool exclusive,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -435,9 +435,12 @@ public:
   virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual int update_container_stats(const DoutPrefixProvider* dpp) override;
   virtual int check_bucket_shards(const DoutPrefixProvider* dpp) override;
-  virtual int chown(const DoutPrefixProvider* dpp, User* new_user,
-		    User* old_user, optional_yield y,
-		    const std::string* marker = nullptr) override;
+  virtual int chown(const DoutPrefixProvider* dpp,
+                    User* new_user,
+		                User* old_user,
+                    optional_yield y,
+		                const std::string* marker = nullptr,
+                    RGWFormatterFlusher* flusher = nullptr) override;
   virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive,
 		       ceph::real_time mtime) override;
   virtual bool is_owner(User* user) override;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -619,7 +619,12 @@ int MotrBucket::check_bucket_shards(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int MotrBucket::chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
+int MotrBucket::chown(const DoutPrefixProvider* dpp,
+                      User* new_user,
+                      User* old_user,
+                      optional_yield y,
+                      const std::string* marker,
+                      RGWFormatterFlusher* flusher)
 {
   // TODO: update bucket with new owner
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -319,7 +319,12 @@ class MotrBucket : public StoreBucket {
     virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual int update_container_stats(const DoutPrefixProvider *dpp) override;
     virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
-    virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
+    virtual int chown(const DoutPrefixProvider* dpp,
+                      User* new_user,
+                      User* old_user,
+                      optional_yield y,
+                      const std::string* marker = nullptr,
+                      RGWFormatterFlusher* flusher = nullptr) override;
     virtual int put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) override;
     virtual bool is_owner(User* user) override;
     virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;


### PR DESCRIPTION
rgw: add bucket chown entrypoint

Added an admin rest entrypoint for changing the owner of a bucket.
The call is mapped over the existing: RGWHandler_Bucket::op_put().
The query string must contain the parameter: owner in order to trigger a chown.

Example:

admin/bucket?owner&uid=john&bucket=foo

This invocation changes the bucket foo's owner with the user john.
All the objects inside the bucket are updated according to the new owner
as well.

The user calling chown entrypoint must have users capability set with write permission.
On success, the operation returns a 200 HTTP code with a body summarizing the call's details; example:

```
{
        old_user_id : "jack",
        new_user_id : "john",
        object_progression : [
                {
                        processed_objects : 100,
                        processing_object : "obj_101"
                },
                {
                        processed_objects : 200,
                        processing_object : "obj_201"
                }
        ],
        processed_objects : 201
}
```

The object_progression array is incrementally sent to the client as the
operation proceeds.
This behavior prevents a client to timeout when the bucket contains a
significant amount of objects.

Fixes: https://tracker.ceph.com/issues/57569
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
