### PR TITLE
crimson/os/seastore: correct the behavior of reserving space

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -411,7 +411,8 @@ JournalTrimmerImpl::JournalTrimmerImpl(
     config(config),
     journal_type(type),
     roll_start(roll_start),
-    roll_size(roll_size)
+    roll_size(roll_size),
+    reserved_usage(0)
 {
   config.validate();
   ceph_assert(roll_start >= 0);
@@ -1504,12 +1505,18 @@ segment_id_t SegmentCleaner::get_next_reclaim_segment() const
   }
 }
 
-void SegmentCleaner::reserve_projected_usage(std::size_t projected_usage)
+bool SegmentCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
-  ++stats.projected_count;
-  stats.projected_used_bytes_sum += stats.projected_used_bytes;
+  if (should_block_io_on_clean()) {
+    stats.projected_used_bytes -= projected_usage;
+    return false;
+  } else {
+    ++stats.projected_count;
+    stats.projected_used_bytes_sum += stats.projected_used_bytes;
+    return true;
+  }
 }
 
 void SegmentCleaner::release_projected_usage(std::size_t projected_usage)
@@ -1607,10 +1614,11 @@ void RBMCleaner::commit_space_used(paddr_t addr, extent_len_t len)
   }
 }
 
-void RBMCleaner::reserve_projected_usage(std::size_t projected_usage)
+bool RBMCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
   assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
+  return true;
 }
 
 void RBMCleaner::release_projected_usage(std::size_t projected_usage)

--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -67,10 +67,6 @@ public:
   extent_types_t get_type() const final {
     return TYPE;
   }
-
-  bool may_conflict() const final {
-    return false;
-  }
 };
 using BackrefInternalNodeRef = BackrefInternalNode::Ref;
 
@@ -90,10 +86,6 @@ public:
 
   extent_types_t get_type() const final  {
     return TYPE;
-  }
-
-  bool may_conflict() const final {
-    return false;
   }
 
   const_iterator insert(

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1009,6 +1009,8 @@ CachedExtentRef Cache::duplicate_for_write(
 
   auto ret = i->duplicate_for_write();
   ret->prior_instance = i;
+  // duplicate_for_write won't occur after ool write finished
+  assert(!i->prior_poffset);
   t.add_mutated_extent(ret);
   if (ret->get_type() == extent_types_t::ROOT) {
     t.root = ret->cast<RootBlock>();

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -443,7 +443,9 @@ seastar::future<>
 ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
     projected_usage_t usage)
 {
-  ceph_assert(is_ready());
+  if (!is_ready()) {
+    return seastar::now();
+  }
   ceph_assert(!blocking_io);
   // The pipeline configuration prevents another IO from entering
   // prepare until the prior one exits and clears this.
@@ -470,7 +472,7 @@ ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
         ceph_assert(!blocking_io);
         auto res = try_reserve(usage);
         if (res.is_successful()) {
-          assert(stats.io_blocking_num > 0);
+          assert(stats.io_blocking_num == 1);
           --stats.io_blocking_num;
           return seastar::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -421,8 +421,9 @@ ExtentPlacementManager::BackgroundProcess::run_until_halt()
 
 seastar::future<>
 ExtentPlacementManager::BackgroundProcess::reserve_projected_usage(
-    std::size_t projected_usage)
+    projected_usage_t usage)
 {
+  auto projected_usage = usage.inline_usage + usage.ool_usage;
   ceph_assert(is_ready());
   ceph_assert(!blocking_io);
   // The pipeline configuration prevents another IO from entering

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -328,12 +328,12 @@ public:
     return background_process.commit_space_used(addr, len);
   }
 
-  seastar::future<> reserve_projected_usage(std::size_t projected_usage) {
-    return background_process.reserve_projected_usage(projected_usage);
+  seastar::future<> reserve_projected_usage(projected_usage_t usage) {
+    return background_process.reserve_projected_usage(usage);
   }
 
-  void release_projected_usage(std::size_t projected_usage) {
-    return background_process.release_projected_usage(projected_usage);
+  void release_projected_usage(projected_usage_t usage) {
+    background_process.release_projected_usage(usage);
   }
 
   // Testing interfaces
@@ -460,11 +460,11 @@ private:
       return cleaner->commit_space_used(addr, len);
     }
 
-    seastar::future<> reserve_projected_usage(std::size_t projected_usage);
+    seastar::future<> reserve_projected_usage(projected_usage_t usage);
 
-    void release_projected_usage(std::size_t projected_usage) {
+    void release_projected_usage(projected_usage_t usage) {
       ceph_assert(is_ready());
-      return cleaner->release_projected_usage(projected_usage);
+      cleaner->release_projected_usage(usage.inline_usage + usage.ool_usage);
     }
 
     seastar::future<> stop_background();

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -463,9 +463,10 @@ private:
     seastar::future<> reserve_projected_usage(projected_usage_t usage);
 
     void release_projected_usage(projected_usage_t usage) {
-      ceph_assert(is_ready());
-      trimmer->release_inline_usage(usage.inline_usage);
-      cleaner->release_projected_usage(usage.inline_usage + usage.ool_usage);
+      if (is_ready()) {
+        trimmer->release_inline_usage(usage.inline_usage);
+        cleaner->release_projected_usage(usage.inline_usage + usage.ool_usage);
+      }
     }
 
     seastar::future<> stop_background();

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -464,6 +464,7 @@ private:
 
     void release_projected_usage(projected_usage_t usage) {
       ceph_assert(is_ready());
+      trimmer->release_inline_usage(usage.inline_usage);
       cleaner->release_projected_usage(usage.inline_usage + usage.ool_usage);
     }
 
@@ -535,6 +536,17 @@ private:
       return trimmer->should_block_io_on_trim() ||
              cleaner->should_block_io_on_clean();
     }
+
+    struct reserve_result_t {
+      bool reserve_inline_success = true;
+      bool reserve_ool_success = true;
+
+      bool is_successful() const {
+        return reserve_inline_success && reserve_ool_success;
+      }
+    };
+
+    reserve_result_t try_reserve(const projected_usage_t &usage);
 
     seastar::future<> do_background_cycle();
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -253,14 +253,41 @@ public:
   }
 
   /**
-   * delayed_allocate_and_write
+   * dispatch_result_t
    *
-   * Performs delayed allocation and do writes for out-of-line extents.
+   * ool extents are placed in alloc_map and passed to
+   * EPM::write_delayed_ool_extents,
+   * delayed_extents is used to update lba mapping.
+   * usage is used to reserve projected space
+   */
+  struct projected_usage_t {
+    std::size_t inline_usage = 0;
+    std::size_t ool_usage = 0;
+  };
+  using extents_by_writer_t =
+    std::map<ExtentOolWriter*, std::list<LogicalCachedExtentRef>>;
+  struct dispatch_result_t {
+    extents_by_writer_t alloc_map;
+    std::list<LogicalCachedExtentRef> delayed_extents;
+    projected_usage_t usage;
+  };
+
+  /**
+   * dispatch_delayed_extents
+   *
+   * Performs delayed allocation
+   */
+  dispatch_result_t dispatch_delayed_extents(Transaction& t);
+
+  /**
+   * write_delayed_ool_extents
+   *
+   * Do writes for out-of-line extents.
    */
   using alloc_paddr_iertr = ExtentOolWriter::alloc_write_iertr;
-  alloc_paddr_iertr::future<> delayed_allocate_and_write(
+  alloc_paddr_iertr::future<> write_delayed_ool_extents(
     Transaction& t,
-    const std::list<LogicalCachedExtentRef>& delayed_extents);
+    extents_by_writer_t& alloc_map);
 
   /**
    * write_preallocated_ool_extents
@@ -331,6 +358,18 @@ private:
     ceph_assert(devices_by_id[device_id] == nullptr);
     devices_by_id[device_id] = device;
     ++num_devices;
+  }
+
+  /**
+   * dispatch_delayed_extent
+   *
+   * Specify the extent inline or ool
+   * return true indicates inline otherwise ool
+   */
+  bool dispatch_delayed_extent(LogicalCachedExtentRef& extent) {
+    // TODO: all delayed extents are ool currently
+    boost::ignore_unused(extent);
+    return false;
   }
 
   ExtentOolWriter* get_writer(placement_hint_t hint,
@@ -536,4 +575,12 @@ private:
 
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;
 
+std::ostream &operator<<(std::ostream &, const ExtentPlacementManager::projected_usage_t &);
+
 }
+
+#if FMT_VERSION >= 90000
+template <>
+struct fmt::formatter<crimson::os::seastore::ExtentPlacementManager::projected_usage_t>
+  : fmt::ostream_formatter {};
+#endif

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -9,34 +9,16 @@ namespace crimson::os::seastore {
 LBAManager::update_mappings_ret
 LBAManager::update_mappings(
   Transaction& t,
-  const std::list<LogicalCachedExtentRef>& extents,
-  const std::vector<paddr_t>& original_paddrs)
+  const std::list<LogicalCachedExtentRef>& extents)
 {
-  assert(extents.size() == original_paddrs.size());
-  auto extents_end = extents.end();
-  return seastar::do_with(
-      extents.begin(),
-      original_paddrs.begin(),
-      [this, extents_end, &t](auto& iter_extents,
-                              auto& iter_original_paddrs) {
-    return trans_intr::repeat(
-      [this, extents_end, &t, &iter_extents, &iter_original_paddrs]
-    {
-      if (extents_end == iter_extents) {
-        return update_mappings_iertr::make_ready_future<
-          seastar::stop_iteration>(seastar::stop_iteration::yes);
-      }
-      return update_mapping(
-          t,
-          (*iter_extents)->get_laddr(),
-          *iter_original_paddrs,
-          (*iter_extents)->get_paddr()
-      ).si_then([&iter_extents, &iter_original_paddrs] {
-        ++iter_extents;
-        ++iter_original_paddrs;
-        return seastar::stop_iteration::no;
-      });
-    });
+  return trans_intr::do_for_each(extents,
+				 [this, &t](auto &extent) {
+    return update_mapping(
+      t,
+      extent->get_laddr(),
+      extent->get_prior_paddr_and_reset(),
+      extent->get_paddr()
+    );
   });
 }
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -177,8 +177,7 @@ public:
   using update_mappings_ret = update_mapping_ret;
   update_mappings_ret update_mappings(
     Transaction& t,
-    const std::list<LogicalCachedExtentRef>& extents,
-    const std::vector<paddr_t>& original_paddrs);
+    const std::list<LogicalCachedExtentRef>& extents);
 
   /**
    * get_physical_extent_if_live

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -187,13 +187,17 @@ public:
     write_set.insert(*ref);
   }
 
-  void mark_delayed_extent_ool(LogicalCachedExtentRef& ref, paddr_t final_addr) {
+  void mark_delayed_extent_ool(LogicalCachedExtentRef& ref) {
+    written_ool_block_list.push_back(ref);
+  }
+
+  void update_delayed_ool_extent_addr(LogicalCachedExtentRef& ref,
+                                      paddr_t final_addr) {
     write_set.erase(*ref);
     assert(ref->get_paddr().is_delayed());
     ref->set_paddr(final_addr, /* need_update_mapping: */ true);
     assert(!ref->get_paddr().is_null());
     assert(!ref->is_inline());
-    written_ool_block_list.push_back(ref);
     write_set.insert(*ref);
   }
 
@@ -264,6 +268,10 @@ public:
       }
     }
     return ret;
+  }
+
+  const auto &get_inline_block_list() {
+    return inline_block_list;
   }
 
   const auto &get_mutated_block_list() {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -180,7 +180,8 @@ public:
   void mark_delayed_extent_inline(LogicalCachedExtentRef& ref) {
     write_set.erase(*ref);
     assert(ref->get_paddr().is_delayed());
-    ref->set_paddr(make_record_relative_paddr(offset));
+    ref->set_paddr(make_record_relative_paddr(offset),
+                   /* need_update_mapping: */ true);
     offset += ref->get_length();
     inline_block_list.push_back(ref);
     write_set.insert(*ref);
@@ -189,7 +190,7 @@ public:
   void mark_delayed_extent_ool(LogicalCachedExtentRef& ref, paddr_t final_addr) {
     write_set.erase(*ref);
     assert(ref->get_paddr().is_delayed());
-    ref->set_paddr(final_addr);
+    ref->set_paddr(final_addr, /* need_update_mapping: */ true);
     assert(!ref->get_paddr().is_null());
     assert(!ref->is_inline());
     written_ool_block_list.push_back(ref);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -312,12 +312,6 @@ public:
     return fresh_block_stats;
   }
 
-  size_t get_allocation_size() const {
-    size_t ret = 0;
-    for_each_fresh_block([&ret](auto &e) { ret += e->get_length(); });
-    return ret;
-  }
-
   using src_t = transaction_type_t;
   src_t get_src() const {
     return src;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -301,24 +301,12 @@ TransactionManager::submit_transaction_direct(
   return trans_intr::make_interruptible(
     tref.get_handle().enter(write_pipeline.ool_writes)
   ).then_interruptible([this, FNAME, &tref] {
-    auto delayed_extents = tref.get_delayed_alloc_list();
-    auto num_extents = delayed_extents.size();
-    SUBTRACET(seastore_t, "process {} delayed extents", tref, num_extents);
-    std::vector<paddr_t> delayed_paddrs;
-    delayed_paddrs.reserve(num_extents);
-    for (auto& ext : delayed_extents) {
-      assert(ext->get_paddr().is_delayed());
-      delayed_paddrs.push_back(ext->get_paddr());
-    }
-    return seastar::do_with(
-      std::move(delayed_extents),
-      std::move(delayed_paddrs),
-      [this, FNAME, &tref](auto& delayed_extents, auto& delayed_paddrs)
-    {
+    return seastar::do_with(tref.get_delayed_alloc_list(),
+			    [this, FNAME, &tref](auto &delayed_extents) {
       return epm->delayed_allocate_and_write(tref, delayed_extents
-      ).si_then([this, FNAME, &tref, &delayed_extents, &delayed_paddrs] {
+      ).si_then([this, FNAME, &tref, &delayed_extents] {
         SUBTRACET(seastore_t, "update delayed extent mappings", tref);
-        return lba_manager->update_mappings(tref, delayed_extents, delayed_paddrs);
+        return lba_manager->update_mappings(tref, delayed_extents);
       }).handle_error_interruptible(
         crimson::ct_error::input_output_error::pass_further(),
         crimson::ct_error::assert_all("invalid error")

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -278,12 +278,13 @@ TransactionManager::submit_transaction(
   return trans_intr::make_interruptible(
     t.get_handle().enter(write_pipeline.reserve_projected_usage)
   ).then_interruptible([this, FNAME, &t] {
-    size_t projected_usage = t.get_allocation_size();
+    auto dispatch_result = epm->dispatch_delayed_extents(t);
+    auto projected_usage = dispatch_result.usage;
     SUBTRACET(seastore_t, "waiting for projected_usage: {}", t, projected_usage);
     return trans_intr::make_interruptible(
       epm->reserve_projected_usage(projected_usage)
-    ).then_interruptible([this, &t] {
-      return submit_transaction_direct(t);
+    ).then_interruptible([this, &t, dispatch_result = std::move(dispatch_result)] {
+      return do_submit_transaction(t, std::move(dispatch_result));
     }).finally([this, FNAME, projected_usage, &t] {
       SUBTRACET(seastore_t, "releasing projected_usage: {}", t, projected_usage);
       epm->release_projected_usage(projected_usage);
@@ -296,17 +297,30 @@ TransactionManager::submit_transaction_direct(
   Transaction &tref,
   std::optional<journal_seq_t> trim_alloc_to)
 {
-  LOG_PREFIX(TransactionManager::submit_transaction_direct);
+  return do_submit_transaction(
+    tref,
+    epm->dispatch_delayed_extents(tref),
+    trim_alloc_to);
+}
+
+TransactionManager::submit_transaction_direct_ret
+TransactionManager::do_submit_transaction(
+  Transaction &tref,
+  ExtentPlacementManager::dispatch_result_t dispatch_result,
+  std::optional<journal_seq_t> trim_alloc_to)
+{
+  LOG_PREFIX(TransactionManager::do_submit_transaction);
   SUBTRACET(seastore_t, "start", tref);
   return trans_intr::make_interruptible(
     tref.get_handle().enter(write_pipeline.ool_writes)
-  ).then_interruptible([this, FNAME, &tref] {
-    return seastar::do_with(tref.get_delayed_alloc_list(),
-			    [this, FNAME, &tref](auto &delayed_extents) {
-      return epm->delayed_allocate_and_write(tref, delayed_extents
-      ).si_then([this, FNAME, &tref, &delayed_extents] {
+  ).then_interruptible([this, FNAME, &tref,
+			dispatch_result = std::move(dispatch_result)] {
+    return seastar::do_with(std::move(dispatch_result),
+			    [this, FNAME, &tref](auto &dispatch_result) {
+      return epm->write_delayed_ool_extents(tref, dispatch_result.alloc_map
+      ).si_then([this, FNAME, &tref, &dispatch_result] {
         SUBTRACET(seastore_t, "update delayed extent mappings", tref);
-        return lba_manager->update_mappings(tref, delayed_extents);
+        return lba_manager->update_mappings(tref, dispatch_result.delayed_extents);
       }).handle_error_interruptible(
         crimson::ct_error::input_output_error::pass_further(),
         crimson::ct_error::assert_all("invalid error")

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -637,6 +637,11 @@ private:
     Transaction& t,
     LogicalCachedExtentRef extent);
 
+  submit_transaction_direct_ret do_submit_transaction(
+    Transaction &t,
+    ExtentPlacementManager::dispatch_result_t dispatch_result,
+    std::optional<journal_seq_t> seq_to_trim = std::nullopt);
+
 public:
   // Testing interfaces
   auto get_epm() {

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -61,6 +61,10 @@ struct btree_test_base :
 
   void update_journal_tails(journal_seq_t, journal_seq_t) final {}
 
+  bool try_reserve_inline_usage(std::size_t) final { return true; }
+
+  void release_inline_usage(std::size_t) final {}
+
   /*
    * SegmentProvider interfaces
    */

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -65,6 +65,10 @@ struct btree_test_base :
 
   void release_inline_usage(std::size_t) final {}
 
+  std::size_t get_trim_size_per_cycle() const final {
+    return 0;
+  }
+
   /*
    * SegmentProvider interfaces
    */

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -167,6 +167,10 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
 
   void release_inline_usage(std::size_t) final {}
 
+  std::size_t get_trim_size_per_cycle() const final {
+    return 0;
+  }
+
   auto submit_record(record_t&& record) {
     entries.push_back(record);
     OrderingHandle handle = get_dummy_ordering_handle();

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -163,6 +163,10 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
     return seastar::now();
   }
 
+  bool try_reserve_inline_usage(std::size_t) final { return true; }
+
+  void release_inline_usage(std::size_t) final {}
+
   auto submit_record(record_t&& record) {
     entries.push_back(record);
     OrderingHandle handle = get_dummy_ordering_handle();

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -104,6 +104,10 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
 
   void release_inline_usage(std::size_t) final {}
 
+  std::size_t get_trim_size_per_cycle() const final {
+    return 0;
+  }
+
   /*
    * SegmentProvider interfaces
    */

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -100,6 +100,10 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
 
   void update_journal_tails(journal_seq_t, journal_seq_t) final {}
 
+  bool try_reserve_inline_usage(std::size_t) final { return true; }
+
+  void release_inline_usage(std::size_t) final {}
+
   /*
    * SegmentProvider interfaces
    */


### PR DESCRIPTION
According to the previous discussion(https://github.com/ceph/ceph/pull/47974#issuecomment-1253434857 and https://github.com/ceph/ceph/pull/47974#issuecomment-1254464951), current reservation actually doesn't work, this PR fixes this issue.

Overview:
1. fine grained reservation. Change single "projected_usage" to "inline_usage" and "ool_usage";
2. divide "EPM::delayed_alloc_extents_or_ool_write" into "EPM::dispatch_delayed_extents" and "EPM::ool_write";
3. IO transaction might be blocked on the trimmer, cleaner, or both of two;
4. trimmer transaction(TRIM_ALLOC/TRIM_DIRTY) might be blocked on cleaner(by ool_usage);
5. start a temporary cleaner process when the trimmer is blocked by the cleaner.
6. introduce the “try_reserve" helper method with side effects. If "try_reserve" can succeed in reserving inline and out-of-line space at the same time, it will update the state directly and return true, otherwise, reset the state, return false, and wake up the background process.

@cyx1231st 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
