### PR TITLE
pacific: doc/cephadm: s/ssh/SSH/ in doc/cephadm (complete)

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -113,15 +113,15 @@ Adoption process
       ssh-copy-id -f -i ~/ceph.pub root@<host>
 
    .. note::
-     It is also possible to import an existing ssh key. See
-     :ref:`ssh errors <cephadm-ssh-errors>` in the troubleshooting
+     It is also possible to import an existing SSH key. See
+     :ref:`SSH errors <cephadm-ssh-errors>` in the troubleshooting
      document for instructions that describe how to import existing
-     ssh keys.
+     SSH keys.
 
    .. note::
-     It is also possible to have cephadm use a non-root user to ssh
+     It is also possible to have cephadm use a non-root user to SSH 
      into cluster hosts. This user needs to have passwordless sudo access.
-     Use ``ceph cephadm set-user <user>`` and copy the ssh key to that user.
+     Use ``ceph cephadm set-user <user>`` and copy the SSH key to that user.
      See :ref:`cephadm-ssh-user`
 
 #. Tell cephadm which hosts to manage:

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -318,7 +318,7 @@ cephadm operations. Use the command:
 
    ceph cephadm set-user <user>
 
-Prior to running this the cluster ssh key needs to be added to this users
+Prior to running this the cluster SSH key needs to be added to this users
 authorized_keys file and non-root users must have passwordless sudo access.
 
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -210,8 +210,8 @@ available options.
       EOF
       $ ./cephadm bootstrap --config initial-ceph.conf ...
 
-* The ``--ssh-user *<user>*`` option makes it possible to choose which ssh
-  user cephadm will use to connect to hosts. The associated ssh key will be
+* The ``--ssh-user *<user>*`` option makes it possible to choose which SSH 
+  user cephadm will use to connect to hosts. The associated SSH key will be
   added to ``/home/*<user>*/.ssh/authorized_keys``. The user that you 
   designate with this option must have passwordless sudo access.
 


### PR DESCRIPTION
This PR alters "ssh" to "SSH" in the text (that is, not in commands) every location in the doc/cephadm/ directory where "ssh" should be "SSH".

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 5c217c1de57ddcdda19bd83993a26d2f257a03b7)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
