### PR TITLE
mgr/restful: support for http requests

### DIFF
--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -197,6 +197,7 @@ class Module(MgrModule):
         {'name': 'server_port'},
         {'name': 'key_file'},
         {'name': 'enable_auth', 'type': 'bool', 'default': True},
+        {'name': 'https_mode', 'type': 'bool', 'default': True},
     ]
 
     COMMANDS = [
@@ -304,6 +305,7 @@ class Module(MgrModule):
             pkey_fname = self.get_localized_module_option('key_file')
 
         self.enable_auth = self.get_localized_module_option('enable_auth', True)
+        self.https_mode = self.get_localized_module_option('https_mode', True)
         
         if not cert_fname or not pkey_fname:
             raise CannotServe('no certificate configured')
@@ -315,7 +317,10 @@ class Module(MgrModule):
         # Publish the URI that others may use to access the service we're
         # about to start serving
         addr = self.get_mgr_ip() if server_addr == "::" else server_addr
-        self.set_uri(build_url(scheme='https', host=addr, port=server_port, path='/'))
+        if self.https_mode:
+            self.set_uri(build_url(scheme='https', host=addr, port=server_port, path='/'))
+        else:
+            self.set_uri(build_url(scheme='http', host=addr, port=server_port, path='/'))
 
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(


### PR DESCRIPTION
Support ceph config set mgr mgr/restful/https_mode false/true to control HTTP/HTTPS access.

Fixes: https://tracker.ceph.com/issues/58064

Signed-off-by: huangyuanchun <huangyuanchun_yewu@cmss.chinamobile.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
