### PR TITLE
pacific: rbd: device map/unmap --namespace handling fixes

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -46,6 +46,10 @@
   If that is the case, in OSD logs the "You can be hit by THE DUPS BUG" warning
   will be visible.
   Relevant tracker: https://tracker.ceph.com/issues/53729
+* RBD: `rbd device unmap` command gained `--namespace` option.  Support for
+  namespaces was added to RBD in Nautilus 14.2.0 and it has been possible to
+  map and unmap images in namespaces using the `image-spec` syntax since then
+  but the corresponding option available in most other commands was missing.
 
 >=16.2.8
 --------

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -113,10 +113,10 @@ function get_pid()
 
 unmap_device()
 {
-    local dev=$1
+    local args=$1
     local pid=$2
 
-    _sudo rbd device --device-type nbd unmap ${dev}
+    _sudo rbd device --device-type nbd unmap ${args}
     rbd device --device-type nbd list | expect_false grep "^${pid}\\b" || return 1
     ps -C rbd-nbd | expect_false grep "^ *${pid}\\b" || return 1
 
@@ -236,6 +236,15 @@ rbd snap create ${POOL}/${NS}/${IMAGE}@snap
 DEV=`_sudo rbd device --device-type nbd map ${POOL}/${NS}/${IMAGE}@snap`
 get_pid ${POOL} ${NS}
 unmap_device "${POOL}/${NS}/${IMAGE}@snap" ${PID}
+DEV=
+
+# map/unmap namespace using options test
+DEV=`_sudo rbd device --device-type nbd map --pool ${POOL} --namespace ${NS} --image ${IMAGE}`
+get_pid ${POOL} ${NS}
+unmap_device "--pool ${POOL} --namespace ${NS} --image ${IMAGE}" ${PID}
+DEV=`_sudo rbd device --device-type nbd map --pool ${POOL} --namespace ${NS} --image ${IMAGE} --snap snap`
+get_pid ${POOL} ${NS}
+unmap_device "--pool ${POOL} --namespace ${NS} --image ${IMAGE} --snap snap" ${PID}
 DEV=
 
 # unmap by image name test 2

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -670,19 +670,21 @@
   
   rbd help device unmap
   usage: rbd device unmap [--device-type <device-type>] [--pool <pool>] 
-                          [--image <image>] [--snap <snap>] [--options <options>] 
+                          [--namespace <namespace>] [--image <image>] 
+                          [--snap <snap>] [--options <options>] 
                           <image-or-snap-or-device-spec> 
   
   Unmap a rbd device.
   
   Positional arguments
     <image-or-snap-or-device-spec>  image, snapshot, or device specification
-                                    [<pool-name>/]<image-name>[@<snap-name>] or
-                                    <device-path>
+                                    [<pool-name>/[<namespace>/]]<image-name>[@<sna
+                                    p-name>] or <device-path>
   
   Optional arguments
     -t [ --device-type ] arg        device type [ggate, krbd (default), nbd]
     -p [ --pool ] arg               pool name
+    --namespace arg                 namespace name
     --image arg                     image name
     --snap arg                      snapshot name
     -o [ --options ] arg            device specific options

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -274,6 +274,57 @@ int get_pool_image_id(const po::variables_map &vm,
   return 0;
 }
 
+int get_image_or_snap_spec(const po::variables_map &vm, std::string *spec) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string nspace_name;
+  std::string image_name;
+  std::string snap_name;
+  int r = get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &nspace_name,
+    &image_name, &snap_name, true, SNAPSHOT_PRESENCE_PERMITTED,
+    SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  if (pool_name.empty()) {
+    // connect to the cluster to get the default pool
+    librados::Rados rados;
+    r = init_rados(&rados);
+    if (r < 0) {
+      return r;
+    }
+
+    normalize_pool_name(&pool_name);
+  }
+
+  spec->append(pool_name);
+  spec->append("/");
+  if (!nspace_name.empty()) {
+    spec->append(nspace_name);
+    spec->append("/");
+  }
+  spec->append(image_name);
+  if (!snap_name.empty()) {
+    spec->append("@");
+    spec->append(snap_name);
+  }
+
+  return 0;
+}
+
+void append_options_as_args(const std::vector<std::string> &options,
+                            std::vector<std::string> *args) {
+  for (auto &opts : options) {
+    std::vector<std::string> args_;
+    boost::split(args_, opts, boost::is_any_of(","));
+    for (auto &o : args_) {
+      args->push_back("--" + o);
+    }
+  }
+}
+
 int get_pool_image_snapshot_names(const po::variables_map &vm,
                                   at::ArgumentModifier mod,
                                   size_t *spec_arg_index,

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -104,6 +104,12 @@ std::string get_positional_argument(
 void normalize_pool_name(std::string* pool_name);
 std::string get_default_pool_name();
 
+int get_image_or_snap_spec(const boost::program_options::variables_map &vm,
+                           std::string *spec);
+
+void append_options_as_args(const std::vector<std::string> &options,
+                            std::vector<std::string> *args);
+
 int get_pool_and_namespace_names(
     const boost::program_options::variables_map &vm, bool validate_pool_name,
     std::string* pool_name, std::string* namespace_name, size_t *arg_index);

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -195,8 +195,9 @@ void get_unmap_arguments(po::options_description *positional,
   positional->add_options()
     ("image-or-snap-or-device-spec",
      "image, snapshot, or device specification\n"
-     "[<pool-name>/]<image-name>[@<snap-name>] or <device-path>");
+     "[<pool-name>/[<namespace>/]]<image-name>[@<snap-name>] or <device-path>");
   at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_namespace_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);
   add_device_specific_options(options);

--- a/src/tools/rbd/action/Ggate.cc
+++ b/src/tools/rbd/action/Ggate.cc
@@ -51,59 +51,6 @@ static int call_ggate_cmd(const po::variables_map &vm,
 
   return 0;
 }
-
-int get_image_or_snap_spec(const po::variables_map &vm, std::string *spec) {
-  size_t arg_index = 0;
-  std::string pool_name;
-  std::string nspace_name;
-  std::string image_name;
-  std::string snap_name;
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &nspace_name,
-    &image_name, &snap_name, true,
-    utils::SNAPSHOT_PRESENCE_PERMITTED, utils::SPEC_VALIDATION_NONE);
-  if (r < 0) {
-    return r;
-  }
-
-  if (pool_name.empty()) {
-    // connect to the cluster to get the default pool
-    librados::Rados rados;
-    r = utils::init_rados(&rados);
-    if (r < 0) {
-      return r;
-    }
-
-    utils::normalize_pool_name(&pool_name);
-  }
-
-  spec->append(pool_name);
-  spec->append("/");
-  if (!nspace_name.empty()) {
-    spec->append(nspace_name);
-    spec->append("/");
-  }
-  spec->append(image_name);
-  if (!snap_name.empty()) {
-    spec->append("@");
-    spec->append(snap_name);
-  }
-
-  return 0;
-}
-
-int parse_options(const std::vector<std::string> &options,
-                  std::vector<std::string> *args) {
-  for (auto &opts : options) {
-    std::vector<std::string> args_;
-    boost::split(args_, opts, boost::is_any_of(","));
-    for (auto &o : args_) {
-      args->push_back("--" + o);
-    }
-  }
-
-  return 0;
-}
 #endif
 
 int execute_list(const po::variables_map &vm,
@@ -138,7 +85,7 @@ int execute_map(const po::variables_map &vm,
 
   args.push_back("map");
   std::string img;
-  int r = get_image_or_snap_spec(vm, &img);
+  int r = utils::get_image_or_snap_spec(vm, &img);
   if (r < 0) {
     return r;
   }
@@ -161,10 +108,8 @@ int execute_map(const po::variables_map &vm,
   }
 
   if (vm.count("options")) {
-    r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_ggate_cmd(vm, args, ceph_global_init_args);
@@ -184,7 +129,7 @@ int execute_unmap(const po::variables_map &vm,
 
   std::string image_name;
   if (device_name.empty()) {
-    int r = get_image_or_snap_spec(vm, &image_name);
+    int r = utils::get_image_or_snap_spec(vm, &image_name);
     if (r < 0) {
       return r;
     }
@@ -202,10 +147,8 @@ int execute_unmap(const po::variables_map &vm,
   args.push_back(device_name.empty() ? image_name : device_name);
 
   if (vm.count("options")) {
-    int r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_ggate_cmd(vm, args, ceph_global_init_args);

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -60,61 +60,6 @@ static int call_nbd_cmd(const po::variables_map &vm,
   #endif
 }
 
-#if !defined(__FreeBSD__) && !defined(_WIN32)
-int get_image_or_snap_spec(const po::variables_map &vm, std::string *spec) {
-  size_t arg_index = 0;
-  std::string pool_name;
-  std::string nspace_name;
-  std::string image_name;
-  std::string snap_name;
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &nspace_name,
-    &image_name, &snap_name, true, utils::SNAPSHOT_PRESENCE_PERMITTED,
-    utils::SPEC_VALIDATION_NONE);
-  if (r < 0) {
-    return r;
-  }
-
-  if (pool_name.empty()) {
-    // connect to the cluster to get the default pool
-    librados::Rados rados;
-    r = utils::init_rados(&rados);
-    if (r < 0) {
-      return r;
-    }
-
-    utils::normalize_pool_name(&pool_name);
-  }
-
-  spec->append(pool_name);
-  spec->append("/");
-  if (!nspace_name.empty()) {
-    spec->append(nspace_name);
-    spec->append("/");
-  }
-  spec->append(image_name);
-  if (!snap_name.empty()) {
-    spec->append("@");
-    spec->append(snap_name);
-  }
-
-  return 0;
-}
-
-int parse_options(const std::vector<std::string> &options,
-                  std::vector<std::string> *args) {
-  for (auto &opts : options) {
-    std::vector<std::string> args_;
-    boost::split(args_, opts, boost::is_any_of(","));
-    for (auto &o : args_) {
-      args->push_back("--" + o);
-    }
-  }
-
-  return 0;
-}
-#endif
-
 int execute_list(const po::variables_map &vm,
                  const std::vector<std::string> &ceph_global_init_args) {
 #if defined(__FreeBSD__) || defined(_WIN32)
@@ -148,7 +93,7 @@ int execute_attach(const po::variables_map &vm,
 
   args.push_back("attach");
   std::string img;
-  int r = get_image_or_snap_spec(vm, &img);
+  int r = utils::get_image_or_snap_spec(vm, &img);
   if (r < 0) {
     return r;
   }
@@ -195,10 +140,8 @@ int execute_attach(const po::variables_map &vm,
   }
 
   if (vm.count("options")) {
-    r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
@@ -218,7 +161,7 @@ int execute_detach(const po::variables_map &vm,
 
   std::string image_name;
   if (device_name.empty()) {
-    int r = get_image_or_snap_spec(vm, &image_name);
+    int r = utils::get_image_or_snap_spec(vm, &image_name);
     if (r < 0) {
       return r;
     }
@@ -236,10 +179,8 @@ int execute_detach(const po::variables_map &vm,
   args.push_back(device_name.empty() ? image_name : device_name);
 
   if (vm.count("options")) {
-    int r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
@@ -256,7 +197,7 @@ int execute_map(const po::variables_map &vm,
 
   args.push_back("map");
   std::string img;
-  int r = get_image_or_snap_spec(vm, &img);
+  int r = utils::get_image_or_snap_spec(vm, &img);
   if (r < 0) {
     return r;
   }
@@ -289,10 +230,8 @@ int execute_map(const po::variables_map &vm,
   }
 
   if (vm.count("options")) {
-    r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
@@ -312,7 +251,7 @@ int execute_unmap(const po::variables_map &vm,
 
   std::string image_name;
   if (device_name.empty()) {
-    int r = get_image_or_snap_spec(vm, &image_name);
+    int r = utils::get_image_or_snap_spec(vm, &image_name);
     if (r < 0) {
       return r;
     }
@@ -330,10 +269,8 @@ int execute_unmap(const po::variables_map &vm,
   args.push_back(device_name.empty() ? image_name : device_name);
 
   if (vm.count("options")) {
-    int r = parse_options(vm["options"].as<std::vector<std::string>>(), &args);
-    if (r < 0) {
-      return r;
-    }
+    utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),
+                                  &args);
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);

--- a/src/tools/rbd/action/Wnbd.cc
+++ b/src/tools/rbd/action/Wnbd.cc
@@ -126,26 +126,17 @@ int execute_unmap(const po::variables_map &vm,
   std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
   return -EOPNOTSUPP;
 #else
-  std::string device_name = utils::get_positional_argument(vm, 0);
-
   std::string image_name;
-  if (device_name.empty()) {
-    int r = utils::get_image_or_snap_spec(vm, &image_name);
-    if (r < 0) {
-      return r;
-    }
-  }
 
-  if (device_name.empty() && image_name.empty()) {
-    std::cerr << "rbd: unmap requires either image name or device path"
-              << std::endl;
-    return -EINVAL;
+  int r = utils::get_image_or_snap_spec(vm, &image_name);
+  if (r < 0) {
+    return r;
   }
 
   std::vector<std::string> args;
 
   args.push_back("unmap");
-  args.push_back(device_name.empty() ? image_name : device_name);
+  args.push_back(image_name);
 
   if (vm.count("options")) {
     utils::append_options_as_args(vm["options"].as<std::vector<std::string>>(),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57844

---

backport of https://github.com/ceph/ceph/pull/48367
parent tracker: https://tracker.ceph.com/issues/57765

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh