### PR TITLE
containers: use quay.io/ceph/keepalived in docs

### DIFF
--- a/src/cephadm/containers/keepalived/README.md
+++ b/src/cephadm/containers/keepalived/README.md
@@ -1,4 +1,4 @@
-# arcts/keepalived
+# quay.io/ceph/keepalived
 
 A small [ubi8-minimal](https://catalog.redhat.com/software/containers/registry/registry.access.redhat.com/repository/ubi8/ubi-minimal) based Docker container that provides a method of IP high availability via [keepalived](http://www.keepalived.org/) (VRRP failover), and optional Kubernetes API Server monitoring. If allowed to auto configure (default behaviour) it will automatically generate a unicast based failover configuration with a minimal amount of user supplied information.
 
@@ -6,7 +6,7 @@ For specific information on Keepalived, please see the man page on [keepalived.c
 
 
 ## Index
-- [arcts/keepalived](#arctskeepalived)
+- [quay.io/ceph/keepalived](#cephkeepalived)
   - [Index](#index)
   - [Prerequisites](#prerequisites)
   - [Configuration](#configuration)
@@ -213,7 +213,7 @@ docker run -d --net=host --cap-add NET_ADMIN \
 -e KEEPALVED_TRACK_INTERFACE_2=eth1          \
 -e KEEPALIVED_VIRTUAL_IPADDRESS_1="10.10.0.3/24 dev eth0" \
 -e KEEPALIVED_VIRTUAL_IPADDRESS_EXCLUDED_1="172.16.1.20/24 dev eth1" \
-arcts/keepalived
+quay.io/ceph/keepalived
 ```
 
 ##### Example Backup Run Command
@@ -229,5 +229,5 @@ docker run -d --net=host --cap-add NET_ADMIN \
 -e KEEPALVED_TRACK_INTERFACE_2=eth1          \
 -e KEEPALIVED_VIRTUAL_IPADDRESS_1="10.10.0.3/24 dev eth0" \
 -e KEEPALIVED_VIRTUAL_IPADDRESS_EXCLUDED_1="172.16.1.20/24 dev eth1" \
-arcts/keepalived
+quay.io/ceph/keepalived
 ```


### PR DESCRIPTION
Hi :wave:, 

the documentation should reflect the keepalived container image fork rather than arcts/keepalived. This is a follow-up to https://github.com/ceph/ceph/pull/44894/. 

Let me know whether you want me to change something.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
