### PR TITLE
qa: fix test_rbd_wnbd.py

### DIFF
--- a/qa/workunits/windows/test_rbd_wnbd.py
+++ b/qa/workunits/windows/test_rbd_wnbd.py
@@ -286,6 +286,13 @@ class RbdImage(object):
         return f"\\\\.\\PhysicalDrive{self.disk_number}"
 
     @Tracer.trace
+    def set_writable(self):
+        execute(
+            "powershell.exe", "-command",
+            "Set-Disk", "-Number", str(self.disk_number),
+            "-IsReadOnly", "$false")
+
+    @Tracer.trace
     def map(self, timeout: int = 60):
         LOG.info("Mapping image: %s", self.name)
         tstart = time.time()
@@ -296,7 +303,9 @@ class RbdImage(object):
         self.disk_number = self.get_disk_number(timeout=timeout)
 
         elapsed = time.time() - tstart
-        self._wait_for_disk(timeout=timeout - elapsed, )
+        self._wait_for_disk(timeout=timeout - elapsed)
+
+        self.set_writable()
 
     @Tracer.trace
     def unmap(self):


### PR DESCRIPTION
qa: fix test_rbd_wnbd.py

The rbd-wnbd Python test now fails as the wnbd driver changed
the bus type from "virtual" to "SAS" in order to accommodate
Microsoft Failover Cluster.

SAS is considered a shared bus, so with the default SAN policy
(offlineShared), the disks will be offline/read-only by
default[1][2].

That being considered, we're updating the test to set the rw disk
flag before attempting any write operations.

While at it, we'll make a few more improvements:

* expose fio write validation, defaulting to crc32c
* added fs tests
* change the default fio operation to "rw"
* enable the disk and clear the "rw" flag only if required by the test and
  if "--skip-enabling-disk" is not set (useful with custom SAN policies)
* print fio read and write results separately instead of aggregating them,
  useful when running rw tests

[1] https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-partitionmanager-sanpolicy
[2] https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/san

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
