### PR TITLE
mgr/dashboard: expose more grafana configs in service form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -685,6 +685,65 @@
             </div>
           </div>
         </ng-container>
+        <!-- Grafana -->
+        <ng-container *ngIf="serviceForm.controls.service_type.value === 'grafana'">
+          <div class="form-group row">
+            <label class="cd-col-form-label"
+                   for="grafana_port">
+              <span i18n>Grafana Port</span>
+              <cd-helper>
+                <span i18n>The default port used by grafana.</span>
+              </cd-helper>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="grafana_port"
+                     class="form-control"
+                     type="number"
+                     formControlName="grafana_port"
+                     min="1"
+                     max="65535">
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('grafana_port', frm, 'pattern')"
+                    i18n>The entered value needs to be a number.</span>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('grafana_port', frm, 'min')"
+                    i18n>The value must be at least 1.</span>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('grafana_port', frm, 'max')"
+                    i18n>The value cannot exceed 65535.</span>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('grafana_port', frm, 'required')"
+                    i18n>This field is required.</span>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label i18n
+                   class="cd-col-form-label"
+                   for="grafana_admin_password">
+              <span>Grafana Password</span>
+              <cd-helper>The password of the default Grafana Admin. Set once on first-run.</cd-helper>
+            </label>
+            <div class="cd-col-form-input">
+              <div class="input-group">
+                <input id="grafana_admin_password"
+                       class="form-control"
+                       type="password"
+                       autocomplete="new-password"
+                       [attr.disabled]="editing ? true:null"
+                       formControlName="grafana_admin_password">
+                <span class="input-group-append">
+                  <button type="button"
+                          class="btn btn-light"
+                          cdPasswordButton="grafana_admin_password">
+                  </button>
+                  <cd-copy-2-clipboard-button source="grafana_admin_password">
+                  </cd-copy-2-clipboard-button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </ng-container>
       </div>
 
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -120,17 +120,7 @@ describe('ServiceFormComponent', () => {
 
     it('should test various services', () => {
       _.forEach(
-        [
-          'alertmanager',
-          'crash',
-          'grafana',
-          'mds',
-          'mgr',
-          'mon',
-          'node-exporter',
-          'prometheus',
-          'rbd-mirror'
-        ],
+        ['alertmanager', 'crash', 'mds', 'mgr', 'mon', 'node-exporter', 'prometheus', 'rbd-mirror'],
         (serviceType) => {
           formHelper.setValue('service_type', serviceType);
           component.onSubmit();
@@ -141,6 +131,36 @@ describe('ServiceFormComponent', () => {
           });
         }
       );
+    });
+
+    describe('should test service grafana', () => {
+      beforeEach(() => {
+        formHelper.setValue('service_type', 'grafana');
+      });
+
+      it('should sumbit grafana', () => {
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'grafana',
+          placement: {},
+          unmanaged: false,
+          initial_admin_password: null,
+          port: null
+        });
+      });
+
+      it('should sumbit grafana with custom port and initial password', () => {
+        formHelper.setValue('grafana_port', 1234);
+        formHelper.setValue('grafana_admin_password', 'foo');
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'grafana',
+          placement: {},
+          unmanaged: false,
+          initial_admin_password: 'foo',
+          port: 1234
+        });
+      });
     });
 
     describe('should test service nfs', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -334,7 +334,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
             privacy_protocol: { op: '!empty' }
           })
         ]
-      ]
+      ],
+      grafana_port: [null, [CdValidators.number(false)]],
+      grafana_admin_password: [null]
     });
   }
 
@@ -479,6 +481,12 @@ export class ServiceFormComponent extends CdForm implements OnInit {
                   .get('snmp_community')
                   .setValue(response[0].spec['credentials']['snmp_community']);
               }
+              break;
+            case 'grafana':
+              this.serviceForm.get('grafana_port').setValue(response[0].spec.port);
+              this.serviceForm
+                .get('grafana_admin_password')
+                .setValue(response[0].spec.initial_admin_password);
               break;
           }
         });
@@ -654,6 +662,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           }
           serviceSpec['virtual_interface_networks'] = values['virtual_interface_networks'];
           break;
+        case 'grafana':
+          serviceSpec['port'] = values['grafana_port'];
+          serviceSpec['initial_admin_password'] = values['grafana_admin_password'];
       }
     }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -35,6 +35,8 @@ export interface CephServiceAdditionalSpec {
   ssl: boolean;
   ssl_cert: string;
   ssl_key: string;
+  port: number;
+  initial_admin_password: string;
 }
 
 export interface CephServicePlacement {


### PR DESCRIPTION
Show the grafana_port and initial_admin_password in the form but disable
the password field in the edit option

![Screenshot from 2023-01-24 11-32-52](https://user-images.githubusercontent.com/71764184/214222797-840ccc19-ae73-4c61-8b98-fcb3962ae5e5.png)


Fixes: https://tracker.ceph.com/issues/58016
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
