### PR TITLE
quincy: ceph-mixing: fix ceph_hosts variable

### DIFF
--- a/monitoring/ceph-mixin/dashboards/host.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/host.libsonnet
@@ -318,7 +318,7 @@ local g = import 'grafonnet/grafana.libsonnet';
     .addTemplate(
       $.addTemplateSchema('ceph_hosts',
                           '$datasource',
-                          'label_values({%(clusterMatcher)s}, instance)' % $.matchers(),
+                          if $._config.showMultiCluster then ('label_values({%(clusterMatcher)s}, instance)' % $.matchers()) else 'label_values(instance)',
                           1,
                           false,
                           3,

--- a/monitoring/ceph-mixin/dashboards_out/host-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/host-details.json
@@ -1195,7 +1195,7 @@
             "multi": false,
             "name": "ceph_hosts",
             "options": [ ],
-            "query": "label_values({}, instance)",
+            "query": "label_values(instance)",
             "refresh": 1,
             "regex": "([^.:]*).*",
             "sort": 3,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58043

---

backport of https://github.com/ceph/ceph/pull/48851
parent tracker: https://tracker.ceph.com/issues/57987

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh