### PR TITLE
rbd-mirror: a way to perform mirror image checksum

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -493,6 +493,9 @@ Commands
   path to a JSON-encoded source-spec file using the *--source-spec-path*
   optionals.
 
+:command:`mirror image checksum` *image-spec*
+  Perform checksum validation on image for RBD mirroring.
+
 :command:`mirror image demote` *image-spec*
   Demote a primary image to non-primary for RBD mirroring.
 

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1311,6 +1311,8 @@ CEPH_RBD_API int rbd_metadata_remove(rbd_image_t image, const char *key);
 CEPH_RBD_API int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t max,
     char *keys, size_t *key_len, char *values, size_t *vals_len);
 
+CEPH_RBD_API int rbd_mirror_image_checksum(rbd_image_t image);
+
 // RBD image mirroring support functions
 CEPH_RBD_API int rbd_mirror_image_enable(rbd_image_t image) CEPH_RBD_DEPRECATED;
 CEPH_RBD_API int rbd_mirror_image_enable2(rbd_image_t image,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -811,6 +811,7 @@ public:
   int mirror_image_disable(bool force);
   int mirror_image_promote(bool force);
   int mirror_image_demote();
+  int mirror_image_checksum();
   int mirror_image_resync();
   int mirror_image_create_snapshot(uint64_t *snap_id);
   int mirror_image_create_snapshot2(uint32_t flags, uint64_t *snap_id);

--- a/src/librbd/api/Mirror.h
+++ b/src/librbd/api/Mirror.h
@@ -87,6 +87,7 @@ struct Mirror {
   static void image_promote(ImageCtxT *ictx, bool force, Context *on_finish);
   static int image_demote(ImageCtxT *ictx);
   static void image_demote(ImageCtxT *ictx, Context *on_finish);
+  static int image_checksum(ImageCtxT *ictx);
   static int image_resync(ImageCtxT *ictx);
   static int image_get_info(ImageCtxT *ictx,
                             mirror_image_info_t *mirror_image_info);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2939,6 +2939,12 @@ namespace librbd {
     return librbd::api::Mirror<>::image_demote(ictx);
   }
 
+  int Image::mirror_image_checksum()
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Mirror<>::image_checksum(ictx);
+  }
+
   int Image::mirror_image_resync()
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
@@ -6548,6 +6554,12 @@ extern "C" int rbd_mirror_image_resync(rbd_image_t image)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   return librbd::api::Mirror<>::image_resync(ictx);
+}
+
+extern "C" int rbd_mirror_image_checksum(rbd_image_t image)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::api::Mirror<>::image_checksum(ictx);
 }
 
 extern "C" int rbd_mirror_image_create_snapshot(rbd_image_t image,

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -83,6 +83,8 @@
       migration commit                  Commit image migration.
       migration execute                 Execute image migration.
       migration prepare                 Prepare image migration.
+      mirror image checksum             Perform checksum validation on image for
+                                        RBD mirroring.
       mirror image demote               Demote an image to non-primary for RBD
                                         mirroring.
       mirror image disable              Disable RBD mirroring for an image.
@@ -1620,6 +1622,22 @@
     (*) supports enabling/disabling on existing images
     (-) supports disabling-only on existing images
     (+) enabled by default for new images if features not specified
+  
+  rbd help mirror image checksum
+  usage: rbd mirror image checksum [--pool <pool>] [--namespace <namespace>] 
+                                   [--image <image>] 
+                                   <image-spec> 
+  
+  Perform checksum validation on image for RBD mirroring.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
   
   rbd help mirror image demote
   usage: rbd mirror image demote [--pool <pool>] [--namespace <namespace>] 


### PR DESCRIPTION
* librbd: add new API for mirror image checksum validation              
                                                                      
This API establishes a connection to the remote image and performs object-level checksum verification.

* rbd: CLI to perform mirror image checksum                    
```                                                             
$ rbd --cluster site-b mirror image checksum pool1/test_image
verified image checksum successfully.                        
```

* doc: update documentation about mirror image checksum operation

Fixes: https://tracker.ceph.com/issues/57988
Signed-off-by: Prasanna Kumar Kalever prasanna.kalever@redhat.com\>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
