### PR TITLE
doc/cephadm: add airgapped install procedure

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -364,7 +364,9 @@ Different deployment scenarios
 Single host
 -----------
 
-To configure a Ceph cluster to run on a single host, use the ``--single-host-defaults`` flag when bootstrapping. For use cases of this, see :ref:`one-node-cluster`.
+To configure a Ceph cluster to run on a single host, use the
+``--single-host-defaults`` flag when bootstrapping. For use cases of this, see
+:ref:`one-node-cluster`.
 
 The ``--single-host-defaults`` flag sets the following configuration options::
 
@@ -372,12 +374,22 @@ The ``--single-host-defaults`` flag sets the following configuration options::
   global/osd_pool_default_size = 2
   mgr/mgr_standby_modules = False
 
-For more information on these options, see :ref:`one-node-cluster` and ``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
+For more information on these options, see :ref:`one-node-cluster` and
+``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
+
+.. _cephadm-airgap:
 
 Deployment in an isolated environment
 -------------------------------------
 
-You can install Cephadm in an isolated environment by using a custom container registry. You can either configure Podman or Docker to use an insecure registry, or make the registry secure. Ensure your container image is inside the registry and that you have access to all hosts you wish to add to the cluster.
+You can install Cephadm in an isolated environment by using a custom container
+registry. You can either configure Podman or Docker to use an insecure
+registry, or make the registry secure. This is sometimes referred to as
+"airgapping". Registries that are not directly connected to the internet are
+referred to as "airgapped".
+
+Ensure your container image is inside the registry and that you
+have access to all hosts you wish to add to the cluster.
 
 Run a local container registry:
 
@@ -385,13 +397,36 @@ Run a local container registry:
 
    podman run --privileged -d --name registry -p 5000:5000 -v /var/lib/registry:/var/lib/registry --restart=always registry:2
 
-If you are using an insecure registry, configure Podman or Docker with the hostname and port where the registry is running.
+If you are using an insecure registry, configure Podman or Docker with the
+hostname and port where the registry is running.
 
 .. note:: For every host which accesses the local insecure registry, you will need to repeat this step on the host.
 
 Next, push your container image to your local registry.
 
-Then run bootstrap using the ``--image`` flag with your container image. For example:
+* Ceph container image. See :ref:`containers`.
+* Prometheus container image
+* Node exporter container image
+* Grafana container image
+* Alertmanager container image
+
+Now, create a temporary configuration file for setting the montoring
+images. (See :ref:`cephadm_monitoring-images`):
+
+.. prompt:: bash $
+
+      $ cat <<EOF > initial-ceph.conf
+
+::
+
+      [mgr]
+      mgr/cephadm/container_image_prometheus *<hostname>*:5000/prometheus
+      mgr/cephadm/container_image_node_exporter *<hostname>*:5000/node_exporter
+      mgr/cephadm/container_image_grafana *<hostname>*:5000/grafana
+      mgr/cephadm/container_image_alertmanager *<hostname>*:5000/alertmanger
+
+Then run bootstrap using the ``--image`` flag with your container image. For
+example:
 
 .. prompt:: bash #
 

--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -125,6 +125,8 @@ example spec file:
     spec:
       port: 4200
 
+.. _cephadm_monitoring-images:
+
 Using custom images
 ~~~~~~~~~~~~~~~~~~~
 
@@ -182,6 +184,8 @@ For example, if you had changed the prometheus image
      .. code-block:: bash
 
           ceph config rm mgr mgr/cephadm/container_image_prometheus
+
+See also :ref:`cephadm-airgap`.
 
 .. _cephadm-overwrite-jinja2-templates:
 


### PR DESCRIPTION
Add a procedure describing an installation with an airgapped registry.

This commit ingests work done in https://github.com/ceph/ceph/pull/44346 that was abandoned for lo these past eleven months. The PR connected with this commit supersedes that PR.

Signed-off-by: Zac Dover <zac.dover@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
