### PR TITLE
quincy: doc/cephadm: arrange "listing hosts" section

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -4,17 +4,25 @@
 Host Management
 ===============
 
-To list hosts associated with the cluster:
+Listing Hosts
+=============
+
+Run a command of this form to list hosts associated with the cluster:
 
 .. prompt:: bash #
 
    ceph orch host ls [--format yaml] [--host-pattern <name>] [--label <label>] [--host-status <status>]
 
-where the optional arguments "host-pattern", "label" and "host-status" are used for filtering.
-"host-pattern" is a regex that will match against hostnames and will only return matching hosts
-"label" will only return hosts with the given label
-"host-status" will only return hosts with the given status (currently "offline" or "maintenance")
-Any combination of these filtering flags is valid. You may filter against name, label and/or status simultaneously
+In commands of this form, the arguments "host-pattern", "label" and
+"host-status" are optional and are used for filtering. 
+
+- "host-pattern" is a regex that will match against hostnames and will only
+  return matching hosts.
+- "label" returns only hosts with the specified label.
+- "host-status" returns only hosts with the specified status (currently
+  "offline" or "maintenance").
+- Any combination of these filtering flags is valid. You may filter against
+  name, label and/or status simultaneously.
 
 .. _cephadm-adding-hosts:    
     


### PR DESCRIPTION
Collect the material at the top of this page into a "Listing Hosts" section and clean the English so that it is clearer.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit d16e4e0737f8852f00b88c4f30b44a13096e6f42)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
