### PR TITLE
quincy: rgw: adding BUCKET_REWRITE and OBJECT_REWRITE OPS to

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4241,7 +4241,9 @@ int main(int argc, const char **argv)
 			 OPT::OBJECTS_EXPIRE_STALE_RM,
 			 OPT::LC_PROCESS,
        OPT::BUCKET_SYNC_RUN,
-       OPT::DATA_SYNC_RUN
+       OPT::DATA_SYNC_RUN,
+       OPT::BUCKET_REWRITE,
+       OPT::OBJECT_REWRITE
     };
 
     raw_storage_op = (raw_storage_ops_list.find(opt_cmd) != raw_storage_ops_list.end() ||


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55227

---

backport of https://github.com/ceph/ceph/pull/45760
parent tracker: https://tracker.ceph.com/issues/54742

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh