### PR TITLE
quincy: doc/dev: add submodule-update link to dev guide

### DIFF
--- a/doc/dev/developer_guide/basic-workflow.rst
+++ b/doc/dev/developer_guide/basic-workflow.rst
@@ -201,6 +201,9 @@ upstream repository:
 This procedure should be followed often, in order to keep your local ``main``
 in sync with upstream ``main``.
 
+If the command ``git status`` returns a line that reads "Untracked files", see
+:ref:`the procedure on updating submodules <update-submodules>`.
+
 .. _bugfix_branch:
 
 Creating a Bugfix branch

--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -92,7 +92,7 @@ Updating Submodules
 
       git status
 
-   #. If your submodules are up to date 
+   A. If your submodules are up to date 
          If your submodules are up to date, the following console output will
          appear: 
 
@@ -107,7 +107,7 @@ Updating Submodules
          You do not need this procedure.
 
 
-   #. If your submodules are not up to date 
+   B. If your submodules are not up to date 
          If your submodules are not up to date, you will see a message that
          includes a list of "untracked files". The example here shows such a
          list, which was generated from a real situation in which the


### PR DESCRIPTION
This commit links to the procedure in install/clone-source.rst that explains how to update submodules.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit e55c3b114be402eae94550c603cf7c028c9b64bf)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
