### PR TITLE
crimson: Suite testing minor adjustment

### DIFF
--- a/qa/suites/crimson-rados/thrash/thrashers/default.yaml
+++ b/qa/suites/crimson-rados/thrash/thrashers/default.yaml
@@ -1,5 +1,6 @@
 overrides:
   ceph:
+    wait-for-scrub: false
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
@@ -31,3 +32,4 @@ tasks:
     thrash_primary_affinity: false
     ceph_objectstore_tool: false
     chance_inject_pause_short: 0
+    chance_thrash_cluster_full: 0

--- a/src/test/librbd/test_DeepCopy.cc
+++ b/src/test/librbd/test_DeepCopy.cc
@@ -9,6 +9,7 @@
 #include "librbd/api/Snapshot.h"
 #include "librbd/internal.h"
 #include "librbd/io/ReadResult.h"
+#include "test/librados/crimson_utils.h"
 
 void register_test_deep_copy() {
 }
@@ -512,6 +513,7 @@ TEST_F(TestDeepCopy, Stress)
 
 TEST_F(TestDeepCopy, NoSnaps_LargerDstObjSize)
 {
+  SKIP_IF_CRIMSON();
   uint64_t order = m_src_ictx->order + 1;
   ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_ORDER, order));
 
@@ -520,6 +522,7 @@ TEST_F(TestDeepCopy, NoSnaps_LargerDstObjSize)
 
 TEST_F(TestDeepCopy, Snaps_LargerDstObjSize)
 {
+  SKIP_IF_CRIMSON();
   uint64_t order = m_src_ictx->order + 1;
   ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_ORDER, order));
 
@@ -550,6 +553,7 @@ TEST_F(TestDeepCopy, CloneFlatten_LargerDstObjSize)
 
 TEST_F(TestDeepCopy, Stress_LargerDstObjSize)
 {
+  SKIP_IF_CRIMSON();
   uint64_t order = m_src_ictx->order + 1 + rand() % 2;
   ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_ORDER, order));
 


### PR DESCRIPTION
* Skip LargerDstObjSize for Crimson until resolved. (Tracked WIP: [gist](https://gist.github.com/Matan-B/a659e0aae647d8e9d4e570edeab518b8))
* Do not wait for scrub and reduce `chance_thrash_cluster_full`.

Marked as draft until tested with:
#48527
#48831
#48682
#49075
~#49029~


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
