### PR TITLE
client/fuse: set max_idle_threads to the correct value and add support for 3.12 API of libfuse

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1605,9 +1605,10 @@ int CephFuse::Handle::loop()
   if (fuse_multithreaded) {
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
     {
-      struct fuse_loop_config conf = { 0 };
-
-      conf.clone_fd = opts.clone_fd;
+      struct fuse_loop_config conf = {
+        clone_fd: opts.clone_fd,
+        max_idle_threads: opts.max_idle_threads
+      };
       return fuse_session_loop_mt(se, &conf);
     }
 #elif FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1603,7 +1603,21 @@ int CephFuse::Handle::loop()
   auto fuse_multithreaded = client->cct->_conf.get_val<bool>(
     "fuse_multithreaded");
   if (fuse_multithreaded) {
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 12)
+    {
+      struct fuse_loop_config *conf = fuse_loop_cfg_create();
+      ceph_assert(conf != nullptr);
+
+      fuse_loop_cfg_set_clone_fd(conf, opts.clone_fd);
+      fuse_loop_cfg_set_idle_threads(conf, opts.max_idle_threads);
+      fuse_loop_cfg_set_max_threads(conf, opts.max_threads);
+
+      int r = fuse_session_loop_mt(se, conf);
+
+      fuse_loop_cfg_destroy(conf);
+      return r;
+    }
+#elif FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
     {
       struct fuse_loop_config conf = {
         clone_fd: opts.clone_fd,

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -20,7 +20,7 @@
  * fuse.h is included.
  */
 #ifndef FUSE_USE_VERSION
-#define FUSE_USE_VERSION	35
+#define FUSE_USE_VERSION	312
 #endif
 
 #include <fuse.h>


### PR DESCRIPTION
I try to use ceph-fuse with libfuse3 and have a problem.
When the version of the libfuse is 3.1 or later, the fuse worker thread of ceph-fuse keeps recreating and deleting file or directory will be blocked forever.
It is caused by parameter 'max_idle_threads' being set to 0 and the relevant logic is in function 'fuse_do_work' of libfuse.
Parameter 'max_idle_threads' can be set by function 'fuse_parse_cmdline', it may be the default value(10 before version 3.12 and -1 after) or a value set by user. It should not be set to 0.

Fixes: https://tracker.ceph.com/issues/58109
Signed-off-by: Zhansong Gao <zhsgao@hotmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
