### PR TITLE
common & osd: fix OpTracker event duration calculation errror

### DIFF
--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -187,8 +187,8 @@ public:
     typename T::Ref retval(new T(params, this));
     retval->tracking_start();
     if (is_tracking()) {
-      retval->mark_event("throttled", params->get_throttle_stamp());
       retval->mark_event("header_read", params->get_recv_stamp());
+      retval->mark_event("throttled", params->get_throttle_stamp());
       retval->mark_event("all_read", params->get_recv_complete_stamp());
       retval->mark_event("dispatched", params->get_dispatch_stamp());
     }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -31,7 +31,7 @@ using std::stringstream;
 using ceph::Formatter;
 
 OpRequest::OpRequest(Message* req, OpTracker* tracker)
-    : TrackedOp(tracker, req->get_throttle_stamp()),
+    : TrackedOp(tracker, req->get_recv_stamp()),
       request(req),
       hit_flag_points(0),
       latest_flag_point(0),


### PR DESCRIPTION
The event order is:
- initiated/throttled // throttle_stamp
- throttled // throttle_stamp
- header_read // recv_stamp
- all_read // recv_complete_stamp
- dispatched // dispatch_stamp

The right order should be:
- initiated/recv_stamp  // recv_stamp
- header_read // recv_stamp
- throttled // throttle_stamp
- all_read // recv_complete_stamp
- dispatched // dispatch_stamp

Fixes: https://tracker.ceph.com/issues/58012
Signed-off-by: Yang Honggang <yanghonggang_yewu@cmss.chinamobile.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
