### PR TITLE
crimson/osd: simplify cloning

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -807,15 +807,14 @@ void OpsExecuter::make_writeable(std::vector<pg_log_entry_t>& log_entries)
     osd_op_params->at_version.version++;
 
     // TODO: update most recent clone_overlap and usage stats
-
-    if (snapc.seq > obc->ssc->snapset.seq) {
-       // update snapset with latest snap context
-       obc->ssc->snapset.seq = snapc.seq;
-       obc->ssc->snapset.snaps.clear();
-    }
-    logger().debug("{} {} done, snapset={}",
-      __func__, soid, obc->ssc->snapset);
   }
+  if (snapc.seq > obc->ssc->snapset.seq) {
+     // update snapset with latest snap context
+     obc->ssc->snapset.seq = snapc.seq;
+     obc->ssc->snapset.snaps.clear();
+  }
+  logger().debug("{} {} done, snapset={}",
+    __func__, soid, obc->ssc->snapset);
 }
 
 const object_info_t OpsExecuter::prepare_clone(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -748,9 +748,9 @@ void OpsExecuter::make_writeable(std::vector<pg_log_entry_t>& log_entries)
                  obc->ssc->snapset, snapc);
 
   // clone?
-  if (head_os.exists &&                          // old obs.exists
-      snapc.snaps.size() &&                      // there are snaps
-      snapc.snaps[0] > obc->ssc->snapset.seq) {  // existing obj is old
+  if (initial_os.existed && !initial_os.is_whiteout &&  // old obs.exists
+      snapc.snaps.size() &&                             // there are snaps
+      snapc.snaps[0] > obc->ssc->snapset.seq) {         // existing obj is old
 
     // clone object, the snap field is set to the seq of the SnapContext
     // at its creation.

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -455,6 +455,7 @@ auto OpsExecuter::do_write_op(Func&& f, OpsExecuter::modified_by m) {
   ++num_write;
   if (!osd_op_params) {
     osd_op_params.emplace();
+    fill_op_params_bump_pg_version();
   }
   user_modify = (m == modified_by::user);
   return std::forward<Func>(f)(pg->get_backend(), obc->obs, txn);
@@ -476,7 +477,6 @@ OpsExecuter::call_errorator::future<> OpsExecuter::do_assert_ver(
 OpsExecuter::interruptible_errorated_future<OpsExecuter::osd_op_errorator>
 OpsExecuter::execute_op(OSDOp& osd_op)
 {
-  head_os = obc->obs;
   return do_execute_op(osd_op).handle_error_interruptible(
     osd_op_errorator::all_same_way([&osd_op](auto e, auto&& e_raw)
       -> OpsExecuter::osd_op_errorator::future<> {
@@ -704,20 +704,21 @@ void OpsExecuter::fill_op_params_bump_pg_version()
   osd_op_params->pg_trim_to = pg->get_pg_trim_to();
   osd_op_params->min_last_complete_ondisk = pg->get_min_last_complete_ondisk();
   osd_op_params->last_complete = pg->get_info().last_complete;
-  if (user_modify) {
-    osd_op_params->user_at_version = osd_op_params->at_version.version;
-  }
 }
 
 std::vector<pg_log_entry_t> OpsExecuter::prepare_transaction(
   const std::vector<OSDOp>& ops)
 {
   std::vector<pg_log_entry_t> log_entries;
-  log_entries.emplace_back(obc->obs.exists ?
+  log_entries.emplace_back(
+    obc->obs.exists ?
       pg_log_entry_t::MODIFY : pg_log_entry_t::DELETE,
-    obc->obs.oi.soid, osd_op_params->at_version, obc->obs.oi.version,
+    obc->obs.oi.soid,
+    osd_op_params->at_version,
+    obc->obs.oi.version,
     osd_op_params->user_modify ? osd_op_params->at_version.version : 0,
-    osd_op_params->req_id, osd_op_params->mtime,
+    osd_op_params->req_id,
+    osd_op_params->mtime,
     op_info.allows_returnvec() && !ops.empty() ? ops.back().rval.code : 0);
   if (op_info.allows_returnvec()) {
     // also the per-op values are recorded in the pg log
@@ -740,95 +741,121 @@ version_t OpsExecuter::get_last_user_version() const
   return pg->get_last_user_version();
 }
 
-void OpsExecuter::make_writeable(std::vector<pg_log_entry_t>& log_entries)
+std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
+  const SnapContext& snapc,
+  const ObjectState& initial_obs,
+  const SnapSet& initial_snapset,
+  PGBackend& backend,
+  ceph::os::Transaction& txn)
 {
-  const hobject_t& soid = obc->obs.oi.soid;
+  const hobject_t& soid = initial_obs.oi.soid;
   logger().debug("{} {} snapset={} snapc={}",
                  __func__, soid,
-                 obc->ssc->snapset, snapc);
+                 initial_snapset, snapc);
 
-  // clone?
-  if (initial_os.existed && !initial_os.is_whiteout &&  // old obs.exists
-      snapc.snaps.size() &&                             // there are snaps
-      snapc.snaps[0] > obc->ssc->snapset.seq) {         // existing obj is old
+  auto cloning_ctx = std::make_unique<CloningContext>();
+  cloning_ctx->new_snapset = initial_snapset;
 
-    // clone object, the snap field is set to the seq of the SnapContext
-    // at its creation.
-    hobject_t coid = soid;
-    coid.snap = snapc.seq;
+  // clone object, the snap field is set to the seq of the SnapContext
+  // at its creation.
+  hobject_t coid = soid;
+  coid.snap = snapc.seq;
 
-    // existing snaps are stored in descending order in snapc,
-    // cloned_snaps vector will hold all the snaps stored until snapset.seq
-    const std::vector<snapid_t> cloned_snaps = [&] {
-      auto last = std::find_if(
-        std::begin(snapc.snaps), std::end(snapc.snaps),
-        [&](snapid_t snap_id) { return snap_id <= obc->ssc->snapset.seq; });
-      return std::vector<snapid_t>{std::begin(snapc.snaps), last};
-    }();
+  // existing snaps are stored in descending order in snapc,
+  // cloned_snaps vector will hold all the snaps stored until snapset.seq
+  const std::vector<snapid_t> cloned_snaps = [&] {
+    auto last = std::find_if(
+      std::begin(snapc.snaps), std::end(snapc.snaps),
+      [&](snapid_t snap_id) { return snap_id <= initial_snapset.seq; });
+    return std::vector<snapid_t>{std::begin(snapc.snaps), last};
+  }();
 
-    // version
+  auto [snap_oi, clone_obc] = prepare_clone(coid);
+  // make clone
+  backend.clone(snap_oi, initial_obs, clone_obc->obs, txn);
+
+  delta_stats.num_objects++;
+  if (snap_oi.is_omap()) {
+    delta_stats.num_objects_omap++;
+  }
+  delta_stats.num_object_clones++;
+  // newsnapset is obc's ssc
+  cloning_ctx->new_snapset.clones.push_back(coid.snap);
+  cloning_ctx->new_snapset.clone_size[coid.snap] = initial_obs.oi.size;
+  cloning_ctx->new_snapset.clone_snaps[coid.snap] = cloned_snaps;
+
+  // clone_overlap should contain an entry for each clone
+  // (an empty interval_set if there is no overlap)
+  auto &overlap = cloning_ctx->new_snapset.clone_overlap[coid.snap];
+  if (initial_obs.oi.size) {
+    overlap.insert(0, initial_obs.oi.size);
+  }
+
+  // log clone
+  logger().debug("cloning v {} to {} v {} snaps={} snapset={}",
+                 initial_obs.oi.version, coid,
+                 osd_op_params->at_version, cloned_snaps, cloning_ctx->new_snapset);
+
+  cloning_ctx->log_entry = {
+    pg_log_entry_t::CLONE,
+    coid,
+    osd_op_params->at_version,
+    initial_obs.oi.version,
+    initial_obs.oi.user_version,
+    osd_reqid_t(),
+    initial_obs.oi.mtime, // will be replaced in `apply_to()`
+    0
+  };
+  encode(cloned_snaps, cloning_ctx->log_entry.snaps);
+
+  // TODO: update most recent clone_overlap and usage stats
+  return cloning_ctx;
+}
+
+void OpsExecuter::CloningContext::apply_to(
+  const eversion_t& at_version,
+  std::vector<pg_log_entry_t>& log_entries,
+  ObjectContext& processed_obc) &&
+{
+  log_entry.mtime = processed_obc.obs.oi.mtime;
+  log_entry.version = at_version;
+  log_entries.emplace_back(std::move(log_entry));
+  processed_obc.ssc->snapset = std::move(new_snapset);
+}
+
+void OpsExecuter::flush_clone_metadata(
+  std::vector<pg_log_entry_t>& log_entries)
+{
+  assert(!txn.empty());
+  if (cloning_ctx) {
     osd_op_params->at_version = pg->next_version();
-
-    auto snap_oi = prepare_clone(coid);
-
-    // make clone
-    do_write_op([this, &snap_oi](auto& backend, auto& os, auto& txn) {
-      return backend.clone(snap_oi, os, clone_obc->obs, txn);
-    });
-
-    delta_stats.num_objects++;
-    if (snap_oi.is_omap()) {
-      delta_stats.num_objects_omap++;
-    }
-    delta_stats.num_object_clones++;
-    // newsnapset is obc's ssc
-    obc->ssc->snapset.clones.push_back(coid.snap);
-    obc->ssc->snapset.clone_size[coid.snap] = obc->obs.oi.size;
-    obc->ssc->snapset.clone_snaps[coid.snap] = cloned_snaps;
-
-    // clone_overlap should contain an entry for each clone
-    // (an empty interval_set if there is no overlap)
-    auto &overlap = obc->ssc->snapset.clone_overlap[coid.snap];
-    if (obc->obs.oi.size) {
-      overlap.insert(0, obc->obs.oi.size);
-    }
-
-    // log clone
-    logger().debug("cloning v {} to {} v {} snaps= {} snapset={}",
-                   obc->obs.oi.version, coid,
-                   osd_op_params->at_version, cloned_snaps, obc->ssc->snapset);
-
-    log_entries.emplace_back(pg_log_entry_t::CLONE,
-                             coid, osd_op_params->at_version,
-                             obc->obs.oi.version, obc->obs.oi.user_version,
-                             osd_reqid_t(),
-			     obc->obs.oi.mtime, 0);
-    encode(cloned_snaps, log_entries.back().snaps);
-    osd_op_params->at_version.version++;
-
-    // TODO: update most recent clone_overlap and usage stats
+    std::move(*cloning_ctx).apply_to(osd_op_params->at_version,
+                                     log_entries,
+                                     *obc);
   }
   if (snapc.seq > obc->ssc->snapset.seq) {
      // update snapset with latest snap context
      obc->ssc->snapset.seq = snapc.seq;
      obc->ssc->snapset.snaps.clear();
   }
-  logger().debug("{} {} done, snapset={}",
-    __func__, soid, obc->ssc->snapset);
+  logger().debug("{} done, initial snapset={}, new snapset={}",
+    __func__, obc->obs.oi.soid, obc->ssc->snapset);
 }
 
-const object_info_t OpsExecuter::prepare_clone(
+// TODO: make this static
+std::pair<object_info_t, ObjectContextRef> OpsExecuter::prepare_clone(
   const hobject_t& coid)
 {
   object_info_t static_snap_oi(coid);
   static_snap_oi.version = osd_op_params->at_version;
-  static_snap_oi.prior_version = head_os.oi.version;
-  static_snap_oi.copy_user_bits(head_os.oi);
+  static_snap_oi.prior_version = obc->obs.oi.version;
+  static_snap_oi.copy_user_bits(obc->obs.oi);
   if (static_snap_oi.is_whiteout()) {
     // clone shouldn't be marked as whiteout
     static_snap_oi.clear_flag(object_info_t::FLAG_WHITEOUT);
   }
 
+  ObjectContextRef clone_obc;
   if (pg->is_primary()) {
     // lookup_or_create
     auto [c_obc, existed] =
@@ -842,13 +869,35 @@ const object_info_t OpsExecuter::prepare_clone(
     logger().debug("clone_obc: {}", c_obc->obs.oi);
     clone_obc = std::move(c_obc);
   }
-  return static_snap_oi;
+  return std::make_pair(std::move(static_snap_oi), std::move(clone_obc));
 }
 
 void OpsExecuter::apply_stats()
 {
   pg->get_peering_state().apply_op_stats(get_target(), delta_stats);
   pg->publish_stats_to_osd();
+}
+
+OpsExecuter::OpsExecuter(Ref<PG> pg,
+                         ObjectContextRef _obc,
+                         const OpInfo& op_info,
+                         abstracted_msg_t&& msg,
+                         const SnapContext& _snapc)
+  : pg(std::move(pg)),
+    obc(std::move(_obc)),
+    op_info(op_info),
+    msg(std::move(msg)),
+    snapc(_snapc)
+{
+  if (op_info.may_write() && should_clone(*obc, snapc)) {
+    do_write_op([this](auto& backend, auto& os, auto& txn) {
+      cloning_ctx = execute_clone(std::as_const(snapc),
+                                  std::as_const(obc->obs),
+                                  std::as_const(obc->ssc->snapset),
+                                  backend,
+                                  txn);
+    });
+  }
 }
 
 static inline std::unique_ptr<const PGLSFilter> get_pgls_filter(

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -166,6 +166,15 @@ private:
   };
 
   Ref<PG> pg; // for the sake of object class
+  const struct initial_os_t {
+    bool existed;
+    bool is_whiteout;
+
+    initial_os_t(const ObjectContext& obc)
+      : existed(obc.obs.exists),
+        is_whiteout(obc.obs.oi.is_whiteout()) {
+    }
+  } initial_os;
   ObjectContextRef obc;
   ObjectContextRef clone_obc; // if we create a clone
   ObjectState head_os;
@@ -259,6 +268,7 @@ public:
               const MsgT& msg,
               const SnapContext& snapc)
     : pg(std::move(pg)),
+      initial_os(*obc),
       obc(std::move(obc)),
       op_info(op_info),
       msg(std::in_place_type_t<ExecutableMessagePimpl<MsgT>>{}, &msg),

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -166,21 +166,12 @@ private:
   };
 
   Ref<PG> pg; // for the sake of object class
-  const struct initial_os_t {
-    bool existed;
-    bool is_whiteout;
-
-    initial_os_t(const ObjectContext& obc)
-      : existed(obc.obs.exists),
-        is_whiteout(obc.obs.oi.is_whiteout()) {
-    }
-  } initial_os;
   ObjectContextRef obc;
-  ObjectContextRef clone_obc; // if we create a clone
-  ObjectState head_os;
   const OpInfo& op_info;
-  ceph::static_ptr<ExecutableMessage,
-                   sizeof(ExecutableMessagePimpl<void>)> msg;
+  using abstracted_msg_t =
+    ceph::static_ptr<ExecutableMessage,
+                     sizeof(ExecutableMessagePimpl<void>)>;
+  abstracted_msg_t msg;
   std::optional<osd_op_params_t> osd_op_params;
   bool user_modify = false;
   ceph::os::Transaction txn;
@@ -189,6 +180,70 @@ private:
   size_t num_write = 0;   ///< count update ops
 
   SnapContext snapc; // writer snap context
+  struct CloningContext {
+    SnapSet new_snapset;
+    pg_log_entry_t log_entry;
+
+    void apply_to(
+      const eversion_t& at_version,
+      std::vector<pg_log_entry_t>& log_entries,
+      ObjectContext& processed_obc) &&;
+  };
+  std::unique_ptr<CloningContext> cloning_ctx;
+
+
+  /**
+   * execute_clone
+   *
+   * If snapc contains a snap which occurred logically after the last write
+   * seen by this object (see OpsExecutor::should_clone()), we first need
+   * make a clone of the object at its current state.  execute_clone primes
+   * txn with that clone operation and returns an
+   * OpsExecutor::CloningContext which will allow us to fill in the corresponding
+   * metadata and log_entries once the operations have been processed.
+   *
+   * Note that this strategy differs from classic, which instead performs this
+   * work at the end and reorders the transaction.  See
+   * PrimaryLogPG::make_writeable
+   *
+   * @param snapc [in] snapc for this operation (from the client if from the
+   *                   client, from the pool otherwise)
+   * @param initial_obs [in] objectstate for the object at operation start
+   * @param initial_snapset [in] snapset for the object at operation start
+   * @param backend [in,out] interface for generating mutations
+   * @param txn [out] transaction for the operation
+   */
+  std::unique_ptr<CloningContext> execute_clone(
+    const SnapContext& snapc,
+    const ObjectState& initial_obs,
+    const SnapSet& initial_snapset,
+    PGBackend& backend,
+    ceph::os::Transaction& txn);
+
+
+  /**
+   * should_clone
+   *
+   * Predicate returning whether a user write with snap context snapc
+   * contains a snap which occurred prior to the most recent write
+   * on the object reflected in initial_obc.
+   *
+   * @param initial_obc [in] obc for object to be mutated
+   * @param snapc [in] snapc for this operation (from the client if from the
+   *                   client, from the pool otherwise)
+   */
+  static bool should_clone(
+    const ObjectContext& initial_obc,
+    const SnapContext& snapc) {
+    // clone?
+    return initial_obc.obs.exists                       // both nominally and...
+      && !initial_obc.obs.oi.is_whiteout()              // ... logically exists
+      && snapc.snaps.size()                             // there are snaps
+      && snapc.snaps[0] > initial_obc.ssc->snapset.seq; // existing obj is old
+  }
+
+  void flush_clone_metadata(
+    std::vector<pg_log_entry_t>& log_entries);
 
   // this gizmo could be wrapped in std::optional for the sake of lazy
   // initialization. we don't need it for ops that doesn't have effect
@@ -260,6 +315,12 @@ private:
   interruptible_errorated_future<osd_op_errorator>
   do_execute_op(OSDOp& osd_op);
 
+  OpsExecuter(Ref<PG> pg,
+              ObjectContextRef obc,
+              const OpInfo& op_info,
+              abstracted_msg_t&& msg,
+              const SnapContext& snapc);
+
 public:
   template <class MsgT>
   OpsExecuter(Ref<PG> pg,
@@ -267,12 +328,14 @@ public:
               const OpInfo& op_info,
               const MsgT& msg,
               const SnapContext& snapc)
-    : pg(std::move(pg)),
-      initial_os(*obc),
-      obc(std::move(obc)),
-      op_info(op_info),
-      msg(std::in_place_type_t<ExecutableMessagePimpl<MsgT>>{}, &msg),
-      snapc(snapc) {
+    : OpsExecuter(
+        std::move(pg),
+        std::move(obc),
+        op_info,
+        abstracted_msg_t{
+          std::in_place_type_t<ExecutableMessagePimpl<MsgT>>{},
+          &msg},
+        snapc) {
   }
 
   template <class Func>
@@ -326,13 +389,7 @@ public:
 
   version_t get_last_user_version() const;
 
-  const SnapContext& get_snapc() const {
-    return snapc;
-  }
-
-  void make_writeable(std::vector<pg_log_entry_t>& log_entries);
-
-  const object_info_t prepare_clone(
+  std::pair<object_info_t, ObjectContextRef> prepare_clone(
     const hobject_t& coid);
 
   void apply_stats();
@@ -389,10 +446,15 @@ OpsExecuter::flush_changes_n_do_ops_effects(
     interruptor::make_ready_future<rep_op_fut_tuple>(
 	seastar::now(),
 	interruptor::make_interruptible(osd_op_errorator::now()));
+  if (cloning_ctx) {
+    ceph_assert(want_mutate);
+  }
   if (want_mutate) {
-    fill_op_params_bump_pg_version();
+    if (user_modify) {
+      osd_op_params->user_at_version = osd_op_params->at_version.version;
+    }
     auto log_entries = prepare_transaction(ops);
-    make_writeable(log_entries);
+    flush_clone_metadata(log_entries);
     apply_stats();
     auto [submitted, all_completed] = std::forward<MutFunc>(mut_func)(std::move(txn),
                                                     std::move(obc),

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -104,15 +104,15 @@ PGBackend::load_metadata(const hobject_t& oid)
           bool object_corrupted = true;
           if (auto ssiter = attrs.find(SS_ATTR); ssiter != attrs.end()) {
             object_corrupted = false;
-            logger().debug(
-              "load_metadata: object {} and snapset {} present",
-              oid, ssiter->second);
             bufferlist bl = std::move(ssiter->second);
             if (bl.length()) {
               ret->ssc = new crimson::osd::SnapSetContext(oid.get_snapdir());
               try {
                 ret->ssc->snapset = SnapSet(bl);
                 ret->ssc->exists = true;
+                logger().debug(
+                  "load_metadata: object {} and snapset {} present",
+                   oid, ret->ssc->snapset);
               } catch (const buffer::error&) {
                 logger().warn("unable to decode SnapSet");
                 throw crimson::osd::invalid_argument();

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1159,17 +1159,13 @@ void PGBackend::clone(
   const ObjectState& d_os,
   ceph::os::Transaction& txn)
 {
-  // Prepend the cloning operation to txn
-  ceph::os::Transaction c_txn;
-  c_txn.clone(coll->get_cid(), ghobject_t{os.oi.soid}, ghobject_t{d_os.oi.soid});
-  // Operations will be removed from txn while appending
-  c_txn.append(txn);
-  txn = std::move(c_txn);
-
-  ceph::bufferlist bv;
-  snap_oi.encode_no_oid(bv, CEPH_FEATURES_ALL);
-
-  txn.setattr(coll->get_cid(), ghobject_t{d_os.oi.soid}, OI_ATTR, bv);
+  // See OpsExecutor::execute_clone documentation
+  txn.clone(coll->get_cid(), ghobject_t{os.oi.soid}, ghobject_t{d_os.oi.soid});
+  {
+    ceph::bufferlist bv;
+    snap_oi.encode_no_oid(bv, CEPH_FEATURES_ALL);
+    txn.setattr(coll->get_cid(), ghobject_t{d_os.oi.soid}, OI_ATTR, bv);
+  }
   txn.rmattr(coll->get_cid(), ghobject_t{d_os.oi.soid}, SS_ATTR);
 }
 

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1154,9 +1154,9 @@ PGBackend::rm_xattr(
 }
 
 void PGBackend::clone(
-  object_info_t& snap_oi,
-  ObjectState& os,
-  ObjectState& d_os,
+  /* const */object_info_t& snap_oi,
+  const ObjectState& os,
+  const ObjectState& d_os,
   ceph::os::Transaction& txn)
 {
   // Prepend the cloning operation to txn

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -262,9 +262,9 @@ public:
     const OSDOp& osd_op,
     ceph::os::Transaction& trans);
   void clone(
-    object_info_t& snap_oi,
-    ObjectState& os,
-    ObjectState& d_os,
+    /* const */object_info_t& snap_oi,
+    const ObjectState& os,
+    const ObjectState& d_os,
     ceph::os::Transaction& trans);
   interruptible_future<struct stat> stat(
     CollectionRef c,


### PR DESCRIPTION
1. Drop `head_os` and any other thing that could be a counterpart of the classical _old obs_ structure.
2. The cloning operation, now executed at the very beginning of `OpsExecuter`'s life cycle, produces `new_snapset` that is applied to `obc` after executing all other operations. (execute+commit).
3. It also creates a `pg_log_entry` which is appended at the end of `log_entires` at the flush (preserved the orignal logic, havent't experimented with it yet).
4. `TestLibRBD.TestIOToSnapshot` is green without any reordering within `txn` (tested with other recent fixes for cloning).


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
