### PR TITLE
osd/scrub: no 'ScrubFinish' transition in ActiveReplica state

### DIFF
--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -379,8 +379,7 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ScrubMachine>,
 struct ActiveReplica : sc::state<ActiveReplica, ScrubMachine>, NamedSimply {
   explicit ActiveReplica(my_context ctx);
   using reactions = mpl::list<sc::custom_reaction<SchedReplica>,
-			      sc::custom_reaction<FullReset>,
-			      sc::transition<ScrubFinished, NotActive>>;
+			      sc::custom_reaction<FullReset>>;
 
   sc::result react(const SchedReplica&);
   sc::result react(const FullReset&);


### PR DESCRIPTION
That event is not generated for a replica.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
