### PR TITLE
quincy: rgw/coroutine: check for null stack on wakeup

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -1046,7 +1046,9 @@ bool RGWCoroutine::drain_children(int num_cr_left,
 
 void RGWCoroutine::wakeup()
 {
-  stack->wakeup();
+  if (stack) {
+    stack->wakeup();
+  }
 }
 
 RGWCoroutinesEnv *RGWCoroutine::get_env() const


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57237

---

backport of https://github.com/ceph/ceph/pull/47613
parent tracker: https://tracker.ceph.com/issues/56920

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh