### PR TITLE
rgw: Fix truncated ListBuckets response.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2433,6 +2433,8 @@ void RGWListBuckets::execute(optional_yield y)
       break;
     }
 
+    is_truncated = buckets.is_truncated();
+
     /* We need to have stats for all our policies - even if a given policy
      * isn't actually used in a given account. In such situation its usage
      * stats would be simply full of zeros. */


### PR DESCRIPTION
Commit 54b470facffe8251dc37b2020e771d4d061cb2ae caused s3:ListBuckets to return a maximum of 1000 buckets by default as it removed the truncation detection from this code.

Make this code look like other uses of RGWBucketList, where it's allocated on the stack outside of the loop so that we can check is_truncated() directly.

Tracker: https://tracker.ceph.com/issues/57901