### PR TITLE
doc/man: remove docs about support for unix domain sockets

### DIFF
--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -53,10 +53,6 @@ Options
 
    Run in foreground, log to usual location
 
-.. option:: --rgw-socket-path=path
-
-   Specify a unix domain socket path.
-
 .. option:: --rgw-region=region
 
    The region where radosgw runs
@@ -80,27 +76,22 @@ and ``mod_proxy_fcgi`` have to be present in the server. Unlike ``mod_fastcgi``,
 or process management may be available in the FastCGI application framework
 in use.
 
-``Apache`` can be configured in a way that enables ``mod_proxy_fcgi`` to be used
-with localhost tcp or through unix domain socket. ``mod_proxy_fcgi`` that doesn't
-support unix domain socket such as the ones in Apache 2.2 and earlier versions of
-Apache 2.4, needs to be configured for use with localhost tcp. Later versions of
-Apache like Apache 2.4.9 or later support unix domain socket and as such they
-allow for the configuration with unix domain socket instead of localhost tcp.
+``Apache`` must be configured in a way that enables ``mod_proxy_fcgi`` to be used
+with localhost tcp.
 
 The following steps show the configuration in Ceph's configuration file i.e,
 ``/etc/ceph/ceph.conf`` and the gateway configuration file i.e,
 ``/etc/httpd/conf.d/rgw.conf`` (RPM-based distros) or
 ``/etc/apache2/conf-available/rgw.conf`` (Debian-based distros) with localhost
-tcp and through unix domain socket:
+tcp:
 
 #. For distros with Apache 2.2 and early versions of Apache 2.4 that use
-   localhost TCP and do not support Unix Domain Socket, append the following
+   localhost TCP append the following
    contents to ``/etc/ceph/ceph.conf``::
 
 	[client.radosgw.gateway]
 	host = {hostname}
 	keyring = /etc/ceph/ceph.client.radosgw.keyring
-	rgw socket path = ""
 	log file = /var/log/ceph/client.radosgw.gateway.log
 	rgw frontends = fastcgi socket_port=9000 socket_host=0.0.0.0
 	rgw print continue = false
@@ -149,16 +140,6 @@ tcp and through unix domain socket:
 
 		</VirtualHost>
 
-#. For distros with Apache 2.4.9 or later that support Unix Domain Socket,
-   append the following configuration to ``/etc/ceph/ceph.conf``::
-
-	[client.radosgw.gateway]
-	host = {hostname}
-	keyring = /etc/ceph/ceph.client.radosgw.keyring
-	rgw socket path = /var/run/ceph/ceph.radosgw.gateway.fastcgi.sock
-	log file = /var/log/ceph/client.radosgw.gateway.log
-	rgw print continue = false
-
 #. Add the following content in the gateway configuration file:
 
    For CentOS/RHEL add in ``/etc/httpd/conf.d/rgw.conf``::
@@ -181,10 +162,6 @@ tcp and through unix domain socket:
 		ProxyPass / unix:///var/run/ceph/ceph.radosgw.gateway.fastcgi.sock|fcgi://localhost:9000/
 
 		</VirtualHost>
-
-   Please note, ``Apache 2.4.7`` does not have Unix Domain Socket support in
-   it and as such it has to be configured with localhost tcp. The Unix Domain
-   Socket support is available in ``Apache 2.4.9`` and later versions.
 
 #. Generate a key for radosgw to use for authentication with the cluster. ::
 


### PR DESCRIPTION
doc/man: support for unix domain sockets is not implemented, hence we removed documentation about it.

Signed-off-by: Rok Jaklič <rjaklic@gmail.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
