### PR TITLE
quincy: doc/glossary: add "BlueStore"

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -4,11 +4,15 @@
 
 .. glossary::
 
-	bluestore
-                OSD BlueStore is a new back end for OSD daemons (kraken and
-                newer versions). Unlike :term:`filestore` it stores objects
-                directly on the Ceph block devices without any file system
-                interface.
+	:ref:`BlueStore<rados_config_storage_devices_bluestore>`
+                OSD BlueStore is a storage back end used by OSD daemons, and
+                was designed specifically for use with Ceph. BlueStore was
+                introduced in the Ceph Kraken release. In the Ceph Luminous
+                release, BlueStore became Ceph's default storage back end,
+                supplanting FileStore. Unlike :term:`filestore`, BlueStore
+                stores objects directly on Ceph block devices without any file
+                system interface. Since Luminous (12.2), BlueStore has been
+                Ceph's default and recommended storage back end.
 
 	Ceph
 	Ceph Block Device

--- a/doc/rados/configuration/storage-devices.rst
+++ b/doc/rados/configuration/storage-devices.rst
@@ -32,6 +32,8 @@ As of the Luminous 12.2.z release, the default (and recommended) backend is
 *BlueStore*.  Prior to the Luminous release, the default (and only option) was
 *Filestore*.
 
+.. _rados_config_storage_devices_bluestore:
+
 BlueStore
 ---------
 


### PR DESCRIPTION
Define "BlueStore" in the glossary and link to the BlueStore section in the RADOS Configuration "Storage Devices" chapter.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 77da4e66b0399a1cfd1c661bd3a11d76ec5f7847)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
