### PR TITLE
mgr/dashboard: fix CephPGImbalance alert

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -324,6 +324,7 @@ class Module(MgrModule):
     last_optimize_started = ''
     last_optimize_duration = ''
     optimize_result = ''
+    no_optimization_needed = False
     success_string = 'Optimization plan created successfully'
     in_progress_string = 'in progress'
 
@@ -342,6 +343,7 @@ class Module(MgrModule):
             'last_optimize_started': self.last_optimize_started,
             'last_optimize_duration': self.last_optimize_duration,
             'optimize_result': self.optimize_result,
+            'no_optimization_needed': self.no_optimization_needed,
             'mode': self.get_module_option('mode'),
         }
         return (0, json.dumps(s, indent=4, sort_keys=True), '')
@@ -1023,6 +1025,7 @@ class Module(MgrModule):
                 break
         self.log.info('prepared %d/%d changes' % (total_did, max_optimizations))
         if total_did == 0:
+            self.no_optimization_needed = True
             return -errno.EALREADY, 'Unable to find further optimization, ' \
                                     'or pool(s) pg_num is decreasing, ' \
                                     'or distribution is already perfect'


### PR DESCRIPTION
The CephPGImbalance might be inaccurate in some specific environments. The CephPGImbalance alert is going to be raised, if the amount of PGs of an OSD is 30% less than the average amount of PGs of all OSDs. The amount of PGs of an OSD is normally related to e.g. number of OSDs and size or class of device. For a well-functioning cluster the Balancer takes care of balancing the PGs.

In some cases e.g. if the cluster consists of a lot of bigger HDDs and some smaller SSDs, the alert might be raised. Although the configuration and balance of the PGs is handled correctly.

Fixes: https://tracker.ceph.com/issues/55568
Signed-off-by: Aashish Sharma aasharma@redhat.com


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
