### PR TITLE
rgw: pass RGWProcessEnv into process_request()

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -124,7 +124,6 @@ class RadosStore : public StoreDriver {
   private:
     RGWRados* rados;
     RGWUserCtl* user_ctl;
-    std::string luarocks_path;
     std::unique_ptr<RadosZone> zone;
 
   public:
@@ -241,13 +240,6 @@ class RadosStore : public StoreDriver {
 
     virtual CephContext* ctx(void) override { return rados->ctx(); }
 
-    virtual const std::string& get_luarocks_path() const override {
-      return luarocks_path;
-    }
-
-    virtual void set_luarocks_path(const std::string& path) override {
-      luarocks_path = path;
-    }
     virtual void register_admin_apis(RGWRESTMgr* mgr) override;
 
     /* Unique to RadosStore */

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -390,8 +390,6 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
    * the dynamic reconfiguration. */
   implicit_tenant_context.reset(new rgw::auth::ImplicitTenants{g_conf()});
   g_conf().add_observer(implicit_tenant_context.get());
-  auto auth_registry =
-    rgw::auth::StrategyRegistry::create(dpp->get_cct(), *implicit_tenant_context, env.driver);
 
   /* allocate a mime table (you'd never guess that from the name) */
   rgw_tools_init(dpp, dpp->get_cct());
@@ -406,7 +404,8 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
   // initialize RGWProcessEnv
   env.rest = &rest;
   env.olog = olog;
-  env.auth_registry = auth_registry;
+  env.auth_registry = rgw::auth::StrategyRegistry::create(
+      dpp->get_cct(), *implicit_tenant_context, env.driver);
   env.ratelimiting = ratelimiter.get();
   env.lua_background = lua_background.get();
 

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -416,12 +416,10 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
     RGWFrontend* fe = nullptr;
 
     if (framework == "loadgen") {
-      int port;
-      config->get_val("port", 80, &port);
       std::string uri_prefix;
       config->get_val("prefix", "", &uri_prefix);
 
-      RGWProcessEnv env = {driver, &rest, olog, port, uri_prefix,
+      RGWProcessEnv env = {driver, &rest, olog, uri_prefix,
 	    auth_registry, ratelimiter.get(), lua_background.get()};
 
       fe = new RGWLoadGenFrontend(env, config);
@@ -431,13 +429,12 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       config->get_val("port", 80, &port);
       std::string uri_prefix;
       config->get_val("prefix", "", &uri_prefix);
-      RGWProcessEnv env{driver, &rest, olog, port, uri_prefix,
+      RGWProcessEnv env{driver, &rest, olog, uri_prefix,
 	    auth_registry, ratelimiter.get(), lua_background.get()};
       fe = new RGWAsioFrontend(env, config, *(sched_ctx.get()));
     }
     else if (framework == "rgw-nfs") {
-      int port = 80;
-      RGWProcessEnv env = { driver, &rest, olog, port };
+      RGWProcessEnv env = { driver, &rest, olog };
       fe = new RGWLibFrontend(env, config);
       if (rgwlib) {
         rgwlib->set_fe(static_cast<RGWLibFrontend*>(fe));

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -469,13 +469,14 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
   if (env.driver->get_name() == "rados") {
     // add a watcher to respond to realm configuration changes
     pusher = std::make_unique<RGWPeriodPusher>(dpp, env.driver, null_yield);
-    fe_pauser = std::make_unique<RGWFrontendPauser>(fes, *(implicit_tenant_context.get()), pusher.get());
+    fe_pauser = std::make_unique<RGWFrontendPauser>(fes, pusher.get());
     rgw_pauser = std::make_unique<RGWPauser>();
     rgw_pauser->add_pauser(fe_pauser.get());
     if (lua_background) {
       rgw_pauser->add_pauser(lua_background.get());
     }
-    reloader = std::make_unique<RGWRealmReloader>(env, service_map_meta, rgw_pauser.get());
+    reloader = std::make_unique<RGWRealmReloader>(
+        env, *implicit_tenant_context, service_map_meta, rgw_pauser.get());
     realm_watcher = std::make_unique<RGWRealmWatcher>(dpp, g_ceph_context,
 				  static_cast<rgw::sal::RadosStore*>(env.driver)->svc()->zone->get_realm());
     realm_watcher->add_watcher(RGWRealmNotify::Reload, *reloader);

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -408,6 +408,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       dpp->get_cct(), *implicit_tenant_context, env.driver);
   env.ratelimiting = ratelimiter.get();
   env.lua_background = lua_background.get();
+  env.lua_manager = env.driver->get_lua_manager();
 
   int fe_count = 0;
   for (multimap<string, RGWFrontendConfig *>::iterator fiter = fe_map.begin();

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -416,10 +416,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
     RGWFrontend* fe = nullptr;
 
     if (framework == "loadgen") {
-      std::string uri_prefix;
-      config->get_val("prefix", "", &uri_prefix);
-
-      RGWProcessEnv env = {driver, &rest, olog, uri_prefix,
+      RGWProcessEnv env = {driver, &rest, olog,
 	    auth_registry, ratelimiter.get(), lua_background.get()};
 
       fe = new RGWLoadGenFrontend(env, config);
@@ -427,9 +424,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
     else if (framework == "beast") {
       int port;
       config->get_val("port", 80, &port);
-      std::string uri_prefix;
-      config->get_val("prefix", "", &uri_prefix);
-      RGWProcessEnv env{driver, &rest, olog, uri_prefix,
+      RGWProcessEnv env{driver, &rest, olog,
 	    auth_registry, ratelimiter.get(), lua_background.get()};
       fe = new RGWAsioFrontend(env, config, *(sched_ctx.get()));
     }

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -450,7 +450,7 @@ class AsioFrontend {
   void stop();
   void join();
   void pause();
-  void unpause(rgw::sal::Driver* driver, rgw_auth_registry_ptr_t);
+  void unpause();
 };
 
 unsigned short parse_port(const char *input, boost::system::error_code& ec)
@@ -1118,12 +1118,9 @@ void AsioFrontend::pause()
   }
 }
 
-void AsioFrontend::unpause(rgw::sal::Driver* const driver,
-                           rgw_auth_registry_ptr_t auth_registry)
+void AsioFrontend::unpause()
 {
-  env.driver = driver;
-  env.auth_registry = std::move(auth_registry);
-  lua_manager = driver->get_lua_manager();
+  lua_manager = env.driver->get_lua_manager();
 
   // unpause to unblock connections
   pause_mutex.unlock();
@@ -1182,9 +1179,7 @@ void RGWAsioFrontend::pause_for_new_config()
   impl->pause();
 }
 
-void RGWAsioFrontend::unpause_with_new_config(
-  rgw::sal::Driver* const driver,
-  rgw_auth_registry_ptr_t auth_registry
-) {
-  impl->unpause(driver, std::move(auth_registry));
+void RGWAsioFrontend::unpause_with_new_config()
+{
+  impl->unpause();
 }

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -270,13 +270,8 @@ void handle_connection(boost::asio::io_context& context,
       string user = "-";
       const auto started = ceph::coarse_real_clock::now();
       ceph::coarse_real_clock::duration latency{};
-      process_request(env.driver, env.rest, &req, uri_prefix,
-                      *env.auth_registry, &client, env.olog, y,
-                      scheduler, &user, &latency,
-                      env.ratelimiting->get_active(),
-                      env.lua_background,
-                      env.lua_manager,
-                      &http_ret);
+      process_request(env, &req, uri_prefix, &client, y,
+                      scheduler, &user, &latency, &http_ret);
 
       if (cct->_conf->subsys.should_gather(ceph_subsys_rgw_access, 1)) {
         // access log line elements begin per Apache Combined Log Format with additions following

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -375,7 +375,7 @@ class ConnectionList {
 
 namespace dmc = rgw::dmclock;
 class AsioFrontend {
-  RGWProcessEnv env;
+  RGWProcessEnv& env;
   RGWFrontendConfig* conf;
   boost::asio::io_context context;
   std::string uri_prefix;
@@ -421,7 +421,7 @@ class AsioFrontend {
   void accept(Listener& listener, boost::system::error_code ec);
 
  public:
-  AsioFrontend(const RGWProcessEnv& env, RGWFrontendConfig* conf,
+  AsioFrontend(RGWProcessEnv& env, RGWFrontendConfig* conf,
 	       dmc::SchedulerCtx& sched_ctx)
     : env(env), conf(conf), pause_mutex(context.get_executor()),
     lua_manager(env.driver->get_lua_manager())
@@ -1143,12 +1143,12 @@ void AsioFrontend::unpause(rgw::sal::Driver* const driver,
 
 class RGWAsioFrontend::Impl : public AsioFrontend {
  public:
-  Impl(const RGWProcessEnv& env, RGWFrontendConfig* conf,
+  Impl(RGWProcessEnv& env, RGWFrontendConfig* conf,
        rgw::dmclock::SchedulerCtx& sched_ctx)
     : AsioFrontend(env, conf, sched_ctx) {}
 };
 
-RGWAsioFrontend::RGWAsioFrontend(const RGWProcessEnv& env,
+RGWAsioFrontend::RGWAsioFrontend(RGWProcessEnv& env,
                                  RGWFrontendConfig* conf,
 				 rgw::dmclock::SchedulerCtx& sched_ctx)
   : impl(new Impl(env, conf, sched_ctx))

--- a/src/rgw/rgw_asio_frontend.h
+++ b/src/rgw/rgw_asio_frontend.h
@@ -12,7 +12,7 @@ class RGWAsioFrontend : public RGWFrontend {
   class Impl;
   std::unique_ptr<Impl> impl;
 public:
-  RGWAsioFrontend(const RGWProcessEnv& env, RGWFrontendConfig* conf,
+  RGWAsioFrontend(RGWProcessEnv& env, RGWFrontendConfig* conf,
 		  rgw::dmclock::SchedulerCtx& sched_ctx);
   ~RGWAsioFrontend() override;
 

--- a/src/rgw/rgw_asio_frontend.h
+++ b/src/rgw/rgw_asio_frontend.h
@@ -22,8 +22,7 @@ public:
   void join() override;
 
   void pause_for_new_config() override;
-  void unpause_with_new_config(rgw::sal::Driver* driver,
-                               rgw_auth_registry_ptr_t auth_registry) override;
+  void unpause_with_new_config() override;
 };
 
 #endif // RGW_ASIO_FRONTEND_H

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -518,7 +518,7 @@ private:
   };
 public:
   ImplicitTenants(const ConfigProxy& c) { recompute_value(c);}
-  ImplicitTenantValue get_value() {
+  ImplicitTenantValue get_value() const {
     return ImplicitTenantValue(saved);
   }
 private:
@@ -591,7 +591,7 @@ protected:
   const acl_strategy_t extra_acl_strategy;
 
   const AuthInfo info;
-  rgw::auth::ImplicitTenants& implicit_tenant_context;
+  const rgw::auth::ImplicitTenants& implicit_tenant_context;
   const rgw::auth::ImplicitTenants::implicit_tenant_flag_bits implicit_tenant_bit;
 
   virtual void create_account(const DoutPrefixProvider* dpp,
@@ -604,7 +604,7 @@ public:
                 rgw::sal::Driver* driver,
                 acl_strategy_t&& extra_acl_strategy,
                 const AuthInfo& info,
-		rgw::auth::ImplicitTenants& implicit_tenant_context,
+		const rgw::auth::ImplicitTenants& implicit_tenant_context,
                 rgw::auth::ImplicitTenants::implicit_tenant_flag_bits implicit_tenant_bit)
     : cct(cct),
       driver(driver),

--- a/src/rgw/rgw_auth_registry.h
+++ b/src/rgw/rgw_auth_registry.h
@@ -84,11 +84,11 @@ public:
     return sts_strategy;
   }
 
-  static std::shared_ptr<StrategyRegistry>
+  static std::unique_ptr<StrategyRegistry>
   create(CephContext* const cct,
          const ImplicitTenants& implicit_tenant_context,
          rgw::sal::Driver* driver) {
-    return std::make_shared<StrategyRegistry>(cct, implicit_tenant_context, driver);
+    return std::make_unique<StrategyRegistry>(cct, implicit_tenant_context, driver);
   }
 };
 
@@ -96,6 +96,6 @@ public:
 } /* namespace rgw */
 
 using rgw_auth_registry_t = rgw::auth::StrategyRegistry;
-using rgw_auth_registry_ptr_t = std::shared_ptr<rgw_auth_registry_t>;
+using rgw_auth_registry_ptr_t = std::unique_ptr<rgw_auth_registry_t>;
 
 #endif /* CEPH_RGW_AUTH_REGISTRY_H */

--- a/src/rgw/rgw_auth_registry.h
+++ b/src/rgw/rgw_auth_registry.h
@@ -37,7 +37,7 @@ class StrategyRegistry {
     s3_main_strategy_boto2_t s3_main_strategy_boto2;
 
     s3_main_strategy_t(CephContext* const cct,
-		       ImplicitTenants& implicit_tenant_context,
+		       const ImplicitTenants& implicit_tenant_context,
 		       rgw::sal::Driver* driver)
       : s3_main_strategy_plain(cct, implicit_tenant_context, driver),
         s3_main_strategy_boto2(cct, implicit_tenant_context, driver) {
@@ -60,7 +60,7 @@ class StrategyRegistry {
 
 public:
   StrategyRegistry(CephContext* const cct,
-                   ImplicitTenants& implicit_tenant_context,
+                   const ImplicitTenants& implicit_tenant_context,
                    rgw::sal::Driver* driver)
     : s3_main_strategy(cct, implicit_tenant_context, driver),
       s3_post_strategy(cct, implicit_tenant_context, driver),
@@ -86,7 +86,7 @@ public:
 
   static std::shared_ptr<StrategyRegistry>
   create(CephContext* const cct,
-         ImplicitTenants& implicit_tenant_context,
+         const ImplicitTenants& implicit_tenant_context,
          rgw::sal::Driver* driver) {
     return std::make_shared<StrategyRegistry>(cct, implicit_tenant_context, driver);
   }

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -36,7 +36,7 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                         public rgw::auth::RoleApplier::Factory {
   typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;
   rgw::sal::Driver* driver;
-  rgw::auth::ImplicitTenants& implicit_tenant_context;
+  const rgw::auth::ImplicitTenants& implicit_tenant_context;
 
   STSEngine  sts_engine;
 
@@ -74,7 +74,7 @@ class STSAuthStrategy : public rgw::auth::Strategy,
 public:
   STSAuthStrategy(CephContext* const cct,
                        rgw::sal::Driver* driver,
-                       rgw::auth::ImplicitTenants& implicit_tenant_context,
+                       const rgw::auth::ImplicitTenants& implicit_tenant_context,
                        AWSEngine::VersionAbstractor* const ver_abstractor)
     : driver(driver),
       implicit_tenant_context(implicit_tenant_context),
@@ -96,7 +96,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
                              public rgw::auth::RemoteApplier::Factory {
   typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;
   rgw::sal::Driver* driver;
-  rgw::auth::ImplicitTenants& implicit_tenant_context;
+  const rgw::auth::ImplicitTenants& implicit_tenant_context;
 
   using keystone_config_t = rgw::keystone::CephCtxConfig;
   using keystone_cache_t = rgw::keystone::TokenCache;
@@ -121,7 +121,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
 public:
   ExternalAuthStrategy(CephContext* const cct,
                        rgw::sal::Driver* driver,
-                       rgw::auth::ImplicitTenants& implicit_tenant_context,
+                       const rgw::auth::ImplicitTenants& implicit_tenant_context,
                        AWSEngine::VersionAbstractor* const ver_abstractor)
     : driver(driver),
       implicit_tenant_context(implicit_tenant_context),
@@ -219,7 +219,7 @@ public:
   }
 
   AWSAuthStrategy(CephContext* const cct,
-                  rgw::auth::ImplicitTenants& implicit_tenant_context,
+                  const rgw::auth::ImplicitTenants& implicit_tenant_context,
                   rgw::sal::Driver* driver)
     : driver(driver),
       ver_abstractor(cct),

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -269,8 +269,9 @@ void req_info::rebuild_from(req_info& src)
 }
 
 
-req_state::req_state(CephContext* _cct, RGWEnv* e, uint64_t id)
-  : cct(_cct), info(_cct, e), id(id)
+req_state::req_state(CephContext* _cct, const RGWProcessEnv& penv,
+                     RGWEnv* e, uint64_t id)
+  : cct(_cct), penv(penv), info(_cct, e), id(id)
 {
   enable_ops_log = e->get_enable_ops_log();
   enable_usage_log = e->get_enable_usage_log();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1218,9 +1218,6 @@ struct req_state : DoutPrefixProvider {
   //Principal tags that come in as part of AssumeRoleWithWebIdentity
   std::vector<std::pair<std::string, std::string>> principal_tags;
 
-  rgw::lua::Background* lua_background = nullptr;
-  rgw::sal::LuaManager* lua_manager = nullptr;
-
   req_state(CephContext* _cct, const RGWProcessEnv& penv, RGWEnv* e, uint64_t id);
   ~req_state();
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -56,6 +56,8 @@ namespace rgw::lua {
   class Background;
 }
 
+struct RGWProcessEnv;
+
 using ceph::crypto::MD5;
 
 #define RGW_ATTR_PREFIX  "user.rgw."
@@ -1068,6 +1070,7 @@ class RGWObjectCtx;
 /** Store all the state necessary to complete and respond to an HTTP request*/
 struct req_state : DoutPrefixProvider {
   CephContext *cct;
+  const RGWProcessEnv& penv;
   rgw::io::BasicClient *cio{nullptr};
   http_op op{OP_UNKNOWN};
   RGWOpType op_type{};
@@ -1218,7 +1221,7 @@ struct req_state : DoutPrefixProvider {
   rgw::lua::Background* lua_background = nullptr;
   rgw::sal::LuaManager* lua_manager = nullptr;
 
-  req_state(CephContext* _cct, RGWEnv* e, uint64_t id);
+  req_state(CephContext* _cct, const RGWProcessEnv& penv, RGWEnv* e, uint64_t id);
   ~req_state();
 
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1659,10 +1659,12 @@ namespace rgw {
 	return -EIO;
       }
 
+      const RGWProcessEnv& penv = g_rgwlib->get_fe()->get_process()->get_env();
+
       /* start */
       std::string object_name = relative_object_name();
       f->write_req =
-	new RGWWriteRequest(g_rgwlib->get_driver(),
+	new RGWWriteRequest(g_rgwlib->get_driver(), penv,
 			    g_rgwlib->get_driver()->get_user(fs->get_user()->user_id),
 			    this, bucket_name(), object_name);
       rc = g_rgwlib->get_fe()->start_req(f->write_req);

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2489,11 +2489,11 @@ public:
   size_t bytes_written;
   bool eio;
 
-  RGWWriteRequest(rgw::sal::Driver* driver,
+  RGWWriteRequest(rgw::sal::Driver* driver, const RGWProcessEnv& penv,
 		  std::unique_ptr<rgw::sal::User> _user,
 		  RGWFileHandle* _fh, const std::string& _bname,
 		  const std::string& _oname)
-    : RGWLibContinuedReq(driver->ctx(), std::move(_user)),
+    : RGWLibContinuedReq(driver->ctx(), penv, std::move(_user)),
       bucket_name(_bname), obj_name(_oname),
       rgw_fh(_fh), filter(nullptr), timer_id(0), real_ofs(0),
       bytes_written(0), eio(false) {

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -92,7 +92,7 @@ class RGWProcessFrontend : public RGWFrontend {
 protected:
   RGWFrontendConfig* conf;
   RGWProcess* pprocess;
-  RGWProcessEnv env;
+  RGWProcessEnv& env;
   RGWProcessControlThread* thread;
 
 public:
@@ -156,7 +156,7 @@ public:
     conf->get_val("prefix", "", &uri_prefix);
 
     RGWLoadGenProcess *pp = new RGWLoadGenProcess(
-        g_ceph_context, &env, num_threads, std::move(uri_prefix), conf);
+        g_ceph_context, env, num_threads, std::move(uri_prefix), conf);
 
     pprocess = pp;
 

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -12,6 +12,7 @@
 
 #include "rgw_request.h"
 #include "rgw_process.h"
+#include "rgw_process_env.h"
 #include "rgw_realm_reloader.h"
 
 #include "rgw_auth_registry.h"

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -152,8 +152,11 @@ public:
   int init() override {
     int num_threads;
     conf->get_val("num_threads", g_conf()->rgw_thread_pool_size, &num_threads);
-    RGWLoadGenProcess *pp = new RGWLoadGenProcess(g_ceph_context, &env,
-						  num_threads, conf);
+    std::string uri_prefix;
+    conf->get_val("prefix", "", &uri_prefix);
+
+    RGWLoadGenProcess *pp = new RGWLoadGenProcess(
+        g_ceph_context, &env, num_threads, std::move(uri_prefix), conf);
 
     pprocess = pp;
 

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -449,8 +449,9 @@ namespace rgw {
 
   int RGWLibFrontend::init()
   {
+    std::string uri_prefix; // empty
     pprocess = new RGWLibProcess(g_ceph_context, &env,
-				 g_conf()->rgw_thread_pool_size, conf);
+				 g_conf()->rgw_thread_pool_size, uri_prefix, conf);
     return 0;
   }
 

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -204,7 +204,7 @@ namespace rgw {
     rgw_env.set("HTTP_HOST", "");
 
     /* XXX and -then- bloat up req_state with string copies from it */
-    req_state rstate(req->cct, &rgw_env, req->id);
+    req_state rstate(req->cct, env, &rgw_env, req->id);
     req_state *s = &rstate;
 
     // XXX fix this

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -211,7 +211,7 @@ namespace rgw {
     s->cio = io;
 
     /* XXX and -then- stash req_state pointers everywhere they are needed */
-    ret = req->init(rgw_env, driver, io, s);
+    ret = req->init(rgw_env, env.driver, io, s);
     if (ret < 0) {
       ldpp_dout(op, 10) << "failed to initialize request" << dendl;
       abort_req(s, op, ret);
@@ -307,7 +307,7 @@ namespace rgw {
               << e.what() << dendl;
     }
     if (should_log) {
-      rgw_log_op(nullptr /* !rest */, s, op, olog);
+      rgw_log_op(nullptr /* !rest */, s, op, env.olog);
     }
 
     int http_ret = s->err.http_ret;
@@ -347,7 +347,7 @@ namespace rgw {
 
     rgw_env.set("HTTP_HOST", "");
 
-    int ret = req->init(rgw_env, driver, &io_ctx, s);
+    int ret = req->init(rgw_env, env.driver, &io_ctx, s);
     if (ret < 0) {
       ldpp_dout(op, 10) << "failed to initialize request" << dendl;
       abort_req(s, op, ret);
@@ -450,7 +450,7 @@ namespace rgw {
   int RGWLibFrontend::init()
   {
     std::string uri_prefix; // empty
-    pprocess = new RGWLibProcess(g_ceph_context, &env,
+    pprocess = new RGWLibProcess(g_ceph_context, env,
 				 g_conf()->rgw_thread_pool_size, uri_prefix, conf);
     return 0;
   }

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -180,10 +180,10 @@ namespace rgw {
     req_state rstate;
   public:
 
-    RGWLibContinuedReq(CephContext* _cct,
+    RGWLibContinuedReq(CephContext* _cct, const RGWProcessEnv& penv,
 		       std::unique_ptr<rgw::sal::User> _user)
       :  RGWLibRequest(_cct, std::move(_user)), io_ctx(),
-	 rstate(_cct, &io_ctx.get_env(), id)
+	 rstate(_cct, penv, &io_ctx.get_env(), id)
       {
 	io_ctx.init(_cct);
 

--- a/src/rgw/rgw_lib_frontend.h
+++ b/src/rgw/rgw_lib_frontend.h
@@ -25,7 +25,7 @@ namespace rgw {
     using unique_lock = std::unique_lock<std::mutex>;
 
   public:
-    RGWLibProcess(CephContext* cct, RGWProcessEnv* pe, int num_threads,
+    RGWLibProcess(CephContext* cct, RGWProcessEnv& pe, int num_threads,
 		  std::string uri_prefix, RGWFrontendConfig* _conf) :
       RGWProcess(cct, pe, num_threads, std::move(uri_prefix), _conf),
       gen(0), shutdown(false) {}

--- a/src/rgw/rgw_lib_frontend.h
+++ b/src/rgw/rgw_lib_frontend.h
@@ -26,8 +26,9 @@ namespace rgw {
 
   public:
     RGWLibProcess(CephContext* cct, RGWProcessEnv* pe, int num_threads,
-		  RGWFrontendConfig* _conf) :
-      RGWProcess(cct, pe, num_threads, _conf), gen(0), shutdown(false) {}
+		  std::string uri_prefix, RGWFrontendConfig* _conf) :
+      RGWProcess(cct, pe, num_threads, std::move(uri_prefix), _conf),
+      gen(0), shutdown(false) {}
 
     void run() override;
     void checkpoint();

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -138,7 +138,7 @@ void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest
                             null_yield, nullptr, nullptr, nullptr,
                             ratelimit.get_active(),
                             nullptr,
-                            lua_manager);
+                            env.lua_manager);
   if (ret < 0) {
     /* we don't really care about return code */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -132,13 +132,8 @@ void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest
 
   RGWLoadGenIO real_client_io(&renv);
   RGWRestfulIO client_io(cct, &real_client_io);
-  ActiveRateLimiter ratelimit(cct);
-  int ret = process_request(env.driver, env.rest, req, uri_prefix,
-                            *env.auth_registry, &client_io, env.olog,
-                            null_yield, nullptr, nullptr, nullptr,
-                            ratelimit.get_active(),
-                            nullptr,
-                            env.lua_manager);
+  int ret = process_request(env, req, uri_prefix, &client_io,
+                            null_yield, nullptr, nullptr, nullptr);
   if (ret < 0) {
     /* we don't really care about return code */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -107,7 +107,7 @@ void RGWLoadGenProcess::gen_request(const string& method,
 				    int content_length, std::atomic<bool>* fail_flag)
 {
   RGWLoadGenRequest* req =
-    new RGWLoadGenRequest(driver->get_new_req_id(), method, resource,
+    new RGWLoadGenRequest(env.driver->get_new_req_id(), method, resource,
 			  content_length, fail_flag);
   dout(10) << "allocated request req=" << hex << req << dec << dendl;
   req_throttle.get(1);
@@ -118,23 +118,23 @@ void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest
 {
   RGWLoadGenRequest* req = static_cast<RGWLoadGenRequest*>(r);
 
-  RGWLoadGenRequestEnv env;
+  RGWLoadGenRequestEnv renv;
 
   utime_t tm = ceph_clock_now();
 
-  env.port = 80;
-  env.content_length = req->content_length;
-  env.content_type = "binary/octet-stream";
-  env.request_method = req->method;
-  env.uri = req->resource;
-  env.set_date(tm);
-  env.sign(dpp, access_key);
+  renv.port = 80;
+  renv.content_length = req->content_length;
+  renv.content_type = "binary/octet-stream";
+  renv.request_method = req->method;
+  renv.uri = req->resource;
+  renv.set_date(tm);
+  renv.sign(dpp, access_key);
 
-  RGWLoadGenIO real_client_io(&env);
+  RGWLoadGenIO real_client_io(&renv);
   RGWRestfulIO client_io(cct, &real_client_io);
   ActiveRateLimiter ratelimit(cct);
-  int ret = process_request(driver, rest, req, uri_prefix,
-                            *auth_registry, &client_io, olog,
+  int ret = process_request(env.driver, env.rest, req, uri_prefix,
+                            *env.auth_registry, &client_io, env.olog,
                             null_yield, nullptr, nullptr, nullptr,
                             ratelimit.get_active(),
                             nullptr,

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -154,10 +154,11 @@ int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, optio
   return lua_mgr->list_packages(dpp, y, packages);
 }
 
-int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, optional_yield y, packages_t& failed_packages, std::string& output) {
+int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
+                     optional_yield y, const std::string& luarocks_path,
+                     packages_t& failed_packages, std::string& output) {
   // luarocks directory cleanup
   std::error_code ec;
-  const auto& luarocks_path = driver->get_luarocks_path();
   if (std::filesystem::remove_all(luarocks_path, ec)
       == static_cast<std::uintmax_t>(-1) &&
       ec != std::errc::no_such_file_or_directory) {

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -59,7 +59,9 @@ int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, optio
 
 // install all packages from the allowlist
 // return the list of packages that failed to install and the output of the install command
-int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, optional_yield y, packages_t& failed_packages, std::string& output);
+int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
+                     optional_yield y, const std::string& luarocks_path,
+                     packages_t& failed_packages, std::string& output);
 #endif
 }
 

--- a/src/rgw/rgw_lua_data_filter.cc
+++ b/src/rgw/rgw_lua_data_filter.cc
@@ -2,6 +2,7 @@
 #include "rgw_lua_utils.h"
 #include "rgw_lua_request.h"
 #include "rgw_lua_background.h"
+#include "rgw_process_env.h"
 #include <lua.hpp>
 
 namespace rgw::lua {
@@ -102,9 +103,9 @@ int RGWObjFilter::execute(bufferlist& bl, off_t offset, const char* op_name) con
   lua_pushinteger(L, offset);
   lua_setglobal(L, "Offset");
 
-  if (s->lua_background) {
+  if (s->penv.lua_background) {
     // create the "RGW" table
-    s->lua_background->create_background_metatable(L);
+    s->penv.lua_background->create_background_metatable(L);
     lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
     ceph_assert(lua_istable(L, -1));
   }

--- a/src/rgw/rgw_lua_data_filter.cc
+++ b/src/rgw/rgw_lua_data_filter.cc
@@ -103,9 +103,9 @@ int RGWObjFilter::execute(bufferlist& bl, off_t offset, const char* op_name) con
   lua_pushinteger(L, offset);
   lua_setglobal(L, "Offset");
 
-  if (s->penv.lua_background) {
+  if (s->penv.lua.background) {
     // create the "RGW" table
-    s->penv.lua_background->create_background_metatable(L);
+    s->penv.lua.background->create_background_metatable(L);
     lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
     ceph_assert(lua_istable(L, -1));
   }

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -7,7 +7,8 @@
 #include "rgw_lua.h"
 #include "rgw_common.h"
 #include "rgw_log.h"
-#include "rgw_process.h"
+#include "rgw_op.h"
+#include "rgw_process_env.h"
 #include "rgw_zone.h"
 #include "rgw_acl.h"
 #include "rgw_sal_rados.h"
@@ -878,8 +879,8 @@ int execute(
   lua_pushcclosure(L, RequestLog, FOUR_UPVALS);
   lua_rawset(L, -3);
   
-  if (s->lua_background) {
-    s->lua_background->create_background_metatable(L);
+  if (s->penv.lua_background) {
+    s->penv.lua_background->create_background_metatable(L);
     lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
     ceph_assert(lua_istable(L, -1));
   }

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -859,9 +859,7 @@ int execute(
   lua_state_guard lguard(L);
 
   open_standard_libs(L);
-  set_package_path(L, driver ?
-      driver->get_luarocks_path() :
-      "");
+  set_package_path(L, s->penv.lua.luarocks_path);
 
   create_debug_action(L, s->cct);  
   

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -879,8 +879,8 @@ int execute(
   lua_pushcclosure(L, RequestLog, FOUR_UPVALS);
   lua_rawset(L, -3);
   
-  if (s->penv.lua_background) {
-    s->penv.lua_background->create_background_metatable(L);
+  if (s->penv.lua.background) {
+    s->penv.lua.background->create_background_metatable(L);
     lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
     ceph_assert(lua_istable(L, -1));
   }

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -75,8 +75,8 @@ class AppMain {
   std::unique_ptr<RGWFrontendPauser> fe_pauser;
   std::unique_ptr<RGWRealmWatcher> realm_watcher;
   std::unique_ptr<RGWPauser> rgw_pauser;
-  rgw::sal::Driver* driver;
   DoutPrefixProvider* dpp;
+  RGWProcessEnv env;
 
 public:
   AppMain(DoutPrefixProvider* dpp)
@@ -87,7 +87,7 @@ public:
 	       = []() { /* nada */});
 
   rgw::sal::Driver* get_driver() {
-    return driver;
+    return env.driver;
   }
 
   rgw::LDAPHelper* get_ldh() {

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -25,7 +25,6 @@
 #include "rgw_realm_reloader.h"
 #include "rgw_ldap.h"
 #include "rgw_lua.h"
-#include "rgw_lua_background.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 #include "rgw_ratelimit.h"
 
@@ -50,6 +49,8 @@ public:
 };
 
 namespace rgw {
+
+namespace lua { class Background; }
 
 class RGWLib;
 class AppMain {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -47,6 +47,7 @@
 #include "rgw_putobj_processor.h"
 #include "rgw_crypt.h"
 #include "rgw_perf_counters.h"
+#include "rgw_process_env.h"
 #include "rgw_notify.h"
 #include "rgw_notify_event_type.h"
 #include "rgw_sal.h"
@@ -2087,7 +2088,7 @@ int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 
 int RGWGetObj::get_lua_filter(std::unique_ptr<RGWGetObj_Filter>* filter, RGWGetObj_Filter* cb) {
   std::string script;
-  const auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::getData, script);
+  const auto rc = rgw::lua::read_script(s, s->penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::getData, script);
   if (rc == -ENOENT) {
     // no script, nothing to do
     return 0;
@@ -3874,7 +3875,7 @@ static CompressorRef get_compressor_plugin(const req_state *s,
 
 int RGWPutObj::get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter, rgw::sal::DataProcessor* cb) {
   std::string script;
-  const auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
+  const auto rc = rgw::lua::read_script(s, s->penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
   if (rc == -ENOENT) {
     // no script, nothing to do
     return 0;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2088,7 +2088,7 @@ int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 
 int RGWGetObj::get_lua_filter(std::unique_ptr<RGWGetObj_Filter>* filter, RGWGetObj_Filter* cb) {
   std::string script;
-  const auto rc = rgw::lua::read_script(s, s->penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::getData, script);
+  const auto rc = rgw::lua::read_script(s, s->penv.lua.manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::getData, script);
   if (rc == -ENOENT) {
     // no script, nothing to do
     return 0;
@@ -3875,7 +3875,7 @@ static CompressorRef get_compressor_plugin(const req_state *s,
 
 int RGWPutObj::get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter, rgw::sal::DataProcessor* cb) {
   std::string script;
-  const auto rc = rgw::lua::read_script(s, s->penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
+  const auto rc = rgw::lua::read_script(s, s->penv.lua.manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
   if (rc == -ENOENT) {
     // no script, nothing to do
     return 0;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -326,12 +326,10 @@ int process_request(const RGWProcessEnv& penv,
     abort_early(s, NULL, -ERR_METHOD_NOT_ALLOWED, handler, yield);
     goto done;
   }
-  s->lua_background = penv.lua_background;
-  s->lua_manager = penv.lua_manager.get();
   {
     s->trace_enabled = tracing::rgw::tracer.is_enabled();
     std::string script;
-    auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::preRequest, script);
+    auto rc = rgw::lua::read_script(s, penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::preRequest, script);
     if (rc == -ENOENT) {
       // no script, nothing to do
     } else if (rc < 0) {
@@ -416,7 +414,7 @@ done:
       }
     }
     std::string script;
-    auto rc = rgw::lua::read_script(s, s->lua_manager, s->bucket_tenant, s->yield, rgw::lua::context::postRequest, script);
+    auto rc = rgw::lua::read_script(s, penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::postRequest, script);
     if (rc == -ENOENT) {
       // no script, nothing to do
     } else if (rc < 0) {

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -7,6 +7,7 @@
 #include "include/scope_guard.h"
 
 #include <utility>
+#include "rgw_auth_registry.h"
 #include "rgw_dmclock_scheduler.h"
 #include "rgw_rest.h"
 #include "rgw_frontend.h"

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -278,7 +278,7 @@ int process_request(const RGWProcessEnv& penv,
 
   RGWEnv& rgw_env = client_io->get_env();
 
-  req_state rstate(g_ceph_context, &rgw_env, req->id);
+  req_state rstate(g_ceph_context, penv, &rgw_env, req->id);
   req_state *s = &rstate;
 
   s->ratelimit_data = penv.ratelimiting->get_active();

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -329,7 +329,7 @@ int process_request(const RGWProcessEnv& penv,
   {
     s->trace_enabled = tracing::rgw::tracer.is_enabled();
     std::string script;
-    auto rc = rgw::lua::read_script(s, penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::preRequest, script);
+    auto rc = rgw::lua::read_script(s, penv.lua.manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::preRequest, script);
     if (rc == -ENOENT) {
       // no script, nothing to do
     } else if (rc < 0) {
@@ -414,7 +414,7 @@ done:
       }
     }
     std::string script;
-    auto rc = rgw::lua::read_script(s, penv.lua_manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::postRequest, script);
+    auto rc = rgw::lua::read_script(s, penv.lua.manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::postRequest, script);
     if (rc == -ENOENT) {
       // no script, nothing to do
     } else if (rc < 0) {

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -110,6 +110,8 @@ public:
   
   virtual ~RGWProcess() = default;
 
+  const RGWProcessEnv& get_env() const { return env; }
+
   virtual void run() = 0;
   virtual void handle_request(const DoutPrefixProvider *dpp, RGWRequest *req) = 0;
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -32,7 +32,6 @@ struct RGWProcessEnv {
   rgw::sal::Driver* driver = nullptr;
   RGWREST *rest = nullptr;
   OpsLogSink *olog = nullptr;
-  std::string uri_prefix;
   std::shared_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
   rgw::lua::Background* lua_background = nullptr;
@@ -96,6 +95,7 @@ public:
   RGWProcess(CephContext* const cct,
              RGWProcessEnv* const pe,
              const int num_threads,
+             std::string uri_prefix,
              RGWFrontendConfig* const conf)
     : cct(cct),
       driver(pe->driver),
@@ -106,7 +106,7 @@ public:
       rest(pe->rest),
       conf(conf),
       sock_fd(-1),
-      uri_prefix(pe->uri_prefix),
+      uri_prefix(std::move(uri_prefix)),
       lua_background(pe->lua_background),
       lua_manager(driver->get_lua_manager()),
       req_wq(this,
@@ -155,8 +155,8 @@ class RGWLoadGenProcess : public RGWProcess {
   RGWAccessKey access_key;
 public:
   RGWLoadGenProcess(CephContext* cct, RGWProcessEnv* pe, int num_threads,
-		  RGWFrontendConfig* _conf) :
-  RGWProcess(cct, pe, num_threads, _conf) {}
+                    std::string uri_prefix, RGWFrontendConfig* _conf)
+    : RGWProcess(cct, pe, num_threads, std::move(uri_prefix), _conf) {}
   void run() override;
   void checkpoint();
   void handle_request(const DoutPrefixProvider *dpp, RGWRequest* req) override;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -6,11 +6,8 @@
 
 #include "rgw_common.h"
 #include "rgw_acl.h"
-#include "rgw_auth_registry.h"
 #include "rgw_user.h"
-#include "rgw_op.h"
 #include "rgw_rest.h"
-#include "rgw_ratelimit.h"
 #include "include/ceph_assert.h"
 
 #include "common/WorkQueue.h"
@@ -24,23 +21,8 @@
 namespace rgw::dmclock {
   class Scheduler;
 }
-namespace rgw::lua {
-  class Background;
-}
-namespace rgw::sal {
-  class LuaManager;
-}
 
-struct RGWProcessEnv {
-  rgw::sal::Driver* driver = nullptr;
-  RGWREST *rest = nullptr;
-  OpsLogSink *olog = nullptr;
-  rgw_auth_registry_ptr_t auth_registry;
-  ActiveRateLimiter* ratelimiting = nullptr;
-  rgw::lua::Background* lua_background = nullptr;
-  std::unique_ptr<rgw::sal::LuaManager> lua_manager;
-};
-
+struct RGWProcessEnv;
 class RGWFrontendConfig;
 class RGWRequest;
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -155,20 +155,14 @@ public:
   void set_access_key(RGWAccessKey& key) { access_key = key; }
 };
 /* process stream request */
-extern int process_request(rgw::sal::Driver* driver,
-                           RGWREST* rest,
+extern int process_request(const RGWProcessEnv& penv,
                            RGWRequest* req,
                            const std::string& frontend_prefix,
-                           const rgw_auth_registry_t& auth_registry,
                            RGWRestfulIO* client_io,
-                           OpsLogSink* olog,
                            optional_yield y,
                            rgw::dmclock::Scheduler *scheduler,
                            std::string* user,
                            ceph::coarse_real_clock::duration* latency,
-                           std::shared_ptr<RateLimiter> ratelimit,
-                           rgw::lua::Background* lua_background,
-                           std::unique_ptr<rgw::sal::LuaManager>& lua_manager,
                            int* http_ret = nullptr);
 
 extern int rgw_process_authenticated(RGWHandler_REST* handler,

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -29,14 +29,13 @@ namespace rgw::lua {
 }
 
 struct RGWProcessEnv {
-  rgw::sal::Driver* driver;
-  RGWREST *rest;
-  OpsLogSink *olog;
+  rgw::sal::Driver* driver = nullptr;
+  RGWREST *rest = nullptr;
+  OpsLogSink *olog = nullptr;
   std::string uri_prefix;
   std::shared_ptr<rgw::auth::StrategyRegistry> auth_registry;
-  //maybe there is a better place to driver the rate limit data structure
-  ActiveRateLimiter* ratelimiting;
-  rgw::lua::Background* lua_background;
+  ActiveRateLimiter* ratelimiting = nullptr;
+  rgw::lua::Background* lua_background = nullptr;
 };
 
 class RGWFrontendConfig;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -32,7 +32,7 @@ struct RGWProcessEnv {
   rgw::sal::Driver* driver = nullptr;
   RGWREST *rest = nullptr;
   OpsLogSink *olog = nullptr;
-  std::shared_ptr<rgw::auth::StrategyRegistry> auth_registry;
+  rgw_auth_registry_ptr_t auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
   rgw::lua::Background* lua_background = nullptr;
 };

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -32,7 +32,6 @@ struct RGWProcessEnv {
   rgw::sal::Driver* driver;
   RGWREST *rest;
   OpsLogSink *olog;
-  int port;
   std::string uri_prefix;
   std::shared_ptr<rgw::auth::StrategyRegistry> auth_registry;
   //maybe there is a better place to driver the rate limit data structure

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -115,11 +115,8 @@ public:
     m_tp.pause();
   }
 
-  void unpause_with_new_config(rgw::sal::Driver* const driver,
-                               rgw_auth_registry_ptr_t auth_registry) {
-    env.driver = driver;
-    env.auth_registry = std::move(auth_registry);
-    lua_manager = driver->get_lua_manager();
+  void unpause_with_new_config() {
+    lua_manager = env.driver->get_lua_manager();
     m_tp.unpause();
   }
 

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include <memory>
+
+class ActiveRateLimiter;
+class OpsLogSink;
+class RGWREST;
+
+namespace rgw::auth {
+  class StrategyRegistry;
+}
+namespace rgw::lua {
+  class Background;
+}
+namespace rgw::sal {
+  class Store;
+  class LuaManager;
+}
+
+struct RGWProcessEnv {
+  rgw::sal::Driver* driver = nullptr;
+  RGWREST *rest = nullptr;
+  OpsLogSink *olog = nullptr;
+  std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
+  ActiveRateLimiter* ratelimiting = nullptr;
+  rgw::lua::Background* lua_background = nullptr;
+  std::unique_ptr<rgw::sal::LuaManager> lua_manager;
+};

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -21,6 +21,7 @@ namespace rgw::sal {
 }
 
 struct RGWLuaProcessEnv {
+  std::string luarocks_path;
   rgw::lua::Background* background = nullptr;
   std::unique_ptr<rgw::sal::LuaManager> manager;
 };

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -20,12 +20,16 @@ namespace rgw::sal {
   class LuaManager;
 }
 
+struct RGWLuaProcessEnv {
+  rgw::lua::Background* background = nullptr;
+  std::unique_ptr<rgw::sal::LuaManager> manager;
+};
+
 struct RGWProcessEnv {
+  RGWLuaProcessEnv lua;
   rgw::sal::Driver* driver = nullptr;
   RGWREST *rest = nullptr;
   OpsLogSink *olog = nullptr;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
-  rgw::lua::Background* lua_background = nullptr;
-  std::unique_ptr<rgw::sal::LuaManager> lua_manager;
 };

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -3,11 +3,12 @@
 
 #include "rgw_realm_reloader.h"
 
+#include "rgw_auth_registry.h"
 #include "rgw_bucket.h"
 #include "rgw_log.h"
 #include "rgw_rest.h"
 #include "rgw_user.h"
-#include "rgw_process.h"
+#include "rgw_process_env.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
 

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -180,6 +180,7 @@ void RGWRealmReloader::reload()
    * the dynamic reconfiguration. */
   env.auth_registry = rgw::auth::StrategyRegistry::create(
       cct, implicit_tenants, env.driver);
+  env.lua.manager = env.driver->get_lua_manager();
 
   ldpp_dout(&dp, 1) << "Resuming frontends with new realm configuration." << dendl;
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -9,6 +9,7 @@
 #include "rgw_sal_fwd.h"
 
 struct RGWProcessEnv;
+namespace rgw::auth { class ImplicitTenants; }
 
 /**
  * RGWRealmReloader responds to new period notifications by recreating RGWRados
@@ -33,7 +34,9 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
     virtual void resume(rgw::sal::Driver* driver) = 0;
   };
 
-  RGWRealmReloader(RGWProcessEnv& env, std::map<std::string, std::string>& service_map_meta,
+  RGWRealmReloader(RGWProcessEnv& env,
+                   const rgw::auth::ImplicitTenants& implicit_tenants,
+                   std::map<std::string, std::string>& service_map_meta,
                    Pauser* frontends);
   ~RGWRealmReloader() override;
 
@@ -47,6 +50,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
   class C_Reload; //< Context that calls reload()
 
   RGWProcessEnv& env;
+  const rgw::auth::ImplicitTenants& implicit_tenants;
   std::map<std::string, std::string>& service_map_meta;
   Pauser *const frontends;
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -8,6 +8,8 @@
 #include "common/Cond.h"
 #include "rgw_sal_fwd.h"
 
+struct RGWProcessEnv;
+
 /**
  * RGWRealmReloader responds to new period notifications by recreating RGWRados
  * with the updated realm configuration.
@@ -31,7 +33,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
     virtual void resume(rgw::sal::Driver* driver) = 0;
   };
 
-  RGWRealmReloader(rgw::sal::Driver*& driver, std::map<std::string, std::string>& service_map_meta,
+  RGWRealmReloader(RGWProcessEnv& env, std::map<std::string, std::string>& service_map_meta,
                    Pauser* frontends);
   ~RGWRealmReloader() override;
 
@@ -44,8 +46,7 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
 
   class C_Reload; //< Context that calls reload()
 
-  /// main()'s driver pointer as a reference, modified by reload()
-  rgw::sal::Driver*& driver;
+  RGWProcessEnv& env;
   std::map<std::string, std::string>& service_map_meta;
   Pauser *const frontends;
 

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -3,11 +3,8 @@
 
 #include <boost/tokenizer.hpp>
 
-#include "rgw_rest.h"
+#include "rgw_auth_s3.h"
 #include "rgw_rest_iam.h"
-
-#include "rgw_request.h"
-#include "rgw_process.h"
 
 #include "rgw_rest_role.h"
 #include "rgw_rest_user_policy.h"

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -85,7 +85,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
                         public rgw::auth::TokenExtractor,
                         public rgw::auth::WebIdentityApplier::Factory {
   rgw::sal::Driver* driver;
-  ImplicitTenants& implicit_tenant_context;
+  const ImplicitTenants& implicit_tenant_context;
 
   /* The engine. */
   const WebTokenEngine web_token_engine;
@@ -111,7 +111,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
 
 public:
   DefaultStrategy(CephContext* const cct,
-                  ImplicitTenants& implicit_tenant_context,
+                  const ImplicitTenants& implicit_tenant_context,
                   rgw::sal::Driver* driver)
     : driver(driver),
       implicit_tenant_context(implicit_tenant_context),

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -21,6 +21,7 @@
 #include "rgw_compression.h"
 
 #include "rgw_auth.h"
+#include "rgw_auth_registry.h"
 #include "rgw_swift_auth.h"
 
 #include "rgw_request.h"

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -448,10 +448,6 @@ class Driver {
     /** Get the Ceph context associated with this driver.  May be removed. */
     virtual CephContext* ctx(void) = 0;
 
-    /** Get the location of where lua packages are installed */
-    virtual const std::string& get_luarocks_path() const = 0;
-    /** Set the location of where lua packages are installed */
-    virtual void set_luarocks_path(const std::string& path) = 0;
     /** Register admin APIs unique to this driver */
     virtual void register_admin_apis(RGWRESTMgr* mgr) = 0;
 };

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -881,7 +881,6 @@ class DaosMultipartUpload : public StoreMultipartUpload {
 
 class DaosStore : public StoreDriver {
  private:
-  std::string luarocks_path;
   DaosZone zone;
   RGWSyncModuleInstanceRef sync_module;
 
@@ -1043,14 +1042,6 @@ class DaosStore : public StoreDriver {
   virtual void finalize(void) override;
 
   virtual CephContext* ctx(void) override { return cctx; }
-
-  virtual const std::string& get_luarocks_path() const override {
-    return luarocks_path;
-  }
-
-  virtual void set_luarocks_path(const std::string& path) override {
-    luarocks_path = path;
-  }
 
   virtual int initialize(CephContext* cct,
                          const DoutPrefixProvider* dpp) override;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -762,7 +762,6 @@ public:
        * multiple db handles (for eg., one for each tenant),
        * use dbsm->getDB(tenant) */
       DB *db;
-      std::string luarocks_path;
       DBZone zone;
       RGWSyncModuleInstanceRef sync_module;
       RGWLC* lc;
@@ -903,13 +902,6 @@ public:
         return db->ctx();
       }
 
-      virtual const std::string& get_luarocks_path() const override {
-        return luarocks_path;
-      }
-
-      virtual void set_luarocks_path(const std::string& path) override {
-        luarocks_path = path;
-      }
       virtual void register_admin_apis(RGWRESTMgr* mgr) override { };
 
       /* Unique to DBStore */

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -542,16 +542,6 @@ CephContext* FilterDriver::ctx(void)
   return next->ctx();
 }
 
-const std::string& FilterDriver::get_luarocks_path() const
-{
-  return next->get_luarocks_path();
-}
-
-void FilterDriver::set_luarocks_path(const std::string& path)
-{
-  next->set_luarocks_path(path);
-}
-
 int FilterUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& marker,
 			     const std::string& end_marker, uint64_t max,
 			     bool need_stats, BucketList &buckets, optional_yield y)

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -305,9 +305,7 @@ public:
 
   virtual CephContext* ctx(void) override;
 
-  virtual const std::string& get_luarocks_path() const override;
-  virtual void set_luarocks_path(const std::string& path) override;
-  virtual void  register_admin_apis(RGWRESTMgr* mgr)override {
+  virtual void register_admin_apis(RGWRESTMgr* mgr) override {
       return next->register_admin_apis(mgr);
   }
 };

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -899,7 +899,6 @@ public:
 
 class MotrStore : public StoreDriver {
   private:
-    std::string luarocks_path;
     MotrZone zone;
     RGWSyncModuleInstanceRef sync_module;
 
@@ -1033,13 +1032,6 @@ class MotrStore : public StoreDriver {
       return cctx;
     }
 
-    virtual const std::string& get_luarocks_path() const override {
-      return luarocks_path;
-    }
-
-    virtual void set_luarocks_path(const std::string& path) override {
-      luarocks_path = path;
-    }
     virtual void register_admin_apis(RGWRESTMgr* mgr) override { };
 
     int open_idx(struct m0_uint128 *id, bool create, struct m0_idx *out);

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -186,7 +186,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
                         public rgw::auth::LocalApplier::Factory,
                         public rgw::auth::swift::TempURLApplier::Factory {
   rgw::sal::Driver* driver;
-  ImplicitTenants& implicit_tenant_context;
+  const ImplicitTenants& implicit_tenant_context;
 
   /* The engines. */
   const rgw::auth::swift::TempURLEngine tempurl_engine;
@@ -255,7 +255,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
 
 public:
   DefaultStrategy(CephContext* const cct,
-                  ImplicitTenants& implicit_tenant_context,
+                  const ImplicitTenants& implicit_tenant_context,
                   rgw::sal::Driver* _driver)
     : driver(_driver),
       implicit_tenant_context(implicit_tenant_context),

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -24,8 +24,10 @@
 #include "common/ceph_context.h"
 #include "global/global_init.h"
 #include "rgw_auth.h"
+#include "rgw_auth_registry.h"
 #include "rgw_iam_policy.h"
 #include "rgw_op.h"
+#include "rgw_process_env.h"
 #include "rgw_sal_rados.h"
 
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -904,13 +904,14 @@ TEST_F(IPPolicyTest, asNetworkInvalid) {
 }
 
 TEST_F(IPPolicyTest, IPEnvironment) {
+  RGWProcessEnv penv;
   // Unfortunately RGWCivetWeb is too tightly tied to civetweb to test RGWCivetWeb::init_env.
   RGWEnv rgw_env;
   rgw::sal::RadosStore store;
   std::unique_ptr<rgw::sal::User> user = store.get_user(rgw_user());
   rgw_env.set("REMOTE_ADDR", "192.168.1.1");
   rgw_env.set("HTTP_HOST", "1.2.3.4");
-  req_state rgw_req_state(cct.get(), &rgw_env, 0);
+  req_state rgw_req_state(cct.get(), penv, &rgw_env, 0);
   rgw_req_state.set_user(user);
   rgw_build_iam_environment(&store, &rgw_req_state);
   auto ip = rgw_req_state.env.find("aws:SourceIp");

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #include "common/ceph_context.h"
 #include "rgw_common.h"
-#include "rgw_auth.h"
-#include "rgw_process.h"
+#include "rgw_auth_registry.h"
+#include "rgw_process_env.h"
 #include "rgw_sal_rados.h"
 #include "rgw_lua_request.h"
 #include "rgw_lua_background.h"
@@ -163,7 +163,7 @@ CctCleaner cleaner(g_cct);
 
 tracing::Tracer tracer;
 
-#define DEFINE_REQ_STATE RGWEnv e; req_state s(g_cct, &e, 0);
+#define DEFINE_REQ_STATE RGWProcessEnv pe; RGWEnv e; req_state s(g_cct, pe, &e, 0);
 #define INIT_TRACE tracer.init("test"); \
                    s.trace = tracer.start_trace("test", true);
 
@@ -774,7 +774,7 @@ TEST(TestRGWLuaBackground, RequestScript)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   // to make sure test is consistent we have to puase the background
   lua_background.pause();
@@ -925,7 +925,7 @@ TEST(TestRGWLuaBackground, TableValues)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -946,7 +946,7 @@ TEST(TestRGWLuaBackground, TablePersist)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -980,7 +980,7 @@ TEST(TestRGWLuaBackground, TableValuesFromRequest)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val1");
@@ -1010,7 +1010,7 @@ TEST(TestRGWLuaBackground, TableInvalidValue)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val2");
 
@@ -1036,7 +1036,7 @@ TEST(TestRGWLuaBackground, TableErase)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1078,7 +1078,7 @@ TEST(TestRGWLuaBackground, TableIterate)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1104,7 +1104,7 @@ TEST(TestRGWLuaBackground, TableIncrement)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1127,7 +1127,7 @@ TEST(TestRGWLuaBackground, TableIncrementBy)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1148,7 +1148,7 @@ TEST(TestRGWLuaBackground, TableDecrement)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1171,7 +1171,7 @@ TEST(TestRGWLuaBackground, TableDecrementBy)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1189,7 +1189,7 @@ TEST(TestRGWLuaBackground, TableIncrementValueError)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_NE(rc, 0);
@@ -1225,7 +1225,7 @@ TEST(TestRGWLuaBackground, TableIncrementError)
   )";
 
   DEFINE_REQ_STATE;
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_NE(rc, 0);
@@ -1309,7 +1309,7 @@ TEST(TestRGWLua, Data)
   TestBackground lua_background(store.get(), "");
   DEFINE_REQ_STATE;
   s.host_id = "foo";
-  s.lua_background = &lua_background;
+  pe.lua_background = &lua_background;
   lua::RGWObjFilter filter(&s, script);
   bufferlist bl;
   bl.append("The quick brown fox jumps over the lazy dog");

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -774,7 +774,7 @@ TEST(TestRGWLuaBackground, RequestScript)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   // to make sure test is consistent we have to puase the background
   lua_background.pause();
@@ -925,7 +925,7 @@ TEST(TestRGWLuaBackground, TableValues)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -946,7 +946,7 @@ TEST(TestRGWLuaBackground, TablePersist)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -980,7 +980,7 @@ TEST(TestRGWLuaBackground, TableValuesFromRequest)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val1");
@@ -1010,7 +1010,7 @@ TEST(TestRGWLuaBackground, TableInvalidValue)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
   s.tagset.add_tag("key1", "val1");
   s.tagset.add_tag("key2", "val2");
 
@@ -1036,7 +1036,7 @@ TEST(TestRGWLuaBackground, TableErase)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1078,7 +1078,7 @@ TEST(TestRGWLuaBackground, TableIterate)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1104,7 +1104,7 @@ TEST(TestRGWLuaBackground, TableIncrement)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1127,7 +1127,7 @@ TEST(TestRGWLuaBackground, TableIncrementBy)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1148,7 +1148,7 @@ TEST(TestRGWLuaBackground, TableDecrement)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1171,7 +1171,7 @@ TEST(TestRGWLuaBackground, TableDecrementBy)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_EQ(rc, 0);
@@ -1189,7 +1189,7 @@ TEST(TestRGWLuaBackground, TableIncrementValueError)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_NE(rc, 0);
@@ -1225,7 +1225,7 @@ TEST(TestRGWLuaBackground, TableIncrementError)
   )";
 
   DEFINE_REQ_STATE;
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
 
   auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, request_script);
   ASSERT_NE(rc, 0);
@@ -1309,7 +1309,7 @@ TEST(TestRGWLua, Data)
   TestBackground lua_background(store.get(), "");
   DEFINE_REQ_STATE;
   s.host_id = "foo";
-  pe.lua_background = &lua_background;
+  pe.lua.background = &lua_background;
   lua::RGWObjFilter filter(&s, script);
   bufferlist bl;
   bl.append("The quick brown fox jumps over the lazy dog");


### PR DESCRIPTION
shares `struct RGWProcessEnv` between frontends, instead of making a copy for each. this lets us use it to store globals and reload parts of it in `RGWRealmReloader` without frontend interaction. passes a `const RGWProcessEnv&` into `process_request()` for access in rgw ops. moves `struct RGWProcessEnv` into a new header rgw_process_env.h so ops don't have to include all of rgw_process.h

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
