### PR TITLE
[DNM] qa/suites: temporarily switch suites to the internal quay url

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/pacific.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/pacific.yaml
@@ -9,7 +9,7 @@ tasks:
       - ceph-volume
 - print: "**** done install task..."
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:pacific
+    image: quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:pacific
     roleless: true
     cephadm_branch: pacific
     cephadm_git_url: https://github.com/ceph/ceph

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
@@ -9,10 +9,10 @@ upgrade-tasks:
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
           - ceph config set global log_to_journald false --force
-          - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
+          - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types mgr
           - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
           - ceph versions | jq -e '.mgr | length == 1'
           - ceph versions | jq -e '.mgr | keys' | grep $sha1
           - ceph versions | jq -e '.overall | length == 2'
-          - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
+          - ceph orch upgrade check quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
           - ceph orch ps

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
@@ -11,7 +11,7 @@ upgrade-tasks:
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
           - ceph config set global log_to_journald false --force
-          - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+          - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
     - cephadm.shell:
         env: [sha1]
         host.a:

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/3-upgrade-with-workload.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/3-upgrade-with-workload.yaml
@@ -12,7 +12,7 @@ upgrade-tasks:
         - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
         - ceph config set global log_to_journald false --force
         - ceph mgr module enable nfs --force
-        - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+        - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
   - cephadm.shell:
       env: [sha1]
       host.a:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -11,4 +11,4 @@ tasks:
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
       - ceph config set global log_to_journald false --force
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -18,7 +18,7 @@ tasks:
       - ceph orch ls
       # doing staggered upgrade requires mgr daemons being on a version that contains the staggered upgrade code
       # until there is a stable version that contains it, we can test by manually upgrading a mgr daemon
-      - ceph config set mgr container_image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph config set mgr container_image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
       - ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)"
       - ceph orch ps --refresh
       - sleep 180
@@ -32,7 +32,7 @@ tasks:
       - sleep 180
       # now try upgrading the other mgr
       # we should now have access to --image flag for the daemon redeploy command
-      - ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
       - ceph orch ps --refresh
       - sleep 180
       # gather more possible debugging info
@@ -54,7 +54,7 @@ tasks:
       - ceph versions
       # to make sure mgr daemons upgrade is fully completed, including being deployed by a mgr on new new version
       # also serves as an early failure if manually upgrading the mgrs failed as --daemon-types won't be recognized
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types mgr
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       # verify only one version found for mgrs and that their version hash matches what we are upgrading to
       - ceph versions | jq -e '.mgr | length == 1'
@@ -62,50 +62,50 @@ tasks:
       # verify overall we still se two versions, basically to make sure --daemon-types wans't ignored and all daemons upgraded
       - ceph versions | jq -e '.overall | length == 2'
       # check that exactly two daemons have been upgraded to the new image (our 2 mgr daemons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
+      - ceph orch upgrade check quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
       # upgrade only the mons on one of the two hosts
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.x | awk '{print $2}')
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.x | awk '{print $2}')
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify tow different version seen for mons
       - ceph versions | jq -e '.mon | length == 2'
       # upgrade mons on the other hosts
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.y | awk '{print $2}')
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.y | awk '{print $2}')
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify all mons now on same version and version hash matches what we are upgrading to
       - ceph versions | jq -e '.mon | length == 1'
       - ceph versions | jq -e '.mon | keys' | grep $sha1
       # verify exactly 5 daemons are now upgraded (2 mgrs, 3 mons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'
+      - ceph orch upgrade check quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'
       # upgrade exactly 2 osd daemons
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types osd --limit 2
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types osd --limit 2
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify two different versions now seen for osds
       - ceph versions | jq -e '.osd | length == 2'
       # verify exactly 7 daemons have been upgraded (2 mgrs, 3 mons, 2 osds)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'
+      - ceph orch upgrade check quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'
       # upgrade one more osd
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd --limit 1
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types crash,osd --limit 1
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       - ceph versions | jq -e '.osd | length == 2'
       # verify now 8 daemons have been upgraded
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
+      - ceph orch upgrade check quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
       # upgrade the rest of the osds
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --daemon-types crash,osd
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify all osds are now on same version and version hash matches what we are upgrading to
       - ceph versions | jq -e '.osd | length == 1'
       - ceph versions | jq -e '.osd | keys' | grep $sha1
       # upgrade the rgw daemons using --services
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --services rgw.r.z
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1 --services rgw.r.z
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify all rgw daemons on same version and version hash matches what we are upgrading to
       - ceph versions | jq -e '.rgw | length == 1'
       - ceph versions | jq -e '.rgw | keys' | grep $sha1
       # run upgrade one more time with no filter parameters to make sure anything left gets upgraded
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1

--- a/qa/suites/upgrade/pacific-x/parallel/upgrade-sequence.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/upgrade-sequence.yaml
@@ -6,7 +6,7 @@ upgrade-sequence:
        env: [sha1]
        mon.a:
          - ceph config set global log_to_journald false --force
-         - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+         - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
          - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
          - ceph orch ps
          - ceph versions

--- a/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
@@ -54,7 +54,7 @@ first-half-sequence:
       - ceph config set mgr mgr/cephadm/daemon_cache_timeout 60
       - ceph config set global log_to_journald false --force
 
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
       - ceph orch ps
 
       - echo wait for minority of mons to upgrade

--- a/qa/suites/upgrade/quincy-x/parallel/upgrade-sequence.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/upgrade-sequence.yaml
@@ -6,7 +6,7 @@ upgrade-sequence:
        env: [sha1]
        mon.a:
          - ceph config set global log_to_journald false --force
-         - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+         - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
          - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
          - ceph orch ps
          - ceph versions

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -54,7 +54,7 @@ first-half-sequence:
       - ceph config set mgr mgr/cephadm/daemon_cache_timeout 60
       - ceph config set global log_to_journald false --force
 
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
       - ceph orch ps
 
       - echo wait for minority of mons to upgrade

--- a/qa/suites/upgrade/telemetry-upgrade/pacific-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/pacific-x/1-tasks.yaml
@@ -37,7 +37,7 @@ tasks:
         env: [sha1]
         mon.a:
             - ceph config set global log_to_journald false --force
-            - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+            - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
             - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
             - ceph orch ps
             - ceph versions

--- a/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/quincy-x/1-tasks.yaml
@@ -36,7 +36,7 @@ tasks:
         env: [sha1]
         mon.a:
             - ceph config set global log_to_journald false --force
-            - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+            - ceph orch upgrade start --image quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:$sha1
             - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
             - ceph orch ps
             - ceph versions

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -9,9 +9,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
-IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
-IMAGE_PACIFIC=${IMAGE_PACIFIC:-'quay.ceph.io/ceph-ci/ceph:pacific'}
-#IMAGE_OCTOPUS=${IMAGE_OCTOPUS:-'quay.ceph.io/ceph-ci/ceph:octopus'}
+IMAGE_MAIN=${IMAGE_MAIN:-'quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:main'}
+IMAGE_PACIFIC=${IMAGE_PACIFIC:-'quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:pacific'}
+#IMAGE_OCTOPUS=${IMAGE_OCTOPUS:-'quay-quay-quay.apps.os.sepia.ceph.com/ceph-ci/ceph:octopus'}
 IMAGE_DEFAULT=${IMAGE_MAIN}
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"


### PR DESCRIPTION
This commit is in light of https://tracker.ceph.com/issues/57914, where the quay.ceph.io VM was corrupted. This change should be temporary until we can make the new VM public-facing.

Still deciding if we actually want to go this route, but I'm posing it here as an option.

Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
