### PR TITLE
crimson/osd: send proper reply on obc load failure

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -253,7 +253,7 @@ ClientRequest::process_op(instance_handle_t &ihref, Ref<PG> &pg)
   }));
 }
 
-auto ClientRequest::reply_op_error(Ref<PG>& pg, int err)
+auto ClientRequest::reply_op_error(const Ref<PG>& pg, int err)
 {
   logger().debug("{}: replying with error {}", *this, err);
   auto reply = crimson::make_message<MOSDOpReply>(

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -212,7 +212,7 @@ public:
 private:
   template <typename FuncT>
   interruptible_future<> with_sequencer(FuncT&& func);
-  auto reply_op_error(Ref<PG>& pg, int err);
+  auto reply_op_error(const Ref<PG>& pg, int err);
 
   enum class seq_mode_t {
     IN_ORDER,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1074,7 +1074,7 @@ PG::with_clone_obc(hobject_t oid, with_obc_func_t&& func)
     auto coid = resolve_oid(head->get_ro_ss(), oid);
     if (!coid) {
       logger().error("with_clone_obc: {} clone not found", coid);
-      return load_obc_iertr::future<>{crimson::ct_error::object_corrupted::make()};
+      return load_obc_iertr::future<>{crimson::ct_error::enoent::make()};
     }
     auto [clone, existed] = shard_services.get_cached_obc(*coid);
     return clone->template with_lock<State, IOInterruptCondition>(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -510,6 +510,7 @@ public:
     const hobject_t &oid);
 
   using load_obc_ertr = crimson::errorator<
+    crimson::ct_error::enoent,
     crimson::ct_error::object_corrupted>;
   using load_obc_iertr =
     ::crimson::interruptible::interruptible_errorator<


### PR DESCRIPTION
These two issues were causing the hang in `TestLibRBD.TestIOToSnapshot` around:

```cpp
TEST_F(TestLibRBD, TestIOToSnapshot)
{
  // ...
  rbd_snap_set(image, "orig");
  ASSERT_PASSED(read_test_data, image, orig_data, 0, TEST_IO_TO_SNAP_SIZE, 0);
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
