### PR TITLE
quincy: ceph.spec.in: disable system_pmdk on s390x for SUSE distros

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -61,7 +61,11 @@
 %global _remote_tarball_prefix https://download.ceph.com/tarballs/
 %endif
 %if 0%{?suse_version}
+%ifarch s390x
+%bcond_with system_pmdk
+%else
 %bcond_without system_pmdk
+%endif
 %bcond_with amqp_endpoint
 %bcond_with cephfs_java
 %bcond_with kafka_endpoint


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57885

---

backport of https://github.com/ceph/ceph/pull/48471
parent tracker: https://tracker.ceph.com/issues/57860

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh