### PR TITLE
mgr/rgw: Add usage trim support on interval

### DIFF
--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -149,8 +149,8 @@ list of realms.
 
 Set the ``usage_trim_older_than_days`` config option to the amount of
 days usage logs older than this should be trimmed. Optionally you can
-set the interval that trim will be performed with ``usage_trim_interval``,
-it defaults to every twelve hours.
+set the interval in seconds that trim will be performed with
+``usage_trim_interval``, it defaults to every twelve hours.
 
 The below example will trim logs from start date 1970-01-01 to the current
 date minus 30 days.

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -139,3 +139,32 @@ Join an existing realm by creating a new secondary zone (using the realm token)
   ceph rgw admin [*]
 
 RGW admin command
+
+Automatic usage log trimming
+----------------------------
+
+Enable automatic usage log trimming for one or more RGW realms by
+setting the config option ``usage_trim_realms`` to a comma separated
+list of realms.
+
+Set the ``usage_trim_older_than_days`` config option to the amount of
+days usage logs older than this should be trimmed. Optionally you can
+set the interval that trim will be performed with ``usage_trim_interval``,
+it defaults to every twelve hours.
+
+The below example will trim logs from start date 1970-01-01 to the current
+date minus 30 days.
+
+::
+
+    ceph config set mgr mgr/rgw/usage_trim_realms default
+    ceph config set mgr mgr/rgw/usage_trim_older_than_days 30
+
+The above is equivalent to running the following command assuming that todays
+date is 2022-11-13.
+::
+
+    radosgw-admin --rgw-realm=default usage trim --start-date=1970-01-01 --end-date=2022-10-14
+
+End date is thus calculated as (today - usage_trim_older_than_days) which is
+equal to (2022-11-13 - 30 days) = 2022-10-14.

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -111,7 +111,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                desc='Trim usage log entries older than this amount of days, must be set to a positive value'),
         Option(name='usage_trim_interval',
                default=43200,
-               desc='Interval between trimming usage log entries, defaults to 12 hours'),
+               desc='Interval in seconds between trimming usage log entries, defaults to 12 hours'),
     ]
 
     # These are "native" Ceph options that this module cares about.

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -5,6 +5,7 @@ import errno
 import base64
 import functools
 import sys
+from datetime import datetime, timedelta
 
 from mgr_module import MgrModule, CLICommand, HandleCommandResult, Option
 import orchestrator
@@ -101,7 +102,17 @@ def check_orchestrator(func: FuncT) -> FuncT:
 
 
 class Module(orchestrator.OrchestratorClientMixin, MgrModule):
-    MODULE_OPTIONS: List[Option] = []
+    MODULE_OPTIONS: List[Option] = [
+        Option(name='usage_trim_realms',
+               default='',
+               desc='Comma separated list with realms to usage trim'),
+        Option(name='usage_trim_older_than_days',
+               default=0,
+               desc='Trim usage log entries older than this amount of days, must be set to a positive value'),
+        Option(name='usage_trim_interval',
+               default=43200,
+               desc='Interval between trimming usage log entries, defaults to 12 hours'),
+    ]
 
     # These are "native" Ceph options that this module cares about.
     NATIVE_OPTIONS: List[Option] = []
@@ -340,6 +351,27 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             return HandleCommandResult(retval=e.retcode, stdout=e.stdout, stderr=e.stderr)
 
         return HandleCommandResult(retval=retval, stdout=out, stderr=err)
+
+    def serve(self) -> None:
+        self.run = True
+
+        self.log.info('Starting usage trim loop')
+        while self.run:
+            if self.usage_trim_older_than_days <= 0:
+                self.log.info('Skipping usage trim because usage_trim_older_than_days is not > 0')
+                self.event.sleep(self.usage_trim_interval)
+                continue
+            startDate = '1970-01-01'
+            endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')
+            realms = cast(str, self.usage_trim_realms, default='').split(',')
+            for realm in realms:
+                self.log.info('Running usage trim for realm {} with startDate={} and endDate={}'.format(
+                              realm, startDate, endDate))
+                try:
+                    RGWAM(self.env).usage_op().trim(realm=realm, startDate=startDate, endDate=endDate)
+                except Exception:
+                    self.log.exception("Failed to usage trim:")
+            self.event.sleep(self.usage_trim_interval)
 
     def shutdown(self) -> None:
         """

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -357,20 +357,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         self.log.info('Starting usage trim loop')
         while self.run:
-            if self.usage_trim_older_than_days <= 0:
+            usage_trim_older_than_days = cast(int, self.get_module_option('usage_trim_older_than_days'))
+            if usage_trim_older_than_days <= 0:
                 self.log.debug('Skipping usage trim because usage_trim_older_than_days is not > 0')
-                self.event.sleep(60)
+                self.event.wait(60)
                 continue
             startDate = '1970-01-01'
-            endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')
-            realms = cast(str, self.usage_trim_realms, default='').split(',')
+            endDate = (datetime.today() - timedelta(days=usage_trim_older_than_days)).strftime('%Y-%m-%d')
+            usage_trim_realms = cast(str, self.get_module_option('usage_trim_realms'))
+            realms = usage_trim_realms.split(',')
             for realm in realms:
                 self.log.info(f'Running usage trim for realm {realm} with startDate={startDate} and endDate={endDate}')
                 try:
                     RGWAM(self.env).usage_op().trim(realm=realm, startDate=startDate, endDate=endDate)
                 except Exception:
                     self.log.exception("Failed to usage trim:")
-            self.event.sleep(self.usage_trim_interval)
+            usage_trim_interval = cast(int, self.get_module_option('usage_trim_interval'))
+            self.event.wait(usage_trim_interval)
 
     def shutdown(self) -> None:
         """

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -365,8 +365,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')
             realms = cast(str, self.usage_trim_realms, default='').split(',')
             for realm in realms:
-                self.log.info('Running usage trim for realm {} with startDate={} and endDate={}'.format(
-                              realm, startDate, endDate))
+                self.log.info(f'Running usage trim for realm {realm} with startDate={startDate} and endDate={endDate}')
                 try:
                     RGWAM(self.env).usage_op().trim(realm=realm, startDate=startDate, endDate=endDate)
                 except Exception:

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -358,8 +358,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self.log.info('Starting usage trim loop')
         while self.run:
             if self.usage_trim_older_than_days <= 0:
-                self.log.info('Skipping usage trim because usage_trim_older_than_days is not > 0')
-                self.event.sleep(self.usage_trim_interval)
+                self.log.debug('Skipping usage trim because usage_trim_older_than_days is not > 0')
+                self.event.sleep(60)
                 continue
             startDate = '1970-01-01'
             endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -424,15 +424,16 @@ class UsageOp:
     def __init__(self, env):
         self.env = env
 
-    def trim(self, realm: EntityKey = None, startDate: str = '', endDate: str = ''):
+    def trim(self, realm: EntityKey = None, startDate: Optional[str] = None,
+             endDate: Optional[str] = None):
         ze = ZoneEnv(self.env, realm=realm)
 
         params = ['trim']
 
-        if startDate != '':
+        if startDate is not None:
             params += ['--start-date=%s' % startDate]
 
-        if endDate != '':
+        if endDate is not None:
             params += ['--end-date=%s' % endDate]
 
         return RGWAdminCmd(ze).run(params)

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -420,6 +420,24 @@ class UserOp:
         return RGWAdminCmd(ze).run(params)
 
 
+class UsageOp:
+    def __init__(self, env):
+        self.env = env
+
+    def trim(self, realm: EntityKey = None, startDate: str = '', endDate: str = ''):
+        ze = ZoneEnv(self.env, realm=realm)
+
+        params = ['trim']
+
+        if startDate != '':
+            params += ['--start-date=%s' % startDate]
+
+        if endDate != '':
+            params += ['--end-date=%s' % endDate]
+
+        return RGWAdminCmd(ze).run(params)
+
+
 class RGWAM:
     def __init__(self, env):
         self.env = env
@@ -438,6 +456,9 @@ class RGWAM:
 
     def user_op(self):
         return UserOp(self.env)
+
+    def usage_op(self):
+        return UsageOp(self.env)
 
     def get_realm(self, realm_name):
         try:

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -429,7 +429,7 @@ class UsageOp:
              endDate: Optional[str] = None):
         ze = ZoneEnv(self.env, realm=realm)
 
-        params = ['trim']
+        params = ['usage', 'trim']
 
         if startDate is not None:
             params += ['--start-date=%s' % startDate]

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -12,6 +12,7 @@ import socket
 import base64
 import logging
 import errno
+from typing import Optional
 
 from .types import RGWAMException, RGWAMCmdRunException, RGWPeriod, RGWUser, RealmToken
 from .diff import RealmsEPs


### PR DESCRIPTION
This adds support in the rgw ceph-mgr module to trim the usage log on a regular interval so that one does not need to run radosgw-admin inside a cronjob or manually.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
