### PR TITLE
pacific: doc/osd: Fixes the introduction for writeback mode of cache tier.

### DIFF
--- a/doc/rados/operations/cache-tiering.rst
+++ b/doc/rados/operations/cache-tiering.rst
@@ -46,15 +46,17 @@ configure how this migration takes place by setting the ``cache-mode``. There ar
 two main scenarios:
 
 - **writeback** mode: When admins configure tiers with ``writeback`` mode, Ceph
-  clients write data to the cache tier and receive an ACK from the cache tier.
-  In time, the data written to the cache tier migrates to the storage tier
-  and gets flushed from the cache tier. Conceptually, the cache tier is 
-  overlaid "in front" of the backing storage tier. When a Ceph client needs 
-  data that resides in the storage tier, the cache tiering agent migrates the
-  data to the cache tier on read, then it is sent to the Ceph client. 
-  Thereafter, the Ceph client can perform I/O using the cache tier, until the 
-  data becomes inactive. This is ideal for mutable data (e.g., photo/video 
-  editing, transactional data, etc.).
+  clients write data to the base tier and receive an ACK from it. Then the cache
+  tiering agent compares ``osd_tier_default_cache_min_write_recency_for_promote``,
+  that means if the data is written over given times at a interval, it will
+  be promoted to the cache tier. When Ceph clients need data that resides in
+  the base tier, the cache tier will proxy read the data from the base tier
+  and return to the client. Meanwhile, as same as write does, the cache tiering
+  agent will decide whether migrating the data to the cache tier based on
+  ``osd_tier_default_cache_min_read_recency_for_promote``. After the data
+  is promoted to from the base tier, the Ceph client can perform I/O using
+  the cache tier, until the data becomes inactive. This is ideal for mutable
+  data (e.g., photo/video editing, transactional data, etc.).
 
 - **readproxy** mode: This mode will use any objects that already
   exist in the cache tier, but if an object is not present in the


### PR DESCRIPTION
Now, the statement of writeback is incorrect, it says the clients write data to cache tier firstly, then flush to base tier. But is not in fact, that will make users confused. Reads too.

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>
(cherry picked from commit fbee2f1334af81a5f0b1a030b2a24d87908b959c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
