### PR TITLE
ceph-volume: fix a bug in get_all_devices_vgs()

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -794,7 +794,7 @@ def get_all_devices_vgs(name_prefix=''):
         verbose_on_failure=False
     )
     vgs = _output_parser(stdout, vg_fields)
-    return [VolumeGroup(**vg) for vg in vgs]
+    return [VolumeGroup(**vg) for vg in vgs if vg['vg_name']]
 
 #################################
 #


### PR DESCRIPTION
When a physical volume isn't a member of any volume group, the function `get_all_devices_vgs()` in `ceph_volume.api.lvm` shouldn't try to return an `VolumeGroup()` object against this device.

Fixes: https://tracker.ceph.com/issues/57918

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
