### PR TITLE
quincy: make-dist: don't set Release tag in ceph.spec for SUSE distros

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -168,6 +168,19 @@ echo "including src/.git_version, ceph.spec"
 
 (git rev-parse HEAD ; echo $version) 2> /dev/null > src/.git_version
 
+if [ -r /etc/os-release ]; then
+    source /etc/os-release
+    case $ID in
+        opensuse*|suse|sles)
+            if [ "x$rpm_release" != "x0" ] ; then
+                rpm_release=$(echo $rpm_release | sed 's/.g/+g/')
+                rpm_version="${rpm_version}.${rpm_release}"
+                rpm_release="0"
+            fi
+            ;;
+    esac
+fi
+
 for spec in ceph.spec.in; do
     cat $spec |
         sed "s/@PROJECT_VERSION@/$rpm_version/g" |


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57916

---

backport of https://github.com/ceph/ceph/pull/48547
parent tracker: https://tracker.ceph.com/issues/57893

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh