### PR TITLE
qa/standalone/erasure-code: give osdmap 5 seconds to refresh

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-code.sh
+++ b/qa/standalone/erasure-code/test-erasure-code.sh
@@ -88,7 +88,11 @@ function rados_put_get() {
     local -a initial_osds=($(get_osds $poolname $objname))
     local last=$((${#initial_osds[@]} - 1))
     ceph osd out ${initial_osds[$last]} || return 1
+
+    # give the osdmap up to 5 seconds to refresh
+    sleep 5
     ! get_osds $poolname $objname | grep '\<'${initial_osds[$last]}'\>' || return 1
+
     rados --pool $poolname get $objname $dir/COPY || return 1
     diff $dir/ORIGINAL $dir/COPY || return 1
     ceph osd in ${initial_osds[$last]} || return 1


### PR DESCRIPTION
Per discussion on the Tracker, we suspect that `get_osds` sometimes uses an older osdmap in this workunit. The failure is very transient (seen in http://pulpito.front.sepia.ceph.com/lflores-2022-10-17_18:19:55-rados:standalone-main-distro-default-smithi/), which suggests that the osdmap sometimes needs a little longer to refresh.

Sleeping for a few seconds before checking the acting set should allow the osdmap enough time to refresh after an OSD is marked down.

Fixes: https://tracker.ceph.com/issues/57883
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
