### PR TITLE
pacific: doc/releases: improve grammar in pacific.rst

### DIFF
--- a/doc/releases/pacific.rst
+++ b/doc/releases/pacific.rst
@@ -9,25 +9,25 @@ This is a hotfix release that resolves two security flaws.
 
 Notable Changes
 ---------------
-* Users who were running OpenStack Manila to export native CephFS, who
+* Users who were running OpenStack Manila to export native CephFS and who
   upgraded their Ceph cluster from Nautilus (or earlier) to a later
-  major version, were vulnerable to an attack by malicious users. The
+  major version were vulnerable to an attack by malicious users. The
   vulnerability allowed users to obtain access to arbitrary portions of
-  the CephFS filesystem hierarchy, instead of being properly restricted
+  the CephFS filesystem hierarchy instead of being properly restricted
   to their own subvolumes. The vulnerability is due to a bug in the
   "volumes" plugin in Ceph Manager. This plugin is responsible for
-  managing Ceph File System subvolumes which are used by OpenStack
+  managing Ceph File System subvolumes, which are used by OpenStack
   Manila services as a way to provide shares to Manila users.
 
   With this hotfix, the vulnerability is fixed. Administrators who are
   concerned they may have been impacted should audit the CephX keys in
   their cluster for proper path restrictions.
-
-  Again, this vulnerability only impacts OpenStack Manila clusters which
+  
+  Again, this vulnerability impacts only OpenStack Manila clusters that 
   provided native CephFS access to their users.
 
 * A regression made it possible to dereference a null pointer for
-  for s3website requests that don't refer to a bucket resulting in an RGW
+  s3website requests that don't refer to a bucket resulting in an RGW
   segfault.
 
 Changelog


### PR DESCRIPTION
This commit accepts the grammar suggestions that were made by Cole Mitchell in https://github.com/ceph/ceph/pull/48404.

(cherry picked from commit 560d7590fdf66ef3827203bc7c5725f167a1a7b2)
Signed-off-by: Zac Dover <zac.dover@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
