### PR TITLE
build scripts: various cleanups and minor changes preparing for containerized build and test

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -12,6 +12,14 @@
 #  version 2.1 of the License, or (at your option) any later version.
 #
 set -e
+
+if ! [ "${_SOURCED_LIB_BUILD}" = 1 ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    CEPH_ROOT="${SCRIPT_DIR}"
+    . "${CEPH_ROOT}/src/script/lib-build.sh" || exit 2
+fi
+
+
 DIR=/tmp/install-deps.$$
 trap "rm -fr $DIR" EXIT
 mkdir -p $DIR
@@ -24,9 +32,6 @@ export LC_ALL=C.UTF-8
 
 ARCH=$(uname -m)
 
-function in_jenkins() {
-    test -n "$JENKINS_HOME"
-}
 
 function munge_ceph_spec_in {
     local with_seastar=$1

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -68,7 +68,7 @@ function munge_debian_control {
 }
 
 function ensure_decent_gcc_on_ubuntu {
-    in_jenkins && echo "CI_DEBUG: Start ensure_decent_gcc_on_ubuntu() in install-deps.sh"
+    ci_debug "Start ensure_decent_gcc_on_ubuntu() in install-deps.sh"
     # point gcc to the one offered by g++-7 if the used one is not
     # new enough
     local old=$(gcc -dumpfullversion -dumpversion)
@@ -105,7 +105,7 @@ ENDOFKEY
 }
 
 function ensure_python3_sphinx_on_ubuntu {
-    in_jenkins && echo "CI_DEBUG: Running ensure_python3_sphinx_on_ubuntu() in install-deps.sh"
+    ci_debug "Running ensure_python3_sphinx_on_ubuntu() in install-deps.sh"
     local sphinx_command=/usr/bin/sphinx-build
     # python-sphinx points $sphinx_command to
     # ../share/sphinx/scripts/python2/sphinx-build when it's installed
@@ -116,7 +116,7 @@ function ensure_python3_sphinx_on_ubuntu {
 }
 
 function install_pkg_on_ubuntu {
-    in_jenkins && echo "CI_DEBUG: Running install_pkg_on_ubuntu() in install-deps.sh"
+    ci_debug "Running install_pkg_on_ubuntu() in install-deps.sh"
     local project=$1
     shift
     local sha1=$1
@@ -133,7 +133,7 @@ function install_pkg_on_ubuntu {
         for pkg in $pkgs; do
             if ! apt -qq list $pkg 2>/dev/null | grep -q installed; then
                 missing_pkgs+=" $pkg"
-                in_jenkins && echo "CI_DEBUG: missing_pkgs=$missing_pkgs"
+                ci_debug "missing_pkgs=$missing_pkgs"
             fi
         done
     fi
@@ -146,7 +146,7 @@ function install_pkg_on_ubuntu {
 }
 
 function install_boost_on_ubuntu {
-    in_jenkins && echo "CI_DEBUG: Running install_boost_on_ubuntu() in install-deps.sh"
+    ci_debug "Running install_boost_on_ubuntu() in install-deps.sh"
     local ver=1.79
     local installed_ver=$(apt -qq list --installed ceph-libboost*-dev 2>/dev/null |
                               grep -e 'libboost[0-9].[0-9]\+-dev' |
@@ -187,7 +187,7 @@ function install_boost_on_ubuntu {
 }
 
 function install_libzbd_on_ubuntu {
-    in_jenkins && echo "CI_DEBUG: Running install_libzbd_on_ubuntu() in install-deps.sh"
+    ci_debug "Running install_libzbd_on_ubuntu() in install-deps.sh"
     local codename=$1
     local project=libzbd
     local sha1=1fadde94b08fab574b17637c2bebd2b1e7f9127b
@@ -259,7 +259,7 @@ EOF
 }
 
 function populate_wheelhouse() {
-    in_jenkins && echo "CI_DEBUG: Running populate_wheelhouse() in install-deps.sh"
+    ci_debug "Running populate_wheelhouse() in install-deps.sh"
     local install=$1
     shift
 
@@ -277,7 +277,7 @@ function populate_wheelhouse() {
 }
 
 function activate_virtualenv() {
-    in_jenkins && echo "CI_DEBUG: Running activate_virtualenv() in install-deps.sh"
+    ci_debug "Running activate_virtualenv() in install-deps.sh"
     local top_srcdir=$1
     local env_dir=$top_srcdir/install-deps-python3
 
@@ -293,7 +293,7 @@ function activate_virtualenv() {
 }
 
 function preload_wheels_for_tox() {
-    in_jenkins && echo "CI_DEBUG: Running preload_wheels_for_tox() in install-deps.sh"
+    ci_debug "Running preload_wheels_for_tox() in install-deps.sh"
     local ini=$1
     shift
     pushd . > /dev/null
@@ -407,7 +407,7 @@ else
                 # state. Run the command again after `dpkg --configure -a` to
                 # bring package manager back into a clean state.
                 $SUDO dpkg --configure -a
-                in_jenkins && echo "CI_DEBUG: trying to install $INSTALL_EXTRA_PACKAGES again"
+                ci_debug "trying to install $INSTALL_EXTRA_PACKAGES again"
                 $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES
             fi
         fi
@@ -439,7 +439,7 @@ else
         fi
         touch $DIR/status
 
-        in_jenkins && echo "CI_DEBUG: Running munge_debian_control() in install-deps.sh"
+        ci_debug "Running munge_debian_control() in install-deps.sh"
         backports=""
         control=$(munge_debian_control "$VERSION" "debian/control")
         case "$VERSION" in
@@ -462,19 +462,17 @@ else
             build_profiles+=",pkg.ceph.pmdk"
         fi
 
-        in_jenkins && cat <<EOF
-CI_DEBUG: for_make_check=$for_make_check
-CI_DEBUG: with_seastar=$with_seastar
-CI_DEBUG: with_jaeger=$with_jaeger
-CI_DEBUG: build_profiles=$build_profiles
-CI_DEBUG: Now running 'mk-build-deps' and installing ceph-build-deps package
-EOF
+        ci_debug "for_make_check=$for_make_check"
+        ci_debug "with_seastar=$with_seastar"
+        ci_debug "with_jaeger=$with_jaeger"
+        ci_debug "build_profiles=$build_profiles"
+        ci_debug "Now running 'mk-build-deps' and installing ceph-build-deps package"
 
         $SUDO env DEBIAN_FRONTEND=noninteractive mk-build-deps \
               --build-profiles "${build_profiles#,}" \
               --install --remove \
               --tool="apt-get -y --no-install-recommends $backports" $control || exit 1
-        in_jenkins && echo "CI_DEBUG: Removing ceph-build-deps"
+        ci_debug "Removing ceph-build-deps"
         $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
         if [ "$control" != "debian/control" ] ; then rm $control; fi
 
@@ -572,4 +570,4 @@ if $for_make_check; then
     type git > /dev/null || (echo "Dashboard uses git to pull dependencies." ; false)
 fi
 
-in_jenkins && echo "CI_DEBUG: End install-deps.sh" || true
+ci_debug "End install-deps.sh" || true

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -395,7 +395,16 @@ else
     debian|ubuntu|devuan|elementary|softiron)
         echo "Using apt-get to install dependencies"
         if [ "$INSTALL_EXTRA_PACKAGES" ]; then
-            $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES
+            if ! $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES ; then
+                # try again. ported over from run-make.sh (orignally e278295)
+                # In the case that apt-get is interrupted, like when a jenkins
+                # job is cancelled, the package manager will be in an inconsistent
+                # state. Run the command again after `dpkg --configure -a` to
+                # bring package manager back into a clean state.
+                $SUDO dpkg --configure -a
+                in_jenkins && echo "CI_DEBUG: trying to install $INSTALL_EXTRA_PACKAGES again"
+                $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES
+            fi
         fi
         $SUDO apt-get install -y devscripts equivs
         $SUDO apt-get install -y dpkg-dev

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -325,6 +325,10 @@ else
 fi
 
 if [ x$(uname)x = xFreeBSDx ]; then
+    if [ "$INSTALL_EXTRA_PACKAGES" ]; then
+        echo "Installing extra packages not supported on FreeBSD" >&2
+        exit 1
+    fi
     $SUDO pkg install -yq \
         devel/babeltrace \
         devel/binutils \
@@ -390,6 +394,9 @@ else
     case "$ID" in
     debian|ubuntu|devuan|elementary|softiron)
         echo "Using apt-get to install dependencies"
+        if [ "$INSTALL_EXTRA_PACKAGES" ]; then
+            $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES
+        fi
         $SUDO apt-get install -y devscripts equivs
         $SUDO apt-get install -y dpkg-dev
         ensure_python3_sphinx_on_ubuntu
@@ -493,6 +500,9 @@ EOF
                 fi
                 ;;
         esac
+        if [ "$INSTALL_EXTRA_PACKAGES" ]; then
+            $SUDO dnf install -y $INSTALL_EXTRA_PACKAGES
+        fi
         munge_ceph_spec_in $with_seastar $with_zbd $for_make_check $DIR/ceph.spec
         # for python3_pkgversion macro defined by python-srpm-macros, which is required by python3-devel
         $SUDO dnf install -y python3-devel
@@ -516,6 +526,9 @@ EOF
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install systemd-rpm-macros rpm-build || exit 1
+        if [ "$INSTALL_EXTRA_PACKAGES" ]; then
+            $SUDO $zypp_install $INSTALL_EXTRA_PACKAGES
+        fi
         munge_ceph_spec_in $with_seastar false $for_make_check $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -33,11 +33,13 @@ function run() {
     # increase the aio-max-nr, which is by default 65536. we could reach this
     # limit while running seastar tests and bluestore tests.
     local m=16
-    if [ $(nproc) -gt $m ]; then
-        m=$(nproc)
+    local procs="$(($(get_processors) * 2))"
+    if [ "${procs}" -gt $m ]; then
+        m="${procs}"
     fi
-    if [ "$(/sbin/sysctl -n fs.aio-max-nr )" -lt "$((65536 * $(nproc)))" ]; then
-        $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr=$((65536 * $(nproc)))
+    local aiomax="$((65536 * procs))"
+    if [ "$(/sbin/sysctl -n fs.aio-max-nr )" -lt "${aiomax}" ]; then
+        $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr="${aiomax}"
     fi
 
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -22,10 +22,6 @@ source src/script/run-make.sh
 
 set -e
 
-function in_jenkins() {
-    test -n "$JENKINS_HOME"
-}
-
 function run() {
     # to prevent OSD EMFILE death on tests, make sure ulimit >= 1024
     $DRY_RUN ulimit -n $(ulimit -Hn)
@@ -40,7 +36,9 @@ function run() {
     if [ $(nproc) -gt $m ]; then
         m=$(nproc)
     fi
-    $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr=$((65536 * $(nproc)))
+    if [ "$(/sbin/sysctl -n fs.aio-max-nr )" -lt "$((65536 * $(nproc)))" ]; then
+        $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr=$((65536 * $(nproc)))
+    fi
 
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     if in_jenkins; then
@@ -71,43 +69,13 @@ function main() {
     fi
     # uses run-make.sh to install-deps
     FOR_MAKE_CHECK=1 prepare
-    local cxx_compiler=g++
-    local c_compiler=gcc
-    for i in $(seq 14 -1 10); do
-        if type -t clang-$i > /dev/null; then
-            cxx_compiler="clang++-$i"
-            c_compiler="clang-$i"
-            break
-        fi
-    done
-    # Init defaults after deps are installed.
-    local cmake_opts
-    cmake_opts+=" -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler"
-    cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=-Werror"
-    cmake_opts+=" -DENABLE_GIT_VERSION=OFF"
-    cmake_opts+=" -DWITH_GTEST_PARALLEL=ON"
-    cmake_opts+=" -DWITH_FIO=ON"
-    cmake_opts+=" -DWITH_CEPHFS_SHELL=ON"
-    cmake_opts+=" -DWITH_GRAFANA=ON"
-    cmake_opts+=" -DWITH_SPDK=ON"
-    cmake_opts+=" -DWITH_RBD_MIRROR=ON"
-    if [ $WITH_SEASTAR ]; then
-        cmake_opts+=" -DWITH_SEASTAR=ON"
-    fi
-    if [ $WITH_ZBD ]; then
-        cmake_opts+=" -DWITH_ZBD=ON"
-    fi
-    if [ $WITH_RBD_RWL ]; then
-        cmake_opts+=" -DWITH_RBD_RWL=ON"
-    fi
-    cmake_opts+=" -DWITH_RBD_SSD_CACHE=ON"
-    in_jenkins && echo "CI_DEBUG: Our cmake_opts are: $cmake_opts
-                        CI_DEBUG: Running ./configure"
-    configure "$cmake_opts" "$@"
+    configure "$@"
     in_jenkins && echo "CI_DEBUG: Running 'build tests'"
     build tests
     echo "make check: successful build on $(git rev-parse HEAD)"
     FOR_MAKE_CHECK=1 run
 }
 
-main "$@"
+if [ "$0" = "$BASH_SOURCE" ]; then
+    main "$@"
+fi

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -71,6 +71,15 @@ function discover_compiler() {
             break
         fi
     done
+    # but if this is {centos,rhel} we need gcc-toolset
+    if [ -f "/opt/rh/gcc-toolset-11/enable" ]; then
+        ci_debug "Detected SCL gcc-toolset-11 environment file"
+        compiler_env="/opt/rh/gcc-toolset-11/enable"
+        # shellcheck disable=SC1090
+        cxx_compiler="$(. ${compiler_env} && command -v g++)"
+        # shellcheck disable=SC1090
+        c_compiler="$(. ${compiler_env} && command -v gcc)"
+    fi
 
     export discovered_c_compiler="${c_compiler}"
     export discovered_cxx_compiler="${cxx_compiler}"

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# lib-build.sh - A library of build and test bash shell functions.
+#
+# There should be few, or none, globals in this file beyond function
+# definitions.
+#
+# This script should be `shellcheck`ed. Please run shellcheck when
+# making changes to this script and use ignore comments
+# (ref: https://www.shellcheck.net/wiki/Ignore ) to explicitly mark
+# where a line is intentionally ignoring a typical rule.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+
+# The following global only exists to help detect if lib-build has already been
+# sourced. This is only needed because the scripts that are being migrated are
+# often sourcing (as opposed to exec'ing one another).
+# shellcheck disable=SC2034
+_SOURCED_LIB_BUILD=1
+
+function in_jenkins() {
+    [ -n "$JENKINS_HOME" ]
+}

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -25,3 +25,9 @@ _SOURCED_LIB_BUILD=1
 function in_jenkins() {
     [ -n "$JENKINS_HOME" ]
 }
+
+function ci_debug() {
+    if in_jenkins || [ "${FORCE_CI_DEBUG}" ]; then
+        echo "CI_DEBUG: $*"
+    fi
+}

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -48,3 +48,32 @@ function get_processors() {
         fi
     fi
 }
+
+# discover_compiler takes one argument, purpose, which may be used
+# to adjust the results for a specific need. It sets three environment
+# variables `discovered_c_compiler`, `discovered_cxx_compiler` and
+# `discovered_compiler_env`. The `discovered_compiler_env` variable
+# may be blank. If not, it will contain a file that needs to be sourced
+# prior to using the compiler.
+function discover_compiler() {
+    # nb: currently purpose is not used for detection
+    local purpose="$1"
+    ci_debug "Finding compiler for ${purpose}"
+
+    local compiler_env=""
+    local cxx_compiler=g++
+    local c_compiler=gcc
+    # ubuntu/debian ci builds prefer clang
+    for i in {14..10}; do
+        if type -t "clang-$i" > /dev/null; then
+            cxx_compiler="clang++-$i"
+            c_compiler="clang-$i"
+            break
+        fi
+    done
+
+    export discovered_c_compiler="${c_compiler}"
+    export discovered_cxx_compiler="${cxx_compiler}"
+    export discovered_compiler_env="${compiler_env}"
+    return 0
+}

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -31,3 +31,20 @@ function ci_debug() {
         echo "CI_DEBUG: $*"
     fi
 }
+
+# get_processors returns 1/2 the value of the value returned by
+# the nproc program OR the value of the environment variable NPROC
+# allowing the user to tune the number of cores visible to the
+# build scripts.
+function get_processors() {
+    # get_processors() depends on coreutils nproc.
+    if [ -n "$NPROC" ]; then
+        echo "$NPROC"
+    else
+        if [ "$(nproc)" -ge 2 ]; then
+            echo "$(($(nproc) / 2))"
+        else
+            echo 1
+        fi
+    fi
+}

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -92,6 +92,10 @@ EOM
     if ! discover_compiler ci-build ; then
         ci_debug "Failed to discover a compiler"
     fi
+    if [ "${discovered_compiler_env}" ]; then
+        ci_debug "Enabling compiler environment file: ${discovered_compiler_env}"
+        . "${discovered_compiler_env}"
+    fi
     local cxx_compiler="${discovered_cxx_compiler}"
     local c_compiler="${discovered_c_compiler}"
     local cmake_opts

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -89,15 +89,11 @@ EOM
     fi
     $DRY_RUN ccache -sz # Reset the ccache statistics and show the current configuration
 
-    local cxx_compiler=g++
-    local c_compiler=gcc
-    for i in $(seq 14 -1 10); do
-        if type -t clang-$i > /dev/null; then
-            cxx_compiler="clang++-$i"
-            c_compiler="clang-$i"
-            break
-        fi
-    done
+    if ! discover_compiler ci-build ; then
+        ci_debug "Failed to discover a compiler"
+    fi
+    local cxx_compiler="${discovered_cxx_compiler}"
+    local c_compiler="${discovered_c_compiler}"
     local cmake_opts
     cmake_opts+=" -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler"
     cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=-Werror"

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -195,7 +195,11 @@ function build() {
     if test -n "$targets"; then
         targets="--target $targets"
     fi
-    $DRY_RUN cd build
+    local bdir=build
+    if [ "$BUILD_DIR" ]; then
+        bdir="$BUILD_DIR"
+    fi
+    $DRY_RUN cd "${bdir}"
     BUILD_MAKEOPTS=${BUILD_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     test "$BUILD_MAKEOPTS" && echo "make will run with option(s) $BUILD_MAKEOPTS"
     # older cmake does not support --parallel or -j, so pass it to underlying generator

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -68,7 +68,7 @@ function prepare() {
     fi
 
     if test -f ./install-deps.sh ; then
-        in_jenkins && echo "CI_DEBUG: Running install-deps.sh"
+        ci_debug "Running install-deps.sh"
         INSTALL_EXTRA_PACKAGES="ccache git $which_pkg clang"
         $DRY_RUN source ./install-deps.sh || return 1
         trap clean_up_after_myself EXIT
@@ -134,9 +134,9 @@ EOM
 
     cmake_opts+=$(detect_ceph_dev_pkgs)
 
-    in_jenkins && echo "CI_DEBUG: Our cmake_opts are: $cmake_opts
-                        CI_DEBUG: Running ./configure"
-    in_jenkins && echo "CI_DEBUG: Running do_cmake.sh"
+    ci_debug "Our cmake_opts are: $cmake_opts"
+    ci_debug "Running ./configure"
+    ci_debug "Running do_cmake.sh"
 
     $DRY_RUN ./do_cmake.sh $cmake_opts $@ || return 1
 }
@@ -154,7 +154,7 @@ function build() {
     BUILD_MAKEOPTS=${BUILD_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     test "$BUILD_MAKEOPTS" && echo "make will run with option(s) $BUILD_MAKEOPTS"
     # older cmake does not support --parallel or -j, so pass it to underlying generator
-    in_jenkins && echo "CI_DEBUG: Running cmake"
+    ci_debug "Running cmake"
     $DRY_RUN cmake --build . $targets -- $BUILD_MAKEOPTS || return 1
     $DRY_RUN ccache -s # print the ccache statistics to evaluate the efficiency
 }

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -2,14 +2,17 @@
 
 set -e
 
+if ! [ "${_SOURCED_LIB_BUILD}" = 1 ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    CEPH_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+    . "${CEPH_ROOT}/src/script/lib-build.sh" || exit 2
+fi
+
+
 trap clean_up_after_myself EXIT
 
 ORIGINAL_CCACHE_CONF="$HOME/.ccache/ccache.conf"
 SAVED_CCACHE_CONF="$HOME/.run-make-check-saved-ccache-conf"
-
-function in_jenkins() {
-    test -n "$JENKINS_HOME"
-}
 
 function save_ccache_conf() {
     test -f $ORIGINAL_CCACHE_CONF && cp $ORIGINAL_CCACHE_CONF $SAVED_CCACHE_CONF || true

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -67,7 +67,11 @@ function do_install() {
     pkgs=$@
     shift
     ret=0
-    $DRY_RUN sudo $install_cmd $pkgs || ret=$?
+    SUDO=""
+    if [ "$EUID" -ne 0 ]; then
+        SUDO="sudo"
+    fi
+    $DRY_RUN $SUDO $install_cmd $pkgs || ret=$?
     if test $ret -eq 0 ; then
         return
     fi
@@ -75,9 +79,9 @@ function do_install() {
     if [[ $install_cmd == *"apt-get"* ]]; then
         if test $ret -eq 100 ; then
             # dpkg was interrupted
-            $DRY_RUN sudo dpkg --configure -a
-            in_jenkins && echo "CI_DEBUG: Running 'sudo $install_cmd $pkgs'"
-            $DRY_RUN sudo $install_cmd $pkgs
+            $DRY_RUN $SUDO dpkg --configure -a
+            in_jenkins && echo "CI_DEBUG: Running '$SUDO $install_cmd $pkgs'"
+            $DRY_RUN $SUDO $install_cmd $pkgs
         else
             return $ret
         fi
@@ -88,11 +92,7 @@ function prepare() {
     local which_pkg="which"
     source /etc/os-release
     if test -f /etc/redhat-release ; then
-        if ! type bc > /dev/null 2>&1 ; then
-            echo "Please install bc and re-run." 
-            exit 1
-        fi
-        if test "$(echo "$VERSION_ID >= 22" | bc)" -ne 0; then
+        if [ "$VERSION_ID" -ge "22" ]; then
             install_cmd="dnf -y install"
         else
             install_cmd="yum install -y"
@@ -104,14 +104,14 @@ function prepare() {
         which_pkg="debianutils"
     fi
 
-    if ! type sudo > /dev/null 2>&1 ; then
+    if [ "$EUID" -ne 0 ] && ! type sudo > /dev/null 2>&1 ; then
         echo "Please install sudo and re-run. This script assumes it is running"
-        echo "as a normal user with the ability to run commands as root via sudo." 
+        echo "as a normal user with the ability to run commands as root via sudo."
         exit 1
     fi
     if [ -n "$install_cmd" ]; then
         in_jenkins && echo "CI_DEBUG: Running '$install_cmd ccache $which_pkg clang'"
-        do_install "$install_cmd" ccache $which_pkg clang
+        do_install "$install_cmd" ccache git $which_pkg clang
     else
         echo "WARNING: Don't know how to install packages" >&2
         echo "This probably means distribution $ID is not supported by run-make-check.sh" >&2
@@ -127,7 +127,9 @@ function prepare() {
         $DRY_RUN source ./install-deps.sh || return 1
         trap clean_up_after_myself EXIT
     fi
+}
 
+function configure() {
     cat <<EOM
 Note that the binaries produced by this script do not contain correct time
 and git version information, which may make them unsuitable for debugging
@@ -148,12 +150,44 @@ EOM
         ccache -p | grep max_size
     fi
     $DRY_RUN ccache -sz # Reset the ccache statistics and show the current configuration
-}
 
-function configure() {
-    local cmake_build_opts=$(detect_ceph_dev_pkgs)
+    local cxx_compiler=g++
+    local c_compiler=gcc
+    for i in $(seq 14 -1 10); do
+        if type -t clang-$i > /dev/null; then
+            cxx_compiler="clang++-$i"
+            c_compiler="clang-$i"
+            break
+        fi
+    done
+    local cmake_opts
+    cmake_opts+=" -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler"
+    cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=-Werror"
+    cmake_opts+=" -DENABLE_GIT_VERSION=OFF"
+    cmake_opts+=" -DWITH_GTEST_PARALLEL=ON"
+    cmake_opts+=" -DWITH_FIO=ON"
+    cmake_opts+=" -DWITH_CEPHFS_SHELL=ON"
+    cmake_opts+=" -DWITH_GRAFANA=ON"
+    cmake_opts+=" -DWITH_SPDK=ON"
+    cmake_opts+=" -DWITH_RBD_MIRROR=ON"
+    if [ $WITH_SEASTAR ]; then
+        cmake_opts+=" -DWITH_SEASTAR=ON"
+    fi
+    if [ $WITH_ZBD ]; then
+        cmake_opts+=" -DWITH_ZBD=ON"
+    fi
+    if [ $WITH_RBD_RWL ]; then
+        cmake_opts+=" -DWITH_RBD_RWL=ON"
+    fi
+    cmake_opts+=" -DWITH_RBD_SSD_CACHE=ON"
+
+    cmake_opts+=$(detect_ceph_dev_pkgs)
+
+    in_jenkins && echo "CI_DEBUG: Our cmake_opts are: $cmake_opts
+                        CI_DEBUG: Running ./configure"
     in_jenkins && echo "CI_DEBUG: Running do_cmake.sh"
-    $DRY_RUN ./do_cmake.sh $cmake_build_opts $@ || return 1
+
+    $DRY_RUN ./do_cmake.sh $cmake_opts $@ || return 1
 }
 
 function build() {

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -27,19 +27,6 @@ function clean_up_after_myself() {
     restore_ccache_conf
 }
 
-function get_processors() {
-    # get_processors() depends on coreutils nproc.
-    if test -n "$NPROC" ; then
-        echo $NPROC
-    else
-        if test $(nproc) -ge 2 ; then
-            expr $(nproc) / 2
-        else
-            echo 1
-        fi
-    fi
-}
-
 function detect_ceph_dev_pkgs() {
     local cmake_opts="-DWITH_FMT_VERSION=9.0.0"
     local boost_root=/opt/ceph


### PR DESCRIPTION
The first patch is directly from @epuertat original patch, but just the shell script parts.

The remainder is a bunch of small things that I found while working on running the build and test scripts within a centos8 container. Some of them fix actual blockers to running in the container. Others are there to try and slightly clean up, reorganise, and de-duplicate parts of the scripts.

In particular, I'm adding a new src/script/lib-build.sh to share some common bits and parts of the current scripts pulled into new functions.  Beyond getting some things to work in the centos 8 container environment there should be no externally visible behavior changes to the existing scripts.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
