### PR TITLE
qa: no need to link the test/scratch to the local directories

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -72,18 +72,12 @@ class XFSTestsDev(CephFSTestCase):
         # read var name as "test dir's mount path"
         self.test_dirs_mount_path = self.mount_a.client_remote.mkdtemp(
             suffix=self.test_dirname)
-        self.mount_a.run_shell(['sudo','ln','-s',join(self.mount_a.mountpoint,
-                                                      self.test_dirname),
-                                self.test_dirs_mount_path])
 
         self.scratch_dirname = 'scratch'
         self.mount_a.run_shell(['mkdir', self.scratch_dirname])
         # read var name as "scratch dir's mount path"
         self.scratch_dirs_mount_path = self.mount_a.client_remote.mkdtemp(
             suffix=self.scratch_dirname)
-        self.mount_a.run_shell(['sudo','ln','-s',join(self.mount_a.mountpoint,
-                                                      self.scratch_dirname),
-                                self.scratch_dirs_mount_path])
 
     def install_deps(self):
         from teuthology.misc import get_system_type


### PR DESCRIPTION
The xfstests-dev tool will mount the test/scratch to the local directories. The soft links here make no sense.

Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
