### PR TITLE
qa: Fix vstart_runner

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -705,14 +705,14 @@ class LocalFuseMount(LocalCephFSMount, FuseMount):
     def _create_mntpt(self):
         self.client_remote.run(args=f'mkdir -p -v {self.hostfs_mntpt}')
 
-    def _run_mount_cmd(self, mntopts, check_status):
-        retval = super(type(self), self)._run_mount_cmd(mntopts, check_status)
+    def _run_mount_cmd(self, mntopts, mntargs, check_status):
+        retval = super(type(self), self)._run_mount_cmd(mntopts, mntargs, check_status)
         if retval is None: # None represents success
             self._set_fuse_daemon_pid(check_status)
         return retval
 
-    def _get_mount_cmd(self, mntopts):
-        mount_cmd = super(type(self), self)._get_mount_cmd(mntopts)
+    def _get_mount_cmd(self, mntopts, mntargs):
+        mount_cmd = super(type(self), self)._get_mount_cmd(mntopts, mntargs)
 
         if os.getuid() != 0:
             mount_cmd += ['--client_die_on_failed_dentry_invalidate=false']


### PR DESCRIPTION
The following tracebacks have been fixed.

1.

 File "./qa/tasks/cephfs/fuse_mount.py", line 75, in _run_mount_cmd
	mount_cmd = self._get_mount_cmd(mntopts, mntargs)
TypeError: _get_mount_cmd() takes 2 positional arguments but 3 were given

2.

 File "./qa/tasks/cephfs/fuse_mount.py", line 68, in _mount
    retval = self._run_mount_cmd(mntopts, mntargs, check_status)
TypeError: _run_mount_cmd() takes 3 positional arguments but 4 were given

Signed-off-by: Kotresh HR <khiremat@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
