### PR TITLE
osdc/Journaler: function wait_for_readable may cause the caller to block forever while waiting for the condition variable later

### DIFF
--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -1292,7 +1292,7 @@ void Journaler::wait_for_readable(Context *onreadable)
   }
 
   ceph_assert(on_readable == 0);
-  if (!readable) {
+  if (!readable && read_pos < write_pos) {
     ldout(cct, 10) << "wait_for_readable at " << read_pos << " onreadable "
 		   << onreadable << dendl;
     on_readable = wrap_finisher(onreadable);


### PR DESCRIPTION
When using CephFS, I found that sometimes the thread 'md_log_replay' of mds standby-replay would be blocked at code 'readable_waiter.wait()' in function 'MDLog::_replay_thread' all the time. At this time I found that function 'Journaler::_finish_read' was called before code 'journaler->wait_for_readable(&readable_waiter)' in function 'MDLog::_replay_thread', then the thread would wait forever at code 'readable_waiter.wait()' because function 'Journaler::_finish_read' could not be called any more. When function 'Journaler::wait_for_readable' was called before waiting forever, 'readable' was false and 'read_pos' was equal to 'write_pos'.
I think when 'read_pos' is equal to 'write_pos', the condition variable should be put into the queue of finisher in function 'Journaler::wait_for_readable'. So the thread 'md_log_replay' does not need to wait for function 'Journaler::_finish_read' to wake up.

Fixes: https://tracker.ceph.com/issues/57764
Signed-off-by: Zhansong Gao <zhsgao@hotmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
