### PR TITLE
crimson,mon: add guards to avoid accidental crimson deployment and to avoid usage of unsupported features with crimson

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       mon:
         osd pool default crimson: true
+    flavor: crimson
   workunit:
     env:
       CRIMSON_COMPAT: '1'

--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     conf:
+      global:
+        enable experimental unrecoverable data corrupting features: crimson
       mon:
         osd pool default crimson: true
     flavor: crimson

--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -1,4 +1,8 @@
 overrides:
+  ceph:
+    conf:
+      mon:
+        osd pool default crimson: true
   workunit:
     env:
       CRIMSON_COMPAT: '1'

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -377,6 +377,24 @@ def crush_setup(ctx, config):
 
 
 @contextlib.contextmanager
+def check_enable_crimson(ctx, config):
+    # enable crimson-osds if crimson
+    log.info("check_enable_crimson: {}".format(is_crimson(config)))
+    if is_crimson(config):
+        cluster_name = config['cluster']
+        first_mon = teuthology.get_first_mon(ctx, config, cluster_name)
+        (mon_remote,) = ctx.cluster.only(first_mon).remotes.keys()
+        log.info('check_enable_crimson: setting set-allow-crimson')
+        mon_remote.run(
+            args=[
+                'sudo', 'ceph', '--cluster', cluster_name,
+                'osd', 'set-allow-crimson', '--yes-i-really-mean-it'
+            ]
+        )
+    yield
+
+
+@contextlib.contextmanager
 def setup_manager(ctx, config):
     first_mon = teuthology.get_first_mon(ctx, config, config['cluster'])
     (mon,) = ctx.cluster.only(first_mon).remotes.keys()
@@ -597,9 +615,12 @@ def create_simple_monmap(ctx, remote, conf, mons,
     return fsid
 
 
+def is_crimson(config):
+    return config.get('flavor', 'default') == 'crimson'
+
+
 def maybe_redirect_stderr(config, type_, args, log_path):
-    if type_ == 'osd' and \
-       config.get('flavor', 'default') == 'crimson':
+    if type_ == 'osd' and is_crimson(config):
         # teuthworker uses ubuntu:ubuntu to access the test nodes
         create_log_cmd = \
             f'sudo install -b -o ubuntu -g ubuntu /dev/null {log_path}'
@@ -870,6 +891,7 @@ def cluster(ctx, config):
     teuthology.deep_merge(ctx.disk_config.remote_to_roles_to_dev, remote_to_roles_to_devs)
 
     log.info("ctx.disk_config.remote_to_roles_to_dev: {r}".format(r=str(ctx.disk_config.remote_to_roles_to_dev)))
+
     for remote, roles_for_host in osds.remotes.items():
         roles_to_devs = remote_to_roles_to_devs[remote]
 
@@ -1882,6 +1904,7 @@ def task(ctx, config):
         lambda: run_daemon(ctx=ctx, config=config, type_='mon'),
         lambda: run_daemon(ctx=ctx, config=config, type_='mgr'),
         lambda: crush_setup(ctx=ctx, config=config),
+        lambda: check_enable_crimson(ctx=ctx, config=config),
         lambda: run_daemon(ctx=ctx, config=config, type_='osd'),
         lambda: setup_manager(ctx=ctx, config=config),
         lambda: create_rbd_pool(ctx=ctx, config=config),

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -27,6 +27,15 @@ options:
   default: 4_K
   services:
   - mon
+- name: osd_pool_default_crimson
+  type: bool
+  level: advanced
+  desc: Create pools by default with FLAG_CRIMSON
+  default: false
+  services :
+  - mon
+  flags:
+  - runtime
 - name: mon_max_pool_pg_num
   type: uint
   level: advanced

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -531,6 +531,10 @@ seastar::future<> OSD::_send_boot()
                                   cluster_addrs,
                                   CEPH_FEATURES_ALL);
   collect_sys_info(&m->metadata, NULL);
+
+  // See OSDMonitor::preprocess_boot, prevents boot without allow_crimson
+  // OSDMap flag
+  m->metadata["osd_type"] = "crimson";
   return monc->send_message(std::move(m));
 }
 

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -511,6 +511,15 @@ seastar::future<Ref<PG>> ShardServices::handle_pg_create_info(
 	      return seastar::make_ready_future<
 		std::tuple<Ref<PG>, OSDMapService::cached_map_t>
 		>(std::make_tuple(Ref<PG>(), startmap));
+	    } else if (!pool->is_crimson()) {
+	      logger().debug(
+		"{} ignoring pgid {}, pool lacks crimson flag",
+		__func__,
+		pgid);
+	      local_state.pg_map.pg_creation_canceled(pgid);
+	      return seastar::make_ready_future<
+		std::tuple<Ref<PG>, OSDMapService::cached_map_t>
+		>(std::make_tuple(Ref<PG>(), startmap));
 	    }
 	    ceph_assert(get_map()->require_osd_release >=
 			ceph_release_t::octopus);

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1084,7 +1084,8 @@ COMMAND("osd pool create "
 	"name=bulk,type=CephBool,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0.0,req=false "\
-	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"name=yes_i_really_mean_it,type=CephBool,req=false"
+	"name=crimson,type=CephBool,req=false",
 	"create pool", "osd", "rw")
 COMMAND_WITH_FLAG("osd pool delete "
 	"name=pool,type=CephPoolname "

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1173,6 +1173,13 @@ COMMAND("osd force_recovery_stretch_mode " \
 	"pool size to its non-failure value if currently degraded and "
 	"all monitor buckets are up",
 	"osd", "rw")
+COMMAND("osd set-allow-crimson " \
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"Allow crimson-osds to boot and join the cluster.  Note, crimson-osd is "
+	"not yet considered stable and may crash or cause data loss -- should "
+	"be avoided outside of testing and development.  This setting is "
+	"irrevocable",
+	"osd", "rw")
 
 
 // tiering

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14414,6 +14414,19 @@ bool OSDMonitor::_check_become_tier(
   const std::string &tier_pool_name = osdmap.get_pool_name(tier_pool_id);
   const std::string &base_pool_name = osdmap.get_pool_name(base_pool_id);
 
+  if (tier_pool->is_crimson()) {
+    *ss << "pool '" << tier_pool_name << "' is a crimson pool, tiering "
+	<< "features are not supported";
+    *err = -EINVAL;
+    return false;
+  }
+  if (base_pool->is_crimson()) {
+    *ss << "pool '" << base_pool_name << "' is a crimson pool, tiering "
+	<< "features are not supported";
+    *err = -EINVAL;
+    return false;
+  }
+
   const FSMap &pending_fsmap = mon.mdsmon()->get_pending_fsmap();
   if (pending_fsmap.pool_in_use(tier_pool_id)) {
     *ss << "pool '" << tier_pool_name << "' is in use by CephFS";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8422,6 +8422,10 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     }
     p.min_size = n;
   } else if (var == "pg_num_actual") {
+    if (p.has_flag(pg_pool_t::FLAG_NOPGCHANGE)) {
+      ss << "pool pg_num change is disabled; you must unset nopgchange flag for the pool first";
+      return -EPERM;
+    }
     if (interr.length()) {
       ss << "error parsing integer value '" << val << "': " << interr;
       return -EINVAL;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8172,8 +8172,10 @@ int OSDMonitor::prepare_new_pool(string& name,
     pi->use_gmt_hitset = true;
   else
     pi->use_gmt_hitset = false;
-  if (crimson)
+  if (crimson) {
     pi->set_flag(pg_pool_t::FLAG_CRIMSON);
+    pi->set_flag(pg_pool_t::FLAG_NOPGCHANGE);
+  }
 
   pi->size = size;
   pi->min_size = min_size;
@@ -8621,6 +8623,10 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     if (val == "true" || (interr.empty() && n == 1)) {
       p.set_flag(flag);
     } else if (val == "false" || (interr.empty() && n == 0)) {
+      if (flag == pg_pool_t::FLAG_NOPGCHANGE && p.is_crimson()) {
+	ss << "cannot clear FLAG_NOPGCHANGE on a crimson pool";
+	return -EINVAL;
+      }
       p.unset_flag(flag);
     } else {
       ss << "expecting value 'true', 'false', '0', or '1'";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7376,6 +7376,7 @@ int OSDMonitor::prepare_new_pool(MonOpRequestRef op)
 			 0, 0, 0, 0, 0, 0, 0.0,
 			 erasure_code_profile,
 			 pg_pool_t::TYPE_REPLICATED, 0, FAST_READ_OFF, {}, bulk,
+			 cct->_conf.get_val<bool>("osd_pool_default_crimson"),
 			 &ss);
 
   if (ret < 0) {
@@ -7982,6 +7983,9 @@ int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, int crush_rule,
  * @param pool_type TYPE_ERASURE, or TYPE_REP
  * @param expected_num_objects expected number of objects on the pool
  * @param fast_read fast read type. 
+ * @param pg_autoscale_mode autoscale mode, one of on, off, warn
+ * @param bool bulk indicates whether pool should be a bulk pool
+ * @param bool crimson indicates whether pool is a crimson pool
  * @param ss human readable error message, if any.
  *
  * @return 0 on success, negative errno on failure.
@@ -7999,12 +8003,21 @@ int OSDMonitor::prepare_new_pool(string& name,
                                  const unsigned pool_type,
                                  const uint64_t expected_num_objects,
                                  FastReadType fast_read,
-				 const string& pg_autoscale_mode,
+				 string pg_autoscale_mode,
 				 bool bulk,
+				 bool crimson,
 				 ostream *ss)
 {
+  if (crimson && pg_autoscale_mode.empty()) {
+    // default pg_autoscale_mode to off for crimson, we'll error out below if
+    // the user tried to actually set pg_autoscale_mode to something other than
+    // "off"
+    pg_autoscale_mode = "off";
+  }
+
   if (name.length() == 0)
     return -EINVAL;
+
   if (pg_num == 0) {
     auto pg_num_from_mode =
       [pg_num=g_conf().get_val<uint64_t>("osd_pool_default_pg_num")]
@@ -8031,6 +8044,25 @@ int OSDMonitor::prepare_new_pool(string& name,
         << ", which in this case is " << pg_num;
     return -ERANGE;
   }
+
+  if (crimson) {
+    /* crimson-osd requires that the pool be replicated and that pg_num/pgp_num
+     * be static.  User must also have specified set-allow-crimson */
+    const auto *suffix = " (--crimson specified or osd_pool_default_crimson set)";
+    if (pool_type != pg_pool_t::TYPE_REPLICATED) {
+      *ss << "crimson-osd only supports replicated pools" << suffix;
+      return -EINVAL;
+    } else if (pg_autoscale_mode != "off") {
+      *ss << "crimson-osd does not support changing pg_num or pgp_num, "
+	  << "pg_autoscale_mode must be set to 'off'" << suffix;
+      return -EINVAL;
+    } else if (!osdmap.get_allow_crimson()) {
+      *ss << "set-allow-crimson must be set to create a pool with the "
+	  << "crimson flag" << suffix;
+      return -EINVAL;
+    }
+  }
+
   if (pool_type == pg_pool_t::TYPE_REPLICATED && fast_read == FAST_READ_ON) {
     *ss << "'fast_read' can only apply to erasure coding pool";
     return -EINVAL;
@@ -8140,6 +8172,8 @@ int OSDMonitor::prepare_new_pool(string& name,
     pi->use_gmt_hitset = true;
   else
     pi->use_gmt_hitset = false;
+  if (crimson)
+    pi->set_flag(pg_pool_t::FLAG_CRIMSON);
 
   pi->size = size;
   pi->min_size = min_size;
@@ -13186,6 +13220,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     cmd_getval(cmdmap, "autoscale_mode", pg_autoscale_mode);
 
     bool bulk = cmd_getval_or<bool>(cmdmap, "bulk", 0);
+
+    bool crimson = cmd_getval_or<bool>(cmdmap, "crimson", false) ||
+      cct->_conf.get_val<bool>("osd_pool_default_crimson");
+
     err = prepare_new_pool(poolstr,
 			   -1, // default crush rule
 			   rule_name,
@@ -13196,6 +13234,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
                            fast_read,
 			   pg_autoscale_mode,
 			   bulk,
+			   crimson,
 			   &ss);
     if (err < 0) {
       switch(err) {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -530,8 +530,9 @@ private:
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,
                        FastReadType fast_read,
-		       const std::string& pg_autoscale_mode,
+		       std::string pg_autoscale_mode,
 		       bool bulk,
+		       bool crimson,
 		       std::ostream *ss);
   int prepare_new_pool(MonOpRequestRef op);
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -371,6 +371,13 @@ public:
     bool stretch_mode_enabled{false};
     bool change_stretch_mode{false};
 
+    enum class mutate_allow_crimson_t : uint8_t {
+      NONE = 0,
+      SET = 1,
+      // Monitor won't allow CLEAR to be set currently, but we may allow it later
+      CLEAR = 2
+    } mutate_allow_crimson = mutate_allow_crimson_t::NONE;
+
     // full (rare)
     ceph::buffer::list fullmap;  // in lieu of below.
     ceph::buffer::list crush;
@@ -517,6 +524,8 @@ public:
       }
       return p->second.contains(snap);
     }
+
+    void set_allow_crimson() { mutate_allow_crimson = mutate_allow_crimson_t::SET; }
   };
   
 private:
@@ -652,6 +661,7 @@ private:
   uint32_t degraded_stretch_mode; // 0 if not degraded; else count of up sites
   uint32_t recovering_stretch_mode; // 0 if not recovering; else 1
   int32_t stretch_mode_bucket; // the bucket type we're stretched across
+  bool allow_crimson{false};
 private:
   uint32_t crush_version = 1;
 
@@ -853,6 +863,10 @@ public:
   }
   const mempool::osdmap::map<std::string,std::map<std::string,std::string>> &get_erasure_code_profiles() const {
     return erasure_code_profiles;
+  }
+
+  bool get_allow_crimson() const {
+    return allow_crimson;
   }
 
   bool exists(int osd) const {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1235,6 +1235,10 @@ struct pg_pool_t {
     FLAG_CREATING = 1<<15,          // initial pool PGs are being created
     FLAG_EIO = 1<<16,               // return EIO for all client ops
     FLAG_BULK = 1<<17, //pool is large
+    // PGs from this pool are allowed to be created on crimson osds.
+    // Pool features are restricted to those supported by crimson-osd.
+    // Note, does not prohibit being created on classic osd.
+    FLAG_CRIMSON = 1<<18,
   };
 
   static const char *get_flag_name(uint64_t f) {
@@ -1257,6 +1261,7 @@ struct pg_pool_t {
     case FLAG_CREATING: return "creating";
     case FLAG_EIO: return "eio";
     case FLAG_BULK: return "bulk";
+    case FLAG_CRIMSON: return "crimson";
     default: return "???";
     }
   }
@@ -1311,6 +1316,8 @@ struct pg_pool_t {
       return FLAG_EIO;
     if (name == "bulk")
       return FLAG_BULK;
+    if (name == "crimson")
+      return FLAG_CRIMSON;
     return 0;
   }
 
@@ -1711,6 +1718,10 @@ public:
 
   bool allows_ecoverwrites() const {
     return has_flag(FLAG_EC_OVERWRITES);
+  }
+
+  bool is_crimson() const {
+    return has_flag(FLAG_CRIMSON);
   }
 
   bool can_shift_osds() const {

--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -67,6 +67,7 @@ rados_t RadosTestECNS::s_cluster = NULL;
 
 void RadosTestECNS::SetUpTestCase()
 {
+  SKIP_IF_CRIMSON();
   auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
   pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
@@ -74,6 +75,7 @@ void RadosTestECNS::SetUpTestCase()
 
 void RadosTestECNS::TearDownTestCase()
 {
+  SKIP_IF_CRIMSON();
   ASSERT_EQ(0, destroy_one_ec_pool(pool_name, &s_cluster));
 }
 
@@ -163,6 +165,7 @@ rados_t RadosTestEC::s_cluster = NULL;
 
 void RadosTestEC::SetUpTestCase()
 {
+  SKIP_IF_CRIMSON();
   auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name()); 
   pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
@@ -170,11 +173,13 @@ void RadosTestEC::SetUpTestCase()
 
 void RadosTestEC::TearDownTestCase()
 {
+  SKIP_IF_CRIMSON();
   ASSERT_EQ(0, destroy_one_ec_pool(pool_name, &s_cluster));
 }
 
 void RadosTestEC::SetUp()
 {
+  SKIP_IF_CRIMSON();
   cluster = RadosTestEC::s_cluster;
   ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
   nspace = get_temp_pool_name();
@@ -188,6 +193,7 @@ void RadosTestEC::SetUp()
 
 void RadosTestEC::TearDown()
 {
+  SKIP_IF_CRIMSON();
   if (cleanup) {
     cleanup_default_namespace(ioctx);
     cleanup_namespace(ioctx, nspace);

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -473,6 +473,7 @@ public:
   ~LibRadosTwoPoolsECPP() override {};
 protected:
   static void SetUpTestCase() {
+    SKIP_IF_CRIMSON();
     pool_name = get_temp_pool_name();
     ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
     src_pool_name = get_temp_pool_name();
@@ -487,6 +488,7 @@ protected:
     src_ioctx.application_enable("rados", true);
   }
   static void TearDownTestCase() {
+    SKIP_IF_CRIMSON();
     ASSERT_EQ(0, s_cluster.pool_delete(src_pool_name.c_str()));
     ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
   }

--- a/src/test/librados/pool.cc
+++ b/src/test/librados/pool.cc
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <vector>
+#include "crimson_utils.h"
 #include "gtest/gtest.h"
 #include "include/rados/librados.h"
 #include "test/librados/test.h"
@@ -135,6 +136,7 @@ TEST(LibRadosPools, PoolCreateWithCrushRule) {
 }
 
 TEST(LibRadosPools, PoolGetBaseTier) {
+  SKIP_IF_CRIMSON();
   rados_t cluster;
   std::string pool_name = get_temp_pool_name();
   ASSERT_EQ("", create_one_pool(pool_name, &cluster));

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include "test_cxx.h"
 #include "test_shared.h"
+#include "crimson_utils.h"
 #include "include/scope_guard.h"
 
 using namespace librados;
@@ -103,9 +104,10 @@ void RadosTestParamPPNS::TearDownTestCase()
 
 void RadosTestParamPPNS::SetUp()
 {
-  if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
+  if (!is_crimson_cluster() && strcmp(GetParam(), "cache") == 0 &&
+      cache_pool_name.empty()) {
     auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
-    cache_pool_name = get_temp_pool_name(pool_prefix);
+    cache_pool_name = get_temp_pool_name();
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -303,9 +305,10 @@ void RadosTestParamPP::TearDownTestCase()
 
 void RadosTestParamPP::SetUp()
 {
-  if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
+  if (!is_crimson_cluster() && strcmp(GetParam(), "cache") == 0 &&
+      cache_pool_name.empty()) {
     auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
-    cache_pool_name = get_temp_pool_name(pool_prefix);
+    cache_pool_name = get_temp_pool_name();
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -367,6 +370,7 @@ Rados RadosTestECPP::s_cluster;
 
 void RadosTestECPP::SetUpTestCase()
 {
+  SKIP_IF_CRIMSON();
   auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
   pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
@@ -374,11 +378,13 @@ void RadosTestECPP::SetUpTestCase()
 
 void RadosTestECPP::TearDownTestCase()
 {
+  SKIP_IF_CRIMSON();
   ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
 }
 
 void RadosTestECPP::SetUp()
 {
+  SKIP_IF_CRIMSON();
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
   nspace = get_temp_pool_name();
   ioctx.set_namespace(nspace);
@@ -391,6 +397,7 @@ void RadosTestECPP::SetUp()
 
 void RadosTestECPP::TearDown()
 {
+  SKIP_IF_CRIMSON();
   if (cleanup) {
     cleanup_default_namespace(ioctx);
     cleanup_namespace(ioctx, nspace);

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -6264,10 +6264,12 @@ public:
   ~LibRadosTwoPoolsECPP() override {};
 protected:
   static void SetUpTestCase() {
+    SKIP_IF_CRIMSON();
     pool_name = get_temp_pool_name();
     ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
   }
   static void TearDownTestCase() {
+    SKIP_IF_CRIMSON();
     ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
   }
   static std::string cache_pool_name;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -150,6 +150,7 @@ nodaemon=0
 redirect=0
 smallmds=0
 short=0
+crimson=0
 ec=0
 cephadm=0
 parallel=true
@@ -334,11 +335,13 @@ case $1 in
         short=1
         ;;
     --crimson)
+        crimson=1
         ceph_osd=crimson-osd
         nodaemon=1
         msgr=2
         ;;
     --crimson-foreground)
+        crimson=1
         ceph_osd=crimson-osd
         nodaemon=0
         msgr=2
@@ -961,6 +964,10 @@ EOF
     do
         run 'mon' $f $CEPH_BIN/ceph-mon -i $f $ARGS $CMON_ARGS
     done
+
+    if [ "$crimson" -eq 1 ]; then
+        $CEPH_BIN/ceph osd set-allow-crimson --yes-i-really-mean-it
+    fi
 }
 
 start_osd() {

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -852,6 +852,12 @@ $CMONDEBUG
         osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
         auth allow insecure global id reclaim = false
 EOF
+
+    if [ "$crimson" -eq 1 ]; then
+        wconf <<EOF
+        osd pool default crimson = true
+EOF
+    fi
 }
 
 write_logrotate_conf() {


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
