### PR TITLE
doc/rados: add prompts to add-or-rm-prompts.rst

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -197,7 +197,7 @@ quorum.
       ssh {mon-host}
       systemctl stop ceph-mon.target
 
-    Repeat for all monitor hosts.
+   Repeat for all monitor hosts.
 
 #. Identify a surviving monitor and log in to that host:
 
@@ -355,14 +355,20 @@ networks  are unable to communicate.  Use the following procedure:
 
 #. Retrieve the monitor map, where ``{tmp}`` is the path to 
    the retrieved monitor map, and ``{filename}`` is the name of the file 
-   containing the retrieved monitor map. :: 
+   containing the retrieved monitor map:
 
-	ceph mon getmap -o {tmp}/{filename}
+   .. prompt:: bash $
 
-#. The following example demonstrates the contents of the monmap. ::
+      ceph mon getmap -o {tmp}/{filename}
 
-	$ monmaptool --print {tmp}/{filename}
-	
+#. The following example demonstrates the contents of the monmap:
+
+   .. prompt:: bash $
+
+      monmaptool --print {tmp}/{filename}
+
+   ::	
+
 	monmaptool: monmap file {tmp}/{filename}
 	epoch 1
 	fsid 224e376d-c5fe-4504-96bb-ea6332a19e61
@@ -372,27 +378,41 @@ networks  are unable to communicate.  Use the following procedure:
 	1: 10.0.0.2:6789/0 mon.b
 	2: 10.0.0.3:6789/0 mon.c
 
-#. Remove the existing monitors. ::
+#. Remove the existing monitors:
 
-	$ monmaptool --rm a --rm b --rm c {tmp}/{filename}
+   .. prompt:: bash $
+
+      monmaptool --rm a --rm b --rm c {tmp}/{filename}
 	
+
+   ::
+
 	monmaptool: monmap file {tmp}/{filename}
 	monmaptool: removing a
 	monmaptool: removing b
 	monmaptool: removing c
 	monmaptool: writing epoch 1 to {tmp}/{filename} (0 monitors)
 
-#. Add the new monitor locations. ::
+#. Add the new monitor locations:
 
-	$ monmaptool --add a 10.1.0.1:6789 --add b 10.1.0.2:6789 --add c 10.1.0.3:6789 {tmp}/{filename}
+   .. prompt:: bash $
+
+      monmaptool --add a 10.1.0.1:6789 --add b 10.1.0.2:6789 --add c 10.1.0.3:6789 {tmp}/{filename}
+
+
+   ::
 	
-	monmaptool: monmap file {tmp}/{filename}
-	monmaptool: writing epoch 1 to {tmp}/{filename} (3 monitors)
+      monmaptool: monmap file {tmp}/{filename}
+      monmaptool: writing epoch 1 to {tmp}/{filename} (3 monitors)
 
-#. Check new contents. ::
+#. Check new contents:
 
-	$ monmaptool --print {tmp}/{filename}
+   .. prompt:: bash $
+
+       monmaptool --print {tmp}/{filename}
 	
+   ::
+
 	monmaptool: monmap file {tmp}/{filename}
 	epoch 1
 	fsid 224e376d-c5fe-4504-96bb-ea6332a19e61
@@ -409,9 +429,11 @@ monitors, and inject the modified monmap into each new monitor.
 #. First, make sure to stop all your monitors.  Injection must be done while 
    the daemon is not running.
 
-#. Inject the monmap. ::
+#. Inject the monmap: 
 
-	ceph-mon -i {mon-id} --inject-monmap {tmp}/{filename}
+   .. prompt:: bash $
+
+      ceph-mon -i {mon-id} --inject-monmap {tmp}/{filename}
 
 #. Restart the monitors.
 


### PR DESCRIPTION
Add unselectable prompts to add-or-rm-prompts.rst. This is part 2 of 2.

Signed-off-by: Zac Dover <zac.dover@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
