### PR TITLE
pacific: mgr/prometheus: avoid duplicates and deleted entries for rbd_stats_pools

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1274,7 +1274,10 @@ class Module(MgrModule):
         # stats are collected for every namespace in the pool. The wildcard
         # '*' can be used to indicate all pools or namespaces
         pools_string = cast(str, self.get_localized_module_option('rbd_stats_pools'))
-        pool_keys = []
+        pool_keys = set()
+        osd_map = self.get('osd_map')
+        rbd_pools = [pool['pool_name'] for pool in osd_map['pools']
+                     if 'rbd' in pool.get('application_metadata', {})]
         for x in re.split(r'[\s,]+', pools_string):
             if not x:
                 continue
@@ -1287,13 +1290,11 @@ class Module(MgrModule):
 
             if pool_name == "*":
                 # collect for all pools
-                osd_map = self.get('osd_map')
-                for pool in osd_map['pools']:
-                    if 'rbd' not in pool.get('application_metadata', {}):
-                        continue
-                    pool_keys.append((pool['pool_name'], namespace_name))
+                for pool in rbd_pools:
+                    pool_keys.add((pool, namespace_name))
             else:
-                pool_keys.append((pool_name, namespace_name))
+                if pool_name in rbd_pools:
+                    pool_keys.add((pool_name, namespace_name))  # avoids adding deleted pool
 
         pools = {}  # type: Dict[str, Set[str]]
         for pool_key in pool_keys:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57887

---

backport of https://github.com/ceph/ceph/pull/48398
parent tracker: https://tracker.ceph.com/issues/57797

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh