### PR TITLE
fmt: pickup v9.1.0

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -215,6 +215,8 @@ if(WITH_JAEGER)
 endif()
 
 add_library(rgw_common STATIC ${librgw_common_srcs})
+target_compile_definitions(rgw_common
+  PUBLIC "FMT_HEADER_ONLY")
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wimplicit-const-int-float-conversion"

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -253,7 +253,8 @@ target_link_libraries(rgw_common
   PUBLIC
     ${LUA_LIBRARIES}
     RapidJSON::RapidJSON
-    spawn)
+    spawn
+    fmt::fmt)
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -11,10 +11,6 @@
 #include <iostream>
 #include <mutex>
 #include <condition_variable>
-// this seems safe to use, at least for now--arguably, we should
-// prefer header-only fmt, in general
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 #include <map>
 #include "rgw_sal_store.h"

--- a/src/rgw/driver/dbstore/config/sqlite.cc
+++ b/src/rgw/driver/dbstore/config/sqlite.cc
@@ -17,8 +17,6 @@
 #include <initializer_list>
 #include <map>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include <sqlite3.h>

--- a/src/rgw/driver/dbstore/config/store.cc
+++ b/src/rgw/driver/dbstore/config/store.cc
@@ -15,8 +15,6 @@
 
 #include <stdexcept>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "store.h"

--- a/src/rgw/driver/dbstore/sqlite/connection.h
+++ b/src/rgw/driver/dbstore/sqlite/connection.h
@@ -18,8 +18,6 @@
 #include <memory>
 #include <sqlite3.h>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "sqlite/statement.h"

--- a/src/rgw/driver/rados/cls_fifo_legacy.cc
+++ b/src/rgw/driver/rados/cls_fifo_legacy.cc
@@ -18,8 +18,6 @@
 #include <optional>
 #include <string_view>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/rados/librados.hpp"

--- a/src/rgw/driver/rados/cls_fifo_legacy.h
+++ b/src/rgw/driver/rados/cls_fifo_legacy.h
@@ -25,8 +25,6 @@
 #include <string_view>
 #include <vector>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/rados/librados.hpp"

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -3472,7 +3472,7 @@ public:
       status.shards_done_with_gen.resize(marker_mgr.get().size());
       status.incremental_gen = info.latest_gen;
 
-      ldout(cct, 20) << "writing bucket sync status during init. state=" << status.state << ". marker=" << status.full.position.to_str() << dendl;
+      ldout(cct, 20) << "writing bucket sync status during init. state=" << status.state << ". marker=" << status.full.position << dendl;
 
       // write bucket sync status
       using CR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -340,9 +340,9 @@ struct RGWDataSyncEnv {
 
 // pretty ostream output for `radosgw-admin bucket sync run`
 template<typename ...T>
-void pretty_print(const RGWDataSyncEnv* env, T&& ...t) {
+void pretty_print(const RGWDataSyncEnv* env, fmt::format_string<T...> fmt, T&& ...t) {
   if (unlikely(!!env->ostr)) {
-    fmt::print(*env->ostr, std::forward<T>(t)...);
+    fmt::print(*env->ostr, fmt, std::forward<T>(t)...);
     env->ostr->flush();
   }
 }

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -4,8 +4,6 @@
 #ifndef CEPH_RGW_DATA_SYNC_H
 #define CEPH_RGW_DATA_SYNC_H
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -17,8 +17,6 @@
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/buffer.h"

--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -14,8 +14,6 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/system/error_code.hpp>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/rados/librados.hpp"

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -12,8 +12,6 @@ extern "C" {
 #include <liboath/oath.h>
 }
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "auth/Crypto.h"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -21,6 +21,10 @@
 #include <atomic>
 #include <unordered_map>
 
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
 #include "common/ceph_crypto.h"
 #include "common/random_string.h"
 #include "rgw_acl.h"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -21,8 +21,6 @@
 #include <atomic>
 #include <unordered_map>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "common/ceph_crypto.h"

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -32,10 +32,6 @@
 #include "rgw_lc_tier.h"
 #include "rgw_notify.h"
 
-// this seems safe to use, at least for now--arguably, we should
-// prefer header-only fmt, in general
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 
 #include "services/svc_sys_obj.h"

--- a/src/rgw/rgw_obj_types.h
+++ b/src/rgw/rgw_obj_types.h
@@ -397,6 +397,13 @@ inline std::ostream& operator<<(std::ostream& out, const rgw_obj_key &o) {
   return out << o.to_str();
 }
 
+template<> struct fmt::formatter<rgw_obj_key> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const rgw_obj_key& key, FormatContext& ctx) const {
+    return formatter<std::string_view>::format(key.to_str(), ctx);
+  }
+};
+
 struct rgw_raw_obj {
   rgw_pool pool;
   std::string oid;


### PR DESCRIPTION
fmt 9.0.0 dropped automatic `std::ostream` insertion operator discovery when `fmt/ostream.h` to prevent ODR violations. instead of defining `FMT_DEPRECATED_OSTREAM`, we took efforts to specialize `fmt::formatter<..>` to be compatible with the new fmtlib. to avoid breaking the build with fmt v9 and up, let's bump up the fmt submodule.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
