### PR TITLE
quincy: doc/rados: add prompts to erasure-code-lrc.rst

### DIFF
--- a/doc/rados/operations/erasure-code-lrc.rst
+++ b/doc/rados/operations/erasure-code-lrc.rst
@@ -22,45 +22,51 @@ Reduce recovery bandwidth between hosts
 
 Although it is probably not an interesting use case when all hosts are
 connected to the same switch, reduced bandwidth usage can actually be
-observed.::
+observed.:
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             k=4 m=2 l=3 \
-             crush-failure-domain=host
-        $ ceph osd pool create lrcpool erasure LRCprofile
+.. prompt:: bash $
+
+   ceph osd erasure-code-profile set LRCprofile \
+      plugin=lrc \
+      k=4 m=2 l=3 \
+      crush-failure-domain=host
+   ceph osd pool create lrcpool erasure LRCprofile
 
 
 Reduce recovery bandwidth between racks
 ---------------------------------------
 
 In Firefly the bandwidth reduction will only be observed if the primary
-OSD is in the same rack as the lost chunk.::
+OSD is in the same rack as the lost chunk.:
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             k=4 m=2 l=3 \
-             crush-locality=rack \
-             crush-failure-domain=host
-        $ ceph osd pool create lrcpool erasure LRCprofile
+.. prompt:: bash $
+
+   ceph osd erasure-code-profile set LRCprofile \
+      plugin=lrc \
+      k=4 m=2 l=3 \
+      crush-locality=rack \
+      crush-failure-domain=host
+   ceph osd pool create lrcpool erasure LRCprofile
 
 
 Create an lrc profile
 =====================
 
-To create a new lrc erasure code profile::
+To create a new lrc erasure code profile:
 
-        ceph osd erasure-code-profile set {name} \
-             plugin=lrc \
-             k={data-chunks} \
-             m={coding-chunks} \
-             l={locality} \
-             [crush-root={root}] \
-             [crush-locality={bucket-type}] \
-             [crush-failure-domain={bucket-type}] \
-             [crush-device-class={device-class}] \
-             [directory={directory}] \
-             [--force]
+.. prompt:: bash $
+
+   ceph osd erasure-code-profile set {name} \
+       plugin=lrc \
+       k={data-chunks} \
+       m={coding-chunks} \
+       l={locality} \
+       [crush-root={root}] \
+       [crush-locality={bucket-type}] \
+       [crush-failure-domain={bucket-type}] \
+       [crush-device-class={device-class}] \
+       [directory={directory}] \
+       [--force]
 
 Where:
 
@@ -190,13 +196,15 @@ Minimal testing
 
 It is strictly equivalent to using a *K=2* *M=1* erasure code profile. The *DD*
 implies *K=2*, the *c* implies *M=1* and the *jerasure* plugin is used
-by default.::
+by default.:
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             mapping=DD_ \
-             layers='[ [ "DDc", "" ] ]'
-        $ ceph osd pool create lrcpool erasure LRCprofile
+.. prompt:: bash $
+   
+   ceph osd erasure-code-profile set LRCprofile \
+      plugin=lrc \
+      mapping=DD_ \
+      layers='[ [ "DDc", "" ] ]'
+   ceph osd pool create lrcpool erasure LRCprofile
 
 Reduce recovery bandwidth between hosts
 ---------------------------------------
@@ -204,38 +212,43 @@ Reduce recovery bandwidth between hosts
 Although it is probably not an interesting use case when all hosts are
 connected to the same switch, reduced bandwidth usage can actually be
 observed. It is equivalent to **k=4**, **m=2** and **l=3** although
-the layout of the chunks is different::
+the layout of the chunks is different. **WARNING: PROMPTS ARE SELECTABLE**
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             mapping=__DD__DD \
-             layers='[
-                       [ "_cDD_cDD", "" ],
-                       [ "cDDD____", "" ],
-                       [ "____cDDD", "" ],
-                     ]'
-        $ ceph osd pool create lrcpool erasure LRCprofile
+::
+
+   $ ceph osd erasure-code-profile set LRCprofile \
+        plugin=lrc \
+        mapping=__DD__DD \
+        layers='[
+                  [ "_cDD_cDD", "" ],
+                  [ "cDDD____", "" ],
+                  [ "____cDDD", "" ],
+                ]'
+   $ ceph osd pool create lrcpool erasure LRCprofile
 
 
 Reduce recovery bandwidth between racks
 ---------------------------------------
 
-In Firefly the reduced bandwidth will only be observed if the primary
-OSD is in the same rack as the lost chunk.::
+In Firefly the reduced bandwidth will only be observed if the primary OSD is in
+the same rack as the lost chunk. **WARNING: PROMPTS ARE SELECTABLE**
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             mapping=__DD__DD \
-             layers='[
-                       [ "_cDD_cDD", "" ],
-                       [ "cDDD____", "" ],
-                       [ "____cDDD", "" ],
-                     ]' \
-             crush-steps='[
-                             [ "choose", "rack", 2 ],
-                             [ "chooseleaf", "host", 4 ],
-                            ]'
-        $ ceph osd pool create lrcpool erasure LRCprofile
+::
+
+   $ ceph osd erasure-code-profile set LRCprofile \
+       plugin=lrc \
+       mapping=__DD__DD \
+       layers='[
+                 [ "_cDD_cDD", "" ],
+                 [ "cDDD____", "" ],
+                 [ "____cDDD", "" ],
+               ]' \
+       crush-steps='[
+                       [ "choose", "rack", 2 ],
+                       [ "chooseleaf", "host", 4 ],
+                      ]'
+  
+   $ ceph osd pool create lrcpool erasure LRCprofile
 
 Testing with different Erasure Code backends
 --------------------------------------------
@@ -245,26 +258,30 @@ specify the EC backend/algorithm on a per layer basis using the low
 level configuration. The second argument in layers='[ [ "DDc", "" ] ]'
 is actually an erasure code profile to be used for this level. The
 example below specifies the ISA backend with the cauchy technique to
-be used in the lrcpool.::
+be used in the lrcpool.:
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             mapping=DD_ \
-             layers='[ [ "DDc", "plugin=isa technique=cauchy" ] ]'
-        $ ceph osd pool create lrcpool erasure LRCprofile
+.. prompt:: bash $
 
-You could also use a different erasure code profile for for each
-layer.::
+   ceph osd erasure-code-profile set LRCprofile \
+      plugin=lrc \
+      mapping=DD_ \
+      layers='[ [ "DDc", "plugin=isa technique=cauchy" ] ]'
+   ceph osd pool create lrcpool erasure LRCprofile
 
-        $ ceph osd erasure-code-profile set LRCprofile \
-             plugin=lrc \
-             mapping=__DD__DD \
-             layers='[
-                       [ "_cDD_cDD", "plugin=isa technique=cauchy" ],
-                       [ "cDDD____", "plugin=isa" ],
-                       [ "____cDDD", "plugin=jerasure" ],
-                     ]'
-        $ ceph osd pool create lrcpool erasure LRCprofile
+You could also use a different erasure code profile for each
+layer. **WARNING: PROMPTS ARE SELECTABLE**
+
+::
+
+   $ ceph osd erasure-code-profile set LRCprofile \
+        plugin=lrc \
+        mapping=__DD__DD \
+        layers='[
+                  [ "_cDD_cDD", "plugin=isa technique=cauchy" ],
+                  [ "cDDD____", "plugin=isa" ],
+                  [ "____cDDD", "plugin=jerasure" ],
+                ]'
+   $ ceph osd pool create lrcpool erasure LRCprofile
 
 
 


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/erasure-code-lrc.rst.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit fca696cc71dac23dce8f0a3713b7b28e6285be83)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
