### PR TITLE
quincy: doc/rados: add prompts to add-or-rm-prompts.rst

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -95,7 +95,9 @@ without the ``mon.`` prefix (i.e., ``{mon-id}`` should be the ``a``
 on ``mon.a``).
 
 #. Create the default directory on the machine that will host your 
-   new monitor. :: 
+   new monitor:
+
+   .. prompt:: bash $
 
 	ssh {new-mon-host}
 	sudo mkdir /var/lib/ceph/mon/ceph-{mon-id}
@@ -103,36 +105,46 @@ on ``mon.a``).
 #. Create a temporary directory ``{tmp}`` to keep the files needed during 
    this process. This directory should be different from the monitor's default 
    directory created in the previous step, and can be removed after all the 
-   steps are executed. :: 
+   steps are executed:
+
+   .. prompt:: bash $
 
 	mkdir {tmp}
 
 #. Retrieve the keyring for your monitors, where ``{tmp}`` is the path to 
    the retrieved keyring, and ``{key-filename}`` is the name of the file 
-   containing the retrieved monitor key. :: 
+   containing the retrieved monitor key:
 
-	ceph auth get mon. -o {tmp}/{key-filename}
+   .. prompt:: bash $
+
+      ceph auth get mon. -o {tmp}/{key-filename}
 
 #. Retrieve the monitor map, where ``{tmp}`` is the path to 
    the retrieved monitor map, and ``{map-filename}`` is the name of the file 
-   containing the retrieved monitor map. :: 
+   containing the retrieved monitor map:
 
-	ceph mon getmap -o {tmp}/{map-filename}
+   .. prompt:: bash $
+
+      ceph mon getmap -o {tmp}/{map-filename}
 
 #. Prepare the monitor's data directory created in the first step. You must 
    specify the path to the monitor map so that you can retrieve the 
    information about a quorum of monitors and their ``fsid``. You must also 
-   specify a path to the monitor keyring:: 
+   specify a path to the monitor keyring:
+   
+   .. prompt:: bash $
 
-	sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
+      sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
 	
 
 #. Start the new monitor and it will automatically join the cluster.
    The daemon needs to know which address to bind to, via either the
    ``--public-addr {ip}`` or ``--public-network {network}`` argument.
-   For example::
+   For example:
+   
+   .. prompt:: bash $
 
-	ceph-mon -i {mon-id} --public-addr {ip:port}
+      ceph-mon -i {mon-id} --public-addr {ip:port}
 
 .. _removing-monitors:
 
@@ -154,13 +166,17 @@ procedure results in only two monitor daemons, you may add or remove another
 monitor until you have a number of ``ceph-mon`` daemons that can achieve a 
 quorum.
 
-#. Stop the monitor. ::
+#. Stop the monitor:
 
-	service ceph -a stop mon.{mon-id}
+   .. prompt:: bash $
+
+      service ceph -a stop mon.{mon-id}
 	
-#. Remove the monitor from the cluster. ::
+#. Remove the monitor from the cluster:
 
-	ceph mon remove {mon-id}
+   .. prompt:: bash $
+
+      ceph mon remove {mon-id}
 	
 #. Remove the monitor entry from ``ceph.conf``. 
 
@@ -174,38 +190,61 @@ cluster, for example a cluster where the monitors cannot form a
 quorum.
 
 
-#. Stop all ``ceph-mon`` daemons on all monitor hosts. ::
+#. Stop all ``ceph-mon`` daemons on all monitor hosts:
 
-	ssh {mon-host}
-	systemctl stop ceph-mon.target
-	# and repeat for all mons
+   .. prompt:: bash $
 
-#. Identify a surviving monitor and log in to that host. :: 
+      ssh {mon-host}
+      systemctl stop ceph-mon.target
 
-	ssh {mon-host}
+    Repeat for all monitor hosts.
 
-#. Extract a copy of the monmap file.  ::
+#. Identify a surviving monitor and log in to that host:
 
-        ceph-mon -i {mon-id} --extract-monmap {map-path}
-        # in most cases, that's
-        ceph-mon -i `hostname` --extract-monmap /tmp/monmap
+   .. prompt:: bash $
+
+      ssh {mon-host}
+
+#. Extract a copy of the monmap file:
+
+   .. prompt:: bash $
+
+      ceph-mon -i {mon-id} --extract-monmap {map-path}
+
+   In most cases, this command will be:
+
+   .. prompt:: bash $
+
+      ceph-mon -i `hostname` --extract-monmap /tmp/monmap
 
 #. Remove the non-surviving or problematic monitors.  For example, if
    you have three monitors, ``mon.a``, ``mon.b``, and ``mon.c``, where
-   only ``mon.a`` will survive, follow the example below::
+   only ``mon.a`` will survive, follow the example below:
 
-	monmaptool {map-path} --rm {mon-id}
-	# for example,
-	monmaptool /tmp/monmap --rm b
-	monmaptool /tmp/monmap --rm c
+   .. prompt:: bash $
+
+      monmaptool {map-path} --rm {mon-id}
+
+   For example,
+
+   .. prompt:: bash $
+
+      monmaptool /tmp/monmap --rm b
+      monmaptool /tmp/monmap --rm c
 	
 #. Inject the surviving map with the removed monitors into the
    surviving monitor(s).  For example, to inject a map into monitor
-   ``mon.a``, follow the example below::
+   ``mon.a``, follow the example below:
 
-	ceph-mon -i {mon-id} --inject-monmap {map-path}
-	# for example,
-	ceph-mon -i a --inject-monmap /tmp/monmap
+   .. prompt:: bash $
+
+      ceph-mon -i {mon-id} --inject-monmap {map-path}
+
+   For example:
+
+   .. prompt:: bash $
+
+      ceph-mon -i a --inject-monmap /tmp/monmap
 
 #. Start only the surviving monitors.
 


### PR DESCRIPTION
Add unselectable prompts to add-or-rm-prompts.rst. This commit covers the first 300 lines of the file. This is part 1 of 2.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 6f4b64df349320a3c4cf7bf355c646f6b458525f)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
