### PR TITLE
cmake: s/c-ares::c-ares/c-ares::cares/

### DIFF
--- a/cmake/modules/Buildc-ares.cmake
+++ b/cmake/modules/Buildc-ares.cmake
@@ -11,12 +11,14 @@ function(build_c_ares)
     BINARY_DIR "${C-ARES_BINARY_DIR}"
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
     INSTALL_COMMAND "")
-  add_library(c-ares::c-ares STATIC IMPORTED)
-  add_dependencies(c-ares::c-ares c-ares_ext)
-  set_target_properties(c-ares::c-ares PROPERTIES
+  add_library(c-ares::cares STATIC IMPORTED)
+  add_dependencies(c-ares::cares c-ares_ext)
+  set_target_properties(c-ares::cares PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${C-ARES_SOURCE_DIR};${C-ARES_BINARY_DIR}"
     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
     IMPORTED_LOCATION "${C-ARES_BINARY_DIR}/lib/libcares.a")
   # to appease find_package()
-  add_custom_target(c-ares DEPENDS c-ares::c-ares)
+  add_custom_target(c-ares DEPENDS c-ares::cares)
+  # to be compatible with old Seastar
+  add_library(c-ares::c-ares ALIAS c-ares::cares)
 endfunction()

--- a/cmake/modules/Findc-ares.cmake
+++ b/cmake/modules/Findc-ares.cmake
@@ -21,10 +21,12 @@ find_package_handle_standard_args(c-ares
     c-ares_LIBRARY
   VERSION_VAR c-ares_VERSION)
 
-if(c-ares_FOUND AND NOT (TARGET c-ares::c-ares))
-  add_library(c-ares::c-ares UNKNOWN IMPORTED)
-  set_target_properties(c-ares::c-ares PROPERTIES
+if(c-ares_FOUND AND NOT (TARGET c-ares::cares))
+  add_library(c-ares::cares UNKNOWN IMPORTED)
+  set_target_properties(c-ares::cares PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${c-ares_INCLUDE_DIR}"
     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
     IMPORTED_LOCATION "${c-ares_LIBRARY}")
+  # to be compatible with old Seastar
+  add_library(c-ares::c-ares ALIAS c-ares::cares)
 endif()


### PR DESCRIPTION
to be aligned with the c-ares upstream, which provides c-ares-config.cmake in c-ares v1.17 and up. this cmake config file is also packaged by fedora and CentOS stream in c-ares-devel-1.17.1 and up.

this change prepares us for bumping up Seastar submodule, which also has a similar change: https://github.com/scylladb/seastar/commit/aea45c98f255e2013d4b9b399944e9810ee1d972

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
