### PR TITLE
osd: don't lose information when stringifying pg state into 'unknown'

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1185,10 +1185,13 @@ std::string pg_state_string(uint64_t state)
   if (state & PG_STATE_WAIT)
     *css << "wait+";
   auto ret = css->str();
-  if (ret.length() > 0)
+  if (ret.length() > 0) {
+    // kill the last "+"
     ret.resize(ret.length() - 1);
-  else
-    ret = "unknown";
+  } else {
+    *css << "unknown(" << std::hex << state << std::dec << ")";
+    ret = css->str();
+  }
   return ret;
 }
 


### PR DESCRIPTION
The reason behind this patch is direct attention to the fact we lose a pretty usueful information for troubleshooting when a PG state is being converted into a string representation.

If there is no available human-readable state name, "unkown" (without any extra details) is used. This means multiple different states can be strigified to the same string which consitutes the data loss.

This patch alters the unknown state by appending the exact state value in hex. The format becomes "unknown(%x)".

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
