### PR TITLE
quincy: doc/rados: add prompts to balancer.rst

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -1,4 +1,3 @@
-
 .. _balancer:
 
 Balancer
@@ -11,9 +10,11 @@ supervised fashion.
 Status
 ------
 
-The current status of the balancer can be checked at any time with::
+The current status of the balancer can be checked at any time with:
 
-  ceph balancer status
+   .. prompt:: bash $
+
+      ceph balancer status
 
 
 Automatic balancing
@@ -21,9 +22,11 @@ Automatic balancing
 
 The automatic balancing feature is enabled by default in ``upmap``
 mode. Please refer to :ref:`upmap` for more details. The balancer can be
-turned off with::
+turned off with:
 
-  ceph balancer off
+   .. prompt:: bash $
+
+      ceph balancer off
 
 The balancer mode can be changed to ``crush-compat`` mode, which is
 backward compatible with older clients, and will make small changes to
@@ -40,37 +43,51 @@ healed itself).
 When the cluster is healthy, the balancer will throttle its changes
 such that the percentage of PGs that are misplaced (i.e., that need to
 be moved) is below a threshold of (by default) 5%.  The
-``target_max_misplaced_ratio`` threshold can be adjusted with::
+``target_max_misplaced_ratio`` threshold can be adjusted with:
 
-  ceph config set mgr target_max_misplaced_ratio .07   # 7%
+   .. prompt:: bash $
 
-Set the number of seconds to sleep in between runs of the automatic balancer::
+      ceph config set mgr target_max_misplaced_ratio .07   # 7%
 
-  ceph config set mgr mgr/balancer/sleep_interval 60
+Set the number of seconds to sleep in between runs of the automatic balancer:
 
-Set the time of day to begin automatic balancing in HHMM format::
+   .. prompt:: bash $
 
-  ceph config set mgr mgr/balancer/begin_time 0000
+      ceph config set mgr mgr/balancer/sleep_interval 60
 
-Set the time of day to finish automatic balancing in HHMM format::
+Set the time of day to begin automatic balancing in HHMM format:
 
-  ceph config set mgr mgr/balancer/end_time 2400
+   .. prompt:: bash $
+
+      ceph config set mgr mgr/balancer/begin_time 0000
+
+Set the time of day to finish automatic balancing in HHMM format:
+
+   .. prompt:: bash $
+
+      ceph config set mgr mgr/balancer/end_time 2359
 
 Restrict automatic balancing to this day of the week or later. 
-Uses the same conventions as crontab, 0 or 7 is Sunday, 1 is Monday, and so on::
+Uses the same conventions as crontab, 0 is Sunday, 1 is Monday, and so on:
 
-  ceph config set mgr mgr/balancer/begin_weekday 0
+   .. prompt:: bash $
+
+      ceph config set mgr mgr/balancer/begin_weekday 0
 
 Restrict automatic balancing to this day of the week or earlier. 
-Uses the same conventions as crontab, 0 or 7 is Sunday, 1 is Monday, and so on::
+Uses the same conventions as crontab, 0 is Sunday, 1 is Monday, and so on:
 
-  ceph config set mgr mgr/balancer/end_weekday 7
+   .. prompt:: bash $
+
+      ceph config set mgr mgr/balancer/end_weekday 6
 
 Pool IDs to which the automatic balancing will be limited. 
 The default for this is an empty string, meaning all pools will be balanced. 
-The numeric pool IDs can be gotten with the :command:`ceph osd pool ls detail` command::
+The numeric pool IDs can be gotten with the :command:`ceph osd pool ls detail` command:
 
-  ceph config set mgr mgr/balancer/pool_ids 1,2,3
+   .. prompt:: bash $
+
+      ceph config set mgr mgr/balancer/pool_ids 1,2,3
 
 
 Modes
@@ -112,9 +129,11 @@ There are currently two supported balancer modes:
 
    Note that using upmap requires that all clients be Luminous or newer.
 
-The default mode is ``upmap``.  The mode can be adjusted with::
+The default mode is ``upmap``.  The mode can be adjusted with:
 
-  ceph balancer mode crush-compat
+   .. prompt:: bash $
+
+      ceph balancer mode crush-compat
 
 Supervised optimization
 -----------------------
@@ -125,43 +144,63 @@ The balancer operation is broken into a few distinct phases:
 #. evaluating the quality of the data distribution, either for the current PG distribution, or the PG distribution that would result after executing a *plan*
 #. executing the *plan*
 
-To evaluate and score the current distribution::
+To evaluate and score the current distribution:
 
-  ceph balancer eval
+   .. prompt:: bash $
 
-You can also evaluate the distribution for a single pool with::
+      ceph balancer eval
 
-  ceph balancer eval <pool-name>
+You can also evaluate the distribution for a single pool with:
 
-Greater detail for the evaluation can be seen with::
+   .. prompt:: bash $
 
-  ceph balancer eval-verbose ...
+      ceph balancer eval <pool-name>
+
+Greater detail for the evaluation can be seen with:
+
+   .. prompt:: bash $
+
+      ceph balancer eval-verbose ...
   
-The balancer can generate a plan, using the currently configured mode, with::
+The balancer can generate a plan, using the currently configured mode, with:
 
-  ceph balancer optimize <plan-name>
+   .. prompt:: bash $
 
-The name is provided by the user and can be any useful identifying string.  The contents of a plan can be seen with::
+      ceph balancer optimize <plan-name>
 
-  ceph balancer show <plan-name>
+The name is provided by the user and can be any useful identifying string.  The contents of a plan can be seen with:
 
-All plans can be shown with::
+   .. prompt:: bash $
 
-  ceph balancer ls
+      ceph balancer show <plan-name>
 
-Old plans can be discarded with::
+All plans can be shown with:
 
-  ceph balancer rm <plan-name>
+   .. prompt:: bash $
 
-Currently recorded plans are shown as part of the status command::
+      ceph balancer ls
 
-  ceph balancer status
+Old plans can be discarded with:
 
-The quality of the distribution that would result after executing a plan can be calculated with::
+   .. prompt:: bash $
 
-  ceph balancer eval <plan-name>
+      ceph balancer rm <plan-name>
 
-Assuming the plan is expected to improve the distribution (i.e., it has a lower score than the current cluster state), the user can execute that plan with::
+Currently recorded plans are shown as part of the status command:
 
-  ceph balancer execute <plan-name>
+   .. prompt:: bash $
+
+      ceph balancer status
+
+The quality of the distribution that would result after executing a plan can be calculated with:
+
+   .. prompt:: bash $
+
+      ceph balancer eval <plan-name>
+
+Assuming the plan is expected to improve the distribution (i.e., it has a lower score than the current cluster state), the user can execute that plan with:
+
+   .. prompt:: bash $
+
+      ceph balancer execute <plan-name>
 


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/balancer.rst.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit e7fd6e75dac6a2e84f07519a259d27c4ebf973ac)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
