### PR TITLE
crimson/os/seastore: define the usage of generation

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -31,7 +31,7 @@ void segment_info_t::set_open(
   ceph_assert(_seq != NULL_SEG_SEQ);
   ceph_assert(_type != segment_type_t::NULL_SEG);
   ceph_assert(_category != data_category_t::NUM);
-  ceph_assert(_generation < RECLAIM_GENERATIONS);
+  ceph_assert(is_reclaim_generation(_generation));
   state = Segment::segment_state_t::OPEN;
   seq = _seq;
   type = _type;
@@ -66,7 +66,7 @@ void segment_info_t::init_closed(
   ceph_assert(_seq != NULL_SEG_SEQ);
   ceph_assert(_type != segment_type_t::NULL_SEG);
   ceph_assert(_category != data_category_t::NUM);
-  ceph_assert(_generation < RECLAIM_GENERATIONS);
+  ceph_assert(is_reclaim_generation(_generation));
   state = Segment::segment_state_t::CLOSED;
   seq = _seq;
   type = _type;
@@ -612,7 +612,7 @@ JournalTrimmerImpl::trim_dirty()
             dirty_list,
             [this, &t](auto &e) {
             return extent_callback->rewrite_extent(
-                t, e, DIRTY_GENERATION, NULL_TIME);
+                t, e, INIT_GENERATION, NULL_TIME);
           });
         });
       }).si_then([this, &t] {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -38,7 +38,7 @@ struct segment_info_t {
 
   data_category_t category = data_category_t::NUM;
 
-  reclaim_gen_t generation = NULL_GENERATION;
+  rewrite_gen_t generation = NULL_GENERATION;
 
   sea_time_point modify_time = NULL_TIME;
 
@@ -64,11 +64,11 @@ struct segment_info_t {
   }
 
   void init_closed(segment_seq_t, segment_type_t,
-                   data_category_t, reclaim_gen_t,
+                   data_category_t, rewrite_gen_t,
                    segment_off_t);
 
   void set_open(segment_seq_t, segment_type_t,
-                data_category_t, reclaim_gen_t);
+                data_category_t, rewrite_gen_t);
 
   void set_empty();
 
@@ -214,10 +214,10 @@ public:
 
   // initiate non-empty segments, the others are by default empty
   void init_closed(segment_id_t, segment_seq_t, segment_type_t,
-                   data_category_t, reclaim_gen_t);
+                   data_category_t, rewrite_gen_t);
 
   void mark_open(segment_id_t, segment_seq_t, segment_type_t,
-                 data_category_t, reclaim_gen_t);
+                 data_category_t, rewrite_gen_t);
 
   void mark_empty(segment_id_t);
 
@@ -328,7 +328,7 @@ public:
   virtual rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
-    reclaim_gen_t target_generation,
+    rewrite_gen_t target_generation,
     sea_time_point modify_time) = 0;
 
   /**
@@ -596,7 +596,7 @@ public:
   virtual const segment_info_t& get_seg_info(segment_id_t id) const = 0;
 
   virtual segment_id_t allocate_segment(
-      segment_seq_t, segment_type_t, data_category_t, reclaim_gen_t) = 0;
+      segment_seq_t, segment_type_t, data_category_t, rewrite_gen_t) = 0;
 
   virtual void close_segment(segment_id_t) = 0;
 
@@ -949,7 +949,7 @@ public:
   }
 
   segment_id_t allocate_segment(
-      segment_seq_t, segment_type_t, data_category_t, reclaim_gen_t) final;
+      segment_seq_t, segment_type_t, data_category_t, rewrite_gen_t) final;
 
   void close_segment(segment_id_t segment) final;
 
@@ -1075,19 +1075,19 @@ private:
   segment_id_t get_next_reclaim_segment() const;
 
   struct reclaim_state_t {
-    reclaim_gen_t generation;
-    reclaim_gen_t target_generation;
+    rewrite_gen_t generation;
+    rewrite_gen_t target_generation;
     segment_off_t segment_size;
     paddr_t start_pos;
     paddr_t end_pos;
 
     static reclaim_state_t create(
         segment_id_t segment_id,
-        reclaim_gen_t generation,
+        rewrite_gen_t generation,
         segment_off_t segment_size) {
-      ceph_assert(is_reclaim_generation(generation));
+      ceph_assert(is_rewrite_generation(generation));
 
-      reclaim_gen_t target_gen;
+      rewrite_gen_t target_gen;
       if (generation < MIN_REWRITE_GENERATION) {
         target_gen = MIN_REWRITE_GENERATION;
       } else {
@@ -1096,7 +1096,7 @@ private:
         target_gen = generation + 1;
       }
 
-      assert(is_target_reclaim_generation(target_gen));
+      assert(is_target_rewrite_generation(target_gen));
       return {generation,
               target_gen,
               segment_size,
@@ -1219,7 +1219,7 @@ private:
       segment_seq_t seq,
       segment_type_t s_type,
       data_category_t category,
-      reclaim_gen_t generation) {
+      rewrite_gen_t generation) {
     assert(background_callback->get_state() == state_t::MOUNT);
     ceph_assert(s_type == segment_type_t::OOL ||
                 trimmer != nullptr); // segment_type_t::JOURNAL

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -315,7 +315,7 @@ public:
       c.trans,
       node_size,
       placement_hint_t::HOT,
-      0);
+      INIT_GENERATION);
     root_leaf->set_size(0);
     fixed_kv_node_meta_t<node_key_t> meta{min_max_t<node_key_t>::min, min_max_t<node_key_t>::max, 1};
     root_leaf->set_meta(meta);
@@ -818,6 +818,7 @@ public:
         c.trans,
         fixed_kv_extent.get_length(),
         fixed_kv_extent.get_user_hint(),
+        // get target reclaim generation
         fixed_kv_extent.get_reclaim_generation());
       fixed_kv_extent.get_bptr().copy_out(
         0,
@@ -1406,7 +1407,7 @@ private:
 
     if (split_from == iter.get_depth()) {
       auto nroot = c.cache.template alloc_new_extent<internal_node_t>(
-        c.trans, node_size, placement_hint_t::HOT, 0);
+        c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
       fixed_kv_node_meta_t<node_key_t> meta{
         min_max_t<node_key_t>::min, min_max_t<node_key_t>::max, iter.get_depth() + 1};
       nroot->set_meta(meta);

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -818,8 +818,8 @@ public:
         c.trans,
         fixed_kv_extent.get_length(),
         fixed_kv_extent.get_user_hint(),
-        // get target reclaim generation
-        fixed_kv_extent.get_reclaim_generation());
+        // get target rewrite generation
+        fixed_kv_extent.get_rewrite_generation());
       fixed_kv_extent.get_bptr().copy_out(
         0,
         fixed_kv_extent.get_length(),

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -154,9 +154,9 @@ struct FixedKVInternalNode
   std::tuple<Ref, Ref, NODE_KEY>
   make_split_children(op_context_t<NODE_KEY> c) {
     auto left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto pivot = this->split_into(*left, *right);
     left->pin.set_range(left->get_meta());
     right->pin.set_range(right->get_meta());
@@ -170,7 +170,7 @@ struct FixedKVInternalNode
     op_context_t<NODE_KEY> c,
     Ref &right) {
     auto replacement = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     replacement->merge_from(*this, *right->template cast<node_type_t>());
     replacement->pin.set_range(replacement->get_meta());
     return replacement;
@@ -184,9 +184,9 @@ struct FixedKVInternalNode
     ceph_assert(_right->get_type() == this->get_type());
     auto &right = *_right->template cast<node_type_t>();
     auto replacement_left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto replacement_right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
 
     auto pivot = this->balance_into_new_nodes(
       *this,
@@ -355,9 +355,9 @@ struct FixedKVLeafNode
   std::tuple<Ref, Ref, NODE_KEY>
   make_split_children(op_context_t<NODE_KEY> c) {
     auto left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto pivot = this->split_into(*left, *right);
     left->pin.set_range(left->get_meta());
     right->pin.set_range(right->get_meta());
@@ -371,7 +371,7 @@ struct FixedKVLeafNode
     op_context_t<NODE_KEY> c,
     Ref &right) {
     auto replacement = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     replacement->merge_from(*this, *right->template cast<node_type_t>());
     replacement->pin.set_range(replacement->get_meta());
     return replacement;
@@ -385,9 +385,9 @@ struct FixedKVLeafNode
     ceph_assert(_right->get_type() == this->get_type());
     auto &right = *_right->template cast<node_type_t>();
     auto replacement_left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
     auto replacement_right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size, placement_hint_t::HOT, 0);
+      c.trans, node_size, placement_hint_t::HOT, INIT_GENERATION);
 
     auto pivot = this->balance_into_new_nodes(
       *this,

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -701,7 +701,7 @@ void Cache::add_extent(
 {
   assert(ref->is_valid());
   assert(ref->user_hint == PLACEMENT_HINT_NULL);
-  assert(ref->reclaim_generation == NULL_GENERATION);
+  assert(ref->rewrite_generation == NULL_GENERATION);
   extents.insert(*ref);
   if (ref->is_dirty()) {
     add_to_dirty(ref);
@@ -946,12 +946,12 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
   extent_types_t type,   ///< [in] type tag
   extent_len_t length,   ///< [in] length
   placement_hint_t hint, ///< [in] user hint
-  reclaim_gen_t gen      ///< [in] reclaim generation
+  rewrite_gen_t gen      ///< [in] rewrite generation
 )
 {
   LOG_PREFIX(Cache::alloc_new_extent_by_type);
   SUBDEBUGT(seastore_cache, "allocate {} {}B, hint={}, gen={}",
-            t, type, length, hint, reclaim_gen_printer_t{gen});
+            t, type, length, hint, rewrite_gen_printer_t{gen});
   switch (type) {
   case extent_types_t::ROOT:
     ceph_assert(0 == "ROOT is never directly alloc'd");

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -629,11 +629,11 @@ public:
     Transaction &t,         ///< [in, out] current transaction
     extent_len_t length,    ///< [in] length
     placement_hint_t hint,  ///< [in] user hint
-    reclaim_gen_t gen       ///< [in] reclaim generation
+    rewrite_gen_t gen       ///< [in] rewrite generation
   ) {
     LOG_PREFIX(Cache::alloc_new_extent);
     SUBTRACET(seastore_cache, "allocate {} {}B, hint={}, gen={}",
-              t, T::TYPE, length, hint, reclaim_gen_printer_t{gen});
+              t, T::TYPE, length, hint, rewrite_gen_printer_t{gen});
     auto result = epm.alloc_new_extent(t, T::TYPE, length, hint, gen);
     auto ret = CachedExtent::make_cached_extent_ref<T>(std::move(result.bp));
     ret->init(CachedExtent::extent_state_t::INITIAL_WRITE_PENDING,
@@ -644,7 +644,7 @@ public:
     SUBDEBUGT(seastore_cache,
               "allocated {} {}B extent at {}, hint={}, gen={} -- {}",
               t, T::TYPE, length, result.paddr,
-              hint, reclaim_gen_printer_t{result.gen}, *ret);
+              hint, rewrite_gen_printer_t{result.gen}, *ret);
     return ret;
   }
 
@@ -658,7 +658,7 @@ public:
     extent_types_t type,   ///< [in] type tag
     extent_len_t length,   ///< [in] length
     placement_hint_t hint, ///< [in] user hint
-    reclaim_gen_t gen      ///< [in] reclaim generation
+    rewrite_gen_t gen      ///< [in] rewrite generation
     );
 
   /**

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -118,6 +118,7 @@ public:
             paddr_t paddr,
             placement_hint_t hint,
             reclaim_gen_t gen) {
+    assert(gen == NULL_GENERATION || is_reclaim_generation(gen));
     state = _state;
     set_paddr(paddr);
     user_hint = hint;
@@ -402,8 +403,10 @@ public:
     reclaim_generation = NULL_GENERATION;
   }
 
-  void set_reclaim_generation(reclaim_gen_t gen) {
-    assert(gen < RECLAIM_GENERATIONS);
+  /// assign the target reclaim generation for the followup rewrite
+  void set_target_reclaim_generation(reclaim_gen_t gen) {
+    assert(is_target_reclaim_generation(gen));
+
     user_hint = placement_hint_t::REWRITE;
     reclaim_generation = gen;
   }
@@ -485,10 +488,11 @@ private:
 
   read_set_item_t<Transaction>::list transactions;
 
-  placement_hint_t user_hint;
+  placement_hint_t user_hint = PLACEMENT_HINT_NULL;
 
-  /// > 0 and not null means the extent is under reclaimming
-  reclaim_gen_t reclaim_generation;
+  // the target reclaim generation for the followup rewrite
+  // or the reclaim generation for the fresh write
+  reclaim_gen_t reclaim_generation = NULL_GENERATION;
 
 protected:
   CachedExtent(CachedExtent &&other) = delete;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -117,12 +117,12 @@ public:
   void init(extent_state_t _state,
             paddr_t paddr,
             placement_hint_t hint,
-            reclaim_gen_t gen) {
-    assert(gen == NULL_GENERATION || is_reclaim_generation(gen));
+            rewrite_gen_t gen) {
+    assert(gen == NULL_GENERATION || is_rewrite_generation(gen));
     state = _state;
     set_paddr(paddr);
     user_hint = hint;
-    reclaim_generation = gen;
+    rewrite_generation = gen;
   }
 
   void set_modify_time(sea_time_point t) {
@@ -213,7 +213,7 @@ public:
 	<< ", last_committed_crc=" << last_committed_crc
 	<< ", refcount=" << use_count()
 	<< ", user_hint=" << user_hint
-	<< ", reclaim_gen=" << reclaim_gen_printer_t{reclaim_generation};
+	<< ", rewrite_gen=" << rewrite_gen_printer_t{rewrite_generation};
     if (state != extent_state_t::INVALID &&
         state != extent_state_t::CLEAN_PENDING) {
       print_detail(out);
@@ -394,21 +394,21 @@ public:
     return user_hint;
   }
 
-  reclaim_gen_t get_reclaim_generation() const {
-    return reclaim_generation;
+  rewrite_gen_t get_rewrite_generation() const {
+    return rewrite_generation;
   }
 
   void invalidate_hints() {
     user_hint = PLACEMENT_HINT_NULL;
-    reclaim_generation = NULL_GENERATION;
+    rewrite_generation = NULL_GENERATION;
   }
 
-  /// assign the target reclaim generation for the followup rewrite
-  void set_target_reclaim_generation(reclaim_gen_t gen) {
-    assert(is_target_reclaim_generation(gen));
+  /// assign the target rewrite generation for the followup rewrite
+  void set_target_rewrite_generation(rewrite_gen_t gen) {
+    assert(is_target_rewrite_generation(gen));
 
     user_hint = placement_hint_t::REWRITE;
-    reclaim_generation = gen;
+    rewrite_generation = gen;
   }
 
   bool is_inline() const {
@@ -490,9 +490,9 @@ private:
 
   placement_hint_t user_hint = PLACEMENT_HINT_NULL;
 
-  // the target reclaim generation for the followup rewrite
-  // or the reclaim generation for the fresh write
-  reclaim_gen_t reclaim_generation = NULL_GENERATION;
+  // the target rewrite generation for the followup rewrite
+  // or the rewrite generation for the fresh write
+  rewrite_gen_t rewrite_generation = NULL_GENERATION;
 
 protected:
   CachedExtent(CachedExtent &&other) = delete;

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -12,7 +12,7 @@ namespace crimson::os::seastore {
 
 SegmentedOolWriter::SegmentedOolWriter(
   data_category_t category,
-  reclaim_gen_t gen,
+  rewrite_gen_t gen,
   SegmentProvider& sp,
   SegmentSeqAllocator &ssa)
   : segment_allocator(nullptr, category, gen, sp, ssa),
@@ -182,7 +182,7 @@ void ExtentPlacementManager::init(
   ceph_assert(segment_cleaner != nullptr);
   auto num_writers = generation_to_writer(REWRITE_GENERATIONS);
   data_writers_by_gen.resize(num_writers, {});
-  for (reclaim_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+  for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
     writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
           data_category_t::DATA, gen, *segment_cleaner,
           segment_cleaner->get_ool_segment_seq_allocator()));
@@ -190,7 +190,7 @@ void ExtentPlacementManager::init(
   }
 
   md_writers_by_gen.resize(num_writers, {});
-  for (reclaim_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+  for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
     writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
           data_category_t::METADATA, gen, *segment_cleaner,
           segment_cleaner->get_ool_segment_seq_allocator()));
@@ -252,7 +252,7 @@ ExtentPlacementManager::delayed_alloc_or_ool_write(
       auto writer_ptr = get_writer(
           extent->get_user_hint(),
           get_extent_category(extent->get_type()),
-          extent->get_reclaim_generation());
+          extent->get_rewrite_generation());
       alloc_map[writer_ptr].emplace_back(extent);
     }
     return trans_intr::do_for_each(alloc_map, [&t](auto& p) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -47,7 +47,7 @@ using ExtentOolWriterRef = std::unique_ptr<ExtentOolWriter>;
 class SegmentedOolWriter : public ExtentOolWriter {
 public:
   SegmentedOolWriter(data_category_t category,
-                     reclaim_gen_t gen,
+                     rewrite_gen_t gen,
                      SegmentProvider &sp,
                      SegmentSeqAllocator &ssa);
 
@@ -136,17 +136,17 @@ public:
   struct alloc_result_t {
     paddr_t paddr;
     bufferptr bp;
-    reclaim_gen_t gen;
+    rewrite_gen_t gen;
   };
   alloc_result_t alloc_new_extent(
     Transaction& t,
     extent_types_t type,
     extent_len_t length,
     placement_hint_t hint,
-    reclaim_gen_t gen
+    rewrite_gen_t gen
   ) {
     assert(hint < placement_hint_t::NUM_HINTS);
-    assert(is_target_reclaim_generation(gen));
+    assert(is_target_rewrite_generation(gen));
     assert(gen == INIT_GENERATION || hint == placement_hint_t::REWRITE);
 
     // XXX: bp might be extended to point to differnt memory (e.g. PMem)
@@ -265,9 +265,9 @@ private:
 
   ExtentOolWriter* get_writer(placement_hint_t hint,
                               data_category_t category,
-                              reclaim_gen_t gen) {
+                              rewrite_gen_t gen) {
     assert(hint < placement_hint_t::NUM_HINTS);
-    assert(is_reclaim_generation(gen));
+    assert(is_rewrite_generation(gen));
     assert(gen != INLINE_GENERATION);
     if (category == data_category_t::DATA) {
       return data_writers_by_gen[generation_to_writer(gen)];

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -15,7 +15,7 @@ namespace crimson::os::seastore::journal {
 SegmentAllocator::SegmentAllocator(
   JournalTrimmer *trimmer,
   data_category_t category,
-  reclaim_gen_t gen,
+  rewrite_gen_t gen,
   SegmentProvider &sp,
   SegmentSeqAllocator &ssa)
   : print_name{fmt::format("{}_G{}", category, gen)},

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -33,7 +33,7 @@ class SegmentAllocator {
  public:
   SegmentAllocator(JournalTrimmer *trimmer,
                    data_category_t category,
-                   reclaim_gen_t gen,
+                   rewrite_gen_t gen,
                    SegmentProvider &sp,
                    SegmentSeqAllocator &ssa);
 
@@ -122,7 +122,7 @@ class SegmentAllocator {
   std::string print_name;
   const segment_type_t type; // JOURNAL or OOL
   const data_category_t category;
-  const reclaim_gen_t gen;
+  const rewrite_gen_t gen;
   SegmentProvider &segment_provider;
   SegmentManagerGroup &sm_group;
   SegmentRef current_segment;

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -33,7 +33,7 @@ SegmentedJournal::SegmentedJournal(
       new SegmentSeqAllocator(segment_type_t::JOURNAL)),
     journal_segment_allocator(&trimmer,
                               data_category_t::METADATA,
-                              0, // generation
+                              INLINE_GENERATION,
                               segment_provider,
                               *segment_seq_allocator),
     record_submitter(crimson::common::get_conf<uint64_t>(

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -249,9 +249,15 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
 std::ostream &operator<<(std::ostream &out, reclaim_gen_printer_t gen)
 {
   if (gen.gen == NULL_GENERATION) {
-    return out << "NULL_GEN";
-  } else if (gen.gen >= RECLAIM_GENERATIONS) {
-    return out << "INVALID_GEN(" << (unsigned)gen.gen << ")";
+    return out << "GEN_NULL";
+  } else if (gen.gen == INIT_GENERATION) {
+    return out << "GEN_INIT";
+  } else if (gen.gen == INLINE_GENERATION) {
+    return out << "GEN_INL";
+  } else if (gen.gen == OOL_GENERATION) {
+    return out << "GEN_OOL";
+  } else if (gen.gen > REWRITE_GENERATIONS) {
+    return out << "GEN_INVALID(" << (unsigned)gen.gen << ")!";
   } else {
     return out << "GEN(" << (unsigned)gen.gen << ")";
   }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -246,7 +246,7 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
   }
 }
 
-std::ostream &operator<<(std::ostream &out, reclaim_gen_printer_t gen)
+std::ostream &operator<<(std::ostream &out, rewrite_gen_printer_t gen)
 {
   if (gen.gen == NULL_GENERATION) {
     return out << "GEN_NULL";
@@ -349,7 +349,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
              << " " << header.type
              << " " << segment_seq_printer_t{header.segment_seq}
              << " " << header.category
-             << " " << reclaim_gen_printer_t{header.generation}
+             << " " << rewrite_gen_printer_t{header.generation}
              << ", dirty_tail=" << header.dirty_tail
              << ", alloc_tail=" << header.alloc_tail
              << ", segment_nonce=" << header.segment_nonce

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1118,7 +1118,7 @@ constexpr bool is_backref_node(extent_types_t type)
 std::ostream &operator<<(std::ostream &out, extent_types_t t);
 
 /**
- * reclaim_gen_t
+ * rewrite_gen_t
  *
  * The goal is to group the similar aged extents in the same segment for better
  * bimodel utilization distribution, and also to the same device tier. For EPM,
@@ -1137,16 +1137,16 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t);
  * to not increase the generation if want to keep the hot tier as filled as
  * possible.
  */
-using reclaim_gen_t = uint8_t;
+using rewrite_gen_t = uint8_t;
 
 // INIT_GENERATION requires EPM decision to INLINE/OOL_GENERATION
-constexpr reclaim_gen_t INIT_GENERATION = 0;
-constexpr reclaim_gen_t INLINE_GENERATION = 1; // to the journal
-constexpr reclaim_gen_t OOL_GENERATION = 2;
+constexpr rewrite_gen_t INIT_GENERATION = 0;
+constexpr rewrite_gen_t INLINE_GENERATION = 1; // to the journal
+constexpr rewrite_gen_t OOL_GENERATION = 2;
 
 // All the rewritten extents start with MIN_REWRITE_GENERATION
-constexpr reclaim_gen_t MIN_REWRITE_GENERATION = 3;
-constexpr reclaim_gen_t MAX_REWRITE_GENERATION = 4;
+constexpr rewrite_gen_t MIN_REWRITE_GENERATION = 3;
+constexpr rewrite_gen_t MAX_REWRITE_GENERATION = 4;
 
 /**
  * TODO:
@@ -1154,30 +1154,30 @@ constexpr reclaim_gen_t MAX_REWRITE_GENERATION = 4;
  * hot tier.
  */
 
-constexpr reclaim_gen_t REWRITE_GENERATIONS = MAX_REWRITE_GENERATION + 1;
-constexpr reclaim_gen_t NULL_GENERATION =
-  std::numeric_limits<reclaim_gen_t>::max();
+constexpr rewrite_gen_t REWRITE_GENERATIONS = MAX_REWRITE_GENERATION + 1;
+constexpr rewrite_gen_t NULL_GENERATION =
+  std::numeric_limits<rewrite_gen_t>::max();
 
-struct reclaim_gen_printer_t {
-  reclaim_gen_t gen;
+struct rewrite_gen_printer_t {
+  rewrite_gen_t gen;
 };
 
-std::ostream &operator<<(std::ostream &out, reclaim_gen_printer_t gen);
+std::ostream &operator<<(std::ostream &out, rewrite_gen_printer_t gen);
 
-constexpr std::size_t generation_to_writer(reclaim_gen_t gen) {
+constexpr std::size_t generation_to_writer(rewrite_gen_t gen) {
   // caller to assert the gen is in the reasonable range
   return gen - OOL_GENERATION;
 }
 
 // before EPM decision
-constexpr bool is_target_reclaim_generation(reclaim_gen_t gen) {
+constexpr bool is_target_rewrite_generation(rewrite_gen_t gen) {
   return gen == INIT_GENERATION ||
          (gen >= MIN_REWRITE_GENERATION &&
           gen <= REWRITE_GENERATIONS);
 }
 
 // after EPM decision
-constexpr bool is_reclaim_generation(reclaim_gen_t gen) {
+constexpr bool is_rewrite_generation(rewrite_gen_t gen) {
   return gen >= INLINE_GENERATION &&
          gen < REWRITE_GENERATIONS;
 }
@@ -1694,7 +1694,7 @@ struct segment_header_t {
   segment_type_t type;
 
   data_category_t category;
-  reclaim_gen_t generation;
+  rewrite_gen_t generation;
 
   segment_type_t get_type() const {
     return type;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1117,11 +1117,44 @@ constexpr bool is_backref_node(extent_types_t type)
 
 std::ostream &operator<<(std::ostream &out, extent_types_t t);
 
+/**
+ * reclaim_gen_t
+ *
+ * The goal is to group the similar aged extents in the same segment for better
+ * bimodel utilization distribution, and also to the same device tier. For EPM,
+ * it has the flexibility to make placement decisions by re-assigning the
+ * generation. And each non-inline generation will be statically mapped to a
+ * writer in EPM.
+ *
+ * All the fresh and dirty extents start with INIT_GENERATION upon allocation,
+ * and they will be assigned to INLINE/OOL generation by EPM before the initial
+ * writes. After that, the generation can only be increased upon rewrite.
+ *
+ * Note, although EPM can re-assign the generations according to the tiering
+ * status, it cannot decrease the generation for the correctness of space
+ * reservation. It may choose to assign a larger generation if the extent is
+ * hinted cold, or if want to evict extents to the cold tier. And it may choose
+ * to not increase the generation if want to keep the hot tier as filled as
+ * possible.
+ */
 using reclaim_gen_t = uint8_t;
 
-constexpr reclaim_gen_t DIRTY_GENERATION = 1;
-constexpr reclaim_gen_t COLD_GENERATION = 1;
-constexpr reclaim_gen_t RECLAIM_GENERATIONS = 3;
+// INIT_GENERATION requires EPM decision to INLINE/OOL_GENERATION
+constexpr reclaim_gen_t INIT_GENERATION = 0;
+constexpr reclaim_gen_t INLINE_GENERATION = 1; // to the journal
+constexpr reclaim_gen_t OOL_GENERATION = 2;
+
+// All the rewritten extents start with MIN_REWRITE_GENERATION
+constexpr reclaim_gen_t MIN_REWRITE_GENERATION = 3;
+constexpr reclaim_gen_t MAX_REWRITE_GENERATION = 4;
+
+/**
+ * TODO:
+ * For tiering, might introduce 5 and 6 for the cold tier, and 1 ~ 4 for the
+ * hot tier.
+ */
+
+constexpr reclaim_gen_t REWRITE_GENERATIONS = MAX_REWRITE_GENERATION + 1;
 constexpr reclaim_gen_t NULL_GENERATION =
   std::numeric_limits<reclaim_gen_t>::max();
 
@@ -1130,6 +1163,24 @@ struct reclaim_gen_printer_t {
 };
 
 std::ostream &operator<<(std::ostream &out, reclaim_gen_printer_t gen);
+
+constexpr std::size_t generation_to_writer(reclaim_gen_t gen) {
+  // caller to assert the gen is in the reasonable range
+  return gen - OOL_GENERATION;
+}
+
+// before EPM decision
+constexpr bool is_target_reclaim_generation(reclaim_gen_t gen) {
+  return gen == INIT_GENERATION ||
+         (gen >= MIN_REWRITE_GENERATION &&
+          gen <= REWRITE_GENERATIONS);
+}
+
+// after EPM decision
+constexpr bool is_reclaim_generation(reclaim_gen_t gen) {
+  return gen >= INLINE_GENERATION &&
+         gen < REWRITE_GENERATIONS;
+}
 
 enum class data_category_t : uint8_t {
   METADATA = 0,

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -451,8 +451,8 @@ TransactionManager::rewrite_logical_extent(
     lextent->get_type(),
     lextent->get_length(),
     lextent->get_user_hint(),
-    // get target reclaim generation
-    lextent->get_reclaim_generation())->cast<LogicalCachedExtent>();
+    // get target rewrite generation
+    lextent->get_rewrite_generation())->cast<LogicalCachedExtent>();
   lextent->get_bptr().copy_out(
     0,
     lextent->get_length(),
@@ -477,7 +477,7 @@ TransactionManager::rewrite_logical_extent(
 TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
   Transaction &t,
   CachedExtentRef extent,
-  reclaim_gen_t target_generation,
+  rewrite_gen_t target_generation,
   sea_time_point modify_time)
 {
   LOG_PREFIX(TransactionManager::rewrite_extent);
@@ -494,9 +494,9 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
 
   assert(extent->is_valid() && !extent->is_initial_pending());
   if (extent->is_dirty()) {
-    extent->set_target_reclaim_generation(INIT_GENERATION);
+    extent->set_target_rewrite_generation(INIT_GENERATION);
   } else {
-    extent->set_target_reclaim_generation(target_generation);
+    extent->set_target_rewrite_generation(target_generation);
     ceph_assert(modify_time != NULL_TIME);
     extent->set_modify_time(modify_time);
   }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -451,6 +451,7 @@ TransactionManager::rewrite_logical_extent(
     lextent->get_type(),
     lextent->get_length(),
     lextent->get_user_hint(),
+    // get target reclaim generation
     lextent->get_reclaim_generation())->cast<LogicalCachedExtent>();
   lextent->get_bptr().copy_out(
     0,
@@ -493,9 +494,9 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
 
   assert(extent->is_valid() && !extent->is_initial_pending());
   if (extent->is_dirty()) {
-    extent->set_reclaim_generation(DIRTY_GENERATION);
+    extent->set_target_reclaim_generation(INIT_GENERATION);
   } else {
-    extent->set_reclaim_generation(target_generation);
+    extent->set_target_reclaim_generation(target_generation);
     ceph_assert(modify_time != NULL_TIME);
     extent->set_modify_time(modify_time);
   }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -320,7 +320,7 @@ public:
       t,
       len,
       placement_hint,
-      0);
+      INIT_GENERATION);
     return lba_manager->alloc_extent(
       t,
       laddr_hint,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -486,7 +486,7 @@ public:
   rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
-    reclaim_gen_t target_generation,
+    rewrite_gen_t target_generation,
     sea_time_point modify_time) final;
 
   using ExtentCallbackInterface::get_extents_if_live_ret;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -75,7 +75,7 @@ struct btree_test_base :
     segment_seq_t seq,
     segment_type_t type,
     data_category_t,
-    reclaim_gen_t
+    rewrite_gen_t
   ) final {
     auto ret = next;
     next = segment_id_t{

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -114,7 +114,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
     segment_seq_t seq,
     segment_type_t type,
     data_category_t,
-    reclaim_gen_t
+    rewrite_gen_t
   ) final {
     auto ret = next;
     next = segment_id_t{


### PR DESCRIPTION
I'm trying to clarify the intention of the `rewrite_gen_t`, which is related to the developments of RBM and device tiering. Does it make sense to you @myoungwon @zhscn ?

Instead of allowing writers to freely and correctly redirect write streams, I think it might be simpler to allow EPM to make decisions on the generation, see the comments of `rewrite_gen_t`.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
