### PR TITLE
quincy: do_cmake.sh: build with python3.10 on ubuntu version >= 22.0

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -42,6 +42,13 @@ if [ -r /etc/os-release ]; then
           ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
           ARGS+=" -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
           ;;
+      ubuntu)
+          MAJOR_VER=$(echo "$VERSION_ID" | sed -e 's/\..*$//')
+          if [ "$MAJOR_VER" -ge "22" ] ; then
+              PYBUILD="3.10"
+          fi
+          ;;
+
   esac
 elif [ "$(uname)" == FreeBSD ] ; then
   PYBUILD="3"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57463

---

backport of https://github.com/ceph/ceph/pull/47741
parent tracker: https://tracker.ceph.com/issues/57230

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh