### PR TITLE
crimson/osd: add the delete-head special case of CEPH_OSD_OP_ROLLBACK

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -566,6 +566,11 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
     return do_write_op([this, &osd_op](auto& backend, auto& os, auto& txn) {
       return backend.writefull(os, osd_op, txn, *osd_op_params, delta_stats);
     });
+  case CEPH_OSD_OP_ROLLBACK:
+    return do_write_op([this, &ss=obc->get_ro_ss(),
+                        &osd_op](auto& backend, auto& os, auto& txn) {
+      return backend.rollback(ss, os, osd_op, txn, *osd_op_params, delta_stats);
+    });
   case CEPH_OSD_OP_APPEND:
     return do_write_op([this, &osd_op](auto& backend, auto& os, auto& txn) {
       return backend.append(os, osd_op, txn, *osd_op_params, delta_stats);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -700,6 +700,55 @@ PGBackend::write_iertr::future<> PGBackend::writefull(
   return seastar::now();
 }
 
+using mocked_load_clone_obc_ertr = crimson::errorator<
+  crimson::ct_error::enoent,
+  crimson::ct_error::object_corrupted>;
+using mocked_lock_clone_obc_iertr =
+  ::crimson::interruptible::interruptible_errorator<
+    ::crimson::osd::IOInterruptCondition,
+    mocked_load_clone_obc_ertr>;
+
+static mocked_lock_clone_obc_iertr::future<crimson::osd::ObjectContextRef>
+mocked_load_clone_obc(const auto& coid)
+{
+  return crimson::ct_error::enoent::make();
+}
+
+static auto head2clone(const hobject_t& hoid)
+{
+  // TODO: transform hoid into coid
+  return hoid;
+}
+
+PGBackend::rollback_iertr::future<> PGBackend::rollback(
+  const SnapSet &ss,
+  ObjectState& os,
+  const OSDOp& osd_op,
+  ceph::os::Transaction& txn,
+  osd_op_params_t& osd_op_params,
+  object_stat_sum_t& delta_stats)
+{
+  assert(os.oi.soid.is_head());
+  logger().debug("{} deleting {} and rolling back to old snap {}",
+                  __func__, os.oi.soid, osd_op.op.snap.snapid);
+  return mocked_load_clone_obc(
+    head2clone(os.oi.soid)
+  ).safe_then_interruptible([](auto clone_obc) {
+    // TODO: implement me!
+    static_cast<void>(clone_obc);
+    return remove_iertr::now();
+  }, crimson::ct_error::enoent::handle([this, &os, &txn, &delta_stats] {
+    // there's no snapshot here, or there's no object.
+    // if there's no snapshot, we delete the object; otherwise, do nothing.
+    logger().debug("rollback: deleting head on {}"
+                   " because got ENOENT|whiteout on obc lookup",
+                   os.oi.soid);
+    return remove(os, txn, delta_stats, true /*whiteout*/);
+  }), mocked_load_clone_obc_ertr::assert_all{
+    "unexpected error code in rollback"
+  });
+}
+
 PGBackend::append_ierrorator::future<> PGBackend::append(
   ObjectState& os,
   OSDOp& osd_op,

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -186,6 +186,19 @@ public:
     ceph::os::Transaction& trans,
     osd_op_params_t& osd_op_params,
     object_stat_sum_t& delta_stats);
+  using rollback_ertr = crimson::errorator<
+    crimson::ct_error::enoent>;
+  using rollback_iertr =
+    ::crimson::interruptible::interruptible_errorator<
+      ::crimson::osd::IOInterruptCondition,
+      rollback_ertr>;
+  rollback_iertr::future<> rollback(
+    const SnapSet &ss,
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& txn,
+    osd_op_params_t& osd_op_params,
+    object_stat_sum_t& delta_stats);
   write_iertr::future<> truncate(
     ObjectState& os,
     const OSDOp& osd_op,


### PR DESCRIPTION
This allows to pass `TestLibRBD.TestIOToSnapshot`:

```
[rzarzynski@o06 build]$ CRIMSON_COMPAT=true RBD_FEATURES=1 bin/ceph_test_librbd --gtest_filter=TestLibRBD.TestIOToSnapshot
seed 3954016
Note: Google Test filter = TestLibRBD.TestIOToSnapshot
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from TestLibRBD
[ RUN      ] TestLibRBD.TestIOToSnapshot
using new format!
...
opening testimg@orig
read: 80
write to snapshot returned -30
Read-only file system
num snaps is: 2
expected: 2
snap: orig
snap: written
found orig with size 2097152
found written with size 2097152
num snaps is: 1
expected: 1
snap: orig
found orig with size 2097152
num snaps is: 0
expected: 0
[       OK ] TestLibRBD.TestIOToSnapshot (7510 ms)
[----------] 1 test from TestLibRBD (7510 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (8504 ms total)
[  PASSED  ] 1 test.
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
