### PR TITLE
PeeringState: clearing primary state when restart peering 

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -7200,21 +7200,6 @@ PeeringState::Incomplete::Incomplete(my_context ctx)
   pl->publish_stats_to_osd();
 }
 
-boost::statechart::result PeeringState::Incomplete::react(const AdvMap &advmap) {
-  DECLARE_LOCALS;
-  int64_t poolnum = ps->info.pgid.pool();
-
-  // Reset if min_size turn smaller than previous value, pg might now be able to go active
-  if (!advmap.osdmap->have_pg_pool(poolnum) ||
-      advmap.lastmap->get_pools().find(poolnum)->second.min_size >
-      advmap.osdmap->get_pools().find(poolnum)->second.min_size) {
-    post_event(advmap);
-    return transit< Reset >();
-  }
-
-  return forward_event();
-}
-
 boost::statechart::result PeeringState::Incomplete::react(const MNotifyRec& notevt) {
   DECLARE_LOCALS;
   psdout(7) << "handle_pg_notify from osd." << notevt.from << dendl;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1369,13 +1369,11 @@ public:
 
   struct Incomplete : boost::statechart::state< Incomplete, Peering>, NamedState {
     typedef boost::mpl::list <
-      boost::statechart::custom_reaction< AdvMap >,
       boost::statechart::custom_reaction< MNotifyRec >,
       boost::statechart::custom_reaction< QueryUnfound >,
       boost::statechart::custom_reaction< QueryState >
       > reactions;
     explicit Incomplete(my_context ctx);
-    boost::statechart::result react(const AdvMap &advmap);
     boost::statechart::result react(const MNotifyRec& infoevt);
     boost::statechart::result react(const QueryUnfound& q);
     boost::statechart::result react(const QueryState& q);


### PR DESCRIPTION
If auth_log_shard changed due to a new shard up/down, we may not
resent log request. That can cause divergent entries not being rollbacked
in the previous auth_log_shard during restart peering, which might lead
to failure


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
