### PR TITLE
pacific: osd/scrub: use the actual active set when requesting replicas

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -786,7 +786,7 @@ void PgScrubber::get_replicas_maps(bool replica_can_preempt)
   m_primary_scrubmap_pos.reset();
 
   // ask replicas to scan and send maps
-  for (const auto& i : m_pg->get_acting_recovery_backfill()) {
+  for (const auto& i : m_pg->get_actingset()) {
 
     if (i == m_pg_whoami)
       continue;
@@ -1293,7 +1293,7 @@ void PgScrubber::scrub_compare_maps()
   map<pg_shard_t, ScrubMap*> maps;
   maps[m_pg_whoami] = &m_primary_scrubmap;
 
-  for (const auto& i : m_pg->get_acting_recovery_backfill()) {
+  for (const auto& i : m_pg->get_actingset()) {
     if (i == m_pg_whoami)
       continue;
     dout(2) << __func__ << " replica " << i << " has "
@@ -1317,7 +1317,7 @@ void PgScrubber::scrub_compare_maps()
     m_osds->clog->warn(ss);
   }
 
-  if (m_pg->recovery_state.get_acting_recovery_backfill().size() > 1) {
+  if (m_pg->recovery_state.get_actingset().size() > 1) {
 
     dout(10) << __func__ << "  comparing replica scrub maps" << dendl;
 


### PR DESCRIPTION
… to scrub

Note that get_acting_set() may differ from
get_acting_recovery_backfill() - if we are remapped

Fixes: https://tracker.ceph.com/issues/57698
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

(cherry picked from commit 6b57a469e36ae150f8ac4973b9b72f37cedee286)

