### PR TITLE
quincy: rook:PR for Fix for bug 57954

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1065,7 +1065,7 @@ class RookCluster(object):
             return rook_nfsgw
 
         create_ganesha_pool(mgr)
-        NFSRados(mgr_module, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
+        NFSRados(mgr_module.rados, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
         return self._create_or_patch(cnfs.CephNFS, 'cephnfses', service_id,
                 _update_nfs, _create_nfs)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58004

---

backport of https://github.com/ceph/ceph/pull/48694
parent tracker: https://tracker.ceph.com/issues/57954

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh