### PR TITLE
cmake: add c-ares::cares as a global visible library

### DIFF
--- a/cmake/modules/Findc-ares.cmake
+++ b/cmake/modules/Findc-ares.cmake
@@ -22,7 +22,7 @@ find_package_handle_standard_args(c-ares
   VERSION_VAR c-ares_VERSION)
 
 if(c-ares_FOUND AND NOT (TARGET c-ares::cares))
-  add_library(c-ares::cares UNKNOWN IMPORTED)
+  add_library(c-ares::cares UNKNOWN IMPORTED GLOBAL)
   set_target_properties(c-ares::cares PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${c-ares_INCLUDE_DIR}"
     IMPORTED_LINK_INTERFACE_LANGUAGES "C"


### PR DESCRIPTION
to address the build failure like:
```
-- Checking for one of the modules 'libcares'
CMake Error at cmake/modules/BuildBoost.cmake:287 (_add_library):
  _add_library cannot create ALIAS target "c-ares::c-ares" because target
  "c-ares::cares" is imported but not globally visible.
Call Stack (most recent call first):
  cmake/modules/Findc-ares.cmake:31 (add_library)
  src/CMakeLists.txt:344 (find_package)
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
