### PR TITLE
rgw: list with Delimiter should url encode when encoding-type=url

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1765,7 +1765,11 @@ void RGWListBucket_ObjStore_S3::send_common_response()
   s->formatter->dump_string("Prefix", prefix);
   s->formatter->dump_int("MaxKeys", max);
   if (!delimiter.empty()) {
-    s->formatter->dump_string("Delimiter", delimiter);
+    if (encode_key) {
+      s->formatter->dump_string("Delimiter", url_encode(delimiter, false));
+    } else {
+      s->formatter->dump_string("Delimiter", delimiter);
+    }
   }
   s->formatter->dump_string("IsTruncated", (max && is_truncated ? "true"
               : "false"));


### PR DESCRIPTION
put obj(boto3) and list with Delimiter='%' (java sdk)
```
print s3_client.put_object(Bucket=bucket_name, Key="b%ar", Body='a')
print s3_client.put_object(Bucket=bucket_name, Key="b%az", Body='a')
print s3_client.put_object(Bucket=bucket_name, Key="c%ab", Body='a')
print s3_client.put_object(Bucket=bucket_name, Key="foo", Body='a')
```

```
        ListObjectsRequest request = new ListObjectsRequest();
        request.setBucketName(bucket);
        request.setDelimiter("%");
        s3.listObjects(request);
```

java sdk throw bad xml error

![图片](https://user-images.githubusercontent.com/20007497/205293613-83c7d4f0-2563-41c3-8cd3-045a53529324.png)


![图片](https://user-images.githubusercontent.com/20007497/205293869-bd80531a-4553-4100-a36d-9960dec7bfa9.png)


