### PR TITLE
pacific: ceph-crash: drop privleges to run as "ceph" user, rather than root (CVE-2022-3650)

### DIFF
--- a/qa/workunits/rados/test_crash.sh
+++ b/qa/workunits/rados/test_crash.sh
@@ -24,6 +24,11 @@ for f in $(find $TESTDIR/archive/coredump -type f); do
 	fi
 done
 
+# ceph-crash runs as the unprivileged "ceph" user, but when under test
+# the ceph osd daemons are running as root, so their crash files aren't
+# readable.  let's chown them so they behave as they would in real life.
+sudo chown -R ceph:ceph /var/lib/ceph/crash
+
 # let daemon find crashdumps on startup
 sudo systemctl restart ceph-crash
 sleep 30

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -3,8 +3,10 @@
 # vim: ts=4 sw=4 smarttab expandtab
 
 import argparse
+import grp
 import logging
 import os
+import pwd
 import signal
 import socket
 import subprocess
@@ -88,8 +90,25 @@ def handler(signum, frame):
     sys.exit(0)
 
 
+def drop_privs():
+    if os.getuid() == 0:
+        try:
+            ceph_uid = pwd.getpwnam("ceph").pw_uid
+            ceph_gid = grp.getgrnam("ceph").gr_gid
+            os.setgroups([])
+            os.setgid(ceph_gid)
+            os.setuid(ceph_uid)
+        except Exception as e:
+            log.error(f"Unable to drop privileges: {e}")
+            sys.exit(1)
+
+
 def main():
     global auth_names
+
+    # run as unprivileged ceph user
+    drop_privs()
+
     # exit code 0 on SIGINT, SIGTERM
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
@@ -108,7 +127,10 @@ def main():
 
     log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
     while True:
-        scrape_path(args.path)
+        try:
+            scrape_path(args.path)
+        except Exception as e:
+            log.error(f"Error scraping {args.path}: {e}")
         if args.delay == 0:
             sys.exit(0)
         time.sleep(args.delay * 60)

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -18,6 +18,7 @@ auth_names = ['client.crash.%s' % socket.gethostname(),
               'client.crash',
               'client.admin']
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -29,7 +30,8 @@ def parse_args():
     )
     parser.add_argument(
         '--name', '-n',
-        help='ceph name to authenticate as (default: try client.crash, client.admin)')
+        help='ceph name to authenticate as '
+             '(default: try client.crash, client.admin)')
     parser.add_argument(
         '--log-level', '-l',
         help='log level output (default: INFO), support INFO or DEBUG')
@@ -79,9 +81,11 @@ def scrape_path(path):
                     (metapath, p, os.path.join('posted/', p))
                 )
 
+
 def handler(signum, frame):
     print('*** Interrupted with signal %d ***' % signum)
     sys.exit(0)
+
 
 def main():
     global auth_names

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -79,7 +79,7 @@ def scrape_path(path):
                     (metapath, p, os.path.join('posted/', p))
                 )
 
-def handler(signum):
+def handler(signum, frame):
     print('*** Interrupted with signal %d ***' % signum)
     sys.exit(0)
 

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -66,6 +66,9 @@ def post_crash(path):
 def scrape_path(path):
     for p in os.listdir(path):
         crashpath = os.path.join(path, p)
+        if not os.access(crashpath, os.R_OK):
+            log.warning('unable to read crash path %s' % (crashpath))
+            continue
         metapath = os.path.join(crashpath, 'meta')
         donepath = os.path.join(crashpath, 'done')
         if os.path.isfile(metapath):

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -50,7 +50,8 @@ def post_crash(path):
             stderr=subprocess.PIPE,
         )
         f = open(os.path.join(path, 'meta'), 'rb')
-        stderr = pr.communicate(input=f.read())
+        (_, stderr) = pr.communicate(input=f.read())
+        stderr = stderr.decode()
         rc = pr.wait()
         f.close()
         if rc != 0 or stderr != "":


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57996

---

backport of https://github.com/ceph/ceph/pull/48713
parent tracker: https://tracker.ceph.com/issues/57967

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh