### PR TITLE
mgr/dashboard: fix server side encryption config error

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -209,7 +209,7 @@ class RgwBucket(RgwRESTController):
 
         CephService.set_encryption_config(encryption_type, kms_provider, auth_method,
                                           secret_engine, secret_path, namespace, address,
-                                          token, ssl_cert, client_cert, client_key)
+                                          token, daemon_name, ssl_cert, client_cert, client_key)
 
     def _get_encryption(self, bucket_name, daemon_name, owner):
         rgw_client = RgwClient.instance(owner, daemon_name)
@@ -390,8 +390,8 @@ class RgwBucket(RgwRESTController):
 
     @RESTController.Collection(method='GET', path='/getEncryptionConfig')
     @allow_empty_body
-    def get_encryption_config(self):
-        return CephService.get_encryption_config()
+    def get_encryption_config(self, daemon_name=None, owner=None):
+        return CephService.get_encryption_config(daemon_name)
 
 
 @APIRouter('/rgw/user', Scope.RGW)

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -186,8 +186,8 @@ export class RgwBucketService extends ApiClient {
   }
 
   getEncryptionConfig() {
-    return this.rgwDaemonService.request(() => {
-      return this.http.get(`${this.url}/getEncryptionConfig`);
+    return this.rgwDaemonService.request((params: HttpParams) => {
+      return this.http.get(`${this.url}/getEncryptionConfig`, { params: params });
     });
   }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -7761,7 +7761,17 @@ paths:
       - RgwBucket
   /api/rgw/bucket/getEncryptionConfig:
     get:
-      parameters: []
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: daemon_name
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: owner
+        schema:
+          type: string
       responses:
         '200':
           content:


### PR DESCRIPTION
After setting SSE-S3 values from dashboard, it throws 500 error and also it sets the config values to incorrect RGW processes. This PR intends to fix this issue.

Fixes: https://tracker.ceph.com/issues/58296
Signed-off-by: Aashish Sharma <aasharma@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
