### PR TITLE
osdc/Journaler.cc: the condition variable should be put into the queue of finisher when read_pos = write_pos in function wait_for_readable

### DIFF
--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -1292,7 +1292,7 @@ void Journaler::wait_for_readable(Context *onreadable)
   }
 
   ceph_assert(on_readable == 0);
-  if (!readable) {
+  if (!readable && read_pos < write_pos) {
     ldout(cct, 10) << "wait_for_readable at " << read_pos << " onreadable "
 		   << onreadable << dendl;
     on_readable = wrap_finisher(onreadable);


### PR DESCRIPTION
When using CephFS, I found that sometimes the thread 'md_log_replay' of mds standby-replay would be blocked at code 'readable_waiter.wait()' in function 'MDLog::_replay_thread' all the time. At this time I found that function 'Journaler::_finish_read' was called before code 'journaler->wait_for_readable(&readable_waiter)' in function 'MDLog::_replay_thread', then the thread would wait forever at code 'readable_waiter.wait()' because function 'Journaler::_finish_read' could not be called any more. When function 'Journaler::wait_for_readable' was called before waiting, 'readable' was false and 'read_pos' was equal to 'write_pos'. 
I think when 'read_pos' is equal to 'write_pos', the condition variable should be put into the queue of finisher in function 'Journaler::wait_for_readable'. So the thread 'md_log_replay' does not need to wait for function 'Journaler::_finish_read' to wake up.