### PR TITLE
quincy: rgw: fix segfault in UserAsyncRefreshHandler::init_fetch

### DIFF
--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -973,7 +973,6 @@ int RGWSI_User_RADOS::read_stats_async(const DoutPrefixProvider *dpp, RGWSI_Meta
   RGWGetUserStatsContext *cb = new RGWGetUserStatsContext(_cb);
   int r = cls_user_get_header_async(dpp, user_str, cb);
   if (r < 0) {
-    _cb->put();
     delete cb;
     return r;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54493

---

backport of https://github.com/ceph/ceph/pull/44859
parent tracker: https://tracker.ceph.com/issues/54112

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh