### PR TITLE
*: include fmt/ostream.h if FMT_VERSION >= 9

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -19,6 +19,9 @@
 #include <iostream>
 #include <string>
 #include <optional>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 #include <sys/time.h>
 
 #if defined(__APPLE__)

--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -7,6 +7,9 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -16,6 +16,10 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
 namespace ceph {
   class Formatter;
 }

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -21,6 +21,9 @@
 #include <string_view>
 
 #include <boost/intrusive/list.hpp>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 
 #include "include/Context.h"
 #include "common/RefCountedObj.h"

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -8,6 +8,9 @@
 #include "common/hobject_fmt.h"
 #include "osd/osd_types.h"
 #include <fmt/chrono.h>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 
 template <>
 struct fmt::formatter<osd_reqid_t> {


### PR DESCRIPTION
before this change, we assume that `fmt/ostream.h` is included, and reference `fmt::ostream_formatter`. this breaks the build if the tree is compiled on {fmt} v9 and up.

after this change, `fmt/ostream.h` is conditionally included. as the compiling unit is supposed to include fmt headers before including headers in this project, we can tell if fmt/ostream.h is needed or not by checking the FMT_VERSION macro.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
