### PR TITLE
osd: unhealthy osd cannot be marked down in time

### DIFF
--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -488,11 +488,19 @@ Heartbeat::Session::failed_since(Heartbeat::clock::time_point now) const
     auto oldest_deadline = ping_history.begin()->second.deadline;
     auto failed_since = std::min(last_rx_back, last_rx_front);
     if (clock::is_zero(failed_since)) {
-      logger().error("Heartbeat::Session::failed_since(): no reply from osd.{} "
-                     "ever on either front or back, first ping sent {} "
-                     "(oldest deadline {})",
-                     peer, first_tx, oldest_deadline);
-      failed_since = first_tx;
+        if (last_rx_front == last_rx_back) {
+            logger().error("Heartbeat::Session::failed_since(): no reply from osd.{} "
+                           "ever on both front and back, first ping sent {} "
+                           "(oldest deadline {})",
+                           peer, first_tx, oldest_deadline);
+            failed_since = clock::zero() + std::chrono::seconds(1);
+        } else {
+            logger().error("Heartbeat::Session::failed_since(): no reply from osd.{} "
+                           "ever on either front or back, first ping sent {} "
+                           "(oldest deadline {})",
+                           peer, first_tx, oldest_deadline);
+            failed_since = first_tx;
+        }
     } else {
       logger().error("Heartbeat::Session::failed_since(): no reply from osd.{} "
                      "since back {} front {} (oldest deadline {})",

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5841,7 +5841,18 @@ void OSD::heartbeat_check()
 	     << dendl;
     if (p->second.is_unhealthy(now)) {
       utime_t oldest_deadline = p->second.ping_history.begin()->second.first;
-      if (p->second.last_rx_back == utime_t() ||
+      if (p->second.last_rx_back == utime_t() &&
+          p->second.last_rx_front == utime_t()) {
+        derr << "heartbeat_check: no reply from "
+             << p->second.con_front->get_peer_addr().get_sockaddr()
+             << " osd." << p->first
+             << " ever on both front and back, first ping sent "
+             << p->second.first_tx
+             << " (oldest deadline " << oldest_deadline << ")"
+             << dendl;
+        // fail
+        failure_queue[p->first] = utime_t() + utime_t(1,0);
+      } else if (p->second.last_rx_back == utime_t() ||
 	  p->second.last_rx_front == utime_t()) {
         derr << "heartbeat_check: no reply from "
              << p->second.con_front->get_peer_addr().get_sockaddr()


### PR DESCRIPTION
Before an unhealthy osd is marked down by mon, other osd may choose it as heartbeat peer and then report an incorrect failure time(first_tx) to mon.

Fixes:  https://tracker.ceph.com/issues/57852
Signed-off-by:  wanwencong <wanwc@chinatelecom.cn>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
