### PR TITLE
mon/Elector: Change how we handle removed_ranks and notify_rank_removed() 

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -496,7 +496,7 @@ function test_run_mon() {
 
     setup $dir || return 1
 
-    run_mon $dir a --mon-initial-members=a || return 1
+    run_mon $dir a || return 1
     ceph mon dump | grep "mon.a" || return 1
     kill_daemons $dir || return 1
 

--- a/qa/standalone/mon/misc.sh
+++ b/qa/standalone/mon/misc.sh
@@ -169,7 +169,6 @@ function TEST_mon_features() {
     MONC=127.0.0.1:7129 # git grep '\<7129\>' ; there must be only one
     CEPH_ARGS_orig=$CEPH_ARGS
     CEPH_ARGS="--fsid=$fsid --auth-supported=none "
-    CEPH_ARGS+="--mon-initial-members=a,b,c "
     CEPH_ARGS+="--mon-host=$MONA,$MONB,$MONC "
     CEPH_ARGS+="--mon-debug-no-initial-persistent-features "
     CEPH_ARGS+="--mon-debug-no-require-reef "

--- a/qa/standalone/mon/mon-bind.sh
+++ b/qa/standalone/mon/mon-bind.sh
@@ -60,7 +60,6 @@ function TEST_mon_client_connect_fails() {
 
     # start the mon with a public-bind-addr that is different
     # from the public-addr.
-    CEPH_ARGS+="--mon-initial-members=a "
     CEPH_ARGS+="--mon-host=${MON_IP}:${MONA_PUBLIC} "
     run_mon $dir a --mon-host=${MON_IP}:${MONA_PUBLIC} --public-bind-addr=${MON_IP}:${MONA_BIND} || return 1
 
@@ -74,7 +73,6 @@ function TEST_mon_client_connect() {
 
     # start the mon with a public-bind-addr that is different
     # from the public-addr.
-    CEPH_ARGS+="--mon-initial-members=a "
     CEPH_ARGS+="--mon-host=${MON_IP}:${MONA_PUBLIC} "
     run_mon $dir a --mon-host=${MON_IP}:${MONA_PUBLIC} --public-bind-addr=${MON_IP}:${MONA_BIND} || return 1
 
@@ -90,7 +88,6 @@ function TEST_mon_quorum() {
 
     # start the mon with a public-bind-addr that is different
     # from the public-addr.
-    CEPH_ARGS+="--mon-initial-members=a,b,c "
     CEPH_ARGS+="--mon-host=${MON_IP}:${MONA_PUBLIC},${MON_IP}:${MONB_PUBLIC},${MON_IP}:${MONC_PUBLIC} "
     run_mon $dir a --public-addr=${MON_IP}:${MONA_PUBLIC} --public-bind-addr=${MON_IP}:${MONA_BIND} || return 1
     run_mon $dir b --public-addr=${MON_IP}:${MONB_PUBLIC} --public-bind-addr=${MON_IP}:${MONB_BIND} || return 1
@@ -117,7 +114,6 @@ function TEST_put_get() {
 
     # start the mon with a public-bind-addr that is different
     # from the public-addr.
-    CEPH_ARGS+="--mon-initial-members=a,b,c "
     CEPH_ARGS+="--mon-host=${MON_IP}:${MONA_PUBLIC},${MON_IP}:${MONB_PUBLIC},${MON_IP}:${MONC_PUBLIC} "
     run_mon $dir a --public-addr=${MON_IP}:${MONA_PUBLIC} --public-bind-addr=${MON_IP}:${MONA_BIND} || return 1
     run_mon $dir b --public-addr=${MON_IP}:${MONB_PUBLIC} --public-bind-addr=${MON_IP}:${MONB_BIND} || return 1

--- a/qa/standalone/mon/mon-handle-forward.sh
+++ b/qa/standalone/mon/mon-handle-forward.sh
@@ -28,7 +28,7 @@ function run() {
         FSID=$(uuidgen)
         export CEPH_ARGS
         CEPH_ARGS+="--fsid=$FSID --auth-supported=none "
-        CEPH_ARGS+="--mon-initial-members=a,b --mon-host=$MONA,$MONB "
+        CEPH_ARGS+="--mon-host=$MONA,$MONB "
         run_mon $dir a --public-addr $MONA || return 1
         run_mon $dir b --public-addr $MONB || return 1
     )

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -152,6 +152,7 @@ class ConnectionTracker {
     encoding.clear();
     peer_reports.clear();
     my_reports = ConnectionReport();
+    my_reports.rank = rank;
   }
 
  public:
@@ -180,6 +181,10 @@ class ConnectionTracker {
     my_reports = o.my_reports;
   }
   void notify_reset() { clear_peer_reports(); }
+  void set_rank(int new_rank) {
+    rank = new_rank;
+    my_reports.rank = rank;
+  }
   void notify_rank_changed(int new_rank);
   void notify_rank_removed(int rank_removed, int new_rank);
   friend std::ostream& operator<<(std::ostream& o, const ConnectionTracker& c);

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -181,7 +181,7 @@ class ConnectionTracker {
   }
   void notify_reset() { clear_peer_reports(); }
   void notify_rank_changed(int new_rank);
-  void notify_rank_removed(int rank_removed);
+  void notify_rank_removed(int rank_removed, int new_rank);
   friend std::ostream& operator<<(std::ostream& o, const ConnectionTracker& c);
   friend ConnectionReport *get_connection_reports(ConnectionTracker& ct);
   friend std::map<int,ConnectionReport> *get_peer_reports(ConnectionTracker& ct);

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -121,6 +121,13 @@ class ConnectionTracker {
   void get_total_connection_score(int peer_rank, double *rating,
 				  int *live_count) const;
   /**
+  * Check if our ranks are clean and make
+  * sure there are no extra peer_report lingering.
+  * In the future we also want to check the reports
+  * current and history of each peer_report.
+  */
+  bool is_clean(int mon_rank, int monmap_size);
+  /**
    * Encode this ConnectionTracker. Useful both for storing on disk
    * and for sending off to peers for decoding and import
    * with receive_peer_report() above.
@@ -185,6 +192,7 @@ class ConnectionTracker {
     rank = new_rank;
     my_reports.rank = rank;
   }
+
   void notify_rank_changed(int new_rank);
   void notify_rank_removed(int rank_removed, int new_rank);
   friend std::ostream& operator<<(std::ostream& o, const ConnectionTracker& c);

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -718,8 +718,11 @@ void Elector::start_participating()
 
 void Elector::notify_clear_peer_state()
 {
-  dout(10) << __func__ << dendl; 
+  dout(10) << __func__ << dendl;
+  dout(20) << " peer_tracker before: " << peer_tracker << dendl;
   peer_tracker.notify_reset();
+  peer_tracker.set_rank(mon->rank);
+  dout(20) << " peer_tracker after: " << peer_tracker << dendl;
 }
 
 void Elector::notify_rank_changed(int new_rank)

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -64,7 +64,7 @@ Elector::Elector(Monitor *m, int strategy) : logic(this, static_cast<ElectionLog
 						   m->cct),
 					     peer_tracker(this, m->rank,
 					    m->cct->_conf.get_val<uint64_t>("mon_con_tracker_score_halflife"),
-					    m->cct->_conf.get_val<uint64_t>("mon_con_tracker_persist_interval")),
+					    m->cct->_conf.get_val<uint64_t>("mon_con_tracker_persist_interval"), m->cct),
 			       ping_timeout(m->cct->_conf.get_val<double>("mon_elector_ping_timeout")),
 			       PING_DIVISOR(m->cct->_conf.get_val<uint64_t>("mon_elector_ping_divisor")),
 			       mon(m), elector(this) {
@@ -87,6 +87,7 @@ void Elector::persist_epoch(epoch_t e)
 
 void Elector::persist_connectivity_scores()
 {
+  dout(20) << __func__ << dendl;
   auto t(std::make_shared<MonitorDBStore::Transaction>());
   t->put(Monitor::MONITOR_NAME, "connectivity_scores", peer_tracker.get_encoded_bl());
   mon->store->apply_transaction(t);
@@ -222,7 +223,8 @@ void Elector::cancel_timer()
 
 void Elector::assimilate_connection_reports(const bufferlist& tbl)
 {
-  ConnectionTracker pct(tbl);
+  dout(10) << __func__ << dendl;
+  ConnectionTracker pct(tbl, mon->cct);
   peer_tracker.receive_peer_report(pct);
 }
 
@@ -311,7 +313,7 @@ void Elector::handle_propose(MonOpRequestRef op)
   }
   ConnectionTracker *oct = NULL;
   if (m->sharing_bl.length()) {
-    oct = new ConnectionTracker(m->sharing_bl);
+    oct = new ConnectionTracker(m->sharing_bl, mon->cct);
   }
   logic.receive_propose(from, m->epoch, oct);
   delete oct;
@@ -451,7 +453,9 @@ void Elector::handle_nak(MonOpRequestRef op)
 
 void Elector::begin_peer_ping(int peer)
 {
+  dout(20) << __func__ << " against " << peer << dendl;
   if (live_pinging.count(peer)) {
+    dout(20) << peer << " already in live_pinging ... return " << dendl;
     return;
   }
 
@@ -459,8 +463,6 @@ void Elector::begin_peer_ping(int peer)
 				      ceph::features::mon::FEATURE_PINGING)) {
     return;
   }
-
-  dout(5) << __func__ << " against " << peer << dendl;
 
   peer_tracker.report_live_connection(peer, 0); // init this peer as existing
   live_pinging.insert(peer);
@@ -563,9 +565,8 @@ void Elector::dead_ping(int peer)
 void Elector::handle_ping(MonOpRequestRef op)
 {
   MMonPing *m = static_cast<MMonPing*>(op->get_req());
-  dout(10) << __func__ << " " << *m << dendl;
-
   int prank = mon->monmap->get_rank(m->get_source_addr());
+  dout(20) << __func__ << " from: " << prank << dendl;
   begin_peer_ping(prank);
   assimilate_connection_reports(m->tracker_bl);
   switch(m->op) {
@@ -577,19 +578,28 @@ void Elector::handle_ping(MonOpRequestRef op)
     break;
 
   case MMonPing::PING_REPLY:
+
     const utime_t& previous_acked = peer_acked_ping[prank];
     const utime_t& newest = peer_sent_ping[prank];
+
     if (m->stamp > newest && !newest.is_zero()) {
       derr << "dropping PING_REPLY stamp " << m->stamp
 	   << " as it is newer than newest sent " << newest << dendl;
       return;
     }
+
     if (m->stamp > previous_acked) {
+      dout(20) << "m->stamp > previous_acked" << dendl;
       peer_tracker.report_live_connection(prank, m->stamp - previous_acked);
       peer_acked_ping[prank] = m->stamp;
+    } else{
+      dout(20) << "m->stamp <= previous_acked .. we don't report_live_connection" << dendl;
     }
     utime_t now = ceph_clock_now();
+    dout(30) << "now: " << now << " m->stamp: " << m->stamp << " ping_timeout: "
+      << ping_timeout << " PING_DIVISOR: " << PING_DIVISOR << dendl;
     if (now - m->stamp > ping_timeout / PING_DIVISOR) {
+      dout(30) << "(now - m->stamp > ping_timeout / PING_DIVISOR)" << dendl;
       send_peer_ping(prank, &now);
     }
     break;
@@ -615,7 +625,6 @@ void Elector::dispatch(MonOpRequestRef op)
       }
 
       auto em = op->get_req<MMonElection>();
-
       // assume an old message encoding would have matched
       if (em->fsid != mon->monmap->fsid) {
 	dout(0) << " ignoring election msg fsid " 
@@ -708,11 +717,13 @@ void Elector::start_participating()
 
 void Elector::notify_clear_peer_state()
 {
+  dout(10) << __func__ << dendl; 
   peer_tracker.notify_reset();
 }
 
 void Elector::notify_rank_changed(int new_rank)
 {
+  dout(10) << __func__ << " to " << new_rank << dendl; 
   peer_tracker.notify_rank_changed(new_rank);
   live_pinging.erase(new_rank);
   dead_pinging.erase(new_rank);
@@ -720,6 +731,7 @@ void Elector::notify_rank_changed(int new_rank)
 
 void Elector::notify_rank_removed(unsigned rank_removed)
 {
+  dout(10) << __func__ << ": " << rank_removed << dendl; 
   peer_tracker.notify_rank_removed(rank_removed);
   /* we have to clean up the pinging state, which is annoying
      because it's not indexed anywhere (and adding indexing

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -625,6 +625,7 @@ void Elector::dispatch(MonOpRequestRef op)
       }
 
       auto em = op->get_req<MMonElection>();
+      dout(20) << __func__ << " from: " << mon->monmap->get_rank(em->get_source_addr()) << dendl;
       // assume an old message encoding would have matched
       if (em->fsid != mon->monmap->fsid) {
 	dout(0) << " ignoring election msg fsid " 
@@ -729,10 +730,10 @@ void Elector::notify_rank_changed(int new_rank)
   dead_pinging.erase(new_rank);
 }
 
-void Elector::notify_rank_removed(unsigned rank_removed)
+void Elector::notify_rank_removed(unsigned rank_removed, unsigned new_rank)
 {
   dout(10) << __func__ << ": " << rank_removed << dendl; 
-  peer_tracker.notify_rank_removed(rank_removed);
+  peer_tracker.notify_rank_removed(rank_removed, new_rank);
   /* we have to clean up the pinging state, which is annoying
      because it's not indexed anywhere (and adding indexing
      would also be annoying).

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -716,6 +716,11 @@ void Elector::start_participating()
   logic.participating = true;
 }
 
+bool Elector::peer_tracker_is_clean()
+{
+  return peer_tracker.is_clean(mon->rank, paxos_size());
+}
+
 void Elector::notify_clear_peer_state()
 {
   dout(10) << __func__ << dendl;

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -358,6 +358,11 @@ class Elector : public ElectionOwner, RankProvider {
    */
   void start_participating();
   /**
+  * Check if our peer_tracker is self-consistent, not suffering from
+  * https://tracker.ceph.com/issues/58049
+  */
+  bool peer_tracker_is_clean();
+  /**
    * Forget everything about our peers. :(
    */
   void notify_clear_peer_state();

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -371,7 +371,7 @@ class Elector : public ElectionOwner, RankProvider {
    * This is safe to call even if we haven't joined or are currently
    * in a quorum.
    */
-  void notify_rank_removed(unsigned rank_removed);
+  void notify_rank_removed(unsigned rank_removed, unsigned new_rank);
   void notify_strategy_maybe_changed(int strategy);
   /**
    * Set the disallowed leaders.

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -368,7 +368,7 @@ void MonMap::print_summary(ostream& out) const
     out << p->first << "=" << p->second.public_addrs;
     has_printed = true;
   }
-  out << "}";
+  out << "}" << " removed_ranks: {" << removed_ranks << "}";
 }
  
 void MonMap::print(ostream& out) const
@@ -412,6 +412,7 @@ void MonMap::dump(Formatter *f) const
   f->dump_stream("disallowed_leaders: ") << disallowed_leaders;
   f->dump_bool("stretch_mode", stretch_mode_enabled);
   f->dump_string("tiebreaker_mon", tiebreaker_mon);
+  f->dump_stream("removed_ranks: ") << removed_ranks;
   f->open_object_section("features");
   persistent_features.dump(f, "persistent");
   optional_features.dump(f, "optional");

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -943,7 +943,15 @@ int Monitor::init()
   osdmon()->get_filestore_osd_list();
 
   state = STATE_PROBING;
+
   bootstrap();
+
+  if (!elector.peer_tracker_is_clean()){
+    dout(10) << "peer_tracker looks inconsistent"
+      << " previous bad logic, clearing ..." << dendl;
+    elector.notify_clear_peer_state();
+  }
+
   // add features of myself into feature_map
   session_map.feature_map.add_mon(con_self->get_features());
   return 0;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6624,10 +6624,19 @@ void Monitor::notify_new_monmap(bool can_change_external_state, bool remove_rank
     dout(10) << __func__ << " we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
     for (auto i = monmap->removed_ranks.rbegin();
         i != monmap->removed_ranks.rend(); ++i) {
-      int rank = *i;
-      dout(10) << __func__ << " removing rank " << rank << dendl;
+      int remove_rank = *i;
+      dout(10) << __func__ << " removing rank " << remove_rank << dendl;
+      if (rank == remove_rank) {
+        dout(5) << "We are removing our own rank, probably we"
+          << " are removed from monmap before we shutdown ... dropping." << dendl;
+        continue;
+      }
       int new_rank = monmap->get_rank(messenger->get_myaddrs());
-      elector.notify_rank_removed(rank, new_rank);
+      if (new_rank == -1) {
+        dout(5) << "We no longer exists in the monmap! ... dropping." << dendl;
+        continue;
+      }
+      elector.notify_rank_removed(remove_rank, new_rank);
     }
   }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1996,10 +1996,16 @@ void Monitor::handle_probe_reply(MonOpRequestRef op)
 			       !has_ever_joined)) {
       dout(10) << " got newer/committed monmap epoch " << newmap->get_epoch()
 	       << ", mine was " << monmap->get_epoch() << dendl;
+      int epoch_diff = newmap->get_epoch() - monmap->get_epoch();
       delete newmap;
       monmap->decode(m->monmap_bl);
-      notify_new_monmap(false);
-
+      dout(20) << "has_ever_joined: " << has_ever_joined << dendl;
+      if (epoch_diff == 1 && has_ever_joined) {
+        notify_new_monmap(false);
+      } else {
+        notify_new_monmap(false, false);
+        elector.notify_clear_peer_state();
+      }
       bootstrap();
       return;
     }
@@ -6595,7 +6601,7 @@ void Monitor::set_mon_crush_location(const string& loc)
   need_set_crush_loc = true;
 }
 
-void Monitor::notify_new_monmap(bool can_change_external_state)
+void Monitor::notify_new_monmap(bool can_change_external_state, bool remove_rank_elector)
 {
   if (need_set_crush_loc) {
     auto my_info_i = monmap->mon_info.find(name);
@@ -6605,12 +6611,16 @@ void Monitor::notify_new_monmap(bool can_change_external_state)
     }
   }
   elector.notify_strategy_maybe_changed(monmap->strategy);
-  dout(30) << __func__ << "we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
-  for (auto i = monmap->removed_ranks.rbegin();
-       i != monmap->removed_ranks.rend(); ++i) {
-    unsigned rank = *i;
-    dout(10) << __func__ << "removing rank " << rank << dendl;
-    elector.notify_rank_removed(rank);
+  if (remove_rank_elector){
+    dout(10) << __func__ << " we have " << monmap->ranks.size()<< " ranks" << dendl;
+    dout(10) << __func__ << " we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
+    for (auto i = monmap->removed_ranks.rbegin();
+        i != monmap->removed_ranks.rend(); ++i) {
+      int rank = *i;
+      dout(10) << __func__ << " removing rank " << rank << dendl;
+      int new_rank = monmap->get_rank(messenger->get_myaddrs());
+      elector.notify_rank_removed(rank, new_rank);
+    }
   }
 
   if (monmap->stretch_mode_enabled) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -876,7 +876,7 @@ public:
   /** can_change_external_state if we can do things like
    *  call elections as a result of the new map.
    */
-  void notify_new_monmap(bool can_change_external_state=false);
+  void notify_new_monmap(bool can_change_external_state=false, bool remove_rank_elector=true);
 
 public:
   struct C_Command : public C_MonOp {

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -129,7 +129,7 @@ void MonmapMonitor::create_pending()
   pending_map = *mon.monmap;
   pending_map.epoch++;
   pending_map.last_changed = ceph_clock_now();
-  dout(10) << __func__ << " monmap epoch " << pending_map.epoch << dendl;
+  pending_map.removed_ranks.clear();
 }
 
 void MonmapMonitor::encode_pending(MonitorDBStore::TransactionRef t)
@@ -755,8 +755,6 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     pending_map.remove(name);
     pending_map.disallowed_leaders.erase(name);
     pending_map.last_changed = ceph_clock_now();
-    ss << "removing mon." << name << " at " << addrs
-       << ", there will be " << pending_map.size() << " monitors" ;
     propose = true;
     err = 0;
 

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -106,7 +106,7 @@ struct Owner : public ElectionOwner, RankProvider {
  Owner(int r, ElectionLogic::election_strategy es, double tracker_halflife,
        Election *p) : parent(p), rank(r), persisted_epoch(0),
     ever_joined(false),
-    peer_tracker(this, rank, tracker_halflife, 5),
+    peer_tracker(this, rank, tracker_halflife, 5, g_ceph_context),
     logic(this, es, &peer_tracker, 0.0005, g_ceph_context),
     victory_accepters(0),
     timer_steps(-1), timer_election(true) {

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -124,9 +124,13 @@ struct Owner : public ElectionOwner, RankProvider {
   // don't need to do anything with our state right now
   void notify_bump_epoch() {}
   void notify_rank_removed(int removed_rank) {
-    peer_tracker.notify_rank_removed(removed_rank);
-    if (rank > removed_rank)
+    ldout(g_ceph_context, 1) << "removed_rank: " << removed_rank << dendl;
+    ldout(g_ceph_context, 1) << "rank before: " << rank << dendl;
+    if (removed_rank < rank) {
       --rank;
+    }
+    peer_tracker.notify_rank_removed(removed_rank, rank);
+    ldout(g_ceph_context, 1) << "rank after: " << rank << dendl;
   }
   void notify_deleted() { rank_deleted = true; rank = -1; cancel_timer(); }
   // pass back to ElectionLogic; we don't need this redirect ourselves
@@ -216,7 +220,7 @@ struct Owner : public ElectionOwner, RankProvider {
     }
   }
   void receive_scores(bufferlist bl) {
-    ConnectionTracker oct(bl);
+    ConnectionTracker oct(bl, g_ceph_context);
     peer_tracker.receive_peer_report(oct);
     ldout(g_ceph_context, 10) << "received scores " << oct << dendl;
   }
@@ -362,7 +366,7 @@ void Election::propose_to(int from, int to, epoch_t e, bufferlist& cbl)
   Owner *o = electors[to];
   ConnectionTracker *oct = NULL;
   if (cbl.length()) {
-    oct = new ConnectionTracker(cbl); // we leak these on blocked cons, meh
+    oct = new ConnectionTracker(cbl, g_ceph_context); // we leak these on blocked cons, meh
   }
   queue_election_message(from, to, [o, from, e, oct] {
       o->receive_propose(from, e, oct);


### PR DESCRIPTION
Problem:

Currently, there is an issue when performing a DR test with 2 sites stretch cluster
where removing monitors and adding new ones to the cluster
causes incorrect ``rank`` in ConnectionTracker class.

This causes the monitor to think that they are someone else
in the ``peer_tracker`` copy and will never update the
correct field of itself, causing a deadlock in the election process (Ceph becoming unresponsive)
when using election strategy: 3 (Connectivity mode).

Solution:

1. It was really hard to debug the issue so the first thing we did was to add additional loggings to ConnectionTracker,
Elector and ElectionLogic Classes.

2. In `ConnectionTracker::receive_peer_report` we loop through ranks which is bad when there is `notify_rank_removed` before this and the ranks are not adjusted yet. When we rely on the rank in certain scenarios, we end up with extra peer_report copy which we don't want. Therefore, instead of passing `report.rank` in the function
`ConnectionTracker::reports`, we pass `i.first` instead so that we trim old ranks properly. We also added an assert in notify_rank_removed(), comparing the expected rank provided by the monmap against the rank that we adjust ourselves to as a sanity check. We edited test/mon/test_election.cc to reflect the changes made in notify_rank_removed().

3. MonMap::removed_rank does not get cleared every update of the epoch, this was the root cause of the problem. Therefore, we fix this by making MonMap clear removed_ranks every update. Moreover, When there is discontinuity between monmaps for more than 1 epoch or the new monitor never joined the quorum before,
we always reset `peer_tracker`.

4. Added a way for us to manually reset `peer_tracker.rank` when executing the command: `ceph connection scores reset` for each monitor. The peer_tracker.rank will match the current rank of the Monitor.

5. When upgrading the monitors (including booting up), we check if `peer_tracker` is dirty or not. If so, we clear it. Added some functions in the `Elector` and `ConnectionTracker` classes to check for clean `peer_tracker`. Moreover, there could be some cases where due to startup weirdness or abnormal circumstances, we might get a report from our own rank. Therefore, it doesn't hurt to add a sanity check in `ConnectionTracker::report_live_connection` and `ConnectionTracker::report_dead_connection`.

6. --mon-initial-members does nothing but cause monmap
to populate ``removed_ranks``, therefore, remove all instances of --mon-initial-members in the standalone test as it has no impact on the nature of the tests themselves.

7. `Monitor::notify_new_monmap()` skips removal of non-exist rank
In RHCS the user can choose to manually remove a monitor rank
before shutting the monitor down. Causing inconsistency in monmap.
Therefore, in `Monitor::notify_new_monmap()` we prevent the function from going into removing our own rank or ranks that don't exist in monmap.

Fixes: https://tracker.ceph.com/issues/58049
Fixes: https://tracker.ceph.com/issues/58132

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
