### PR TITLE
pacific: mon/MonCommands: Support dump_historic_slow_ops

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1402,6 +1402,10 @@ COMMAND_WITH_FLAG("sessions",
             "mon", "r",
             FLAG(TELL))
 COMMAND_WITH_FLAG("dump_historic_ops",
-            "dump_historic_ops",
+            "show recent ops",
+            "mon", "r",
+            FLAG(TELL))
+COMMAND_WITH_FLAG("dump_historic_slow_ops",
+            "show recent slow ops",
             "mon", "r",
             FLAG(TELL))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58144

---

backport of https://github.com/ceph/ceph/pull/48972
parent tracker: https://tracker.ceph.com/issues/58141

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh