### PR TITLE
cephfs-top: reset filters when no fs

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -855,6 +855,11 @@ class FSTop(object):
             if fs not in fs_list:
                 help = f"Error: The selected filesystem '{fs}' is not available now. " \
                     "[Press 'q' to go back to home (All Filesystem Info) screen]"
+                # reset the sort/limit settings if fs_list is empty, otherwise continue the
+                # settings for the other filesystems.
+                if not fs_list:
+                    current_states["last_field"] = 'chit'
+                    current_states["limit"] = None
                 self.header.erase()  # erase previous text
                 self.fsstats.erase()
                 self.create_header(stats_json, help, screen_title, 3)
@@ -981,6 +986,9 @@ class FSTop(object):
             vscrollEnd = 0
             if not fs_list:
                 help = "INFO: No filesystem is available [Press 'q' to quit]"
+                # reset the sort/limit settings
+                current_states["last_field"] = 'chit'
+                current_states["limit"] = None
                 self.header.erase()  # erase previous text
                 self.fsstats.erase()
                 self.create_header(stats_json, help, screen_title, 2)


### PR DESCRIPTION
No need to keep the sort/limit setting when the filesystems are removed. Use default setting for the upcoming new filesystems and clients.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>