### PR TITLE
quincy: cephadm: run tests as root 

### DIFF
--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -1,3 +1,4 @@
+from calendar import c
 import mock
 import os
 import pytest
@@ -68,17 +69,17 @@ def cephadm_fs(
          mock.patch('platform.processor', return_value='x86_64'), \
          mock.patch('cephadm.extract_uid_gid', return_value=(uid, gid)):
 
-            if not fake_filesystem.is_root():
-                fake_filesystem.set_uid(0)
+        if not fake_filesystem.is_root():
+            fake_filesystem.set_uid(0)
 
-            fs.create_dir(cd.DATA_DIR)
-            fs.create_dir(cd.LOG_DIR)
-            fs.create_dir(cd.LOCK_DIR)
-            fs.create_dir(cd.LOGROTATE_DIR)
-            fs.create_dir(cd.UNIT_DIR)
-            fs.create_dir('/sys/block')
+        fs.create_dir(cd.DATA_DIR)
+        fs.create_dir(cd.LOG_DIR)
+        fs.create_dir(cd.LOCK_DIR)
+        fs.create_dir(cd.LOGROTATE_DIR)
+        fs.create_dir(cd.UNIT_DIR)
+        fs.create_dir('/sys/block')
 
-            yield fs
+        yield fs
 
 
 @contextmanager

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -68,11 +68,15 @@ def cephadm_fs(
          mock.patch('platform.processor', return_value='x86_64'), \
          mock.patch('cephadm.extract_uid_gid', return_value=(uid, gid)):
 
+            if not fake_filesystem.is_root():
+                fake_filesystem.set_uid(0)
+
             fs.create_dir(cd.DATA_DIR)
             fs.create_dir(cd.LOG_DIR)
             fs.create_dir(cd.LOCK_DIR)
             fs.create_dir(cd.LOGROTATE_DIR)
             fs.create_dir(cd.UNIT_DIR)
+            fs.create_dir('/sys/block')
 
             yield fs
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -17,6 +17,7 @@ from .fixtures import (
     mock_bad_firewalld,
 )
 
+from pyfakefs import fake_filesystem
 from pyfakefs import fake_filesystem_unittest
 
 with mock.patch('builtins.open', create=True):
@@ -2446,6 +2447,9 @@ class TestRescan(fake_filesystem_unittest.TestCase):
 
     def setUp(self):
         self.setUpPyfakefs()
+        if not fake_filesystem.is_root():
+            fake_filesystem.set_uid(0)
+
         self.fs.create_dir('/sys/class')
         self.ctx = cd.CephadmContext()
         self.ctx.func = cd.command_rescan_disks

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -34,7 +34,7 @@ addopts =
 [testenv]
 skip_install=true
 deps =
-  pyfakefs
+  pyfakefs == 5.0
   mock
   pytest
 commands=pytest {posargs}


### PR DESCRIPTION

Backport of #48421

I saw it failing in quincy PRs as well.  https://github.com/ceph/ceph/pull/48432, https://jenkins.ceph.com/job/ceph-pull-requests/105103/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
