### PR TITLE
common/options/rgw.yaml.in: fix typos

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3298,9 +3298,9 @@ options:
   desc: Set the type of dmclock scheduler, defaults to throttler Other valid values
     are dmclock which is experimental
   fmt_desc: |
-    The RGW scheduler to use. Valid values are ``throttler` and
+    The RGW scheduler to use. Valid values are ``throttler`` and
     ``dmclock``. Currently defaults to ``throttler`` which throttles Beast
-    frontend requests. ``dmclock` is *experimental* and requires the
+    frontend requests. ``dmclock`` is *experimental* and requires the
     ``dmclock`` to be included in the ``experimental_feature_enabled``
     configuration option.
 


### PR DESCRIPTION
fix typos from single backtick to double backticks.

Signed-off-by: xuxiaopang <1540892727@qq.com>