### PR TITLE
quincy: rbd: add --snap-id option to "rbd device map" to allow mapping arbitrary snapshots

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--notrim] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
+| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--snap-id *snap-id*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--notrim] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
 | **rbd-nbd** unmap *nbd device* | *image-spec* | *snap-spec*
 | **rbd-nbd** list-mapped
 | **rbd-nbd** attach --device *nbd device* *image-spec* | *snap-spec*
@@ -70,6 +70,10 @@ Options
    Specify timeout for the kernel to wait for a new rbd-nbd process is
    attached after the old process is detached. The default is 30
    second.
+
+.. option:: --snap-id *snapid*
+
+   Specify a snapshot to map/unmap/attach/detach by ID instead of by name.
 
 Image and snap specs
 ====================

--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -258,7 +258,7 @@ Commands
   Show the rbd images that are mapped via the rbd kernel module
   (default) or other supported device.
 
-:command:`device map` [-t | --device-type *device-type*] [--cookie *device-cookie*] [--show-cookie] [--read-only] [--exclusive] [-o | --options *device-options*] *image-spec* | *snap-spec*
+:command:`device map` [-t | --device-type *device-type*] [--cookie *device-cookie*] [--show-cookie] [--snap-id *snap-id*] [--read-only] [--exclusive] [-o | --options *device-options*] *image-spec* | *snap-spec*
   Map the specified image to a block device via the rbd kernel module
   (default) or other supported device (*nbd* on Linux or *ggate* on
   FreeBSD).
@@ -266,14 +266,14 @@ Commands
   The --options argument is a comma separated list of device type
   specific options (opt1,opt2=val,...).
 
-:command:`device unmap` [-t | --device-type *device-type*] [-o | --options *device-options*] *image-spec* | *snap-spec* | *device-path*
+:command:`device unmap` [-t | --device-type *device-type*] [-o | --options *device-options*] [--snap-id *snap-id*] *image-spec* | *snap-spec* | *device-path*
   Unmap the block device that was mapped via the rbd kernel module
   (default) or other supported device.
 
   The --options argument is a comma separated list of device type
   specific options (opt1,opt2=val,...).
 
-:command:`device attach` [-t | --device-type *device-type*] --device *device-path* [--cookie *device-cookie*] [--show-cookie] [--read-only] [--exclusive] [--force] [-o | --options *device-options*] *image-spec* | *snap-spec*
+:command:`device attach` [-t | --device-type *device-type*] --device *device-path* [--cookie *device-cookie*] [--show-cookie] [--snap-id *snap-id*] [--read-only] [--exclusive] [--force] [-o | --options *device-options*] *image-spec* | *snap-spec*
   Attach the specified image to the specified block device (currently only
   `nbd` on Linux). This operation is unsafe and should not be normally used.
   In particular, specifying the wrong image or the wrong block device may
@@ -282,7 +282,7 @@ Commands
   The --options argument is a comma separated list of device type
   specific options (opt1,opt2=val,...).
 
-:command:`device detach` [-t | --device-type *device-type*] [-o | --options *device-options*] *image-spec* | *snap-spec* | *device-path*
+:command:`device detach` [-t | --device-type *device-type*] [-o | --options *device-options*] [--snap-id *snap-id*] *image-spec* | *snap-spec* | *device-path*
   Detach the block device that was mapped or attached (currently only `nbd`
   on Linux). This operation is unsafe and should not be normally used.
 

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -253,11 +253,25 @@ get_pid ${POOL}
 unmap_device "${IMAGE}@snap" ${PID}
 DEV=
 
+# map/unmap snap test with --snap-id
+SNAPID=`rbd snap ls ${POOL}/${IMAGE} | awk '$2 == "snap" {print $1}'`
+DEV=`_sudo rbd device --device-type nbd map --snap-id ${SNAPID} ${POOL}/${IMAGE}`
+get_pid ${POOL}
+unmap_device "--snap-id ${SNAPID} ${IMAGE}" ${PID}
+DEV=
+
 # map/unmap namespace test
 rbd snap create ${POOL}/${NS}/${IMAGE}@snap
 DEV=`_sudo rbd device --device-type nbd map ${POOL}/${NS}/${IMAGE}@snap`
 get_pid ${POOL} ${NS}
 unmap_device "${POOL}/${NS}/${IMAGE}@snap" ${PID}
+DEV=
+
+# map/unmap namespace test with --snap-id
+SNAPID=`rbd snap ls ${POOL}/${NS}/${IMAGE} | awk '$2 == "snap" {print $1}'`
+DEV=`_sudo rbd device --device-type nbd map --snap-id ${SNAPID} ${POOL}/${NS}/${IMAGE}`
+get_pid ${POOL} ${NS}
+unmap_device "--snap-id ${SNAPID} ${POOL}/${NS}/${IMAGE}" ${PID}
 DEV=
 
 # map/unmap namespace using options test
@@ -408,5 +422,22 @@ if [ -n "${COOKIE}" ]; then
     test "${ANOTHER_COOKIE}" = "abc de"
     unmap_device ${DEV} ${PID}
 fi
+
+# test detach/attach with --snap-id
+SNAPID=`rbd snap ls ${POOL}/${IMAGE} | awk '$2 == "snap" {print $1}'`
+OUT=`_sudo rbd device --device-type nbd --options try-netlink,show-cookie map --snap-id ${SNAPID} ${POOL}/${IMAGE}`
+read DEV COOKIE <<< "${OUT}"
+get_pid ${POOL}
+_sudo rbd device detach ${POOL}/${IMAGE} --snap-id ${SNAPID} --device-type nbd
+expect_false get_pid ${POOL}
+expect_false _sudo rbd device attach --device ${DEV} --snap-id ${SNAPID} ${POOL}/${IMAGE} --device-type nbd
+if [ -n "${COOKIE}" ]; then
+    _sudo rbd device attach --device ${DEV} --cookie ${COOKIE} --snap-id ${SNAPID} ${POOL}/${IMAGE} --device-type nbd
+else
+    _sudo rbd device attach --device ${DEV} --snap-id ${SNAPID} ${POOL}/${IMAGE} --device-type nbd --force
+fi
+get_pid ${POOL}
+_sudo rbd device detach ${DEV} --device-type nbd
+expect_false get_pid ${POOL}
 
 echo OK

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -422,6 +422,7 @@ if [ -n "${COOKIE}" ]; then
     test "${ANOTHER_COOKIE}" = "abc de"
     unmap_device ${DEV} ${PID}
 fi
+DEV=
 
 # test detach/attach with --snap-id
 SNAPID=`rbd snap ls ${POOL}/${IMAGE} | awk '$2 == "snap" {print $1}'`
@@ -439,5 +440,6 @@ fi
 get_pid ${POOL}
 _sudo rbd device detach ${DEV} --device-type nbd
 expect_false get_pid ${POOL}
+DEV=
 
 echo OK

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -737,8 +737,7 @@ int Image<I>::snap_set(I *ictx,
   std::string name(snap_name == nullptr ? "" : snap_name);
   if (!name.empty()) {
     std::shared_lock image_locker{ictx->image_lock};
-    snap_id = ictx->get_snap_id(cls::rbd::UserSnapshotNamespace{},
-                                snap_name);
+    snap_id = ictx->get_snap_id(snap_namespace, snap_name);
     if (snap_id == CEPH_NOSNAP) {
       return -ENOENT;
     }

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -610,20 +610,21 @@
   
   rbd help device detach
   usage: rbd device detach [--device-type <device-type>] [--pool <pool>] 
-                           [--image <image>] [--snap <snap>] 
-                           [--options <options>] 
+                           [--namespace <namespace>] [--image <image>] 
+                           [--snap <snap>] [--options <options>] 
                            <image-or-snap-or-device-spec> 
   
   Detach image from device.
   
   Positional arguments
     <image-or-snap-or-device-spec>  image, snapshot, or device specification
-                                    [<pool-name>/]<image-name>[@<snap-name>] or
-                                    <device-path>
+                                    [<pool-name>/[<namespace>/]]<image-name>[@<sna
+                                    p-name>] or <device-path>
   
   Optional arguments
     -t [ --device-type ] arg        device type [ggate, krbd (default), nbd]
     -p [ --pool ] arg               pool name
+    --namespace arg                 namespace name
     --image arg                     image name
     --snap arg                      snapshot name
     -o [ --options ] arg            device specific options

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -581,7 +581,8 @@
                            [--snap <snap>] --device <device> [--show-cookie] 
                            [--cookie <cookie>] [--read-only] [--force] 
                            [--exclusive] [--quiesce] 
-                           [--quiesce-hook <quiesce-hook>] [--options <options>] 
+                           [--quiesce-hook <quiesce-hook>] [--snap-id <snap-id>] 
+                           [--options <options>] 
                            <image-or-snap-spec> 
   
   Attach image to device.
@@ -606,12 +607,14 @@
     --exclusive              disable automatic exclusive lock transitions
     --quiesce                use quiesce hooks
     --quiesce-hook arg       quiesce hook path
+    --snap-id arg            snapshot id
     -o [ --options ] arg     device specific options
   
   rbd help device detach
   usage: rbd device detach [--device-type <device-type>] [--pool <pool>] 
                            [--namespace <namespace>] [--image <image>] 
-                           [--snap <snap>] [--options <options>] 
+                           [--snap <snap>] [--snap-id <snap-id>] 
+                           [--options <options>] 
                            <image-or-snap-or-device-spec> 
   
   Detach image from device.
@@ -627,6 +630,7 @@
     --namespace arg                 namespace name
     --image arg                     image name
     --snap arg                      snapshot name
+    --snap-id arg                   snapshot id
     -o [ --options ] arg            device specific options
   
   rbd help device list
@@ -645,7 +649,8 @@
                         [--namespace <namespace>] [--image <image>] 
                         [--snap <snap>] [--show-cookie] [--cookie <cookie>] 
                         [--read-only] [--exclusive] [--quiesce] 
-                        [--quiesce-hook <quiesce-hook>] [--options <options>] 
+                        [--quiesce-hook <quiesce-hook>] [--snap-id <snap-id>] 
+                        [--options <options>] 
                         <image-or-snap-spec> 
   
   Map an image to a block device.
@@ -668,12 +673,14 @@
     --exclusive              disable automatic exclusive lock transitions
     --quiesce                use quiesce hooks
     --quiesce-hook arg       quiesce hook path
+    --snap-id arg            snapshot id
     -o [ --options ] arg     device specific options
   
   rbd help device unmap
   usage: rbd device unmap [--device-type <device-type>] [--pool <pool>] 
                           [--namespace <namespace>] [--image <image>] 
-                          [--snap <snap>] [--options <options>] 
+                          [--snap <snap>] [--snap-id <snap-id>] 
+                          [--options <options>] 
                           <image-or-snap-or-device-spec> 
   
   Unmap a rbd device.
@@ -689,6 +696,7 @@
     --namespace arg                 namespace name
     --image arg                     image name
     --snap arg                      snapshot name
+    --snap-id arg                   snapshot id
     -o [ --options ] arg            device specific options
   
   rbd help diff

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -236,8 +236,9 @@ void get_detach_arguments(po::options_description *positional,
   positional->add_options()
     ("image-or-snap-or-device-spec",
      "image, snapshot, or device specification\n"
-     "[<pool-name>/]<image-name>[@<snap-name>] or <device-path>");
+     "[<pool-name>/[<namespace>/]]<image-name>[@<snap-name>] or <device-path>");
   at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_namespace_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);
   add_device_specific_options(options);

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -181,6 +181,7 @@ void get_map_arguments(po::options_description *positional,
     ("exclusive", po::bool_switch(), "disable automatic exclusive lock transitions")
     ("quiesce", po::bool_switch(), "use quiesce hooks")
     ("quiesce-hook", po::value<std::string>(), "quiesce hook path");
+  at::add_snap_id_option(options);
   add_device_specific_options(options);
 }
 
@@ -200,6 +201,7 @@ void get_unmap_arguments(po::options_description *positional,
   at::add_namespace_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_snap_id_option(options);
   add_device_specific_options(options);
 }
 
@@ -222,6 +224,7 @@ void get_attach_arguments(po::options_description *positional,
     ("exclusive", po::bool_switch(), "disable automatic exclusive lock transitions")
     ("quiesce", po::bool_switch(), "use quiesce hooks")
     ("quiesce-hook", po::value<std::string>(), "quiesce hook path");
+  at::add_snap_id_option(options);
   add_device_specific_options(options);
 }
 
@@ -241,6 +244,7 @@ void get_detach_arguments(po::options_description *positional,
   at::add_namespace_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_snap_id_option(options);
   add_device_specific_options(options);
 }
 

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -122,6 +122,11 @@ int execute_attach(const po::variables_map &vm,
     return -EINVAL;
   }
 
+  if (vm.count(at::SNAPSHOT_ID)) {
+    args.push_back("--snap-id");
+    args.push_back(std::to_string(vm[at::SNAPSHOT_ID].as<uint64_t>()));
+  }
+
   if (vm["quiesce"].as<bool>()) {
     args.push_back("--quiesce");
   }
@@ -159,23 +164,28 @@ int execute_detach(const po::variables_map &vm,
     device_name.clear();
   }
 
+  std::vector<std::string> args;
+
+  args.push_back("detach");
   std::string image_name;
   if (device_name.empty()) {
     int r = utils::get_image_or_snap_spec(vm, &image_name);
     if (r < 0) {
       return r;
     }
+
+    if (image_name.empty()) {
+      std::cerr << "rbd: detach requires either image name or device path"
+                << std::endl;
+      return -EINVAL;
+    }
+
+    if (vm.count(at::SNAPSHOT_ID)) {
+      args.push_back("--snap-id");
+      args.push_back(std::to_string(vm[at::SNAPSHOT_ID].as<uint64_t>()));
+    }
   }
 
-  if (device_name.empty() && image_name.empty()) {
-    std::cerr << "rbd: detach requires either image name or device path"
-              << std::endl;
-    return -EINVAL;
-  }
-
-  std::vector<std::string> args;
-
-  args.push_back("detach");
   args.push_back(device_name.empty() ? image_name : device_name);
 
   if (vm.count("options")) {
@@ -216,6 +226,11 @@ int execute_map(const po::variables_map &vm,
     args.push_back(vm["cookie"].as<std::string>());
   }
 
+  if (vm.count(at::SNAPSHOT_ID)) {
+    args.push_back("--snap-id");
+    args.push_back(std::to_string(vm[at::SNAPSHOT_ID].as<uint64_t>()));
+  }
+
   if (vm["read-only"].as<bool>()) {
     args.push_back("--read-only");
   }
@@ -249,23 +264,28 @@ int execute_unmap(const po::variables_map &vm,
     device_name.clear();
   }
 
+  std::vector<std::string> args;
+
+  args.push_back("unmap");
   std::string image_name;
   if (device_name.empty()) {
     int r = utils::get_image_or_snap_spec(vm, &image_name);
     if (r < 0) {
       return r;
     }
+
+    if (image_name.empty()) {
+      std::cerr << "rbd: unmap requires either image name or device path"
+                << std::endl;
+      return -EINVAL;
+    }
+
+    if (vm.count(at::SNAPSHOT_ID)) {
+      args.push_back("--snap-id");
+      args.push_back(std::to_string(vm[at::SNAPSHOT_ID].as<uint64_t>()));
+    }
   }
 
-  if (device_name.empty() && image_name.empty()) {
-    std::cerr << "rbd: unmap requires either image name or device path"
-              << std::endl;
-    return -EINVAL;
-  }
-
-  std::vector<std::string> args;
-
-  args.push_back("unmap");
   args.push_back(device_name.empty() ? image_name : device_name);
 
   if (vm.count("options")) {

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -125,6 +125,7 @@ struct Config {
   Command command = None;
   int pid = 0;
   std::string cookie;
+  uint64_t snapid = CEPH_NOSNAP;
 
   std::string image_spec() const {
     std::string spec = poolname + "/";
@@ -168,6 +169,11 @@ static void usage()
             << "  --try-netlink                 Use the nbd netlink interface\n"
             << "  --show-cookie                 Show device cookie\n"
             << "  --cookie                      Specify device cookie\n"
+            << "  --snap-id <snap-id>           Specify snapshot by ID instead of by name\n"
+            << "\n"
+            << "Unmap and detach options:\n"
+            << "  --device <device path>        Specify nbd device path (/dev/nbd{num})\n"
+            << "  --snap-id <snap-id>           Specify snapshot by ID instead of by name\n"
             << "\n"
             << "List options:\n"
             << "  --format plain|json|xml Output format (default: plain)\n"
@@ -1656,10 +1662,20 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     }
   }
 
-  if (!cfg->snapname.empty()) {
-    r = image.snap_set(cfg->snapname.c_str());
-    if (r < 0)
+  if (cfg->snapid != CEPH_NOSNAP) {
+    r = image.snap_set_by_id(cfg->snapid);
+    if (r < 0) {
+      cerr << "rbd-nbd: failed to set snap id: " << cpp_strerror(r)
+           << std::endl;
       goto close_fd;
+    }
+  } else if (!cfg->snapname.empty()) {
+    r = image.snap_set(cfg->snapname.c_str());
+    if (r < 0) {
+      cerr << "rbd-nbd: failed to set snap name: " << cpp_strerror(r)
+           << std::endl;
+      goto close_fd;
+    }
   }
 
   if (cfg->encryption_format.has_value()) {
@@ -1944,23 +1960,23 @@ static int do_list_mapped_devices(const std::string &format, bool pretty_format)
   Config cfg;
   NBDListIterator it;
   while (it.get(&cfg)) {
+    std::string snap = (cfg.snapid != CEPH_NOSNAP ?
+        "@" + std::to_string(cfg.snapid) : cfg.snapname);
     if (f) {
       f->open_object_section("device");
       f->dump_int("id", cfg.pid);
       f->dump_string("pool", cfg.poolname);
       f->dump_string("namespace", cfg.nsname);
       f->dump_string("image", cfg.imgname);
-      f->dump_string("snap", cfg.snapname);
+      f->dump_string("snap", snap);
       f->dump_string("device", cfg.devpath);
       f->dump_string("cookie", cfg.cookie);
       f->close_section();
     } else {
       should_print = true;
-      if (cfg.snapname.empty()) {
-        cfg.snapname = "-";
-      }
       tbl << cfg.pid << cfg.poolname << cfg.nsname << cfg.imgname
-          << cfg.snapname << cfg.devpath << cfg.cookie << TextTable::endrow;
+          << (snap.empty() ? "-" : snap) << cfg.devpath << cfg.cookie
+	  << TextTable::endrow;
     }
   }
 
@@ -1981,7 +1997,8 @@ static bool find_mapped_dev_by_spec(Config *cfg, int skip_pid=-1) {
     if (c.pid != skip_pid &&
         c.poolname == cfg->poolname && c.nsname == cfg->nsname &&
         c.imgname == cfg->imgname && c.snapname == cfg->snapname &&
-        (cfg->devpath.empty() || c.devpath == cfg->devpath)) {
+        (cfg->devpath.empty() || c.devpath == cfg->devpath) &&
+        c.snapid == cfg->snapid) {
       *cfg = c;
       return true;
     }
@@ -2024,6 +2041,7 @@ static int parse_args(vector<const char*>& args, std::ostream *err_msg,
   std::vector<const char*>::iterator i;
   std::ostringstream err;
   std::string arg_value;
+  long long snapid;
 
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
@@ -2100,6 +2118,17 @@ static int parse_args(vector<const char*>& args, std::ostream *err_msg,
     } else if (ceph_argparse_flag(args, i, "--show-cookie", (char *)NULL)) {
       cfg->show_cookie = true;
     } else if (ceph_argparse_witharg(args, i, &cfg->cookie, "--cookie", (char *)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &snapid, err,
+                                     "--snap-id", (char *)NULL)) {
+      if (!err.str().empty()) {
+        *err_msg << "rbd-nbd: " << err.str();
+        return -EINVAL;
+      }
+      if (snapid < 0) {
+        *err_msg << "rbd-nbd: Invalid argument for snap-id!";
+        return -EINVAL;
+      }
+      cfg->snapid = snapid;
     } else if (ceph_argparse_witharg(args, i, &arg_value,
                                      "--encryption-format", (char *)NULL)) {
       if (arg_value == "luks1") {

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -2227,6 +2227,11 @@ static int parse_args(vector<const char*>& args, std::ostream *err_msg,
       break;
   }
 
+  if (cfg->snapid != CEPH_NOSNAP && !cfg->snapname.empty()) {
+    *err_msg << "rbd-nbd: use either snapname or snapid, not both";
+    return -EINVAL;
+  }
+
   if (args.begin() != args.end()) {
     *err_msg << "rbd-nbd: unknown args: " << *args.begin();
     return -EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58151

---

backport of https://github.com/ceph/ceph/pull/48680
parent tracker: https://tracker.ceph.com/issues/57902