### PR TITLE
mds: add option mds_log_periods_per_segment to solve the problem of large subtreemap event

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -534,6 +534,14 @@ options:
   services:
   - mds
   with_legacy: true
+- name: mds_log_periods_per_segment
+  type: int
+  level: advanced
+  desc: maximum number of periods in an MDS journal segment
+  default: 1
+  services:
+  - mds
+  with_legacy: true
 # segment size for mds log, default to default file_layout_t
 - name: mds_log_segment_size
   type: size

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -314,7 +314,7 @@ void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase *c)
     // do not insert ESubtreeMap among EImportFinish events that finish
     // disambiguate imports. Because the ESubtreeMap reflects the subtree
     // state when all EImportFinish events are replayed.
-  } else if (ls->end/period != ls->offset/period ||
+  } else if (ls->end/period - ls->offset/period >= g_conf()->mds_log_periods_per_segment ||
 	     ls->num_events >= g_conf()->mds_log_events_per_segment) {
     dout(10) << "submit_entry also starting new segment: last = "
 	     << ls->seq  << "/" << ls->offset << ", event seq = " << event_seq << dendl;


### PR DESCRIPTION
When the first event(subtreemap event) in journal segment is too large(close to or more than layout period, default is 4 MB), segment creation is very frequent and each segment can contain only a few other events. A lot of segment creations whill lead to a lot of large subtreemap event creations, this will consume a lot of CPU and network resources and cause slow metadata writing. So add option mds_log_periods_per_segment to adjust segment max size. I tried option mds_log_segment_size, it does not work when the mds journal has been created. And this option also modifies layout period, I don't think it's a good choice.

Signed-off-by: Zhansong Gao <zhsgao@hotmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
