### PR TITLE
quincy: common: fix build with GCC 13 (missing <cstdint> include)

### DIFF
--- a/src/common/subsys_types.h
+++ b/src/common/subsys_types.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 
 enum ceph_subsys_id_t {
   ceph_subsys_,   // default


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/48661 to quincy.