### PR TITLE
mds: adjust the capacity of a journal segment according to the size of subtreemap event, user can also configure it

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -534,6 +534,14 @@ options:
   services:
   - mds
   with_legacy: true
+- name: mds_log_periods_per_segment
+  type: int
+  level: advanced
+  desc: maximum number of periods in an MDS journal segment
+  default: 0
+  services:
+  - mds
+  with_legacy: true
 # segment size for mds log, default to default file_layout_t
 - name: mds_log_segment_size
   type: size

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -39,7 +39,7 @@ class LogSegment {
   using seq_t = uint64_t;
 
   LogSegment(uint64_t _seq, loff_t off=-1) :
-    seq(_seq), offset(off), end(off),
+    seq(_seq), offset(off), end(off), expected_end(off),
     dirty_dirfrags(member_offset(CDir, item_dirty)),
     new_dirfrags(member_offset(CDir, item_new)),
     dirty_inodes(member_offset(CInode, item_dirty)),
@@ -69,7 +69,7 @@ class LogSegment {
   }
 
   const seq_t seq;
-  uint64_t offset, end;
+  uint64_t offset, end, expected_end;
   int num_events = 0;
 
   // dirty items

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -305,6 +305,8 @@ private:
   void _expired(LogSegment *ls);
   void _trim_expired_segments();
   void write_head(MDSContext *onfinish);
+  // get segment expected end by offset and end of subtreemap in journal
+  uint64_t get_segment_expected_end(uint64_t offset, uint64_t end) const;
 
   // -- events --
   LogEvent *cur_event = nullptr;


### PR DESCRIPTION
This is to solve the same problem mentioned in PR #48615. If option 'mds_log_periods_per_segment' is set to '0'(default), it will calculate the capacity of a journal segment according to the size of subtreemap event.
We can think of the first event(subtreemap event) in a segment as the segment head and any other events make up the body. If the body of a segment is larger than its head, we call it a good segment. Each segment will try to be a good segment until it is intercepted by option 'mds_log_events_per_segment'.

Signed-off-by: Zhansong Gao <zhsgao@hotmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
