### PR TITLE
blkin: remove blkin trace submodule and cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,9 +35,6 @@
 [submodule "src/crypto/isa-l/isa-l_crypto"]
 	path = src/crypto/isa-l/isa-l_crypto
 	url = https://github.com/intel/isa-l_crypto
-[submodule "src/blkin"]
-	path = src/blkin
-	url = https://github.com/ceph/blkin
 [submodule "src/rapidjson"]
 	path = src/rapidjson
 	url = https://github.com/ceph/rapidjson

--- a/cmake/modules/BuildOpentelemetry.cmake
+++ b/cmake/modules/BuildOpentelemetry.cmake
@@ -82,4 +82,5 @@ function(build_opentelemetry)
     PROPERTIES
       INTERFACE_LINK_LIBRARIES "${opentelemetry_deps}"
       INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_include_dir}")
+  include_directories(SYSTEM "${opentelemetry_include_dir}")
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -299,6 +299,15 @@ if (WITH_BLKIN)
   add_subdirectory(blkin/blkin-lib)
 endif(WITH_BLKIN)
 
+if(WITH_JAEGER)
+  find_package(thrift 0.13.0 REQUIRED)
+  include(BuildOpentelemetry)
+  build_opentelemetry()
+  add_library(jaeger_base INTERFACE)
+  target_link_libraries(jaeger_base INTERFACE opentelemetry::libopentelemetry
+    thrift::libthrift)
+endif()
+
 set(mds_files)
 list(APPEND mds_files
   mds/MDSMap.cc
@@ -424,12 +433,6 @@ target_compile_definitions(common-objs PRIVATE
 add_dependencies(common-objs legacy-option-headers)
 
 if(WITH_JAEGER)
-  find_package(thrift 0.13.0 REQUIRED)
-  include(BuildOpentelemetry)
-  build_opentelemetry()
-  add_library(jaeger_base INTERFACE)
-  target_link_libraries(jaeger_base INTERFACE opentelemetry::libopentelemetry
-    thrift::libthrift)
   add_dependencies(common-objs jaeger_base)
   target_link_libraries(common-objs jaeger_base)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,10 +295,6 @@ if(WITH_CEPHFS_JAVA)
   add_subdirectory(java)
 endif()
 
-if (WITH_BLKIN)
-  add_subdirectory(blkin/blkin-lib)
-endif(WITH_BLKIN)
-
 if(WITH_JAEGER)
   find_package(thrift 0.13.0 REQUIRED)
   include(BuildOpentelemetry)
@@ -469,7 +465,6 @@ set(ceph_common_deps
   fmt::fmt
   ${BLKID_LIBRARIES}
   ${Backtrace_LIBRARIES}
-  ${BLKIN_LIBRARIES}
   ${CRYPTO_LIBS}
   ${GSSAPI_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -18,7 +18,7 @@ class ObjecterWriteback : public WritebackHandler {
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags,
-                    const ZTracer::Trace &parent_trace,
+                    const jspan_context &otel_trace,
                     Context *onfinish) override {
     m_objecter->read_trunc(oid, oloc, off, len, snapid, pbl, 0,
 			   trunc_size, trunc_seq,
@@ -36,7 +36,7 @@ class ObjecterWriteback : public WritebackHandler {
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-                           const ZTracer::Trace &parent_trace,
+                           const jspan_context &otel_trace,
 			   Context *oncommit) override {
     return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
 				   trunc_size, trunc_seq,

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -14,6 +14,7 @@
 #include "common/strtol.h"
 #include "common/escape.h"
 #include "common/config_proxy.h"
+#include "common/tracer.h"
 #include "osd/osd_types.h"
 
 #include "include/compat.h"
@@ -149,7 +150,8 @@ static void bi_log_index_key(cls_method_context_t hctx, string& key, string& id,
 static int log_index_operation(cls_method_context_t hctx, const cls_rgw_obj_key& obj_key,
                                RGWModifyOp op, const string& tag, real_time timestamp,
                                const rgw_bucket_entry_ver& ver, RGWPendingState state, uint64_t index_ver,
-                               string& max_marker, uint16_t bilog_flags, string *owner, string *owner_display_name, rgw_zone_set *zones_trace)
+                               string& max_marker, uint16_t bilog_flags, string *owner, string *owner_display_name, rgw_zone_set *zones_trace,
+                               const jspan_context* bilog_trace = nullptr)
 {
   bufferlist bl;
 
@@ -172,6 +174,9 @@ static int log_index_operation(cls_method_context_t hctx, const cls_rgw_obj_key&
   }
   if (zones_trace) {
     entry.zones_trace = std::move(*zones_trace);
+  }
+  if (bilog_trace) {
+    entry.bi_trace = std::move(*bilog_trace);
   }
 
   string key;
@@ -1264,7 +1269,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     rc = log_index_operation(hctx, op.key, op.op, op.tag, entry.meta.mtime,
 			     entry.ver, CLS_RGW_STATE_COMPLETE, header.ver,
 			     header.max_marker, op.bilog_flags, NULL, NULL,
-			     &op.zones_trace);
+			     &op.zones_trace, &op.bi_trace);
     if (rc < 0) {
       CLS_LOG_BITX(bitx_inst, 0,
 		   "ERROR: %s: log_index_operation failed with rc=%d",

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -286,7 +286,8 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, const s
                                 const rgw_bucket_dir_entry_meta& dir_meta,
 				const list<cls_rgw_obj_key> *remove_objs, bool log_op,
                                 uint16_t bilog_flags,
-                                const rgw_zone_set *zones_trace)
+                                const rgw_zone_set *zones_trace,
+                                const jspan_context* bilog_trace)
 {
 
   bufferlist in;
@@ -302,6 +303,9 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, const s
     call.remove_objs = *remove_objs;
   if (zones_trace) {
     call.zones_trace = *zones_trace;
+  }
+  if (bilog_trace) {
+    call.bi_trace = *bilog_trace;
   }
   encode(call, in);
   o.exec(RGW_CLASS, RGW_BUCKET_COMPLETE_OP, in);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -355,7 +355,8 @@ void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp o
                                 const cls_rgw_obj_key& key,
                                 const rgw_bucket_dir_entry_meta& dir_meta,
 				const std::list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                uint16_t bilog_op, const rgw_zone_set *zones_trace);
+                                uint16_t bilog_op, const rgw_zone_set *zones_trace,
+                                const jspan_context* bilog_trace = nullptr);
 
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, std::list<std::string>& keep_attr_prefixes);
 void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const std::string& attr);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -542,6 +542,7 @@ void rgw_bi_log_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("owner", owner, obj);
   JSONDecoder::decode_json("owner_display_name", owner_display_name, obj);
   JSONDecoder::decode_json("zones_trace", zones_trace, obj);
+  JSONDecoder::decode_json("bi_trace", bi_trace, obj);
 }
 
 void rgw_bi_log_entry::dump(Formatter *f) const
@@ -575,6 +576,7 @@ void rgw_bi_log_entry::dump(Formatter *f) const
   f->dump_string("owner", owner);
   f->dump_string("owner_display_name", owner_display_name);
   encode_json("zones_trace", zones_trace, f);
+  encode_json("bi_trace", bi_trace, f);
 }
 
 void rgw_bi_log_entry::generate_test_instances(list<rgw_bi_log_entry*>& ls)
@@ -857,4 +859,21 @@ void cls_rgw_lc_obj_head::dump(Formatter *f) const
 
 void cls_rgw_lc_obj_head::generate_test_instances(list<cls_rgw_lc_obj_head*>& ls)
 {
+}
+
+void encode_json(const char *name, const jspan_context& span_ctx, Formatter *f) {
+  using namespace opentelemetry;
+  using namespace trace;
+  ceph::bufferlist bl;
+  tracing::encode(span_ctx, bl);
+  encode_json("bi_trace", bl, f);
+}
+
+void decode_json_obj(jspan_context& span_ctx, JSONObj *obj) {
+  using namespace opentelemetry;
+  using namespace trace;
+  bufferlist bl;
+  decode_json_obj(bl, obj);
+  auto bl_iter = bl.cbegin();
+  tracing::decode(span_ctx, bl_iter);
 }

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -282,10 +282,10 @@ protected:
   virtual bool filter_out(const std::set<std::string>& filters) { return true; }
 
 public:
-  ZTracer::Trace osd_trace;
-  ZTracer::Trace pg_trace;
-  ZTracer::Trace store_trace;
-  ZTracer::Trace journal_trace;
+  jspan_context osd_trace{false, false};
+  jspan_context pg_trace{false, false};
+  jspan_context store_trace{false, false};
+  jspan_context journal_trace{false, false};
 
   virtual ~TrackedOp() {}
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -22,7 +22,7 @@
 #include "common/hostname.h"
 #include "common/strtol.h"
 #include "common/valgrind.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 
 #define dout_subsys ceph_subsys_
 
@@ -95,7 +95,6 @@ void common_init_finish(CephContext *cct)
   }
   cct->_finished = true;
   cct->init_crypto();
-  ZTracer::ztrace_init();
 
   if (!cct->_log->is_started()) {
     cct->_log->start();

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3752,18 +3752,6 @@ options:
   level: advanced
   default: 30
   with_legacy: true
-# create a blkin trace for all osd requests
-- name: osd_blkin_trace_all
-  type: bool
-  level: advanced
-  default: false
-  with_legacy: true
-# create a blkin trace for all objecter requests
-- name: osdc_blkin_trace_all
-  type: bool
-  level: advanced
-  default: false
-  with_legacy: true
 - name: osd_discard_disconnected_ops
   type: bool
   level: advanced

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -385,13 +385,6 @@ options:
   default: false
   services:
   - rbd
-- name: rbd_blkin_trace_all
-  type: bool
-  level: advanced
-  desc: create a blkin trace for all RBD requests
-  default: false
-  services:
-  - rbd
 - name: rbd_validate_pool
   type: bool
   level: advanced

--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -50,7 +50,7 @@ jspan Tracer::start_trace(opentelemetry::nostd::string_view trace_name, bool tra
 }
 
 jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan& parent_span) {
-  if (is_enabled() && parent_span->IsRecording()) {
+  if (is_enabled() && parent_span && parent_span->IsRecording()) {
     opentelemetry::trace::StartSpanOptions span_opts;
     span_opts.parent = parent_span->GetContext();
     return tracer->StartSpan(span_name, span_opts);
@@ -71,41 +71,6 @@ bool Tracer::is_enabled() const {
   return g_ceph_context->_conf->jaeger_tracing_enable;
 }
 
-void encode(const jspan_context& span_ctx, bufferlist& bl, uint64_t f) {
-  ENCODE_START(1, 1, bl);
-  using namespace opentelemetry;
-  using namespace trace;
-  auto is_valid = span_ctx.IsValid();
-  encode(is_valid, bl);
-  if (is_valid) {
-    encode_nohead(std::string_view(reinterpret_cast<const char*>(span_ctx.trace_id().Id().data()), TraceId::kSize), bl);
-    encode_nohead(std::string_view(reinterpret_cast<const char*>(span_ctx.span_id().Id().data()), SpanId::kSize), bl);
-    encode(span_ctx.trace_flags().flags(), bl);
-  }
-  ENCODE_FINISH(bl);
-}
-
-void decode(jspan_context& span_ctx, bufferlist::const_iterator& bl) {
-  using namespace opentelemetry;
-  using namespace trace;
-  DECODE_START(1, bl);
-  bool is_valid;
-  decode(is_valid, bl);
-  if (is_valid) {
-    std::array<uint8_t, TraceId::kSize> trace_id;
-    std::array<uint8_t, SpanId::kSize> span_id;
-    uint8_t flags;
-    decode(trace_id, bl);
-    decode(span_id, bl);
-    decode(flags, bl);
-    span_ctx = SpanContext(
-      TraceId(nostd::span<uint8_t, TraceId::kSize>(trace_id)),
-      SpanId(nostd::span<uint8_t, SpanId::kSize>(span_id)),
-      TraceFlags(flags),
-      true);
-  }
-  DECODE_FINISH(bl);
-}
 } // namespace tracing
 
 #endif // HAVE_JAEGER

--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -50,7 +50,7 @@ jspan Tracer::start_trace(opentelemetry::nostd::string_view trace_name, bool tra
 }
 
 jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan& parent_span) {
-  if (is_enabled() && parent_span && parent_span->IsRecording()) {
+  if (parent_span && parent_span->IsRecording()) {
     opentelemetry::trace::StartSpanOptions span_opts;
     span_opts.parent = parent_span->GetContext();
     return tracer->StartSpan(span_name, span_opts);
@@ -59,7 +59,7 @@ jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan&
 }
 
 jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan_context& parent_ctx) {
-  if (is_enabled() && parent_ctx.IsValid()) {
+  if (parent_ctx.IsValid()) {
     opentelemetry::trace::StartSpanOptions span_opts;
     span_opts.parent = parent_ctx;
     return tracer->StartSpan(span_name, span_opts);

--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -15,6 +15,8 @@ using jspan_attribute = opentelemetry::common::AttributeValue;
 
 namespace tracing {
 
+const static jspan_context noop_span_ctx{false, false};
+
 class Tracer {
  private:
   const static opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> noop_tracer;
@@ -125,6 +127,7 @@ class jspan {
 };
 
 namespace tracing {
+const static jspan_context noop_span_ctx{};
 
 struct Tracer {
   bool is_enabled() const { return false; }

--- a/src/common/zipkin_trace.h
+++ b/src/common/zipkin_trace.h
@@ -6,79 +6,12 @@
 #include "acconfig.h"
 #include "include/encoding.h"
 
-#ifdef WITH_BLKIN
-
-#include <ztracer.hpp>
-
-#else // !WITH_BLKIN
-
-// add stubs for noop Trace and Endpoint
-
 // match the "real" struct
 struct blkin_trace_info {
     int64_t trace_id;
     int64_t span_id;
     int64_t parent_span_id;
 };
-
-namespace ZTracer
-{
-static inline int ztrace_init() { return 0; }
-
-class Endpoint {
- public:
-  Endpoint(const char *name) {}
-  Endpoint(const char *ip, int port, const char *name) {}
-
-  void copy_ip(const std::string &newip) {}
-  void copy_name(const std::string &newname) {}
-  void copy_address_from(const Endpoint *endpoint) {}
-  void share_address_from(const Endpoint *endpoint) {}
-  void set_port(int p) {}
-};
-
-class Trace {
- public:
-  Trace() {}
-  Trace(const char *name, const Endpoint *ep, const Trace *parent = NULL) {}
-  Trace(const char *name, const Endpoint *ep,
-        const blkin_trace_info *i, bool child=false) {}
-
-  bool valid() const { return false; }
-  operator bool() const { return false; }
-
-  int init(const char *name, const Endpoint *ep, const Trace *parent = NULL) {
-    return 0;
-  }
-  int init(const char *name, const Endpoint *ep,
-           const blkin_trace_info *i, bool child=false) {
-    return 0;
-  }
-
-  void copy_name(const std::string &newname) {}
-
-  const blkin_trace_info* get_info() const { return NULL; }
-  void set_info(const blkin_trace_info *i) {}
-
-  void keyval(const char *key, const char *val) const {}
-  void keyval(const char *key, int64_t val) const {}
-  void keyval(const char *key, const char *val, const Endpoint *ep) const {}
-  void keyval(const char *key, int64_t val, const Endpoint *ep) const {}
-
-  void event(const char *event) const {}
-  void event(const char *event, const Endpoint *ep) const {}
-};
-} // namespace ZTrace
-
-#endif // !WITH_BLKIN
-
-static inline void encode(const blkin_trace_info& b, ceph::buffer::list& bl)
-{
-  using ceph::encode;
-  encode(b.trace_id, bl);
-  encode(b.span_id, bl);
-  encode(b.parent_span_id, bl);
-}
 
 static inline void decode(blkin_trace_info& b, ceph::buffer::list::const_iterator& p)
 {
@@ -87,7 +20,5 @@ static inline void decode(blkin_trace_info& b, ceph::buffer::list::const_iterato
   decode(b.span_id, p);
   decode(b.parent_span_id, p);
 }
-
-
 
 #endif // COMMON_ZIPKIN_TRACE_H

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -307,9 +307,6 @@
 /* Defined if pthread_rwlockattr_setkind_np() is available */
 #cmakedefine HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP
 
-/* Defined if blkin enabled */
-#cmakedefine WITH_BLKIN
-
 /* Defined if pthread_set_name_np() is available */
 #cmakedefine HAVE_PTHREAD_SET_NAME_NP
 

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -59,6 +59,8 @@
 
 #include "common/ceph_time.h"
 
+using jspan_context = opentelemetry::trace::SpanContext;
+
 namespace neorados {
 class Object;
 class IOContext;
@@ -553,24 +555,24 @@ public:
   auto execute(const Object& o, const IOContext& ioc, ReadOp&& op,
 	       ceph::buffer::list* bl,
 	       CompletionToken&& token, uint64_t* objver = nullptr,
-	       const blkin_trace_info* trace_info = nullptr) {
+	       const jspan_context* otel_trace = nullptr) {
     boost::asio::async_completion<CompletionToken, Op::Signature> init(token);
     execute(o, ioc, std::move(op), bl,
 	    ReadOp::Completion::create(get_executor(),
 				       std::move(init.completion_handler)),
-	    objver, trace_info);
+	    objver, otel_trace);
     return init.result.get();
   }
 
   template<typename CompletionToken>
   auto execute(const Object& o, const IOContext& ioc, WriteOp&& op,
 	       CompletionToken&& token, uint64_t* objver = nullptr,
-	       const blkin_trace_info* trace_info = nullptr) {
+	       const jspan_context* otel_trace = nullptr) {
     boost::asio::async_completion<CompletionToken, Op::Signature> init(token);
     execute(o, ioc, std::move(op),
 	    Op::Completion::create(get_executor(),
 				   std::move(init.completion_handler)),
-	    objver, trace_info);
+	    objver, otel_trace);
     return init.result.get();
   }
 
@@ -977,11 +979,11 @@ private:
 
   void execute(const Object& o, const IOContext& ioc, ReadOp&& op,
 	       ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,
-	       uint64_t* objver, const blkin_trace_info* trace_info);
+	       uint64_t* objver, const jspan_context* otel_trace);
 
   void execute(const Object& o, const IOContext& ioc, WriteOp&& op,
 	       std::unique_ptr<Op::Completion> c, uint64_t* objver,
-	       const blkin_trace_info* trace_info);
+	       const jspan_context* otel_trace);
 
   void execute(const Object& o, std::int64_t pool, ReadOp&& op,
 	       ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -391,12 +391,6 @@ typedef void *rados_read_op_t;
 typedef void *rados_completion_t;
 
 /**
- * @struct blkin_trace_info
- * blkin trace information for Zipkin tracing
- */
-struct blkin_trace_info;
-
-/**
  * Get the version of librados.
  *
  * The version number is major.minor.extra. Note that this is

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -14,6 +14,8 @@
 #include "librados_fwd.hpp"
 #include "rados_types.hpp"
 
+typedef opentelemetry::trace::SpanContext jspan_context;
+
 namespace libradosstriper
 {
   class RadosStriper;
@@ -1168,11 +1170,11 @@ inline namespace v14_2_0 {
 
     // compound object operations
     int operate(const std::string& oid, ObjectWriteOperation *op);
-    int operate(const std::string& oid, ObjectWriteOperation *op, int flags);
+    int operate(const std::string& oid, ObjectWriteOperation *op, int flags, const jspan_context *trace_info = nullptr);
     int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl);
     int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl, int flags);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op);
-    int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags);
+    int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags, const jspan_context *trace_info = nullptr);
     /**
      * Schedule an async write operation with explicit snapshot parameters
      *

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1195,11 +1195,11 @@ inline namespace v14_2_0 {
     int aio_operate(const std::string& oid, AioCompletion *c,
         ObjectWriteOperation *op, snap_t seq,
         std::vector<snap_t>& snaps,
-        const blkin_trace_info *trace_info);
+        const jspan_context *trace_info);
     int aio_operate(const std::string& oid, AioCompletion *c,
         ObjectWriteOperation *op, snap_t seq,
         std::vector<snap_t>& snaps, int flags,
-        const blkin_trace_info *trace_info);
+        const jspan_context *trace_info);
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, bufferlist *pbl);
 
@@ -1213,7 +1213,7 @@ inline namespace v14_2_0 {
 		    bufferlist *pbl);
     int aio_operate(const std::string& oid, AioCompletion *c,
         ObjectReadOperation *op, int flags,
-        bufferlist *pbl, const blkin_trace_info *trace_info);
+        bufferlist *pbl, const jspan_context *trace_info);
 
     // watch/notify
     int watch2(const std::string& o, uint64_t *handle,

--- a/src/include/rados/librados_fwd.hpp
+++ b/src/include/rados/librados_fwd.hpp
@@ -3,6 +3,16 @@
 
 struct blkin_trace_info;
 
+namespace opentelemetry {
+inline namespace v1 {
+namespace trace {
+
+class SpanContext;
+
+} // namespace trace
+} // inline namespace v1
+} // namespace opentelemetry
+
 namespace libradosstriper {
 
 class RadosStriper;

--- a/src/include/rados/librados_fwd.hpp
+++ b/src/include/rados/librados_fwd.hpp
@@ -1,8 +1,6 @@
 #ifndef __LIBRADOS_FWD_HPP
 #define __LIBRADOS_FWD_HPP
 
-struct blkin_trace_info;
-
 namespace opentelemetry {
 inline namespace v1 {
 namespace trace {

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -637,7 +637,7 @@ int librados::IoCtxImpl::writesame(const object_t& oid, bufferlist& bl,
 }
 
 int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
-				 ceph::real_time *pmtime, int flags)
+				 ceph::real_time *pmtime, int flags, const jspan_context* otel_trace)
 {
   ceph::real_time ut = (pmtime ? *pmtime :
     ceph::real_clock::now());
@@ -664,7 +664,7 @@ int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
     oid, oloc,
     *o, snapc, ut,
     flags | extra_op_flags,
-    oncommit, &ver);
+    oncommit, &ver, osd_reqid_t(), nullptr, otel_trace);
   objecter->op_submit(objecter_op);
 
   {
@@ -752,7 +752,7 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
 				     const SnapContext& snap_context, int flags,
-                                     const blkin_trace_info *trace_info)
+                                     const blkin_trace_info *trace_info, const jspan_context *otel_trace)
 {
   FUNCTRACE(client->cct);
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_WRITE_OP_BEGIN");
@@ -778,7 +778,7 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
   trace.event("init root span");
   Objecter::Op *op = objecter->prepare_mutate_op(
     oid, oloc, *o, snap_context, ut, flags | extra_op_flags,
-    oncomplete, &c->objver, osd_reqid_t(), &trace);
+    oncomplete, &c->objver, osd_reqid_t(), &trace, otel_trace);
   objecter->op_submit(op, &c->tid);
   trace.event("rados operate op submitted");
 

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -154,11 +154,11 @@ struct librados::IoCtxImpl {
   int getxattrs(const object_t& oid, std::map<std::string, bufferlist>& attrset);
   int rmxattr(const object_t& oid, const char *name);
 
-  int operate(const object_t& oid, ::ObjectOperation *o, ceph::real_time *pmtime, int flags=0);
+  int operate(const object_t& oid, ::ObjectOperation *o, ceph::real_time *pmtime, int flags=0, const jspan_context *otel_trace = nullptr);
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags, const blkin_trace_info *trace_info = nullptr);
+		  int flags, const blkin_trace_info *trace_info = nullptr, const jspan_context *otel_trace = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -20,7 +20,6 @@
 #include "common/Cond.h"
 #include "common/ceph_mutex.h"
 #include "common/snap_types.h"
-#include "common/zipkin_trace.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
@@ -158,9 +157,9 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags, const blkin_trace_info *trace_info = nullptr, const jspan_context *otel_trace = nullptr);
+		  int flags, const jspan_context *otel_trace = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
-		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
+		       AioCompletionImpl *c, int flags, bufferlist *pbl, const jspan_context *otel_trace = nullptr);
 
   struct C_aio_stat_Ack : public Context {
     librados::AioCompletionImpl *c;
@@ -189,10 +188,10 @@ struct librados::IoCtxImpl {
 
   int aio_read(const object_t oid, AioCompletionImpl *c,
 	       bufferlist *pbl, size_t len, uint64_t off, uint64_t snapid,
-	       const blkin_trace_info *info = nullptr);
+	       const jspan_context *otel_trace = nullptr);
   int aio_read(object_t oid, AioCompletionImpl *c,
 	       char *buf, size_t len, uint64_t off, uint64_t snapid,
-	       const blkin_trace_info *info = nullptr);
+	       const jspan_context *otel_trace = nullptr);
   int aio_sparse_read(const object_t oid, AioCompletionImpl *c,
 		      std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
 		      size_t len, uint64_t off, uint64_t snapid);
@@ -202,7 +201,7 @@ struct librados::IoCtxImpl {
 		      const char *cmp_buf, size_t cmp_len, uint64_t off);
   int aio_write(const object_t &oid, AioCompletionImpl *c,
 		const bufferlist& bl, size_t len, uint64_t off,
-		const blkin_trace_info *info = nullptr);
+		const jspan_context *otel_trace = nullptr);
   int aio_append(const object_t &oid, AioCompletionImpl *c,
 		 const bufferlist& bl, size_t len);
   int aio_write_full(const object_t &oid, AioCompletionImpl *c,

--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -143,7 +143,7 @@ auto async_write(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 template <typename ExecutionContext, typename CompletionToken>
 auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
                    ObjectReadOperation *read_op, int flags,
-                   CompletionToken&& token)
+                   CompletionToken&& token, const jspan_context* trace_ctx = nullptr)
 {
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
@@ -167,7 +167,7 @@ auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 template <typename ExecutionContext, typename CompletionToken>
 auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
                    ObjectWriteOperation *write_op, int flags,
-                   CompletionToken &&token)
+                   CompletionToken &&token, const jspan_context* trace_ctx = nullptr)
 {
   using Op = detail::AsyncOp<void>;
   using Signature = typename Op::Signature;
@@ -175,7 +175,7 @@ auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
   auto p = Op::create(ctx.get_executor(), init.completion_handler);
   auto& op = p->user_data;
 
-  int ret = io.aio_operate(oid, op.aio_completion.get(), write_op, flags);
+  int ret = io.aio_operate(oid, op.aio_completion.get(), write_op, flags, trace_ctx);
   if (ret < 0) {
     auto ec = boost::system::error_code{-ret, boost::system::system_category()};
     ceph::async::post(std::move(p), ec);

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2746,28 +2746,6 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write)(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write);
 
-#ifdef WITH_BLKIN
-extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_traced)(
-  rados_ioctx_t io, const char *o,
-  rados_completion_t completion,
-  const char *buf, size_t len, uint64_t off,
-  struct blkin_trace_info *info)
-{
-  tracepoint(librados, rados_aio_write_enter, io, o, completion, buf, len, off);
-  if (len > UINT_MAX/2)
-    return -E2BIG;
-  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
-  object_t oid(o);
-  bufferlist bl;
-  bl.append(buf, len);
-  int retval = ctx->aio_write(oid, (librados::AioCompletionImpl*)completion,
-                              bl, len, off, info);
-  tracepoint(librados, rados_aio_write_exit, retval);
-  return retval;
-}
-LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_traced);
-#endif
-
 extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_append)(
   rados_ioctx_t io, const char *o,
   rados_completion_t completion,

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1528,12 +1528,12 @@ int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperat
   return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt);
 }
 
-int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperation *o, int flags)
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperation *o, int flags, const jspan_context* otel_trace)
 {
   object_t obj(oid);
   if (unlikely(!o->impl))
     return -EINVAL;
-  return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt, translate_flags(flags));
+  return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt, translate_flags(flags), otel_trace);
 }
 
 int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl)
@@ -1562,14 +1562,14 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				  io_ctx_impl->snapc, 0);
 }
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
-				 ObjectWriteOperation *o, int flags)
+				 ObjectWriteOperation *o, int flags, const jspan_context* otel_trace)
 {
   object_t obj(oid);
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
 				  io_ctx_impl->snapc,
-				  translate_flags(flags));
+				  translate_flags(flags), nullptr, otel_trace);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1569,7 +1569,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
 				  io_ctx_impl->snapc,
-				  translate_flags(flags), nullptr, otel_trace);
+				  translate_flags(flags), otel_trace);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1591,7 +1591,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
          librados::ObjectWriteOperation *o,
          snap_t snap_seq, std::vector<snap_t>& snaps,
-         const blkin_trace_info *trace_info)
+         const jspan_context *otel_trace)
 {
   if (unlikely(!o->impl))
     return -EINVAL;
@@ -1602,13 +1602,13 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-          snapc, 0, trace_info);
+          snapc, 0, otel_trace);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
          librados::ObjectWriteOperation *o,
          snap_t snap_seq, std::vector<snap_t>& snaps, int flags,
-         const blkin_trace_info *trace_info)
+         const jspan_context *otel_trace)
 {
   if (unlikely(!o->impl))
     return -EINVAL;
@@ -1619,7 +1619,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc,
-                                  translate_flags(flags), trace_info);
+                                  translate_flags(flags), otel_trace);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1667,13 +1667,13 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
          librados::ObjectReadOperation *o,
-         int flags, bufferlist *pbl, const blkin_trace_info *trace_info)
+         int flags, bufferlist *pbl, const jspan_context *otel_trace)
 {
   if (unlikely(!o->impl))
     return -EINVAL;
   object_t obj(oid);
   return io_ctx_impl->aio_operate_read(obj, &o->impl->o, c->pc,
-               translate_flags(flags), pbl, trace_info);
+               translate_flags(flags), pbl, otel_trace);
 }
 
 void librados::IoCtx::snap_set_read(snap_t seq)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -119,9 +119,7 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
       op_work_queue(asio_engine->get_work_queue()),
       plugin_registry(new PluginRegistry<ImageCtx>(this)),
       event_socket_completions(32),
-      asok_hook(nullptr),
-      trace_endpoint("librbd")
-  {
+      asok_hook(nullptr)  {
     ldout(cct, 10) << this << " " << __func__ << ": "
                    << "image_name=" << image_name << ", "
                    << "image_id=" << image_id << dendl;
@@ -195,7 +193,6 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
       pname += snap_name;
     }
 
-    trace_endpoint.copy_name(pname);
     perf_start(pname);
 
     ceph_assert(image_watcher == NULL);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -19,7 +19,7 @@
 #include "common/event_socket.h"
 #include "common/Readahead.h"
 #include "common/snap_types.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 
 #include "include/common_fwd.h"
 #include "include/buffer_fwd.h"
@@ -227,8 +227,6 @@ namespace librbd {
 
     exclusive_lock::Policy *exclusive_lock_policy = nullptr;
     journal::Policy *journal_policy = nullptr;
-
-    ZTracer::Endpoint trace_endpoint;
 
     crypto::CryptoInterface* crypto = nullptr;
 

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -329,7 +329,7 @@ template <typename I>
 void ObjectMap<I>::aio_update(uint64_t snap_id, uint64_t start_object_no,
                               uint64_t end_object_no, uint8_t new_state,
                               const boost::optional<uint8_t> &current_state,
-                              const ZTracer::Trace &parent_trace,
+                              const jspan_context &parent_trace,
                               bool ignore_enoent, Context *on_finish) {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx.image_lock));
   ceph_assert((m_image_ctx.features & RBD_FEATURE_OBJECT_MAP) != 0);

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -15,7 +15,6 @@
 #include <boost/optional.hpp>
 
 class Context;
-namespace ZTracer { struct Trace; }
 
 namespace librbd {
 
@@ -68,7 +67,7 @@ public:
   template <typename T, void(T::*MF)(int) = &T::complete>
   bool aio_update(uint64_t snap_id, uint64_t start_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
-                  const ZTracer::Trace &parent_trace, bool ignore_enoent,
+                  const jspan_context &parent_trace, bool ignore_enoent,
                   T *callback_object) {
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
@@ -79,7 +78,7 @@ public:
   bool aio_update(uint64_t snap_id, uint64_t start_object_no,
                   uint64_t end_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
-                  const ZTracer::Trace &parent_trace, bool ignore_enoent,
+                  const jspan_context &parent_trace, bool ignore_enoent,
                   T *callback_object) {
     ceph_assert(start_object_no < end_object_no);
     std::unique_lock locker{m_lock};
@@ -127,14 +126,14 @@ private:
     uint64_t end_object_no;
     uint8_t new_state;
     boost::optional<uint8_t> current_state;
-    ZTracer::Trace parent_trace;
+    jspan_context parent_trace{false, false};
     bool ignore_enoent;
     Context *on_finish;
 
     UpdateOperation(uint64_t start_object_no, uint64_t end_object_no,
                     uint8_t new_state,
                     const boost::optional<uint8_t> &current_state,
-                    const ZTracer::Trace &parent_trace,
+                    const jspan_context &parent_trace,
                     bool ignore_enoent, Context *on_finish)
       : start_object_no(start_object_no), end_object_no(end_object_no),
         new_state(new_state), current_state(current_state),
@@ -161,7 +160,7 @@ private:
   void aio_update(uint64_t snap_id, uint64_t start_object_no,
                   uint64_t end_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
-                  const ZTracer::Trace &parent_trace, bool ignore_enoent,
+                  const jspan_context &parent_trace, bool ignore_enoent,
                   Context *on_finish);
   bool update_required(const ceph::BitVector<2>::Iterator &it,
                        uint8_t new_state);

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -9,7 +9,7 @@
 #include "include/ceph_assert.h"
 #include "include/Context.h"
 #include "common/snap_types.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/RefCountedObj.h"
 
 #include <atomic>
@@ -246,15 +246,6 @@ bool calc_sparse_extent(const bufferptr &bp,
                         size_t *write_offset,
                         size_t *write_length,
                         size_t *offset);
-
-template <typename I>
-inline ZTracer::Trace create_trace(const I &image_ctx, const char *trace_name,
-				   const ZTracer::Trace &parent_trace) {
-  if (parent_trace.valid()) {
-    return ZTracer::Trace(trace_name, &image_ctx.trace_endpoint, &parent_trace);
-  }
-  return ZTracer::Trace();
-}
 
 bool is_metadata_config_override(const std::string& metadata_key,
                                  std::string* config_key);

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -75,7 +75,7 @@ public:
       m_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,
       aio_comp, {{m_image_offset, m_image_length}},
       {m_diff_context.from_snap_id, m_diff_context.end_snap_id},
-      list_snaps_flags, &m_snapshot_delta, {});
+      list_snaps_flags, &m_snapshot_delta, tracing::noop_span_ctx);
     req->send();
   }
 
@@ -184,7 +184,7 @@ int DiffIterate<I>::diff_iterate(I *ictx,
                                                         io::AIO_TYPE_FLUSH);
     auto req = io::ImageDispatchSpec::create_flush(
       *ictx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,
-      aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
+      aio_comp, io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     req->send();
   }
   int r = flush_ctx.wait();

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -690,7 +690,7 @@ int Image<I>::deep_copy(I *src, I *dest, bool flatten,
                                                         io::AIO_TYPE_FLUSH);
     auto req = io::ImageDispatchSpec::create_flush(
       *src, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,
-      aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
+      aio_comp, io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     req->send();
   }
   int r = flush_ctx.wait();

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -211,11 +211,6 @@ void Io<I>::aio_read(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
                      bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: read", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_READ);
   ldout(cct, 20) << "ictx=" << &image_ctx << ", "
@@ -233,7 +228,7 @@ void Io<I>::aio_read(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   auto req = io::ImageDispatchSpec::create_read(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
     std::move(read_result), image_ctx.get_data_io_context(), op_flags, 0,
-    trace);
+    tracing::noop_span_ctx);
   req->send();
 }
 
@@ -243,11 +238,6 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
                       bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: write", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_WRITE);
   ldout(cct, 20) << "ictx=" << &image_ctx << ", "
@@ -264,7 +254,7 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
 
   auto req = io::ImageDispatchSpec::create_write(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+    std::move(bl), image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -274,11 +264,6 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
                         bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: discard", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_DISCARD);
   ldout(cct, 20) << "ictx=" << &image_ctx << ", "
@@ -295,7 +280,7 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
 
   auto req = io::ImageDispatchSpec::create_discard(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+    discard_granularity_bytes, image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   req->send();
 }
 
@@ -305,11 +290,6 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
                            int op_flags, bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: writesame", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_WRITESAME);
   ldout(cct, 20) << "ictx=" << &image_ctx << ", "
@@ -327,7 +307,7 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
 
   auto req = io::ImageDispatchSpec::create_write_same(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+    std::move(bl), image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -337,11 +317,6 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
                              int op_flags, bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: write_zeroes", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   auto io_type = io::AIO_TYPE_DISCARD;
   if ((zero_flags & RBD_WRITE_ZEROES_FLAG_THICK_PROVISION) != 0) {
@@ -400,7 +375,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       aio_comp->aio_type = io::AIO_TYPE_WRITE;
       auto req = io::ImageDispatchSpec::create_write(
         image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+        std::move(bl), image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
       req->send();
       return;
     } else if (prepend_length == 0 && append_length == 0) {
@@ -410,7 +385,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
       auto req = io::ImageDispatchSpec::create_write_same(
         image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+        std::move(bl), image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
       req->send();
       return;
     }
@@ -439,7 +414,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto prepend_req = io::ImageDispatchSpec::create_write(
         image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
         {{prepend_offset, prepend_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+        image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
       prepend_req->send();
     }
 
@@ -453,7 +428,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto append_req = io::ImageDispatchSpec::create_write(
         image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
         {{append_offset, append_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+        image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
       append_req->send();
     }
 
@@ -466,7 +441,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
     auto req = io::ImageDispatchSpec::create_write_same(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
       write_same_offset, write_same_length, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
     req->send();
     return;
   }
@@ -476,7 +451,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
   auto req = io::ImageDispatchSpec::create_discard(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+    discard_granularity_bytes, image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   req->send();
 }
 
@@ -488,11 +463,6 @@ void Io<I>::aio_compare_and_write(I &image_ctx, io::AioCompletion *aio_comp,
                                   int op_flags, bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: compare_and_write", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx),
                       io::AIO_TYPE_COMPARE_AND_WRITE);
@@ -511,7 +481,7 @@ void Io<I>::aio_compare_and_write(I &image_ctx, io::AioCompletion *aio_comp,
   auto req = io::ImageDispatchSpec::create_compare_and_write(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
     std::move(cmp_bl), std::move(bl), mismatch_off,
-    image_ctx.get_data_io_context(), op_flags, trace);
+    image_ctx.get_data_io_context(), op_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -520,11 +490,6 @@ void Io<I>::aio_flush(I &image_ctx, io::AioCompletion *aio_comp,
                       bool native_async) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
-  ZTracer::Trace trace;
-  if (image_ctx.blkin_trace_all) {
-    trace.init("io: flush", &image_ctx.trace_endpoint);
-    trace.event("init");
-  }
 
   aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_FLUSH);
   ldout(cct, 20) << "ictx=" << &image_ctx << ", "
@@ -540,7 +505,7 @@ void Io<I>::aio_flush(I &image_ctx, io::AioCompletion *aio_comp,
 
   auto req = io::ImageDispatchSpec::create_flush(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-    io::FLUSH_SOURCE_USER, trace);
+    io::FLUSH_SOURCE_USER, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -33,12 +33,11 @@ void ImageWriteback<I>::aio_read(Extents &&image_extents, bufferlist *bl,
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_READ);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), io::ReadResult{bl},
     image_ctx->get_data_io_context(),
-    fadvise_flags, 0, trace);
+    fadvise_flags, 0, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -53,11 +52,10 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_WRITE);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), std::move(bl),
-    image_ctx->get_data_io_context(), fadvise_flags, trace);
+    image_ctx->get_data_io_context(), fadvise_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -73,11 +71,10 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_DISCARD);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_discard(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
     length, discard_granularity_bytes,
-    image_ctx->get_data_io_context(), trace);
+    image_ctx->get_data_io_context(), tracing::noop_span_ctx);
   req->send();
 }
 
@@ -91,10 +88,9 @@ void ImageWriteback<I>::aio_flush(io::FlushSource flush_source,
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_FLUSH);
 
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_flush(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    flush_source, trace);
+    flush_source, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -111,11 +107,10 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_WRITESAME);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write_same(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
     length, std::move(bl), image_ctx->get_data_io_context(),
-    fadvise_flags, trace);
+    fadvise_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -133,12 +128,11 @@ void ImageWriteback<I>::aio_compare_and_write(Extents &&image_extents,
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_COMPARE_AND_WRITE);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_compare_and_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), std::move(cmp_bl), std::move(bl),
     mismatch_offset, image_ctx->get_data_io_context(),
-    fadvise_flags, trace);
+    fadvise_flags, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -184,7 +184,7 @@ void ObjectCacherObjectDispatch<I>::shut_down(Context* on_finish) {
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::read(
     uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -237,11 +237,10 @@ bool ObjectCacherObjectDispatch<I>::read(
     off += read_extent.length;
   }
 
-  ZTracer::Trace trace(parent_trace);
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
 
   m_cache_lock.lock();
-  int r = m_object_cacher->readx(rd, m_object_set, on_dispatched, &trace);
+  int r = m_object_cacher->readx(rd, m_object_set, on_dispatched, nullptr);
   m_cache_lock.unlock();
   if (r != 0) {
     on_dispatched->complete(r);
@@ -253,7 +252,7 @@ template <typename I>
 bool ObjectCacherObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     IOContext io_context, int discard_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -295,7 +294,7 @@ bool ObjectCacherObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -342,11 +341,10 @@ bool ObjectCacherObjectDispatch<I>::write(
   extent.buffer_extents.push_back({0, data.length()});
   wr->extents.push_back(extent);
 
-  ZTracer::Trace trace(parent_trace);
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
 
   std::lock_guard locker{m_cache_lock};
-  m_object_cacher->writex(wr, m_object_set, on_dispatched, &trace);
+  m_object_cacher->writex(wr, m_object_set, on_dispatched, nullptr);
   return true;
 }
 
@@ -355,7 +353,7 @@ bool ObjectCacherObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -378,7 +376,7 @@ template <typename I>
 bool ObjectCacherObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -417,18 +415,17 @@ bool ObjectCacherObjectDispatch<I>::compare_and_write(
                                                       on_dispatched);
 
   // flush any pending writes from the cache before compare
-  ZTracer::Trace trace(parent_trace);
   *dispatch_result = io::DISPATCH_RESULT_CONTINUE;
 
   std::lock_guard cache_locker{m_cache_lock};
-  m_object_cacher->flush_set(m_object_set, object_extents, &trace,
+  m_object_cacher->flush_set(m_object_set, object_extents, nullptr,
                              on_dispatched);
   return true;
 }
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::flush(
-    io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+    io::FlushSource flush_source, const jspan_context &parent_trace,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -43,7 +43,7 @@ public:
 
   bool read(
       uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -51,7 +51,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -59,7 +59,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -67,26 +67,26 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      io::FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, io::SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       io::SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -67,7 +67,7 @@ class C_OrderedWrite : public Context {
 public:
   C_OrderedWrite(CephContext *cct,
                  ObjectCacherWriteback::write_result_d *result,
-                 const ZTracer::Trace &trace, ObjectCacherWriteback *wb)
+                 const jspan_context &trace, ObjectCacherWriteback *wb)
     : m_cct(cct), m_result(result), m_trace(trace), m_wb_handler(wb) {}
   ~C_OrderedWrite() override {}
   void finish(int r) override {
@@ -80,12 +80,11 @@ public:
       m_wb_handler->complete_writes(m_result->oid);
     }
     ldout(m_cct, 20) << "C_OrderedWrite finished " << m_result << dendl;
-    m_trace.event("finish");
   }
 private:
   CephContext *m_cct;
   ObjectCacherWriteback::write_result_d *m_result;
-  ZTracer::Trace m_trace;
+  jspan_context m_trace;
   ObjectCacherWriteback *m_wb_handler;
 };
 
@@ -118,16 +117,9 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
                                  uint64_t off, uint64_t len, snapid_t snapid,
                                  bufferlist *pbl, uint64_t trunc_size,
                                  __u32 trunc_seq, int op_flags,
-                                 const ZTracer::Trace &parent_trace,
+                                 const jspan_context &otel_trace,
                                  Context *onfinish)
 {
-  ZTracer::Trace trace;
-  if (parent_trace.valid()) {
-    trace.init("", &m_ictx->trace_endpoint, &parent_trace);
-    trace.copy_name("cache read " + oid.name);
-    trace.event("start");
-  }
-
   // on completion, take the mutex and then call onfinish.
   onfinish = new C_ReadRequest(m_ictx->cct, onfinish, &m_lock);
 
@@ -151,7 +143,7 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
 
   auto req = io::ObjectDispatchSpec::create_read(
     m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, &req_comp->extents,
-    io_context, op_flags, read_flags, trace, nullptr, req_comp);
+    io_context, op_flags, read_flags, tracing::noop_span_ctx, nullptr, req_comp);
   req->send();
 }
 
@@ -187,16 +179,9 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
                                         ceph::real_time mtime,
                                         uint64_t trunc_size,
                                         __u32 trunc_seq, ceph_tid_t journal_tid,
-                                        const ZTracer::Trace &parent_trace,
+                                        const jspan_context &otel_trace,
                                         Context *oncommit)
 {
-  ZTracer::Trace trace;
-  if (parent_trace.valid()) {
-    trace.init("", &m_ictx->trace_endpoint, &parent_trace);
-    trace.copy_name("writeback " + oid.name);
-    trace.event("start");
-  }
-
   uint64_t object_no = oid_to_object_no(oid.name, m_ictx->object_prefix);
 
   write_result_d *result = new write_result_d(oid.name, oncommit);
@@ -205,7 +190,7 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
 
   bufferlist bl_copy(bl);
 
-  Context *ctx = new C_OrderedWrite(m_ictx->cct, result, trace, this);
+  Context *ctx = new C_OrderedWrite(m_ictx->cct, result, tracing::noop_span_ctx, this);
   ctx = util::create_async_context_callback(*m_ictx, ctx);
 
   auto io_context = m_ictx->duplicate_data_io_context();
@@ -216,7 +201,7 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
 
   auto req = io::ObjectDispatchSpec::create_write(
     m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, off, std::move(bl_copy),
-    io_context, 0, 0, std::nullopt, journal_tid, trace, ctx);
+    io_context, 0, 0, std::nullopt, journal_tid, tracing::noop_span_ctx, ctx);
   req->object_dispatch_flags = (
     io::OBJECT_DISPATCH_FLAG_FLUSH |
     io::OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR);

--- a/src/librbd/cache/ObjectCacherWriteback.h
+++ b/src/librbd/cache/ObjectCacherWriteback.h
@@ -29,7 +29,7 @@ public:
             const object_locator_t& oloc, uint64_t off, uint64_t len,
             snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
             __u32 trunc_seq, int op_flags,
-            const ZTracer::Trace &parent_trace, Context *onfinish) override;
+            const jspan_context &otel_trace, Context *onfinish) override;
 
   // Determine whether a read to this extent could be affected by a
   // write-triggered copy-on-write
@@ -42,7 +42,7 @@ public:
                    const SnapContext& snapc, const bufferlist &bl,
                    ceph::real_time mtime, uint64_t trunc_size,
                    __u32 trunc_seq, ceph_tid_t journal_tid,
-                   const ZTracer::Trace &parent_trace,
+                   const jspan_context &otel_trace,
                    Context *oncommit) override;
   using WritebackHandler::write;
 

--- a/src/librbd/cache/ParentCacheObjectDispatch.cc
+++ b/src/librbd/cache/ParentCacheObjectDispatch.cc
@@ -67,7 +67,7 @@ void ParentCacheObjectDispatch<I>::init(Context* on_finish) {
 template <typename I>
 bool ParentCacheObjectDispatch<I>::read(
     uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -111,7 +111,7 @@ bool ParentCacheObjectDispatch<I>::read(
 template <typename I>
 void ParentCacheObjectDispatch<I>::handle_read_cache(
      ObjectCacheRequest* ack, uint64_t object_no, io::ReadExtents* extents,
-     IOContext io_context, const ZTracer::Trace &parent_trace,
+     IOContext io_context, const jspan_context &parent_trace,
      io::DispatchResult* dispatch_result, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -45,7 +45,7 @@ public:
 
   bool read(
       uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -53,7 +53,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
     return false;
@@ -63,7 +63,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
     return false;
@@ -73,7 +73,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
     return false;
@@ -82,7 +82,7 @@ public:
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
@@ -90,7 +90,7 @@ public:
   }
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      io::FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_id, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
     return false;
@@ -98,7 +98,7 @@ public:
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, io::SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       io::SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -139,7 +139,7 @@ private:
   void handle_read_cache(ceph::immutable_obj_cache::ObjectCacheRequest* ack,
                          uint64_t object_no, io::ReadExtents* extents,
                          IOContext io_context,
-                         const ZTracer::Trace &parent_trace,
+                         const jspan_context &parent_trace,
                          io::DispatchResult* dispatch_result,
                          Context* on_dispatched);
   int handle_register_client(bool reg);

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -58,7 +58,7 @@ void WriteAroundObjectDispatch<I>::shut_down(Context* on_finish) {
 template <typename I>
 bool WriteAroundObjectDispatch<I>::read(
     uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -74,7 +74,7 @@ template <typename I>
 bool WriteAroundObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     IOContext io_context, int discard_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -90,7 +90,7 @@ bool WriteAroundObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context**on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -106,7 +106,7 @@ bool WriteAroundObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context**on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -121,7 +121,7 @@ template <typename I>
 bool WriteAroundObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -131,7 +131,7 @@ bool WriteAroundObjectDispatch<I>::compare_and_write(
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::flush(
-    io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+    io::FlushSource flush_source, const jspan_context &parent_trace,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -43,7 +43,7 @@ public:
 
   bool read(
       uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -51,7 +51,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
@@ -59,7 +59,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
@@ -67,26 +67,26 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      io::FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, io::SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       io::SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -38,7 +38,7 @@ bool WriteLogImageDispatch<I>::read(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     io::ReadResult &&read_result, IOContext io_context,
     int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -67,7 +67,7 @@ bool WriteLogImageDispatch<I>::read(
 template <typename I>
 bool WriteLogImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -90,7 +90,7 @@ template <typename I>
 bool WriteLogImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -116,7 +116,7 @@ template <typename I>
 bool WriteLogImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&bl, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -142,7 +142,7 @@ template <typename I>
 bool WriteLogImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -165,7 +165,7 @@ bool WriteLogImageDispatch<I>::compare_and_write(
 template <typename I>
 bool WriteLogImageDispatch<I>::flush(
     io::AioCompletion* aio_comp, io::FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -187,7 +187,7 @@ bool WriteLogImageDispatch<I>::list_snaps(
     io::AioCompletion* aio_comp, io::Extents&& image_extents,
     io::SnapIds&& snap_ids,
     int list_snaps_flags, io::SnapshotDelta* snapshot_delta,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/cache/WriteLogImageDispatch.h
+++ b/src/librbd/cache/WriteLogImageDispatch.h
@@ -7,7 +7,7 @@
 #include "librbd/io/ImageDispatchInterface.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
 #include "librbd/plugin/Api.h"
@@ -42,26 +42,26 @@ public:
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       io::ReadResult &&read_result, IOContext io_context,
       int op_flags, int read_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
     bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
@@ -70,13 +70,13 @@ public:
       bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool flush(
       io::AioCompletion* aio_comp, io::FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
@@ -84,7 +84,7 @@ public:
     io::AioCompletion* aio_comp, io::Extents&& image_extents,
     io::SnapIds&& snap_ids, int list_snaps_flags,
     io::SnapshotDelta* snapshot_delta,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) override;

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -27,7 +27,7 @@ public:
   bool read(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       io::ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -37,7 +37,7 @@ public:
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -47,7 +47,7 @@ public:
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -57,7 +57,7 @@ public:
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -67,7 +67,7 @@ public:
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -76,7 +76,7 @@ public:
 
   bool flush(
       io::AioCompletion* aio_comp, io::FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -86,7 +86,7 @@ public:
   bool list_snaps(
       io::AioCompletion* aio_comp, io::Extents&& image_extents,
       io::SnapIds&& snap_ids, int list_snaps_flags,
-      io::SnapshotDelta* snapshot_delta, const ZTracer::Trace &parent_trace,
+      io::SnapshotDelta* snapshot_delta, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -32,7 +32,7 @@ struct C_AlignedObjectReadRequest : public Context {
     uint64_t object_no;
     io::ReadExtents* extents;
     IOContext io_context;
-    const ZTracer::Trace parent_trace;
+    const jspan_context parent_trace{false, false};
     uint64_t* version;
     Context* on_finish;
     io::ObjectDispatchSpec* req;
@@ -41,7 +41,7 @@ struct C_AlignedObjectReadRequest : public Context {
     C_AlignedObjectReadRequest(
             I* image_ctx, ceph::ref_t<CryptoInterface> crypto,
             uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-            int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+            int op_flags, int read_flags, const jspan_context &parent_trace,
             uint64_t* version, int* object_dispatch_flags,
             Context* on_dispatched
             ) : image_ctx(image_ctx), crypto(crypto), object_no(object_no),
@@ -111,7 +111,7 @@ struct C_UnalignedObjectReadRequest : public Context {
     C_UnalignedObjectReadRequest(
             I* image_ctx, ceph::ref_t<CryptoInterface> crypto,
             uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-            int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+            int op_flags, int read_flags, const jspan_context &parent_trace,
             uint64_t* version, int* object_dispatch_flags,
             Context* on_dispatched) : cct(image_ctx->cct), extents(extents),
                                       on_finish(on_dispatched) {
@@ -197,7 +197,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
     int op_flags;
     int write_flags;
     std::optional<uint64_t> assert_version;
-    const ZTracer::Trace parent_trace;
+    const jspan_context parent_trace{false, false};
     int* object_dispatch_flags;
     uint64_t* journal_tid;
     Context* on_finish;
@@ -214,7 +214,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
             ceph::bufferlist&& cmp_data, uint64_t* mismatch_offset,
             IOContext io_context, int op_flags, int write_flags,
             std::optional<uint64_t> assert_version,
-            const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+            const jspan_context &parent_trace, int* object_dispatch_flags,
             uint64_t* journal_tid, Context* on_dispatched, bool may_copyup
             ) : image_ctx(image_ctx), crypto(crypto), object_no(object_no),
                 object_off(object_off), data(data), cmp_data(cmp_data),
@@ -444,7 +444,7 @@ void CryptoObjectDispatch<I>::shut_down(Context* on_finish) {
 template <typename I>
 bool CryptoObjectDispatch<I>::read(
     uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -476,7 +476,7 @@ bool CryptoObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -509,7 +509,7 @@ bool CryptoObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -543,7 +543,7 @@ template <typename I>
 bool CryptoObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -568,7 +568,7 @@ template <typename I>
 bool CryptoObjectDispatch<I>::discard(
         uint64_t object_no, uint64_t object_off, uint64_t object_len,
         IOContext io_context, int discard_flags,
-        const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+        const jspan_context &parent_trace, int* object_dispatch_flags,
         uint64_t* journal_tid, io::DispatchResult* dispatch_result,
         Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -33,7 +33,7 @@ public:
 
   bool read(
       uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -41,7 +41,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -49,7 +49,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -57,20 +57,20 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      io::FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override {
     return false;
@@ -78,7 +78,7 @@ public:
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, io::SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       io::SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/crypto/FormatRequest.cc
+++ b/src/librbd/crypto/FormatRequest.cc
@@ -90,7 +90,7 @@ void FormatRequest<I>::flush() {
     ctx, librbd::util::get_image_ctx(m_image_ctx), io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec::create_flush(
     *m_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-    io::FLUSH_SOURCE_INTERNAL, {});
+    io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -143,11 +143,10 @@ void FormatRequest<I>::send() {
   auto aio_comp = io::AioCompletion::create_and_start(
           ctx, librbd::util::get_image_ctx(m_image_ctx), io::AIO_TYPE_WRITE);
 
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
           {{0, bl.length()}}, std::move(bl),
-          m_image_ctx->get_data_io_context(), 0, trace);
+          m_image_ctx->get_data_io_context(), 0, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -60,11 +60,10 @@ void LoadRequest<I>::read(uint64_t end_offset, Context* on_finish) {
   auto aio_comp = io::AioCompletion::create_and_start(
           on_finish, librbd::util::get_image_ctx(m_image_ctx),
           io::AIO_TYPE_READ);
-  ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_read(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
           {{m_offset, length}}, io::ReadResult{&m_bl},
-          m_image_ctx->get_data_io_context(), 0, 0, trace);
+          m_image_ctx->get_data_io_context(), 0, 0, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -105,7 +105,7 @@ void ObjectCopyRequest<I>::send_list_snaps() {
   auto req = io::ImageDispatchSpec::create_list_snaps(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_NONE, aio_comp,
     io::Extents{m_image_extents}, std::move(snap_ids), list_snaps_flags,
-    &m_snapshot_delta, {});
+    &m_snapshot_delta, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -173,7 +173,7 @@ void ObjectCopyRequest<I>::send_read() {
   auto req = io::ImageDispatchSpec::create_read(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
     std::move(image_extents), std::move(read_result), io_context, op_flags,
-    read_flags, {});
+    read_flags, tracing::noop_span_ctx);
   req->send();
 }
 
@@ -248,7 +248,7 @@ void ObjectCopyRequest<I>::send_update_object_map() {
   auto dst_image_ctx = m_dst_image_ctx;
   bool sent = dst_image_ctx->object_map->template aio_update<
     Context, &Context::complete>(dst_snap_id, m_dst_object_number, object_state,
-                                 {}, {}, false, ctx);
+                                 {}, tracing::noop_span_ctx, false, ctx);
 
   // NOTE: state machine might complete before we reach here
   dst_image_ctx->image_lock.unlock_shared();

--- a/src/librbd/exclusive_lock/ImageDispatch.cc
+++ b/src/librbd/exclusive_lock/ImageDispatch.cc
@@ -66,7 +66,7 @@ void ImageDispatch<I>::set_require_lock(bool init_shutdown,
     *m_image_ctx, io::IMAGE_DISPATCH_LAYER_EXCLUSIVE_LOCK, aio_comp,
     (init_shutdown ?
       io::FLUSH_SOURCE_EXCLUSIVE_LOCK_SKIP_REFRESH :
-      io::FLUSH_SOURCE_EXCLUSIVE_LOCK), {});
+      io::FLUSH_SOURCE_EXCLUSIVE_LOCK), tracing::noop_span_ctx);
   req->send();
 }
 
@@ -106,7 +106,7 @@ template <typename I>
 bool ImageDispatch<I>::read(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     io::ReadResult &&read_result, IOContext io_context, int op_flags,
-    int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int read_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -123,7 +123,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -142,7 +142,7 @@ template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -160,7 +160,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -179,7 +179,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -197,7 +197,7 @@ bool ImageDispatch<I>::compare_and_write(
 template <typename I>
 bool ImageDispatch<I>::flush(
     io::AioCompletion* aio_comp, io::FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/exclusive_lock/ImageDispatch.h
+++ b/src/librbd/exclusive_lock/ImageDispatch.h
@@ -8,7 +8,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "common/ceph_mutex.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
 #include <atomic>
@@ -52,39 +52,39 @@ public:
   bool read(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       io::ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       io::AioCompletion* aio_comp, io::FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -92,7 +92,7 @@ public:
   bool list_snaps(
       io::AioCompletion* aio_comp, io::Extents&& image_extents,
       io::SnapIds&& snap_ids, int list_snaps_flags,
-      io::SnapshotDelta* snapshot_delta, const ZTracer::Trace &parent_trace,
+      io::SnapshotDelta* snapshot_delta, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -236,7 +236,7 @@ void PreReleaseRequest<I>::send_flush_io() {
     ctx, util::get_image_ctx(&m_image_ctx), librbd::io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec::create_flush(
     m_image_ctx, io::IMAGE_DISPATCH_LAYER_EXCLUSIVE_LOCK, aio_comp,
-    io::FLUSH_SOURCE_EXCLUSIVE_LOCK_SKIP_REFRESH, {});
+    io::FLUSH_SOURCE_EXCLUSIVE_LOCK_SKIP_REFRESH, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -105,7 +105,7 @@ void CloseRequest<I>::send_flush() {
                                                       io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec::create_flush(
     *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-    io::FLUSH_SOURCE_SHUTDOWN, {});
+    io::FLUSH_SOURCE_SHUTDOWN, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1277,7 +1277,7 @@ Context *RefreshRequest<I>::send_flush_aio() {
       ctx, util::get_image_ctx(&m_image_ctx), io::AIO_TYPE_FLUSH);
     auto req = io::ImageDispatchSpec::create_flush(
       m_image_ctx, io::IMAGE_DISPATCH_LAYER_REFRESH, aio_comp,
-      io::FLUSH_SOURCE_REFRESH, {});
+      io::FLUSH_SOURCE_REFRESH, tracing::noop_span_ctx);
     req->send();
     return nullptr;
   } else if (m_error_result < 0) {

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -8,15 +8,13 @@
 #include "include/buffer.h"
 #include "include/interval_set.h"
 #include "common/ceph_mutex.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/AsyncOperation.h"
 #include "librbd/io/Types.h"
 
 #include <map>
 #include <string>
 #include <vector>
-
-namespace ZTracer { struct Trace; }
 
 namespace librbd {
 
@@ -31,13 +29,13 @@ class CopyupRequest {
 public:
   static CopyupRequest* create(ImageCtxT *ictx, uint64_t objectno,
                                Extents &&image_extents,
-                               const ZTracer::Trace &parent_trace) {
+                               const jspan_context &parent_trace) {
     return new CopyupRequest(ictx, objectno, std::move(image_extents),
                              parent_trace);
   }
 
   CopyupRequest(ImageCtxT *ictx, uint64_t objectno, Extents &&image_extents,
-                const ZTracer::Trace &parent_trace);
+                const jspan_context &parent_trace);
   ~CopyupRequest();
 
   void append_request(AbstractObjectWriteRequest<ImageCtxT> *req,
@@ -83,7 +81,7 @@ private:
   ImageCtxT *m_image_ctx;
   uint64_t m_object_no;
   Extents m_image_extents;
-  ZTracer::Trace m_trace;
+  jspan_context m_trace;
 
   bool m_flatten = false;
   bool m_copyup_required = true;

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -36,7 +36,7 @@ template <typename I>
 bool ImageDispatch<I>::read(
     AioCompletion* aio_comp, Extents &&image_extents, ReadResult &&read_result,
     IOContext io_context, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -55,7 +55,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -75,7 +75,7 @@ template <typename I>
 bool ImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -94,7 +94,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -114,7 +114,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -133,7 +133,7 @@ bool ImageDispatch<I>::compare_and_write(
 template <typename I>
 bool ImageDispatch<I>::flush(
     AioCompletion* aio_comp, FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -151,7 +151,7 @@ template <typename I>
 bool ImageDispatch<I>::list_snaps(
     AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
     int list_snaps_flags, SnapshotDelta* snapshot_delta,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/io/ImageDispatch.h
+++ b/src/librbd/io/ImageDispatch.h
@@ -7,7 +7,7 @@
 #include "librbd/io/ImageDispatchInterface.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
 
@@ -36,39 +36,39 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -76,7 +76,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -6,7 +6,7 @@
 
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
@@ -34,39 +34,39 @@ struct ImageDispatchInterface {
   virtual bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
+      IOContext io_context, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
@@ -74,7 +74,7 @@ struct ImageDispatchInterface {
   virtual bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -34,7 +34,7 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
 template <typename I>
 bool ObjectDispatch<I>::read(
     uint64_t object_no, ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -53,7 +53,7 @@ template <typename I>
 bool ObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     IOContext io_context, int discard_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -73,7 +73,7 @@ bool ObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -94,7 +94,7 @@ bool ObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -115,7 +115,7 @@ template <typename I>
 bool ObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -138,7 +138,7 @@ bool ObjectDispatch<I>::compare_and_write(
 template <typename I>
 bool ObjectDispatch<I>::list_snaps(
     uint64_t object_no, io::Extents&& extents, SnapIds&& snap_ids,
-    int list_snap_flags, const ZTracer::Trace &parent_trace,
+    int list_snap_flags, const jspan_context &parent_trace,
     SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/Types.h"
 #include "librbd/io/ObjectDispatchInterface.h"
 
@@ -34,7 +34,7 @@ public:
 
   bool read(
       uint64_t object_no, ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -42,7 +42,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -50,7 +50,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -58,20 +58,20 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override {
     return false;
@@ -79,7 +79,7 @@ public:
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 
@@ -35,7 +35,7 @@ struct ObjectDispatchInterface {
 
   virtual bool read(
       uint64_t object_no, ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
@@ -43,7 +43,7 @@ struct ObjectDispatchInterface {
   virtual bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;
 
@@ -51,14 +51,14 @@ struct ObjectDispatchInterface {
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;
 
   virtual bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context**on_finish,
       Context* on_dispatched) = 0;
@@ -66,19 +66,19 @@ struct ObjectDispatchInterface {
   virtual bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
 
   virtual bool flush(
-      FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) = 0;
 
   virtual bool list_snaps(
       uint64_t object_no, Extents&& extents, SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -8,7 +8,7 @@
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 #include <boost/variant/variant.hpp>
@@ -162,13 +162,13 @@ public:
   Request request;
   IOContext io_context;
   int op_flags;
-  ZTracer::Trace parent_trace;
+  jspan_context parent_trace{false, false};
 
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_read(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       uint64_t object_no, ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, Context* on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
@@ -183,7 +183,7 @@ public:
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags, uint64_t journal_tid,
-      const ZTracer::Trace &parent_trace, Context *on_finish) {
+      const jspan_context &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   DiscardRequest{object_no, object_off,
@@ -198,7 +198,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version, uint64_t journal_tid,
-      const ZTracer::Trace &parent_trace, Context *on_finish) {
+      const jspan_context &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   WriteRequest{object_no, object_off,
@@ -214,7 +214,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, uint64_t journal_tid,
-      const ZTracer::Trace &parent_trace, Context *on_finish) {
+      const jspan_context &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   WriteSameRequest{object_no, object_off,
@@ -232,7 +232,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context,
       uint64_t *mismatch_offset, int op_flags, uint64_t journal_tid,
-      const ZTracer::Trace &parent_trace, Context *on_finish) {
+      const jspan_context &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   CompareAndWriteRequest{object_no,
@@ -249,7 +249,7 @@ public:
   static ObjectDispatchSpec* create_flush(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       FlushSource flush_source, uint64_t journal_tid,
-      const ZTracer::Trace &parent_trace, Context *on_finish) {
+      const jspan_context &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   FlushRequest{flush_source, journal_tid},
@@ -260,7 +260,7 @@ public:
   static ObjectDispatchSpec* create_list_snaps(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       uint64_t object_no, Extents&& extents, SnapIds&& snap_ids,
-      int list_snaps_flags, const ZTracer::Trace &parent_trace,
+      int list_snaps_flags, const jspan_context &parent_trace,
       SnapshotDelta* snapshot_delta, Context* on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
@@ -281,7 +281,7 @@ private:
   ObjectDispatchSpec(ObjectDispatcherInterface* object_dispatcher,
                      ObjectDispatchLayer object_dispatch_layer,
                      Request&& request, IOContext io_context, int op_flags,
-                     const ZTracer::Trace& parent_trace, Context* on_finish)
+                     const jspan_context& parent_trace, Context* on_finish)
     : dispatcher_ctx(this, on_finish), object_dispatcher(object_dispatcher),
       dispatch_layer(object_dispatch_layer), request(std::move(request)),
       io_context(io_context), op_flags(op_flags), parent_trace(parent_trace) {

--- a/src/librbd/io/QosImageDispatch.cc
+++ b/src/librbd/io/QosImageDispatch.cc
@@ -121,7 +121,7 @@ template <typename I>
 bool QosImageDispatch<I>::read(
     AioCompletion* aio_comp, Extents &&image_extents, ReadResult &&read_result,
     IOContext io_context, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -144,7 +144,7 @@ bool QosImageDispatch<I>::read(
 template <typename I>
 bool QosImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -168,7 +168,7 @@ template <typename I>
 bool QosImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -191,7 +191,7 @@ bool QosImageDispatch<I>::discard(
 template <typename I>
 bool QosImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -215,7 +215,7 @@ template <typename I>
 bool QosImageDispatch<I>::compare_and_write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -238,7 +238,7 @@ bool QosImageDispatch<I>::compare_and_write(
 template <typename I>
 bool QosImageDispatch<I>::flush(
     AioCompletion* aio_comp, FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -10,7 +10,7 @@
 #include "librbd/io/ImageDispatchInterface.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/Throttle.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
@@ -56,39 +56,39 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -96,7 +96,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -41,7 +41,7 @@ template <typename I>
 bool QueueImageDispatch<I>::read(
     AioCompletion* aio_comp, Extents &&image_extents, ReadResult &&read_result,
     IOContext io_context, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -54,7 +54,7 @@ bool QueueImageDispatch<I>::read(
 template <typename I>
 bool QueueImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -68,7 +68,7 @@ template <typename I>
 bool QueueImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -81,7 +81,7 @@ bool QueueImageDispatch<I>::discard(
 template <typename I>
 bool QueueImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -95,7 +95,7 @@ template <typename I>
 bool QueueImageDispatch<I>::compare_and_write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -108,7 +108,7 @@ bool QueueImageDispatch<I>::compare_and_write(
 template <typename I>
 bool QueueImageDispatch<I>::flush(
     AioCompletion* aio_comp, FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/io/QueueImageDispatch.h
+++ b/src/librbd/io/QueueImageDispatch.h
@@ -7,7 +7,7 @@
 #include "librbd/io/ImageDispatchInterface.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/Throttle.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
@@ -40,39 +40,39 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -80,7 +80,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/io/RefreshImageDispatch.cc
+++ b/src/librbd/io/RefreshImageDispatch.cc
@@ -31,7 +31,7 @@ template <typename I>
 bool RefreshImageDispatch<I>::read(
     AioCompletion* aio_comp, Extents &&image_extents, ReadResult &&read_result,
     IOContext io_context, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -49,7 +49,7 @@ bool RefreshImageDispatch<I>::read(
 template <typename I>
 bool RefreshImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -68,7 +68,7 @@ template <typename I>
 bool RefreshImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -86,7 +86,7 @@ bool RefreshImageDispatch<I>::discard(
 template <typename I>
 bool RefreshImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -105,7 +105,7 @@ template <typename I>
 bool RefreshImageDispatch<I>::compare_and_write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -123,7 +123,7 @@ bool RefreshImageDispatch<I>::compare_and_write(
 template <typename I>
 bool RefreshImageDispatch<I>::flush(
     AioCompletion* aio_comp, FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/io/RefreshImageDispatch.h
+++ b/src/librbd/io/RefreshImageDispatch.h
@@ -7,7 +7,7 @@
 #include "librbd/io/ImageDispatchInterface.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/Throttle.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
@@ -36,39 +36,39 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -76,7 +76,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -166,7 +166,7 @@ void SimpleSchedulerObjectDispatch<I>::ObjectRequests::dispatch_delayed_requests
     auto req = ObjectDispatchSpec::create_write(
         image_ctx, OBJECT_DISPATCH_LAYER_SCHEDULER,
         m_object_no, offset, std::move(merged_requests.data), m_io_context,
-        m_op_flags, 0, std::nullopt, 0, {}, ctx);
+        m_op_flags, 0, std::nullopt, 0, tracing::noop_span_ctx, ctx);
 
     req->object_dispatch_flags = m_object_dispatch_flags;
     req->send();
@@ -220,7 +220,7 @@ void SimpleSchedulerObjectDispatch<I>::shut_down(Context* on_finish) {
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::read(
     uint64_t object_no, ReadExtents* extents, IOContext io_context,
-    int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, int read_flags, const jspan_context &parent_trace,
     uint64_t* version, int* object_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -243,7 +243,7 @@ template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     IOContext io_context, int discard_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -262,7 +262,7 @@ bool SimpleSchedulerObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -304,7 +304,7 @@ bool SimpleSchedulerObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -322,7 +322,7 @@ template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -339,7 +339,7 @@ bool SimpleSchedulerObjectDispatch<I>::compare_and_write(
 
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::flush(
-    FlushSource flush_source, const ZTracer::Trace &parent_trace,
+    FlushSource flush_source, const jspan_context &parent_trace,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -50,7 +50,7 @@ public:
 
   bool read(
       uint64_t object_no, ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -58,7 +58,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -66,7 +66,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -74,26 +74,26 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -85,7 +85,7 @@ bool assemble_write_same_extent(
 
 template <typename I>
 void read_parent(I *image_ctx, uint64_t object_no, ReadExtents* extents,
-                 librados::snap_t snap_id, const ZTracer::Trace &trace,
+                 librados::snap_t snap_id, const jspan_context &trace,
                  Context* on_finish) {
 
   auto cct = image_ctx->cct;
@@ -171,7 +171,7 @@ bool trigger_copyup(I* image_ctx, uint64_t object_no, IOContext io_context,
   bufferlist bl;
   auto req = new ObjectWriteRequest<I>(
           image_ctx, object_no, 0, std::move(bl), io_context, 0, 0,
-          std::nullopt, {}, on_finish);
+          std::nullopt, tracing::noop_span_ctx, on_finish);
   if (!req->has_parent()) {
     delete req;
     return false;
@@ -220,7 +220,7 @@ uint64_t get_file_offset(I* image_ctx, uint64_t object_no, uint64_t offset) {
 
 template void librbd::io::util::read_parent(
     librbd::ImageCtx *image_ctx, uint64_t object_no, ReadExtents* extents,
-    librados::snap_t snap_id, const ZTracer::Trace &trace, Context* on_finish);
+    librados::snap_t snap_id, const jspan_context &trace, Context* on_finish);
 template int librbd::io::util::clip_request(
     librbd::ImageCtx *image_ctx, Extents *image_extents);
 template bool librbd::io::util::trigger_copyup(

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include "include/buffer_fwd.h"
 #include "include/rados/rados_types.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 #include <map>
@@ -33,7 +33,7 @@ bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
 template <typename ImageCtxT = librbd::ImageCtx>
 void read_parent(ImageCtxT *image_ctx, uint64_t object_no,
                  ReadExtents* extents, librados::snap_t snap_id,
-                 const ZTracer::Trace &trace, Context* on_finish);
+                 const jspan_context &trace, Context* on_finish);
 
 template <typename ImageCtxT = librbd::ImageCtx>
 int clip_request(ImageCtxT *image_ctx, Extents *image_extents);

--- a/src/librbd/io/WriteBlockImageDispatch.cc
+++ b/src/librbd/io/WriteBlockImageDispatch.cc
@@ -127,7 +127,7 @@ void WriteBlockImageDispatch<I>::wait_on_writes_unblocked(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -141,7 +141,7 @@ template <typename I>
 bool WriteBlockImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
     uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -154,7 +154,7 @@ bool WriteBlockImageDispatch<I>::discard(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -168,7 +168,7 @@ template <typename I>
 bool WriteBlockImageDispatch<I>::compare_and_write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int op_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -181,7 +181,7 @@ bool WriteBlockImageDispatch<I>::compare_and_write(
 template <typename I>
 bool WriteBlockImageDispatch<I>::flush(
     AioCompletion* aio_comp, FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -245,7 +245,7 @@ void WriteBlockImageDispatch<I>::flush_io(Context* on_finish) {
     on_finish, util::get_image_ctx(m_image_ctx), librbd::io::AIO_TYPE_FLUSH);
   auto req = ImageDispatchSpec::create_flush(
     *m_image_ctx, IMAGE_DISPATCH_LAYER_WRITE_BLOCK, aio_comp,
-    FLUSH_SOURCE_WRITE_BLOCK, {});
+    FLUSH_SOURCE_WRITE_BLOCK, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/io/WriteBlockImageDispatch.h
+++ b/src/librbd/io/WriteBlockImageDispatch.h
@@ -8,7 +8,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "common/ceph_mutex.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/Throttle.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
@@ -49,7 +49,7 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -57,33 +57,33 @@ public:
   }
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -91,7 +91,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -82,7 +82,7 @@ template <typename I>
 bool ObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     IOContext io_context, int discard_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*journal_tid == 0) {
@@ -110,7 +110,7 @@ bool ObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*journal_tid == 0) {
@@ -138,7 +138,7 @@ bool ObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+    const jspan_context &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*journal_tid == 0) {
@@ -165,7 +165,7 @@ template <typename I>
 bool ObjectDispatch<I>::compare_and_write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
     ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-    const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+    const jspan_context &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -193,7 +193,7 @@ bool ObjectDispatch<I>::compare_and_write(
 
 template <typename I>
 bool ObjectDispatch<I>::flush(
-    io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+    io::FlushSource flush_source, const jspan_context &parent_trace,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*journal_tid == 0) {

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/io/Types.h"
 #include "librbd/io/ObjectDispatchInterface.h"
 
@@ -38,7 +38,7 @@ public:
 
   bool read(
       uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, int read_flags, const jspan_context &parent_trace,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
@@ -48,7 +48,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -56,7 +56,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
@@ -64,26 +64,26 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
+      const jspan_context &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      io::FlushSource flush_source, const jspan_context &parent_trace,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, io::SnapIds&& snap_ids,
-      int list_snap_flags, const ZTracer::Trace &parent_trace,
+      int list_snap_flags, const jspan_context &parent_trace,
       io::SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -275,7 +275,7 @@ void Replay<I>::shut_down(bool cancel_ops, Context *on_finish) {
   if (flush_comp != nullptr) {
     std::shared_lock owner_locker{m_image_ctx.owner_lock};
     io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
-                                   io::FLUSH_SOURCE_INTERNAL, {});
+                                   io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   }
   if (on_finish != nullptr) {
     on_finish->complete(0);
@@ -296,7 +296,7 @@ void Replay<I>::flush(Context *on_finish) {
 
   std::shared_lock owner_locker{m_image_ctx.owner_lock};
   io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp,
-                                 io::FLUSH_SOURCE_INTERNAL, {});
+                                 io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
 }
 
 template <typename I>
@@ -357,7 +357,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
     io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp,
                                      {{event.offset, event.length}},
                                      event.discard_granularity_bytes,
-                                     m_image_ctx.get_data_io_context(), {});
+                                     m_image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   }
 
   if (flush_required) {
@@ -367,7 +367,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
 
     if (flush_comp != nullptr) {
       io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
-                                     io::FLUSH_SOURCE_INTERNAL, {});
+                                     io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     }
   }
 }
@@ -392,7 +392,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
     io::ImageRequest<I>::aio_write(&m_image_ctx, aio_comp,
                                    {{event.offset, event.length}},
                                    std::move(data),
-                                   m_image_ctx.get_data_io_context(), 0, {});
+                                   m_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   }
 
   if (flush_required) {
@@ -402,7 +402,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
 
     if (flush_comp != nullptr) {
       io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
-                                     io::FLUSH_SOURCE_INTERNAL, {});
+                                     io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     }
   }
 }
@@ -421,7 +421,7 @@ void Replay<I>::handle_event(const journal::AioFlushEvent &event,
 
   if (aio_comp != nullptr) {
     io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp,
-                                   io::FLUSH_SOURCE_INTERNAL, {});
+                                   io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   }
   on_ready->complete(0);
 }
@@ -447,7 +447,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
                                        {{event.offset, event.length}},
                                        std::move(data),
                                        m_image_ctx.get_data_io_context(), 0,
-                                       {});
+                                       tracing::noop_span_ctx);
   }
 
   if (flush_required) {
@@ -457,7 +457,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
 
     if (flush_comp != nullptr) {
       io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
-                                     io::FLUSH_SOURCE_INTERNAL, {});
+                                     io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     }
   }
 }
@@ -483,7 +483,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
                                                std::move(write_data),
                                                nullptr,
                                                m_image_ctx.get_data_io_context(),
-                                               0, {});
+                                               0, tracing::noop_span_ctx);
   }
 
   if (flush_required) {
@@ -492,7 +492,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     m_lock.unlock();
 
     io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
-                                   io::FLUSH_SOURCE_INTERNAL, {});
+                                   io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   }
 }
 

--- a/src/librbd/migration/FormatInterface.h
+++ b/src/librbd/migration/FormatInterface.h
@@ -6,7 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 #include <map>
@@ -38,12 +38,12 @@ struct FormatInterface {
   virtual bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
                     io::Extents&& image_extents, io::ReadResult&& read_result,
                     int op_flags, int read_flags,
-                    const ZTracer::Trace &parent_trace) = 0;
+                    const jspan_context &parent_trace) = 0;
 
   virtual void list_snaps(io::Extents&& image_extents, io::SnapIds&& snap_ids,
                           int list_snaps_flags,
                           io::SnapshotDelta* snapshot_delta,
-                          const ZTracer::Trace &parent_trace,
+                          const jspan_context &parent_trace,
                           Context* on_finish) = 0;
 };
 

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -36,7 +36,7 @@ template <typename I>
 bool ImageDispatch<I>::read(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     io::ReadResult &&read_result, IOContext io_context, int op_flags,
-    int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+    int read_flags, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -52,7 +52,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -67,7 +67,7 @@ template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     uint32_t discard_granularity_bytes,
-    IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
+    IOContext io_context, const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -81,7 +81,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -96,7 +96,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    IOContext io_context, int op_flags, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -110,7 +110,7 @@ bool ImageDispatch<I>::compare_and_write(
 template <typename I>
 bool ImageDispatch<I>::flush(
     io::AioCompletion* aio_comp, io::FlushSource flush_source,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
+    const jspan_context &parent_trace, uint64_t tid,
     std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -126,7 +126,7 @@ template <typename I>
 bool ImageDispatch<I>::list_snaps(
     io::AioCompletion* aio_comp, io::Extents&& image_extents,
     io::SnapIds&& snap_ids, int list_snaps_flags,
-    io::SnapshotDelta* snapshot_delta, const ZTracer::Trace &parent_trace,
+    io::SnapshotDelta* snapshot_delta, const jspan_context &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -36,39 +36,39 @@ public:
   bool read(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       io::ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
+      IOContext io_context, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(
       io::AioCompletion* aio_comp, io::FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -76,7 +76,7 @@ public:
   bool list_snaps(
       io::AioCompletion* aio_comp, io::Extents&& image_extents,
       io::SnapIds&& snap_ids, int list_snaps_flags,
-      io::SnapshotDelta* snapshot_delta, const ZTracer::Trace &parent_trace,
+      io::SnapshotDelta* snapshot_delta, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -289,7 +289,7 @@ template <typename I>
 void NativeFormat<I>::list_snaps(io::Extents&& image_extents,
                                  io::SnapIds&& snap_ids, int list_snaps_flags,
                                  io::SnapshotDelta* snapshot_delta,
-                                 const ZTracer::Trace &parent_trace,
+                                 const jspan_context &parent_trace,
                                  Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
@@ -299,7 +299,7 @@ void NativeFormat<I>::list_snaps(io::Extents&& image_extents,
   auto req = io::ImageDispatchSpec::create_list_snaps(
     *m_image_ctx, io::IMAGE_DISPATCH_LAYER_MIGRATION, aio_comp,
     std::move(image_extents), std::move(snap_ids), list_snaps_flags,
-    snapshot_delta, {});
+    snapshot_delta, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/migration/NativeFormat.h
+++ b/src/librbd/migration/NativeFormat.h
@@ -48,13 +48,13 @@ public:
   bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
             io::Extents&& image_extents, io::ReadResult&& read_result,
             int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override {
+            const jspan_context &parent_trace) override {
     return false;
   }
 
   void list_snaps(io::Extents&& image_extents, io::SnapIds&& snap_ids,
                   int list_snaps_flags, io::SnapshotDelta* snapshot_delta,
-                  const ZTracer::Trace &parent_trace,
+                  const jspan_context &parent_trace,
                   Context* on_finish) override;
 
 private:

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -1439,7 +1439,7 @@ template <typename I>
 bool QCOWFormat<I>::read(
     io::AioCompletion* aio_comp, uint64_t snap_id, io::Extents&& image_extents,
     io::ReadResult&& read_result, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace) {
+    const jspan_context &parent_trace) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "snap_id=" << snap_id << ", "
                  << "image_extents=" << image_extents << dendl;
@@ -1472,7 +1472,7 @@ template <typename I>
 void QCOWFormat<I>::list_snaps(io::Extents&& image_extents,
                               io::SnapIds&& snap_ids, int list_snaps_flags,
                               io::SnapshotDelta* snapshot_delta,
-                              const ZTracer::Trace &parent_trace,
+                              const jspan_context &parent_trace,
                               Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;

--- a/src/librbd/migration/QCOWFormat.h
+++ b/src/librbd/migration/QCOWFormat.h
@@ -69,11 +69,11 @@ public:
   bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
             io::Extents&& image_extents, io::ReadResult&& read_result,
             int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override;
+            const jspan_context &parent_trace) override;
 
   void list_snaps(io::Extents&& image_extents, io::SnapIds&& snap_ids,
                   int list_snaps_flags, io::SnapshotDelta* snapshot_delta,
-                  const ZTracer::Trace &parent_trace,
+                  const jspan_context &parent_trace,
                   Context* on_finish) override;
 
 private:

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -166,7 +166,7 @@ template <typename I>
 bool RawFormat<I>::read(
     io::AioCompletion* aio_comp, uint64_t snap_id, io::Extents&& image_extents,
     io::ReadResult&& read_result, int op_flags, int read_flags,
-    const ZTracer::Trace &parent_trace) {
+    const jspan_context &parent_trace) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "snap_id=" << snap_id << ", "
                  << "image_extents=" << image_extents << dendl;
@@ -187,7 +187,7 @@ template <typename I>
 void RawFormat<I>::list_snaps(io::Extents&& image_extents,
                               io::SnapIds&& snap_ids, int list_snaps_flags,
                               io::SnapshotDelta* snapshot_delta,
-                              const ZTracer::Trace &parent_trace,
+                              const jspan_context &parent_trace,
                               Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -47,11 +47,11 @@ public:
   bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
             io::Extents&& image_extents, io::ReadResult&& read_result,
             int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override;
+            const jspan_context &parent_trace) override;
 
   void list_snaps(io::Extents&& image_extents, io::SnapIds&& snap_ids,
                   int list_snaps_flags, io::SnapshotDelta* snapshot_delta,
-                  const ZTracer::Trace &parent_trace,
+                  const jspan_context &parent_trace,
                   Context* on_finish) override;
 
 private:

--- a/src/librbd/migration/RawSnapshot.cc
+++ b/src/librbd/migration/RawSnapshot.cc
@@ -181,7 +181,7 @@ void RawSnapshot<I>::read(io::AioCompletion* aio_comp,
                           io::Extents&& image_extents,
                           io::ReadResult&& read_result, int op_flags,
                           int read_flags,
-                          const ZTracer::Trace &parent_trace) {
+                          const jspan_context &parent_trace) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;
 
@@ -200,7 +200,7 @@ template <typename I>
 void RawSnapshot<I>::list_snap(io::Extents&& image_extents,
                                int list_snaps_flags,
                                io::SparseExtents* sparse_extents,
-                               const ZTracer::Trace &parent_trace,
+                               const jspan_context &parent_trace,
                                Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "image_extents=" << image_extents << dendl;

--- a/src/librbd/migration/RawSnapshot.h
+++ b/src/librbd/migration/RawSnapshot.h
@@ -6,7 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 #include "librbd/migration/SnapshotInterface.h"
@@ -46,11 +46,11 @@ public:
 
   void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
             io::ReadResult&& read_result, int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override;
+            const jspan_context &parent_trace) override;
 
   void list_snap(io::Extents&& image_extents, int list_snaps_flags,
                  io::SparseExtents* sparse_extents,
-                 const ZTracer::Trace &parent_trace,
+                 const jspan_context &parent_trace,
                  Context* on_finish) override;
 
 private:

--- a/src/librbd/migration/SnapshotInterface.h
+++ b/src/librbd/migration/SnapshotInterface.h
@@ -6,7 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
 #include <string>
@@ -34,11 +34,11 @@ struct SnapshotInterface {
 
   virtual void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
                     io::ReadResult&& read_result, int op_flags, int read_flags,
-                    const ZTracer::Trace &parent_trace) = 0;
+                    const jspan_context &parent_trace) = 0;
 
   virtual void list_snap(io::Extents&& image_extents, int list_snaps_flags,
                          io::SparseExtents* sparse_extents,
-                         const ZTracer::Trace &parent_trace,
+                         const jspan_context &parent_trace,
                          Context* on_finish) = 0;
 };
 

--- a/src/librbd/object_map/UpdateRequest.cc
+++ b/src/librbd/object_map/UpdateRequest.cc
@@ -63,7 +63,7 @@ void UpdateRequest<I>::update_object_map() {
   std::vector<librados::snap_t> snaps;
   int r = m_image_ctx.md_ctx.aio_operate(
     oid, rados_completion, &op, 0, snaps,
-    (m_trace.valid() ? m_trace.get_info() : nullptr));
+    nullptr);
   ceph_assert(r == 0);
   rados_completion->release();
 }

--- a/src/librbd/object_map/UpdateRequest.h
+++ b/src/librbd/object_map/UpdateRequest.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include "librbd/object_map/Request.h"
 #include "common/bit_vector.hpp"
-#include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "librbd/Utils.h"
 #include <boost/optional.hpp>
 
@@ -28,7 +28,7 @@ public:
                                uint64_t snap_id, uint64_t start_object_no,
                                uint64_t end_object_no, uint8_t new_state,
                                const boost::optional<uint8_t> &current_state,
-                               const ZTracer::Trace &parent_trace,
+                               const jspan_context &parent_trace,
                                bool ignore_enoent, Context *on_finish) {
     return new UpdateRequest(image_ctx, object_map_lock, object_map, snap_id,
                              start_object_no, end_object_no, new_state,
@@ -41,21 +41,18 @@ public:
                 uint64_t start_object_no, uint64_t end_object_no,
                 uint8_t new_state,
                 const boost::optional<uint8_t> &current_state,
-      	        const ZTracer::Trace &parent_trace, bool ignore_enoent,
+      	        const jspan_context &parent_trace, bool ignore_enoent,
                 Context *on_finish)
     : Request(image_ctx, snap_id, on_finish),
       m_object_map_lock(object_map_lock), m_object_map(*object_map),
       m_start_object_no(start_object_no), m_end_object_no(end_object_no),
       m_update_start_object_no(start_object_no), m_new_state(new_state),
       m_current_state(current_state),
-      m_trace(util::create_trace(image_ctx, "update object map", parent_trace)),
+      m_trace(tracing::noop_span_ctx),
       m_ignore_enoent(ignore_enoent)
-  {
-    m_trace.event("start");
-  }
-  virtual ~UpdateRequest() {
-    m_trace.event("finish");
-  }
+  {}
+
+  virtual ~UpdateRequest() {}
 
   void send() override;
 
@@ -86,7 +83,7 @@ private:
   uint64_t m_update_end_object_no = 0;
   uint8_t m_new_state;
   boost::optional<uint8_t> m_current_state;
-  ZTracer::Trace m_trace;
+  jspan_context m_trace;
   bool m_ignore_enoent;
 
   int m_ret_val = 0;

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -119,7 +119,7 @@ private:
       bufferlist bl;
       auto req = new io::ObjectWriteRequest<I>(&image_ctx, m_object_no, 0,
                                                std::move(bl), m_io_context, 0,
-                                               0, std::nullopt, {}, ctx);
+                                               0, std::nullopt, tracing::noop_span_ctx, ctx);
 
       ldout(cct, 20) << "copyup object req " << req << ", object_no "
                      << m_object_no << dendl;

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -198,7 +198,7 @@ void ResizeRequest<I>::send_flush_cache() {
     ctx, util::get_image_ctx(&image_ctx), io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec::create_flush(
     image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-    io::FLUSH_SOURCE_INTERNAL, {});
+    io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   req->send();
 }
 

--- a/src/librbd/operation/SparsifyRequest.cc
+++ b/src/librbd/operation/SparsifyRequest.cc
@@ -237,7 +237,7 @@ public:
 
     bool sent = image_ctx.object_map->template aio_update<
       Context, &Context::complete>(CEPH_NOSNAP, m_object_no, OBJECT_PENDING,
-                                   OBJECT_EXISTS, {}, false, ctx);
+                                   OBJECT_EXISTS, tracing::noop_span_ctx, false, ctx);
 
     // NOTE: state machine might complete before we reach here
     image_ctx.image_lock.unlock_shared();
@@ -310,7 +310,7 @@ public:
       sent = image_ctx.object_map->template aio_update<
         Context, &Context::complete>(CEPH_NOSNAP, m_object_no,
                                      exists ? OBJECT_EXISTS : OBJECT_NONEXISTENT,
-                                     OBJECT_PENDING, {}, false, ctx);
+                                     OBJECT_PENDING, tracing::noop_span_ctx, false, ctx);
     }
     if (!sent) {
       ctx->complete(0);

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -48,7 +48,7 @@ public:
     auto object_dispatch_spec = io::ObjectDispatchSpec::create_discard(
       &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, m_object_no, 0,
       image_ctx.layout.object_size, m_io_context,
-      io::OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE, 0, {}, this);
+      io::OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE, 0, tracing::noop_span_ctx, this);
     object_dispatch_spec->send();
     return 0;
   }
@@ -207,7 +207,7 @@ void TrimRequest<I>::send_pre_trim() {
 
       if (image_ctx.object_map->template aio_update<AsyncRequest<I> >(
             CEPH_NOSNAP, m_delete_start_min, m_num_objects, OBJECT_PENDING,
-            OBJECT_EXISTS, {}, false, this)) {
+            OBJECT_EXISTS, tracing::noop_span_ctx, false, this)) {
         return;
       }
     }
@@ -301,7 +301,7 @@ void TrimRequest<I>::send_post_trim() {
 
       if (image_ctx.object_map->template aio_update<AsyncRequest<I> >(
             CEPH_NOSNAP, m_delete_start_min, m_num_objects, OBJECT_NONEXISTENT,
-            OBJECT_PENDING, {}, false, this)) {
+            OBJECT_PENDING, tracing::noop_span_ctx, false, this)) {
         return;
       }
     }
@@ -354,7 +354,7 @@ void TrimRequest<I>::send_clean_boundary() {
 
     auto object_dispatch_spec = io::ObjectDispatchSpec::create_discard(
       &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, extent.objectno, extent.offset,
-      extent.length, io_context, 0, 0, {}, req_comp);
+      extent.length, io_context, 0, 0, tracing::noop_span_ctx, req_comp);
     object_dispatch_spec->send();
   }
   completion->finish_adding_requests();

--- a/src/librbd/plugin/Api.cc
+++ b/src/librbd/plugin/Api.cc
@@ -15,7 +15,7 @@ namespace plugin {
 template <typename I>
 void Api<I>::read_parent(
     I *image_ctx, uint64_t object_no, io::ReadExtents* extents,
-    librados::snap_t snap_id, const ZTracer::Trace &trace,
+    librados::snap_t snap_id, const jspan_context &trace,
     Context* on_finish) {
   io::util::read_parent<I>(image_ctx, object_no, extents, snap_id, trace,
                            on_finish);

--- a/src/librbd/plugin/Api.h
+++ b/src/librbd/plugin/Api.h
@@ -12,8 +12,6 @@
 #include "librbd/io/Types.h"
 #include "librbd/io/ReadResult.h"
 
-namespace ZTracer { struct Trace; }
-
 namespace librbd {
 
 namespace io {
@@ -34,7 +32,7 @@ struct Api {
 
   virtual void read_parent(
       ImageCtxT *image_ctx, uint64_t object_no, io::ReadExtents* extents,
-      librados::snap_t snap_id, const ZTracer::Trace &trace,
+      librados::snap_t snap_id, const jspan_context &trace,
       Context* on_finish);
 
   virtual void execute_image_metadata_set(

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -20,8 +20,8 @@
 
 class MOSDECSubOpRead : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 3;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 4;
+  static constexpr int COMPAT_VERSION = 2;
 
 public:
   spg_t pgid;
@@ -51,7 +51,10 @@ public:
     decode(pgid, p);
     decode(map_epoch, p);
     decode(op, p);
-    if (header.version >= 3) {
+    if (header.version >= 4) {
+      decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 3) {
       decode(min_epoch, p);
       decode_trace(p);
     } else {
@@ -65,7 +68,7 @@ public:
     encode(map_epoch, payload);
     encode(op, payload, features);
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
   }
 
   std::string_view get_type_name() const override { return "MOSDECSubOpRead"; }

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -20,8 +20,8 @@
 
 class MOSDECSubOpReadReply : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 3;
+  static constexpr int COMPAT_VERSION = 2;
 
 public:
   spg_t pgid;
@@ -51,7 +51,10 @@ public:
     decode(pgid, p);
     decode(map_epoch, p);
     decode(op, p);
-    if (header.version >= 2) {
+    if (header.version >= 3) {
+      decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 2) {
       decode(min_epoch, p);
       decode_trace(p);
     } else {
@@ -65,7 +68,7 @@ public:
     encode(map_epoch, payload);
     encode(op, payload);
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
   }
 
   std::string_view get_type_name() const override { return "MOSDECSubOpReadReply"; }

--- a/src/messages/MOSDECSubOpWrite.h
+++ b/src/messages/MOSDECSubOpWrite.h
@@ -20,8 +20,8 @@
 
 class MOSDECSubOpWrite : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 3;
+  static constexpr int COMPAT_VERSION = 2;
 
 public:
   spg_t pgid;
@@ -55,7 +55,10 @@ public:
     decode(pgid, p);
     decode(map_epoch, p);
     decode(op, p);
-    if (header.version >= 2) {
+    if (header.version >= 4) {
+      decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 2) {
       decode(min_epoch, p);
       decode_trace(p);
     } else {
@@ -69,7 +72,7 @@ public:
     encode(map_epoch, payload);
     encode(op, payload);
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
   }
 
   std::string_view get_type_name() const override { return "MOSDECSubOpWrite"; }

--- a/src/messages/MOSDECSubOpWriteReply.h
+++ b/src/messages/MOSDECSubOpWriteReply.h
@@ -20,8 +20,8 @@
 
 class MOSDECSubOpWriteReply : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 3;
+  static constexpr int COMPAT_VERSION = 2;
 
 public:
   spg_t pgid;
@@ -53,6 +53,9 @@ public:
     decode(op, p);
     if (header.version >= 2) {
       decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 2) {
+      decode(min_epoch, p);
       decode_trace(p);
     } else {
       min_epoch = map_epoch;
@@ -65,7 +68,7 @@ public:
     encode(map_epoch, payload);
     encode(op, payload);
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
   }
 
   std::string_view get_type_name() const override { return "MOSDECSubOpWriteReply"; }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -36,7 +36,7 @@ namespace _mosdop {
 template<typename V>
 class MOSDOp final : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 8;
+  static constexpr int HEAD_VERSION = 9;
   static constexpr int COMPAT_VERSION = 3;
 
 private:
@@ -371,6 +371,7 @@ struct ceph_osd_request_head {
       encode(flags, payload);
       encode(reqid, payload);
       encode_trace(payload, features);
+      encode_otel_trace(payload, features);
 
       // -- above decoded up front; below decoded post-dispatch thread --
 
@@ -400,6 +401,16 @@ struct ceph_osd_request_head {
 
     // Always keep here the newest version of decoding order/rule
     if (header.version == HEAD_VERSION) {
+      decode(pgid, p);
+      uint32_t hash;
+      decode(hash, p);
+      hobj.set_hash(hash);
+      decode(osdmap_epoch, p);
+      decode(flags, p);
+      decode(reqid, p);
+      decode_trace(p);
+      decode_otel_trace(p);
+    } else if (header.version == 8) {
       decode(pgid, p);      // actual pgid
       uint32_t hash;
       decode(hash, p); // raw hash value

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -370,7 +370,6 @@ struct ceph_osd_request_head {
       encode(osdmap_epoch, payload);
       encode(flags, payload);
       encode(reqid, payload);
-      encode_trace(payload, features);
       encode_otel_trace(payload, features);
 
       // -- above decoded up front; below decoded post-dispatch thread --
@@ -408,7 +407,6 @@ struct ceph_osd_request_head {
       decode(osdmap_epoch, p);
       decode(flags, p);
       decode(reqid, p);
-      decode_trace(p);
       decode_otel_trace(p);
     } else if (header.version == 8) {
       decode(pgid, p);      // actual pgid

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -31,8 +31,8 @@
 
 class MOSDOpReply final : public Message {
 private:
-  static constexpr int HEAD_VERSION = 8;
-  static constexpr int COMPAT_VERSION = 2;
+  static constexpr int HEAD_VERSION = 9;
+  static constexpr int COMPAT_VERSION = 3;
 
   object_t oid;
   pg_t pgid;
@@ -222,7 +222,7 @@ public:
           encode(redirect, payload);
         }
       }
-      encode_trace(payload, features);
+      encode_otel_trace(payload, features);
     }
   }
   void decode_payload() override {

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -24,8 +24,8 @@
 
 class MOSDRepOp final : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 3;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 4;
+  static constexpr int COMPAT_VERSION = 2;
 
 public:
   epoch_t map_epoch, min_epoch;
@@ -81,7 +81,10 @@ public:
     p = payload.cbegin();
     // split to partial and final
     decode(map_epoch, p);
-    if (header.version >= 2) {
+    if (header.version >= 3) {
+      decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 2) {
       decode(min_epoch, p);
       decode_trace(p);
     } else {
@@ -127,7 +130,7 @@ public:
     assert(HAVE_FEATURE(features, SERVER_OCTOPUS));
     header.version = HEAD_VERSION;
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
     encode(reqid, payload);
     encode(pgid, payload);
     encode(poid, payload);

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -29,8 +29,8 @@
 
 class MOSDRepOpReply final : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 3;
+  static constexpr int COMPAT_VERSION = 2;
 public:
   epoch_t map_epoch, min_epoch;
 
@@ -64,7 +64,10 @@ public:
     using ceph::decode;
     p = payload.cbegin();
     decode(map_epoch, p);
-    if (header.version >= 2) {
+    if (header.version >= 3) {
+      decode(min_epoch, p);
+      decode_otel_trace(p);
+    } else if (header.version >= 2) {
       decode(min_epoch, p);
       decode_trace(p);
     } else {
@@ -90,7 +93,7 @@ public:
     encode(map_epoch, payload);
     header.version = HEAD_VERSION;
     encode(min_epoch, payload);
-    encode_trace(payload, features);
+    encode_otel_trace(payload, features);
     encode(reqid, payload);
     encode(pgid, payload);
     encode(ack_type, payload);

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -1023,6 +1023,15 @@ void Message::decode_trace(ceph::bufferlist::const_iterator &p, bool create)
 #endif
 }
 
+void Message::encode_otel_trace(ceph::bufferlist &bl, uint64_t features) const
+{
+  tracing::encode(otel_trace, bl);
+}
+
+void Message::decode_otel_trace(ceph::bufferlist::const_iterator &p, bool create)
+{
+  tracing::decode(otel_trace, p);
+}
 
 // This routine is not used for ordinary messages, but only when encapsulating a message
 // for forwarding and routing.  It's also used in a backward compatibility test, which only

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -217,9 +217,6 @@
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 
-#ifdef WITH_BLKIN
-#include "Messenger.h"
-#endif
 
 #define DEBUGLVL  10    // debug level of output
 
@@ -986,41 +983,10 @@ Message *decode_message(CephContext *cct,
   return m.detach();
 }
 
-void Message::encode_trace(ceph::bufferlist &bl, uint64_t features) const
-{
-  using ceph::encode;
-  auto p = trace.get_info();
-  static const blkin_trace_info empty = { 0, 0, 0 };
-  if (!p) {
-    p = &empty;
-  }
-  encode(*p, bl);
-}
-
 void Message::decode_trace(ceph::bufferlist::const_iterator &p, bool create)
 {
-  blkin_trace_info info = {};
+  static blkin_trace_info info = {};
   decode(info, p);
-
-#ifdef WITH_BLKIN
-  if (!connection)
-    return;
-
-  const auto msgr = connection->get_messenger();
-  const auto endpoint = msgr->get_trace_endpoint();
-  if (info.trace_id) {
-    trace.init(get_type_name().data(), endpoint, &info, true);
-    trace.event("decoded trace");
-  } else if (create || (msgr->get_myname().is_osd() &&
-                        msgr->cct->_conf->osd_blkin_trace_all)) {
-    // create a trace even if we didn't get one on the wire
-    trace.init(get_type_name().data(), endpoint);
-    trace.event("created trace");
-  }
-  trace.keyval("tid", get_tid());
-  trace.keyval("entity type", get_source().type_str());
-  trace.keyval("entity num", get_source().num());
-#endif
 }
 
 void Message::encode_otel_trace(ceph::bufferlist &bl, uint64_t features) const

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -28,6 +28,7 @@
 #include "common/ref.h"
 #include "common/debug.h"
 #include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "include/ceph_assert.h" // Because intrusive_ptr clobbers our assert...
 #include "include/buffer.h"
 #include "include/types.h"
@@ -283,6 +284,11 @@ public:
   ZTracer::Trace trace;
   void encode_trace(ceph::buffer::list &bl, uint64_t features) const;
   void decode_trace(ceph::buffer::list::const_iterator &p, bool create = false);
+
+  // otel tracing
+  jspan_context otel_trace{false, false};
+  void encode_otel_trace(ceph::buffer::list &bl, uint64_t features) const;
+  void decode_otel_trace(ceph::buffer::list::const_iterator &p, bool create = false);
 
   class CompletionHook : public Context {
   protected:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -280,9 +280,7 @@ protected:
   boost::intrusive::list_member_hook<> dispatch_q;
 
 public:
-  // zipkin tracing
-  ZTracer::Trace trace;
-  void encode_trace(ceph::buffer::list &bl, uint64_t features) const;
+  // zipkin tracing - for backward compatibility
   void decode_trace(ceph::buffer::list::const_iterator &p, bool create = false);
 
   // otel tracing
@@ -347,7 +345,6 @@ protected:
     if (byte_throttler)
       byte_throttler->put(payload.length() + middle.length() + data.length());
     release_message_throttle();
-    trace.event("message destructed");
     /* call completion hooks (if any) */
     if (completion_hook)
       completion_hook->complete(0);

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -50,8 +50,7 @@ Messenger *Messenger::create(CephContext *cct, const std::string &type,
 static int get_default_crc_flags(const ConfigProxy&);
 
 Messenger::Messenger(CephContext *cct_, entity_name_t w)
-  : trace_endpoint("0.0.0.0", 0, "Messenger"),
-    my_name(w),
+  : my_name(w),
     default_send_priority(CEPH_MSG_PRIO_DEFAULT),
     started(false),
     magic(0),
@@ -65,26 +64,6 @@ Messenger::Messenger(CephContext *cct_, entity_name_t w)
   comp_registry.refresh_config();
 }
 
-void Messenger::set_endpoint_addr(const entity_addr_t& a,
-                                  const entity_name_t &name)
-{
-  size_t hostlen;
-  if (a.get_family() == AF_INET)
-    hostlen = sizeof(struct sockaddr_in);
-  else if (a.get_family() == AF_INET6)
-    hostlen = sizeof(struct sockaddr_in6);
-  else
-    hostlen = 0;
-
-  if (hostlen) {
-    char buf[NI_MAXHOST] = { 0 };
-    getnameinfo(a.get_sockaddr(), hostlen, buf, sizeof(buf),
-                NULL, 0, NI_NUMERICHOST);
-
-    trace_endpoint.copy_ip(buf);
-  }
-  trace_endpoint.set_port(a.get_port());
-}
 
 /**
  * Get the default crc flags for this messenger.

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -93,11 +93,8 @@ class Messenger {
 private:
   std::deque<Dispatcher*> dispatchers;
   std::deque<Dispatcher*> fast_dispatchers;
-  ZTracer::Endpoint trace_endpoint;
 
 protected:
-  void set_endpoint_addr(const entity_addr_t& a,
-                         const entity_name_t &name);
 
 protected:
   /// the "name" of the local daemon. eg client.99
@@ -240,15 +237,8 @@ protected:
    */
   virtual void set_myaddrs(const entity_addrvec_t& a) {
     my_addrs = a;
-    set_endpoint_addr(a.front(), my_name);
   }
 public:
-  /**
-   * @return the zipkin trace endpoint
-   */
-  const ZTracer::Endpoint* get_trace_endpoint() const {
-    return &trace_endpoint;
-  }
 
   /**
    * set the name of the local entity. The name is reported to others and

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -237,7 +237,6 @@ void ProtocolV1::send_message(Message *m) {
     m->put();
   } else {
     m->queue_start = ceph::mono_clock::now();
-    m->trace.event("async enqueueing message");
     out_q[m->get_priority()].emplace_back(std::move(bl), m);
     ldout(cct, 15) << __func__ << " inline write is denied, reschedule m=" << m
                    << dendl;
@@ -1167,7 +1166,6 @@ ssize_t ProtocolV1::write_message(Message *m, ceph::buffer::list &bl, bool more)
     connection->outgoing_bl.append((char *)&old_footer, sizeof(old_footer));
   }
 
-  m->trace.event("async writing message");
   ldout(cct, 20) << __func__ << " sending " << m->get_seq() << " " << m
                  << dendl;
   ssize_t total_send_size = connection->outgoing_bl.length();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -453,7 +453,6 @@ void ProtocolV2::send_message(Message *m) {
     ldout(cct, 5) << __func__ << " enqueueing message m=" << m
                   << " type=" << m->get_type() << " " << *m << dendl;
     m->queue_start = ceph::mono_clock::now();
-    m->trace.event("async enqueueing message");
     out_queue[m->get_priority()].emplace_back(
       out_queue_entry_t{is_prepared, m});
     ldout(cct, 15) << __func__ << " inline write is denied, reschedule m=" << m
@@ -551,7 +550,6 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
   ldout(cct, 5) << __func__ << " sending message m=" << m
                 << " seq=" << m->get_seq() << " " << *m << dendl;
 
-  m->trace.event("async writing message");
   ldout(cct, 20) << __func__ << " sending m=" << m << " seq=" << m->get_seq()
                  << " src=" << entity_name_t(messenger->get_myname())
                  << " off=" << header2.data_off

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12450,15 +12450,6 @@ BlueStore::TransContext *BlueStore::_txc_create(
   TransContext *txc = new TransContext(cct, c, osr, on_commits);
   txc->t = db->get_transaction();
 
-#ifdef WITH_BLKIN
-  if (osd_op && osd_op->pg_trace) {
-    txc->trace.init("TransContext", &trace_endpoint,
-                    &osd_op->pg_trace);
-    txc->trace.event("txc create");
-    txc->trace.keyval("txc seq", txc->seq);
-  }
-#endif
-
   osr->queue_new(txc);
   dout(20) << __func__ << " osr " << osr << " = " << txc
 	   << " seq " << txc->seq << dendl;
@@ -12520,11 +12511,6 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       throttle.log_state_latency(*txc, logger, l_bluestore_state_prepare_lat);
       if (txc->ioc.has_pending_aios()) {
 	txc->set_state(TransContext::STATE_AIO_WAIT);
-#ifdef WITH_BLKIN
-        if (txc->trace) {
-          txc->trace.keyval("pending aios", txc->ioc.num_pending.load());
-        }
-#endif
 	txc->had_ios = true;
 	_txc_aio_submit(txc);
 	return;
@@ -12799,12 +12785,6 @@ void BlueStore::_txc_apply_kv(TransContext *txc, bool sync_submit_transaction)
   {
 #if defined(WITH_LTTNG)
     auto start = mono_clock::now();
-#endif
-
-#ifdef WITH_BLKIN
-    if (txc->trace) {
-      txc->trace.event("db async submit");
-    }
 #endif
 
     int r = cct->_conf->bluestore_debug_omit_kv_commit ? 0 : db->submit_transaction(txc->t);
@@ -13346,14 +13326,6 @@ void BlueStore::_kv_sync_thread()
       int r = cct->_conf->bluestore_debug_omit_kv_commit ? 0 : db->submit_transaction_sync(synct);
       ceph_assert(r == 0);
 
-#ifdef WITH_BLKIN
-      for (auto txc : kv_committing) {
-        if (txc->trace) {
-          txc->trace.event("db sync submit");
-          txc->trace.keyval("kv_committing size", kv_committing.size());
-        }
-      }
-#endif
 
       int committing_size = kv_committing.size();
       int deferred_size = deferred_stable.size();
@@ -14119,11 +14091,6 @@ int BlueStore::queue_transactions(
 
   _txc_finalize_kv(txc, txc->t);
 
-#ifdef WITH_BLKIN
-  if (txc->trace) {
-    txc->trace.event("txc encode finished");
-  }
-#endif
 
   if (handle)
     handle->suspend_tp_timeout();
@@ -14176,11 +14143,6 @@ int BlueStore::queue_transactions(
     }
   }
 
-#ifdef WITH_BLKIN
-  if (txc->trace) {
-    txc->trace.event("txc applied");
-  }
-#endif
 
   log_latency("submit_transact",
     l_bluestore_submit_lat,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -53,9 +53,6 @@
 #include "BlueFS.h"
 #include "common/EventTrace.h"
 
-#ifdef WITH_BLKIN
-#include "common/zipkin_trace.h"
-#endif
 
 class Allocator;
 class FreelistManager;
@@ -1685,11 +1682,6 @@ public:
 
     inline void set_state(state_t s) {
        state = s;
-#ifdef WITH_BLKIN
-       if (trace) {
-         trace.event(get_state_name());
-       } 
-#endif
     }
     inline state_t get_state() {
       return state;
@@ -1742,9 +1734,6 @@ public:
     bool tracing = false;
 #endif
 
-#ifdef WITH_BLKIN
-    ZTracer::Trace trace;
-#endif
 
     explicit TransContext(CephContext* cct, Collection *c, OpSequencer *o,
 			  std::list<Context*> *on_commits)
@@ -1758,11 +1747,6 @@ public:
       }
     }
     ~TransContext() {
-#ifdef WITH_BLKIN
-      if (trace) {
-        trace.event("txc destruct");
-      }
-#endif
       delete deferred_txn;
     }
 
@@ -2535,9 +2519,6 @@ private:
     void _resize_shards(bool interval_stats);
   } mempool_thread;
 
-#ifdef WITH_BLKIN
-  ZTracer::Endpoint trace_endpoint {"0.0.0.0", 0, "BlueStore"};
-#endif
 
   // --------------------------------------------------------
   // private methods

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -935,8 +935,6 @@ void FileJournal::queue_completions_thru(uint64_t seq)
       finisher->queue(next.finish);
     if (next.tracked_op) {
       next.tracked_op->mark_event("journaled_completion_queued");
-      next.tracked_op->journal_trace.event("queued completion");
-      next.tracked_op->journal_trace.keyval("completed through", seq);
     }
     items.erase(it++);
   }
@@ -984,7 +982,6 @@ int FileJournal::prepare_single_write(write_item &next_write, bufferlist& bl, of
   bl.claim_append(ebl);
   if (next_write.tracked_op) {
     next_write.tracked_op->mark_event("write_thread_in_journal_buffer");
-    next_write.tracked_op->journal_trace.event("prepare_single_write");
   }
 
   journalq.push_back(pair<uint64_t,off64_t>(seq, queue_pos));
@@ -1629,11 +1626,6 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 
   if (osd_op) {
     osd_op->mark_event("commit_queued_for_journal_write");
-    if (osd_op->store_trace) {
-      osd_op->journal_trace.init("journal", &trace_endpoint, &osd_op->store_trace);
-      osd_op->journal_trace.event("submit_entry");
-      osd_op->journal_trace.keyval("seq", seq);
-    }
   }
   {
     std::lock_guard l1{writeq_lock};
@@ -1654,8 +1646,6 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
     if (writeq.empty())
       writeq_cond.notify_all();
     writeq.push_back(write_item(seq, e, orig_len, osd_op));
-    if (osd_op)
-      osd_op->journal_trace.keyval("queue depth", writeq.size());
   }
 }
 

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -24,7 +24,6 @@
 #include "common/Finisher.h"
 #include "common/TrackedOp.h"
 #include "os/ObjectStore.h"
-#include "common/zipkin_trace.h"
 
 
 class Journal {

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -61,29 +61,29 @@ public:
     ceph_tid_t tid,
     eversion_t version,
     eversion_t last_complete,
-    const ZTracer::Trace &trace);
+    const jspan_context &otel_trace);
   void handle_sub_write(
     pg_shard_t from,
     OpRequestRef msg,
     ECSubWrite &op,
-    const ZTracer::Trace &trace
+    const jspan_context &otel_trace
     );
   void handle_sub_read(
     pg_shard_t from,
     const ECSubRead &op,
     ECSubReadReply *reply,
-    const ZTracer::Trace &trace
+    const jspan_context &otel_trace
     );
   void handle_sub_write_reply(
     pg_shard_t from,
     const ECSubWriteReply &op,
-    const ZTracer::Trace &trace
+    const jspan_context &otel_trace
     );
   void handle_sub_read_reply(
     pg_shard_t from,
     ECSubReadReply &op,
     RecoveryMessages *m,
-    const ZTracer::Trace &trace
+    const jspan_context &otel_trace
     );
 
   /// @see ReadOp below
@@ -373,7 +373,7 @@ public:
     // of the available shards.
     bool for_recovery;
 
-    ZTracer::Trace trace;
+    jspan_context otel_trace{false, false};
 
     std::map<hobject_t, std::set<int>> want_to_read;
     std::map<hobject_t, read_request_t> to_read;
@@ -456,7 +456,7 @@ public:
     std::vector<pg_log_entry_t> log_entries;
     ceph_tid_t tid;
     osd_reqid_t reqid;
-    ZTracer::Trace trace;
+    jspan_context otel_trace{false, false};
 
     eversion_t roll_forward_to; /// Soon to be generated internally
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7272,7 +7272,12 @@ void OSD::ms_fast_dispatch(Message *m)
     tracepoint(osd, ms_fast_dispatch, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
-  op->osd_parent_span = tracing::osd::tracer.start_trace("op-request-created");
+
+  if (m->otel_trace.IsValid()) {
+    op->osd_parent_span = tracing::osd::tracer.add_span("op-request-created", m->otel_trace);
+  } else {
+    op->osd_parent_span = tracing::osd::tracer.start_trace("op-request-created");
+  }
 
   if (m->trace)
     op->osd_trace.init("osd op", &trace_endpoint, &m->trace);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -25,7 +25,6 @@
 #include "common/AsyncReserver.h"
 #include "common/ceph_context.h"
 #include "common/config_cacher.h"
-#include "common/zipkin_trace.h"
 #include "common/ceph_timer.h"
 
 #include "mgr/MgrClient.h"
@@ -1124,7 +1123,6 @@ protected:
   bool store_is_rotational = true;
   bool journal_is_rotational = true;
 
-  ZTracer::Endpoint trace_endpoint;
   PerfCounters* create_logger();
   PerfCounters* create_recoverystate_perf();
   void tick();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -197,7 +197,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
     p.get_split_bits(_pool.info.get_pg_num()),
     _pool.id,
     p.shard),
-  trace_endpoint("0.0.0.0", 0, "PG"),
   info_struct_v(0),
   pgmeta_oid(p.make_pgmeta_oid()),
   stat_queue_item(this),
@@ -220,11 +219,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
 {
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
-#endif
-#ifdef WITH_BLKIN
-  std::stringstream ss;
-  ss << "PG " << info.pgid;
-  trace_endpoint.copy_name(ss.str());
 #endif
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -871,8 +871,6 @@ protected:
 
 protected:
 
-  ZTracer::Endpoint trace_endpoint;
-
 
 protected:
   __u8 info_struct_v = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1798,9 +1798,8 @@ void PrimaryLogPG::do_request(
   OpRequestRef& op,
   ThreadPool::TPHandle &handle)
 {
-  if (op->osd_trace) {
-    op->pg_trace.init("pg op", &trace_endpoint, &op->osd_trace);
-    op->pg_trace.event("do request");
+  if (op->osd_trace.IsValid()) {
+    tracing::osd::tracer.add_span("pg op", op->osd_trace);
   }
 
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -560,7 +560,6 @@ void ReplicatedBackend::op_commit(const ceph::ref_t<InProgressOp>& op)
   dout(10) << __func__ << ": " << op->tid << dendl;
   if (op->op) {
     op->op->mark_event("op_commit");
-    op->op->pg_trace.event("op commit");
   }
 
   op->waiting_for_commit.erase(get_parent()->whoami_shard());
@@ -609,7 +608,6 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
       ip_op.waiting_for_commit.erase(from);
       if (ip_op.op) {
 	ip_op.op->mark_event("sub_op_commit_rec");
-	ip_op.op->pg_trace.event("sub_op_commit_rec");
       }
     } else {
       // legacy peer; ignore
@@ -1003,7 +1001,6 @@ void ReplicatedBackend::issue_op(
 {
   if (parent->get_acting_recovery_backfill_shards().size() > 1) {
     if (op->op) {
-      op->op->pg_trace.event("issue replication ops");
       ostringstream ss;
       set<pg_shard_t> replicas = parent->get_acting_recovery_backfill_shards();
       replicas.erase(parent->whoami_shard());
@@ -1034,8 +1031,6 @@ void ReplicatedBackend::issue_op(
 	  op_t,
 	  shard,
 	  pinfo);
-      if (op->op && op->op->pg_trace)
-	wr->trace.init("replicated op", nullptr, &op->op->pg_trace);
       get_parent()->send_message_osd_cluster(
 	  shard.osd, wr, get_osdmap_epoch());
     }
@@ -1148,7 +1143,6 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
 void ReplicatedBackend::repop_commit(RepModifyRef rm)
 {
   rm->op->mark_commit_sent();
-  rm->op->pg_trace.event("sup_op_commit");
   rm->committed = true;
 
   // send commit.
@@ -1167,7 +1161,7 @@ void ReplicatedBackend::repop_commit(RepModifyRef rm)
     0, get_osdmap_epoch(), m->get_min_epoch(), CEPH_OSD_FLAG_ONDISK);
   reply->set_last_complete_ondisk(rm->last_complete);
   reply->set_priority(CEPH_MSG_PRIO_HIGH); // this better match ack priority!
-  reply->trace = rm->op->pg_trace;
+  reply->otel_trace = rm->op->pg_trace;
   get_parent()->send_message_osd_cluster(
     rm->ackerosd, reply, get_osdmap_epoch());
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3231,6 +3231,10 @@ Objecter::MOSDOp *Objecter::_prepare_osd_op(Op *op)
     m->set_reqid(op->reqid);
   }
 
+  if (op->otel_trace && op->otel_trace->IsValid()) {
+     m->otel_trace = jspan_context(*op->otel_trace);
+  }
+
   logger->inc(l_osdc_op_send);
   ssize_t sum = 0;
   for (unsigned i = 0; i < m->ops.size(); i++) {

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2271,7 +2271,6 @@ void Objecter::op_submit(Op *op, ceph_tid_t *ptid, int *ctx_budget)
   ceph_tid_t tid = 0;
   if (!ptid)
     ptid = &tid;
-  op->trace.event("op submit");
   _op_submit_with_budget(op, rl, ptid, ctx_budget);
 }
 
@@ -3218,10 +3217,6 @@ Objecter::MOSDOp *Objecter::_prepare_osd_op(Op *op)
   m->set_mtime(op->mtime);
   m->set_retry_attempt(op->attempts++);
 
-  if (!op->trace.valid() && cct->_conf->osdc_blkin_trace_all) {
-    op->trace.init("op", &trace_endpoint);
-  }
-
   if (op->priority)
     m->set_priority(op->priority);
   else
@@ -3312,9 +3307,6 @@ void Objecter::_send_op(Op *op)
 
   op->incarnation = op->session->incarnation;
 
-  if (op->trace.valid()) {
-    m->trace.init("op msg", nullptr, &op->trace);
-  }
   op->session->con->send_message(m);
 }
 
@@ -3412,7 +3404,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 		<< " attempt " << m->get_retry_attempt()
 		<< dendl;
   Op *op = iter->second;
-  op->trace.event("osd op reply");
 
   if (retry_writes_after_first_reply && op->attempts == 1 &&
       (op->target.flags & CEPH_OSD_FLAG_WRITE)) {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -49,6 +49,7 @@
 #include "common/config_obs.h"
 #include "common/shunique_lock.h"
 #include "common/zipkin_trace.h"
+#include "common/tracer.h"
 #include "common/Throttle.h"
 
 #include "mon/MonClient.h"
@@ -1957,6 +1958,7 @@ public:
 
     osd_reqid_t reqid; // explicitly setting reqid
     ZTracer::Trace trace;
+    const jspan_context* otel_trace = nullptr;
 
     static bool has_completion(decltype(onfinish)& f) {
       return std::visit([](auto&& arg) { return bool(arg);}, f);
@@ -2006,7 +2008,7 @@ public:
 
     Op(const object_t& o, const object_locator_t& ol, osdc_opvec&& _ops,
        int f, Context* fin, version_t *ov, int *offset = nullptr,
-       ZTracer::Trace *parent_trace = nullptr) :
+       ZTracer::Trace *parent_trace = nullptr, const jspan_context *otel_trace = nullptr) :
       target(o, ol, f),
       ops(std::move(_ops)),
       out_bl(ops.size(), nullptr),
@@ -2015,7 +2017,8 @@ public:
       out_ec(ops.size(), nullptr),
       onfinish(fin),
       objver(ov),
-      data_offset(offset) {
+      data_offset(offset),
+      otel_trace(otel_trace) {
       if (target.base_oloc.key == o)
 	target.base_oloc.key.clear();
       if (parent_trace && parent_trace->valid()) {
@@ -2917,10 +2920,11 @@ public:
     ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     osd_reqid_t reqid = osd_reqid_t(),
-    ZTracer::Trace *parent_trace = nullptr) {
+    ZTracer::Trace *parent_trace = nullptr,
+    const jspan_context *otel_trace = nullptr) {
     Op *o = new Op(oid, oloc, std::move(op.ops), flags | global_op_flags |
 		   CEPH_OSD_FLAG_WRITE, oncommit, objver,
-		   nullptr, parent_trace);
+		   nullptr, nullptr, otel_trace);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -5,7 +5,6 @@
 
 #include "include/Context.h"
 #include "include/types.h"
-#include "common/zipkin_trace.h"
 #include "osd/osd_types.h"
 
 class WritebackHandler {
@@ -17,7 +16,7 @@ class WritebackHandler {
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, ceph::buffer::list *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags,
-                    const ZTracer::Trace &parent_trace, Context *onfinish) = 0;
+                    const jspan_context &otel_trace, Context *onfinish) = 0;
   /**
    * check if a given extent read result may change due to a write
    *
@@ -37,7 +36,7 @@ class WritebackHandler {
 			   const ceph::buffer::list &bl, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
                            ceph_tid_t journal_tid,
-                           const ZTracer::Trace &parent_trace,
+                           const jspan_context &otel_trace,
                            Context *oncommit) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -96,7 +96,7 @@ class Aio {
   static OpFunc librados_op(librados::ObjectReadOperation&& op,
                             optional_yield y);
   static OpFunc librados_op(librados::ObjectWriteOperation&& op,
-                            optional_yield y);
+                            optional_yield y, jspan_context *trace_ctx = nullptr);
   static OpFunc d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
                              off_t read_ofs, off_t read_len, std::string& location);
 };

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -722,7 +722,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   rgw::sal::RadosObject src_obj(store, key, &bucket);
   rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
   rgw::sal::RadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
-    
+  dest_obj.set_trace(std::move(trace_ctx));
+
   std::string etag;
 
   std::optional<uint64_t> bytes_transferred;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -25,6 +25,7 @@
 #include "rgw_sync_error_repo.h"
 #include "rgw_sync_module.h"
 #include "rgw_sal.h"
+#include "rgw_tracer.h"
 
 #include "cls/lock/cls_lock_client.h"
 #include "cls/rgw/cls_rgw_client.h"
@@ -2273,7 +2274,7 @@ class RGWDefaultDataSyncModule : public RGWDataSyncModule {
 public:
   RGWDefaultDataSyncModule() {}
 
-  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override;
+  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override;
   RGWCoroutine *remove_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *create_delete_marker(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, real_time& mtime,
                                      rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
@@ -2603,19 +2604,23 @@ class RGWObjFetchCR : public RGWCoroutine {
 
   int try_num{0};
   std::shared_ptr<bool> need_retry;
+
+  const jspan_context *trace_ctx;
 public:
   RGWObjFetchCR(RGWDataSyncCtx *_sc,
                 rgw_bucket_sync_pipe& _sync_pipe,
                 rgw_obj_key& _key,
                 std::optional<rgw_obj_key> _dest_key,
                 std::optional<uint64_t> _versioned_epoch,
-                rgw_zone_set *_zones_trace) : RGWCoroutine(_sc->cct),
+                rgw_zone_set *_zones_trace,
+                const jspan_context *_trace_ctx = nullptr) : RGWCoroutine(_sc->cct),
                                               sc(_sc), sync_env(_sc->env),
                                               sync_pipe(_sync_pipe),
                                               key(_key),
                                               dest_key(_dest_key),
                                               versioned_epoch(_versioned_epoch),
-                                              zones_trace(_zones_trace) {
+                                              zones_trace(_zones_trace),
+                                              trace_ctx(_trace_ctx) {
   }
 
 
@@ -2740,7 +2745,7 @@ public:
                                        key, dest_key, versioned_epoch,
                                        true,
                                        std::static_pointer_cast<RGWFetchObjFilter>(filter),
-                                       zones_trace, sync_env->counters, dpp));
+                                       zones_trace, sync_env->counters, dpp, trace_ctx));
         }
         if (retcode < 0) {
           if (*need_retry) {
@@ -2760,9 +2765,9 @@ public:
   }
 };
 
-RGWCoroutine *RGWDefaultDataSyncModule::sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace)
+RGWCoroutine *RGWDefaultDataSyncModule::sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx)
 {
-  return new RGWObjFetchCR(sc, sync_pipe, key, std::nullopt, versioned_epoch, zones_trace);
+  return new RGWObjFetchCR(sc, sync_pipe, key, std::nullopt, versioned_epoch, zones_trace, trace_ctx);
 }
 
 RGWCoroutine *RGWDefaultDataSyncModule::remove_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key,
@@ -2787,7 +2792,7 @@ class RGWArchiveDataSyncModule : public RGWDefaultDataSyncModule {
 public:
   RGWArchiveDataSyncModule() {}
 
-  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override;
+  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override;
   RGWCoroutine *remove_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *create_delete_marker(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, real_time& mtime,
                                      rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
@@ -2814,7 +2819,7 @@ int RGWArchiveSyncModule::create_instance(const DoutPrefixProvider *dpp, CephCon
   return 0;
 }
 
-RGWCoroutine *RGWArchiveDataSyncModule::sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace)
+RGWCoroutine *RGWArchiveDataSyncModule::sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx)
 {
   auto sync_env = sc->env;
   ldout(sc->cct, 5) << "SYNC_ARCHIVE: sync_object: b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
@@ -4066,6 +4071,8 @@ class RGWBucketSyncSingleEntryCR : public RGWCoroutine {
   RGWSyncTraceNodeRef tn;
   std::string zone_name;
 
+  const jspan_context trace_ctx;
+
 public:
   RGWBucketSyncSingleEntryCR(RGWDataSyncCtx *_sc,
                              rgw_bucket_sync_pipe& _sync_pipe,
@@ -4075,7 +4082,7 @@ public:
                              const rgw_bucket_entry_owner& _owner,
                              RGWModifyOp _op, RGWPendingState _op_state,
 		             const T& _entry_marker, RGWSyncShardMarkerTrack<T, K> *_marker_tracker, rgw_zone_set& _zones_trace,
-                             RGWSyncTraceNodeRef& _tn_parent) : RGWCoroutine(_sc->cct),
+                             RGWSyncTraceNodeRef& _tn_parent, const jspan_context& _trace_ctx) : RGWCoroutine(_sc->cct),
 						      sc(_sc), sync_env(_sc->env),
                                                       sync_pipe(_sync_pipe), bs(_sync_pipe.info.source_bs),
                                                       key(_key), versioned(_versioned), versioned_epoch(_versioned_epoch),
@@ -4084,7 +4091,8 @@ public:
                                                       op_state(_op_state),
                                                       entry_marker(_entry_marker),
                                                       marker_tracker(_marker_tracker),
-                                                      sync_status(0){
+                                                      sync_status(0),
+                                                      trace_ctx(_trace_ctx) {
     stringstream ss;
     ss << bucket_shard_str{bs} << "/" << key << "[" << versioned_epoch.value_or(0) << "]";
     set_description() << "bucket sync single entry (source_zone=" << sc->source_zone << ") b=" << ss.str() << " log_entry=" << entry_marker << " op=" << (int)op << " op_state=" << (int)op_state;
@@ -4139,7 +4147,7 @@ public:
 	      pretty_print(sc->env, "Syncing object s3://{}/{} in sync from zone {}\n",
 			   bs.bucket.name, key, zone_name);
 	    }
-            call(data_sync_module->sync_object(dpp, sc, sync_pipe, key, versioned_epoch, &zones_trace));
+            call(data_sync_module->sync_object(dpp, sc, sync_pipe, key, versioned_epoch, &zones_trace, &trace_ctx));
           } else if (op == CLS_RGW_OP_DEL || op == CLS_RGW_OP_UNLINK_INSTANCE) {
             set_status("removing obj");
 	    if (versioned_epoch) {
@@ -4353,7 +4361,7 @@ int RGWBucketFullSyncCR::operate(const DoutPrefixProvider *dpp)
                                  false, /* versioned, only matters for object removal */
                                  entry->versioned_epoch, entry->mtime,
                                  entry->owner, entry->get_modify_op(), CLS_RGW_STATE_COMPLETE,
-                                 entry->key, &marker_tracker, zones_trace, tn),
+                                 entry->key, &marker_tracker, zones_trace, tn, jspan_context{false, false}),
                       false);
         }
         drain_with_cb(cct->_conf->rgw_bucket_sync_spawn_window,
@@ -4566,6 +4574,8 @@ public:
 int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
 {
   int ret;
+  jspan trace;
+  jspan_context trace_ctx{false, false};
   reenter(this) {
     do {
       if (lease_cr && !lease_cr->is_locked()) {
@@ -4731,6 +4741,8 @@ int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
           marker_tracker.try_update_high_marker(cur_id, 0, entry->timestamp);
           continue;
         }
+        trace = tracing::rgw::tracer.add_span("RGWBucketShardIncrementalSyncCR::operate", entry->bi_trace);
+        trace->SetAttribute(tracing::rgw::HOST_ID, sync_env->store->get_host_id());
         // yield {
           set_status() << "start object sync";
           if (!marker_tracker.start(cur_id, 0, entry->timestamp)) {
@@ -4746,7 +4758,8 @@ int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
             spawn(new SyncCR(sc, sync_pipe, key,
                              entry->is_versioned(), versioned_epoch,
                              entry->timestamp, owner, entry->op, entry->state,
-                             cur_id, &marker_tracker, entry->zones_trace, tn),
+                             cur_id, &marker_tracker, entry->zones_trace, tn,
+                             trace->GetContext()),
                   false);
           }
         // }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3980,6 +3980,8 @@ void RGWPutObj::execute(optional_yield y)
 
   rgw_placement_rule *pdest_placement = &s->dest_placement;
 
+  s->object->set_trace(s->trace->GetContext());
+
   if (multipart) {
     std::unique_ptr<rgw::sal::MultipartUpload> upload;
     upload = s->bucket->get_multipart_upload(s->object->get_name(),

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -387,11 +387,8 @@ int process_request(rgw::sal::Store* const store,
       goto done;
     }
 
-
-    const auto trace_name = std::string(op->name()) + " " + s->trans_id;
-    s->trace = tracing::rgw::tracer.start_trace(trace_name, s->trace_enabled);
-    s->trace->SetAttribute(tracing::rgw::OP, op->name());
-    s->trace->SetAttribute(tracing::rgw::TYPE, tracing::rgw::REQUEST);
+    s->trace = tracing::rgw::tracer.start_trace(op->name(), s->trace_enabled);
+    s->trace->SetAttribute(tracing::rgw::TRANS_ID, s->trans_id);
 
     ret = rgw_process_authenticated(handler, op, req, s, yield, store);
     if (ret < 0) {
@@ -406,7 +403,9 @@ int process_request(rgw::sal::Store* const store,
 done:
   if (op) {
     if (s->trace) {
-      s->trace->SetAttribute(tracing::rgw::RETURN, op->get_ret());
+      s->trace->SetAttribute(tracing::rgw::OP_RESULT, op->get_ret());
+      s->trace->SetAttribute(tracing::rgw::HOST_ID, store->get_host_id());
+
       if (!rgw::sal::User::empty(s->user)) {
         s->trace->SetAttribute(tracing::rgw::USER_ID, s->user->get_id().id);
       }

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -110,7 +110,7 @@ int RadosWriter::process(bufferlist&& bl, uint64_t offset)
     op.write(offset, data);
   }
   constexpr uint64_t id = 0; // unused
-  auto c = aio->get(stripe_obj, Aio::librados_op(std::move(op), y), cost, id);
+  auto c = aio->get(stripe_obj, Aio::librados_op(std::move(op), y, &head_obj->get_trace()), cost, id);
   return process_completed(c, &written);
 }
 
@@ -124,7 +124,7 @@ int RadosWriter::write_exclusive(const bufferlist& data)
   op.write_full(data);
 
   constexpr uint64_t id = 0; // unused
-  auto c = aio->get(stripe_obj, Aio::librados_op(std::move(op), y), cost, id);
+  auto c = aio->get(stripe_obj, Aio::librados_op(std::move(op), y, &head_obj->get_trace()), cost, id);
   auto d = aio->drain();
   c.splice(c.end(), d);
   return process_completed(c, &written);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3240,7 +3240,7 @@ int RGWRados::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
   auto& ioctx = ref.pool.ioctx();
 
   tracepoint(rgw_rados, operate_enter, req_id.c_str());
-  r = rgw_rados_operate(dpp, ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
+  r = rgw_rados_operate(dpp, ref.pool.ioctx(), ref.obj.oid, &op, null_yield, 0, &target->get_target()->get_trace());
   tracepoint(rgw_rados, operate_exit, req_id.c_str());
   if (r < 0) { /* we can expect to get -ECANCELED if object was replaced under,
                 or -ENOENT if was removed, or -EEXIST if it did not exist

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -911,6 +911,7 @@ public:
       bool blind;
       bool prepared{false};
       rgw_zone_set *zones_trace{nullptr};
+      jspan_context bilog_trace{false, false};
 
       int init_bs(const DoutPrefixProvider *dpp) {
         int r =
@@ -951,6 +952,10 @@ public:
       
       void set_zones_trace(rgw_zone_set *_zones_trace) {
         zones_trace = _zones_trace;
+      }
+
+      void set_bilog_trace(jspan_context&& _bilog_trace) {
+        bilog_trace = _bilog_trace;
       }
 
       int prepare(const DoutPrefixProvider *dpp, RGWModifyOp, const std::string *write_tag, optional_yield y);
@@ -1384,9 +1389,11 @@ public:
 
   int cls_obj_prepare_op(const DoutPrefixProvider *dpp, BucketShard& bs, RGWModifyOp op, std::string& tag, rgw_obj& obj, uint16_t bilog_flags, optional_yield y, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, std::string& tag, int64_t pool, uint64_t epoch,
-                          rgw_bucket_dir_entry& ent, RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
+                          rgw_bucket_dir_entry& ent, RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr,
+                          const jspan_context *bilog_trace = nullptr);
   int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, std::string& tag, int64_t pool, uint64_t epoch, rgw_bucket_dir_entry& ent,
-                           RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
+                           RGWObjCategory category, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr,
+                           const jspan_context *bilog_trace = nullptr);
   int cls_obj_complete_del(BucketShard& bs, std::string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
                            ceph::real_time& removed_mtime, std::list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1089,6 +1089,9 @@ class Object {
     /** Get a unique copy of this object */
     virtual std::unique_ptr<Object> clone() = 0;
 
+    virtual jspan_context& get_trace() = 0;
+    virtual void set_trace (jspan_context&& _trace_ctx) = 0;
+
     /* dang - This is temporary, until the API is completed */
     /** Get the key for this object */
     virtual rgw_obj_key& get_key() = 0;

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -678,6 +678,9 @@ public:
     return std::make_unique<FilterObject>(*this);
   }
 
+  virtual jspan_context& get_trace() { return next->get_trace(); }
+  virtual void set_trace (jspan_context&& _trace_ctx) { next->set_trace(std::move(_trace_ctx)); }
+
   virtual void print(std::ostream& out) const override { return next->print(out); }
 
   /* Internal to Filters */

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -158,6 +158,7 @@ class StoreObject : public Object {
     Bucket* bucket;
     Attrs attrs;
     bool delete_marker{false};
+    jspan_context trace_ctx{false, false};
 
   public:
 
@@ -245,6 +246,8 @@ class StoreObject : public Object {
        * work with lifecycle */
       return -1;
     }
+    virtual jspan_context& get_trace() { return trace_ctx; }
+    virtual void set_trace (jspan_context&& _trace_ctx) { trace_ctx = _trace_ctx; }
 
     virtual void print(std::ostream& out) const override {
       if (bucket)

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -30,7 +30,7 @@ public:
   virtual RGWCoroutine *start_sync(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc) {
     return nullptr;
   }
-  virtual RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) = 0;
+  virtual RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) = 0;
   virtual RGWCoroutine *remove_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& bucket_info, rgw_obj_key& key, real_time& mtime,
                                       bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) = 0;
   virtual RGWCoroutine *create_delete_marker(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& bucket_info, rgw_obj_key& key, real_time& mtime,

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -1796,7 +1796,7 @@ public:
 
   RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key,
                             std::optional<uint64_t> versioned_epoch,
-                            rgw_zone_set *zones_trace) override {
+                            rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override {
     ldout(sc->cct, 0) << instance.id << ": sync_object: b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
     return new RGWAWSHandleRemoteObjCR(sc, sync_pipe, key, instance, versioned_epoch.value_or(0));
   }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -886,7 +886,7 @@ public:
     return new RGWElasticGetESInfoCBCR(sc, conf);
   }
 
-  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override {
+  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override {
     ldpp_dout(dpp, 10) << conf->id << ": sync_object: b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
     if (!conf->should_handle_operation(sync_pipe.dest_bucket_info)) {
       ldpp_dout(dpp, 10) << conf->id << ": skipping operation (bucket not approved)" << dendl;

--- a/src/rgw/rgw_sync_module_log.cc
+++ b/src/rgw/rgw_sync_module_log.cc
@@ -43,7 +43,7 @@ class RGWLogDataSyncModule : public RGWDataSyncModule {
 public:
   explicit RGWLogDataSyncModule(const string& _prefix) : prefix(_prefix) {}
 
-  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override {
+  RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override {
     ldpp_dout(dpp, 0) << prefix << ": SYNC_LOG: sync_object: b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
     return new RGWLogStatRemoteObjCR(sc, sync_pipe.info.source_bs.bucket, key);
   }

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -1343,7 +1343,7 @@ public:
   }
 
   RGWCoroutine *sync_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, 
-      rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override {
+      rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace, const jspan_context *trace_ctx = nullptr) override {
     ldpp_dout(dpp, 10) << conf->id << ": sync_object: b=" << sync_pipe << 
           " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
     return new RGWPSHandleObjCreateCR(sc, sync_pipe, key, env, versioned_epoch);

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -186,7 +186,7 @@ thread_local bool is_asio_thread = false;
 
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectReadOperation *op, bufferlist* pbl,
-                      optional_yield y, int flags)
+                      optional_yield y, int flags, const jspan_context* trace_info)
 {
   // given a yield_context, call async_operate() to yield the coroutine instead
   // of blocking
@@ -210,19 +210,19 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
 
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectWriteOperation *op, optional_yield y,
-		      int flags)
+		      int flags, const jspan_context* trace_info)
 {
   if (y) {
     auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
-    librados::async_operate(context, ioctx, oid, op, flags, yield[ec]);
+    librados::async_operate(context, ioctx, oid, op, flags, yield[ec], trace_info);
     return -ec.value();
   }
   if (is_asio_thread) {
     ldpp_dout(dpp, 20) << "WARNING: blocking librados call" << dendl;
   }
-  return ioctx.operate(oid, op, flags);
+  return ioctx.operate(oid, op, flags, trace_info);
 }
 
 int rgw_rados_notify(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -96,10 +96,10 @@ extern thread_local bool is_asio_thread;
 /// perform the rados operation, using the yield context when given
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectReadOperation *op, bufferlist* pbl,
-                      optional_yield y, int flags = 0);
+                      optional_yield y, int flags = 0, const jspan_context* trace_info = nullptr);
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectWriteOperation *op, optional_yield y,
-		      int flags = 0);
+		      int flags = 0, const jspan_context* trace_info = nullptr);
 int rgw_rados_notify(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                      bufferlist& bl, uint64_t timeout_ms, bufferlist* pbl,
                      optional_yield y);

--- a/src/rgw/rgw_tracer.h
+++ b/src/rgw/rgw_tracer.h
@@ -8,15 +8,15 @@
 namespace tracing {
 namespace rgw {
 
-const auto OP = "op";
+
 const auto BUCKET_NAME = "bucket_name";
 const auto USER_ID = "user_id";
 const auto OBJECT_NAME = "object_name";
-const auto RETURN = "return";
+const auto OP_RESULT = "op_result";
 const auto UPLOAD_ID = "upload_id";
-const auto TYPE = "type";
-const auto REQUEST = "request";
 const auto MULTIPART = "multipart_upload ";
+const auto TRANS_ID = "trans_id";
+const auto HOST_ID = "host_id";
 
 extern tracing::Tracer tracer;
 

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -148,9 +148,9 @@ int RGWSI_RADOS::Obj::operate(const DoutPrefixProvider *dpp, librados::ObjectRea
   return rgw_rados_operate(dpp, ref.pool.ioctx(), ref.obj.oid, op, pbl, y, flags);
 }
 
-int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op)
+int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op, const jspan_context *trace_ctx)
 {
-  return ref.pool.ioctx().aio_operate(ref.obj.oid, c, op);
+  return ref.pool.ioctx().aio_operate(ref.obj.oid, c, op, 0, trace_ctx);
 }
 
 int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectReadOperation *op,

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -176,7 +176,7 @@ public:
 		int flags = 0);
     int operate(const DoutPrefixProvider *dpp, librados::ObjectReadOperation *op, bufferlist *pbl,
                 optional_yield y, int flags = 0);
-    int aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op);
+    int aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op, const jspan_context *trace_ctx = nullptr);
     int aio_operate(librados::AioCompletion *c, librados::ObjectReadOperation *op,
                     bufferlist *pbl);
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -438,7 +438,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectReadOperation *op, int flags,
-                       bufferlist *pbl, const blkin_trace_info *trace_info) {
+                       bufferlist *pbl, const jspan_context *otel_trace) {
   return aio_operate(oid, c, op, flags, pbl);
 }
 
@@ -452,7 +452,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op, snap_t seq,
                        std::vector<snap_t>& snaps, int flags,
-                       const blkin_trace_info *trace_info) {
+                       const jspan_context *otel_trace) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
 
@@ -474,8 +474,8 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op, snap_t seq,
                        std::vector<snap_t>& snaps,
-		       const blkin_trace_info *trace_info) {
-  return aio_operate(oid, c, op, seq, snaps, 0, trace_info);
+		       const jspan_context *otel_trace) {
+  return aio_operate(oid, c, op, seq, snaps, 0, otel_trace);
 }
 
 int IoCtx::aio_remove(const std::string& oid, AioCompletion *c) {

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -510,7 +510,7 @@ boost::asio::io_context::executor_type neorados::RADOS::get_executor() const {
 
 void RADOS::execute(const Object& o, const IOContext& ioc, ReadOp&& op,
                     ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,
-                    uint64_t* objver, const blkin_trace_info* trace_info) {
+                    uint64_t* objver, const jspan_context* otel_trace) {
   auto io_ctx = impl->get_io_ctx(ioc);
   if (io_ctx == nullptr) {
     c->dispatch(std::move(c), osdc_errc::pool_dne);
@@ -533,7 +533,7 @@ void RADOS::execute(const Object& o, const IOContext& ioc, ReadOp&& op,
 
 void RADOS::execute(const Object& o, const IOContext& ioc, WriteOp&& op,
                     std::unique_ptr<Op::Completion> c, uint64_t* objver,
-                    const blkin_trace_info* trace_info) {
+                    const jspan_context* otel_trace) {
   auto io_ctx = impl->get_io_ctx(ioc);
   if (io_ctx == nullptr) {
     c->dispatch(std::move(c), osdc_errc::pool_dne);

--- a/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
@@ -44,7 +44,7 @@ template <>
 struct Api<MockParentImageCacheImageCtx> {
   MOCK_METHOD6(read_parent, void(MockParentImageCacheImageCtx*, uint64_t,
                                  librbd::io::ReadExtents*, librados::snap_t,
-                                 const ZTracer::Trace &, Context*));
+                                 const jspan_context &, Context*));
 };
 
 } // namespace plugin
@@ -293,24 +293,23 @@ TEST_F(TestMockParentCacheObjectDispatch, test_disble_interface) {
   uint64_t* temp_journal_tid = nullptr;
   Context** temp_on_finish = nullptr;
   Context* temp_on_dispatched = nullptr;
-  ZTracer::Trace* temp_trace = nullptr;
   io::LightweightBufferExtents buffer_extents;
 
   ASSERT_EQ(mock_parent_image_cache->discard(0, 0, 0, io_context, 0,
-            *temp_trace, temp_op_flags, temp_journal_tid, temp_dispatch_result,
+            tracing::noop_span_ctx, temp_op_flags, temp_journal_tid, temp_dispatch_result,
             temp_on_finish, temp_on_dispatched), false);
   ASSERT_EQ(mock_parent_image_cache->write(0, 0, std::move(temp_bl),
-            io_context, 0, 0, std::nullopt, *temp_trace, temp_op_flags,
+            io_context, 0, 0, std::nullopt, tracing::noop_span_ctx, temp_op_flags,
             temp_journal_tid, temp_dispatch_result, temp_on_finish,
             temp_on_dispatched), false);
   ASSERT_EQ(mock_parent_image_cache->write_same(0, 0, 0, std::move(buffer_extents),
-            std::move(temp_bl), io_context, 0, *temp_trace, temp_op_flags,
+            std::move(temp_bl), io_context, 0, tracing::noop_span_ctx, temp_op_flags,
             temp_journal_tid, temp_dispatch_result, temp_on_finish, temp_on_dispatched), false );
   ASSERT_EQ(mock_parent_image_cache->compare_and_write(0, 0, std::move(temp_bl), std::move(temp_bl),
-            io_context, 0, *temp_trace, temp_journal_tid, temp_op_flags,
+            io_context, 0, tracing::noop_span_ctx, temp_journal_tid, temp_op_flags,
             temp_journal_tid, temp_dispatch_result, temp_on_finish,
             temp_on_dispatched), false);
-  ASSERT_EQ(mock_parent_image_cache->flush(io::FLUSH_SOURCE_USER, *temp_trace, temp_journal_tid,
+  ASSERT_EQ(mock_parent_image_cache->flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, temp_journal_tid,
             temp_dispatch_result, temp_on_finish, temp_on_dispatched), false);
   ASSERT_EQ(mock_parent_image_cache->invalidate_cache(nullptr), false);
   ASSERT_EQ(mock_parent_image_cache->reset_existence_cache(nullptr), false);
@@ -361,7 +360,7 @@ TEST_F(TestMockParentCacheObjectDispatch, test_read) {
   io::DispatchResult dispatch_result;
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   mock_parent_image_cache->read(
-    0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, {}, nullptr, 
+    0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, tracing::noop_span_ctx, nullptr, 
     nullptr, &dispatch_result, nullptr, &on_dispatched);
   ASSERT_EQ(0, on_dispatched.wait());
 
@@ -415,7 +414,7 @@ TEST_F(TestMockParentCacheObjectDispatch, test_read_dne) {
   C_SaferCond on_dispatched;
   io::DispatchResult dispatch_result;
   mock_parent_image_cache->read(
-    0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, {}, nullptr,
+    0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, tracing::noop_span_ctx, nullptr,
     nullptr, &dispatch_result, nullptr, &on_dispatched);
   ASSERT_EQ(0, on_dispatched.wait());
 

--- a/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
@@ -73,7 +73,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThrough) {
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
   ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                     std::nullopt, {}, nullptr, nullptr,
+                                     std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                      &dispatch_result, &finish_ctx_ptr,
                                      &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
@@ -97,12 +97,12 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
   ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                     std::nullopt, {}, nullptr, nullptr,
+                                     std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                      &dispatch_result, &finish_ctx_ptr,
                                      &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
 
-  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
+  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr,
                                      &dispatch_result, &finish_ctx_ptr,
                                      &dispatch_ctx));
 
@@ -110,7 +110,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   expect_context_complete(finish_ctx, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr,
                                     &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -142,7 +142,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, DispatchIO) {
   expect_context_complete(finish_ctx, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr,
                                     &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -175,7 +175,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0,  0,
-                                    std::nullopt,{}, nullptr, nullptr,
+                                    std::nullopt,tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -189,7 +189,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(finish_ctx2, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr2,
                                     &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -200,7 +200,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
   ASSERT_TRUE(object_dispatch.write(0, 1024, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr3,
                                     &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -243,7 +243,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -254,7 +254,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
   ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr2,
                                     &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -293,7 +293,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -307,7 +307,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(finish_ctx2, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr2,
                                     &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -318,7 +318,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr3,
                                     &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -353,7 +353,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, Flush) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
+  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr,
                                      &dispatch_result, &finish_ctx_ptr,
                                      &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
@@ -381,7 +381,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnInFlightIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -391,7 +391,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnInFlightIO) {
   MockContext finish_ctx2;
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
-  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
+  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr,
                                      &dispatch_result, &finish_ctx_ptr2,
                                      &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -427,7 +427,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -439,7 +439,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
   ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr2,
                                     &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -449,7 +449,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   MockContext finish_ctx3;
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
-  ASSERT_TRUE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
+  ASSERT_TRUE(object_dispatch.flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr,
                                     &dispatch_result, &finish_ctx_ptr3,
                                     &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -493,7 +493,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushError) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -504,7 +504,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushError) {
   MockContext finish_ctx2;
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
-  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
+  ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr,
                                      &dispatch_result, &finish_ctx_ptr2,
                                      &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -534,7 +534,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIO) {
   Context* finish_ctx_ptr = &finish_ctx;
 
   ASSERT_FALSE(object_dispatch.compare_and_write(0, 0, std::move(data),
-                                                 std::move(data), {}, 0, {},
+                                                 std::move(data), {}, 0, tracing::noop_span_ctx,
                                                  nullptr, nullptr, nullptr,
                                                  &dispatch_result,
                                                  &finish_ctx_ptr,
@@ -564,7 +564,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOInFlightIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -576,7 +576,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOInFlightIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
   ASSERT_TRUE(object_dispatch.compare_and_write(0, 0, std::move(data),
-                                                std::move(data), {}, 0, {},
+                                                std::move(data), {}, 0, tracing::noop_span_ctx,
                                                 nullptr, nullptr, nullptr,
                                                 &dispatch_result,
                                                 &finish_ctx_ptr2,
@@ -611,7 +611,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   expect_context_complete(finish_ctx1, 0);
 
   ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr1,
                                     &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -623,7 +623,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
   ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
-                                    std::nullopt, {}, nullptr, nullptr,
+                                    std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                     &dispatch_result, &finish_ctx_ptr2,
                                     &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -633,7 +633,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
   ASSERT_TRUE(object_dispatch.compare_and_write(0, 0, std::move(data),
-                                                std::move(data), {}, 0, {},
+                                                std::move(data), {}, 0, tracing::noop_span_ctx,
                                                 nullptr, nullptr, nullptr,
                                                 &dispatch_result,
                                                 &finish_ctx_ptr3,
@@ -669,7 +669,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteFUA) {
   Context* finish_ctx_ptr = &finish_ctx;
   ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {},
                                      LIBRADOS_OP_FLAG_FADVISE_FUA, 0,
-                                     std::nullopt, {}, nullptr, nullptr,
+                                     std::nullopt, tracing::noop_span_ctx, nullptr, nullptr,
                                      &dispatch_result, &finish_ctx_ptr,
                                      &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
@@ -693,7 +693,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteSameFUA) {
   Context* finish_ctx_ptr = &finish_ctx;
   ASSERT_FALSE(object_dispatch.write_same(0, 0, 8192, {{0, 8192}},
                                           std::move(data), {},
-                                          LIBRADOS_OP_FLAG_FADVISE_FUA, {},
+                                          LIBRADOS_OP_FLAG_FADVISE_FUA, tracing::noop_span_ctx,
                                           nullptr, nullptr, &dispatch_result,
                                           &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -323,7 +323,7 @@ public:
         expect.WillOnce(DoAll(WithArg<7>(Invoke([&mock_image_ctx, snap_id, state](Context *ctx) {
                                   ceph_assert(ceph_mutex_is_locked(mock_image_ctx.image_ctx->image_lock));
                                   mock_image_ctx.image_ctx->object_map->aio_update<Context>(
-                                    snap_id, 0, 1, state, boost::none, {}, false, ctx);
+                                    snap_id, 0, 1, state, boost::none, tracing::noop_span_ctx, false, ctx);
                                 })),
                               Return(true)));
       }

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -425,7 +425,7 @@ TEST_F(TestMockIoCopyupRequest, Standard) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -482,7 +482,7 @@ TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -522,7 +522,7 @@ TEST_F(TestMockIoCopyupRequest, CopyOnRead) {
                        {{0, 4096}}, data, 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -568,7 +568,7 @@ TEST_F(TestMockIoCopyupRequest, CopyOnReadWithSnaps) {
                        data, 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -614,7 +614,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopy) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -652,7 +652,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyOnRead) {
                            0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -719,7 +719,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPostSnaps) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -791,7 +791,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPreAndPostSnaps) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -833,7 +833,7 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -873,7 +873,7 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyOnRead) {
                        {}, "", 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->send();
   flush_async_operations(ictx);
@@ -907,7 +907,7 @@ TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
   expect_is_empty_write_op(mock_write_request, true);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -947,7 +947,7 @@ TEST_F(TestMockIoCopyupRequest, RestartWrite) {
                            0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   expect_add_copyup_ops(mock_write_request1);
   expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
                        {{0, 4096}}, data, 0);
@@ -992,7 +992,7 @@ TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
   expect_read_parent(mock_parent_image_ctx, {{0, 4096}}, "", -EPERM);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   MockAbstractObjectWriteRequest mock_write_request;
   req->append_request(&mock_write_request, {});
@@ -1026,7 +1026,7 @@ TEST_F(TestMockIoCopyupRequest, PrepareCopyupError) {
   expect_prepare_copyup(mock_image_ctx, -EIO);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   MockAbstractObjectWriteRequest mock_write_request;
   req->append_request(&mock_write_request, {});
@@ -1065,7 +1065,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyError) {
   expect_is_empty_write_op(mock_write_request, false);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1105,7 +1105,7 @@ TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
                            -EINVAL);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1158,7 +1158,7 @@ TEST_F(TestMockIoCopyupRequest, CopyupError) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1203,7 +1203,7 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
   expect_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), data, 0);
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
   req->send();
@@ -1258,7 +1258,7 @@ TEST_F(TestMockIoCopyupRequest, ProcessCopyup) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {{0, 1024}});
   req->send();
@@ -1322,7 +1322,7 @@ TEST_F(TestMockIoCopyupRequest, ProcessCopyupOverwrite) {
   expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
-                                   {{0, 4096}}, {});
+                                   {{0, 4096}}, tracing::noop_span_ctx);
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {{0, 1024}});
   req->send();

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -201,7 +201,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_1(
     mock_image_ctx, aio_comp_1, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_1.send();
@@ -214,7 +214,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_2(
     mock_image_ctx, aio_comp_2, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_2.send();
@@ -257,7 +257,7 @@ TEST_F(TestMockIoImageRequest, AioReadAccessTimestamp) {
   ReadResult rr;
   MockImageReadRequest mock_aio_image_read_1(
     mock_image_ctx, aio_comp_1, {{0, 1}}, std::move(rr),
-    mock_image_ctx.get_data_io_context(), 0, 0, {});
+    mock_image_ctx.get_data_io_context(), 0, 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_read_1.send();
@@ -270,7 +270,7 @@ TEST_F(TestMockIoImageRequest, AioReadAccessTimestamp) {
 
   MockImageReadRequest mock_aio_image_read_2(
     mock_image_ctx, aio_comp_2, {{0, 1}}, std::move(rr),
-    mock_image_ctx.get_data_io_context(), 0, 0, {});
+    mock_image_ctx.get_data_io_context(), 0, 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_read_2.send();
@@ -296,7 +296,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscard) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{16, 63}, {84, 100}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -324,7 +324,7 @@ TEST_F(TestMockIoImageRequest, TailDiscard) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{ictx->layout.object_size - 1024, 1024}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -354,7 +354,7 @@ TEST_F(TestMockIoImageRequest, DiscardGranularity) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -385,7 +385,7 @@ TEST_F(TestMockIoImageRequest, AioWriteJournalAppendDisabled) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write(
     mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();
@@ -414,7 +414,7 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{0, 1}}, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx.get_data_io_context(), tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -442,7 +442,7 @@ TEST_F(TestMockIoImageRequest, AioFlushJournalAppendDisabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_FLUSH);
   MockImageFlushRequest mock_aio_image_flush(mock_image_ctx, aio_comp,
-                                             FLUSH_SOURCE_USER, {});
+                                             FLUSH_SOURCE_USER, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_flush.send();
@@ -473,7 +473,7 @@ TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
   bl.append("1");
   MockImageWriteSameRequest mock_aio_image_writesame(
     mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_writesame.send();
@@ -507,7 +507,7 @@ TEST_F(TestMockIoImageRequest, AioCompareAndWriteJournalAppendDisabled) {
   uint64_t mismatch_offset;
   MockImageCompareAndWriteRequest mock_aio_image_write(
     mock_image_ctx, aio_comp, {{0, 1}}, std::move(cmp_bl), std::move(write_bl),
-    &mismatch_offset, mock_image_ctx.get_data_io_context(), 0, {});
+    &mismatch_offset, mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();
@@ -545,7 +545,7 @@ TEST_F(TestMockIoImageRequest, ListSnaps) {
     &aio_comp_ctx, ictx, AIO_TYPE_GENERIC);
   MockImageListSnapsRequest mock_image_list_snaps_request(
     mock_image_ctx, aio_comp, {{0, 16384}, {16384, 16384}}, {0, CEPH_NOSNAP},
-    0, &snapshot_delta, {});
+    0, &snapshot_delta, tracing::noop_span_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_image_list_snaps_request.send();

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -133,7 +133,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Read) {
   Context *on_finish = &cond;
   io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.read(
-      0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, {}, nullptr,
+      0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, tracing::noop_span_ctx, nullptr,
       nullptr, nullptr, &on_finish, nullptr));
   ASSERT_EQ(on_finish, &cond); // not modified
   on_finish->complete(0);
@@ -151,7 +151,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Discard) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      0, 0, 4096, mock_image_ctx.get_data_io_context(), 0, {}, nullptr, nullptr,
+      0, 0, 4096, mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx, nullptr, nullptr,
       nullptr, &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
@@ -173,7 +173,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Write) {
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr,
       &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
@@ -194,7 +194,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteSame) {
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write_same(
       0, 0, 4096, std::move(buffer_extents), std::move(data),
-      mock_image_ctx.get_data_io_context(), 0, {}, nullptr, nullptr, nullptr,
+      mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx, nullptr, nullptr, nullptr,
       &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
@@ -215,7 +215,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, CompareAndWrite) {
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.compare_and_write(
       0, 0, std::move(cmp_data), std::move(write_data),
-      mock_image_ctx.get_data_io_context(), 0, {}, nullptr, nullptr, nullptr,
+      mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx, nullptr, nullptr, nullptr,
       nullptr, &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
@@ -234,7 +234,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Flush) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.flush(
-      FLUSH_SOURCE_USER, {}, nullptr, &dispatch_result, &on_finish, nullptr));
+      FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr, &dispatch_result, &on_finish, nullptr));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_EQ(on_finish, &cond); // not modified
   on_finish->complete(0);
@@ -260,7 +260,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -273,7 +273,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -308,7 +308,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -321,7 +321,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -333,7 +333,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   C_SaferCond cond3;
   Context *on_finish3 = &cond3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.flush(
-      FLUSH_SOURCE_USER, {}, nullptr, &dispatch_result, &on_finish3, nullptr));
+      FLUSH_SOURCE_USER, tracing::noop_span_ctx, nullptr, &dispatch_result, &on_finish3, nullptr));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_EQ(on_finish3, &cond3);
 
@@ -365,7 +365,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -381,7 +381,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -395,7 +395,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish3, &on_dispatched3));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish3, &cond3);
@@ -408,7 +408,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {},&object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx,&object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish4, &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish4, &cond4);
@@ -421,7 +421,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish5, &on_dispatched5));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish5, &cond5);
@@ -434,7 +434,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond on_dispatched6;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish6, &on_dispatched6));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish6, &cond6);
@@ -482,7 +482,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -498,7 +498,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -514,7 +514,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish3, nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
@@ -547,7 +547,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -564,7 +564,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -580,7 +580,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish3, &on_dispatched3));
   ASSERT_NE(on_finish3, &cond3);
 
@@ -592,7 +592,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond4;
   Context *on_finish4 = &cond4;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      0, 4096, 4096, mock_image_ctx.get_data_io_context(), 0, {}, nullptr,
+      0, 4096, 4096, mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx, nullptr,
       nullptr, nullptr, &on_finish4, nullptr));
   ASSERT_NE(on_finish4, &cond4);
   ASSERT_EQ(0, on_dispatched2.wait());
@@ -610,7 +610,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish5, &on_dispatched5));
   ASSERT_NE(on_finish5, &cond5);
   ASSERT_NE(timer_task, nullptr);
@@ -623,7 +623,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond6;
   Context *on_finish6 = &cond6;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      0, 4096, 4096, mock_image_ctx.get_data_io_context(), 0, {}, nullptr,
+      0, 4096, 4096, mock_image_ctx.get_data_io_context(), 0, tracing::noop_span_ctx, nullptr,
       nullptr, nullptr, &on_finish6, nullptr));
   ASSERT_NE(on_finish6, &cond6);
   ASSERT_EQ(0, on_dispatched5.wait());
@@ -640,7 +640,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond on_dispatched7;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, object_off, std::move(data), mock_image_ctx.get_data_io_context(), 0,
-      0, std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      0, std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish7, &on_dispatched7));
   ASSERT_NE(on_finish7, &cond7);
   ASSERT_NE(timer_task, nullptr);
@@ -703,7 +703,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       object_no, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -717,7 +717,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       object_no, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -731,7 +731,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       object_no, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish3,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish3,
       nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
@@ -741,7 +741,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       object_no, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish4, &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish4, &cond4);
@@ -788,7 +788,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, nullptr, &on_finish1,
       nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -802,7 +802,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
       0, 0, std::move(data), mock_image_ctx.get_data_io_context(), 0, 0,
-      std::nullopt, {}, &object_dispatch_flags, nullptr, &dispatch_result,
+      std::nullopt, tracing::noop_span_ctx, &object_dispatch_flags, nullptr, &dispatch_result,
       &on_finish2, &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -872,7 +872,7 @@ TEST_F(TestJournalReplay, ObjectPosition) {
     &flush_ctx, ictx, librbd::io::AIO_TYPE_FLUSH);
   auto req = librbd::io::ImageDispatchSpec::create_flush(
     *ictx, librbd::io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-    librbd::io::FLUSH_SOURCE_INTERNAL, {});
+    librbd::io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   req->send();
   ASSERT_EQ(0, flush_ctx.wait());
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -33,7 +33,7 @@ struct ImageRequest<MockReplayImageCtx> {
   static void aio_write(MockReplayImageCtx *ictx, AioCompletion *c,
                         Extents &&image_extents, bufferlist &&bl,
                         IOContext io_context, int op_flags,
-                        const ZTracer::Trace &parent_trace) {
+                        const jspan_context &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_write(c, image_extents, bl, op_flags);
   }
@@ -44,14 +44,14 @@ struct ImageRequest<MockReplayImageCtx> {
                           Extents&& image_extents,
                           uint32_t discard_granularity_bytes,
                           IOContext io_context,
-                          const ZTracer::Trace &parent_trace) {
+                          const jspan_context &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_discard(c, image_extents, discard_granularity_bytes);
   }
 
   MOCK_METHOD1(aio_flush, void(AioCompletion *c));
   static void aio_flush(MockReplayImageCtx *ictx, AioCompletion *c,
-                        FlushSource, const ZTracer::Trace &parent_trace) {
+                        FlushSource, const jspan_context &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_flush(c);
   }
@@ -63,7 +63,7 @@ struct ImageRequest<MockReplayImageCtx> {
   static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
                             Extents&& image_extents, bufferlist &&bl,
                             IOContext io_context, int op_flags,
-                            const ZTracer::Trace &parent_trace) {
+                            const jspan_context &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_writesame(c, image_extents, bl, op_flags);
   }
@@ -76,7 +76,7 @@ struct ImageRequest<MockReplayImageCtx> {
                                     Extents &&image_extents, bufferlist &&cmp_bl,
                                     bufferlist &&bl, uint64_t *mismatch_offset,
                                     IOContext io_context, int op_flags,
-                                    const ZTracer::Trace &parent_trace) {
+                                    const jspan_context &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_compare_and_write(c, image_extents, cmp_bl, bl,
                                       mismatch_offset, op_flags);

--- a/src/test/librbd/migration/test_mock_QCOWFormat.cc
+++ b/src/test/librbd/migration/test_mock_QCOWFormat.cc
@@ -836,7 +836,7 @@ TEST_F(TestMockMigrationQCOWFormat, Read) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -871,7 +871,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL1DNE) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -911,7 +911,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL2DNE) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -951,7 +951,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadZero) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -1005,7 +1005,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadSnap) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -1040,7 +1040,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadSnapDNE) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(-ENOENT, ctx2.wait());
 
   C_SaferCond ctx3;
@@ -1091,7 +1091,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterCacheHit) {
   bufferlist bl1;
   io::ReadResult read_result1{&bl1};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp1, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result1), 0, 0, {}));
+                                    std::move(read_result1), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl1, bl1);
 
@@ -1101,7 +1101,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterCacheHit) {
   bufferlist bl2;
   io::ReadResult read_result2{&bl2};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp2, CEPH_NOSNAP, {{66016, 234}},
-                                    std::move(read_result2), 0, 0, {}));
+                                    std::move(read_result2), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(234, ctx3.wait());
   ASSERT_EQ(expect_bl2, bl2);
 
@@ -1143,7 +1143,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterError) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(-EIO, ctx2.wait());
 
   C_SaferCond ctx3;
@@ -1180,7 +1180,7 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL2TableError) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+                                    std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(-EIO, ctx2.wait());
 
   C_SaferCond ctx3;
@@ -1241,7 +1241,7 @@ TEST_F(TestMockMigrationQCOWFormat, ListSnaps) {
   C_SaferCond ctx2;
   io::SnapshotDelta snapshot_delta;
   mock_qcow_format.list_snaps({{0, 196608}}, {1, CEPH_NOSNAP}, 0,
-                              &snapshot_delta, {}, &ctx2);
+                              &snapshot_delta, tracing::noop_span_ctx, &ctx2);
   ASSERT_EQ(0, ctx2.wait());
 
   io::SnapshotDelta expected_snapshot_delta;

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -346,7 +346,7 @@ TEST_F(TestMockMigrationRawFormat, Read) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   ASSERT_TRUE(mock_raw_format.read(aio_comp, CEPH_NOSNAP, {{123, 123}},
-                                   std::move(read_result), 0, 0, {}));
+                                   std::move(read_result), 0, 0, tracing::noop_span_ctx));
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -385,7 +385,7 @@ TEST_F(TestMockMigrationRawFormat, ListSnaps) {
 
   C_SaferCond ctx2;
   io::SnapshotDelta snapshot_delta;
-  mock_raw_format.list_snaps({{0, 123}}, {CEPH_NOSNAP}, 0, &snapshot_delta, {},
+  mock_raw_format.list_snaps({{0, 123}}, {CEPH_NOSNAP}, 0, &snapshot_delta, tracing::noop_span_ctx,
                              &ctx2);
   ASSERT_EQ(0, ctx2.wait());
 
@@ -429,7 +429,7 @@ TEST_F(TestMockMigrationRawFormat, ListSnapsError) {
 
   C_SaferCond ctx2;
   io::SnapshotDelta snapshot_delta;
-  mock_raw_format.list_snaps({{0, 123}}, {CEPH_NOSNAP}, 0, &snapshot_delta, {},
+  mock_raw_format.list_snaps({{0, 123}}, {CEPH_NOSNAP}, 0, &snapshot_delta, tracing::noop_span_ctx,
                              &ctx2);
   ASSERT_EQ(-EINVAL, ctx2.wait());
 
@@ -503,7 +503,7 @@ TEST_F(TestMockMigrationRawFormat, ListSnapsMerge) {
   C_SaferCond ctx2;
   io::SnapshotDelta snapshot_delta;
   mock_raw_format.list_snaps({{0, 123}}, {1, CEPH_NOSNAP}, 0, &snapshot_delta,
-                             {}, &ctx2);
+                             tracing::noop_span_ctx, &ctx2);
   ASSERT_EQ(0, ctx2.wait());
 
   io::SnapshotDelta expected_snapshot_delta;

--- a/src/test/librbd/migration/test_mock_RawSnapshot.cc
+++ b/src/test/librbd/migration/test_mock_RawSnapshot.cc
@@ -211,7 +211,7 @@ TEST_F(TestMockMigrationRawSnapshot, Read) {
   bufferlist bl;
   io::ReadResult read_result{&bl};
   mock_raw_snapshot.read(aio_comp, {{123, 123}}, std::move(read_result), 0, 0,
-                         {});
+                         tracing::noop_span_ctx);
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -243,7 +243,7 @@ TEST_F(TestMockMigrationRawSnapshot, ListSnap) {
 
   C_SaferCond ctx2;
   io::SparseExtents sparse_extents;
-  mock_raw_snapshot.list_snap({{0, 123}}, 0, &sparse_extents, {}, &ctx2);
+  mock_raw_snapshot.list_snap({{0, 123}}, 0, &sparse_extents, tracing::noop_span_ctx, &ctx2);
   ASSERT_EQ(0, ctx2.wait());
 
   C_SaferCond ctx3;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -17,7 +17,6 @@
 #include "test/librbd/mock/io/MockImageDispatcher.h"
 #include "test/librbd/mock/io/MockObjectDispatcher.h"
 #include "common/WorkQueue.h"
-#include "common/zipkin_trace.h"
 #include "librbd/ImageCtx.h"
 #include "gmock/gmock.h"
 #include <string>
@@ -93,12 +92,10 @@ struct MockImageCtx {
       state(new MockImageState()),
       image_watcher(NULL), object_map(NULL),
       exclusive_lock(NULL), journal(NULL),
-      trace_endpoint(image_ctx.trace_endpoint),
       sparse_read_threshold_bytes(image_ctx.sparse_read_threshold_bytes),
       discard_granularity_bytes(image_ctx.discard_granularity_bytes),
       mirroring_replay_delay(image_ctx.mirroring_replay_delay),
       non_blocking_aio(image_ctx.non_blocking_aio),
-      blkin_trace_all(image_ctx.blkin_trace_all),
       enable_alloc_hint(image_ctx.enable_alloc_hint),
       alloc_hint_flags(image_ctx.alloc_hint_flags),
       read_flags(image_ctx.read_flags),
@@ -315,15 +312,12 @@ struct MockImageCtx {
   MockExclusiveLock *exclusive_lock;
   MockJournal *journal;
 
-  ZTracer::Endpoint trace_endpoint;
-
   crypto::CryptoInterface* crypto = nullptr;
 
   uint64_t sparse_read_threshold_bytes;
   uint32_t discard_granularity_bytes;
   int mirroring_replay_delay;
   bool non_blocking_aio;
-  bool blkin_trace_all;
   bool enable_alloc_hint;
   uint32_t alloc_hint_flags;
   uint32_t read_flags;

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -29,7 +29,7 @@ struct MockObjectMap {
   template <typename T, void(T::*MF)(int) = &T::complete>
   bool aio_update(uint64_t snap_id, uint64_t start_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
-                  const ZTracer::Trace &parent_trace, bool ignore_enoent,
+                  const jspan_context &parent_trace, bool ignore_enoent,
                   T *callback_object) {
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
@@ -40,7 +40,7 @@ struct MockObjectMap {
   bool aio_update(uint64_t snap_id, uint64_t start_object_no,
                   uint64_t end_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
-                  const ZTracer::Trace &parent_trace, bool ignore_enoent,
+                  const jspan_context &parent_trace, bool ignore_enoent,
                   T *callback_object) {
     auto ctx = util::create_context_callback<T, MF>(callback_object);
     bool updated = aio_update(snap_id, start_object_no, end_object_no,
@@ -54,7 +54,7 @@ struct MockObjectMap {
   MOCK_METHOD8(aio_update, bool(uint64_t snap_id, uint64_t start_object_no,
                                 uint64_t end_object_no, uint8_t new_state,
                                 const boost::optional<uint8_t> &current_state,
-                                const ZTracer::Trace &parent_trace,
+                                const jspan_context &parent_trace,
                                 bool ignore_enoent, Context *on_finish));
 
   MOCK_METHOD2(snapshot_add, void(uint64_t snap_id, Context *on_finish));

--- a/src/test/librbd/mock/io/MockImageDispatch.h
+++ b/src/test/librbd/mock/io/MockImageDispatch.h
@@ -23,7 +23,7 @@ public:
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,
       ReadResult &&read_result, IOContext io_context, int op_flags,
-      int read_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int read_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -32,7 +32,7 @@ public:
 
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -42,7 +42,7 @@ public:
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
       uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -51,7 +51,7 @@ public:
 
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      IOContext io_context, int op_flags, const jspan_context &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -61,7 +61,7 @@ public:
   bool compare_and_write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
       bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
+      int op_flags, const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -70,7 +70,7 @@ public:
 
   bool flush(
       AioCompletion* aio_comp, FlushSource flush_source,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -80,7 +80,7 @@ public:
   bool list_snaps(
       AioCompletion* aio_comp, Extents&& image_extents, SnapIds&& snap_ids,
       int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
+      const jspan_context &parent_trace, uint64_t tid,
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -29,7 +29,7 @@ public:
                     DispatchResult*, Context*));
   bool read(
       uint64_t object_no, ReadExtents* extents, IOContext io_context,
-      int op_flags, int read_flags, const ZTracer::Trace& parent_trace,
+      int op_flags, int read_flags, const jspan_context& parent_trace,
       uint64_t* version, int* dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
@@ -43,7 +43,7 @@ public:
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       IOContext io_context, int discard_flags,
-      const ZTracer::Trace &parent_trace, int* dispatch_flags,
+      const jspan_context &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
     return execute_discard(object_no, object_off, object_len, io_context,
@@ -59,7 +59,7 @@ public:
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       IOContext io_context, int op_flags, int write_flags,
       std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, int* dispatch_flags,
+      const jspan_context &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override {
     return execute_write(object_no, object_off, data, io_context, write_flags,
@@ -76,7 +76,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, int* dispatch_flags,
+      const jspan_context &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context* *on_finish, Context* on_dispatched) override {
     return execute_write_same(object_no, object_off, object_len, buffer_extents,
@@ -91,7 +91,7 @@ public:
   bool compare_and_write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
       ceph::bufferlist&& write_data, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
+      const jspan_context &parent_trace, uint64_t* mismatch_offset,
       int* dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -103,7 +103,7 @@ public:
 
   MOCK_METHOD4(execute_flush, bool(FlushSource, uint64_t*, DispatchResult*,
                                    Context*));
-  bool flush(FlushSource flush_source, const ZTracer::Trace &parent_trace,
+  bool flush(FlushSource flush_source, const jspan_context &parent_trace,
              uint64_t* journal_tid, DispatchResult* dispatch_result,
              Context** on_finish, Context* on_dispatched) {
     return execute_flush(flush_source, journal_tid, dispatch_result,
@@ -115,7 +115,7 @@ public:
                                         DispatchResult*, Context*));
   bool list_snaps(
       uint64_t object_no, io::Extents&& extents, SnapIds&& snap_ids,
-      int list_snaps_flags, const ZTracer::Trace &parent_trace,
+      int list_snaps_flags, const jspan_context &parent_trace,
       SnapshotDelta* snapshot_delta, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/test/librbd/mock/migration/MockSnapshotInterface.h
+++ b/src/test/librbd/mock/migration/MockSnapshotInterface.h
@@ -24,7 +24,7 @@ struct MockSnapshotInterface : public SnapshotInterface {
                           io::ReadResult&));
   void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
             io::ReadResult&& read_result, int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override {
+            const jspan_context &parent_trace) override {
     read(aio_comp, image_extents, read_result);
   }
 
@@ -32,7 +32,7 @@ struct MockSnapshotInterface : public SnapshotInterface {
                                Context*));
   void list_snap(io::Extents&& image_extents, int list_snaps_flags,
                  io::SparseExtents* sparse_extents,
-                 const ZTracer::Trace &parent_trace,
+                 const jspan_context &parent_trace,
                  Context* on_finish) override {
     list_snap(image_extents, sparse_extents, on_finish);
   }

--- a/src/test/librbd/object_map/test_mock_UpdateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_UpdateRequest.cc
@@ -84,7 +84,7 @@ TEST_F(TestMockObjectMapUpdateRequest, UpdateInMemory) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, CEPH_NOSNAP, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, false, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -118,7 +118,7 @@ TEST_F(TestMockObjectMapUpdateRequest, UpdateHeadOnDisk) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, CEPH_NOSNAP, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, false, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -150,7 +150,7 @@ TEST_F(TestMockObjectMapUpdateRequest, UpdateSnapOnDisk) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, snap_id, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, false, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -179,7 +179,7 @@ TEST_F(TestMockObjectMapUpdateRequest, UpdateOnDiskError) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, CEPH_NOSNAP, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, false, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -211,7 +211,7 @@ TEST_F(TestMockObjectMapUpdateRequest, RebuildSnapOnDisk) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, snap_id, 0, object_map.size(),
-    OBJECT_EXISTS_CLEAN, boost::optional<uint8_t>(), {}, false, &cond_ctx);
+    OBJECT_EXISTS_CLEAN, boost::optional<uint8_t>(), tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -250,7 +250,7 @@ TEST_F(TestMockObjectMapUpdateRequest, BatchUpdate) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, CEPH_NOSNAP, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, false, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, false, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};
@@ -276,7 +276,7 @@ TEST_F(TestMockObjectMapUpdateRequest, IgnoreMissingObjectMap) {
   C_SaferCond cond_ctx;
   AsyncRequest<> *req = new UpdateRequest<>(
     *ictx, &object_map_lock, &object_map, CEPH_NOSNAP, 0, object_map.size(),
-    OBJECT_NONEXISTENT, OBJECT_EXISTS, {}, true, &cond_ctx);
+    OBJECT_NONEXISTENT, OBJECT_EXISTS, tracing::noop_span_ctx, true, &cond_ctx);
   {
     std::shared_lock image_locker{ictx->image_lock};
     std::unique_lock object_map_locker{object_map_lock};

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -209,7 +209,7 @@ TEST_F(TestObjectMap, DISABLED_StressTest) {
 
     if (!ictx->object_map->aio_update<
           Context, &Context::complete>(CEPH_NOSNAP, object_no,
-                                       OBJECT_EXISTS, {}, {}, true,
+                                       OBJECT_EXISTS, {}, tracing::noop_span_ctx, true,
                                        ctx)) {
       ctx->complete(0);
     } else {

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -156,7 +156,7 @@ int TestFixture::flush_writeback_cache(librbd::ImageCtx *image_ctx) {
       &ctx, image_ctx, librbd::io::AIO_TYPE_FLUSH);
     auto req = librbd::io::ImageDispatchSpec::create_flush(
       *image_ctx, librbd::io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-      librbd::io::FLUSH_SOURCE_INTERNAL, {});
+      librbd::io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
     req->send();
     return ctx.wait();
   } else {

--- a/src/test/librbd/test_mock_ObjectMap.cc
+++ b/src/test/librbd/test_mock_ObjectMap.cc
@@ -71,7 +71,7 @@ struct UpdateRequest<MockTestImageCtx> {
                                uint64_t start_object_no, uint64_t end_object_no,
                                uint8_t new_state,
                                const boost::optional<uint8_t> &current_state,
-                               const ZTracer::Trace &parent_trace,
+                               const jspan_context &parent_trace,
                                bool ignore_enoent, Context *on_finish) {
     ceph_assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
@@ -186,8 +186,8 @@ TEST_F(TestMockObjectMap, NonDetainedUpdate) {
   C_SaferCond update_ctx2;
   {
     std::shared_lock image_locker{mock_image_ctx.image_lock};
-    mock_object_map->aio_update(CEPH_NOSNAP, 0, 1, {}, {}, false, &update_ctx1);
-    mock_object_map->aio_update(CEPH_NOSNAP, 1, 1, {}, {}, false, &update_ctx2);
+    mock_object_map->aio_update(CEPH_NOSNAP, 0, 1, {}, tracing::noop_span_ctx, false, &update_ctx1);
+    mock_object_map->aio_update(CEPH_NOSNAP, 1, 1, {}, tracing::noop_span_ctx, false, &update_ctx2);
   }
 
   finish_update_2->complete(0);
@@ -247,13 +247,13 @@ TEST_F(TestMockObjectMap, DetainedUpdate) {
   C_SaferCond update_ctx4;
   {
     std::shared_lock image_locker{mock_image_ctx.image_lock};
-    mock_object_map->aio_update(CEPH_NOSNAP, 1, 4, 1, {}, {}, false,
+    mock_object_map->aio_update(CEPH_NOSNAP, 1, 4, 1, {}, tracing::noop_span_ctx, false,
                                &update_ctx1);
-    mock_object_map->aio_update(CEPH_NOSNAP, 1, 3, 1, {}, {}, false,
+    mock_object_map->aio_update(CEPH_NOSNAP, 1, 3, 1, {}, tracing::noop_span_ctx, false,
                                &update_ctx2);
-    mock_object_map->aio_update(CEPH_NOSNAP, 2, 3, 1, {}, {}, false,
+    mock_object_map->aio_update(CEPH_NOSNAP, 2, 3, 1, {}, tracing::noop_span_ctx, false,
                                &update_ctx3);
-    mock_object_map->aio_update(CEPH_NOSNAP, 0, 2, 1, {}, {}, false,
+    mock_object_map->aio_update(CEPH_NOSNAP, 0, 2, 1, {}, tracing::noop_span_ctx, false,
                                &update_ctx4);
   }
 

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -62,7 +62,7 @@ void FakeWriteback::read(const object_t& oid, uint64_t object_no,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
 			 __u32 trunc_seq, int op_flags,
-                         const ZTracer::Trace &parent_trace,
+                         const jspan_context &otel_trace,
                          Context *onfinish)
 {
   C_Delay *wrapper = new C_Delay(m_cct, onfinish, m_lock, off, pbl,
@@ -77,7 +77,7 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid,
-                                const ZTracer::Trace &parent_trace,
+                                const jspan_context &otel_trace,
                                 Context *oncommit)
 {
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -21,7 +21,7 @@ public:
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags,
-		    const ZTracer::Trace &parent_trace,
+		    const jspan_context &otel_trace,
                     Context *onfinish) override;
 
   ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
@@ -29,7 +29,7 @@ public:
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-                           const ZTracer::Trace &parent_trace,
+                           const jspan_context &otel_trace,
 			   Context *oncommit) override;
 
   using WritebackHandler::write;

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -91,7 +91,7 @@ void MemWriteback::read(const object_t& oid, uint64_t object_no,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
 			 __u32 trunc_seq, int op_flags,
-                         const ZTracer::Trace &parent_trace,
+                         const jspan_context &otel_trace,
                          Context *onfinish)
 {
   ceph_assert(snapid == CEPH_NOSNAP);
@@ -107,7 +107,7 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid,
-                                const ZTracer::Trace &parent_trace,
+                                const jspan_context &otel_trace,
                                 Context *oncommit)
 {
   ceph_assert(snapc.seq == 0);

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -21,7 +21,7 @@ public:
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags,
-                    const ZTracer::Trace &parent_trace,
+                    const jspan_context &otel_trace,
                     Context *onfinish) override;
 
   ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
@@ -29,7 +29,7 @@ public:
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-                           const ZTracer::Trace &parent_trace,
+                           const jspan_context &otel_trace,
 			   Context *oncommit) override;
 
   using WritebackHandler::write;

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -38,7 +38,7 @@ int flush(librbd::ImageCtx *image_ctx) {
     &ctx, image_ctx, librbd::io::AIO_TYPE_FLUSH);
   auto req = librbd::io::ImageDispatchSpec::create_flush(
     *image_ctx, librbd::io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
-    librbd::io::FLUSH_SOURCE_INTERNAL, {});
+    librbd::io::FLUSH_SOURCE_INTERNAL, tracing::noop_span_ctx);
   req->send();
   return ctx.wait();
 }


### PR DESCRIPTION
This PR comes to remove the blkin trace submodule, and all of its usages
including librados API methods and tests that used it.

since the opentelemetry tracing infrastructure becomes mature in ceph, and the blkin is out of use, we can safely remove/replace it

this cleanup also changes some of the messages that were carrying that blkin trace info,
so now those messages carries the o-tel trace info instead of blkin - but for backward compatibility we still support decode of blkin struct for old messages


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
