### PR TITLE
quincy: doc/rados: add prompts to health-checks (1 of 5)

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -73,9 +73,11 @@ not configured to bind to a v2 port in the cluster's monmap.  This
 means that features specific to the msgr2 protocol (e.g., encryption)
 are not available on some or all connections.
 
-In most cases this can be corrected by issuing the command::
+In most cases this can be corrected by issuing the command:
 
-  ceph mon enable-msgr2
+.. prompt:: bash $
+
+   ceph mon enable-msgr2
 
 That command will change any monitor configured for the old default
 port 6789 to continue to listen for v1 connections on 6789 and also
@@ -130,9 +132,11 @@ This warning may also indicate that the monitor has a bug that is
 preventing it from pruning the cluster metadata it stores.  If the
 problem persists, please report a bug.
 
-The warning threshold may be adjusted with::
+The warning threshold may be adjusted with:
 
-  ceph config set global mon_data_size_warn <size>
+.. prompt:: bash $
+
+   ceph config set global mon_data_size_warn <size>
 
 AUTH_INSECURE_GLOBAL_ID_RECLAIM
 _______________________________
@@ -147,33 +151,43 @@ be necessary until all ceph clients have been upgraded), and the
 allows monitors to detect clients with insecure reclaim early by forcing them to
 reconnect right after they first authenticate).
 
-You can identify which client(s) are using unpatched ceph client code with::
+You can identify which client(s) are using unpatched ceph client code with:
 
-  ceph health detail
+.. prompt:: bash $
+
+   ceph health detail
 
 Clients global_id reclaim rehavior can also seen in the
 ``global_id_status`` field in the dump of clients connected to an
 individual monitor (``reclaim_insecure`` means the client is
-unpatched and is contributing to this health alert)::
+unpatched and is contributing to this health alert):
 
-  ceph tell mon.\* sessions
+.. prompt:: bash $
+
+   ceph tell mon.\* sessions
 
 We strongly recommend that all clients in the system are upgraded to a
 newer version of Ceph that correctly reclaims global_id values.  Once
 all clients have been updated, you can stop allowing insecure reconnections
-with::
+with:
 
-  ceph config set mon auth_allow_insecure_global_id_reclaim false
+.. prompt:: bash $
+
+   ceph config set mon auth_allow_insecure_global_id_reclaim false
 
 If it is impractical to upgrade all clients immediately, you can silence
-this warning temporarily with::
+this warning temporarily with:
 
-  ceph health mute AUTH_INSECURE_GLOBAL_ID_RECLAIM 1w   # 1 week
+.. prompt:: bash $
 
-Although we do NOT recommend doing so, you can also disable this warning indefinitely
-with::
+   ceph health mute AUTH_INSECURE_GLOBAL_ID_RECLAIM 1w   # 1 week
 
-  ceph config set mon mon_warn_on_insecure_global_id_reclaim false
+Although we do NOT recommend doing so, you can also disable this warning
+indefinitely with:
+
+.. prompt:: bash $
+
+   ceph config set mon mon_warn_on_insecure_global_id_reclaim false
 
 AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED
 _______________________________________
@@ -187,19 +201,25 @@ versions of Ceph that correctly and securely reclaim their global_id.
 If the ``AUTH_INSECURE_GLOBAL_ID_RECLAIM`` health alert has not also been raised and
 the ``auth_expose_insecure_global_id_reclaim`` setting has not been disabled (it is
 on by default), then there are currently no clients connected that need to be
-upgraded, and it is safe to disallow insecure global_id reclaim with::
+upgraded, and it is safe to disallow insecure global_id reclaim with:
 
-  ceph config set mon auth_allow_insecure_global_id_reclaim false
+.. prompt:: bash $
+
+   ceph config set mon auth_allow_insecure_global_id_reclaim false
 
 If there are still clients that need to be upgraded, then this alert can be
-silenced temporarily with::
+silenced temporarily with:
 
-  ceph health mute AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED 1w   # 1 week
+.. prompt:: bash $
+
+   ceph health mute AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED 1w   # 1 week
 
 Although we do NOT recommend doing so, you can also disable this warning indefinitely
-with::
+with:
 
-  ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false
+.. prompt:: bash $
+
+   ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false
 
 
 Manager


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/health-checks.rst, first 300 lines.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit cbc334e1dda797406876dd24cd09d6098fc1275c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
