### PR TITLE
mon: add exception handling to ceph health mute

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -300,13 +300,19 @@ bool HealthMonitor::prepare_command(MonOpRequestRef op)
     cmd_getval(cmdmap, "sticky", sticky);
     string ttl_str;
     utime_t ttl;
+    std::chrono::seconds secs;
     if (cmd_getval(cmdmap, "ttl", ttl_str)) {
-      auto secs = parse_timespan(ttl_str);
-      if (secs == 0s) {
-	r = -EINVAL;
-	ss << "not a valid duration: " << ttl_str;
-	goto out;
+      try {
+        secs = parse_timespan(ttl_str);
+        if (secs == 0s) {
+          throw std::invalid_argument("timespan = 0");
+        }
+      } catch (const std::invalid_argument& e) {
+        ss << "invalid duration: " << ttl_str << " (" << e.what() << ")";
+        r = -EINVAL;
+        goto out;
       }
+      
       ttl = ceph_clock_now();
       ttl += std::chrono::duration<double>(secs).count();
     }


### PR DESCRIPTION
Running `ceph health mute` with an invalid TTL causes the mon to crash, because the exception thrown by `parse_timespan()` was not properly handled in this case. 

In addition, rather than duplicating the error-handling code, the `if` statement now throws an exception that is caught by the same try-catch.

Tracker: https://tracker.ceph.com/issues/58003