### PR TITLE
rgw: LDAP fix resource leak with wrong credentials

### DIFF
--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -83,10 +83,8 @@ namespace rgw {
 			      (void*) &ldap_ver);
 	if (ret == LDAP_SUCCESS) {
 	  ret = ldap_simple_bind_s(tldap, dn, pwd.c_str());
-	  if (ret == LDAP_SUCCESS) {
-	    (void) ldap_unbind(tldap);
-	  }
 	}
+	(void) ldap_unbind(tldap);
       }
       return ret; // OpenLDAP client error space
     }


### PR DESCRIPTION
/src/rgw/ldap.h: moved ldap_unbind to outside of successful states to always clean up connections

Fixes: https://tracker.ceph.com/issues/57881
Signed-off-by: Johannes Liebl <68052021+jliebl-git@users.noreply.github.com>

