### PR TITLE
quincy: mgr/prometheus: change pg_repaired_objects name to pool_repaired_objects

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1563,13 +1563,13 @@ class Module(MgrModule):
                 cast(MetricCounter, sum_metric).add(duration, (method_name,))
                 cast(MetricCounter, count_metric).add(1, (method_name,))
 
-    def get_pg_repaired_objects(self) -> None:
+    def get_pool_repaired_objects(self) -> None:
         dump = self.get('pg_dump')
         for stats in dump['pool_stats']:
-            path = f'pg_objects_repaired{stats["poolid"]}'
+            path = f'pool_objects_repaired{stats["poolid"]}'
             self.metrics[path] = Metric(
                 'counter',
-                'pg_objects_repaired',
+                'pool_objects_repaired',
                 'Number of objects repaired in a pool Count',
                 ('poolid',)
             )
@@ -1592,7 +1592,7 @@ class Module(MgrModule):
         self.get_mgr_status()
         self.get_metadata_and_osd_status()
         self.get_pg_status()
-        self.get_pg_repaired_objects()
+        self.get_pool_repaired_objects()
         self.get_num_objects()
 
         for daemon, counters in self.get_all_perf_counters().items():


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57838

---

backport of https://github.com/ceph/ceph/pull/48415
parent tracker: https://tracker.ceph.com/issues/57806

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh