### PR TITLE
rbd-mirror: improve status to show additional snapshot details

### DIFF
--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -366,7 +366,7 @@ int execute_status(const po::variables_map &vm,
   }
 
   std::vector<librbd::snap_info_t> snaps;
-  if (status.info.primary && status.info.state == RBD_MIRROR_IMAGE_ENABLED) {
+  if (status.info.state == RBD_MIRROR_IMAGE_ENABLED) {
     librbd::mirror_image_mode_t mode = RBD_MIRROR_IMAGE_MODE_JOURNAL;
     r = image.mirror_image_get_mode(&mode);
     if (r < 0) {

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -432,9 +432,7 @@ int execute_status(const po::variables_map &vm,
       for (auto &snap : snaps) {
         librbd::snap_mirror_namespace_t info;
         r = image.snap_get_mirror_namespace(snap.id, &info, sizeof(info));
-        if (r < 0 ||
-            (info.state != RBD_SNAP_MIRROR_STATE_PRIMARY &&
-             info.state != RBD_SNAP_MIRROR_STATE_PRIMARY_DEMOTED)) {
+        if (r < 0) {
           continue;
         }
         formatter->open_object_section("snapshot");
@@ -496,9 +494,7 @@ int execute_status(const po::variables_map &vm,
       for (auto &snap : snaps) {
         librbd::snap_mirror_namespace_t info;
         r = image.snap_get_mirror_namespace(snap.id, &info, sizeof(info));
-        if (r < 0 ||
-            (info.state != RBD_SNAP_MIRROR_STATE_PRIMARY &&
-             info.state != RBD_SNAP_MIRROR_STATE_PRIMARY_DEMOTED)) {
+        if (r < 0) {
           continue;
         }
 


### PR DESCRIPTION
$ rbd mirror --cluster=site-b image status pool1/test_image
```
test_image:                                                                                                                                                                                                                               
  global_id:   5750c75e-84d1-478b-a086-64c896455abb                                                                                                                                                                                       
  state:       up+replaying                                                                                                                                                                                                               
  description: replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":0.0,"local_snapshot_timestamp":1668063305,"remote_snapshot_timestamp":1668063305,"replay_state":"idle"}                                                            
  service:     admin on localhost.localdomain                                                                                                                                                                                             
  last_update: 2022-11-10 18:44:53                                                                                                                                                                                                        
  peer_sites:                                                                                                                                                                                                                             
    name: 43f2e3d2-8e58-4c4f-8f2a-c205f3627c1c                                                                                                                                                                                            
    state: up+stopped                                                                                                                                                                                                                     
    description: local image is primary                                                                                                                                                                                                   
    last_update: 2022-11-10 18:44:51                                                                                                                                                                                                      
  snapshots:                                                                                                                                                                                                                              
  SNAPID  NAME                                                                                           SIZE    TIMESTAMP                 DETAILS                                                                                        
    ┆ 25  .mirror.non_primary.5750c75e-84d1-478b-a086-64c896455abb.e879fca5-1f08-4711-bdbb-a07c43ac017c  10 MiB  Thu Nov 10 12:25:10 2022  (non-primary peer_uuids:[] 02cabf51-e87e-419f-b767-6c7727db2bd8:23 copied)                     
                                                                                                                                                                                                                                          
```
$ rbd mirror --cluster=site-b image status pool1/test_image --format=json --pretty-format
```
{                                                                                                                                                                                                                                         
    "name": "test_image",                                                                                                                                                                                                                 
    "global_id": "5750c75e-84d1-478b-a086-64c896455abb",                                                                                                                                                                                  
    "state": "up+replaying",                                                                                                                                                                                                              
    "description": "replaying, {\"bytes_per_second\":0.0,\"bytes_per_snapshot\":0.0,\"local_snapshot_timestamp\":1668063305,\"remote_snapshot_timestamp\":1668063305,\"replay_state\":\"idle\"}",                                         
    "daemon_service": {                                                                                                                                                                                                                   
    ┆   "service_id": "4133",                                                                                                                                                                                                             
    ┆   "instance_id": "4135",                                                                                                                                                                                                            
    ┆   "daemon_id": "admin",                                                                                                                                                                                                             
    ┆   "hostname": "localhost.localdomain"                                                                                                                                                                                               
    },                                                                                                                                                                                                                                    
    "last_update": "2022-11-10 18:50:53",                                                                                                                                                                                                 
    "peer_sites": [                                                                                                                                                                                                                       
    ┆   {                                                                                                                                                                                                                                 
    ┆   ┆   "site_name": "43f2e3d2-8e58-4c4f-8f2a-c205f3627c1c",                                                                                                                                                                          
    ┆   ┆   "mirror_uuids": "02cabf51-e87e-419f-b767-6c7727db2bd8",                                                                                                                                                                       
    ┆   ┆   "state": "up+stopped",                                                                                                                                                                                                        
    ┆   ┆   "description": "local image is primary",                                                                                                                                                                                      
    ┆   ┆   "last_update": "2022-11-10 18:51:06"                                                                                                                                                                                          
    ┆   }                                                                                                                                                                                                                                 
    ],                                                                                                                                                                                                                                    
    "snapshots": [                                                                                                                                                                                                                        
    ┆   {                                                                                                                                                                                                                                 
    ┆   ┆   "id": 25,                                                                                                                                                                                                                     
    ┆   ┆   "name": ".mirror.non_primary.5750c75e-84d1-478b-a086-64c896455abb.e879fca5-1f08-4711-bdbb-a07c43ac017c",                                                                                                                      
    ┆   ┆   "size": "10 MiB",                                                                                                                                                                                                             
    ┆   ┆   "timestamp": "Thu Nov 10 12:25:10 2022",                                                                                                                                                                                      
    ┆   ┆   "details": {                                                                                                                                                                                                                  
    ┆   ┆   ┆   "state": "non-primary",                                                                                                                                                                                                   
    ┆   ┆   ┆   "mirror_peer_uuids": [],                                                                                                                                                                                                  
    ┆   ┆   ┆   "complete": true,                                                                                                                                                                                                         
    ┆   ┆   ┆   "primary_mirror_uuid": "02cabf51-e87e-419f-b767-6c7727db2bd8",                                                                                                                                                            
    ┆   ┆   ┆   "primary_snap_id": 23,                                                                                                                                                                                                    
    ┆   ┆   ┆   "last_copied_object_number": 3                                                                                                                                                                                            
    ┆   ┆   }                                                                                                                                                                                                                             
        }                                                                                                                                                                                                                                 
    ]                                                                                                                                                                                                                                     
}                                                                                                                                                                                                                                         
```

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
