### PR TITLE
rgw/notification/test: add support for testing kafka security

### DIFF
--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -220,7 +220,7 @@ def run_tests(ctx, config):
     for client, client_config in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
-        attr = ["!kafka_test", "!amqp_test", "!amqp_ssl_test", "!modification_required", "!manual_test"]
+        attr = ["!kafka_test", "!amqp_test", "!amqp_ssl_test", "!kafka_ssl_test", "!modification_required", "!manual_test"]
 
         if 'extra_attr' in client_config:
             attr = client_config.get('extra_attr')

--- a/src/test/rgw/bucket_notification/kafka-security.sh
+++ b/src/test/rgw/bucket_notification/kafka-security.sh
@@ -1,0 +1,49 @@
+FQDN=localhost
+KEYFILE=server.keystore.jks
+TRUSTFILE=server.truststore.jks
+CAFILE=y-ca.crt
+CAKEYFILE=y-ca.key
+REQFILE=$FQDN.req
+CERTFILE=$FQDN.crt
+MYPW=mypassword
+VALIDITY=36500
+
+rm -f $KEYFILE
+rm -f $TRUSTFILE
+rm -f $CAFILE
+rm -f $REQFILE
+rm -f $CERTFILE
+
+echo "########## create the request in key store '$KEYFILE'"
+keytool -keystore $KEYFILE -alias localhost \
+  -dname "CN=$FQDN, OU=Michigan Engineering, O=Red Hat Inc, \
+  L=Ann Arbor, ST=Michigan, C=US" \
+  -storepass $MYPW -keypass $MYPW \
+  -validity $VALIDITY -genkey -keyalg RSA -ext SAN=DNS:"$FQDN"
+
+echo "########## create the CA '$CAFILE'"
+openssl req -new -nodes -x509 -keyout $CAKEYFILE -out $CAFILE \
+  -days $VALIDITY -subj \
+  '/C=US/ST=Michigan/L=Ann Arbor/O=Red Hat Inc/OU=Michigan Engineering/CN=yuval-1'
+
+echo "########## store the CA in trust store '$TRUSTFILE'"
+keytool -keystore $TRUSTFILE -storepass $MYPW -alias CARoot \
+  -noprompt -importcert -file $CAFILE
+
+echo "########## create a request '$REQFILE' for signing in key store '$KEYFILE'"
+keytool -storepass $MYPW -keystore $KEYFILE \
+  -alias localhost -certreq -file $REQFILE
+
+echo "########## sign and create certificate '$CERTFILE'"
+openssl x509 -req -CA $CAFILE -CAkey $CAKEYFILE -CAcreateserial \
+  -days $VALIDITY \
+  -in $REQFILE -out $CERTFILE
+
+echo "########## store CA '$CAFILE' in key store '$KEYFILE'"
+keytool -storepass $MYPW -keystore $KEYFILE -alias CARoot \
+  -noprompt -importcert -file $CAFILE
+
+echo "########## store certificate '$CERTFILE' in key store '$KEYFILE'"
+keytool -storepass $MYPW -keystore $KEYFILE -alias localhost \
+  -import -file $CERTFILE
+


### PR DESCRIPTION
also reorganize the bucket notification tests file to make manual testing of kafka and amqp easier.

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
