### PR TITLE
cephfs-top: replace isinstance call with current_screen variable

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -160,7 +160,7 @@ class FSTop(object):
     def __init__(self, args):
         self.rados = None
         self.stdscr = None  # curses instance
-        self.current_screen = ""
+        self.active_screen = ""
         self.client_name = args.id
         self.cluster_name = args.cluster
         self.conffile = args.conffile
@@ -306,7 +306,7 @@ class FSTop(object):
                 endmenu = True
             elif key == ord('q'):
                 self.stdscr.erase()
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -346,20 +346,19 @@ class FSTop(object):
                 curr_row1 += 1
             elif key == curses.KEY_ENTER or key in [10, 13]:
                 self.stdscr.erase()
-                last_fs = current_states["last_fs"]
                 if curr_row1 != len(field_menu) - 1:
                     current_states["last_field"] = (field_menu[curr_row1].split('='))[0]
                 else:
                     current_states["last_field"] = 'chit'
                 self.header.erase()  # erase the previous text
-                if isinstance(last_fs, list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
                 endwhile = True
             elif key == ord('q'):
                 self.stdscr.erase()
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -454,7 +453,7 @@ class FSTop(object):
                         current_states["limit"] = key[:-1]
                 self.stdscr.erase()
                 self.header.erase()  # erase the previous text
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -818,7 +817,7 @@ class FSTop(object):
         self.header.erase()
         self.fsstats.erase()
 
-        self.current_screen = FS_TOP_FS_SELECTED_APP
+        self.active_screen = FS_TOP_FS_SELECTED_APP
         screen_title = "Selected Filesystem Info"
         help_commands = "m - select a filesystem | s - sort menu | l - limit number of clients"\
                         " | r - reset to default | q - home (All Filesystem Info) screen"
@@ -943,10 +942,10 @@ class FSTop(object):
 
     def run_all_display(self):
         # clear text from the previous screen
-        if self.current_screen == FS_TOP_FS_SELECTED_APP:
+        if self.active_screen == FS_TOP_FS_SELECTED_APP:
             self.header.erase()
 
-        self.current_screen = FS_TOP_ALL_FS_APP
+        self.active_screen = FS_TOP_ALL_FS_APP
         screen_title = "All Filesystem Info"
         curses.init_pair(2, curses.COLOR_CYAN, -1)
 


### PR DESCRIPTION
It makes more sense to check the 'self.current_screen' variable as it's introduced to identify the `All Filesystem` and `Selected Filesystem` screens. We may rename this variable to `active_screen` or something if it's more appropriate. @neesingh-rh What do you think?





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>