### PR TITLE
mgr/dashboard: build the dashboard from custom assets folder 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,6 +680,8 @@ endif()
 set(DASHBOARD_FRONTEND_LANGS "" CACHE STRING
   "List of comma separated ceph-dashboard frontend languages to build. \
   Use value `ALL` to build all languages")
+set(DASHBOARD_BUILD_ASSETS_FROM "" CACHE STRING
+  "Provide the name of the folder where the frontend should be loaded from.")
 CMAKE_DEPENDENT_OPTION(WITH_MGR_ROOK_CLIENT "Enable the mgr's Rook support" ON
   "WITH_MGR" OFF)
 

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -21,11 +21,12 @@ logger = logging.getLogger("controllers.home")
 
 class LanguageMixin(object):
     def __init__(self):
+        product_name = os.environ.get('DASHBOARD_BUILD_ASSETS_FROM', '')
         try:
             self.LANGUAGES = {
                 f
                 for f in os.listdir(mgr.get_frontend_path())
-                if os.path.isdir(os.path.join(mgr.get_frontend_path(), f))
+                if os.path.isdir(os.path.join(mgr.get_frontend_path(), product_name, f))
             }
         except FileNotFoundError:
             logger.exception("Build directory missing")
@@ -34,7 +35,7 @@ class LanguageMixin(object):
         self.LANGUAGES_PATH_MAP = {
             f.lower(): {
                 'lang': f,
-                'path': os.path.join(mgr.get_frontend_path(), f)
+                'path': os.path.join(mgr.get_frontend_path(), product_name, f)
             }
             for f in self.LANGUAGES
         }
@@ -50,6 +51,7 @@ class LanguageMixin(object):
             config = json.load(f)
         self.DEFAULT_LANGUAGE = config['config']['locale']
         self.DEFAULT_LANGUAGE_PATH = os.path.join(mgr.get_frontend_path(),
+                                                  product_name,
                                                   self.DEFAULT_LANGUAGE)
         super().__init__()
 


### PR DESCRIPTION
Using this new Environment variable called
`DASHBOARD_BUILD_ASSETS_FROM`, we can chose from which folder under the dist/* to serve the dashboard from.

Inorder to properly use this, while building the dashboard we need to set DASHBOARD_BUILD_ASSETS_FROM=rhceph.

From the frontend, we need to manually build assets into a folder named rhceph under the dist/ folder. If the folder is present, then the dashboard frontend will be served from the rhceph folder.

Fixes: https://tracker.ceph.com/issues/58108
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
