### PR TITLE
rgw/cloud-transition: Fix issues with MCG endpoint

### DIFF
--- a/src/rgw/rgw_lc_tier.cc
+++ b/src/rgw/rgw_lc_tier.cc
@@ -326,17 +326,17 @@ class RGWLCStreamRead
   rgw::sal::Object *obj;
   const real_time &mtime;
 
-  bool multipart;
-  uint64_t m_part_size;
-  off_t m_part_off;
-  off_t m_part_end;
+  bool multipart{false};
+  uint64_t m_part_size{0};
+  off_t m_part_off{0};
+  off_t m_part_end{0};
 
   std::unique_ptr<rgw::sal::Object::ReadOp> read_op;
-  off_t ofs;
-  off_t end;
+  off_t ofs{0};
+  off_t end{0};
   rgw_rest_obj rest_obj;
 
-  int retcode;
+  int retcode{0};
 
   public:
   RGWLCStreamRead(CephContext *_cct, const DoutPrefixProvider *_dpp,
@@ -1245,8 +1245,7 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
                                     out_bl, &bl, nullptr, null_yield);
 
   if (ret < 0 ) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to create target bucket: " << tier_ctx.target_bucket_name << ", ret:" << ret << dendl;
-    return ret;
+    ldpp_dout(tier_ctx.dpp, 0) << "create target bucket : " << tier_ctx.target_bucket_name << " returned ret:" << ret << dendl;
   }
   if (out_bl.length() > 0) {
     RGWXMLDecoder::XMLParser parser;
@@ -1269,7 +1268,7 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
       return -EIO;
     }
 
-    if (result.code != "BucketAlreadyOwnedByYou") {
+    if (result.code != "BucketAlreadyOwnedByYou" && result.code != "BucketAlreadyExists") {
       ldpp_dout(tier_ctx.dpp, 0) << "ERROR: Creating target bucket failed with error: " << result.code << dendl;
       return -EIO;
     }
@@ -1278,8 +1277,14 @@ static int cloud_tier_create_bucket(RGWLCCloudTierCtx& tier_ctx) {
   return 0;
 }
 
-int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx) {
+int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets) {
   int ret = 0;
+
+  // check if target_path is already created
+  std::set<std::string>::iterator it;
+
+  it = cloud_targets.find(tier_ctx.target_bucket_name);
+  tier_ctx.target_bucket_created = (it != cloud_targets.end());
 
   /* If run first time attempt to create the target bucket */
   if (!tier_ctx.target_bucket_created) {
@@ -1290,6 +1295,7 @@ int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx) {
       return ret;
     }
     tier_ctx.target_bucket_created = true;
+    cloud_targets.insert(tier_ctx.target_bucket_name);
   }
 
   /* Since multiple zones may try to transition the same object to the cloud,

--- a/src/rgw/rgw_lc_tier.h
+++ b/src/rgw/rgw_lc_tier.h
@@ -49,6 +49,6 @@ struct RGWLCCloudTierCtx {
 };
 
 /* Transition object to cloud endpoint */
-int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx);
+int rgw_cloud_tier_transfer_object(RGWLCCloudTierCtx& tier_ctx, std::set<std::string>& cloud_targets);
 
 #endif

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -389,7 +389,12 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
     return ret;
   }
 
-  return req.complete_request(y);
+  ret = req.complete_request(y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 5) << __func__ << ": complete_request() resource=" << resource << " returned ret=" << ret << dendl;
+  }
+
+  return ret;
 }
 
 RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -1850,24 +1850,14 @@ int RadosObject::transition_to_cloud(Bucket* bucket,
   tier_ctx.multipart_sync_threshold = rtier->get_rt().t.s3.multipart_sync_threshold;
   tier_ctx.storage_class = tier->get_storage_class();
 
-  // check if target_path is already created
-  std::pair<std::set<std::string>::iterator, bool> it;
-
-  it = cloud_targets.insert(bucket_name);
-  tier_ctx.target_bucket_created = !(it.second);
-
   ldpp_dout(dpp, 0) << "Transitioning object(" << o.key << ") to the cloud endpoint(" << endpoint << ")" << dendl;
 
   /* Transition object to cloud end point */
-  int ret = rgw_cloud_tier_transfer_object(tier_ctx);
+  int ret = rgw_cloud_tier_transfer_object(tier_ctx, cloud_targets);
 
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to transfer object(" << o.key << ") to the cloud endpoint(" << endpoint << ") ret=" << ret << dendl;
     return ret;
-
-    if (!tier_ctx.target_bucket_created) {
-      cloud_targets.erase(it.first);
-    }
   }
 
   if (update_object) {


### PR DESCRIPTION
Few s3 endpoints (like Noobaa MCG or AWS) may return BucketAlreadyOwned or BucketAlreadyExists error if the target path (configured for cloud transition) already exists. Do not fail transition in those cases.

Also fixed below issues -
* with racing lc threads, when one lc thread is trying to check and create the target bucket, others may go ahead with the object transition assuming target path exists.
* initialize few fields to avoid setting wrong content_len during transition


Fixes: https://tracker.ceph.com/issues/57979

Signed-off-by: Soumya Koduri <skoduri@redhat.com>





## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
