### PR TITLE
 librbd: add encryption format support for clones (part 2/2)

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -88,6 +88,11 @@
 * RBD: Trailing newline in passphrase files (`<passphrase-file>` argument in
   `rbd encryption format` command and `--encryption-passphrase-file` option
   in other commands) is no longer stripped.
+* RBD: Support for layered client-side encryption is added.  Cloned images
+  can now be encrypted each with its own encryption format and passphrase,
+  potentially different from that of the parent image.  The efficient
+  copy-on-write semantics intrinsic to unformatted (regular) cloned images
+  are retained.
 
 >=17.2.1
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -85,7 +85,9 @@
   notifications needs to pull them (instead of the notifications be pushed 
   to it), an external message bus (e.g. rabbitmq, Kafka) should be used for 
   that purpose.
-
+* RBD: Trailing newline in passphrase files (`<passphrase-file>` argument in
+  `rbd encryption format` command and `--encryption-passphrase-file` option
+  in other commands) is no longer stripped.
 
 >=17.2.1
 

--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -54,7 +54,7 @@ Options
 .. option:: --encryption-format
 
    Image encryption format.
-   Possible values: *luks*
+   Possible values: *luks*, *luks1*, *luks2*
 
 .. option:: --encryption-passphrase-file
 

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -606,7 +606,7 @@ Commands
   Initialize pool for use by RBD. Newly created pools must initialized
   prior to use.
 
-:command:`resize` (-s | --size *size-in-M/G/T*) [--allow-shrink] *image-spec*
+:command:`resize` (-s | --size *size-in-M/G/T*) [--allow-shrink] [--encryption-format *encryption-format* --encryption-passphrase-file *passphrase-file*]... *image-spec*
   Resize rbd image. The size parameter also needs to be specified.
   The --allow-shrink option lets the size be reduced.
   

--- a/doc/rbd/rbd-encryption.rst
+++ b/doc/rbd/rbd-encryption.rst
@@ -112,8 +112,8 @@ randomly-generated encryption key, and is protected by the passphrase read from
 `passphrase-file`.
 
 .. note::
-   If the content of `passphrase-file` ends with a newline character, it will
-   be stripped off.
+   In older versions, if the content of `passphrase-file` ended with a newline
+   character, it was stripped off.
 
 By default, AES-256 in xts-plain64 mode (which is the current recommended mode,
 and the usual default for other tools) will be used. The format operation

--- a/doc/rbd/rbd-encryption.rst
+++ b/doc/rbd/rbd-encryption.rst
@@ -136,9 +136,11 @@ A batch of such unaligned writes can lead to IO races which will further
 deteriorate performance. Thus it is advisable to avoid using RBD encryption
 in cases where incoming writes cannot be guaranteed to be sector-aligned.
 
-To mount a LUKS-encrypted image run::
+To map a LUKS-formatted image run:
 
-    $ rbd -p {pool-name} device map -t nbd -o encryption-format=luks,encryption-passphrase-file={passphrase-file}
+.. prompt:: bash #
+
+    rbd device map -t nbd -o encryption-passphrase-file={passphrase-file} {image-spec}
 
 Note that for security reasons, both the encryption format and encryption load
 operations are CPU-intensive, and may take a few seconds to complete. For the

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -56,7 +56,18 @@ function test_encryption_format() {
   dd if=$LIBRBD_DEV of=/tmp/cmpdata iflag=direct bs=4M count=4
   cmp -n 16MB /tmp/cmpdata /tmp/testdata2
 
-  sudo rbd device unmap -t nbd $LIBRBD_DEV
+  # FIXME: encryption-aware flatten/resize misbehave if proxied to
+  # RAW_DEV mapping (i.e. if RAW_DEV mapping ows the lock)
+  # (acquire and) release the lock as a side effect
+  rbd bench --io-type read --io-size 1 --io-threads 1 --io-total 1 testimg
+
+  # check that encryption-aware resize compensates LUKS header overhead
+  (( $(sudo blockdev --getsize64 $LIBRBD_DEV) < (32 << 20) ))
+  expect_false rbd resize --size 32M testimg
+  rbd resize --size 32M --encryption-passphrase-file /tmp/passphrase testimg
+  (( $(sudo blockdev --getsize64 $LIBRBD_DEV) == (32 << 20) ))
+
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
 }
 
 function test_clone_encryption() {
@@ -77,7 +88,7 @@ function test_clone_encryption() {
   dd if=$LIBRBD_DEV of=/tmp/cmpdata iflag=direct bs=1M count=1
   cmp -n 1MB /tmp/cmpdata /tmp/testdata1
   dd if=/tmp/testdata1 of=$LIBRBD_DEV seek=1 skip=1 oflag=direct bs=1M count=1
-  sudo rbd device unmap -t nbd $LIBRBD_DEV
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
 
   # second clone (luks2)
   rbd snap create testimg1@snap
@@ -91,7 +102,7 @@ function test_clone_encryption() {
   dd if=$LIBRBD_DEV of=/tmp/cmpdata iflag=direct bs=1M count=2
   cmp -n 2MB /tmp/cmpdata /tmp/testdata1
   dd if=/tmp/testdata1 of=$LIBRBD_DEV seek=2 skip=2 oflag=direct bs=1M count=1
-  sudo rbd device unmap -t nbd $LIBRBD_DEV
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
 
   # flatten
   expect_false rbd flatten testimg2 --encryption-format luks1 --encryption-format luks2 --encryption-passphrase-file /tmp/passphrase2 --encryption-passphrase-file /tmp/passphrase
@@ -103,7 +114,7 @@ function test_clone_encryption() {
   sudo chmod 666 /dev/mapper/cryptsetupdev
   dd if=/dev/mapper/cryptsetupdev of=/tmp/cmpdata iflag=direct bs=1M count=3
   cmp -n 3MB /tmp/cmpdata /tmp/testdata1
-  sudo rbd device unmap -t nbd $RAW_FLAT_DEV
+  _sudo rbd device unmap -t nbd $RAW_FLAT_DEV
 }
 
 function test_clone_and_load_with_a_single_passphrase {

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -43,7 +43,7 @@ function test_encryption_format() {
   sudo chmod 666 /dev/mapper/cryptsetupdev
 
   # open encryption with librbd
-  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg -t nbd -o encryption-format=luks,encryption-passphrase-file=/tmp/passphrase)
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg -t nbd -o encryption-passphrase-file=/tmp/passphrase)
   sudo chmod 666 $LIBRBD_DEV
 
   # write via librbd && compare
@@ -117,9 +117,10 @@ function test_clone_and_load_with_a_single_passphrase {
 
   if [ "$expectedfail" = "true" ]
   then
-    expect_false rbd flatten testimg1 --encryption-format luks --encryption-passphrase-file /tmp/passphrase2
+    expect_false rbd flatten testimg1 --encryption-passphrase-file /tmp/passphrase2
+    rbd flatten testimg1 --encryption-passphrase-file /tmp/passphrase2 --encryption-passphrase-file /tmp/passphrase
   else
-    rbd flatten testimg1 --encryption-format luks --encryption-passphrase-file /tmp/passphrase2
+    rbd flatten testimg1 --encryption-passphrase-file /tmp/passphrase2
   fi
 
   rbd remove testimg1

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -94,7 +94,8 @@ function test_clone_encryption() {
   sudo rbd device unmap -t nbd $LIBRBD_DEV
 
   # flatten
-  rbd flatten testimg2 --encryption-format luks --encryption-format luks --encryption-passphrase-file /tmp/passphrase2 --encryption-passphrase-file /tmp/passphrase
+  expect_false rbd flatten testimg2 --encryption-format luks1 --encryption-format luks2 --encryption-passphrase-file /tmp/passphrase2 --encryption-passphrase-file /tmp/passphrase
+  rbd flatten testimg2 --encryption-format luks2 --encryption-format luks1 --encryption-passphrase-file /tmp/passphrase2 --encryption-passphrase-file /tmp/passphrase
 
   # verify with cryptsetup
   RAW_FLAT_DEV=$(_sudo rbd -p rbd map testimg2 -t nbd)

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -184,8 +184,8 @@ dd if=/dev/urandom of=/tmp/testdata1 bs=4M count=4
 dd if=/dev/urandom of=/tmp/testdata2 bs=4M count=4
 
 # create passphrase files
-echo -n "password" > /tmp/passphrase
-echo -n "password2" > /tmp/passphrase2
+printf "pass\0word\n" > /tmp/passphrase
+printf "\t password2   " > /tmp/passphrase2
 
 # create an image
 rbd create testimg --size=32M

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -872,7 +872,7 @@ CEPH_RBD_API int rbd_encryption_load(rbd_image_t image,
  * interpreted as plaintext.
  */
 CEPH_RBD_API int rbd_encryption_load2(rbd_image_t image,
-                                      rbd_encryption_spec_t *specs,
+                                      const rbd_encryption_spec_t *specs,
                                       size_t spec_count);
 
 /* snapshots */

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -600,7 +600,7 @@ public:
                         size_t opts_size);
   int encryption_load(encryption_format_t format, encryption_options_t opts,
                       size_t opts_size);
-  int encryption_load2(encryption_spec_t *specs, size_t spec_count);
+  int encryption_load2(const encryption_spec_t *specs, size_t spec_count);
 
   /* striping */
   uint64_t get_stripe_unit() const;

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -672,12 +672,11 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
     return CEPH_NOSNAP;
   }
 
-  int ImageCtx::get_parent_overlap(snap_t in_snap_id, uint64_t *overlap) const
-  {
-    ceph_assert(ceph_mutex_is_locked(image_lock));
+  int ImageCtx::get_parent_overlap(snap_t in_snap_id,
+                                   uint64_t* raw_overlap) const {
     const auto info = get_parent_info(in_snap_id);
     if (info) {
-      *overlap = info->overlap;
+      *raw_overlap = info->overlap;
       return 0;
     }
     return -ENOENT;

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -36,6 +36,7 @@
 #include "librbd/io/ObjectDispatcher.h"
 #include "librbd/io/QosImageDispatch.h"
 #include "librbd/io/IoOperations.h"
+#include "librbd/io/Utils.h"
 #include "librbd/journal/StandardPolicy.h"
 #include "librbd/operation/ResizeRequest.h"
 
@@ -542,10 +543,7 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
       return 0;
     }
 
-    io::Extents extents = {{raw_size, 0}};
-    io_image_dispatcher->remap_extents(
-            extents, io::IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
-    return extents.front().first;
+    return io::util::raw_to_area_offset(*this, raw_size).first;
   }
 
   uint64_t ImageCtx::get_object_count(snap_t in_snap_id) const {

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -326,9 +326,11 @@ namespace librbd {
                            uint64_t* raw_overlap) const;
     std::pair<uint64_t, io::ImageArea> reduce_parent_overlap(
         uint64_t raw_overlap, bool migration_write) const;
+    uint64_t prune_parent_extents(
+        std::vector<std::pair<uint64_t, uint64_t>>& image_extents,
+        io::ImageArea area, uint64_t raw_overlap, bool migration_write) const;
+
     void register_watch(Context *on_finish);
-    uint64_t prune_parent_extents(std::vector<std::pair<uint64_t,uint64_t> >& objectx,
-				  uint64_t overlap);
 
     void cancel_async_requests();
     void cancel_async_requests(Context *on_finish);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -322,7 +322,7 @@ namespace librbd {
     std::string get_parent_image_id(librados::snap_t in_snap_id) const;
     uint64_t get_parent_snap_id(librados::snap_t in_snap_id) const;
     int get_parent_overlap(librados::snap_t in_snap_id,
-			   uint64_t *overlap) const;
+                           uint64_t* raw_overlap) const;
     void register_watch(Context *on_finish);
     uint64_t prune_parent_extents(std::vector<std::pair<uint64_t,uint64_t> >& objectx,
 				  uint64_t overlap);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -61,6 +61,7 @@ namespace librbd {
   class AioCompletion;
   class AsyncOperation;
   template <typename> class CopyupRequest;
+  enum class ImageArea;
   struct ImageDispatcherInterface;
   struct ObjectDispatcherInterface;
   }
@@ -301,7 +302,7 @@ namespace librbd {
 		 std::string in_snap_name,
 		 librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
-    uint64_t get_effective_image_size(librados::snap_t in_snap_id) const;
+    uint64_t get_area_size(io::ImageArea area) const;
     uint64_t get_object_count(librados::snap_t in_snap_id) const;
     bool test_features(uint64_t test_features) const;
     bool test_features(uint64_t test_features,
@@ -323,6 +324,8 @@ namespace librbd {
     uint64_t get_parent_snap_id(librados::snap_t in_snap_id) const;
     int get_parent_overlap(librados::snap_t in_snap_id,
                            uint64_t* raw_overlap) const;
+    std::pair<uint64_t, io::ImageArea> reduce_parent_overlap(
+        uint64_t raw_overlap, bool migration_write) const;
     void register_watch(Context *on_finish);
     uint64_t prune_parent_extents(std::vector<std::pair<uint64_t,uint64_t> >& objectx,
 				  uint64_t overlap);

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -17,6 +17,7 @@
 #include "librbd/Utils.h"
 #include "librbd/api/Config.h"
 #include "librbd/asio/ContextWQ.h"
+#include "librbd/io/Utils.h"
 #include "librbd/journal/DisabledPolicy.h"
 #include "librbd/journal/StandardPolicy.h"
 #include "librbd/operation/DisableFeaturesRequest.h"
@@ -742,9 +743,12 @@ int Operations<I>::resize(uint64_t size, bool allow_shrink, ProgressContext& pro
   CephContext *cct = m_image_ctx.cct;
 
   m_image_ctx.image_lock.lock_shared();
-  ldout(cct, 5) << this << " " << __func__ << ": "
-                << "size=" << m_image_ctx.size << ", "
-                << "new_size=" << size << dendl;
+  uint64_t raw_size = io::util::area_to_raw_offset(m_image_ctx, size,
+                                                   io::ImageArea::DATA);
+  ldout(cct, 5) << this << " " << __func__
+                << ": size=" << size
+                << " raw_size=" << m_image_ctx.size
+                << " new_raw_size=" << raw_size << dendl;
   m_image_ctx.image_lock.unlock_shared();
 
   int r = m_image_ctx.state->refresh_if_required();
@@ -753,7 +757,7 @@ int Operations<I>::resize(uint64_t size, bool allow_shrink, ProgressContext& pro
   }
 
   if (m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP) &&
-      !ObjectMap<>::is_compatible(m_image_ctx.layout, size)) {
+      !ObjectMap<>::is_compatible(m_image_ctx.layout, raw_size)) {
     lderr(cct) << "New size not compatible with object map" << dendl;
     return -EINVAL;
   }
@@ -783,9 +787,12 @@ void Operations<I>::execute_resize(uint64_t size, bool allow_shrink, ProgressCon
 
   CephContext *cct = m_image_ctx.cct;
   m_image_ctx.image_lock.lock_shared();
-  ldout(cct, 5) << this << " " << __func__ << ": "
-                << "size=" << m_image_ctx.size << ", "
-                << "new_size=" << size << dendl;
+  uint64_t raw_size = io::util::area_to_raw_offset(m_image_ctx, size,
+                                                   io::ImageArea::DATA);
+  ldout(cct, 5) << this << " " << __func__
+                << ": size=" << size
+                << " raw_size=" << m_image_ctx.size
+                << " new_raw_size=" << raw_size << dendl;
 
   if (m_image_ctx.snap_id != CEPH_NOSNAP || m_image_ctx.read_only ||
       m_image_ctx.operations_disabled) {
@@ -794,7 +801,7 @@ void Operations<I>::execute_resize(uint64_t size, bool allow_shrink, ProgressCon
     return;
   } else if (m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
                                        m_image_ctx.image_lock) &&
-             !ObjectMap<>::is_compatible(m_image_ctx.layout, size)) {
+             !ObjectMap<>::is_compatible(m_image_ctx.layout, raw_size)) {
     m_image_ctx.image_lock.unlock_shared();
     on_finish->complete(-EINVAL);
     return;
@@ -802,8 +809,8 @@ void Operations<I>::execute_resize(uint64_t size, bool allow_shrink, ProgressCon
   m_image_ctx.image_lock.unlock_shared();
 
   operation::ResizeRequest<I> *req = new operation::ResizeRequest<I>(
-    m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish), size, allow_shrink,
-    prog_ctx, journal_op_tid, false);
+      m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish), raw_size,
+      allow_shrink, prog_ctx, journal_op_tid, false);
   req->send();
 }
 

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -73,7 +73,7 @@ public:
     }
     auto req = io::ImageDispatchSpec::create_list_snaps(
       m_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,
-      aio_comp, {{m_image_offset, m_image_length}},
+      aio_comp, {{m_image_offset, m_image_length}}, io::ImageArea::DATA,
       {m_diff_context.from_snap_id, m_diff_context.end_snap_id},
       list_snaps_flags, &m_snapshot_delta, {});
     req->send();

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -198,7 +198,7 @@ int DiffIterate<I>::diff_iterate(I *ictx,
   }
 
   ictx->image_lock.lock_shared();
-  r = clip_io(ictx, off, &len);
+  r = clip_io(ictx, off, &len, io::ImageArea::DATA);
   ictx->image_lock.unlock_shared();
   if (r < 0) {
     return r;

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -974,7 +974,7 @@ int Image<I>::encryption_format(I* ictx, encryption_format_t format,
 }
 
 template <typename I>
-int Image<I>::encryption_load(I* ictx, encryption_spec_t *specs,
+int Image<I>::encryption_load(I* ictx, const encryption_spec_t *specs,
                               size_t spec_count, bool c_api) {
   std::vector<std::unique_ptr<crypto::EncryptionFormat<I>>> formats;
 

--- a/src/librbd/api/Image.h
+++ b/src/librbd/api/Image.h
@@ -73,9 +73,8 @@ struct Image {
   static int encryption_format(ImageCtxT *ictx, encryption_format_t format,
                                encryption_options_t opts, size_t opts_size,
                                bool c_api);
-  static int encryption_load(ImageCtxT *ictx, encryption_spec_t *specs,
+  static int encryption_load(ImageCtxT *ictx, const encryption_spec_t *specs,
                              size_t spec_count, bool c_api);
-
 };
 
 } // namespace api

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -63,7 +63,8 @@ ssize_t Io<I>::write(
                  << "len = " << len << dendl;
 
   image_ctx.image_lock.lock_shared();
-  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len,
+                  io::ImageArea::DATA);
   image_ctx.image_lock.unlock_shared();
   if (r < 0) {
     lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;
@@ -90,7 +91,8 @@ ssize_t Io<I>::discard(
                  << "len = " << len << dendl;
 
   image_ctx.image_lock.lock_shared();
-  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len,
+                  io::ImageArea::DATA);
   image_ctx.image_lock.unlock_shared();
   if (r < 0) {
     lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;
@@ -116,7 +118,8 @@ ssize_t Io<I>::write_same(
                  << "len = " << len << ", data_len " << bl.length() << dendl;
 
   image_ctx.image_lock.lock_shared();
-  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len,
+                  io::ImageArea::DATA);
   image_ctx.image_lock.unlock_shared();
   if (r < 0) {
     lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;
@@ -142,7 +145,8 @@ ssize_t Io<I>::write_zeroes(I& image_ctx, uint64_t off, uint64_t len,
                  << "len = " << len << dendl;
 
   image_ctx.image_lock.lock_shared();
-  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len,
+                  io::ImageArea::DATA);
   image_ctx.image_lock.unlock_shared();
   if (r < 0) {
     lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;
@@ -169,7 +173,8 @@ ssize_t Io<I>::compare_and_write(
                  << off << ", " << "len = " << len << dendl;
 
   image_ctx.image_lock.lock_shared();
-  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len,
+                  io::ImageArea::DATA);
   image_ctx.image_lock.unlock_shared();
   if (r < 0) {
     lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -231,9 +231,9 @@ void Io<I>::aio_read(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_read(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(read_result), image_ctx.get_data_io_context(), op_flags, 0,
-    trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, std::move(read_result),
+      image_ctx.get_data_io_context(), op_flags, 0, trace);
   req->send();
 }
 
@@ -263,8 +263,9 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_write(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, std::move(bl),
+      image_ctx.get_data_io_context(), op_flags, trace);
   req->send();
 }
 
@@ -294,8 +295,9 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes,
+      image_ctx.get_data_io_context(), trace);
   req->send();
 }
 
@@ -326,8 +328,9 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
   }
 
   auto req = io::ImageDispatchSpec::create_write_same(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, std::move(bl),
+      image_ctx.get_data_io_context(), op_flags, trace);
   req->send();
 }
 
@@ -399,8 +402,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
       aio_comp->aio_type = io::AIO_TYPE_WRITE;
       auto req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+          {{off, len}}, io::ImageArea::DATA, std::move(bl),
+          image_ctx.get_data_io_context(), op_flags, trace);
       req->send();
       return;
     } else if (prepend_length == 0 && append_length == 0) {
@@ -409,8 +413,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       bl.append_zero(data_length);
 
       auto req = io::ImageDispatchSpec::create_write_same(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+          {{off, len}}, io::ImageArea::DATA, std::move(bl),
+          image_ctx.get_data_io_context(), op_flags, trace);
       req->send();
       return;
     }
@@ -437,9 +442,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto prepend_aio_comp = io::AioCompletion::create_and_start(
         prepend_ctx, &image_ctx, io::AIO_TYPE_WRITE);
       auto prepend_req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
-        {{prepend_offset, prepend_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
+          {{prepend_offset, prepend_length}}, io::ImageArea::DATA,
+          std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
       prepend_req->send();
     }
 
@@ -451,9 +456,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto append_aio_comp = io::AioCompletion::create_and_start(
         append_ctx, &image_ctx, io::AIO_TYPE_WRITE);
       auto append_req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
-        {{append_offset, append_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
+          {{append_offset, append_length}}, io::ImageArea::DATA,
+          std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
       append_req->send();
     }
 
@@ -464,9 +469,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
     auto write_same_aio_comp = io::AioCompletion::create_and_start(
       write_same_ctx, &image_ctx, io::AIO_TYPE_WRITESAME);
     auto req = io::ImageDispatchSpec::create_write_same(
-      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
-      {{write_same_offset, write_same_length}}, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
+        {{write_same_offset, write_same_length}}, io::ImageArea::DATA,
+        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
     req->send();
     return;
   }
@@ -475,8 +480,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
   uint32_t discard_granularity_bytes = 0;
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes,
+      image_ctx.get_data_io_context(), trace);
   req->send();
 }
 
@@ -509,9 +515,9 @@ void Io<I>::aio_compare_and_write(I &image_ctx, io::AioCompletion *aio_comp,
   }
 
   auto req = io::ImageDispatchSpec::create_compare_and_write(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(cmp_bl), std::move(bl), mismatch_off,
-    image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, io::ImageArea::DATA, std::move(cmp_bl), std::move(bl),
+      mismatch_off, image_ctx.get_data_io_context(), op_flags, trace);
   req->send();
 }
 

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -294,7 +294,7 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
+    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
     discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
   req->send();
 }
@@ -326,7 +326,7 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
   }
 
   auto req = io::ImageDispatchSpec::create_write_same(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
+    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
     std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
   req->send();
 }
@@ -409,7 +409,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       bl.append_zero(data_length);
 
       auto req = io::ImageDispatchSpec::create_write_same(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
+        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
         std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
       req->send();
       return;
@@ -465,7 +465,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       write_same_ctx, &image_ctx, io::AIO_TYPE_WRITESAME);
     auto req = io::ImageDispatchSpec::create_write_same(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
-      write_same_offset, write_same_length, std::move(bl),
+      {{write_same_offset, write_same_length}}, std::move(bl),
       image_ctx.get_data_io_context(), op_flags, trace);
     req->send();
     return;
@@ -475,7 +475,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
   uint32_t discard_granularity_bytes = 0;
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
+    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
     discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
   req->send();
 }

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -75,8 +75,8 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
       on_finish, image_ctx, io::AIO_TYPE_DISCARD);
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_discard(
-    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
-    length, discard_granularity_bytes,
+    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
+    {{offset, length}}, discard_granularity_bytes,
     image_ctx->get_data_io_context(), trace);
   req->send();
 }
@@ -113,8 +113,8 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
       on_finish, image_ctx, io::AIO_TYPE_WRITESAME);
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write_same(
-    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
-    length, std::move(bl), image_ctx->get_data_io_context(),
+    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
+    {{offset, length}}, std::move(bl), image_ctx->get_data_io_context(),
     fadvise_flags, trace);
   req->send();
 }

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -36,9 +36,8 @@ void ImageWriteback<I>::aio_read(Extents &&image_extents, bufferlist *bl,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    std::move(image_extents), io::ReadResult{bl},
-    image_ctx->get_data_io_context(),
-    fadvise_flags, 0, trace);
+    std::move(image_extents), io::ImageArea::DATA, io::ReadResult{bl},
+    image_ctx->get_data_io_context(), fadvise_flags, 0, trace);
   req->send();
 }
 
@@ -56,7 +55,7 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    std::move(image_extents), std::move(bl),
+    std::move(image_extents), io::ImageArea::DATA, std::move(bl),
     image_ctx->get_data_io_context(), fadvise_flags, trace);
   req->send();
 }
@@ -76,7 +75,7 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_discard(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    {{offset, length}}, discard_granularity_bytes,
+    {{offset, length}}, io::ImageArea::DATA, discard_granularity_bytes,
     image_ctx->get_data_io_context(), trace);
   req->send();
 }
@@ -114,8 +113,8 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write_same(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    {{offset, length}}, std::move(bl), image_ctx->get_data_io_context(),
-    fadvise_flags, trace);
+    {{offset, length}}, io::ImageArea::DATA, std::move(bl),
+    image_ctx->get_data_io_context(), fadvise_flags, trace);
   req->send();
 }
 
@@ -136,8 +135,8 @@ void ImageWriteback<I>::aio_compare_and_write(Extents &&image_extents,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_compare_and_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    std::move(image_extents), std::move(cmp_bl), std::move(bl),
-    mismatch_offset, image_ctx->get_data_io_context(),
+    std::move(image_extents), io::ImageArea::DATA, std::move(cmp_bl),
+    std::move(bl), mismatch_offset, image_ctx->get_data_io_context(),
     fadvise_flags, trace);
   req->send();
 }

--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -42,6 +42,10 @@ bool WriteLogImageDispatch<I>::read(
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
+    return false;
+  }
+
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 
@@ -71,6 +75,10 @@ bool WriteLogImageDispatch<I>::write(
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
+    return false;
+  }
+
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 
@@ -94,6 +102,10 @@ bool WriteLogImageDispatch<I>::discard(
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
+    return false;
+  }
+
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 
@@ -120,6 +132,10 @@ bool WriteLogImageDispatch<I>::write_same(
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
+    return false;
+  }
+
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 
@@ -146,6 +162,10 @@ bool WriteLogImageDispatch<I>::compare_and_write(
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
+    return false;
+  }
+
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -97,8 +97,11 @@ public:
     return false;
   }
 
-  void remap_extents(io::Extents& image_extents,
-                     io::ImageExtentsMapType type) override;
+  // called directly by ImageDispatcher
+  // TODO: hoist these out and remove CryptoImageDispatch since it's
+  // just a placeholder
+  void remap_to_physical(io::Extents& image_extents, io::ImageArea area);
+  io::ImageArea remap_to_logical(io::Extents& image_extents);
 
 private:
   uint64_t m_data_offset;

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -619,9 +619,8 @@ int CryptoObjectDispatch<I>::prepare_copyup(
       auto [aligned_off, aligned_len] = m_crypto->align(
               extent.get_off(), extent.get_len());
 
-      io::Extents image_extents;
-      io::util::extent_to_file(
-              m_image_ctx, object_no, aligned_off, aligned_len, image_extents);
+      auto [image_extents, _] = io::util::object_to_area_extents(
+          m_image_ctx, object_no, {{aligned_off, aligned_len}});
 
       ceph::bufferlist encrypted_bl;
       uint64_t position = 0;

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -104,6 +104,7 @@ public:
 private:
   ImageCtxT* m_image_ctx;
   CryptoInterface* m_crypto;
+  uint64_t m_data_offset_object_no;
 };
 
 } // namespace crypto

--- a/src/librbd/crypto/EncryptionFormat.h
+++ b/src/librbd/crypto/EncryptionFormat.h
@@ -5,7 +5,6 @@
 #define CEPH_LIBRBD_CRYPTO_ENCRYPTION_FORMAT_H
 
 #include <memory>
-#include "common/ref.h"
 
 struct Context;
 

--- a/src/librbd/crypto/FormatRequest.cc
+++ b/src/librbd/crypto/FormatRequest.cc
@@ -54,7 +54,7 @@ void FormatRequest<I>::send() {
 
   auto ctx = create_context_callback<
           FormatRequest<I>, &FormatRequest<I>::handle_shutdown_crypto>(this);
-  auto *req = ShutDownCryptoRequest<I>::create(m_image_ctx, nullptr, ctx);
+  auto *req = ShutDownCryptoRequest<I>::create(m_image_ctx, ctx);
   req->send();
 }
 

--- a/src/librbd/crypto/ShutDownCryptoRequest.cc
+++ b/src/librbd/crypto/ShutDownCryptoRequest.cc
@@ -23,11 +23,9 @@ namespace crypto {
 using librbd::util::create_context_callback;
 
 template <typename I>
-ShutDownCryptoRequest<I>::ShutDownCryptoRequest(
-        I* image_ctx, EncryptionFormat* format,
-        Context* on_finish) : m_image_ctx(image_ctx), m_format(format),
-                              m_on_finish(on_finish) {
-}
+ShutDownCryptoRequest<I>::ShutDownCryptoRequest(I* image_ctx,
+                                                Context* on_finish)
+    : m_image_ctx(image_ctx), m_on_finish(on_finish) {}
 
 template <typename I>
 void ShutDownCryptoRequest<I>::send() {
@@ -97,12 +95,7 @@ void ShutDownCryptoRequest<I>::finish(int r) {
   if (r == 0) {
     {
       std::unique_lock image_locker{m_image_ctx->image_lock};
-      if (m_format != nullptr) {
-        *m_format = std::move(m_image_ctx->encryption_format);
-        m_format = nullptr;
-      } else {
-        m_image_ctx->encryption_format.reset();
-      }
+      m_image_ctx->encryption_format.reset();
     }
     
     if (m_image_ctx->parent != nullptr) {

--- a/src/librbd/crypto/ShutDownCryptoRequest.h
+++ b/src/librbd/crypto/ShutDownCryptoRequest.h
@@ -14,20 +14,15 @@ class ImageCtx;
 
 namespace crypto {
 
-template <typename> class EncryptionFormat;
-
 template <typename I>
 class ShutDownCryptoRequest {
 public:
-    using EncryptionFormat = decltype(I::encryption_format);
-
-    static ShutDownCryptoRequest* create(
-            I* image_ctx, EncryptionFormat* format, Context* on_finish) {
-      return new ShutDownCryptoRequest(image_ctx, format, on_finish);
+    static ShutDownCryptoRequest* create(I* image_ctx, Context* on_finish) {
+      return new ShutDownCryptoRequest(image_ctx, on_finish);
     }
 
-    ShutDownCryptoRequest(
-            I* image_ctx, EncryptionFormat* format, Context* on_finish);
+    ShutDownCryptoRequest(I* image_ctx, Context* on_finish);
+
     void send();
     void shut_down_object_dispatch();
     void handle_shut_down_object_dispatch(int r);
@@ -37,7 +32,6 @@ public:
 
 private:
     I* m_image_ctx;
-    EncryptionFormat* m_format;
     Context* m_on_finish;
 };
 

--- a/src/librbd/crypto/luks/FlattenRequest.cc
+++ b/src/librbd/crypto/luks/FlattenRequest.cc
@@ -74,8 +74,9 @@ void FlattenRequest<I>::read_header() {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, data_offset}}, io::ReadResult{&m_bl},
-          m_image_ctx->get_data_io_context(), 0, 0, trace);
+          {{0, data_offset}}, io::ImageArea::CRYPTO_HEADER,
+          io::ReadResult{&m_bl}, m_image_ctx->get_data_io_context(), 0, 0,
+          trace);
   req->send();
 }
 
@@ -121,8 +122,8 @@ void FlattenRequest<I>::write_header() {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, m_bl.length()}}, std::move(m_bl),
-          m_image_ctx->get_data_io_context(), 0, trace);
+          {{0, m_bl.length()}}, io::ImageArea::CRYPTO_HEADER,
+          std::move(m_bl), m_image_ctx->get_data_io_context(), 0, trace);
   req->send();
 }
 

--- a/src/librbd/crypto/luks/FlattenRequest.cc
+++ b/src/librbd/crypto/luks/FlattenRequest.cc
@@ -7,7 +7,6 @@
 #include "common/errno.h"
 #include "librbd/Utils.h"
 #include "librbd/crypto/EncryptionFormat.h"
-#include "librbd/crypto/ShutDownCryptoRequest.h"
 #include "librbd/crypto/Utils.h"
 #include "librbd/crypto/luks/LoadRequest.h"
 #include "librbd/crypto/luks/Magic.h"
@@ -35,30 +34,6 @@ FlattenRequest<I>::FlattenRequest(
 
 template <typename I>
 void FlattenRequest<I>::send() {
-  shutdown_crypto();
-}
-
-template <typename I>
-void FlattenRequest<I>::shutdown_crypto() {
-  auto ctx = create_context_callback<
-        FlattenRequest<I>, &FlattenRequest<I>::handle_shutdown_crypto>(this);
-
-  auto *req = ShutDownCryptoRequest<I>::create(
-          m_image_ctx, &m_encryption_format, ctx);
-  req->send();
-}
-
-template <typename I>
-void FlattenRequest<I>::handle_shutdown_crypto(int r) {
-  if (r < 0) {
-    lderr(m_image_ctx->cct) << "error shutting down crypto: "
-                            << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
-  ceph_assert(m_encryption_format.get() != nullptr);
-
   read_header();
 }
 
@@ -66,15 +41,14 @@ template <typename I>
 void FlattenRequest<I>::read_header() {
   auto ctx = create_context_callback<
         FlattenRequest<I>, &FlattenRequest<I>::handle_read_header>(this);
-
-  uint64_t data_offset = m_encryption_format->get_crypto()->get_data_offset();
-
   auto aio_comp = io::AioCompletion::create_and_start(
           ctx, librbd::util::get_image_ctx(m_image_ctx), io::AIO_TYPE_READ);
+
+  auto crypto = m_image_ctx->encryption_format->get_crypto();
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, data_offset}}, io::ImageArea::CRYPTO_HEADER,
+          {{0, crypto->get_data_offset()}}, io::ImageArea::CRYPTO_HEADER,
           io::ReadResult{&m_bl}, m_image_ctx->get_data_io_context(), 0, 0,
           trace);
   req->send();
@@ -168,11 +142,6 @@ void FlattenRequest<I>::handle_flush(int r) {
 template <typename I>
 void FlattenRequest<I>::finish(int r) {
   ldout(m_image_ctx->cct, 20) << "r=" << r << dendl;
-
-  // restore crypto to image context
-  if (m_encryption_format.get() != nullptr) {
-    util::set_crypto(m_image_ctx, std::move(m_encryption_format));
-  }
 
   m_on_finish->complete(r);
   delete this;

--- a/src/librbd/crypto/luks/FlattenRequest.h
+++ b/src/librbd/crypto/luks/FlattenRequest.h
@@ -30,9 +30,6 @@ private:
    * <start>
    *    |
    *    v
-   * SHUTDOWN_CRYPTO
-   *    |
-   *    v
    * READ_HEADER
    *    |
    *    v
@@ -42,17 +39,14 @@ private:
    * FLUSH
    *    |
    *    v
-   * <finish> (+ RESTORE_CRYPTO)
+   * <finish>
    *
    * @endverbatim
    */
     I* m_image_ctx;
     Context* m_on_finish;
     ceph::bufferlist m_bl;
-    EncryptionFormat m_encryption_format;
 
-    void shutdown_crypto();
-    void handle_shutdown_crypto(int r);
     void read_header();
     void handle_read_header(int r);
     void write_header();

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -108,8 +108,8 @@ void FormatRequest<I>::send() {
   uint64_t image_size = m_image_ctx->get_image_size(CEPH_NOSNAP);
   m_image_ctx->image_lock.unlock_shared();
 
-  if (m_header.get_data_offset() >= image_size) {
-    lderr(m_image_ctx->cct) << "image is too small. format requires more than "
+  if (m_header.get_data_offset() > image_size) {
+    lderr(m_image_ctx->cct) << "image is too small, format requires "
                             << m_header.get_data_offset() << " bytes" << dendl;
     finish(-ENOSPC);
     return;

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -167,7 +167,7 @@ void FormatRequest<I>::send() {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, bl.length()}}, std::move(bl),
+          {{0, bl.length()}}, io::ImageArea::DATA, std::move(bl),
           m_image_ctx->get_data_io_context(), 0, trace);
   req->send();
 }

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -185,6 +185,14 @@ void LoadRequest<I>::handle_read_header(int r) {
     return;
   }
 
+  uint64_t stripe_period = m_image_ctx->get_stripe_period();
+  if (m_header.get_data_offset() % stripe_period != 0) {
+    lderr(m_image_ctx->cct) << "incompatible stripe pattern, data offset "
+                            << m_header.get_data_offset() << dendl;
+    finish(-EINVAL);
+    return;
+  }
+
   read_volume_key();
   return;
 }

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -59,7 +59,7 @@ void LoadRequest<I>::read(uint64_t end_offset, Context* on_finish) {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{m_offset, length}}, io::ReadResult{&m_bl},
+          {{m_offset, length}}, io::ImageArea::DATA, io::ReadResult{&m_bl},
           m_image_ctx->get_data_io_context(), 0, 0, trace);
   req->send();
 }

--- a/src/librbd/crypto/luks/LoadRequest.h
+++ b/src/librbd/crypto/luks/LoadRequest.h
@@ -26,15 +26,17 @@ template <typename I>
 class LoadRequest {
 public:
     static LoadRequest* create(
-            I* image_ctx, std::string_view passphrase,
+            I* image_ctx, encryption_format_t format,
+            std::string_view passphrase,
             std::unique_ptr<CryptoInterface>* result_crypto,
             std::string* detected_format_name,
             Context* on_finish) {
-      return new LoadRequest(image_ctx, passphrase, result_crypto,
+      return new LoadRequest(image_ctx, format, passphrase, result_crypto,
                              detected_format_name, on_finish);
     }
 
-    LoadRequest(I* image_ctx, std::string_view passphrase,
+    LoadRequest(I* image_ctx, encryption_format_t format,
+                std::string_view passphrase,
                 std::unique_ptr<CryptoInterface>* result_crypto,
                 std::string* detected_format_name, Context* on_finish);
     void send();
@@ -43,6 +45,7 @@ public:
 
 private:
     I* m_image_ctx;
+    encryption_format_t m_format;
     std::string_view m_passphrase;
     Context* m_on_finish;
     ceph::bufferlist m_bl;

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -72,10 +72,11 @@ void ObjectCopyRequest<I>::send() {
 template <typename I>
 void ObjectCopyRequest<I>::send_list_snaps() {
   // image extents are consistent across src and dst so compute once
-  io::util::extent_to_file(
-          m_dst_image_ctx, m_dst_object_number, 0,
-          m_dst_image_ctx->layout.object_size, m_image_extents);
-  ldout(m_cct, 20) << "image_extents=" << m_image_extents << dendl;
+  std::tie(m_image_extents, m_image_area) = io::util::object_to_area_extents(
+      m_dst_image_ctx, m_dst_object_number,
+      {{0, m_dst_image_ctx->layout.object_size}});
+  ldout(m_cct, 20) << "image_extents=" << m_image_extents
+                   << " area=" << m_image_area << dendl;
 
   auto ctx = create_async_context_callback(
     *m_src_image_ctx, create_context_callback<

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -603,8 +603,9 @@ void ObjectCopyRequest<I>::merge_write_ops() {
     for (auto [image_offset, image_length] : read_op.image_extent_map) {
       // convert image extents back to object extents for the write op
       striper::LightweightObjectExtents object_extents;
-      io::util::file_to_extents(m_dst_image_ctx, image_offset,
-                                image_length, buffer_offset, &object_extents);
+      io::util::area_to_object_extents(m_dst_image_ctx, image_offset,
+                                       image_length, m_image_area,
+                                       buffer_offset, &object_extents);
       for (auto& object_extent : object_extents) {
         ldout(m_cct, 20) << "src_snap_seq=" << src_snap_seq << ", "
                          << "object_offset=" << object_extent.offset << ", "
@@ -759,8 +760,9 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
     for (auto z = zero_interval.begin(); z != zero_interval.end(); ++z) {
       // convert image extents back to object extents for the write op
       striper::LightweightObjectExtents object_extents;
-      io::util::file_to_extents(m_dst_image_ctx, z.get_start(), z.get_len(), 0,
-                                &object_extents);
+      io::util::area_to_object_extents(m_dst_image_ctx, z.get_start(),
+                                       z.get_len(), m_image_area, 0,
+                                       &object_extents);
       for (auto& object_extent : object_extents) {
         ceph_assert(object_extent.offset + object_extent.length <=
                       m_dst_image_ctx->layout.object_size);

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -105,8 +105,8 @@ void ObjectCopyRequest<I>::send_list_snaps() {
     ctx, get_image_ctx(m_src_image_ctx), io::AIO_TYPE_GENERIC);
   auto req = io::ImageDispatchSpec::create_list_snaps(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_NONE, aio_comp,
-    io::Extents{m_image_extents}, std::move(snap_ids), list_snaps_flags,
-    &m_snapshot_delta, {});
+    io::Extents{m_image_extents}, m_image_area, std::move(snap_ids),
+    list_snaps_flags, &m_snapshot_delta, {});
   req->send();
 }
 
@@ -173,8 +173,8 @@ void ObjectCopyRequest<I>::send_read() {
 
   auto req = io::ImageDispatchSpec::create_read(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-    std::move(image_extents), std::move(read_result), io_context, op_flags,
-    read_flags, {});
+    std::move(image_extents), m_image_area, std::move(read_result),
+    io_context, op_flags, read_flags, {});
   req->send();
 }
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -116,6 +116,7 @@ private:
   std::string m_dst_oid;
 
   io::Extents m_image_extents;
+  io::ImageArea m_image_area = io::ImageArea::DATA;
 
   io::SnapshotDelta m_snapshot_delta;
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1348,7 +1348,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 	ctx, src, io::AIO_TYPE_READ);
       auto req = io::ImageDispatchSpec::create_read(
         *src, io::IMAGE_DISPATCH_LAYER_NONE, comp,
-        {{offset, len}}, io::ReadResult{bl},
+        {{offset, len}}, io::ImageArea::DATA, io::ReadResult{bl},
         src->get_data_io_context(), fadvise_flags, 0, trace);
 
       ctx->read_trace = trace;
@@ -1561,7 +1561,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
                                                    io::AIO_TYPE_READ);
       auto req = io::ImageDispatchSpec::create_read(
         *ictx, io::IMAGE_DISPATCH_LAYER_NONE, c,
-        {{off, read_len}}, io::ReadResult{&bl},
+        {{off, read_len}}, io::ImageArea::DATA, io::ReadResult{&bl},
         ictx->get_data_io_context(), 0, 0, trace);
       req->send();
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1542,7 +1542,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 
     uint64_t mylen = len;
     ictx->image_lock.lock_shared();
-    r = clip_io(ictx, off, &mylen);
+    r = clip_io(ictx, off, &mylen, io::ImageArea::DATA);
     ictx->image_lock.unlock_shared();
     if (r < 0)
       return r;
@@ -1595,9 +1595,8 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     return total_read;
   }
 
-  // validate extent against image size; clip to image size if necessary
-  int clip_io(ImageCtx *ictx, uint64_t off, uint64_t *len)
-  {
+  // validate extent against area size; clip to area size if necessary
+  int clip_io(ImageCtx* ictx, uint64_t off, uint64_t* len, io::ImageArea area) {
     ceph_assert(ceph_mutex_is_locked(ictx->image_lock));
 
     if (ictx->snap_id != CEPH_NOSNAP &&
@@ -1609,8 +1608,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     if (*len == 0)
       return 0;
 
-    // TODO: pass area
-    uint64_t area_size = ictx->get_area_size(io::ImageArea::DATA);
+    uint64_t area_size = ictx->get_area_size(area);
 
     // can't start past end
     if (off >= area_size)

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -182,7 +182,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     int obj_order = ictx->order;
     {
       std::shared_lock locker{ictx->image_lock};
-      info.size = ictx->get_effective_image_size(ictx->snap_id);
+      info.size = ictx->get_area_size(io::ImageArea::DATA);
     }
     info.obj_size = 1ULL << obj_order;
     info.num_objs = Striper::get_num_objects(ictx->layout, info.size);
@@ -859,7 +859,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     if (r < 0)
       return r;
     std::shared_lock l2{ictx->image_lock};
-    *size = ictx->get_effective_image_size(ictx->snap_id);
+    *size = ictx->get_area_size(io::ImageArea::DATA);
     return 0;
   }
 
@@ -878,8 +878,16 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     int r = ictx->state->refresh_if_required();
     if (r < 0)
       return r;
+
     std::shared_lock image_locker{ictx->image_lock};
-    return ictx->get_parent_overlap(ictx->snap_id, overlap);
+    uint64_t raw_overlap;
+    r = ictx->get_parent_overlap(ictx->snap_id, &raw_overlap);
+    if (r < 0) {
+      return r;
+    }
+    auto _overlap = ictx->reduce_parent_overlap(raw_overlap, false);
+    *overlap = (_overlap.second == io::ImageArea::DATA ? _overlap.first : 0);
+    return 0;
   }
 
   int get_flags(ImageCtx *ictx, uint64_t *flags)
@@ -1596,19 +1604,21 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
         ictx->get_snap_info(ictx->snap_id) == nullptr) {
       return -ENOENT;
     }
-    uint64_t image_size = ictx->get_effective_image_size(ictx->snap_id);
 
     // special-case "len == 0" requests: always valid
     if (*len == 0)
       return 0;
 
+    // TODO: pass area
+    uint64_t area_size = ictx->get_area_size(io::ImageArea::DATA);
+
     // can't start past end
-    if (off >= image_size)
+    if (off >= area_size)
       return -EINVAL;
 
     // clip requests that extend past end to just end
-    if ((off + *len) > image_size)
-      *len = (size_t)(image_size - off);
+    if ((off + *len) > area_size)
+      *len = (size_t)(area_size - off);
 
     return 0;
   }

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -206,26 +206,6 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     return num;
   }
 
-  void trim_image(ImageCtx *ictx, uint64_t newsize, ProgressContext& prog_ctx)
-  {
-    ceph_assert(ceph_mutex_is_locked(ictx->owner_lock));
-    ceph_assert(ictx->exclusive_lock == nullptr ||
-                ictx->exclusive_lock->is_lock_owner());
-
-    C_SaferCond ctx;
-    ictx->image_lock.lock_shared();
-    operation::TrimRequest<> *req = operation::TrimRequest<>::create(
-      *ictx, &ctx, ictx->size, newsize, prog_ctx);
-    ictx->image_lock.unlock_shared();
-    req->send();
-
-    int r = ctx.wait();
-    if (r < 0) {
-      lderr(ictx->cct) << "warning: failed to remove some object(s): "
-		       << cpp_strerror(r) << dendl;
-    }
-  }
-
   int read_header_bl(IoCtx& io_ctx, const string& header_oid,
 		     bufferlist& header, uint64_t *ver)
   {

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -114,8 +114,6 @@ namespace librbd {
   int break_lock(ImageCtx *ictx, const std::string& client,
 		 const std::string& cookie);
 
-  void trim_image(ImageCtx *ictx, uint64_t newsize, ProgressContext& prog_ctx);
-
   int read_header_bl(librados::IoCtx& io_ctx, const std::string& md_oid,
 		     ceph::bufferlist& header, uint64_t *ver);
   int read_header(librados::IoCtx& io_ctx, const std::string& md_oid,

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -20,7 +20,10 @@
 namespace librbd {
 
   struct ImageCtx;
-  namespace io { struct AioCompletion; }
+  namespace io {
+  struct AioCompletion;
+  enum class ImageArea;
+  }
 
   class NoOpProgressContext : public ProgressContext
   {
@@ -122,7 +125,7 @@ namespace librbd {
   void image_info(const ImageCtx *ictx, image_info_t& info, size_t info_size);
   uint64_t oid_to_object_no(const std::string& oid,
 			    const std::string& object_prefix);
-  int clip_io(ImageCtx *ictx, uint64_t off, uint64_t *len);
+  int clip_io(ImageCtx* ictx, uint64_t off, uint64_t* len, io::ImageArea area);
   void init_rbd_header(struct rbd_obj_header_ondisk& ondisk,
 		       uint64_t size, int order, uint64_t bid);
 

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -179,9 +179,9 @@ void CopyupRequest<I>::read_from_parent() {
     &CopyupRequest<I>::handle_read_from_parent>(
       this, librbd::util::get_image_ctx(m_image_ctx->parent), AIO_TYPE_READ);
 
-  ldout(cct, 20) << "completion=" << comp << ", "
-                 << "extents=" << m_image_extents
-                 << dendl;
+  ldout(cct, 20) << "completion=" << comp
+                 << " image_extents=" << m_image_extents
+                 << " area=" << m_image_area << dendl;
   auto req = io::ImageDispatchSpec::create_read(
     *m_image_ctx->parent, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, comp,
     std::move(m_image_extents), m_image_area,
@@ -677,8 +677,8 @@ void CopyupRequest<I>::convert_copyup_extent_map() {
   // convert the image-extent extent map to object-extents
   for (auto [image_offset, image_length] : image_extent_map) {
     striper::LightweightObjectExtents object_extents;
-    util::file_to_extents(
-      m_image_ctx, image_offset, image_length, 0, &object_extents);
+    util::area_to_object_extents(m_image_ctx, image_offset, image_length,
+                                 m_image_area, 0, &object_extents);
     for (auto& object_extent : object_extents) {
       m_copyup_extent_map.emplace_back(
         object_extent.offset, object_extent.length);

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -118,7 +118,8 @@ template <typename I>
 CopyupRequest<I>::CopyupRequest(I *ictx, uint64_t objectno,
                                 Extents &&image_extents,
                                 const ZTracer::Trace &parent_trace)
-  : m_image_ctx(ictx), m_object_no(objectno), m_image_extents(image_extents),
+  : m_image_ctx(ictx), m_object_no(objectno),
+    m_image_extents(std::move(image_extents)),
     m_trace(librbd::util::create_trace(*m_image_ctx, "copy-up", parent_trace))
 {
   ceph_assert(m_image_ctx->data_ctx.is_valid());

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -116,10 +116,10 @@ private:
 
 template <typename I>
 CopyupRequest<I>::CopyupRequest(I *ictx, uint64_t objectno,
-                                Extents &&image_extents,
+                                Extents &&image_extents, ImageArea area,
                                 const ZTracer::Trace &parent_trace)
   : m_image_ctx(ictx), m_object_no(objectno),
-    m_image_extents(std::move(image_extents)),
+    m_image_extents(std::move(image_extents)), m_image_area(area),
     m_trace(librbd::util::create_trace(*m_image_ctx, "copy-up", parent_trace))
 {
   ceph_assert(m_image_ctx->data_ctx.is_valid());
@@ -184,7 +184,7 @@ void CopyupRequest<I>::read_from_parent() {
                  << dendl;
   auto req = io::ImageDispatchSpec::create_read(
     *m_image_ctx->parent, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, comp,
-    std::move(m_image_extents),
+    std::move(m_image_extents), m_image_area,
     ReadResult{&m_copyup_extent_map, &m_copyup_data},
     m_image_ctx->parent->get_data_io_context(), 0, 0, m_trace);
   req->send();

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -658,11 +658,10 @@ void CopyupRequest<I>::compute_deep_copy_snap_ids() {
       if (parent_overlap == 0) {
         return false;
       }
-      std::vector<std::pair<uint64_t, uint64_t>> extents;
-      util::extent_to_file(m_image_ctx, m_object_no, 0,
-                               m_image_ctx->layout.object_size, extents);
-      auto overlap = m_image_ctx->prune_parent_extents(
-          extents, parent_overlap);
+      auto [parent_extents, _] = util::object_to_area_extents(
+          m_image_ctx, m_object_no, {{0, m_image_ctx->layout.object_size}});
+      auto overlap = m_image_ctx->prune_parent_extents(parent_extents,
+                                                       parent_overlap);
       return overlap > 0;
     });
 }

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -30,13 +30,14 @@ template <typename ImageCtxT = librbd::ImageCtx>
 class CopyupRequest {
 public:
   static CopyupRequest* create(ImageCtxT *ictx, uint64_t objectno,
-                               Extents &&image_extents,
+                               Extents &&image_extents, ImageArea area,
                                const ZTracer::Trace &parent_trace) {
-    return new CopyupRequest(ictx, objectno, std::move(image_extents),
+    return new CopyupRequest(ictx, objectno, std::move(image_extents), area,
                              parent_trace);
   }
 
-  CopyupRequest(ImageCtxT *ictx, uint64_t objectno, Extents &&image_extents,
+  CopyupRequest(ImageCtxT *ictx, uint64_t objectno,
+                Extents &&image_extents, ImageArea area,
                 const ZTracer::Trace &parent_trace);
   ~CopyupRequest();
 
@@ -83,6 +84,7 @@ private:
   ImageCtxT *m_image_ctx;
   uint64_t m_object_no;
   Extents m_image_extents;
+  ImageArea m_image_area;
   ZTracer::Trace m_trace;
 
   bool m_flatten = false;

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -80,10 +80,6 @@ struct ImageDispatchInterface {
       Context* on_dispatched) = 0;
 
   virtual bool invalidate_cache(Context* on_finish) = 0;
-  
-  virtual void remap_extents(Extents& image_extents,
-                             ImageExtentsMapType type) {}
-
 };
 
 } // namespace io

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -238,6 +238,16 @@ private:
     ceph_assert(aio_comp->image_dispatcher_ctx == nullptr);
     aio_comp->image_dispatcher_ctx = &dispatcher_ctx;
     aio_comp->get();
+
+    switch (area) {
+    case ImageArea::DATA:
+      break;
+    case ImageArea::CRYPTO_HEADER:
+      image_dispatch_flags |= IMAGE_DISPATCH_FLAG_CRYPTO_HEADER;
+      break;
+    default:
+      ceph_abort();
+    }
   }
 };
 

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -138,11 +138,12 @@ public:
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_discard(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
-      AioCompletion *aio_comp, uint64_t off, uint64_t len,
+      AioCompletion *aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
       const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
-                                 image_dispatch_layer, aio_comp, {{off, len}},
+                                 image_dispatch_layer, aio_comp,
+                                 std::move(image_extents),
                                  Discard{discard_granularity_bytes},
                                  io_context, 0, parent_trace);
   }
@@ -162,12 +163,13 @@ public:
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_write_same(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
-      AioCompletion *aio_comp, uint64_t off, uint64_t len,
+      AioCompletion *aio_comp, Extents &&image_extents,
       bufferlist &&bl, IOContext io_context, int op_flags,
       const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
-                                 {{off, len}}, WriteSame{std::move(bl)},
+                                 std::move(image_extents),
+                                 WriteSame{std::move(bl)},
                                  io_context, op_flags, parent_trace);
   }
 

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -135,8 +135,11 @@ struct ImageDispatcher<I>::PreprocessVisitor
   }
 
   bool clip_request() const {
+    auto area = (image_dispatch_spec->image_dispatch_flags &
+        IMAGE_DISPATCH_FLAG_CRYPTO_HEADER ? ImageArea::CRYPTO_HEADER :
+                                            ImageArea::DATA);
     int r = util::clip_request(image_dispatcher->m_image_ctx,
-                               &image_dispatch_spec->image_extents);
+                               &image_dispatch_spec->image_extents, area);
     if (r < 0) {
       image_dispatch_spec->fail(r);
       return true;

--- a/src/librbd/io/ImageDispatcher.h
+++ b/src/librbd/io/ImageDispatcher.h
@@ -46,8 +46,8 @@ public:
   void unblock_writes() override;
   void wait_on_writes_unblocked(Context *on_unblocked) override;
 
-  void remap_extents(Extents& image_extents,
-                     ImageExtentsMapType type) override;
+  void remap_to_physical(Extents& image_extents, ImageArea area) override;
+  ImageArea remap_to_logical(Extents& image_extents) override;
 
 protected:
   bool send_dispatch(

--- a/src/librbd/io/ImageDispatcherInterface.h
+++ b/src/librbd/io/ImageDispatcherInterface.h
@@ -30,8 +30,9 @@ public:
   virtual void wait_on_writes_unblocked(Context *on_unblocked) = 0;
 
   virtual void invalidate_cache(Context* on_finish) = 0;
-  virtual void remap_extents(Extents& image_extents,
-                             ImageExtentsMapType type) = 0;
+
+  virtual void remap_to_physical(Extents& image_extents, ImageArea area) = 0;
+  virtual ImageArea remap_to_logical(Extents& image_extents) = 0;
 };
 
 } // namespace io

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -89,9 +89,9 @@ struct C_AssembleSnapshotDeltas : public C_AioRequest {
       SnapshotDelta* assembled_image_snapshot_delta) {
     for (auto& [key, object_extents] : object_snapshot_delta) {
       for (auto& object_extent : object_extents) {
-        Extents image_extents;
-        io::util::extent_to_file(image_ctx, object_no, object_extent.get_off(),
-                                 object_extent.get_len(), image_extents);
+        auto [image_extents, _] = io::util::object_to_area_extents(
+            image_ctx, object_no,
+            {{object_extent.get_off(), object_extent.get_len()}});
 
         auto& intervals = (*image_snapshot_delta)[key];
         auto& assembled_intervals = (*assembled_image_snapshot_delta)[key];

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -156,8 +156,9 @@ void readahead(I *ictx, const Extents& image_extents, IOContext io_context) {
     ldout(ictx->cct, 20) << "(readahead logical) " << readahead_offset << "~"
                          << readahead_length << dendl;
     LightweightObjectExtents readahead_object_extents;
-    io::util::file_to_extents(ictx, readahead_offset, readahead_length, 0,
-                              &readahead_object_extents);
+    io::util::area_to_object_extents(ictx, readahead_offset, readahead_length,
+                                     ImageArea::DATA, 0,
+                                     &readahead_object_extents);
     for (auto& object_extent : readahead_object_extents) {
       ldout(ictx->cct, 20) << "(readahead) "
                            << data_object_name(ictx,
@@ -227,11 +228,11 @@ bool should_update_timestamp(const utime_t& now, const utime_t& timestamp,
 
 template <typename I>
 void ImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
-                               Extents &&image_extents,
+                               Extents &&image_extents, ImageArea area,
                                ReadResult &&read_result, IOContext io_context,
                                int op_flags, int read_flags,
 			       const ZTracer::Trace &parent_trace) {
-  ImageReadRequest<I> req(*ictx, c, std::move(image_extents),
+  ImageReadRequest<I> req(*ictx, c, std::move(image_extents), area,
                           std::move(read_result), io_context, op_flags,
                           read_flags, parent_trace);
   req.send();
@@ -239,21 +240,22 @@ void ImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
 
 template <typename I>
 void ImageRequest<I>::aio_write(I *ictx, AioCompletion *c,
-                                Extents &&image_extents, bufferlist &&bl,
-                                IOContext io_context, int op_flags,
+                                Extents &&image_extents, ImageArea area,
+                                bufferlist &&bl, IOContext io_context,
+                                int op_flags,
 				const ZTracer::Trace &parent_trace) {
-  ImageWriteRequest<I> req(*ictx, c, std::move(image_extents), std::move(bl),
-                           io_context, op_flags, parent_trace);
+  ImageWriteRequest<I> req(*ictx, c, std::move(image_extents), area,
+                           std::move(bl), io_context, op_flags, parent_trace);
   req.send();
 }
 
 template <typename I>
 void ImageRequest<I>::aio_discard(I *ictx, AioCompletion *c,
-                                  Extents &&image_extents,
+                                  Extents &&image_extents, ImageArea area,
                                   uint32_t discard_granularity_bytes,
 				  IOContext io_context,
                                   const ZTracer::Trace &parent_trace) {
-  ImageDiscardRequest<I> req(*ictx, c, std::move(image_extents),
+  ImageDiscardRequest<I> req(*ictx, c, std::move(image_extents), area,
                              discard_granularity_bytes, io_context,
                              parent_trace);
   req.send();
@@ -269,11 +271,11 @@ void ImageRequest<I>::aio_flush(I *ictx, AioCompletion *c,
 
 template <typename I>
 void ImageRequest<I>::aio_writesame(I *ictx, AioCompletion *c,
-                                    Extents &&image_extents,
+                                    Extents &&image_extents, ImageArea area,
                                     bufferlist &&bl, IOContext io_context,
                                     int op_flags,
 				    const ZTracer::Trace &parent_trace) {
-  ImageWriteSameRequest<I> req(*ictx, c, std::move(image_extents),
+  ImageWriteSameRequest<I> req(*ictx, c, std::move(image_extents), area,
                                std::move(bl), io_context, op_flags,
                                parent_trace);
   req.send();
@@ -282,12 +284,13 @@ void ImageRequest<I>::aio_writesame(I *ictx, AioCompletion *c,
 template <typename I>
 void ImageRequest<I>::aio_compare_and_write(I *ictx, AioCompletion *c,
                                             Extents &&image_extents,
+                                            ImageArea area,
                                             bufferlist &&cmp_bl,
                                             bufferlist &&bl,
                                             uint64_t *mismatch_offset,
                                             IOContext io_context, int op_flags,
                                             const ZTracer::Trace &parent_trace) {
-  ImageCompareAndWriteRequest<I> req(*ictx, c, std::move(image_extents),
+  ImageCompareAndWriteRequest<I> req(*ictx, c, std::move(image_extents), area,
                                      std::move(cmp_bl), std::move(bl),
                                      mismatch_offset, io_context, op_flags,
                                      parent_trace);
@@ -363,12 +366,12 @@ void ImageRequest<I>::update_timestamp() {
 
 template <typename I>
 ImageReadRequest<I>::ImageReadRequest(I &image_ctx, AioCompletion *aio_comp,
-                                      Extents &&image_extents,
+                                      Extents &&image_extents, ImageArea area,
                                       ReadResult &&read_result,
                                       IOContext io_context, int op_flags,
 				      int read_flags,
                                       const ZTracer::Trace &parent_trace)
-  : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents),
+  : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents), area,
                     io_context, "read", parent_trace),
     m_op_flags(op_flags), m_read_flags(read_flags) {
   aio_comp->read_result = std::move(read_result);
@@ -380,7 +383,8 @@ void ImageReadRequest<I>::send_request() {
   CephContext *cct = image_ctx.cct;
 
   auto &image_extents = this->m_image_extents;
-  if (image_ctx.cache && image_ctx.readahead_max_bytes > 0 &&
+  if (this->m_image_area == ImageArea::DATA &&
+      image_ctx.cache && image_ctx.readahead_max_bytes > 0 &&
       !(m_op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
     readahead(get_image_ctx(&image_ctx), image_extents, this->m_io_context);
   }
@@ -393,8 +397,9 @@ void ImageReadRequest<I>::send_request() {
       continue;
     }
 
-    util::file_to_extents(&image_ctx, extent.first, extent.second, buffer_ofs,
-                          &object_extents);
+    util::area_to_object_extents(&image_ctx, extent.first, extent.second,
+                                 this->m_image_area, buffer_ofs,
+                                 &object_extents);
     buffer_ofs += extent.second;
   }
 
@@ -444,8 +449,9 @@ void AbstractImageWriteRequest<I>::send_request() {
     }
 
     // map to object extents
-    io::util::file_to_extents(&image_ctx, extent.first, extent.second, clip_len,
-                              &object_extents);
+    io::util::area_to_object_extents(&image_ctx, extent.first, extent.second,
+                                     this->m_image_area, clip_len,
+                                     &object_extents);
     clip_len += extent.second;
   }
 
@@ -814,9 +820,9 @@ int ImageCompareAndWriteRequest<I>::prune_object_extents(
 template <typename I>
 ImageListSnapsRequest<I>::ImageListSnapsRequest(
     I& image_ctx, AioCompletion* aio_comp, Extents&& image_extents,
-    SnapIds&& snap_ids, int list_snaps_flags, SnapshotDelta* snapshot_delta,
-    const ZTracer::Trace& parent_trace)
-  : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents),
+    ImageArea area, SnapIds&& snap_ids, int list_snaps_flags,
+    SnapshotDelta* snapshot_delta, const ZTracer::Trace& parent_trace)
+  : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents), area,
                     image_ctx.get_data_io_context(), "list-snaps",
                     parent_trace),
     m_snap_ids(std::move(snap_ids)), m_list_snaps_flags(list_snaps_flags),
@@ -837,8 +843,9 @@ void ImageListSnapsRequest<I>::send_request() {
     }
 
     striper::LightweightObjectExtents object_extents;
-    io::util::file_to_extents(&image_ctx, image_extent.first,
-                              image_extent.second, 0, &object_extents);
+    io::util::area_to_object_extents(&image_ctx, image_extent.first,
+                                     image_extent.second, this->m_image_area, 0,
+                                     &object_extents);
     for (auto& object_extent : object_extents) {
       object_number_extents[object_extent.object_no].emplace_back(
         object_extent.offset, object_extent.length);

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -145,10 +145,10 @@ void readahead(I *ictx, const Extents& image_extents, IOContext io_context) {
     return;
   }
 
-  uint64_t image_size = ictx->get_effective_image_size(ictx->snap_id);
+  uint64_t data_size = ictx->get_area_size(ImageArea::DATA);
   ictx->image_lock.unlock_shared();
 
-  auto readahead_extent = ictx->readahead.update(image_extents, image_size);
+  auto readahead_extent = ictx->readahead.update(image_extents, data_size);
   uint64_t readahead_offset = readahead_extent.first;
   uint64_t readahead_length = readahead_extent.second;
 

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -343,7 +343,8 @@ void ObjectReadRequest<I>::copyup() {
   if (it == image_ctx->copyup_list.end()) {
     // create and kick off a CopyupRequest
     auto new_req = CopyupRequest<I>::create(
-      image_ctx, this->m_object_no, std::move(parent_extents), this->m_trace);
+        image_ctx, this->m_object_no, std::move(parent_extents), area,
+        this->m_trace);
 
     image_ctx->copyup_list[this->m_object_no] = new_req;
     image_ctx->copyup_list_lock.unlock();
@@ -569,8 +570,8 @@ void AbstractObjectWriteRequest<I>::copyup() {
   auto it = image_ctx->copyup_list.find(this->m_object_no);
   if (it == image_ctx->copyup_list.end()) {
     auto new_req = CopyupRequest<I>::create(
-      image_ctx, this->m_object_no, std::move(this->m_parent_extents),
-      this->m_trace);
+        image_ctx, this->m_object_no, std::move(this->m_parent_extents),
+        m_image_area, this->m_trace);
     this->m_parent_extents.clear();
 
     // make sure to wait on this CopyupRequest

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -992,7 +992,7 @@ void ObjectListSnapsRequest<I>::list_from_parent() {
      m_list_snaps_flags | LIST_SNAPS_FLAG_IGNORE_ZEROED_EXTENTS);
 
   ImageListSnapsRequest<I> req(
-    *image_ctx->parent, aio_comp, std::move(parent_extents),
+    *image_ctx->parent, aio_comp, std::move(parent_extents), m_image_area,
     {0, image_ctx->parent->snap_id}, list_snaps_flags, &m_parent_snapshot_delta,
     this->m_trace);
   req.send();
@@ -1023,8 +1023,9 @@ void ObjectListSnapsRequest<I>::handle_list_from_parent(int r) {
 
       // map image-extents back to this object
       striper::LightweightObjectExtents object_extents;
-      io::util::file_to_extents(image_ctx, image_extent.get_off(),
-                                image_extent.get_len(), 0, &object_extents);
+      io::util::area_to_object_extents(image_ctx, image_extent.get_off(),
+                                       image_extent.get_len(), m_image_area, 0,
+                                       &object_extents);
       for (auto& object_extent : object_extents) {
         ceph_assert(object_extent.object_no == this->m_object_no);
         intervals.insert(

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -145,11 +145,13 @@ void ObjectRequest<I>::add_write_hint(I& image_ctx, neorados::WriteOp* wr) {
 
 template <typename I>
 bool ObjectRequest<I>::compute_parent_extents(Extents *parent_extents,
+                                              ImageArea *area,
                                               bool read_request) {
   ceph_assert(ceph_mutex_is_locked(m_ictx->image_lock));
 
   m_has_parent = false;
   parent_extents->clear();
+  *area = ImageArea::DATA;
 
   uint64_t parent_overlap;
   int r = m_ictx->get_parent_overlap(
@@ -170,13 +172,14 @@ bool ObjectRequest<I>::compute_parent_extents(Extents *parent_extents,
     return false;
   }
 
-  io::util::extent_to_file(m_ictx, m_object_no, 0, m_ictx->layout.object_size,
-                           *parent_extents);
+  std::tie(*parent_extents, *area) = io::util::object_to_area_extents(
+      m_ictx, m_object_no, {{0, m_ictx->layout.object_size}});
   uint64_t object_overlap = m_ictx->prune_parent_extents(*parent_extents,
                                                          parent_overlap);
   if (object_overlap > 0) {
-    ldout(m_ictx->cct, 20) << "overlap " << parent_overlap << " "
-                           << "extents " << *parent_extents << dendl;
+    ldout(m_ictx->cct, 20) << "overlap=" << parent_overlap
+                           << " extents=" << *parent_extents
+                           << " area=" << *area << dendl;
     m_has_parent = !parent_extents->empty();
     return true;
   }
@@ -323,7 +326,8 @@ void ObjectReadRequest<I>::copyup() {
   image_ctx->owner_lock.lock_shared();
   image_ctx->image_lock.lock_shared();
   Extents parent_extents;
-  if (!this->compute_parent_extents(&parent_extents, true) ||
+  ImageArea area;
+  if (!this->compute_parent_extents(&parent_extents, &area, true) ||
       (image_ctx->exclusive_lock != nullptr &&
        !image_ctx->exclusive_lock->is_lock_owner())) {
     image_ctx->image_lock.unlock_shared();
@@ -384,7 +388,7 @@ void AbstractObjectWriteRequest<I>::compute_parent_info() {
   I *image_ctx = this->m_ictx;
   std::shared_lock image_locker{image_ctx->image_lock};
 
-  this->compute_parent_extents(&m_parent_extents, false);
+  this->compute_parent_extents(&m_parent_extents, &m_image_area, false);
 
   if (!this->has_parent() ||
       (m_full_object &&
@@ -711,12 +715,11 @@ template <typename I>
 int ObjectCompareAndWriteRequest<I>::filter_write_result(int r) const {
   if (r <= -MAX_ERRNO) {
     I *image_ctx = this->m_ictx;
-    Extents image_extents;
 
     // object extent compare mismatch
     uint64_t offset = -MAX_ERRNO - r;
-    io::util::extent_to_file(image_ctx, this->m_object_no, offset,
-                             this->m_object_len, image_extents);
+    auto [image_extents, _] = io::util::object_to_area_extents(
+        image_ctx, this->m_object_no, {{offset, this->m_object_len}});
     ceph_assert(image_extents.size() == 1);
 
     if (m_mismatch_offset) {
@@ -956,17 +959,15 @@ void ObjectListSnapsRequest<I>::list_from_parent() {
   }
 
   // calculate reverse mapping onto the parent image
-  Extents parent_image_extents;
-  for (auto [object_off, object_len]: m_object_extents) {
-    io::util::extent_to_file(image_ctx, this->m_object_no, object_off,
-                             object_len, parent_image_extents);
-  }
+  Extents parent_extents;
+  std::tie(parent_extents, m_image_area) = io::util::object_to_area_extents(
+      image_ctx, this->m_object_no, m_object_extents);
 
   uint64_t parent_overlap = 0;
   uint64_t object_overlap = 0;
   int r = image_ctx->get_parent_overlap(snap_id_end, &parent_overlap);
   if (r == 0) {
-    object_overlap = image_ctx->prune_parent_extents(parent_image_extents,
+    object_overlap = image_ctx->prune_parent_extents(parent_extents,
                                                      parent_overlap);
   }
 
@@ -982,14 +983,15 @@ void ObjectListSnapsRequest<I>::list_from_parent() {
     &ObjectListSnapsRequest<I>::handle_list_from_parent>(this);
   auto aio_comp = AioCompletion::create_and_start(
     ctx, librbd::util::get_image_ctx(image_ctx->parent), AIO_TYPE_GENERIC);
-  ldout(cct, 20) << "aio_comp=" << aio_comp<< ", "
-                 << "parent_image_extents " << parent_image_extents << dendl;
+  ldout(cct, 20) << "completion=" << aio_comp
+                 << " parent_extents=" << parent_extents
+                 << " area=" << m_image_area << dendl;
 
    auto list_snaps_flags = (
      m_list_snaps_flags | LIST_SNAPS_FLAG_IGNORE_ZEROED_EXTENTS);
 
   ImageListSnapsRequest<I> req(
-    *image_ctx->parent, aio_comp, std::move(parent_image_extents),
+    *image_ctx->parent, aio_comp, std::move(parent_extents),
     {0, image_ctx->parent->snap_id}, list_snaps_flags, &m_parent_snapshot_delta,
     this->m_trace);
   req.send();

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -74,7 +74,8 @@ public:
   virtual const char *get_op_type() const = 0;
 
 protected:
-  bool compute_parent_extents(Extents *parent_extents, bool read_request);
+  bool compute_parent_extents(Extents *parent_extents, ImageArea *area,
+                              bool read_request);
 
   ImageCtxT *m_ictx;
   uint64_t m_object_no;
@@ -236,6 +237,7 @@ private:
    */
 
   Extents m_parent_extents;
+  ImageArea m_image_area = ImageArea::DATA;
   bool m_object_may_exist = false;
   bool m_copyup_in_progress = false;
   bool m_guarding_migration_write = false;
@@ -476,6 +478,7 @@ private:
   neorados::SnapSet m_snap_set;
   boost::system::error_code m_ec;
 
+  ImageArea m_image_area = ImageArea::DATA;
   SnapshotDelta m_parent_snapshot_delta;
 
   void list_snaps();

--- a/src/librbd/io/Types.cc
+++ b/src/librbd/io/Types.cc
@@ -34,5 +34,16 @@ std::ostream& operator<<(std::ostream& os, const SparseExtent& se) {
   return os;
 }
 
+std::ostream& operator<<(std::ostream& os, ImageArea area) {
+  switch (area) {
+  case ImageArea::DATA:
+    return os << "data";
+  case ImageArea::CRYPTO_HEADER:
+    return os << "crypto_header";
+  default:
+    ceph_abort();
+  }
+}
+
 } // namespace io
 } // namespace librbd

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -95,6 +95,10 @@ enum {
   IMAGE_DISPATCH_FLAG_QOS_MASK                = (
     IMAGE_DISPATCH_FLAG_QOS_BPS_MASK |
     IMAGE_DISPATCH_FLAG_QOS_IOPS_MASK),
+
+  // TODO: pass area through ImageDispatchInterface and remove
+  // this flag
+  IMAGE_DISPATCH_FLAG_CRYPTO_HEADER           = 1 << 6
 };
 
 enum {

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -112,11 +112,6 @@ enum {
     RBD_IO_OPERATION_COMPARE_AND_WRITE)
 };
 
-enum ImageExtentsMapType {
-    IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL,
-    IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL,
-};
-
 enum ObjectDispatchLayer {
   OBJECT_DISPATCH_LAYER_NONE = 0,
   OBJECT_DISPATCH_LAYER_CACHE,
@@ -274,6 +269,13 @@ using striper::LightweightObjectExtents;
 
 typedef std::pair<uint64_t,uint64_t> Extent;
 typedef std::vector<Extent> Extents;
+
+enum class ImageArea {
+  DATA,
+  CRYPTO_HEADER
+};
+
+std::ostream& operator<<(std::ostream& os, ImageArea area);
 
 struct ReadExtent {
     const uint64_t offset;

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -184,12 +184,11 @@ bool trigger_copyup(I* image_ctx, uint64_t object_no, IOContext io_context,
 }
 
 template <typename I>
-void file_to_extents(I* image_ctx, uint64_t offset, uint64_t length,
-                     uint64_t buffer_offset,
-                     striper::LightweightObjectExtents* object_extents) {
+void area_to_object_extents(I* image_ctx, uint64_t offset, uint64_t length,
+                            ImageArea area, uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents) {
   Extents extents = {{offset, length}};
-  // TODO: pass area
-  image_ctx->io_image_dispatcher->remap_to_physical(extents, ImageArea::DATA);
+  image_ctx->io_image_dispatcher->remap_to_physical(extents, area);
   for (auto [off, len] : extents) {
     Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, off, len, 0,
                              buffer_offset, object_extents);
@@ -245,10 +244,10 @@ template int librbd::io::util::clip_request(
 template bool librbd::io::util::trigger_copyup(
         librbd::ImageCtx *image_ctx, uint64_t object_no, IOContext io_context,
         Context* on_finish);
-template void librbd::io::util::file_to_extents(
-        librbd::ImageCtx *image_ctx, uint64_t offset, uint64_t length,
-        uint64_t buffer_offset,
-        striper::LightweightObjectExtents* object_extents);
+template void librbd::io::util::area_to_object_extents(
+    librbd::ImageCtx* image_ctx, uint64_t offset, uint64_t length,
+    ImageArea area, uint64_t buffer_offset,
+    striper::LightweightObjectExtents* object_extents);
 template auto librbd::io::util::object_to_area_extents(
     librbd::ImageCtx* image_ctx, uint64_t object_no, const Extents& extents)
     -> std::pair<Extents, ImageArea>;

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -140,12 +140,12 @@ void read_parent(I *image_ctx, uint64_t object_no, ReadExtents* read_extents,
 }
 
 template <typename I>
-int clip_request(I *image_ctx, Extents *image_extents) {
+int clip_request(I* image_ctx, Extents* image_extents, ImageArea area) {
   std::shared_lock image_locker{image_ctx->image_lock};
   for (auto &image_extent : *image_extents) {
     auto clip_len = image_extent.second;
     int r = clip_io(librbd::util::get_image_ctx(image_ctx),
-                    image_extent.first, &clip_len);
+                    image_extent.first, &clip_len, area);
     if (r < 0) {
       return r;
     }
@@ -231,7 +231,7 @@ template void librbd::io::util::read_parent(
     librbd::ImageCtx *image_ctx, uint64_t object_no, ReadExtents* extents,
     librados::snap_t snap_id, const ZTracer::Trace &trace, Context* on_finish);
 template int librbd::io::util::clip_request(
-    librbd::ImageCtx *image_ctx, Extents *image_extents);
+    librbd::ImageCtx* image_ctx, Extents* image_extents, ImageArea area);
 template bool librbd::io::util::trigger_copyup(
         librbd::ImageCtx *image_ctx, uint64_t object_no, IOContext io_context,
         Context* on_finish);

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -223,15 +223,6 @@ std::pair<uint64_t, ImageArea> raw_to_area_offset(const I& image_ctx,
   return {extents[0].first, area};
 }
 
-template <typename I>
-uint64_t get_file_offset(I* image_ctx, uint64_t object_no, uint64_t offset) {
-  auto off = Striper::get_file_offset(image_ctx->cct, &image_ctx->layout,
-                                      object_no, offset);
-  Extents extents = {{off, 0}};
-  image_ctx->io_image_dispatcher->remap_to_logical(extents);
-  return extents[0].first;
-}
-
 } // namespace util
 } // namespace io
 } // namespace librbd
@@ -256,6 +247,3 @@ template uint64_t librbd::io::util::area_to_raw_offset(
 template auto librbd::io::util::raw_to_area_offset(
     const librbd::ImageCtx& image_ctx, uint64_t offset)
     -> std::pair<uint64_t, ImageArea>;
-template uint64_t librbd::io::util::get_file_offset(
-        librbd::ImageCtx *image_ctx, uint64_t object_no, uint64_t offset);
- 

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -134,7 +134,7 @@ void read_parent(I *image_ctx, uint64_t object_no, ReadExtents* read_extents,
                  << " area=" << area << dendl;
   auto req = io::ImageDispatchSpec::create_read(
     *image_ctx->parent, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, comp,
-    std::move(parent_extents), ReadResult{parent_read_bl},
+    std::move(parent_extents), area, ReadResult{parent_read_bl},
     image_ctx->parent->get_data_io_context(), 0, 0, trace);
   req->send();
 }

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -72,10 +72,6 @@ template <typename ImageCtxT = librbd::ImageCtx>
 std::pair<uint64_t, ImageArea> raw_to_area_offset(const ImageCtxT& image_ctx,
                                                   uint64_t offset);
 
-template <typename ImageCtxT = librbd::ImageCtx>
-uint64_t get_file_offset(ImageCtxT *image_ctx, uint64_t object_no,
-                         uint64_t offset);
-
 inline ObjectDispatchLayer get_previous_layer(ObjectDispatchLayer layer) {
   return (ObjectDispatchLayer)(((int)layer) - 1);
 }

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -53,11 +53,12 @@ void unsparsify(CephContext* cct, ceph::bufferlist* bl,
 template <typename ImageCtxT = librbd::ImageCtx>
 bool trigger_copyup(ImageCtxT *image_ctx, uint64_t object_no,
                     IOContext io_context, Context* on_finish);
-                
+
 template <typename ImageCtxT = librbd::ImageCtx>
-void file_to_extents(ImageCtxT *image_ctx, uint64_t offset, uint64_t length,
-                     uint64_t buffer_offset,
-                     striper::LightweightObjectExtents* object_extents);
+void area_to_object_extents(ImageCtxT* image_ctx, uint64_t offset,
+                            uint64_t length, ImageArea area,
+                            uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents);
 
 template <typename ImageCtxT = librbd::ImageCtx>
 std::pair<Extents, ImageArea> object_to_area_extents(

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -32,7 +32,7 @@ bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
 
 template <typename ImageCtxT = librbd::ImageCtx>
 void read_parent(ImageCtxT *image_ctx, uint64_t object_no,
-                 ReadExtents* extents, librados::snap_t snap_id,
+                 ReadExtents* read_extents, librados::snap_t snap_id,
                  const ZTracer::Trace &trace, Context* on_finish);
 
 template <typename ImageCtxT = librbd::ImageCtx>
@@ -60,9 +60,8 @@ void file_to_extents(ImageCtxT *image_ctx, uint64_t offset, uint64_t length,
                      striper::LightweightObjectExtents* object_extents);
 
 template <typename ImageCtxT = librbd::ImageCtx>
-void extent_to_file(ImageCtxT *image_ctx, uint64_t object_no, uint64_t offset,
-                    uint64_t length,
-                    std::vector<std::pair<uint64_t, uint64_t> >& extents);
+std::pair<Extents, ImageArea> object_to_area_extents(
+    ImageCtxT* image_ctx, uint64_t object_no, const Extents& object_extents);
 
 template <typename ImageCtxT = librbd::ImageCtx>
 uint64_t area_to_raw_offset(const ImageCtxT& image_ctx, uint64_t offset,

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -65,6 +65,14 @@ void extent_to_file(ImageCtxT *image_ctx, uint64_t object_no, uint64_t offset,
                     std::vector<std::pair<uint64_t, uint64_t> >& extents);
 
 template <typename ImageCtxT = librbd::ImageCtx>
+uint64_t area_to_raw_offset(const ImageCtxT& image_ctx, uint64_t offset,
+                            ImageArea area);
+
+template <typename ImageCtxT = librbd::ImageCtx>
+std::pair<uint64_t, ImageArea> raw_to_area_offset(const ImageCtxT& image_ctx,
+                                                  uint64_t offset);
+
+template <typename ImageCtxT = librbd::ImageCtx>
 uint64_t get_file_offset(ImageCtxT *image_ctx, uint64_t object_no,
                          uint64_t offset);
 

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -36,7 +36,7 @@ void read_parent(ImageCtxT *image_ctx, uint64_t object_no,
                  const ZTracer::Trace &trace, Context* on_finish);
 
 template <typename ImageCtxT = librbd::ImageCtx>
-int clip_request(ImageCtxT *image_ctx, Extents *image_extents);
+int clip_request(ImageCtxT* image_ctx, Extents* image_extents, ImageArea area);
 
 inline uint64_t get_extents_length(const Extents &extents) {
   uint64_t total_bytes = 0;

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -51,10 +51,9 @@ struct C_CommitIOEvent : public Context {
     if (r >= 0 ||
         (object_dispatch_flags &
            io::OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR) == 0) {
-      io::Extents file_extents;
-      io::util::extent_to_file(image_ctx, object_no, object_off, object_len,
-                               file_extents);
-      for (auto& extent : file_extents) {
+      auto [image_extents, _] = io::util::object_to_area_extents(
+          image_ctx, object_no, {{object_off, object_len}});
+      for (const auto& extent : image_extents) {
         journal->commit_io_event_extent(journal_tid, extent.first,
                                         extent.second, r);
       }

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -356,6 +356,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
   if (!clipped_io(event.offset, aio_comp)) {
     io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp,
                                      {{event.offset, event.length}},
+                                     io::ImageArea::DATA,
                                      event.discard_granularity_bytes,
                                      m_image_ctx.get_data_io_context(), {});
   }
@@ -391,7 +392,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
   if (!clipped_io(event.offset, aio_comp)) {
     io::ImageRequest<I>::aio_write(&m_image_ctx, aio_comp,
                                    {{event.offset, event.length}},
-                                   std::move(data),
+                                   io::ImageArea::DATA, std::move(data),
                                    m_image_ctx.get_data_io_context(), 0, {});
   }
 
@@ -445,7 +446,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
   if (!clipped_io(event.offset, aio_comp)) {
     io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp,
                                        {{event.offset, event.length}},
-                                       std::move(data),
+                                       io::ImageArea::DATA, std::move(data),
                                        m_image_ctx.get_data_io_context(), 0,
                                        {});
   }
@@ -479,6 +480,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
   if (!clipped_io(event.offset, aio_comp)) {
     io::ImageRequest<I>::aio_compare_and_write(&m_image_ctx, aio_comp,
                                                {{event.offset, event.length}},
+                                               io::ImageArea::DATA,
                                                std::move(cmp_data),
                                                std::move(write_data),
                                                nullptr,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2101,7 +2101,7 @@ namespace librbd {
     return librbd::api::Image<>::encryption_load(ictx, &spec, 1, false);
   }
 
-  int Image::encryption_load2(encryption_spec_t *specs, size_t spec_count)
+  int Image::encryption_load2(const encryption_spec_t *specs, size_t spec_count)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     return librbd::api::Image<>::encryption_load(
@@ -4394,7 +4394,7 @@ extern "C" int rbd_encryption_load(rbd_image_t image,
 }
 
 extern "C" int rbd_encryption_load2(rbd_image_t image,
-                                    rbd_encryption_spec_t *specs,
+                                    const rbd_encryption_spec_t *specs,
                                     size_t spec_count)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -298,8 +298,8 @@ void NativeFormat<I>::list_snaps(io::Extents&& image_extents,
     on_finish, util::get_image_ctx(m_image_ctx), io::AIO_TYPE_GENERIC);
   auto req = io::ImageDispatchSpec::create_list_snaps(
     *m_image_ctx, io::IMAGE_DISPATCH_LAYER_MIGRATION, aio_comp,
-    std::move(image_extents), std::move(snap_ids), list_snaps_flags,
-    snapshot_delta, {});
+    std::move(image_extents), io::ImageArea::DATA, std::move(snap_ids),
+    list_snaps_flags, snapshot_delta, {});
   req->send();
 }
 

--- a/src/librbd/operation/FlattenRequest.h
+++ b/src/librbd/operation/FlattenRequest.h
@@ -17,10 +17,12 @@ class FlattenRequest : public Request<ImageCtxT>
 {
 public:
   FlattenRequest(ImageCtxT &image_ctx, Context *on_finish,
-                 uint64_t overlap_objects, ProgressContext &prog_ctx)
-    : Request<ImageCtxT>(image_ctx, on_finish),
-      m_overlap_objects(overlap_objects), m_prog_ctx(prog_ctx) {
-  }
+                 uint64_t start_object_no, uint64_t overlap_objects,
+                 ProgressContext& prog_ctx)
+      : Request<ImageCtxT>(image_ctx, on_finish),
+        m_start_object_no(start_object_no),
+        m_overlap_objects(overlap_objects),
+        m_prog_ctx(prog_ctx) {}
 
 protected:
   void send_op() override;
@@ -54,6 +56,7 @@ private:
    * @endverbatim
    */
 
+  uint64_t m_start_object_no;
   uint64_t m_overlap_objects;
   ProgressContext &m_prog_ctx;
 

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -728,5 +728,5 @@ cdef extern from "rbd/librbd.h" nogil:
                             rbd_encryption_format_t format,
                             rbd_encryption_options_t opts, size_t opts_size)
     int rbd_encryption_load2(rbd_image_t image,
-                             rbd_encryption_spec_t *specs,
+                             const rbd_encryption_spec_t *specs,
                              size_t spec_count)

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -918,6 +918,6 @@ cdef nogil:
                             rbd_encryption_options_t opts, size_t opts_size):
         pass
     int rbd_encryption_load2(rbd_image_t image,
-                             rbd_encryption_spec_t *specs,
+                             const rbd_encryption_spec_t *specs,
                              size_t spec_count):
         pass

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -878,7 +878,7 @@
     --namespace arg                  namespace name
     --image arg                      image name
     --no-progress                    disable progress output
-    --encryption-format arg          encryption formats [possible values: luks]
+    --encryption-format arg          encryption format (luks, luks1, luks2)
     --encryption-passphrase-file arg path to file containing passphrase for
                                      unlocking the image
   
@@ -2253,7 +2253,7 @@
     -s [ --size ] arg                image size (in M/G/T) [default: M]
     --allow-shrink                   permit shrinking
     --no-progress                    disable progress output
-    --encryption-format arg          encryption formats [possible values: luks]
+    --encryption-format arg          encryption format (luks, luks1, luks2)
     --encryption-passphrase-file arg path to file containing passphrase for
                                      unlocking the image
   

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -879,6 +879,7 @@
     --image arg                      image name
     --no-progress                    disable progress output
     --encryption-format arg          encryption format (luks, luks1, luks2)
+                                     [default: luks]
     --encryption-passphrase-file arg path to file containing passphrase for
                                      unlocking the image
   
@@ -2254,6 +2255,7 @@
     --allow-shrink                   permit shrinking
     --no-progress                    disable progress output
     --encryption-format arg          encryption format (luks, luks1, luks2)
+                                     [default: luks]
     --encryption-passphrase-file arg path to file containing passphrase for
                                      unlocking the image
   

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -2235,22 +2235,27 @@
   rbd help resize
   usage: rbd resize [--pool <pool>] [--namespace <namespace>] 
                     [--image <image>] --size <size> [--allow-shrink] 
-                    [--no-progress] 
+                    [--no-progress] [--encryption-format <encryption-format>] 
+                    [--encryption-passphrase-file <encryption-passphrase-file>] 
                     <image-spec> 
   
   Resize (expand or shrink) image.
   
   Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+    <image-spec>                     image specification
+                                     (example:
+                                     [<pool-name>/[<namespace>/]]<image-name>)
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --image arg          image name
-    -s [ --size ] arg    image size (in M/G/T) [default: M]
-    --allow-shrink       permit shrinking
-    --no-progress        disable progress output
+    -p [ --pool ] arg                pool name
+    --namespace arg                  namespace name
+    --image arg                      image name
+    -s [ --size ] arg                image size (in M/G/T) [default: M]
+    --allow-shrink                   permit shrinking
+    --no-progress                    disable progress output
+    --encryption-format arg          encryption formats [possible values: luks]
+    --encryption-passphrase-file arg path to file containing passphrase for
+                                     unlocking the image
   
   rbd help snap create
   usage: rbd snap create [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -224,10 +224,9 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
             mock_image_ctx->layout.object_size));
   }
 
-  void expect_remap_extents(uint64_t offset, uint64_t length) {
-    EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, remap_extents(
-            ElementsAre(Pair(offset, length)),
-            io::IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL));
+  void expect_remap_to_logical(uint64_t offset, uint64_t length) {
+    EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, remap_to_logical(
+            ElementsAre(Pair(offset, length))));
   }
 
   void expect_get_parent_overlap(uint64_t overlap) {
@@ -517,7 +516,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
 
   expect_get_object_size();
   expect_get_parent_overlap(mock_image_ctx->layout.object_size);
-  expect_remap_extents(0, mock_image_ctx->layout.object_size);
+  expect_remap_to_logical(0, mock_image_ctx->layout.object_size);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
           Return(true));
@@ -562,7 +561,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
 
   expect_get_object_size();
   expect_get_parent_overlap(mock_image_ctx->layout.object_size);
-  expect_remap_extents(0, mock_image_ctx->layout.object_size);
+  expect_remap_to_logical(0, mock_image_ctx->layout.object_size);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
           Return(true));
@@ -751,12 +750,12 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   expect_get_object_size();
   expect_encrypt(6);
   InSequence seq;
-  expect_remap_extents(0, 4096);
-  expect_remap_extents(4096, 4096);
-  expect_remap_extents(8192, 4096);
-  expect_remap_extents(0, 4096);
-  expect_remap_extents(4096, 8192);
-  expect_remap_extents(16384, 4096);
+  expect_remap_to_logical(0, 4096);
+  expect_remap_to_logical(4096, 4096);
+  expect_remap_to_logical(8192, 4096);
+  expect_remap_to_logical(0, 4096);
+  expect_remap_to_logical(4096, 8192);
+  expect_remap_to_logical(16384, 4096);
   ASSERT_EQ(0, mock_crypto_object_dispatch->prepare_copyup(
           0, &snapshot_sparse_bufferlist));
 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -55,12 +55,6 @@ CopyupRequest<librbd::MockImageCtx>* CopyupRequest<
 
 namespace util {
 
-template <> uint64_t get_file_offset(
-        MockImageCtx *image_ctx, uint64_t object_no, uint64_t offset) {
-  return Striper::get_file_offset(image_ctx->cct, &image_ctx->layout,
-                                  object_no, offset);
-}
-
 namespace {
 
 struct Mock {
@@ -97,6 +91,13 @@ template <> void read_parent(
 
 namespace librbd {
 namespace crypto {
+
+template <>
+uint64_t get_file_offset(MockImageCtx *image_ctx, uint64_t object_no,
+                         uint64_t offset) {
+  return Striper::get_file_offset(image_ctx->cct, &image_ctx->layout,
+                                  object_no, offset);
+}
 
 using ::testing::_;
 using ::testing::ElementsAre;
@@ -795,5 +796,5 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   ASSERT_EQ(++it, snap2_result.end());
 }
 
-} // namespace io
+} // namespace crypto
 } // namespace librbd

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -239,7 +239,7 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
   }
 
   void expect_prune_parent_extents(uint64_t object_overlap) {
-    EXPECT_CALL(*mock_image_ctx, prune_parent_extents(_, _))
+    EXPECT_CALL(*mock_image_ctx, prune_parent_extents(_, _, _, _))
             .WillOnce(Return(object_overlap));
   }
 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -39,9 +39,9 @@ struct CopyupRequest<librbd::MockImageCtx> {
             const Extents&));
 
     static CopyupRequest* s_instance;
-    static CopyupRequest* create(librbd::MockImageCtx *ictx,
-                                 uint64_t objectno, Extents &&image_extents,
-                                 const ZTracer::Trace &parent_trace) {
+    static CopyupRequest* create(librbd::MockImageCtx* ictx, uint64_t objectno,
+                                 Extents&& image_extents, ImageArea area,
+                                 const ZTracer::Trace& parent_trace) {
       return s_instance;
     }
 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -275,7 +275,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, Flush) {
 TEST_F(TestMockCryptoCryptoObjectDispatch, Discard) {
   expect_object_write_same();
   ASSERT_TRUE(mock_crypto_object_dispatch->discard(
-          0, 0, 4096, mock_image_ctx->get_data_io_context(), 0, {},
+          11, 0, 4096, mock_image_ctx->get_data_io_context(), 0, {},
           &object_dispatch_flags, nullptr, &dispatch_result, &on_finish,
           on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -289,7 +289,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedReadFail) {
   io::ReadExtents extents = {{0, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-      0, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
+      11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
       nullptr, &object_dispatch_flags, &dispatch_result,
       &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -308,7 +308,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedRead) {
   extents[1].bl.append(std::string(4096, '0'));
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-          0, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
+          11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
           nullptr, &object_dispatch_flags, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -332,9 +332,9 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedRead) {
 TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParent) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
-  expect_read_parent(mock_utils, 0, &extents, CEPH_NOSNAP, 8192);
+  expect_read_parent(mock_utils, 11, &extents, CEPH_NOSNAP, 8192);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-          0, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
+          11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
           nullptr, &object_dispatch_flags, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -350,7 +350,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, ReadFromParentDisabled) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-          0, &extents, mock_image_ctx->get_data_io_context(), 0,
+          11, &extents, mock_image_ctx->get_data_io_context(), 0,
           io::READ_FLAG_DISABLE_READ_FROM_PARENT, {},
           nullptr, &object_dispatch_flags, &dispatch_result,
           &on_finish, on_dispatched));
@@ -379,7 +379,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
 
   expect_object_read(&aligned_extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->read(
-          0, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
+          11, &extents, mock_image_ctx->get_data_io_context(), 0, 0, {},
           nullptr, &object_dispatch_flags, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -403,7 +403,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
 TEST_F(TestMockCryptoCryptoObjectDispatch, AlignedWrite) {
   expect_encrypt();
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-        0, 0, std::move(data), mock_image_ctx->get_data_io_context(), 0, 0,
+        11, 0, std::move(data), mock_image_ctx->get_data_io_context(), 0, 0,
         std::nullopt, {}, nullptr, nullptr, &dispatch_result, &on_finish,
         on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_CONTINUE);
@@ -421,7 +421,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWrite) {
   extents[1].bl.append(std::string(4096, '3'));
   expect_object_read(&extents, version);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -442,7 +442,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithNoObject) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -466,7 +466,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -508,19 +508,20 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
   expect_get_object_size();
-  expect_get_parent_overlap(mock_image_ctx->layout.object_size);
-  expect_remap_to_logical(0, mock_image_ctx->layout.object_size);
+  expect_get_parent_overlap(100 << 20);
+  expect_remap_to_logical(11 * mock_image_ctx->layout.object_size,
+                          mock_image_ctx->layout.object_size);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
           Return(true));
-  EXPECT_CALL(*mock_image_ctx->object_map, object_may_exist(0)).WillOnce(
+  EXPECT_CALL(*mock_image_ctx->object_map, object_may_exist(11)).WillOnce(
           Return(false));
   MockAbstractObjectWriteRequest *write_request = nullptr;
   expect_copyup(&write_request, 0);
@@ -553,19 +554,20 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteEmptyCopyup) {
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
   expect_get_object_size();
-  expect_get_parent_overlap(mock_image_ctx->layout.object_size);
-  expect_remap_to_logical(0, mock_image_ctx->layout.object_size);
+  expect_get_parent_overlap(100 << 20);
+  expect_remap_to_logical(11 * mock_image_ctx->layout.object_size,
+                          mock_image_ctx->layout.object_size);
   expect_prune_parent_extents(mock_image_ctx->layout.object_size);
   EXPECT_CALL(mock_exclusive_lock, is_lock_owner()).WillRepeatedly(
           Return(true));
-  EXPECT_CALL(*mock_image_ctx->object_map, object_may_exist(0)).WillOnce(
+  EXPECT_CALL(*mock_image_ctx->object_map, object_may_exist(11)).WillOnce(
           Return(false));
   MockAbstractObjectWriteRequest *write_request = nullptr;
   expect_copyup(&write_request, 0);
@@ -595,7 +597,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   extents[1].bl.append(std::string(4096, '3'));
   expect_object_read(&extents, version);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::nullopt, {}, nullptr, nullptr, &dispatch_result,
           &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -631,7 +633,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
   extents[1].bl.append(std::string(4096, '3'));
   expect_object_read(&extents, version);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, 0, std::make_optional(assert_version), {}, nullptr, nullptr,
           &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -649,7 +651,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithExclusiveCreate) {
   extents[1].bl.append(std::string(4096, '3'));
   expect_object_read(&extents);
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-          0, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
+          11, 1, std::move(write_data), mock_image_ctx->get_data_io_context(),
           0, io::OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE, std::nullopt, {}, nullptr,
           nullptr, &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -672,7 +674,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
   expect_object_read(&extents, version);
 
   ASSERT_TRUE(mock_crypto_object_dispatch->compare_and_write(
-          0, 1, std::move(cmp_data), std::move(write_data),
+          11, 1, std::move(cmp_data), std::move(write_data),
           mock_image_ctx->get_data_io_context(), 0, {}, nullptr, nullptr,
           nullptr, &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -701,7 +703,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
 
   uint64_t mismatch_offset;
   ASSERT_TRUE(mock_crypto_object_dispatch->compare_and_write(
-          0, 1, std::move(cmp_data), std::move(write_data),
+          11, 1, std::move(cmp_data), std::move(write_data),
           mock_image_ctx->get_data_io_context(), 0, {}, &mismatch_offset,
           nullptr, nullptr, &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -718,7 +720,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, WriteSame) {
   write_data.append(std::string("12"));
   expect_object_write(0, std::string("12121") , 0, std::nullopt);
   ASSERT_TRUE(mock_crypto_object_dispatch->write_same(
-          0, 0, 5, {{0, 5}}, std::move(write_data),
+          11, 0, 5, {{0, 5}}, std::move(write_data),
           mock_image_ctx->get_data_io_context(), 0, {}, nullptr, nullptr,
           &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -750,14 +752,15 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, PrepareCopyup) {
   expect_get_object_size();
   expect_encrypt(6);
   InSequence seq;
-  expect_remap_to_logical(0, 4096);
-  expect_remap_to_logical(4096, 4096);
-  expect_remap_to_logical(8192, 4096);
-  expect_remap_to_logical(0, 4096);
-  expect_remap_to_logical(4096, 8192);
-  expect_remap_to_logical(16384, 4096);
+  uint64_t base = 11 * mock_image_ctx->layout.object_size;
+  expect_remap_to_logical(base, 4096);
+  expect_remap_to_logical(base + 4096, 4096);
+  expect_remap_to_logical(base + 8192, 4096);
+  expect_remap_to_logical(base, 4096);
+  expect_remap_to_logical(base + 4096, 8192);
+  expect_remap_to_logical(base + 16384, 4096);
   ASSERT_EQ(0, mock_crypto_object_dispatch->prepare_copyup(
-          0, &snapshot_sparse_bufferlist));
+      11, &snapshot_sparse_bufferlist));
 
   ASSERT_EQ(2, snapshot_sparse_bufferlist.size());
 

--- a/src/test/librbd/crypto/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/test_mock_FormatRequest.cc
@@ -55,10 +55,8 @@ template <>
 struct ShutDownCryptoRequest<MockTestImageCtx> {
   Context *on_finish = nullptr;
   static ShutDownCryptoRequest *s_instance;
-  static ShutDownCryptoRequest *create(
-          MockTestImageCtx *image_ctx,
-          std::unique_ptr<MockEncryptionFormat>* format,
-          Context *on_finish) {
+  static ShutDownCryptoRequest *create(MockTestImageCtx *image_ctx,
+                                       Context *on_finish) {
     ceph_assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
     return s_instance;

--- a/src/test/librbd/crypto/test_mock_ShutDownCryptoRequest.cc
+++ b/src/test/librbd/crypto/test_mock_ShutDownCryptoRequest.cc
@@ -38,7 +38,6 @@ struct TestMockShutDownCryptoRequest : public TestMockFixture {
   Context *on_finish = &finished_cond;
   MockShutDownCryptoRequest* mock_shutdown_crypto_request;
   MockEncryptionFormat* mock_encryption_format;
-  std::unique_ptr<MockEncryptionFormat> result_format;
   Context* shutdown_object_dispatch_context;
   Context* shutdown_image_dispatch_context;
 
@@ -51,7 +50,7 @@ struct TestMockShutDownCryptoRequest : public TestMockFixture {
     mock_encryption_format = new MockEncryptionFormat();
     mock_image_ctx->encryption_format.reset(mock_encryption_format);
     mock_shutdown_crypto_request = MockShutDownCryptoRequest::create(
-          mock_image_ctx, &result_format, on_finish);
+        mock_image_ctx, on_finish);
   }
 
   void TearDown() override {
@@ -142,7 +141,6 @@ TEST_F(TestMockShutDownCryptoRequest, Success) {
   shutdown_image_dispatch_context->complete(0);
   ASSERT_EQ(0, finished_cond.wait());
   ASSERT_EQ(nullptr, mock_image_ctx->encryption_format.get());
-  ASSERT_EQ(mock_encryption_format, result_format.get());
 }
 
 TEST_F(TestMockShutDownCryptoRequest, ShutdownParent) {
@@ -169,7 +167,6 @@ TEST_F(TestMockShutDownCryptoRequest, ShutdownParent) {
   ASSERT_EQ(0, finished_cond.wait());
   ASSERT_EQ(nullptr, mock_image_ctx->encryption_format.get());
   ASSERT_EQ(nullptr, parent_image_ctx->encryption_format.get());
-  ASSERT_EQ(mock_encryption_format, result_format.get());
   delete parent_image_ctx;
 }
 

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -45,10 +45,11 @@ inline ImageCtx* get_image_ctx(MockTestImageCtx* image_ctx) {
 namespace io {
 namespace util {
 
-template <> void file_to_extents(
-        MockTestImageCtx* image_ctx, uint64_t offset, uint64_t length,
-        uint64_t buffer_offset,
-        striper::LightweightObjectExtents* object_extents) {
+template <>
+void area_to_object_extents(MockTestImageCtx* image_ctx, uint64_t offset,
+                            uint64_t length, ImageArea area,
+                            uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents) {
   Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, offset, length,
                            0, buffer_offset, object_extents);
 }

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -53,12 +53,16 @@ template <> void file_to_extents(
                            0, buffer_offset, object_extents);
 }
 
-template <> void extent_to_file(
-        MockTestImageCtx* image_ctx, uint64_t object_no, uint64_t offset,
-        uint64_t length,
-        std::vector<std::pair<uint64_t, uint64_t> >& extents) {
-  Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no,
-                          offset, length, extents);
+template <>
+std::pair<Extents, ImageArea> object_to_area_extents(
+    MockTestImageCtx* image_ctx, uint64_t object_no,
+    const Extents& object_extents) {
+  Extents extents;
+  for (auto [off, len] : object_extents) {
+    Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no, off,
+                            len, extents);
+  }
+  return {std::move(extents), ImageArea::DATA};
 }
 
 } // namespace util

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -197,7 +197,7 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
 
   void expect_prune_parent_extents(MockTestImageCtx& mock_image_ctx,
                                    uint64_t overlap, uint64_t object_overlap) {
-    EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, overlap))
+    EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, _, overlap, _))
       .WillOnce(WithoutArgs(Invoke([object_overlap]() {
                               return object_overlap;
                             })));

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -428,8 +428,8 @@ TEST_F(TestMockIoCopyupRequest, Standard) {
                        {{0, 4096}}, data, 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -485,8 +485,8 @@ TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
                        data, 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -525,8 +525,8 @@ TEST_F(TestMockIoCopyupRequest, CopyOnRead) {
   expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
                        {{0, 4096}}, data, 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -571,8 +571,8 @@ TEST_F(TestMockIoCopyupRequest, CopyOnReadWithSnaps) {
   expect_sparse_copyup(mock_image_ctx, 0, ictx->get_object_name(0), {{0, 4096}},
                        data, 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -617,8 +617,8 @@ TEST_F(TestMockIoCopyupRequest, DeepCopy) {
                        {}, "", 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -655,8 +655,8 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyOnRead) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -722,8 +722,8 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPostSnaps) {
                        {}, "", 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -794,8 +794,8 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPreAndPostSnaps) {
                        {}, "", 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -836,8 +836,8 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
                        {}, "", 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -876,8 +876,8 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyOnRead) {
   expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
                        {}, "", 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -910,8 +910,8 @@ TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
   MockAbstractObjectWriteRequest mock_write_request;
   expect_is_empty_write_op(mock_write_request, true);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -950,8 +950,8 @@ TEST_F(TestMockIoCopyupRequest, RestartWrite) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   expect_add_copyup_ops(mock_write_request1);
   expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
                        {{0, 4096}}, data, 0);
@@ -995,8 +995,8 @@ TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
 
   expect_read_parent(mock_parent_image_ctx, {{0, 4096}}, "", -EPERM);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   MockAbstractObjectWriteRequest mock_write_request;
   req->append_request(&mock_write_request, {});
@@ -1029,8 +1029,8 @@ TEST_F(TestMockIoCopyupRequest, PrepareCopyupError) {
   expect_read_parent(mock_parent_image_ctx, {{0, 4096}}, data, 0);
   expect_prepare_copyup(mock_image_ctx, -EIO);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   MockAbstractObjectWriteRequest mock_write_request;
   req->append_request(&mock_write_request, {});
@@ -1068,8 +1068,8 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyError) {
 
   expect_is_empty_write_op(mock_write_request, false);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1108,8 +1108,8 @@ TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            -EINVAL);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1161,8 +1161,8 @@ TEST_F(TestMockIoCopyupRequest, CopyupError) {
                        data, -EPERM);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1207,7 +1207,8 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
   expect_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), data, 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1261,8 +1262,8 @@ TEST_F(TestMockIoCopyupRequest, ProcessCopyup) {
                        {{2048, 1024}}, data.substr(0, 1024), 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {{0, 1024}});
   req->send();
@@ -1325,8 +1326,8 @@ TEST_F(TestMockIoCopyupRequest, ProcessCopyupOverwrite) {
                        {{0, 1024}, {2048, 1024}}, data.substr(0, 2048), 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}},
+                                   ImageArea::DATA, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {{0, 1024}});
   req->send();

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -92,12 +92,16 @@ template <> void file_to_extents(
                            0, buffer_offset, object_extents);
 }
 
-template <> void extent_to_file(
-        MockTestImageCtx* image_ctx, uint64_t object_no, uint64_t offset,
-        uint64_t length,
-        std::vector<std::pair<uint64_t, uint64_t> >& extents) {
-  Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no,
-                          offset, length, extents);
+template <>
+std::pair<Extents, ImageArea> object_to_area_extents(
+    MockTestImageCtx* image_ctx, uint64_t object_no,
+    const Extents& object_extents) {
+  Extents extents;
+  for (auto [off, len] : object_extents) {
+    Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no, off,
+                            len, extents);
+  }
+  return {std::move(extents), ImageArea::DATA};
 }
 
 } // namespace util

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -84,10 +84,11 @@ namespace io {
 
 namespace util {
 
-template <> void file_to_extents(
-        MockTestImageCtx* image_ctx, uint64_t offset, uint64_t length,
-        uint64_t buffer_offset,
-        striper::LightweightObjectExtents* object_extents) {
+template <>
+void area_to_object_extents(MockTestImageCtx* image_ctx, uint64_t offset,
+                            uint64_t length, ImageArea area,
+                            uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents) {
   Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, offset, length,
                            0, buffer_offset, object_extents);
 }

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -60,11 +60,11 @@ namespace io {
 
 namespace util {
 
-template<>
-void file_to_extents(
-        MockTestImageCtx *image_ctx, uint64_t offset, uint64_t length,
-        uint64_t buffer_offset,
-        striper::LightweightObjectExtents *object_extents) {
+template <>
+void area_to_object_extents(MockTestImageCtx* image_ctx, uint64_t offset,
+                            uint64_t length, ImageArea area,
+                            uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents) {
   Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, offset, length,
                            0, buffer_offset, object_extents);
 }
@@ -204,7 +204,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_1(
-    mock_image_ctx, aio_comp_1, {{0, 1}}, std::move(bl),
+    mock_image_ctx, aio_comp_1, {{0, 1}}, ImageArea::DATA, std::move(bl),
     mock_image_ctx.get_data_io_context(), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -217,7 +217,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
 
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_2(
-    mock_image_ctx, aio_comp_2, {{0, 1}}, std::move(bl),
+    mock_image_ctx, aio_comp_2, {{0, 1}}, ImageArea::DATA, std::move(bl),
     mock_image_ctx.get_data_io_context(), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -260,7 +260,7 @@ TEST_F(TestMockIoImageRequest, AioReadAccessTimestamp) {
 
   ReadResult rr;
   MockImageReadRequest mock_aio_image_read_1(
-    mock_image_ctx, aio_comp_1, {{0, 1}}, std::move(rr),
+    mock_image_ctx, aio_comp_1, {{0, 1}}, ImageArea::DATA, std::move(rr),
     mock_image_ctx.get_data_io_context(), 0, 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -273,7 +273,7 @@ TEST_F(TestMockIoImageRequest, AioReadAccessTimestamp) {
   expect_object_request_send(mock_image_ctx, 0);
 
   MockImageReadRequest mock_aio_image_read_2(
-    mock_image_ctx, aio_comp_2, {{0, 1}}, std::move(rr),
+    mock_image_ctx, aio_comp_2, {{0, 1}}, ImageArea::DATA, std::move(rr),
     mock_image_ctx.get_data_io_context(), 0, 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -299,7 +299,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscard) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{16, 63}, {84, 100}},
+    mock_image_ctx, aio_comp, {{16, 63}, {84, 100}}, ImageArea::DATA,
     ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -327,7 +327,7 @@ TEST_F(TestMockIoImageRequest, TailDiscard) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
-    {{ictx->layout.object_size - 1024, 1024}},
+    {{ictx->layout.object_size - 1024, 1024}}, ImageArea::DATA,
     ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -358,7 +358,8 @@ TEST_F(TestMockIoImageRequest, DiscardGranularity) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ImageArea::DATA, ictx->discard_granularity_bytes,
+    mock_image_ctx.get_data_io_context(), {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -388,7 +389,7 @@ TEST_F(TestMockIoImageRequest, AioWriteJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl),
     mock_image_ctx.get_data_io_context(), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -417,8 +418,8 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{0, 1}}, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA,
+    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -476,7 +477,7 @@ TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteSameRequest mock_aio_image_writesame(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl),
     mock_image_ctx.get_data_io_context(), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
@@ -510,8 +511,9 @@ TEST_F(TestMockIoImageRequest, AioCompareAndWriteJournalAppendDisabled) {
   write_bl.append("1");
   uint64_t mismatch_offset;
   MockImageCompareAndWriteRequest mock_aio_image_write(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(cmp_bl), std::move(write_bl),
-    &mismatch_offset, mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA,
+    std::move(cmp_bl), std::move(write_bl), &mismatch_offset,
+    mock_image_ctx.get_data_io_context(), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();
@@ -548,8 +550,8 @@ TEST_F(TestMockIoImageRequest, ListSnaps) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_GENERIC);
   MockImageListSnapsRequest mock_image_list_snaps_request(
-    mock_image_ctx, aio_comp, {{0, 16384}, {16384, 16384}}, {0, CEPH_NOSNAP},
-    0, &snapshot_delta, {});
+    mock_image_ctx, aio_comp, {{0, 16384}, {16384, 16384}}, ImageArea::DATA,
+    {0, CEPH_NOSNAP}, 0, &snapshot_delta, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_image_list_snaps_request.send();

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -69,12 +69,16 @@ void file_to_extents(
                            0, buffer_offset, object_extents);
 }
 
-template <> void extent_to_file(
-        MockTestImageCtx* image_ctx, uint64_t object_no, uint64_t offset,
-        uint64_t length,
-        std::vector<std::pair<uint64_t, uint64_t> >& extents) {
-  Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no,
-                          offset, length, extents);
+template <>
+std::pair<Extents, ImageArea> object_to_area_extents(
+    MockTestImageCtx* image_ctx, uint64_t object_no,
+    const Extents& object_extents) {
+  Extents extents;
+  for (auto [off, len] : object_extents) {
+    Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no, off,
+                            len, extents);
+  }
+  return {std::move(extents), ImageArea::DATA};
 }
 
 } // namespace util

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -71,8 +71,9 @@ struct ImageListSnapsRequest<librbd::MockTestImageCtx> {
   }
   ImageListSnapsRequest(
       librbd::MockImageCtx& image_ctx, AioCompletion* aio_comp,
-      Extents&& image_extents, SnapIds&& snap_ids, int list_snaps_flags,
-      SnapshotDelta* snapshot_delta, const ZTracer::Trace& parent_trace) {
+      Extents&& image_extents, ImageArea area, SnapIds&& snap_ids,
+      int list_snaps_flags, SnapshotDelta* snapshot_delta,
+      const ZTracer::Trace& parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_comp = aio_comp;
     s_instance->image_extents = image_extents;
@@ -91,10 +92,11 @@ ImageListSnapsRequest<librbd::MockTestImageCtx>* ImageListSnapsRequest<librbd::M
 
 namespace util {
 
-template <> void file_to_extents(
-        MockTestImageCtx* image_ctx, uint64_t offset, uint64_t length,
-        uint64_t buffer_offset,
-        striper::LightweightObjectExtents* object_extents) {
+template <>
+void area_to_object_extents(MockTestImageCtx* image_ctx, uint64_t offset,
+                            uint64_t length, ImageArea area,
+                            uint64_t buffer_offset,
+                            striper::LightweightObjectExtents* object_extents) {
   Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, offset, length,
                            0, buffer_offset, object_extents);
 }

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -98,12 +98,16 @@ template <> void file_to_extents(
                            0, buffer_offset, object_extents);
 }
 
-template <> void extent_to_file(
-        MockTestImageCtx* image_ctx, uint64_t object_no, uint64_t offset,
-        uint64_t length,
-        std::vector<std::pair<uint64_t, uint64_t> >& extents) {
-  Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no,
-                          offset, length, extents);
+template <>
+std::pair<Extents, ImageArea> object_to_area_extents(
+    MockTestImageCtx* image_ctx, uint64_t object_no,
+    const Extents& object_extents) {
+  Extents extents;
+  for (auto [off, len] : object_extents) {
+    Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no, off,
+                            len, extents);
+  }
+  return {std::move(extents), ImageArea::DATA};
 }
 
 namespace {

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -196,7 +196,7 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   void expect_prune_parent_extents(MockTestImageCtx &mock_image_ctx,
                                    const Extents& extents,
                                    uint64_t overlap, uint64_t object_overlap) {
-    EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, overlap))
+    EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, _, overlap, _))
       .WillOnce(WithArg<0>(Invoke([extents, object_overlap](Extents& e) {
                              e = extents;
                              return object_overlap;

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -46,7 +46,8 @@ struct CopyupRequest<librbd::MockTestImageCtx> : public CopyupRequest<librbd::Mo
   static CopyupRequest* s_instance;
   static CopyupRequest* create(librbd::MockTestImageCtx *ictx,
                                uint64_t objectno, Extents &&image_extents,
-                               const ZTracer::Trace &parent_trace) {
+                               ImageArea area,
+                               const ZTracer::Trace& parent_trace) {
     return s_instance;
   }
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -31,8 +31,8 @@ struct ImageRequest<MockReplayImageCtx> {
   MOCK_METHOD4(aio_write, void(AioCompletion *c, const Extents &image_extents,
                                const bufferlist &bl, int op_flags));
   static void aio_write(MockReplayImageCtx *ictx, AioCompletion *c,
-                        Extents &&image_extents, bufferlist &&bl,
-                        IOContext io_context, int op_flags,
+                        Extents&& image_extents, ImageArea area,
+                        bufferlist&& bl, IOContext io_context, int op_flags,
                         const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_write(c, image_extents, bl, op_flags);
@@ -41,7 +41,7 @@ struct ImageRequest<MockReplayImageCtx> {
   MOCK_METHOD3(aio_discard, void(AioCompletion *c, const Extents& image_extents,
                                  uint32_t discard_granularity_bytes));
   static void aio_discard(MockReplayImageCtx *ictx, AioCompletion *c,
-                          Extents&& image_extents,
+                          Extents&& image_extents, ImageArea area,
                           uint32_t discard_granularity_bytes,
                           IOContext io_context,
                           const ZTracer::Trace &parent_trace) {
@@ -61,8 +61,8 @@ struct ImageRequest<MockReplayImageCtx> {
                                    const bufferlist &bl,
                                    int op_flags));
   static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
-                            Extents&& image_extents, bufferlist &&bl,
-                            IOContext io_context, int op_flags,
+                            Extents&& image_extents, ImageArea area,
+                            bufferlist&& bl, IOContext io_context, int op_flags,
                             const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_writesame(c, image_extents, bl, op_flags);
@@ -73,8 +73,9 @@ struct ImageRequest<MockReplayImageCtx> {
                                            uint64_t *mismatch_offset,
                                            int op_flags));
   static void aio_compare_and_write(MockReplayImageCtx *ictx, AioCompletion *c,
-                                    Extents &&image_extents, bufferlist &&cmp_bl,
-                                    bufferlist &&bl, uint64_t *mismatch_offset,
+                                    Extents&& image_extents, ImageArea area,
+                                    bufferlist&& cmp_bl, bufferlist&& bl,
+                                    uint64_t* mismatch_offset,
                                     IOContext io_context, int op_flags,
                                     const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -69,7 +69,7 @@ struct MockImageCtx {
   MOCK_CONST_METHOD0(get_object_size, uint64_t());
   MOCK_CONST_METHOD0(get_current_size, uint64_t());
   MOCK_CONST_METHOD1(get_image_size, uint64_t(librados::snap_t));
-  MOCK_CONST_METHOD1(get_effective_image_size, uint64_t(librados::snap_t));
+  MOCK_CONST_METHOD1(get_area_size, uint64_t(io::ImageArea));
   MOCK_CONST_METHOD1(get_object_count, uint64_t(librados::snap_t));
   MOCK_CONST_METHOD1(get_read_flags, int(librados::snap_t));
   MOCK_CONST_METHOD2(get_flags, int(librados::snap_t in_snap_id,
@@ -86,6 +86,8 @@ struct MockImageCtx {
   MOCK_CONST_METHOD1(get_parent_info, const ParentImageInfo*(librados::snap_t));
   MOCK_CONST_METHOD2(get_parent_overlap, int(librados::snap_t in_snap_id,
                                              uint64_t *raw_overlap));
+  MOCK_CONST_METHOD2(reduce_parent_overlap,
+                     std::pair<uint64_t, io::ImageArea>(uint64_t, bool));
   MOCK_CONST_METHOD2(prune_parent_extents, uint64_t(std::vector<std::pair<uint64_t,uint64_t> >& ,
                                                     uint64_t));
 

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -88,8 +88,9 @@ struct MockImageCtx {
                                              uint64_t *raw_overlap));
   MOCK_CONST_METHOD2(reduce_parent_overlap,
                      std::pair<uint64_t, io::ImageArea>(uint64_t, bool));
-  MOCK_CONST_METHOD2(prune_parent_extents, uint64_t(std::vector<std::pair<uint64_t,uint64_t> >& ,
-                                                    uint64_t));
+  MOCK_CONST_METHOD4(prune_parent_extents,
+                     uint64_t(std::vector<std::pair<uint64_t, uint64_t>>&,
+                              io::ImageArea, uint64_t, bool));
 
   MOCK_CONST_METHOD2(is_snap_protected, int(librados::snap_t in_snap_id,
                                             bool *is_protected));

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -85,7 +85,7 @@ struct MockImageCtx {
                                           cls::rbd::ParentImageSpec *pspec));
   MOCK_CONST_METHOD1(get_parent_info, const ParentImageInfo*(librados::snap_t));
   MOCK_CONST_METHOD2(get_parent_overlap, int(librados::snap_t in_snap_id,
-                                             uint64_t *overlap));
+                                             uint64_t *raw_overlap));
   MOCK_CONST_METHOD2(prune_parent_extents, uint64_t(std::vector<std::pair<uint64_t,uint64_t> >& ,
                                                     uint64_t));
 

--- a/src/test/librbd/mock/io/MockImageDispatcher.h
+++ b/src/test/librbd/mock/io/MockImageDispatcher.h
@@ -40,7 +40,8 @@ public:
   MOCK_METHOD0(unblock_writes, void());
   MOCK_METHOD1(wait_on_writes_unblocked, void(Context*));
 
-  MOCK_METHOD2(remap_extents, void(Extents&, ImageExtentsMapType));
+  MOCK_METHOD2(remap_to_physical, void(Extents&, ImageArea));
+  MOCK_METHOD1(remap_to_logical, ImageArea(Extents&));
 };
 
 } // namespace io

--- a/src/test/librbd/operation/test_mock_TrimRequest.cc
+++ b/src/test/librbd/operation/test_mock_TrimRequest.cc
@@ -156,6 +156,17 @@ public:
                            })));
   }
 
+  void expect_reduce_parent_overlap(MockTestImageCtx& mock_image_ctx,
+                                    uint64_t overlap) {
+    EXPECT_CALL(mock_image_ctx, reduce_parent_overlap(overlap, false))
+      .WillOnce(Return(std::make_pair(overlap, io::ImageArea::DATA)));
+  }
+
+  void expect_get_area_size(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, get_area_size(io::ImageArea::CRYPTO_HEADER))
+      .WillOnce(Return(0));
+  }
+
   void expect_object_may_exist(MockTestImageCtx &mock_image_ctx,
                                uint64_t object_no, bool exists) {
     if (mock_image_ctx.object_map != nullptr) {
@@ -221,7 +232,9 @@ TEST_F(TestMockOperationTrimRequest, SuccessRemove) {
                            true, 0);
 
   // copy-up
+  expect_get_area_size(mock_image_ctx);
   expect_get_parent_overlap(mock_image_ctx, 0);
+  expect_reduce_parent_overlap(mock_image_ctx, 0);
 
   // remove
   expect_object_may_exist(mock_image_ctx, 0, true);
@@ -277,7 +290,9 @@ TEST_F(TestMockOperationTrimRequest, SuccessCopyUp) {
 
   // copy-up
   io::MockObjectDispatch mock_io_object_dispatch;
+  expect_get_area_size(mock_image_ctx);
   expect_get_parent_overlap(mock_image_ctx, ictx->get_object_size());
+  expect_reduce_parent_overlap(mock_image_ctx, ictx->get_object_size());
   expect_get_object_name(mock_image_ctx, 0, "object0");
   expect_object_discard(mock_image_ctx, mock_io_object_dispatch, 0,
                         ictx->get_object_size(), false, 0);
@@ -369,7 +384,9 @@ TEST_F(TestMockOperationTrimRequest, RemoveError) {
                            false, 0);
 
   // copy-up
+  expect_get_area_size(mock_image_ctx);
   expect_get_parent_overlap(mock_image_ctx, 0);
+  expect_reduce_parent_overlap(mock_image_ctx, 0);
 
   // remove
   expect_object_may_exist(mock_image_ctx, 0, true);
@@ -421,7 +438,9 @@ TEST_F(TestMockOperationTrimRequest, CopyUpError) {
 
   // copy-up
   io::MockObjectDispatch mock_io_object_dispatch;
+  expect_get_area_size(mock_image_ctx);
   expect_get_parent_overlap(mock_image_ctx, ictx->get_object_size());
+  expect_reduce_parent_overlap(mock_image_ctx, ictx->get_object_size());
   expect_get_object_name(mock_image_ctx, 0, "object0");
   expect_object_discard(mock_image_ctx, mock_io_object_dispatch, 0,
                         ictx->get_object_size(), false, -EINVAL);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2254,7 +2254,12 @@ TEST_F(TestLibRBD, TestEncryptionLUKS1)
           _cluster, "rbd_read_from_replica_policy", "balance"));
 
   rbd_image_t image;
-  rbd_encryption_luks1_format_options_t opts = {
+  rbd_encryption_luks1_format_options_t luks1_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  rbd_encryption_luks2_format_options_t luks2_opts = {
           .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
           .passphrase = "password",
           .passphrase_size = 8,
@@ -2267,14 +2272,24 @@ TEST_F(TestLibRBD, TestEncryptionLUKS1)
 
 #ifndef HAVE_LIBCRYPTSETUP
   ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
-          image, RBD_ENCRYPTION_FORMAT_LUKS1, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
   ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
-          image, RBD_ENCRYPTION_FORMAT_LUKS1, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
+          image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
 #else
+  ASSERT_EQ(-EINVAL, rbd_encryption_format(
+          image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
   ASSERT_EQ(0, rbd_encryption_format(
-          image, RBD_ENCRYPTION_FORMAT_LUKS1, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
   ASSERT_EQ(-EEXIST, rbd_encryption_load(
-          image, RBD_ENCRYPTION_FORMAT_LUKS1, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
 
   test_io(image);
 
@@ -2282,6 +2297,16 @@ TEST_F(TestLibRBD, TestEncryptionLUKS1)
   ASSERT_EQ(0, rbd_close(image));
 
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(-EINVAL, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_EQ(0, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
+  ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
+  ASSERT_EQ(0, rbd_close(image));
+
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(-EINVAL, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
   ASSERT_EQ(0, rbd_encryption_load(
           image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
   ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
@@ -2307,7 +2332,12 @@ TEST_F(TestLibRBD, TestEncryptionLUKS2)
           _cluster, "rbd_read_from_replica_policy", "balance"));
 
   rbd_image_t image;
-  rbd_encryption_luks2_format_options_t opts = {
+  rbd_encryption_luks1_format_options_t luks1_opts = {
+          .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
+  rbd_encryption_luks2_format_options_t luks2_opts = {
           .alg = RBD_ENCRYPTION_ALGORITHM_AES256,
           .passphrase = "password",
           .passphrase_size = 8,
@@ -2320,9 +2350,13 @@ TEST_F(TestLibRBD, TestEncryptionLUKS2)
 
 #ifndef HAVE_LIBCRYPTSETUP
   ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
-          image, RBD_ENCRYPTION_FORMAT_LUKS2, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
   ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
-          image, RBD_ENCRYPTION_FORMAT_LUKS2, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
   ASSERT_EQ(-ENOTSUP, rbd_encryption_format(
           image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
   ASSERT_EQ(-ENOTSUP, rbd_encryption_load(
@@ -2331,9 +2365,9 @@ TEST_F(TestLibRBD, TestEncryptionLUKS2)
   ASSERT_EQ(-EINVAL, rbd_encryption_format(
           image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
   ASSERT_EQ(0, rbd_encryption_format(
-          image, RBD_ENCRYPTION_FORMAT_LUKS2, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
   ASSERT_EQ(-EEXIST, rbd_encryption_load(
-          image, RBD_ENCRYPTION_FORMAT_LUKS2, &opts, sizeof(opts)));
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
 
   test_io(image);
 
@@ -2341,6 +2375,16 @@ TEST_F(TestLibRBD, TestEncryptionLUKS2)
   ASSERT_EQ(0, rbd_close(image));
 
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(-EINVAL, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
+  ASSERT_EQ(0, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)));
+  ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
+  ASSERT_EQ(0, rbd_close(image));
+
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+  ASSERT_EQ(-EINVAL, rbd_encryption_load(
+          image, RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)));
   ASSERT_EQ(0, rbd_encryption_load(
           image, RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)));
   ASSERT_PASSED(read_test_data, image, "test", 0, 4, 0);
@@ -2426,9 +2470,13 @@ TEST_F(TestLibRBD, TestCloneEncryption)
   ASSERT_EQ(0, rbd_encryption_format(
           child2, RBD_ENCRYPTION_FORMAT_LUKS2, &child2_opts,
           sizeof(child2_opts)));
+  rbd_encryption_luks_format_options_t child2_lopts = {
+          .passphrase = "password",
+          .passphrase_size = 8,
+  };
   ASSERT_EQ(0, rbd_encryption_load(
-        child2, RBD_ENCRYPTION_FORMAT_LUKS2, &child2_opts,
-        sizeof(child2_opts)));
+          child2, RBD_ENCRYPTION_FORMAT_LUKS, &child2_lopts,
+          sizeof(child2_lopts)));
   ASSERT_PASSED(write_test_data, child2, "cccc", 128 << 20, 4, 0);
   ASSERT_EQ(0, rbd_flush(child2));
 
@@ -2861,6 +2909,124 @@ TEST_F(TestLibRBD, EncryptionLoadBadStripePattern)
     uint64_t size;
     ASSERT_EQ(0, image.size(&size));
     ASSERT_EQ(20 << 20, size);
+  }
+}
+
+TEST_F(TestLibRBD, EncryptionLoadFormatMismatch)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string name1 = get_temp_image_name();
+  std::string name2 = get_temp_image_name();
+  std::string name3 = get_temp_image_name();
+  std::string passphrase = "some passphrase";
+
+  librbd::encryption_luks1_format_options_t luks1_opts = {
+      RBD_ENCRYPTION_ALGORITHM_AES256, passphrase};
+  librbd::encryption_luks2_format_options_t luks2_opts = {
+      RBD_ENCRYPTION_ALGORITHM_AES256, passphrase};
+  librbd::encryption_luks_format_options_t luks_opts = {passphrase};
+
+#define LUKS_ONE {RBD_ENCRYPTION_FORMAT_LUKS1, &luks1_opts, sizeof(luks1_opts)}
+#define LUKS_TWO {RBD_ENCRYPTION_FORMAT_LUKS2, &luks2_opts, sizeof(luks2_opts)}
+#define LUKS_ANY {RBD_ENCRYPTION_FORMAT_LUKS, &luks_opts, sizeof(luks_opts)}
+
+  const std::vector<librbd::encryption_spec_t> bad_specs[] = {
+      {},
+      {LUKS_ONE},
+      {LUKS_TWO},
+      {LUKS_ONE, LUKS_ONE},
+      {LUKS_ONE, LUKS_TWO},
+      {LUKS_ONE, LUKS_ANY},
+      {LUKS_TWO, LUKS_TWO},
+      {LUKS_ANY, LUKS_TWO},
+      {LUKS_ONE, LUKS_ONE, LUKS_ONE},
+      {LUKS_ONE, LUKS_ONE, LUKS_TWO},
+      {LUKS_ONE, LUKS_ONE, LUKS_ANY},
+      {LUKS_ONE, LUKS_TWO, LUKS_ONE},
+      {LUKS_ONE, LUKS_TWO, LUKS_TWO},
+      {LUKS_ONE, LUKS_TWO, LUKS_ANY},
+      {LUKS_ONE, LUKS_ANY, LUKS_ONE},
+      {LUKS_ONE, LUKS_ANY, LUKS_TWO},
+      {LUKS_ONE, LUKS_ANY, LUKS_ANY},
+      {LUKS_TWO, LUKS_ONE, LUKS_TWO},
+      {LUKS_TWO, LUKS_TWO, LUKS_ONE},
+      {LUKS_TWO, LUKS_TWO, LUKS_TWO},
+      {LUKS_TWO, LUKS_TWO, LUKS_ANY},
+      {LUKS_TWO, LUKS_ANY, LUKS_TWO},
+      {LUKS_ANY, LUKS_ONE, LUKS_TWO},
+      {LUKS_ANY, LUKS_TWO, LUKS_ONE},
+      {LUKS_ANY, LUKS_TWO, LUKS_TWO},
+      {LUKS_ANY, LUKS_TWO, LUKS_ANY},
+      {LUKS_ANY, LUKS_ANY, LUKS_TWO},
+      {LUKS_ANY, LUKS_ANY, LUKS_ANY, LUKS_ANY}};
+
+  const std::vector<librbd::encryption_spec_t> good_specs[] = {
+      {LUKS_ANY},
+      {LUKS_TWO, LUKS_ONE},
+      {LUKS_TWO, LUKS_ANY},
+      {LUKS_ANY, LUKS_ONE},
+      {LUKS_ANY, LUKS_ANY},
+      {LUKS_TWO, LUKS_ONE, LUKS_ONE},
+      {LUKS_TWO, LUKS_ONE, LUKS_ANY},
+      {LUKS_TWO, LUKS_ANY, LUKS_ONE},
+      {LUKS_TWO, LUKS_ANY, LUKS_ANY},
+      {LUKS_ANY, LUKS_ONE, LUKS_ONE},
+      {LUKS_ANY, LUKS_ONE, LUKS_ANY},
+      {LUKS_ANY, LUKS_ANY, LUKS_ONE},
+      {LUKS_ANY, LUKS_ANY, LUKS_ANY}};
+
+  static_assert(std::size(bad_specs) + std::size(good_specs) == 1 + 3 + 9 + 27 + 1);
+
+#undef LUKS_ONE
+#undef LUKS_TWO
+#undef LUKS_ANY
+
+  {
+    int order = 0;
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, name1.c_str(), 20 << 20, &order));
+    librbd::Image image1;
+    ASSERT_EQ(0, rbd.open(ioctx, image1, name1.c_str(), nullptr));
+    ASSERT_EQ(0, image1.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1,
+                                          &luks1_opts, sizeof(luks1_opts)));
+
+    ASSERT_EQ(0, image1.snap_create("snap"));
+    ASSERT_EQ(0, image1.snap_protect("snap"));
+    uint64_t features;
+    ASSERT_EQ(0, image1.features(&features));
+    ASSERT_EQ(0, rbd.clone(ioctx, name1.c_str(), "snap", ioctx, name2.c_str(),
+                           features, &order));
+
+    librbd::Image image2;
+    ASSERT_EQ(0, rbd.open(ioctx, image2, name2.c_str(), nullptr));
+    ASSERT_EQ(0, image2.snap_create("snap"));
+    ASSERT_EQ(0, image2.snap_protect("snap"));
+    ASSERT_EQ(0, rbd.clone(ioctx, name2.c_str(), "snap", ioctx, name3.c_str(),
+                           features, &order));
+
+    librbd::Image image3;
+    ASSERT_EQ(0, rbd.open(ioctx, image3, name3.c_str(), nullptr));
+    ASSERT_EQ(0, image3.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS2,
+                                          &luks2_opts, sizeof(luks2_opts)));
+  }
+
+  {
+    librbd::Image image3;
+    ASSERT_EQ(0, rbd.open(ioctx, image3, name3.c_str(), nullptr));
+    for (auto& specs : bad_specs) {
+      ASSERT_EQ(-EINVAL, image3.encryption_load2(specs.data(), specs.size()));
+    }
+  }
+
+  for (auto& specs : good_specs) {
+    librbd::Image image3;
+    ASSERT_EQ(0, rbd.open(ioctx, image3, name3.c_str(), nullptr));
+    ASSERT_EQ(0, image3.encryption_load2(specs.data(), specs.size()));
   }
 }
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2574,6 +2574,57 @@ TEST_F(TestLibRBD, EncryptionFormatNoData)
   }
 }
 
+TEST_F(TestLibRBD, EncryptionLoadBadSize)
+{
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  auto name = get_temp_image_name();
+  uint64_t luks1_meta_size = 4 << 20;
+  std::string passphrase = "some passphrase";
+
+  {
+    int order = 0;
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), luks1_meta_size,
+                                 &order));
+    librbd::Image image;
+    ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), nullptr));
+
+    librbd::encryption_luks1_format_options_t opts = {
+        RBD_ENCRYPTION_ALGORITHM_AES256, passphrase};
+    ASSERT_EQ(0, image.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1, &opts,
+                                         sizeof(opts)));
+  }
+
+  {
+    librbd::Image image;
+    ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), nullptr));
+
+    librbd::encryption_luks_format_options_t opts = {passphrase};
+    ASSERT_EQ(0, image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS, &opts,
+                                       sizeof(opts)));
+    uint64_t size;
+    ASSERT_EQ(0, image.size(&size));
+    ASSERT_EQ(0, size);
+  }
+
+  {
+    librbd::Image image;
+    ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), nullptr));
+    ASSERT_EQ(0, image.resize(luks1_meta_size - 1));
+
+    librbd::encryption_luks_format_options_t opts = {passphrase};
+    ASSERT_EQ(-EINVAL, image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS, &opts,
+                                             sizeof(opts)));
+    uint64_t size;
+    ASSERT_EQ(0, image.size(&size));
+    ASSERT_EQ(luks1_meta_size - 1, size);
+  }
+}
+
 #endif
 
 TEST_F(TestLibRBD, TestIOWithIOHint)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2531,6 +2531,158 @@ TEST_F(TestLibRBD, TestCloneEncryption)
   rados_ioctx_destroy(ioctx);
 }
 
+TEST_F(TestLibRBD, LUKS1UnderLUKS2WithoutResize)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  std::string clone_name = get_temp_image_name();
+  uint64_t data_size = 25 << 20;
+  uint64_t luks1_meta_size = 4 << 20;
+  uint64_t luks2_meta_size = 16 << 20;
+  std::string parent_passphrase = "parent passphrase";
+  std::string clone_passphrase = "clone passphrase";
+
+  {
+    int order = 22;
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(),
+                                 luks1_meta_size + data_size, &order));
+    librbd::Image parent;
+    ASSERT_EQ(0, rbd.open(ioctx, parent, parent_name.c_str(), nullptr));
+
+    librbd::encryption_luks1_format_options_t fopts = {
+        RBD_ENCRYPTION_ALGORITHM_AES256, parent_passphrase};
+    ASSERT_EQ(0, parent.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1, &fopts,
+                                          sizeof(fopts)));
+
+    ceph::bufferlist bl;
+    bl.append(std::string(data_size, 'a'));
+    ASSERT_EQ(data_size, parent.write(0, data_size, bl));
+
+    ASSERT_EQ(0, parent.snap_create("snap"));
+    ASSERT_EQ(0, parent.snap_protect("snap"));
+    uint64_t features;
+    ASSERT_EQ(0, parent.features(&features));
+    ASSERT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap", ioctx,
+                           clone_name.c_str(), features, &order));
+  }
+
+  {
+    librbd::Image clone;
+    ASSERT_EQ(0, rbd.open(ioctx, clone, clone_name.c_str(), nullptr));
+
+    librbd::encryption_luks2_format_options_t fopts =
+        {RBD_ENCRYPTION_ALGORITHM_AES256, clone_passphrase};
+    ASSERT_EQ(0, clone.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS2, &fopts,
+                                         sizeof(fopts)));
+
+    librbd::encryption_luks_format_options_t opts1 = {parent_passphrase};
+    librbd::encryption_luks_format_options_t opts2 = {clone_passphrase};
+    librbd::encryption_spec_t specs[] = {
+        {RBD_ENCRYPTION_FORMAT_LUKS, &opts2, sizeof(opts2)},
+        {RBD_ENCRYPTION_FORMAT_LUKS, &opts1, sizeof(opts1)}};
+    ASSERT_EQ(0, clone.encryption_load2(specs, std::size(specs)));
+
+    uint64_t size;
+    ASSERT_EQ(0, clone.size(&size));
+    EXPECT_EQ(data_size + luks1_meta_size - luks2_meta_size, size);
+    uint64_t overlap;
+    ASSERT_EQ(0, clone.overlap(&overlap));
+    EXPECT_EQ(data_size + luks1_meta_size - luks2_meta_size, overlap);
+
+    ceph::bufferlist expected_bl;
+    expected_bl.append(std::string(
+        data_size + luks1_meta_size - luks2_meta_size, 'a'));
+
+    ceph::bufferlist read_bl;
+    ASSERT_EQ(expected_bl.length(),
+              clone.read(0, expected_bl.length(), read_bl));
+    EXPECT_TRUE(expected_bl.contents_equal(read_bl));
+  }
+}
+
+TEST_F(TestLibRBD, LUKS2UnderLUKS1WithoutResize)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  std::string clone_name = get_temp_image_name();
+  uint64_t data_size = 25 << 20;
+  uint64_t luks1_meta_size = 4 << 20;
+  uint64_t luks2_meta_size = 16 << 20;
+  std::string parent_passphrase = "parent passphrase";
+  std::string clone_passphrase = "clone passphrase";
+
+  {
+    int order = 22;
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(),
+                                 luks2_meta_size + data_size, &order));
+    librbd::Image parent;
+    ASSERT_EQ(0, rbd.open(ioctx, parent, parent_name.c_str(), nullptr));
+
+    librbd::encryption_luks2_format_options_t fopts = {
+        RBD_ENCRYPTION_ALGORITHM_AES256, parent_passphrase};
+    ASSERT_EQ(0, parent.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS2, &fopts,
+                                          sizeof(fopts)));
+
+    ceph::bufferlist bl;
+    bl.append(std::string(data_size, 'a'));
+    ASSERT_EQ(data_size, parent.write(0, data_size, bl));
+
+    ASSERT_EQ(0, parent.snap_create("snap"));
+    ASSERT_EQ(0, parent.snap_protect("snap"));
+    uint64_t features;
+    ASSERT_EQ(0, parent.features(&features));
+    ASSERT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap", ioctx,
+                           clone_name.c_str(), features, &order));
+  }
+
+  {
+    librbd::Image clone;
+    ASSERT_EQ(0, rbd.open(ioctx, clone, clone_name.c_str(), nullptr));
+
+    librbd::encryption_luks1_format_options_t fopts =
+        {RBD_ENCRYPTION_ALGORITHM_AES256, clone_passphrase};
+    ASSERT_EQ(0, clone.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1, &fopts,
+                                         sizeof(fopts)));
+
+    librbd::encryption_luks_format_options_t opts1 = {parent_passphrase};
+    librbd::encryption_luks_format_options_t opts2 = {clone_passphrase};
+    librbd::encryption_spec_t specs[] = {
+        {RBD_ENCRYPTION_FORMAT_LUKS, &opts2, sizeof(opts2)},
+        {RBD_ENCRYPTION_FORMAT_LUKS, &opts1, sizeof(opts1)}};
+    ASSERT_EQ(0, clone.encryption_load2(specs, std::size(specs)));
+
+    uint64_t size;
+    ASSERT_EQ(0, clone.size(&size));
+    EXPECT_EQ(data_size + luks2_meta_size - luks1_meta_size, size);
+    uint64_t overlap;
+    ASSERT_EQ(0, clone.overlap(&overlap));
+    EXPECT_EQ(data_size, overlap);
+
+    ceph::bufferlist expected_bl;
+    expected_bl.append(std::string(data_size, 'a'));
+    expected_bl.append_zero(luks2_meta_size - luks1_meta_size);
+
+    ceph::bufferlist read_bl;
+    ASSERT_EQ(expected_bl.length(),
+              clone.read(0, expected_bl.length(), read_bl));
+    EXPECT_TRUE(expected_bl.contents_equal(read_bl));
+  }
+}
+
 TEST_F(TestLibRBD, EncryptionFormatNoData)
 {
   REQUIRE(!is_feature_enabled(RBD_FEATURE_JOURNALING));

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -333,7 +333,7 @@ void add_encryption_options(boost::program_options::options_description *opt) {
   opt->add_options()
     (ENCRYPTION_FORMAT.c_str(),
      po::value<std::vector<EncryptionFormat>>(),
-     "encryption format (luks, luks1, luks2)");
+     "encryption format (luks, luks1, luks2) [default: luks]");
 
   opt->add_options()
     (ENCRYPTION_PASSPHRASE_FILE.c_str(),

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -331,9 +331,9 @@ void add_snap_create_options(po::options_description *opt) {
 
 void add_encryption_options(boost::program_options::options_description *opt) {
   opt->add_options()
-  (ENCRYPTION_FORMAT.c_str(),
-   po::value<std::vector<EncryptionFormat>>(),
-   "encryption formats [possible values: luks]");
+    (ENCRYPTION_FORMAT.c_str(),
+     po::value<std::vector<EncryptionFormat>>(),
+     "encryption format (luks, luks1, luks2)");
 
   opt->add_options()
     (ENCRYPTION_PASSPHRASE_FILE.c_str(),
@@ -538,14 +538,15 @@ void validate(boost::any& v, const std::vector<std::string>& values,
               EncryptionFormat *target_type, int) {
   po::validators::check_first_occurrence(v);
   const std::string &s = po::validators::get_single_string(values);
-  EncryptionFormat format;
   if (s == "luks") {
-    format.format = RBD_ENCRYPTION_FORMAT_LUKS;
+    v = boost::any(EncryptionFormat{RBD_ENCRYPTION_FORMAT_LUKS});
+  } else if (s == "luks1") {
+    v = boost::any(EncryptionFormat{RBD_ENCRYPTION_FORMAT_LUKS1});
+  } else if (s == "luks2") {
+    v = boost::any(EncryptionFormat{RBD_ENCRYPTION_FORMAT_LUKS2});
   } else {
     throw po::validation_error(po::validation_error::invalid_option_value);
   }
-
-  v = boost::any(format);
 }
 
 void validate(boost::any& v, const std::vector<std::string>& values,

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -721,20 +721,16 @@ int get_snap_create_flags(const po::variables_map &vm, uint32_t *flags) {
 }
 
 int get_encryption_options(const boost::program_options::variables_map &vm,
-                           EncryptionOptions* opts) {
+                           EncryptionOptions* result) {
   std::vector<std::string> passphrase_files;
   if (vm.count(at::ENCRYPTION_PASSPHRASE_FILE)) {
     passphrase_files =
             vm[at::ENCRYPTION_PASSPHRASE_FILE].as<std::vector<std::string>>();
   }
 
-  std::vector<librbd::encryption_format_t> formats;
+  std::vector<at::EncryptionFormat> formats;
   if (vm.count(at::ENCRYPTION_FORMAT)) {
-    auto& format_structs =
-            vm[at::ENCRYPTION_FORMAT].as<std::vector<at::EncryptionFormat>>();
-    for (auto& format_struct : format_structs) {
-      formats.push_back((librbd::encryption_format_t)format_struct.format);
-    }
+    formats = vm[at::ENCRYPTION_FORMAT].as<decltype(formats)>();
   }
 
   if (formats.size() != passphrase_files.size()) {
@@ -743,44 +739,44 @@ int get_encryption_options(const boost::program_options::variables_map &vm,
     return -EINVAL;
   }
 
-  auto spec_count = formats.size();
-  if (spec_count == 0) {
-    return 0;
-  }
-
-  opts->luks_opts.reserve(spec_count);
-
-  auto& specs = opts->specs;
-  specs.resize(spec_count);
-  for (size_t i = 0; i < spec_count; ++i) {
+  result->specs.clear();
+  result->specs.reserve(formats.size());
+  for (size_t i = 0; i < formats.size(); ++i) {
     std::ifstream file(passphrase_files[i], std::ios::in | std::ios::binary);
-    auto sg = make_scope_guard([&] { file.close(); });
-
-    specs[i].format = formats[i];
-    std::string* passphrase;
-    switch (specs[i].format) {
-      case RBD_ENCRYPTION_FORMAT_LUKS: {
-        auto& luks_opts = opts->luks_opts;
-        luks_opts.emplace_back();
-        specs[i].opts = &luks_opts.back();
-        specs[i].opts_size = sizeof(luks_opts.back());
-        passphrase = &luks_opts.back().passphrase;
-        break;
-      }
-      default:
-        std::cerr << "rbd: unsupported encryption format: " << specs[i].format
-                  << std::endl;
-        return -ENOTSUP;
-    }
-
-    passphrase->assign((std::istreambuf_iterator<char>(file)),
-                       (std::istreambuf_iterator<char>()));
-
     if (file.fail()) {
       std::cerr << "rbd: unable to open passphrase file '"
                 << passphrase_files[i] << "': " << cpp_strerror(errno)
                 << std::endl;
       return -errno;
+    }
+    std::string passphrase((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+    file.close();
+
+    switch (formats[i].format) {
+    case RBD_ENCRYPTION_FORMAT_LUKS: {
+      auto opts = new librbd::encryption_luks_format_options_t{
+          std::move(passphrase)};
+      result->specs.push_back(
+          {RBD_ENCRYPTION_FORMAT_LUKS, opts, sizeof(*opts)});
+      break;
+    }
+    case RBD_ENCRYPTION_FORMAT_LUKS1: {
+      auto opts = new librbd::encryption_luks1_format_options_t{
+          .passphrase = std::move(passphrase)};
+      result->specs.push_back(
+          {RBD_ENCRYPTION_FORMAT_LUKS1, opts, sizeof(*opts)});
+      break;
+    }
+    case RBD_ENCRYPTION_FORMAT_LUKS2: {
+      auto opts = new librbd::encryption_luks2_format_options_t{
+          .passphrase = std::move(passphrase)};
+      result->specs.push_back(
+          {RBD_ENCRYPTION_FORMAT_LUKS2, opts, sizeof(*opts)});
+      break;
+    }
+    default:
+      ceph_abort();
     }
   }
 

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -731,6 +731,9 @@ int get_encryption_options(const boost::program_options::variables_map &vm,
   std::vector<at::EncryptionFormat> formats;
   if (vm.count(at::ENCRYPTION_FORMAT)) {
     formats = vm[at::ENCRYPTION_FORMAT].as<decltype(formats)>();
+  } else if (vm.count(at::ENCRYPTION_PASSPHRASE_FILE)) {
+    formats.resize(passphrase_files.size(),
+                   at::EncryptionFormat{RBD_ENCRYPTION_FORMAT_LUKS});
   }
 
   if (formats.size() != passphrase_files.size()) {

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -753,7 +753,7 @@ int get_encryption_options(const boost::program_options::variables_map &vm,
   auto& specs = opts->specs;
   specs.resize(spec_count);
   for (size_t i = 0; i < spec_count; ++i) {
-    std::ifstream file(passphrase_files[i].c_str());
+    std::ifstream file(passphrase_files[i], std::ios::in | std::ios::binary);
     auto sg = make_scope_guard([&] { file.close(); });
 
     specs[i].format = formats[i];
@@ -781,11 +781,6 @@ int get_encryption_options(const boost::program_options::variables_map &vm,
                 << passphrase_files[i] << "': " << cpp_strerror(errno)
                 << std::endl;
       return -errno;
-    }
-
-    if (!passphrase->empty() &&
-        (*passphrase)[passphrase->length() - 1] == '\n') {
-      passphrase->erase(passphrase->length() - 1);
     }
   }
 

--- a/src/tools/rbd/action/Encryption.cc
+++ b/src/tools/rbd/action/Encryption.cc
@@ -58,7 +58,7 @@ int execute(const po::variables_map &vm,
     return -EINVAL;
   }
 
-  std::ifstream file(passphrase_file.c_str());
+  std::ifstream file(passphrase_file, std::ios::in | std::ios::binary);
   if (file.fail()) {
     std::cerr << "rbd: unable to open passphrase file " << passphrase_file
               << ": " << cpp_strerror(errno) << std::endl;
@@ -69,9 +69,6 @@ int execute(const po::variables_map &vm,
   auto sg = make_scope_guard([&] {
       ceph_memzero_s(&passphrase[0], passphrase.size(), passphrase.size()); });
   file.close();
-  if (!passphrase.empty() && passphrase[passphrase.length() - 1] == '\n') {
-    passphrase.erase(passphrase.length() - 1);
-  }
 
   auto alg = RBD_ENCRYPTION_ALGORITHM_AES256;
   if (vm.count("cipher-alg")) {

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1693,7 +1693,8 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     });
 
     for (size_t i = 0; i < encryption_format_count; ++i) {
-      std::ifstream file(cfg->encryption_passphrase_file[i].c_str());
+      std::ifstream file(cfg->encryption_passphrase_file[i],
+                         std::ios::in | std::ios::binary);
       auto sg2 = make_scope_guard([&] { file.close(); });
 
       specs[i].format = cfg->encryption_format[i];
@@ -1722,11 +1723,6 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
                   << cfg->encryption_passphrase_file[i] << "': "
                   << cpp_strerror(errno) << std::endl;
         goto close_fd;
-      }
-
-      if (!passphrase->empty() &&
-          (*passphrase)[passphrase->length() - 1] == '\n') {
-        passphrase->erase(passphrase->length() - 1);
       }
     }
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -153,7 +153,7 @@ static void usage()
             << "Map and attach options:\n"
             << "  --device <device path>        Specify nbd device path (/dev/nbd{num})\n"
             << "  --encryption-format luks|luks1|luks2\n"
-            << "                                Image encryption format\n"
+            << "                                Image encryption format (default: luks)\n"
             << "  --encryption-passphrase-file  Path of file containing passphrase for unlocking image encryption\n"
             << "  --exclusive                   Forbid writes by other clients\n"
             << "  --notrim                      Turn off trim/discard\n"
@@ -2192,6 +2192,12 @@ static int parse_args(vector<const char*>& args, std::ostream *err_msg,
     } else {
       ++i;
     }
+  }
+
+  if (cfg->encryption_formats.empty() &&
+      !cfg->encryption_passphrase_files.empty()) {
+    cfg->encryption_formats.resize(cfg->encryption_passphrase_files.size(),
+                                   RBD_ENCRYPTION_FORMAT_LUKS);
   }
 
   if (cfg->encryption_formats.size() != cfg->encryption_passphrase_files.size()) {


### PR DESCRIPTION
An immediate follow-up for https://github.com/ceph/ceph/pull/40363 containing encrypted I/O path + encrypted flatten + encrypted resize fixes.  

A few TODOs that I have on my list but may just convert to tracker tickets:

- proxied encrypted flatten/resize discussion (https://github.com/ceph/ceph/pull/40363#discussion_r976800950)
- task-based encrypted flatten (`rbd task add flatten --encryption-format ... --encryption-passphrase-file ...`)?
- exercise layered encryption via fsx