### PR TITLE
rgw: add SiteConfig to load/create zonegroup configuration

### DIFF
--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -874,6 +874,37 @@ int create_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
   return 0;
 }
 
+static int create_default_zonegroup(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    sal::ConfigStore* cfgstore,
+                                    bool exclusive,
+                                    const RGWZoneParams& default_zone,
+                                    RGWZoneGroup& info)
+{
+  info.name = default_zonegroup_name;
+  info.api_name = default_zonegroup_name;
+  info.is_master = true;
+
+  // enable all supported features
+  info.enabled_features.insert(rgw::zone_features::supported.begin(),
+                               rgw::zone_features::supported.end());
+
+  // add the zone to the zonegroup
+  bool is_master = true;
+  std::list<std::string> empty_list;
+  rgw::zone_features::set disable_features; // empty
+  int r = add_zone_to_group(dpp, info, default_zone, &is_master, nullptr,
+                            empty_list, nullptr, nullptr, empty_list,
+                            empty_list, nullptr, std::nullopt,
+                            info.enabled_features, disable_features);
+  if (r < 0) {
+    return r;
+  }
+
+  // write the zone
+  return create_zonegroup(dpp, y, cfgstore, exclusive, info);
+}
+
 int set_default_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
                           sal::ConfigStore* cfgstore, const RGWZoneGroup& info,
                           bool exclusive)
@@ -1059,6 +1090,191 @@ int delete_zone(const DoutPrefixProvider* dpp, optional_yield y,
   }
 
   return writer.remove(dpp, y);
+}
+
+
+static int read_or_create_default_zone(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       sal::ConfigStore* cfgstore,
+                                       RGWZoneParams& info)
+{
+  int r = cfgstore->read_zone_by_name(dpp, y, default_zone_name, info, nullptr);
+  if (r == -ENOENT) {
+    info.name = default_zone_name;
+    constexpr bool exclusive = true;
+    r = create_zone(dpp, y, cfgstore, exclusive, info, nullptr);
+    if (r == -EEXIST) {
+      r = cfgstore->read_zone_by_name(dpp, y, default_zone_name, info, nullptr);
+    }
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to create default zone: "
+          << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  return r;
+}
+
+static int read_or_create_default_zonegroup(const DoutPrefixProvider* dpp,
+                                            optional_yield y,
+                                            sal::ConfigStore* cfgstore,
+                                            const RGWZoneParams& zone_params,
+                                            RGWZoneGroup& info)
+{
+  int r = cfgstore->read_zonegroup_by_name(dpp, y, default_zonegroup_name,
+                                           info, nullptr);
+  if (r == -ENOENT) {
+    constexpr bool exclusive = true;
+    r = create_default_zonegroup(dpp, y, cfgstore, exclusive,
+                                 zone_params, info);
+    if (r == -EEXIST) {
+      r = cfgstore->read_zonegroup_by_name(dpp, y, default_zonegroup_name,
+                                           info, nullptr);
+    }
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to create default zonegroup: "
+          << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  return r;
+}
+
+int SiteConfig::load(const DoutPrefixProvider* dpp, optional_yield y,
+                     sal::ConfigStore* cfgstore)
+{
+  // clear existing configuration
+  zone = nullptr;
+  zonegroup = nullptr;
+  local_zonegroup = std::nullopt;
+  period = std::nullopt;
+  zone_params = RGWZoneParams{};
+
+  int r = 0;
+
+  // try to load a realm
+  realm.emplace();
+  std::string realm_name = dpp->get_cct()->_conf->rgw_realm;
+  if (!realm_name.empty()) {
+    r = cfgstore->read_realm_by_name(dpp, y, realm_name, *realm, nullptr);
+  } else {
+    r = cfgstore->read_default_realm(dpp, y, *realm, nullptr);
+    if (r == -ENOENT) { // no realm
+      r = 0;
+      realm = std::nullopt;
+    }
+  }
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to load realm: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // try to load the local zone params
+  std::string zone_name = dpp->get_cct()->_conf->rgw_zone;
+  if (!zone_name.empty()) {
+    r = cfgstore->read_zone_by_name(dpp, y, zone_name, zone_params, nullptr);
+  } else if (realm) {
+    // load the realm's default zone
+    r = cfgstore->read_default_zone(dpp, y, realm->id, zone_params, nullptr);
+  } else {
+    // load or create the "default" zone
+    r = read_or_create_default_zone(dpp, y, cfgstore, zone_params);
+  }
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to load zone: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  if (!realm && !zone_params.realm_id.empty()) {
+    realm.emplace();
+    r = cfgstore->read_realm_by_id(dpp, y, zone_params.realm_id,
+                                   *realm, nullptr);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "failed to load realm: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  if (realm) {
+    // try to load the realm's period
+    r = load_period_zonegroup(dpp, y, cfgstore, *realm, zone_params.id);
+  } else {
+    // fall back to a local zonegroup
+    r = load_local_zonegroup(dpp, y, cfgstore, zone_params.id);
+  }
+
+  return r;
+}
+
+int SiteConfig::load_period_zonegroup(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      sal::ConfigStore* cfgstore,
+                                      const RGWRealm& realm,
+                                      const rgw_zone_id& zone_id)
+{
+  // load the realm's current period
+  period.emplace();
+  int r = cfgstore->read_period(dpp, y, realm.current_period,
+                                std::nullopt, *period);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to load current period: "
+        << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // find our zone and zonegroup in the period
+  for (const auto& zg : period->period_map.zonegroups) {
+    auto z = zg.second.zones.find(zone_id);
+    if (z != zg.second.zones.end()) {
+      zone = &z->second;
+      zonegroup = &zg.second;
+      return 0;
+    }
+  }
+
+  ldpp_dout(dpp, 0) << "ERROR: current period " << period->id
+      << " does not contain zone id " << zone_id << dendl;
+
+  period = std::nullopt;
+  return -ENOENT;
+}
+
+int SiteConfig::load_local_zonegroup(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     sal::ConfigStore* cfgstore,
+                                     const rgw_zone_id& zone_id)
+{
+  int r = 0;
+
+  // load the zonegroup
+  local_zonegroup.emplace();
+  std::string zonegroup_name = dpp->get_cct()->_conf->rgw_zonegroup;
+  if (!zonegroup_name.empty()) {
+    r = cfgstore->read_zonegroup_by_name(dpp, y, zonegroup_name,
+                                         *local_zonegroup, nullptr);
+  } else {
+    r = read_or_create_default_zonegroup(dpp, y, cfgstore, zone_params,
+                                         *local_zonegroup);
+  }
+
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "failed to load zonegroup: "
+        << cpp_strerror(r) << dendl;
+  } else {
+    // find our zone in the zonegroup
+    auto z = local_zonegroup->zones.find(zone_id);
+    if (z != local_zonegroup->zones.end()) {
+      zone = &z->second;
+      zonegroup = &*local_zonegroup;
+      return 0;
+    }
+    ldpp_dout(dpp, 0) << "ERROR: zonegroup " << local_zonegroup->id
+        << " does not contain zone id " << zone_id << dendl;
+    r = -ENOENT;
+  }
+
+  local_zonegroup = std::nullopt;
+  return r;
 }
 
 } // namespace rgw

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -27,7 +27,8 @@
 #include "include/stringify.h"
 #include "rgw_main.h"
 #include "rgw_common.h"
-#include "rgw_sal_rados.h"
+#include "rgw_sal.h"
+#include "rgw_sal_config.h"
 #include "rgw_period_pusher.h"
 #include "rgw_realm_reloader.h"
 #include "rgw_rest.h"
@@ -90,6 +91,11 @@ namespace {
 }
 
 OpsLogFile* rgw::AppMain::ops_log_file;
+
+rgw::AppMain::AppMain(const DoutPrefixProvider* dpp) : dpp(dpp)
+{
+}
+rgw::AppMain::~AppMain() = default;
 
 void rgw::AppMain::init_frontends1(bool nfs) 
 {
@@ -196,9 +202,22 @@ void rgw::AppMain::init_numa()
   }
 } /* init_numa */
 
-void rgw::AppMain::init_storage()
+int rgw::AppMain::init_storage()
 {
-    auto run_gc =
+  auto config_store_type = g_conf().get_val<std::string>("rgw_config_store");
+  cfgstore = DriverManager::create_config_store(dpp, config_store_type);
+  if (!cfgstore) {
+    return -EIO;
+  }
+  env.cfgstore = cfgstore.get();
+
+  int r = site.load(dpp, null_yield, cfgstore.get());
+  if (r < 0) {
+    return r;
+  }
+  env.site = &site;
+
+  auto run_gc =
     (g_conf()->rgw_enable_gc_threads &&
       ((!nfs) || (nfs && g_conf()->rgw_nfs_run_gc_threads)));
 
@@ -224,7 +243,10 @@ void rgw::AppMain::init_storage()
           g_conf().get_val<bool>("rgw_dynamic_resharding"),
           true, // run notification thread
           g_conf()->rgw_cache_enabled);
-
+  if (!env.driver) {
+    return -EIO;
+  }
+  return 0;
 } /* init_storage */
 
 void rgw::AppMain::init_perfcounters()
@@ -586,6 +608,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
     lua_background->shutdown();
   }
 
+  cfgstore.reset(); // deletes
   DriverManager::close_storage(env.driver);
 
   rgw_tools_cleanup();

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -135,15 +135,15 @@ int main(int argc, char *argv[])
   main.init_perfcounters();
   main.init_http_clients();
 
-  main.init_storage();
-  if (! main.get_driver()) {
+  r = main.init_storage();
+  if (r < 0) {
     mutex.lock();
     init_timer.cancel_all_events();
     init_timer.shutdown();
     mutex.unlock();
 
     derr << "Couldn't init storage provider (RADOS)" << dendl;
-    return EIO;
+    return -r;
   }
 
   main.cond_init_apis();

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -51,6 +51,7 @@ public:
 namespace rgw {
 
 namespace lua { class Background; }
+namespace sal { class ConfigStore; }
 
 class RGWLib;
 class AppMain {
@@ -76,17 +77,21 @@ class AppMain {
   std::unique_ptr<RGWFrontendPauser> fe_pauser;
   std::unique_ptr<RGWRealmWatcher> realm_watcher;
   std::unique_ptr<RGWPauser> rgw_pauser;
-  DoutPrefixProvider* dpp;
+  std::unique_ptr<sal::ConfigStore> cfgstore;
+  SiteConfig site;
+  const DoutPrefixProvider* dpp;
   RGWProcessEnv env;
 
 public:
-  AppMain(DoutPrefixProvider* dpp)
-    : dpp(dpp)
-    {}
+  AppMain(const DoutPrefixProvider* dpp);
+  ~AppMain();
 
   void shutdown(std::function<void(void)> finalize_async_signals
 	       = []() { /* nada */});
 
+  sal::ConfigStore* get_config_store() const {
+    return cfgstore.get();
+  }
   rgw::sal::Driver* get_driver() {
     return env.driver;
   }
@@ -97,7 +102,7 @@ public:
 
   void init_frontends1(bool nfs = false);
   void init_numa();
-  void init_storage();
+  int init_storage();
   void init_perfcounters();
   void init_http_clients();
   void cond_init_apis();

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -63,7 +63,7 @@ class AppMain {
   std::vector<RGWFrontendConfig*> fe_configs;
   std::multimap<string, RGWFrontendConfig*> fe_map;
   std::unique_ptr<rgw::LDAPHelper> ldh;
-  OpsLogSink* olog;
+  OpsLogSink* olog = nullptr;
   RGWREST rest;
   std::unique_ptr<rgw::lua::Background> lua_background;
   std::unique_ptr<rgw::auth::ImplicitTenants> implicit_tenant_context;

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -9,6 +9,9 @@ class ActiveRateLimiter;
 class OpsLogSink;
 class RGWREST;
 
+namespace rgw {
+  class SiteConfig;
+}
 namespace rgw::auth {
   class StrategyRegistry;
 }
@@ -16,7 +19,8 @@ namespace rgw::lua {
   class Background;
 }
 namespace rgw::sal {
-  class Store;
+  class ConfigStore;
+  class Driver;
   class LuaManager;
 }
 
@@ -35,7 +39,9 @@ struct RGWLuaProcessEnv {
 
 struct RGWProcessEnv {
   RGWLuaProcessEnv lua;
+  rgw::sal::ConfigStore* cfgstore = nullptr;
   rgw::sal::Driver* driver = nullptr;
+  rgw::SiteConfig* site = nullptr;
   RGWREST *rest = nullptr;
   OpsLogSink *olog = nullptr;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -109,22 +109,24 @@ void RGWRealmReloader::reload()
 
 
   while (!env.driver) {
-    // recreate and initialize a new driver
-    DriverManager::Config cfg;
-    cfg.store_name = "rados";
-    cfg.filter_name = "none";
-    env.driver =
-      DriverManager::get_storage(&dp, cct,
-				   cfg,
-				   cct->_conf->rgw_enable_gc_threads,
-				   cct->_conf->rgw_enable_lc_threads,
-				   cct->_conf->rgw_enable_quota_threads,
-				   cct->_conf->rgw_run_sync_thread,
-				   cct->_conf.get_val<bool>("rgw_dynamic_resharding"),
-                                   true, // run notification thread
-				   cct->_conf->rgw_cache_enabled);
+    // reload the new configuration from ConfigStore
+    int r = env.site->load(&dp, null_yield, env.cfgstore);
+    if (r == 0) {
+      ldpp_dout(&dp, 1) << "Creating new driver" << dendl;
 
-    ldpp_dout(&dp, 1) << "Creating new driver" << dendl;
+      // recreate and initialize a new driver
+      DriverManager::Config cfg;
+      cfg.store_name = "rados";
+      cfg.filter_name = "none";
+      env.driver = DriverManager::get_storage(&dp, cct, cfg,
+          cct->_conf->rgw_enable_gc_threads,
+          cct->_conf->rgw_enable_lc_threads,
+          cct->_conf->rgw_enable_quota_threads,
+          cct->_conf->rgw_run_sync_thread,
+          cct->_conf.get_val<bool>("rgw_dynamic_resharding"),
+          true, // run notification thread
+          cct->_conf->rgw_cache_enabled);
+    }
 
     rgw::sal::Driver* store_cleanup = nullptr;
     {
@@ -135,13 +137,13 @@ void RGWRealmReloader::reload()
       // sleep until we get another notification, and retry until we get
       // a working configuration
       if (env.driver == nullptr) {
-        ldpp_dout(&dp, -1) << "Failed to reinitialize RGWRados after a realm "
+        ldpp_dout(&dp, -1) << "Failed to reload realm after a period "
             "configuration update. Waiting for a new update." << dendl;
 
         // sleep until another event is scheduled
 	cond.wait(lock, [this] { return reload_scheduled; });
-        ldout(cct, 1) << "Woke up with a new configuration, retrying "
-            "RGWRados initialization." << dendl;
+        ldpp_dout(&dp, 1) << "Woke up with a new configuration, retrying "
+            "realm reload." << dendl;
       }
 
       if (reload_scheduled) {
@@ -156,8 +158,8 @@ void RGWRealmReloader::reload()
     }
 
     if (store_cleanup) {
-      ldpp_dout(&dp, 4) << "Got another notification, restarting RGWRados "
-          "initialization." << dendl;
+      ldpp_dout(&dp, 4) << "Got another notification, restarting realm "
+          "reload." << dendl;
 
       DriverManager::close_storage(store_cleanup);
     }


### PR DESCRIPTION
adds a class `rgw::SiteConfig` that exposes const access to the loaded zone/zonegroup configuration

moves the startup logic which loads that configuration (or creates "default" zone/zonegroup) out of the zone service `RGWSI_Zone` into `rgw::SiteConfig::load()`

`rgw::AppMain::init_storage()` now creates a `rgw::sal::ConfigStore` and calls `rgw::SiteConfig::load()` with it. `load()` is also called on realm reload events

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
