### PR TITLE
os/bluestore: faster bluefs allocations in avl/hybrid allocators

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -132,7 +132,7 @@ Allocator *Allocator::create(
   std::string_view type,
   int64_t size,
   int64_t block_size,
-  int64_t zone_size,
+  int64_t secondary_size,
   int64_t first_sequential_zone,
   std::string_view name)
 {
@@ -142,16 +142,16 @@ Allocator *Allocator::create(
   } else if (type == "bitmap") {
     alloc = new BitmapAllocator(cct, size, block_size, name);
   } else if (type == "avl") {
-    return new AvlAllocator(cct, size, block_size, name);
+    return new AvlAllocator(cct, size, block_size, secondary_size, name);
   } else if (type == "btree") {
     return new BtreeAllocator(cct, size, block_size, name);
   } else if (type == "hybrid") {
-    return new HybridAllocator(cct, size, block_size,
+    return new HybridAllocator(cct, size, block_size, secondary_size,
       cct->_conf.get_val<uint64_t>("bluestore_hybrid_alloc_mem_cap"),
       name);
 #ifdef HAVE_LIBZBD
   } else if (type == "zoned") {
-    return new ZonedAllocator(cct, size, block_size, zone_size, first_sequential_zone,
+    return new ZonedAllocator(cct, size, block_size, secondary_size, first_sequential_zone,
 			      name);
 #endif
   }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -40,9 +40,15 @@ enum {
   l_bluefs_max_bytes_wal,
   l_bluefs_max_bytes_db,
   l_bluefs_max_bytes_slow,
-  l_bluefs_main_alloc_unit,
+  l_bluefs_slow_alloc_unit,
   l_bluefs_db_alloc_unit,
   l_bluefs_wal_alloc_unit,
+  l_bluefs_slow_alloc_lat,
+  l_bluefs_db_alloc_lat,
+  l_bluefs_wal_alloc_lat,
+  l_bluefs_slow_alloc_max_lat,
+  l_bluefs_db_alloc_max_lat,
+  l_bluefs_wal_alloc_max_lat,
   l_bluefs_read_random_count,
   l_bluefs_read_random_bytes,
   l_bluefs_read_random_disk_count,
@@ -341,6 +347,8 @@ private:
     l_bluefs_max_bytes_db,
   };
 
+  ceph::timespan max_alloc_lat[MAX_BDEV] = {ceph::make_timespan(0)};
+
   // cache
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::nodes.lock");
@@ -427,6 +435,7 @@ private:
     return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
   }
   const char* get_device_name(unsigned id);
+  void _update_allocate_stats(uint8_t id, const ceph::timespan& d);
   int _allocate(uint8_t bdev, uint64_t len,
                 uint64_t alloc_unit,
 		bluefs_fnode_t* node,

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -12,9 +12,10 @@ class HybridAllocator : public AvlAllocator {
   BitmapAllocator* bmap_alloc = nullptr;
 public:
   HybridAllocator(CephContext* cct, int64_t device_size, int64_t _block_size,
+                  int64_t _large_unit,
                   uint64_t max_mem,
 	          std::string_view name) :
-      AvlAllocator(cct, device_size, _block_size, max_mem, name) {
+      AvlAllocator(cct, device_size, _block_size, _large_unit, max_mem, name) {
   }
   const char* get_type() const override
   {

--- a/src/test/objectstore/hybrid_allocator_test.cc
+++ b/src/test/objectstore/hybrid_allocator_test.cc
@@ -11,9 +11,10 @@ public:
   TestHybridAllocator(CephContext* cct,
                       int64_t device_size,
                       int64_t _block_size,
+                      int64_t _large_unit,
                       uint64_t max_entries,
       const std::string& name) :
-    HybridAllocator(cct, device_size, _block_size,
+    HybridAllocator(cct, device_size, _block_size, _large_unit,
       max_entries,
       name) {
   }
@@ -34,7 +35,7 @@ TEST(HybridAllocator, basic)
   {
     uint64_t block_size = 0x1000;
     uint64_t capacity = 0x10000 * _1m; // = 64GB
-    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size, 0,
       4 * sizeof(range_seg_t), "test_hybrid_allocator");
 
     ASSERT_EQ(0, ha.get_free());
@@ -183,7 +184,7 @@ TEST(HybridAllocator, basic)
   {
     uint64_t block_size = 0x1000;
     uint64_t capacity = 0x10000 * _1m; // = 64GB
-    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size, 0,
       4 * sizeof(range_seg_t), "test_hybrid_allocator");
 
     ha.init_add_free(_1m, _1m);
@@ -212,7 +213,7 @@ TEST(HybridAllocator, fragmentation)
   {
     uint64_t block_size = 0x1000;
     uint64_t capacity = 0x1000 * 0x1000; // = 16M
-    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size, 0,
       4 * sizeof(range_seg_t), "test_hybrid_allocator");
 
     ha.init_add_free(0, 0x2000);


### PR DESCRIPTION
When operating in best-fit mode allocator performs chunk lookups through size-sorted "range_size_tree" container. This is done in two stages:
1) Use container's lower_bound() to search for the first available
   long enough chunk.
2) Iterate sequentially to locate properly aligned chunk,
   starting from the position obtained at step 1)

Step 2) might require significant efforts for bluefs allocations (which uses longer allocation unit than bluestore min_alloc_size, e.g. 64K vs. 4K) if space is highly fragmented. Plenty of potentially available chunks might be unaligned to 64K boundary and once aligned they aren't long enough any more.
Hence the proposed solution is to prepend original sorting key (full_size + offset) with "aligned" chunk size. Hence range_size_tree will group chunks using bluefs aligned sizes and then sort them within each group using full size + chunk offset. E.g. chunks will be sorted in the following manner for bluefs and bluestore alloc sizes equal to  0x10000 and 0x1000 respectively

...
0x200000\~10000
0x210000\~10000
0x10f000\~10000
0x15f000\~10000
0x12f000\~11000
0x38000\~18000
...
0x0\~20000
0x400000\~20000
0x501000\~21000
0x101000\~22000
0x601000\~22000
...

Fixes: https://tracker.ceph.com/issues/62815
Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
