### PR TITLE
 quincy: mgr/dashboard: Unable to change rgw subuser permission

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -804,7 +804,7 @@ class RgwUserSubuserTest(RgwTestCase):
                 'access': 'readwrite',
                 'key_type': 'swift'
             })
-        self.assertStatus(201)
+        self.assertStatus(200)
         data = self.jsonBody()
         subuser = self.find_object_in_list('id', 'teuth-test-user:tux', data)
         self.assertIsInstance(subuser, object)
@@ -827,7 +827,7 @@ class RgwUserSubuserTest(RgwTestCase):
                 'access_key': 'yyy',
                 'secret_key': 'xxx'
             })
-        self.assertStatus(201)
+        self.assertStatus(200)
         data = self.jsonBody()
         subuser = self.find_object_in_list('id', 'teuth-test-user:hugo', data)
         self.assertIsInstance(subuser, object)

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -506,15 +506,32 @@ class RgwUser(RgwRESTController):
     def create_subuser(self, uid, subuser, access, key_type='s3',
                        generate_secret='true', access_key=None,
                        secret_key=None, daemon_name=None):
-        return self.proxy(daemon_name, 'PUT', 'user', {
-            'uid': uid,
-            'subuser': subuser,
-            'key-type': key_type,
-            'access': access,
-            'generate-secret': generate_secret,
-            'access-key': access_key,
-            'secret-key': secret_key
-        })
+        # pylint: disable=R1705
+        subusr_array = []
+        user = json.loads(self.get(uid, daemon_name))  # type: ignore
+        subusers = user["subusers"]
+        for sub_usr in subusers:
+            subusr_array.append(sub_usr["id"])
+        if subuser in subusr_array:
+            return self.proxy(daemon_name, 'POST', 'user', {
+                'uid': uid,
+                'subuser': subuser,
+                'key-type': key_type,
+                'access': access,
+                'generate-secret': generate_secret,
+                'access-key': access_key,
+                'secret-key': secret_key
+            })
+        else:
+            return self.proxy(daemon_name, 'PUT', 'user', {
+                'uid': uid,
+                'subuser': subuser,
+                'key-type': key_type,
+                'access': access,
+                'generate-secret': generate_secret,
+                'access-key': access_key,
+                'secret-key': secret_key
+            })
 
     @RESTController.Resource(method='DELETE', path='/subuser/{subuser}', status=204)
     def delete_subuser(self, uid, subuser, purge_keys='true', daemon_name=None):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57841

---

backport of https://github.com/ceph/ceph/pull/48412
parent tracker: https://tracker.ceph.com/issues/57805

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh