### PR TITLE
neorados: compile with fmt v9

### DIFF
--- a/src/include/neorados/RADOS_Decodable.hpp
+++ b/src/include/neorados/RADOS_Decodable.hpp
@@ -24,6 +24,11 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/core.h>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
 namespace neorados {
 struct Entry {
   std::string nspace;
@@ -103,5 +108,9 @@ struct hash<::neorados::Entry> {
   }
 };
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<neorados::Entry> : ostream_formatter {};
+#endif
 
 #endif // RADOS_DECODABLE_HPP

--- a/src/tools/neorados.cc
+++ b/src/tools/neorados.cc
@@ -293,6 +293,10 @@ const std::array commands = {
 	  "remove OBJECT in POOL"sv }
 };
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<boost::program_options::options_description> : ostream_formatter {};
+#endif // FMT_VERSION
+
 int main(int argc, char* argv[])
 {
   const std::string_view prog(argv[0]);


### PR DESCRIPTION
neorados FTBFS on openSUSE Tumbleweed which includes fmt version 9. On the assumption it's still desirable to support building with older versions, I've put "#if FMT_VERSION" guards around the additions here.

Signed-off-by: Tim Serong <tserong@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
