### PR TITLE
mgr/dashboard: add option to set frame ancestors in CSP header

### DIFF
--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -16,7 +16,6 @@ from .access_control import LocalAuthenticator, UserDoesNotExist
 
 cherrypy.config.update({
     'response.headers.server': 'Ceph-Dashboard',
-    'response.headers.content-security-policy': "frame-ancestors 'self';",
     'response.headers.x-content-type-options': 'nosniff',
     'response.headers.strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
 })


### PR DESCRIPTION
### Configure:
Add config option to set sources for frame ancestors in `Content-Security-Policy` .

The frame ancestors sources can be set using this command
`ceph config set mgr mgr/dashboard/frame_ancestors_sources http://localhost:4200,http://localhost:4201`
Once the config is set you have to restart the dashboard module to see new frame ancestors in CSP header.

### Verify: 
Expected change to be seen in CSP header:
`Content-Security-Policy: frame-ancestors 'self' http://localhost:4200 http://localhost:4201;`

Fixes: https://tracker.ceph.com/issues/58159
Signed-off-by: Avan Thakkar <athakkar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
