### PR TITLE
make-dist: don't set Release tag in ceph.spec for SUSE distros

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -168,6 +168,19 @@ echo "including src/.git_version, ceph.spec"
 
 (git rev-parse HEAD ; echo $version) 2> /dev/null > src/.git_version
 
+if [ -r /etc/os-release ]; then
+    source /etc/os-release
+    case $ID in
+        opensuse*|suse|sles)
+            if [ "x$rpm_release" != "x0" ] ; then
+                rpm_release=$(echo $rpm_release | sed 's/.g/+g/')
+                rpm_version="${rpm_version}.${rpm_release}"
+                rpm_release="0"
+            fi
+            ;;
+    esac
+fi
+
 for spec in ceph.spec.in; do
     cat $spec |
         sed "s/@PROJECT_VERSION@/$rpm_version/g" |


### PR DESCRIPTION
SUSE's Open Build Service overwrites the Release tag with checkin and build counters, so we can't use it to record the number of commits since the last tag, and the last commit hash.  This commit appends that extra information to the Version tag instead for SUSE builds.

Fixes: https://tracker.ceph.com/issues/57893
Signed-off-by: Tim Serong <tserong@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
