### PR TITLE
ceph-volume: fix a bug in lsblk_all()

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -238,9 +238,13 @@ def _udevadm_info(device):
 
 
 def lsblk(device, columns=None, abspath=False):
-    return lsblk_all(device=device,
-                     columns=columns,
-                     abspath=abspath)
+    result = lsblk_all(device=device,
+                       columns=columns,
+                       abspath=abspath)
+    if not result:
+        raise RuntimeError(f"{device} not found is lsblk report")
+
+    return result[0]
 
 def lsblk_all(device='', columns=None, abspath=False):
     """
@@ -320,6 +324,9 @@ def lsblk_all(device='', columns=None, abspath=False):
         base_command.append('-p')
     base_command.append('-o')
     base_command.append(','.join(columns))
+    if device:
+        base_command.append('--nodeps')
+        base_command.append(device)
 
     out, err, rc = process.call(base_command)
 
@@ -331,14 +338,8 @@ def lsblk_all(device='', columns=None, abspath=False):
     for line in out:
         result.append(_lsblk_parser(line))
 
-    if not device:
-        return result
+    return result
 
-    for dev in result:
-        if dev['NAME'] == os.path.basename(device):
-            return dev
-
-    return {}
 
 def is_device(dev):
     """


### PR DESCRIPTION
Rook has a specific use case where devices are copied in /mnt

If the basename (in /mnt) is different from the original device name, then the current logic can't match it.

The idea is to append the device to the `lsblk` command and return the result.

Fixes: https://tracker.ceph.com/issues/58137

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
