### PR TITLE
cephfs-top: run_display: clear the screen and block commands when no fs

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -457,7 +457,8 @@ class FSTop(object):
                 else:
                     self.run_display()
 
-    def set_option(self, opt):
+    def set_option_all_fs(self, opt):
+        # sets the options for 'All Filesystem Info' screen
         if opt == ord('m'):
             if fs_list:
                 curses.wrapper(self.set_key)
@@ -474,17 +475,38 @@ class FSTop(object):
             else:
                 return False
         elif opt == ord('r'):
-            current_states['last_field'] = 'chit'
-            current_states["limit"] = None
-            if isinstance(current_states['last_fs'], list):
-                self.run_all_display()
-            else:
-                self.run_display()
+            if fs_list:
+                current_states['last_field'] = 'chit'
+                current_states["limit"] = None
+            return False  # We are already in run_all_display()
         elif opt == ord('q'):
-            if self.current_screen == FS_TOP_ALL_FS_APP:
-                quit()
+            quit()
+        return True
+
+    def set_option_sel_fs(self, opt, selected_fs):
+        # sets the options for 'Selected Filesystem Info' screen
+        if opt == ord('m'):
+            if selected_fs in fs_list:
+                curses.wrapper(self.set_key)
             else:
-                self.run_all_display()
+                return False
+        elif opt == ord('s'):
+            if selected_fs in fs_list:
+                curses.wrapper(self.choose_field)
+            else:
+                return False
+        elif opt == ord('l'):
+            if selected_fs in fs_list:
+                curses.wrapper(self.set_limit)
+            else:
+                return False
+        elif opt == ord('r'):
+            if selected_fs in fs_list:
+                current_states['last_field'] = 'chit'
+                current_states["limit"] = None
+            return False  # we are already in run_display()
+        elif opt == ord('q'):
+            self.run_all_display()
         return True
 
     def verify_perf_stats_support(self):
@@ -843,19 +865,21 @@ class FSTop(object):
 
         curses.halfdelay(1)
         cmd = self.stdscr.getch()
+        global fs_list, current_states
         while not self.exit_ev.is_set():
-            if cmd in [ord('m'), ord('s'), ord('l'), ord('r'), ord('q')]:
-                self.set_option(cmd)
-                self.exit_ev.set()
-
-            global fs_list, current_states
             fs_list = self.get_fs_names()
             fs = current_states["last_fs"]
+            if cmd in [ord('m'), ord('s'), ord('l'), ord('r'), ord('q')]:
+                if self.set_option_sel_fs(cmd, fs):
+                    self.exit_ev.set()
+
             stats_json = self.perf_stats_query()
             vscrollEnd = 0
             if fs not in fs_list:
-                help = "Error: The selected filesystem is not available now. " + help_commands
+                help = f"Error: The selected filesystem '{fs}' is not available now. " \
+                    "[Press 'q' to go back to home (All Filesystem Info) screen]"
                 self.header.erase()  # erase previous text
+                self.fsstats.erase()
                 self.create_header(stats_json, help, screen_title, 3)
             else:
                 self.tablehead_y = 0
@@ -969,7 +993,7 @@ class FSTop(object):
         cmd = self.stdscr.getch()
         while not self.exit_ev.is_set():
             if cmd in [ord('m'), ord('s'), ord('l'), ord('r'), ord('q')]:
-                if self.set_option(cmd):
+                if self.set_option_all_fs(cmd):
                     self.exit_ev.set()
 
             # header display


### PR DESCRIPTION
This PR needs another round of testing.
FYI: This fix is not related to the scrolling feature. This fix is a continuation of https://github.com/ceph/ceph/commit/a386400c97868638eecdf0f8b20623cd97ec8791, which goes to the 'main' branch only. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>