### PR TITLE
doc: display Windows RBD drive letter

### DIFF
--- a/doc/rbd/rbd-windows.rst
+++ b/doc/rbd/rbd-windows.rst
@@ -139,6 +139,10 @@ initializes a partition::
         New-Partition -AssignDriveLetter -UseMaximumSize | `
         Format-Volume -Force -Confirm:$false
 
+    # Show the partition letter (for example, "D:" or "F:"):
+    (Get-Partition -DiskNumber $diskNumber).DriveLetter
+
+
 Limitations
 -----------
 


### PR DESCRIPTION
Give the Powershell command that identifies the Windows drive letter when partitioning a new RBD image.