### PR TITLE
pacific:  src/mds: increment directory inode's change attr by one

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1097,6 +1097,7 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
   }
 
   /* always take a newer change attr */
+  ldout(cct, 12) << __func__ << " client inode change_attr: " << in->change_attr << " , mds inodestat change_attr:  " << st->change_attr << dendl;
   if (st->change_attr > in->change_attr)
     in->change_attr = st->change_attr;
 
@@ -8236,7 +8237,7 @@ void Client::fill_statx(Inode *in, unsigned int mask, struct ceph_statx *stx)
 {
   ldout(cct, 10) << __func__ << " on " << in->ino << " snap/dev" << in->snapid
 	   << " mode 0" << oct << in->mode << dec
-	   << " mtime " << in->mtime << " ctime " << in->ctime << dendl;
+	   << " mtime " << in->mtime << " ctime " << in->ctime << " change_attr " << in->change_attr << dendl;
   memset(stx, 0, sizeof(struct ceph_statx));
 
   /*

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -50,6 +50,7 @@ ostream& operator<<(ostream &out, const Inode &in)
       << " btime=" << in.btime
       << " mtime=" << in.mtime
       << " ctime=" << in.ctime
+      << " change_attr=" << in.change_attr
       << " caps=" << ccap_string(in.caps_issued());
   if (!in.caps.empty()) {
     out << "(";

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3780,7 +3780,9 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   dout(20) << " pfile " << pfile << " pauth " << pauth
 	   << " plink " << plink << " pxattr " << pxattr
 	   << " plocal " << plocal
+	   << " mtime " << any_i->mtime
 	   << " ctime " << any_i->ctime
+	   << " change_attr " << any_i->change_attr
 	   << " valid=" << valid << dendl;
 
   // file
@@ -4126,7 +4128,7 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
 
   dout(20) << __func__ << " pfile " << pfile
 	   << " pauth " << pauth << " plink " << plink << " pxattr " << pxattr
-	   << " ctime " << i->ctime << dendl;
+	   << " mtime " << i->mtime << " ctime " << i->ctime << " change_attr " << i->change_attr << dendl;
 
   i = pfile ? pi:oi;
   m->set_layout(i->layout);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2523,7 +2523,8 @@ void CInode::finish_scatter_gather_update(int type, MutationRef& mut)
       if (touched_mtime)
 	pi->mtime = pi->ctime = pi->dirstat.mtime;
       if (touched_chattr)
-	pi->change_attr = pi->dirstat.change_attr;
+	pi->change_attr++;
+
       dout(20) << " final dirstat " << pi->dirstat << dendl;
 
       if (dirstat_valid && !dirstat.same_sums(pi->dirstat)) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2173,7 +2173,7 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
       if (do_parent_mtime) {
 	pf->fragstat.mtime = mut->get_op_stamp();
 	pf->fragstat.change_attr++;
-	dout(10) << "predirty_journal_parents bumping change_attr to " << pf->fragstat.change_attr << " on " << parent << dendl;
+	dout(10) << "predirty_journal_parents bumping fragstat change_attr to " << pf->fragstat.change_attr << " on " << parent << dendl;
 	if (pf->fragstat.mtime > pf->rstat.rctime) {
 	  dout(10) << "predirty_journal_parents updating mtime on " << *parent << dendl;
 	  pf->rstat.rctime = pf->fragstat.mtime;
@@ -2299,7 +2299,7 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
       if (touched_mtime)
 	pi.inode->mtime = pi.inode->ctime = pi.inode->dirstat.mtime;
       if (touched_chattr)
-	pi.inode->change_attr = pi.inode->dirstat.change_attr;
+	pi.inode->change_attr++;
       dout(20) << "predirty_journal_parents     gives " << pi.inode->dirstat << " on " << *pin << dendl;
 
       if (parent->get_frag() == frag_t()) { // i.e., we are the only frag

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -191,7 +191,9 @@ public:
     out << " size " << size << "/" << max_size;
     if (truncate_seq)
       out << " ts " << truncate_seq << "/" << truncate_size;
-    out << " mtime " << mtime;
+    out << " mtime " << mtime
+        << " ctime " << ctime
+        << " change_attr " << change_attr;
     if (time_warp_seq)
       out << " tws " << time_warp_seq;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57880

---

backport of https://github.com/ceph/ceph/pull/48241
parent tracker: https://tracker.ceph.com/issues/57210

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh