### PR TITLE
pacific: osd: add created_at meta

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2215,6 +2215,10 @@ int OSD::write_meta(CephContext *cct, ObjectStore *store, uuid_d& cluster_fsid, 
       return r;
   }
 
+  r = store->write_meta("ceph_version_when_created", pretty_version_to_str());
+  if (r < 0)
+    return r;
+
   ostringstream created_at;
   utime_t now = ceph_clock_now();
   now.gmtime(created_at);
@@ -6724,6 +6728,12 @@ void OSD::_collect_metadata(map<string,string> *pm)
     osdspec_affinity = "";
   }
   (*pm)["osdspec_affinity"] = osdspec_affinity;
+  string ceph_version_when_created;
+  r = store->read_meta("ceph_version_when_created", &ceph_version_when_created);
+  if (r <0 || ceph_version_when_created.empty()) {
+    ceph_version_when_created = "";
+  }
+  (*pm)["ceph_version_when_created"] = ceph_version_when_created;
   string created_at;
   r = store->read_meta("created_at", &created_at);
   if (r < 0 || created_at.empty()) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2215,6 +2215,13 @@ int OSD::write_meta(CephContext *cct, ObjectStore *store, uuid_d& cluster_fsid, 
       return r;
   }
 
+  ostringstream created_at;
+  utime_t now = ceph_clock_now();
+  now.gmtime(created_at);
+  r = store->write_meta("created_at", created_at.str());
+  if (r < 0)
+    return r;
+
   r = store->write_meta("ready", "ready");
   if (r < 0)
     return r;
@@ -6717,6 +6724,12 @@ void OSD::_collect_metadata(map<string,string> *pm)
     osdspec_affinity = "";
   }
   (*pm)["osdspec_affinity"] = osdspec_affinity;
+  string created_at;
+  r = store->read_meta("created_at", &created_at);
+  if (r < 0 || created_at.empty()) {
+    created_at = "";
+  }
+  (*pm)["created_at"] = created_at;
   store->collect_metadata(pm);
 
   collect_sys_info(pm, cct);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58039

---

backport of https://github.com/ceph/ceph/pull/48298
parent tracker: https://tracker.ceph.com/issues/58038

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh