### PR TITLE
librbd: avoid EUCLEAN error after "rbd rm" is interrupted

### DIFF
--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -787,12 +787,24 @@ int Image<I>::remove(IoCtx& io_ctx, const std::string &image_name,
     r = Trash<I>::list(io_ctx, trash_entries, false);
     if (r < 0) {
       return r;
-    } else if (r >= 0) {
-      for (auto& entry : trash_entries) {
-        if (entry.name == image_name &&
-            entry.source == RBD_TRASH_IMAGE_SOURCE_REMOVING) {
-          return Trash<I>::remove(io_ctx, entry.id, true, prog_ctx);
+    }
+    for (auto& entry : trash_entries) {
+      if (entry.name == image_name &&
+          entry.source == RBD_TRASH_IMAGE_SOURCE_REMOVING) {
+        cls::rbd::TrashImageSpec spec;
+        r = cls_client::trash_get(&io_ctx, entry.id, &spec);
+        if (r < 0) {
+          lderr(cct) << "error getting image id " << entry.id
+                     << " info from trash: " << cpp_strerror(r) << dendl;
+          return r;
         }
+        if (spec.state == cls::rbd::TRASH_IMAGE_STATE_MOVING) {
+          r = Trash<I>::move(io_ctx, entry.source, entry.name, entry.id, 0);
+          if (r < 0) {
+            return r;
+          }
+        }
+        return Trash<I>::remove(io_ctx, entry.id, true, prog_ctx);
       }
     }
 


### PR DESCRIPTION
If rbd rm process is interrupted (for example, rbd client killed, or ceph_assert fault injection in rbd code), rbd state in trash stays in cls::rbd::TRASH_IMAGE_STATE_MOVING.
Then continue to rbd rm, throw error -EUCLEAN.

Fixes: https://tracker.ceph.com/issues/58060
Signed-off-by: weixinwei <weixw3@lenovo.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
