### PR TITLE
mgr/cephadm: Adding extra arguments support for RGW frontend

### DIFF
--- a/doc/cephadm/services/rgw.rst
+++ b/doc/cephadm/services/rgw.rst
@@ -74,6 +74,33 @@ example spec file:
     spec:
       rgw_frontend_port: 8080
 
+Passing Frontend Extra Arguments
+--------------------------------
+
+The RGW service specification can be used to pass extra arguments to the rgw frontend by using
+the `rgw_frontend_extra_args` arguments list.
+
+example spec file:
+
+.. code-block:: yaml
+
+    service_type: rgw
+    service_id: foo
+    placement:
+      label: rgw
+      count_per_host: 2
+    spec:
+      rgw_realm: myrealm
+      rgw_zone: myzone
+      rgw_frontend_type: "beast"
+      rgw_frontend_port: 5000
+      rgw_frontend_extra_args:
+      - "tcp_nodelay=1"
+      - "max_header_size=65536"
+
+.. note:: cephadm combines the arguments from the `spec` section and the ones from
+	  the `rgw_frontend_extra_args` into a single space-separated arguments list
+	  which is used to set the value of `rgw_frontends` configuration parameter.
 
 Multisite zones
 ---------------

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
@@ -7,4 +7,4 @@ tasks:
       - ceph nfs cluster ls | grep foo
       - ceph nfs export ls foo --detailed
       - rados -p .nfs --all ls -
-      - ceph config get mgr mgr/cephadm/migration_current | grep 5
+      - ceph config get mgr mgr/cephadm/migration_current | grep 6

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -18,7 +18,7 @@ from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent, service
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 
 from .utils import resolve_ip
-from .migrations import queue_migrate_nfs_spec
+from .migrations import queue_migrate_nfs_spec, queue_migrate_rgw_spec
 
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
@@ -247,6 +247,13 @@ class SpecStore():
                 ):
                     self.mgr.log.debug(f'found legacy nfs spec {j}')
                     queue_migrate_nfs_spec(self.mgr, j)
+
+                if (
+                        (self.mgr.migration_current or 0) < 6
+                        and j['spec'].get('service_type') == 'rgw'
+                ):
+                    queue_migrate_rgw_spec(self.mgr, j)
+
                 spec = ServiceSpec.from_json(j['spec'])
                 created = str_to_datetime(cast(str, j['created']))
                 self._specs[service_name] = spec

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -1,8 +1,9 @@
 import json
+import re
 import logging
-from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any
+from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List
 
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec
 from cephadm.schedule import HostAssignment
 import rados
 
@@ -12,7 +13,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 5
+LAST_MIGRATION = 6
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,9 @@ class Migrations:
 
         v = mgr.get_store('nfs_migration_queue')
         self.nfs_migration_queue = json.loads(v) if v else []
+
+        r = mgr.get_store('rgw_migration_queue')
+        self.rgw_migration_queue = json.loads(r) if r else []
 
         # for some migrations, we don't need to do anything except for
         # incrementing migration_current.
@@ -95,6 +99,10 @@ class Migrations:
         if self.mgr.migration_current == 4:
             if self.migrate_4_5():
                 self.set(5)
+
+        if self.mgr.migration_current == 5:
+            if self.migrate_5_6():
+                self.set(6)
 
     def migrate_0_1(self) -> bool:
         """
@@ -335,6 +343,79 @@ class Migrations:
 
             self.mgr.log.info('Done migrating registry login info')
         return True
+
+    def migrate_rgw_spec(self, spec: Dict[Any, Any]) -> Optional[RGWSpec]:
+        """ Migrate an old rgw spec to the new format."""
+        new_spec = spec.copy()
+        field_content: List[str] = re.split(' +', new_spec['spec']['rgw_frontend_type'])
+        valid_spec = False
+        if 'beast' in field_content:
+            new_spec['spec']['rgw_frontend_type'] = 'beast'
+            field_content.remove('beast')
+            valid_spec = True
+        elif 'civetweb' in field_content:
+            new_spec['spec']['rgw_frontend_type'] = 'civetweb'
+            field_content.remove('civetweb')
+            valid_spec = True
+        else:
+            # Error: Should not happen as that would be an invalid RGW spec. In that case
+            # we keep the spec as it, mark it as unmanaged to avoid the daemons being deleted
+            # and raise a health warning so the user can fix the issue manually later.
+            self.mgr.log.error("Cannot migrate RGW spec, bad rgw_frontend_type value: {spec['spec']['rgw_frontend_type']}.")
+
+        if valid_spec:
+            new_spec['spec']['rgw_frontend_extra_args'] = []
+            new_spec['spec']['rgw_frontend_extra_args'].extend(field_content)
+
+        return RGWSpec.from_json(new_spec)
+
+    def rgw_spec_needs_migration(self, spec: Dict[Any, Any]) -> bool:
+        return 'rgw_frontend_type' in spec['spec'] \
+            and spec['spec']['rgw_frontend_type'] is not None \
+            and spec['spec']['rgw_frontend_type'].strip() not in ['beast', 'civetweb']
+
+    def migrate_5_6(self) -> bool:
+        """
+        Migration 5 -> 6
+
+        Old RGW spec used to allow 'bad' values on the rgw_frontend_type field. For example
+        the following value used to be valid:
+
+          rgw_frontend_type: "beast endpoint=10.16.96.54:8043 tcp_nodelay=1"
+
+        As of 17.2.6 release, these kind of entries are not valid anymore and a more strict check
+        has been added to validate this field.
+
+        This migration logic detects this 'bad' values and tries to transform them to the new
+        valid format where rgw_frontend_type field can only be either 'beast' or 'civetweb'.
+        Any extra arguments detected on rgw_frontend_type field will be parsed and passed in the
+        new spec field rgw_frontend_extra_args.
+        """
+        self.mgr.log.debug(f'Starting rgw migration (queue length is {len(self.rgw_migration_queue)})')
+        for s in self.rgw_migration_queue:
+            spec = s['spec']
+            if self.rgw_spec_needs_migration(spec):
+                rgw_spec = self.migrate_rgw_spec(spec)
+                if rgw_spec is not None:
+                    logger.info(f"Migrating {spec} to new RGW with extra args format {rgw_spec}")
+                    self.mgr.spec_store.save(rgw_spec)
+            else:
+                logger.info(f"No Migration is needed for rgw spec: {spec}")
+        self.rgw_migration_queue = []
+        return True
+
+
+def queue_migrate_rgw_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:
+    """
+    As aprt of 17.2.6 a stricter RGW spec validation has been added so the field
+    rgw_frontend_type cannot be used to pass rgw-frontends parameters.
+    """
+    service_id = spec_dict['spec']['service_id']
+    queued = mgr.get_store('rgw_migration_queue') or '[]'
+    ls = json.loads(queued)
+    ls.append(spec_dict)
+    mgr.set_store('rgw_migration_queue', json.dumps(ls))
+    mgr.log.info(f'Queued rgw.{service_id} for migration')
 
 
 def queue_migrate_nfs_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -916,6 +916,12 @@ class RgwService(CephService):
                     args.append(f"port={build_url(host=daemon_spec.ip, port=port).lstrip('/')}")
                 else:
                     args.append(f"port={port}")
+        else:
+            raise OrchestratorError(f'Invalid rgw_frontend_type parameter: {ftype}. Valid values are: beast, civetweb.')
+
+        if spec.rgw_frontend_extra_args is not None:
+            args.extend(spec.rgw_frontend_extra_args)
+
         frontend = f'{ftype} {" ".join(args)}'
 
         ret, out, err = self.mgr.check_mon_command({

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -257,3 +257,58 @@ def test_migrate_set_sane_value(cephadm_module: CephadmOrchestrator):
     ongoing = cephadm_module.migration.is_migration_ongoing()
     assert ongoing
     assert cephadm_module.migration_current == 0
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+def test_migrate_rgw_spec(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(
+            SPEC_STORE_PREFIX + 'rgw',
+            json.dumps({
+                'spec': {
+                    'service_type': 'rgw',
+                    'service_name': 'rgw.foo',
+                    'service_id': 'foo',
+                    'placement': {
+                        'hosts': ['host1']
+                    },
+                    'spec': {
+                        'rgw_frontend_type': 'beast  tcp_nodelay=1    request_timeout_ms=65000   rgw_thread_pool_size=512',
+                        'rgw_frontend_port': '5000',
+                    },
+                },
+                'created': datetime_to_str(datetime_now()),
+            }, sort_keys=True),
+        )
+
+        # make sure rgw_migration_queue is populated accordingly
+        cephadm_module.migration_current = 1
+        cephadm_module.spec_store.load()
+        ls = json.loads(cephadm_module.get_store('rgw_migration_queue'))
+        assert 'rgw' == ls[0]['spec']['service_type']
+
+        # shortcut rgw_migration_queue loading by directly assigning
+        # ls output to rgw_migration_queue list
+        cephadm_module.migration.rgw_migration_queue = ls
+
+        # skip other migrations and go directly to 5_6 migration (RGW spec)
+        cephadm_module.migration_current = 5
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == LAST_MIGRATION
+
+        # make sure the spec has been migrated and the the param=value entries
+        # that were part of the rgw_frontend_type are now in the new
+        # 'rgw_frontend_extra_args' list
+        assert 'rgw.foo' in cephadm_module.spec_store.all_specs
+        rgw_spec = cephadm_module.spec_store.all_specs['rgw.foo']
+        assert dict(rgw_spec.to_json()) == {'service_type': 'rgw',
+                                            'service_id': 'foo',
+                                            'service_name': 'rgw.foo',
+                                            'placement': {'hosts': ['host1']},
+                                            'spec': {
+                                                'rgw_frontend_extra_args': ['tcp_nodelay=1',
+                                                                            'request_timeout_ms=65000',
+                                                                            'rgw_thread_pool_size=512'],
+                                                'rgw_frontend_port': '5000',
+                                                'rgw_frontend_type': 'beast',
+                                            }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -944,18 +944,19 @@ spec:
 class TestRGWService:
 
     @pytest.mark.parametrize(
-        "frontend, ssl, expected",
+        "frontend, ssl, extra_args, expected",
         [
-            ('beast', False, 'beast endpoint=[fd00:fd00:fd00:3000::1]:80'),
-            ('beast', True,
-             'beast ssl_endpoint=[fd00:fd00:fd00:3000::1]:443 ssl_certificate=config://rgw/cert/rgw.foo'),
-            ('civetweb', False, 'civetweb port=[fd00:fd00:fd00:3000::1]:80'),
-            ('civetweb', True,
+            ('beast', False, ['tcp_nodelay=1'],
+             'beast endpoint=[fd00:fd00:fd00:3000::1]:80 tcp_nodelay=1'),
+            ('beast', True, ['tcp_nodelay=0', 'max_header_size=65536'],
+             'beast ssl_endpoint=[fd00:fd00:fd00:3000::1]:443 ssl_certificate=config://rgw/cert/rgw.foo tcp_nodelay=0 max_header_size=65536'),
+            ('civetweb', False, [], 'civetweb port=[fd00:fd00:fd00:3000::1]:80'),
+            ('civetweb', True, None,
              'civetweb port=[fd00:fd00:fd00:3000::1]:443s ssl_certificate=config://rgw/cert/rgw.foo'),
         ]
     )
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_rgw_update(self, frontend, ssl, expected, cephadm_module: CephadmOrchestrator):
+    def test_rgw_update(self, frontend, ssl, extra_args, expected, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'host1'):
             cephadm_module.cache.update_host_networks('host1', {
                 'fd00:fd00:fd00:3000::/64': {
@@ -965,7 +966,8 @@ class TestRGWService:
             s = RGWSpec(service_id="foo",
                         networks=['fd00:fd00:fd00:3000::/64'],
                         ssl=ssl,
-                        rgw_frontend_type=frontend)
+                        rgw_frontend_type=frontend,
+                        rgw_frontend_extra_args=extra_args)
             with with_service(cephadm_module, s) as dds:
                 _, f, _ = cephadm_module.check_mon_command({
                     'prefix': 'config get',

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -872,6 +872,7 @@ class RGWSpec(ServiceSpec):
                  rgw_frontend_port: Optional[int] = None,
                  rgw_frontend_ssl_certificate: Optional[List[str]] = None,
                  rgw_frontend_type: Optional[str] = None,
+                 rgw_frontend_extra_args: Optional[List[str]] = None,
                  unmanaged: bool = False,
                  ssl: bool = False,
                  preview_only: bool = False,
@@ -916,6 +917,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_frontend_ssl_certificate: Optional[List[str]] = rgw_frontend_ssl_certificate
         #: civetweb or beast (default: beast). See :ref:`rgw_frontends`
         self.rgw_frontend_type: Optional[str] = rgw_frontend_type
+        #: List of extra arguments for rgw_frontend in the form opt=value. See :ref:`rgw_frontends`
+        self.rgw_frontend_extra_args: Optional[List[str]] = rgw_frontend_extra_args
         #: enable SSL
         self.ssl = ssl
         self.rgw_realm_token = rgw_realm_token
@@ -941,6 +944,13 @@ class RGWSpec(ServiceSpec):
                     'Cannot add RGW: Realm specified but no zone specified')
         if self.rgw_zone and not self.rgw_realm:
             raise SpecValidationError('Cannot add RGW: Zone specified but no realm specified')
+
+        if self.rgw_frontend_type is not None:
+            if self.rgw_frontend_type not in ['beast', 'civetweb']:
+                raise SpecValidationError(
+                    'Invalid rgw_frontend_type value. Valid values are: beast, civetweb.\n'
+                    'Additional rgw type parameters can be passed using rgw_frontend_extra_args.'
+                )
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -255,6 +255,28 @@ def test_servicespec_map_test(s_type, o_spec, s_id):
     assert spec.validate() is None
     ServiceSpec.from_json(spec.to_json())
 
+
+@pytest.mark.parametrize(
+    "realm, zone, frontend_type, raise_exception, msg",
+    [
+        ('realm', 'zone1', 'beast', False, ''),
+        ('realm', 'zone2', 'civetweb', False, ''),
+        ('realm', None, 'beast', True, 'Cannot add RGW: Realm specified but no zone specified'),
+        (None, 'zone1', 'beast', True, 'Cannot add RGW: Zone specified but no realm specified'),
+        ('realm', 'zone', 'invalid-beast', True, '^Invalid rgw_frontend_type value'),
+        ('realm', 'zone', 'invalid-civetweb', True, '^Invalid rgw_frontend_type value'),
+    ])
+def test_rgw_servicespec_parse(realm, zone, frontend_type, raise_exception, msg):
+    spec = RGWSpec(service_id='foo',
+                   rgw_realm=realm,
+                   rgw_zone=zone,
+                   rgw_frontend_type=frontend_type)
+    if raise_exception:
+        with pytest.raises(SpecValidationError, match=msg):
+            spec.validate()
+    else:
+        spec.validate()
+
 def test_osd_unmanaged():
     osd_spec = {"placement": {"host_pattern": "*"},
                 "service_id": "all-available-devices",


### PR DESCRIPTION
This PR fixes the issue described on the tracker (`rgw_frontend_type` validation) in addition it adds support to specify custom `rgw_frontend` additional parameters that right now there's no way to specify by using a cephadm RGW spec. 

**Testing:**

Let's add the extra args `tcp_nodelay=1` to the RGW cephadm spec

test.yaml:
```
[ceph: root@ceph-node-0 /]# cat test.yaml 
service_type: rgw
service_id: rgw_test
service_name: rgw.rgw_test
placement:
  count: 1
  hosts:
  - ceph-node-0
spec:
  rgw_realm: myrealm
  rgw_zone: myzone
  rgw_frontend_extra_args: 
  - "tcp_nodelay=1"
  - "max_header_size=65536"
  rgw_frontend_type: "beast"
  rgw_frontend_port: 5000 
```

Value is applied correctly to the RGW client configuration:
```
[ceph: root@ceph-node-0 /]# ceph config get client.rgw.rgw_test.ceph-node-0.dcxuih rgw_frontends
beast port=5000 tcp_nodelay=1 max_header_size=65536
```

**RGW logs:** `tcp_nodelay` is set to 1
```
[root@ceph-node-0 ~]# journalctl  -u ceph-6181e0f4-5517-11ed-a4c4-525400140779@rgw.rgw_test.ceph-node-0.dcxuih.service
13:31:31 ceph-node-0 radosgw[155452]: deferred set uid:gid to 167:167 (ceph:ceph)
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: ceph version 17.0.0-10469-g29e1fc17 (29e1fc1722aa5915b44828a5ad02ec45ce760aa3) quincy (dev), process radosgw, pid 2
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: framework: beast
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: framework conf key: port, val: 5000
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: framework conf key: tcp_nodelay, val: 1
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: framework conf key: max_header_size, val: 65536
Oct 26 13:31:31 ceph-node-0 radosgw[155452]: radosgw_Main not setting numa affinity
```


Since this change impacts RGW specs validation (new validation is stricter) a special spec data migration is needed when upgrading from older releases. During the migration we check wether if `rgw_frontend_type` has some extra params, if it's the case then we try to parse this field to generate a list of `rgw_frontend_extra_args` arguments. 

**==== Following is the setup that was used to test the upgrade ===**
1) A healthy cluster running old code where three RGW daemons have been  provisioned:

- rgw_test_1: An RGW spec with has a 'bad' `rgw_frontend_type` (contains extra params) 
- rgw_test_2: An RGW spec with has a good `rgw_frontend_type` field
- rgw_test_3: An RGW spec with no  `rgw_frontend_type` field


```
[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_1 --export
service_type: rgw
service_id: rgw_test_1
service_name: rgw.rgw_test_1
placement:
  count: 1
  hosts:
  - ceph-node-0
spec:
  rgw_frontend_port: 5000
  rgw_frontend_type: beast  tcp_nodelay=1    request_timeout_ms=65000   rgw_thread_pool_size=512
  rgw_realm: myrealm
  rgw_zone: myzone

[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_2 --export
service_type: rgw
service_id: rgw_test_2
service_name: rgw.rgw_test_2
placement:
  count: 1
  hosts:
  - ceph-node-1
spec:
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_realm: myrealm
  rgw_zone: myzone


[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_3 --export
service_type: rgw
service_id: rgw_test_3
service_name: rgw.rgw_test_3
placement:
  count: 1
  hosts:
  - ceph-node-2
spec:
  rgw_realm: myrealm
  rgw_zone: myzone

[ceph: root@ceph-node-0 /]# ceph orch ps | grep rgw
rgw.rgw_test_1.ceph-node-0.prnqae  ceph-node-0  *:5000       running (92s)    87s ago  92s    77.0M        -  18.0.0-594-ge428c0d5  15c47b1dfc17  bd3fbbdf16b1
rgw.rgw_test_2.ceph-node-1.tarnsv  ceph-node-1  *:5000       running (82s)    78s ago  82s     110M        -  18.0.0-594-ge428c0d5  15c47b1dfc17  a2582d9d5e61
rgw.rgw_test_3.ceph-node-2.ouswce  ceph-node-2  *:80         running (68s)    65s ago  68s     109M        -  18.0.0-594-ge428c0d5  15c47b1dfc17  127e9c4606f8

```

This cluster is upgraded to a new image which contains the new code (specs and Migration), after the upgrade we can see that **rgw_test_1** has been migrated correctly and the `rgw_frontend_type` has been fixed correctly. `rgw_frontend_extra_args` has been populated with the extra parameters from this field. The other rgw_test daemons were not impacted as part of the upgade.

```
[ceph: root@ceph-node-0 /]# ceph orch ps | grep rgw
rgw.rgw_test_1.ceph-node-0.prnqae  ceph-node-0  *:5000       running (90s)     11s ago   9m    90.0M        -  18.0.0-594-ge428c0d5  f499ca8721d7  f049af9c1010
rgw.rgw_test_2.ceph-node-1.tarnsv  ceph-node-1  *:5000       running (83s)     37s ago   9m    88.9M        -  18.0.0-594-ge428c0d5  f499ca8721d7  fe74638e7587
rgw.rgw_test_3.ceph-node-2.ouswce  ceph-node-2  *:80         running (78s)     51s ago   9m    88.9M        -  18.0.0-594-ge428c0d5  f499ca8721d7  595287ce8721

[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_1 --export
service_type: rgw
service_id: rgw_test_1
service_name: rgw.rgw_test_1
placement:
  count: 1
  hosts:
  - ceph-node-0
spec:
  rgw_frontend_extra_args:
  - tcp_nodelay=1
  - request_timeout_ms=65000
  - rgw_thread_pool_size=512
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_realm: myrealm
  rgw_zone: myzone


[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_2 --export
service_type: rgw
service_id: rgw_test_2
service_name: rgw.rgw_test_2
placement:
  count: 1
  hosts:
  - ceph-node-1
spec:
  rgw_frontend_port: 5000
  rgw_frontend_type: beast
  rgw_realm: myrealm
  rgw_zone: myzone


[ceph: root@ceph-node-0 /]# ceph orch ls --service_name rgw.rgw_test_3 --export
service_type: rgw
service_id: rgw_test_3
service_name: rgw.rgw_test_3
placement:
  count: 1
  hosts:
  - ceph-node-2
spec:
  rgw_realm: myrealm
  rgw_zone: myzone

```







Fixes: https://tracker.ceph.com/issues/57931

Signed-off-by: Redouane Kachach <rkachach@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
