### PR TITLE
osd: change two ObjectContext flags from bitfields to full variables

### DIFF
--- a/src/osd/osd_internal_types.h
+++ b/src/osd/osd_internal_types.h
@@ -180,9 +180,8 @@ public:
   }
 
   /// in-progress copyfrom ops for this object
-  bool blocked:1;
-  bool requeue_scrub_on_unblock:1;    // true if we need to requeue scrub on unblock
-
+  bool blocked;
+  bool requeue_scrub_on_unblock;    // true if we need to requeue scrub on unblock
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectState& obs)


### PR DESCRIPTION
The change does not increase the size of the structure. It does simplify fmt-formatting of the boolean flags, and has better performance.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

