### PR TITLE
blk/kernel: Fix error code mapping in KernelDevice::read.

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -1229,7 +1229,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 	 << "s" << dendl;
   }
   if (r < 0) {
-    if (ioc->allow_eio && is_expected_ioerr(r)) {
+    if (ioc->allow_eio && is_expected_ioerr(-errno)) {
       r = -EIO;
     } else {
       r = -errno;


### PR DESCRIPTION
pread returns -1 upon error and stores the error code in errno, and thus the wrong error was being passed into is_expected_ioerr. This is handled correctly just a few lines down where we return -errno, so it was likely just an oversight when adapting this logic from the aio codepath, where the return code is indeed the errno.

This logic has been incorrect since it was introduced in 2018 via a1e0ece7f987c7a563b25ec0d02fc6f8445ef54e.

Fixes: https://tracker.ceph.com/issues/57857