### PR TITLE
quincy: doc/rados: add prompts to devices.rst

### DIFF
--- a/doc/rados/operations/devices.rst
+++ b/doc/rados/operations/devices.rst
@@ -1,4 +1,3 @@
-
 .. _devices:
 
 Device Management
@@ -11,19 +10,25 @@ provide tools to predict and/or automatically respond to hardware failure.
 Device tracking
 ---------------
 
-You can query which storage devices are in use with::
+You can query which storage devices are in use with:
 
-  ceph device ls
+.. prompt:: bash $
 
-You can also list devices by daemon or by host::
+   ceph device ls
 
-  ceph device ls-by-daemon <daemon>
-  ceph device ls-by-host <host>
+You can also list devices by daemon or by host:
+
+.. prompt:: bash $
+
+   ceph device ls-by-daemon <daemon>
+   ceph device ls-by-host <host>
 
 For any individual device, you can query information about its
-location and how it is being consumed with::
+location and how it is being consumed with:
 
-  ceph device info <devid>
+.. prompt:: bash $
+
+   ceph device info <devid>
 
 Identifying physical devices
 ----------------------------
@@ -34,18 +39,22 @@ failed disks easy and less error-prone.  Use the following command::
   device light on|off <devid> [ident|fault] [--force]
 
 The ``<devid>`` parameter is the device identification. You can obtain this
-information using the following command::
+information using the following command:
 
-  ceph device ls
+.. prompt:: bash $
+
+   ceph device ls
 
 The ``[ident|fault]`` parameter is used to set the kind of light to blink.
 By default, the `identification` light is used.
 
 .. note::
    This command needs the Cephadm or the Rook `orchestrator <https://docs.ceph.com/docs/master/mgr/orchestrator/#orchestrator-cli-module>`_ module enabled.
-   The orchestrator module enabled is shown by executing the following command::
+   The orchestrator module enabled is shown by executing the following command:
 
-     ceph orch status
+   .. prompt:: bash $
+
+      ceph orch status
 
 The command behind the scene to blink the drive LEDs is `lsmcli`. If you need
 to customize this command you can configure this via a Jinja2 template::
@@ -77,40 +86,54 @@ or unrecoverable read errors.  Other device types like SAS and NVMe
 implement a similar set of metrics (via slightly different standards).
 All of these can be collected by Ceph via the ``smartctl`` tool.
 
-You can enable or disable health monitoring with::
+You can enable or disable health monitoring with:
 
-  ceph device monitoring on
+.. prompt:: bash $
 
-or::
+   ceph device monitoring on
 
-  ceph device monitoring off
+or:
+
+.. prompt:: bash $
+
+   ceph device monitoring off
 
 
 Scraping
 --------
 
-If monitoring is enabled, metrics will automatically be scraped at regular intervals.  That interval can be configured with::
+If monitoring is enabled, metrics will automatically be scraped at regular intervals.  That interval can be configured with:
 
-  ceph config set mgr mgr/devicehealth/scrape_frequency <seconds>
+.. prompt:: bash $
+
+   ceph config set mgr mgr/devicehealth/scrape_frequency <seconds>
 
 The default is to scrape once every 24 hours.
 
-You can manually trigger a scrape of all devices with::
+You can manually trigger a scrape of all devices with:
+   
+.. prompt:: bash $
 
-  ceph device scrape-health-metrics
+   ceph device scrape-health-metrics
 
-A single device can be scraped with::
+A single device can be scraped with:
 
-  ceph device scrape-health-metrics <device-id>
+.. prompt:: bash $
 
-Or a single daemon's devices can be scraped with::
+   ceph device scrape-health-metrics <device-id>
 
-  ceph device scrape-daemon-health-metrics <who>
+Or a single daemon's devices can be scraped with:
+
+.. prompt:: bash $
+
+   ceph device scrape-daemon-health-metrics <who>
 
 The stored health metrics for a device can be retrieved (optionally
-for a specific timestamp) with::
+for a specific timestamp) with:
 
-  ceph device get-health-metrics <devid> [sample-timestamp]
+.. prompt:: bash $
+
+   ceph device get-health-metrics <devid> [sample-timestamp]
 
 Failure prediction
 ------------------
@@ -121,29 +144,39 @@ health metrics it collects.  There are three modes:
 * *none*: disable device failure prediction.
 * *local*: use a pre-trained prediction model from the ceph-mgr daemon
 
-The prediction mode can be configured with::
+The prediction mode can be configured with:
 
-  ceph config set global device_failure_prediction_mode <mode>
+.. prompt:: bash $
+
+   ceph config set global device_failure_prediction_mode <mode>
 
 Prediction normally runs in the background on a periodic basis, so it
 may take some time before life expectancy values are populated.  You
-can see the life expectancy of all devices in output from::
+can see the life expectancy of all devices in output from:
 
-  ceph device ls
+.. prompt:: bash $
 
-You can also query the metadata for a specific device with::
+   ceph device ls
 
-  ceph device info <devid>
+You can also query the metadata for a specific device with:
 
-You can explicitly force prediction of a device's life expectancy with::
+.. prompt:: bash $
 
-  ceph device predict-life-expectancy <devid>
+   ceph device info <devid>
+
+You can explicitly force prediction of a device's life expectancy with:
+
+.. prompt:: bash $
+
+   ceph device predict-life-expectancy <devid>
 
 If you are not using Ceph's internal device failure prediction but
 have some external source of information about device failures, you
-can inform Ceph of a device's life expectancy with::
+can inform Ceph of a device's life expectancy with:
 
-  ceph device set-life-expectancy <devid> <from> [<to>]
+.. prompt:: bash $
+
+   ceph device set-life-expectancy <devid> <from> [<to>]
 
 Life expectancies are expressed as a time interval so that
 uncertainty can be expressed in the form of a wide interval. The
@@ -156,9 +189,11 @@ The ``mgr/devicehealth/warn_threshold`` controls how soon an expected
 device failure must be before we generate a health warning.
 
 The stored life expectancy of all devices can be checked, and any
-appropriate health alerts generated, with::
+appropriate health alerts generated, with:
 
-  ceph device check-health
+.. prompt:: bash $
+
+   ceph device check-health
 
 Automatic Mitigation
 --------------------


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/devices.rst.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 66ddc41be82540ee4e1f0817d3374f004716801b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
