### PR TITLE
rook:PR for Fix for bug 57954

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1065,7 +1065,7 @@ class RookCluster(object):
             return rook_nfsgw
 
         create_ganesha_pool(mgr)
-        NFSRados(mgr_module, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
+        NFSRados(mgr_module.rados, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
         return self._create_or_patch(cnfs.CephNFS, 'cephnfses', service_id,
                 _update_nfs, _create_nfs)
 


### PR DESCRIPTION
NFSRados constructor expects type of rados as a parameter instead of MgrModule. This change should fix nfs cluster creation bug 57954.

Bug to fix: https://tracker.ceph.com/issues/57954
Signed-off-by: Ben Gao <bengao168@msn.com>

