### PR TITLE
rgw: approach to fix uninitialised RGWCopyObj executed as admin.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5573,6 +5573,11 @@ void RGWCopyObj::execute(optional_yield y)
   }
 }
 
+bool RGWCopyObj::check_initialised() const
+{
+  return (dest_object != nullptr && dest_bucket != nullptr);
+}
+
 int RGWGetACLs::verify_permission(optional_yield y)
 {
   bool perm;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -279,6 +279,7 @@ public:
   virtual dmc::client_id dmclock_client() { return dmc::client_id::metadata; }
   virtual dmc::Cost dmclock_cost() { return 1; }
   virtual void write_ops_log_entry(rgw_log_entry& entry) const {};
+  virtual bool check_initialised() const { return true; }
 };
 
 class RGWDefaultResponseOp : public RGWOp {
@@ -1588,6 +1589,7 @@ public:
   RGWOpType get_type() override { return RGW_OP_COPY_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
+  virtual bool check_initialised() const override;
 };
 
 class RGWGetACLs : public RGWOp {

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -225,7 +225,9 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
     std::swap(span, s->trace);
   }
   if (ret < 0) {
-    if (s->system_request) {
+    if (!op->check_initialised()) {
+      return ret;
+    } else if (s->system_request) {
       dout(2) << "overriding permissions due to system operation" << dendl;
     } else if (s->auth.identity->is_admin_of(s->user->get_id())) {
       dout(2) << "overriding permissions due to admin operation" << dendl;


### PR DESCRIPTION
This is a proposal of change in order to verify that a given rgw operation is fully initialised before bypassing possible errors when checking for an operation when running it as admin user.

For example, running the
`s3tests_boto3.functional.test_s3:test_object_copy_to_itself` s3 test as admin user ends up crashing the gateway.

This adds a new method (`check_initialised`) to the `RGWOp` interface that is called before bypassing any possible error detected when checking for permissions.

If the op is not fully initialised (which means this error was detected before the initialisation) it simply returns the error and avoids executing the op (which will much likely end up in undesired results).

This is just a proposal to open a debate in conjuntion with opening the bug and only adds checks for the `RGWCopyObj` operation.

Fixes: https://tracker.ceph.com/issues/58035

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
