### PR TITLE
ceph-crash: Use auth_names when pinging cluster at startup

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -126,8 +126,10 @@ def main():
         time.sleep(30)
 
     log.info("pinging cluster to exercise our key")
-    pr = subprocess.Popen(args=['timeout', '30', 'ceph', '-s'])
-    pr.wait()
+    for n in auth_names:
+        pr = subprocess.Popen(args=['timeout', '30', 'ceph', '-n', n, '-s'])
+        if pr.wait() == 0:
+            break
 
     log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
     while True:


### PR DESCRIPTION
The code to ping the cluster with a key on startup doesn't specify a client name, which means it may not be using the correct key. This becomes obvious when running inside a container, which will have the client.crash.$hostname keyring, but not the admin keyring.

This commit is only necessary for the main branch, as the original ping on startup was never backported anywhere else.

Fixes: 84c4562f7bff9ca1018fd1975657144e62d6b93d
Signed-off-by: Tim Serong <tserong@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
