### PR TITLE
rgw: test kafka sasl scram

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -212,12 +212,9 @@ Request parameters:
  - ``ca-location``: If this is provided and a secure connection is used, the
    specified CA will be used instead of the default CA to authenticate the
    broker. 
- - user/password may be provided over HTTPS. If not, the config parameter
-   `rgw_allow_notification_secrets_in_cleartext` must be `true` in order to create topic
- - user/password may be provided along with ``use-ssl``.
-   The broker credentials will otherwise be sent over insecure transport
- - ``mechanism`` may be provided together with user/password (default: ``PLAIN``).
-   The supported SASL mechanisms are:
+ - user/password: This should be provided over HTTPS. If not, the config parameter `rgw_allow_notification_secrets_in_cleartext` must be `true` in order to create topics.
+ - user/password: This should be provided together with ``use-ssl``. If not, the broker credentials will be sent over insecure transport.
+ - mechanism: may be provided together with user/password (default: ``PLAIN``). The supported SASL mechanisms are:
 
   - PLAIN
   - SCRAM-SHA-256

--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -220,7 +220,7 @@ def run_tests(ctx, config):
     for client, client_config in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
-        attr = ["!kafka_test", "!amqp_test", "!amqp_ssl_test", "!kafka_ssl_test", "!modification_required", "!manual_test"]
+        attr = ["!kafka_test", "!amqp_test", "!amqp_ssl_test", "!kafka_security_test", "!modification_required", "!manual_test"]
 
         if 'extra_attr' in client_config:
             attr = client_config.get('extra_attr')

--- a/src/test/rgw/bucket_notification/README.rst
+++ b/src/test/rgw/bucket_notification/README.rst
@@ -5,12 +5,10 @@
 You will need to use the sample configuration file named ``bntests.conf.SAMPLE``
 that has been provided at ``/path/to/ceph/src/test/rgw/bucket_notification/``. You can also copy this file to the directory where you are
 running the tests and modify it if needed. This file can be used to run the bucket notification tests on a Ceph cluster started
-with vstart.
+with the `vstart.sh` script.
 For the tests covering Kafka and RabbitMQ security, the RGW will need to accept use/password without TLS connection between the client and the RGW.
 So, the cluster will have to be started with the following ``rgw_allow_notification_secrets_in_cleartext`` parameter set to ``true``.
-For example::
 
-  MON=1 OSD=1 MDS=0 MGR=1 RGW=1 ../src/vstart.sh -n -d -o "rgw_allow_notification_secrets_in_cleartext=true"
 
 ===========
 Kafka Tests
@@ -18,22 +16,10 @@ Kafka Tests
 
 You also need to install Kafka which can be downloaded from: https://kafka.apache.org/downloads
 
-To test Kafka security, you should first run the ``kafka-security.sh`` script inside the Kafka directory.
-
 Then edit the Kafka server properties file (``/path/to/kafka/config/server.properties``)
-to have the following lines::
+to have the following line::
 
-  listeners=PLAINTEXT://localhost:9092,SSL://localhost:9093,SASL_SSL://localhost:9094
-  ssl.keystore.location=/home/ylifshit/kafka-3.3.1-src/server.keystore.jks 
-  ssl.keystore.password=mypassword 
-  ssl.key.password=mypassword 
-  ssl.truststore.location=/home/ylifshit/kafka-3.3.1-src/server.truststore.jks 
-  ssl.truststore.password=mypassword 
-  sasl.enabled.mechanisms=PLAIN
-  listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
-     username="alice" \
-     password="alice-secret" \
-     user_alice="alice-secret";
+        listeners=PLAINTEXT://localhost:9092
 
 After following the above steps, start the Zookeeper and Kafka services.
 For starting Zookeeper service run::
@@ -52,13 +38,72 @@ and::
 
         bin/kafka-server-start.sh -daemon config/server.properties
 
-After running vstart, Zookeeper, and Kafka services you're ready to run the Kafka tests::
+After running `vstart.sh`, Zookeeper, and Kafka services you're ready to run the Kafka tests::
 
         BNTESTS_CONF=bntests.conf python -m nose -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -a 'kafka_test'
 
+--------------------
+Kafka Security Tests
+--------------------
+
+First, make sure that vstart was initiated with the following ``rgw_allow_notification_secrets_in_cleartext`` parameter set to ``true``::
+
+        MON=1 OSD=1 MDS=0 MGR=1 RGW=1 ../src/vstart.sh -n -d -o "rgw_allow_notification_secrets_in_cleartext=true"
+
+Then you should run the ``kafka-security.sh`` script inside the Kafka directory::
+
+        cd /path/to/kafka/
+        /path/to/ceph/src/test/rgw/bucket_notification/kafka-security.sh
+
+Then make sure the Kafka server properties file (``/path/to/kafka/config/server.properties``) has the following lines::
+
+
+        # all listeners
+        listeners=PLAINTEXT://localhost:9092,SSL://localhost:9093,SASL_SSL://localhost:9094,SASL_PLAINTEXT://localhost:9095
+
+        # SSL configuration matching the kafka-security.sh script
+        ssl.keystore.location=./server.keystore.jks
+        ssl.keystore.password=mypassword
+        ssl.key.password=mypassword
+        ssl.truststore.location=./server.truststore.jks
+        ssl.truststore.password=mypassword
+
+        # SASL mechanisms
+        sasl.enabled.mechanisms=PLAIN,SCRAM-SHA-256
+
+        # SASL over SSL with SCRAM-SHA-256 mechanism
+        listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+          username="alice" \
+          password="alice-secret" \
+          user_alice="alice-secret";
+
+        # SASL over SSL with PLAIN mechanism
+        listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+          username="alice" \
+          password="alice-secret" \
+          user_alice="alice-secret";
+
+        # PLAINTEXT SASL with SCRAM-SHA-256 mechanism
+        listener.name.sasl_plaintext.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+          username="alice" \
+          password="alice-secret" \
+          user_alice="alice-secret";
+
+        # PLAINTEXT SASL with PLAIN mechanism
+        listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+          username="alice" \
+          password="alice-secret" \
+          user_alice="alice-secret";
+
+
+And restart the Kafka server. Once both Zookeeper and Kafka are up, run the following command (for the SASL SCRAM test) from the Kafka directory::
+
+        bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[iterations=8192,password=alice-secret],SCRAM-SHA-512=[password=alice-secret]' --entity-type users --entity-name alice
+
+
 To run the Kafka security test, you also need to provide the test with the location of the Kafka directory::
 
-        KAFKA_DIR=/path/to/kafkaBNTESTS_CONF=bntests.conf python -m nose -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -a 'kafka_ssl_test'
+        KAFKA_DIR=/path/to/kafka BNTESTS_CONF=bntests.conf python -m nose -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -a 'kafka_security_test'
 
 ==============
 RabbitMQ Tests
@@ -80,7 +125,7 @@ To confirm that the RabbitMQ server is running you can run the following command
 
         sudo /sbin/service rabbitmq-server status
 
-After running vstart and RabbitMQ server you're ready to run the AMQP tests::
+After running `vstart.sh` and RabbitMQ server you're ready to run the AMQP tests::
 
         BNTESTS_CONF=bntests.conf python -m nose -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -a 'amqp_test'
 
@@ -93,4 +138,6 @@ To run the RabbitMQ SSL security tests use the following::
         BNTESTS_CONF=bntests.conf python -m nose -s /path/to/ceph/src/test/rgw/bucket_notification/test_bn.py -v -a 'amqp_ssl_test'
 
 During these tests, the test script will restart the RabbitMQ server with the correct security configuration (``sudo`` privileges will be needed).
+For that reason it is not recommended to run the `amqp_ssl_test` tests, that assumes a manually configured rabbirmq server, in the same run as `amqp_test` tests, 
+that assume the rabbitmq daemon running on the host as a service.
 


### PR DESCRIPTION
this PR is intended to test bucket notifications with Kafka security using `SASL` with `SCRAM-SHA-256` mechanism.
following Kafka configuration is used (added to `config/server.properties`):
```
listeners=PLAINTEXT://localhost:9092,SSL://localhost:9093,SASL_SSL://localhost:9094,SASL_PLAINTEXT://localhost:9095
ssl.keystore.location=/home/ylifshit/kafka-3.3.1-src/server.keystore.jks 
ssl.keystore.password=mypassword 
ssl.key.password=mypassword 
ssl.truststore.location=/home/ylifshit/kafka-3.3.1-src/server.truststore.jks 
ssl.truststore.password=mypassword 
sasl.enabled.mechanisms=SCRAM-SHA-256,PLAIN

listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
   username="alice" \
   password="alice-secret" \
   user_alice="alice-secret";

listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="alice" \
   password="alice-secret" \
   user_alice="alice-secret";

listener.name.sasl_plaintext.scram-sha-256.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
   username="alice" \
   password="alice-secret" \                                                                                                                                                                                                                  
   user_alice="alice-secret";

listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="alice" \
   password="alice-secret" \
   user_alice="alice-secret";
```

SASL and SSL/SASL tests are passing with `PLAIN` mechanism, but failing with `SCRAM-SHA-256` mechanism:

```
[2022-11-16 15:11:18,342] DEBUG Set SASL server state to HANDSHAKE_OR_VERSIONS_REQUEST during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                         
[2022-11-16 15:11:18,342] DEBUG Handling Kafka request API_VERSIONS during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                                            
[2022-11-16 15:11:18,342] TRACE [SocketServer listenerType=ZK_BROKER, nodeId=0] clients: Removed a reference to ClientInformation(softwareName=unknown, softwareVersion=unknown).  0 reference(s) remaining. (org.apache.kafka.common.network.Selector)                                                                                                                                                                                                                                     
[2022-11-16 15:11:18,343] DEBUG Set SASL server state to HANDSHAKE_REQUEST during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                                     
[2022-11-16 15:11:18,343] DEBUG Handling Kafka request SASL_HANDSHAKE during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                                          [2022-11-16 15:11:18,343] DEBUG Using SASL mechanism 'SCRAM-SHA-256' provided by client (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                                              
[2022-11-16 15:11:18,344] DEBUG Setting SASL/SCRAM_SHA_256 server state to RECEIVE_CLIENT_FIRST_MESSAGE (org.apache.kafka.common.security.scram.internals.ScramSaslServer)                                                                    
[2022-11-16 15:11:18,344] DEBUG Set SASL server state to AUTHENTICATE during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)                                                                          [2022-11-16 15:11:18,344] DEBUG Setting SASL/SCRAM_SHA_256 server state to FAILED (org.apache.kafka.common.security.scram.internals.ScramSaslServer)                                                                                          
[2022-11-16 15:11:18,344] DEBUG Set SASL server state to FAILED during authentication (org.apache.kafka.common.security.authenticator.SaslServerAuthenticator)    
```

> Note: DO NOT MERGE. the only new commit in this PR is: ddf48147cfb2ab7c112629ed038f518f1144a07d
all other commits exists in other PRs

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
