### PR TITLE
crimson/osd: Support Pool EIO flag

### DIFF
--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -14,6 +14,7 @@
 #include "include/stringify.h"
 #include "include/scope_guard.h"
 #include "common/ceph_mutex.h"
+#include <fmt/format.h>
 
 #include "test_cxx.h"
 #include "crimson_utils.h"
@@ -2295,9 +2296,14 @@ TEST(LibRadosAio, SimplePoolEIOFlag) {
     ASSERT_TRUE(my_completion);
 
     bufferlist empty;
-	  ASSERT_EQ(0, test_data.m_cluster.mon_command(
-	    "{\"prefix\": \"osd pool set\", \"pool\": \"" + test_data.m_pool_name +
-	    "\", \"var\": \"eio\", \"val\": \"true\"}", empty, nullptr, nullptr));
+    ASSERT_EQ(0, test_data.m_cluster.mon_command(
+      fmt::format(R"({{
+                  "prefix": "osd pool set",
+                  "pool": "{}",
+                  "var": "eio",
+                  "val": "true"
+                  }})", test_data.m_pool_name),
+      empty, nullptr, nullptr));
 
     bufferlist bl;
     bl.append("some data");
@@ -2338,8 +2344,13 @@ TEST(LibRadosAio, PoolEIOFlag) {
 	[&] {
 	  bufferlist empty;
 	  ASSERT_EQ(0, test_data.m_cluster.mon_command(
-	    "{\"prefix\": \"osd pool set\", \"pool\": \"" + test_data.m_pool_name +
-	    "\", \"var\": \"eio\", \"val\": \"true\"}", empty, nullptr, nullptr));
+	    fmt::format(R"({{
+	                "prefix": "osd pool set",
+	                "pool": "{}",
+	                "var": "eio",
+	                "val": "true"
+	                }})", test_data.m_pool_name),
+	    empty, nullptr, nullptr));
 	});
     }
 


### PR DESCRIPTION
```
$ CRIMSON_COMPAT=true RBD_FEATURES= bin/ceph_test_rados_api_aio_pp 
  --gtest_filter="LibRadosAio.*PoolEIOFlag" 
Running main() from gmock_main.cc
Note: Google Test filter = LibRadosAio.*PoolEIOFlag
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from LibRadosAio 
[ RUN      ] LibRadosAio.SimplePoolEIOFlag
[       OK ] LibRadosAio.SimplePoolEIOFlag (15634 ms) 
[ RUN      ] LibRadosAio.PoolEIOFlag  
setting pool EIO
waiting for 99,100
max_success 98, min_failed 99
[       OK ] LibRadosAio.PoolEIOFlag (16008 ms) 
[----------] 2 tests from LibRadosAio (31642 ms total)
[----------] Global test environment tear-down 
[==========] 2 tests from 1 test suite ran. (31642 ms total)  
[  PASSED  ] 2 tests.       
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
