### PR TITLE
dokan: Configurable maximum path length

### DIFF
--- a/src/common/win32/errno.cc
+++ b/src/common/win32/errno.cc
@@ -638,7 +638,7 @@ static const ceph::unordered_map<int,NTSTATUS> cephfs_errno_to_ntstatus = {
   {CEPHFS_EOLDSNAPC,       STATUS_DATA_ERROR}
 };
 
-__u32 cephfs_errno_to_ntsatus(int cephfs_errno)
+__u32 cephfs_errno_to_ntstatus_map(int cephfs_errno)
 {
   cephfs_errno = abs(cephfs_errno);
 

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -93,7 +93,7 @@ static NTSTATUS do_open_file(
   if (fd < 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_open failed. Error: " << fd << dendl;
-    return cephfs_errno_to_ntsatus(fd);
+    return cephfs_errno_to_ntstatus_map(fd);
   }
 
   fdc->fd = fd;
@@ -115,7 +115,7 @@ static NTSTATUS WinCephCreateDirectory(
   if (ret < 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_mkdir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
   return 0;
 }
@@ -335,7 +335,7 @@ static NTSTATUS WinCephReadFile(
     if (fd_new < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_open failed. Error: " << fd_new << dendl;
-      return cephfs_errno_to_ntsatus(fd_new);
+      return cephfs_errno_to_ntstatus_map(fd_new);
     }
 
     int ret = ceph_read(cmount, fd_new, (char*) Buffer, BufferLength, Offset);
@@ -345,7 +345,7 @@ static NTSTATUS WinCephReadFile(
               << ". Offset: " << Offset
               << "Buffer length: " << BufferLength << dendl;
       ceph_close(cmount, fd_new);
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
     *ReadLength = ret;
     ceph_close(cmount, fd_new);
@@ -357,7 +357,7 @@ static NTSTATUS WinCephReadFile(
               << ": ceph_read failed. Error: " << ret
               << ". Offset: " << Offset
               << "Buffer length: " << BufferLength << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
     *ReadLength = ret;
     return 0;
@@ -386,7 +386,7 @@ static NTSTATUS WinCephWriteFile(
       if (ret) {
         dout(2) << __func__ << " " << path
                 << ": ceph_statx failed. Error: " << ret << dendl;
-        return cephfs_errno_to_ntsatus(ret);
+        return cephfs_errno_to_ntstatus_map(ret);
       }
 
       Offset = stbuf.stx_size;
@@ -422,7 +422,7 @@ static NTSTATUS WinCephWriteFile(
     if (fd_new < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_open failed. Error: " << fd_new << dendl;
-      return cephfs_errno_to_ntsatus(fd_new);
+      return cephfs_errno_to_ntstatus_map(fd_new);
     }
 
     int ret = ceph_write(cmount, fd_new, (char*) Buffer,
@@ -433,7 +433,7 @@ static NTSTATUS WinCephWriteFile(
               << ". Offset: " << Offset
               << "Buffer length: " << NumberOfBytesToWrite << dendl;
       ceph_close(cmount, fd_new);
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
     *NumberOfBytesWritten = ret;
     ceph_close(cmount, fd_new);
@@ -446,7 +446,7 @@ static NTSTATUS WinCephWriteFile(
               << ": ceph_write failed. Error: " << ret
               << ". Offset: " << Offset
               << "Buffer length: " << NumberOfBytesToWrite << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
     *NumberOfBytesWritten = ret;
     return 0;
@@ -467,7 +467,7 @@ static NTSTATUS WinCephFlushFileBuffers(
   if (ret) {
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_sync failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
   return 0;
 }
@@ -490,14 +490,14 @@ static NTSTATUS WinCephGetFileInformation(
     if (ret) {
       dout(2) << __func__ << " " << path
               << ": ceph_statx failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
   } else {
     int ret = ceph_fstatx(cmount, fdc->fd, &stbuf, requested_attrs, 0);
     if (ret) {
       dout(2) << __func__ << " " << path
               << ": ceph_fstatx failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
   }
 
@@ -534,7 +534,7 @@ static NTSTATUS WinCephFindFiles(
   if (ret != 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_mkdir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
 
   WIN32_FIND_DATAW findData;
@@ -554,7 +554,7 @@ static NTSTATUS WinCephFindFiles(
     if (ret < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_readdirplus_r failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
 
     to_wstring(result.d_name).copy(findData.cFileName, MAX_PATH);
@@ -617,7 +617,7 @@ static NTSTATUS WinCephDeleteDirectory(
   if (ret != 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_opendir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
 
   WIN32_FIND_DATAW findData;
@@ -654,7 +654,7 @@ static NTSTATUS WinCephMoveFile(
             << ": ceph_rename failed. Error: " << ret << dendl;
   }
 
-  return cephfs_errno_to_ntsatus(ret);
+  return cephfs_errno_to_ntstatus_map(ret);
 }
 
 static NTSTATUS WinCephSetEndOfFile(
@@ -673,7 +673,7 @@ static NTSTATUS WinCephSetEndOfFile(
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_ftruncate failed. Error: " << ret
             << " Offset: " << ByteOffset << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
 
   return 0;
@@ -696,7 +696,7 @@ static NTSTATUS WinCephSetAllocationSize(
   if (ret) {
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_fstatx failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
 
   if ((unsigned long long) AllocSize < stbuf.stx_size) {
@@ -704,7 +704,7 @@ static NTSTATUS WinCephSetAllocationSize(
     if (ret) {
       dout(2) << __func__ << " " << get_path(FileName)
               << ": ceph_ftruncate failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntsatus(ret);
+      return cephfs_errno_to_ntstatus_map(ret);
     }
     return 0;
   }
@@ -756,7 +756,7 @@ static NTSTATUS WinCephSetFileTime(
   if (ret) {
     dout(2) << __func__ << " " << path
             << ": ceph_setattrx failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
   return 0;
 }
@@ -810,7 +810,7 @@ static NTSTATUS WinCephGetDiskFreeSpace(
   int ret = ceph_statfs(cmount, "/", &vfsbuf);
   if (ret) {
     derr << "ceph_statfs failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);;
+    return cephfs_errno_to_ntstatus_map(ret);;
   }
 
   *FreeBytesAvailable   = vfsbuf.f_bsize * vfsbuf.f_bfree;
@@ -874,7 +874,7 @@ NTSTATUS get_volume_serial(PDWORD serial) {
                           fsid_str, sizeof(fsid_str));
   if (ret < 0) {
     dout(2) << "Coudln't retrieve the cluster fsid. Error: " << ret << dendl;
-    return cephfs_errno_to_ntsatus(ret);
+    return cephfs_errno_to_ntstatus_map(ret);
   }
 
   uuid_d fsid;
@@ -931,7 +931,7 @@ int do_map() {
   r = ceph_mount(cmount, g_cfg->root_path.c_str());
   if (r) {
     derr << "ceph_mount failed. Error: " << r << dendl;
-    return cephfs_errno_to_ntsatus(r);
+    return cephfs_errno_to_ntstatus_map(r);
   }
 
   if (g_cfg->win_vol_name.empty()) {

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -789,7 +789,8 @@ static NTSTATUS WinCephGetVolumeInformation(
   g_cfg->win_vol_name.copy(VolumeNameBuffer, VolumeNameSize);
   *VolumeSerialNumber = g_cfg->win_vol_serial;
 
-  *MaximumComponentLength = 256;
+  *MaximumComponentLength = g_cfg->max_path_len;
+
   *FileSystemFlags = FILE_CASE_SENSITIVE_SEARCH |
             FILE_CASE_PRESERVED_NAMES |
             FILE_SUPPORTS_REMOTE_STORAGE |
@@ -947,6 +948,15 @@ int do_map() {
     if (get_volume_serial(&g_cfg->win_vol_serial)) {
       return -EINVAL;
     }
+  }
+
+  if (g_cfg->max_path_len > 260) {
+    dout(0) << "maximum path length set to " << g_cfg->max_path_len 
+            << ". Some Windows utilities may not be able to handle "
+            << "paths that exceed MAX_PATH (260) characters. "
+            << "CreateDirectoryW, used by Powershell, has also been "
+            << "observed to fail when paths exceed 16384 characters."
+            << dendl;
   }
 
   atexit(unmount_atexit);

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -33,6 +33,7 @@ struct Config {
 
   std::wstring win_vol_name = L"";
   unsigned long win_vol_serial = 0;
+  unsigned long max_path_len = 256;
 };
 
 extern Config *g_cfg;

--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -40,6 +40,7 @@ Map options:
   --removable                 use a removable drive
   --win-vol-name arg          The Windows volume name. Default: Ceph - <fs_name>.
   --win-vol-serial arg        The Windows volume serial number. Default: <fs_id>.
+  --max-path-len              The value of the maximum path length. Default: 256.
 
 Unmap options:
   -l [ --mountpoint ] arg     mountpoint (path or drive letter) (e.g -l x).
@@ -85,6 +86,7 @@ int parse_args(
   std::string mountpoint;
   std::string win_vol_name;
   std::string win_vol_serial;
+  std::string max_path_len;
 
   int thread_count;
 
@@ -115,6 +117,23 @@ int parse_args(
     } else if (ceph_argparse_witharg(args, i, &win_vol_serial,
                                      "--win-vol-serial", (char *)NULL)) {
       cfg->win_vol_serial = std::stoul(win_vol_serial);
+    } else if (ceph_argparse_witharg(args, i, &max_path_len,
+                                     "--max-path-len", (char*)NULL)) {
+      unsigned long max_path_length = std::stoul(max_path_len);
+
+      if (max_path_length > 32767) {
+        *err_msg << "ceph-dokan: maximum path length should not "
+                 << "exceed " << 32767;
+        return -EINVAL;
+      }
+
+      if (max_path_length < 256) {
+        *err_msg << "ceph-dokan: maximum path length should not "
+                 << "have a value lower than 256";
+        return -EINVAL;
+      }
+
+      cfg->max_path_len = max_path_length;
     } else if (ceph_argparse_flag(args, i, "--current-session-only", (char *)NULL)) {
       cfg->current_session_only = true;
     } else if (ceph_argparse_witharg(args, i, &thread_count,

--- a/src/include/win32/win32_errno.h
+++ b/src/include/win32/win32_errno.h
@@ -137,7 +137,7 @@ extern "C" {
 
 __s32 wsae_to_errno(__s32 r);
 __u32 errno_to_ntstatus(__s32 r);
-__u32 cephfs_errno_to_ntsatus(int cephfs_errno);
+__u32 cephfs_errno_to_ntstatus_map(int cephfs_errno);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Made ceph-dokan max path length configurable, supporting values between 256 and 32767.

The max path length can be configured using the new ceph-dokan map --max-path-len optarg.
If the value is not specified, the default 256 max path length will be used.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
