### PR TITLE
osd: Reset mClock's OSD capacity config option for inactive device type

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -102,9 +102,11 @@ void mClockScheduler::set_max_osd_capacity()
   if (is_rotational) {
     max_osd_capacity =
       cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_hdd");
+    cct->_conf.set_val("osd_mclock_max_capacity_iops_ssd", "0");
   } else {
     max_osd_capacity =
       cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_ssd");
+    cct->_conf.set_val("osd_mclock_max_capacity_iops_hdd", "0");
   }
   // Set per op-shard iops limit
   max_osd_capacity /= num_shards;


### PR DESCRIPTION
Depending on the underlying device type of an OSD, the mClock's OSD capacity option of either osd_mclock_max_capacity_iops_hdd or osd_mclock_max_capacity_iops_ssd is set during OSD boot-up. Both the options have built-in defaults set. Therefore, when displaying the running configuration of an OSD, both the values would be displayed with non-zero values which could confuse/mislead a user.

To address this, override the inactive device type's capacity for the OSD to '0'.

For e.g., with this change, if the underlying device type for an OSD is an ssd, the cli displays the running configuration of osd_mclock_max_capacity_iops_hdd for that OSD as '0' instead of its default value.

Fixes: https://tracker.ceph.com/issues/57963
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
