### PR TITLE
quincy: doc/cephadm - remove "danger" admonition

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -2,29 +2,6 @@
 Upgrading Ceph
 ==============
 
-.. DANGER:: DATE: 01 NOV 2021. 
-
-   DO NOT UPGRADE TO CEPH PACIFIC FROM AN OLDER VERSION.  
-
-   A recently-discovered bug (https://tracker.ceph.com/issues/53062) can cause
-   data corruption. This bug occurs during OMAP format conversion for
-   clusters that are updated to Pacific. New clusters are not affected by this
-   bug.
-
-   The trigger for this bug is BlueStore's repair/quick-fix functionality. This
-   bug can be triggered in two known ways: 
-
-    (1) manually via the ceph-bluestore-tool, or 
-    (2) automatically, by OSD if ``bluestore_fsck_quick_fix_on_mount`` is set 
-        to true.
-
-   The fix for this bug is expected to be available in Ceph v16.2.7.
-
-   DO NOT set ``bluestore_quick_fix_on_mount`` to true. If it is currently
-   set to true in your configuration, immediately set it to false.
-
-   DO NOT run ``ceph-bluestore-tool``'s repair/quick-fix commands.
-
 Cephadm can safely upgrade Ceph from one bugfix release to the next.  For
 example, you can upgrade from v15.2.0 (the first Octopus release) to the next
 point release, v15.2.1.


### PR DESCRIPTION
Remove the "Danger!" admonition that warned against upgrading to Pacific from an older version of Ceph. That admonition was meant to protect against the issue discussed here: https://tracker.ceph.com/issues/53062. That issue was fixed in this PR:
https://github.com/ceph/ceph/pull/43793.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit ad12da27cc2ee93dadba817e3195a46723a9ee54)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
