### PR TITLE
1st cut: osd/scrub: redesign scrub scheduling code

### DIFF
--- a/doc/dev/osd_internals/scrub.rst
+++ b/doc/dev/osd_internals/scrub.rst
@@ -23,14 +23,6 @@ Scrubbing Behavior Table
 - S = Do regular scrub
 - D = Do deep scrub
 
-State variables
----------------
-
-- Periodic tick state is ``!must_scrub && !must_deep_scrub && !time_for_deep``
-- Periodic tick after ``osd_deep_scrub_interval state is !must_scrub && !must_deep_scrub && time_for_deep``
-- Initiated scrub state is ``must_scrub && !must_deep_scrub && !time_for_deep``
-- Initiated scrub after ``osd_deep_scrub_interval`` state is ``must_scrub && !must_deep_scrub && time_for_deep``
-- Initiated deep scrub state is ``must_scrub && must_deep_scrub``
 
 Scrub Reservations
 ------------------

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -8,6 +8,7 @@
 
 #include <deque>
 #include <list>
+#include <memory>
 #include <vector>
 #include <stdarg.h>
 #include <sstream>
@@ -61,6 +62,12 @@ namespace ceph {
     }
     static Formatter *create(std::string_view type) {
       return create(type, "json-pretty", "");
+    }
+    template <typename... Params>
+    static std::unique_ptr<Formatter> create_unique(Params &&...params)
+    {
+      return std::unique_ptr<Formatter>(
+	  Formatter::create(std::forward<Params>(params)...));
     }
 
     Formatter();

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -287,7 +287,7 @@ options:
   type: float
   level: advanced
   desc: Scrub each PG no more often than this interval
-  fmt_desc: The minimal interval in seconds for scrubbing the Ceph OSD Daemon
+  fmt_desc: The desired interval in seconds for scrubbing the Ceph OSD Daemon
     when the Ceph Storage Cluster load is low.
   default: 1_day
   see_also:
@@ -326,7 +326,7 @@ options:
   type: float
   level: dev
   desc: Backoff ratio for scheduling scrubs
-  long_desc: This is the precentage of ticks that do NOT schedule scrubs, 66% means
+  long_desc: This is the percentage of ticks that do NOT schedule scrubs, 66% means
     that 1 out of 3 ticks will schedule scrubs
   default: 0.66
   with_legacy: true
@@ -334,7 +334,7 @@ options:
   type: int
   level: advanced
   desc: Minimum number of objects to scrub in a single chunk
-  fmt_desc: The minimal number of object store chunks to scrub during single operation.
+  fmt_desc: The minimum number of object store chunks to scrub during single operation.
     Ceph blocks writes to single chunk during scrub.
   default: 5
   see_also:
@@ -484,31 +484,86 @@ options:
     stats (inc. scrub/block duration) every this many seconds.
   default: 120
   with_legacy: false
-# when replicas are slow to respond to scrub resource reservations
-# Note: disable by using a very large value
 - name: osd_scrub_slow_reservation_response
   type: millisecs
   level: advanced
-  desc: Duration before issuing a cluster-log warning
-  long_desc: Waiting too long for a replica to respond (after at least half of the
-    replicas have responded).
+  desc: Maximum wait (milliseconds) for scrub reservations before issuing a cluster-log warning
+  long_desc: Waiting too long for a replica to respond to scrub resource reservation request
+   (after at least half of the replicas have responded). Disable by setting to a very large value.
   default: 2200
   min: 500
   see_also:
   - osd_scrub_reservation_timeout
   with_legacy: false
-# when a replica does not respond to scrub resource request
-# Note: disable by using a very large value
 - name: osd_scrub_reservation_timeout
   type: millisecs
   level: advanced
-  desc: Duration before aborting the scrub session
-  long_desc: Waiting too long for some replicas to respond to
-    scrub reservation requests.
+  desc: Maximum wait (milliseconds) for replicas' response to scrub reservation requests
+  long_desc: Maximum wait (milliseconds) for all replicas to respond to
+    scrub reservation requests, before the scrub session is aborted. Disable by setting
+    to a very large value.
   default: 5000
   min: 2000
   see_also:
   - osd_scrub_slow_reservation_response
+  with_legacy: false
+- name: osd_scrub_busy_replicas_penalty
+  type: int
+  level: advanced
+  desc: Period (in seconds) of low scrub priority following a replica denial
+  long_desc: The period for which a PG that failed to secure replica scrub resources will
+    be given a low scrub priority. Disabled if set to 0.
+  default: 300
+  min: 0
+  with_legacy: false
+- name: osd_scrub_retry_busy_replicas
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying scrub after a replica reservation failure
+  long_desc: Minimum delay after a failed attempt to secure the replicas' scrub resources.
+  default: 5
+  min: 1
+  see_also:
+  - osd_scrub_retry_wrong_time
+  - osd_scrub_busy_replicas_penalty
+  with_legacy: false
+- name: osd_scrub_retry_wrong_time
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying periodic scrub after a badly-timed attempt
+  long_desc: Minimum delay after a failed attempt to initiate a periodic
+    scrub at the wrong time.
+  default: 300
+  min: 1
+  see_also:
+  - osd_scrub_begin_hour
+  - osd_scrub_end_hour
+  - osd_scrub_begin_week_day
+  - osd_scrub_end_week_day
+  with_legacy: false
+- name: osd_scrub_retry_pg_state
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying to scrub a previously inactive/not-clean PG
+  long_desc: Minimum delay after a failed attempt to scrub a PG that was not
+    active or not clean.
+  default: 60
+  min: 1
+  see_also:
+  - osd_scrub_retry_wrong_time
+  with_legacy: false
+- name: osd_scrub_retry_delay
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying a specific PG after a scrub failure
+  long_desc: Minimum delay after a failed attempt to scrub a PG. See the
+    'see also' for the configuration options for some specific delay reasons
+  default: 3
+  min: 1
+  see_also:
+  - osd_scrub_retry_wrong_time
+  - osd_scrub_retry_busy_replicas
+  - osd_scrub_retry_pg_state
   with_legacy: false
 # where rados plugins are stored
 - name: osd_class_dir

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -165,10 +165,6 @@ public:
   void on_primary_status_change(bool was_primary, bool now_primary) final {
   }
 
-  /// Need to reschedule next scrub. Assuming no change in role
-  void reschedule_scrub() final {
-  }
-
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final;
 
   uint64_t get_snap_trimq_size() const final {

--- a/src/include/byteorder.h
+++ b/src/include/byteorder.h
@@ -24,7 +24,7 @@ public:
     v = boost::endian::native_to_little(nv);
     return *this;
   }
-  operator T() const { return boost::endian::little_to_native(v); }
+  constexpr operator T() const { return boost::endian::little_to_native(v); }
   friend inline bool operator==(ceph_le a, ceph_le b) {
     return a.v == b.v;
   }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -504,7 +504,7 @@ struct shard_id_t {
   int8_t id;
 
   shard_id_t() : id(0) {}
-  explicit shard_id_t(int8_t _id) : id(_id) {}
+  constexpr explicit shard_id_t(int8_t _id) : id(_id) {}
 
   operator int8_t() const { return id; }
 

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -56,20 +56,24 @@ public:
     return (tv.tv_sec == 0) && (tv.tv_nsec == 0);
   }
 
-  void normalize() {
+  constexpr void normalize() {
     if (tv.tv_nsec > 1000000000ul) {
       tv.tv_sec = cap_to_u32_max(tv.tv_sec + tv.tv_nsec / (1000000000ul));
       tv.tv_nsec %= 1000000000ul;
     }
   }
 
+  static inline constexpr utime_t max() {
+    return utime_t{time_t{std::numeric_limits<uint32_t>::max()}, 0};
+  }
+
   // cons
-  utime_t() { tv.tv_sec = 0; tv.tv_nsec = 0; }
-  utime_t(time_t s, int n) { tv.tv_sec = s; tv.tv_nsec = n; normalize(); }
-  utime_t(const struct ceph_timespec &v) {
+  constexpr utime_t() { tv.tv_sec = 0; tv.tv_nsec = 0; }
+  constexpr utime_t(time_t s, int n) { tv.tv_sec = s; tv.tv_nsec = n; normalize(); }
+  constexpr utime_t(const struct ceph_timespec &v) {
     decode_timeval(&v);
   }
-  utime_t(const struct timespec v)
+  constexpr utime_t(const struct timespec v)
   {
     // NOTE: this is used by ceph_clock_now() so should be kept
     // as thin as possible.
@@ -125,9 +129,9 @@ public:
   }
 
   // accessors
-  time_t        sec()  const { return tv.tv_sec; }
-  long          usec() const { return tv.tv_nsec/1000; }
-  int           nsec() const { return tv.tv_nsec; }
+  constexpr time_t        sec()  const { return tv.tv_sec; }
+  constexpr long          usec() const { return tv.tv_nsec/1000; }
+  constexpr int           nsec() const { return tv.tv_nsec; }
 
   // ref accessors/modifiers
   __u32&         sec_ref()  { return tv.tv_sec; }
@@ -187,7 +191,7 @@ public:
     t->tv_sec = tv.tv_sec;
     t->tv_nsec = tv.tv_nsec;
   }
-  void decode_timeval(const struct ceph_timespec *t) {
+  constexpr void decode_timeval(const struct ceph_timespec *t) {
     tv.tv_sec = t->tv_sec;
     tv.tv_nsec = t->tv_nsec;
   }
@@ -223,7 +227,7 @@ public:
   }
 
   // cast to double
-  operator double() const {
+  constexpr operator double() const {
     return (double)sec() + ((double)nsec() / 1000000000.0f);
   }
   operator ceph_timespec() const {

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -27,6 +27,8 @@ set(osd_srcs
   scrubber/scrub_machine.cc
   scrubber/ScrubStore.cc
   scrubber/scrub_backend.cc
+  scrubber/scrub_queue.cc
+  scrubber/scrub_resources.cc
   Watch.cc
   Session.cc
   SnapMapper.cc

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1734,6 +1734,12 @@ void OSDService::queue_for_scrub_denied(PG* pg, Scrub::scrub_prio_t with_priorit
   queue_scrub_event_msg<PGScrubDenied>(pg, with_priority);
 }
 
+void OSDService::queue_scrub_recalc_schedule(PG* pg, Scrub::scrub_prio_t with_priority)
+{
+  // Resulting scrub event: 'RecalcSchedule'
+  queue_scrub_event_msg<PGScrubRecalcSchedule>(pg, with_priority);
+}
+
 void OSDService::queue_for_scrub_resched(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'InternalSchedScrub'
@@ -2750,7 +2756,7 @@ will start to track new ops received afterwards.";
     f->close_section();
   } else if (prefix == "dump_scrub_reservations") {
     f->open_object_section("scrub_reservations");
-    service.get_scrub_services().dump_scrub_reservations(f);
+    service.get_scrub_services().resource_bookkeeper().dump_scrub_reservations(f);
     f->close_section();
   } else if (prefix == "get_latest_osdmap") {
     get_latest_osdmap();
@@ -4241,7 +4247,8 @@ void OSD::final_init()
     "pg "			   \
     "name=pgid,type=CephPgid "	   \
     "name=cmd,type=CephChoices,strings=scrub " \
-    "name=time,type=CephInt,req=false",
+    "name=time,type=CephInt,req=false "
+    "name=force,type=CephBool,req=false",
     asok_hook,
     "");
   ceph_assert(r == 0);
@@ -4249,7 +4256,8 @@ void OSD::final_init()
     "pg "			   \
     "name=pgid,type=CephPgid "	   \
     "name=cmd,type=CephChoices,strings=deep_scrub " \
-    "name=time,type=CephInt,req=false",
+    "name=time,type=CephInt,req=false "
+    "name=force,type=CephBool,req=false",
     asok_hook,
     "");
   ceph_assert(r == 0);
@@ -4281,16 +4289,18 @@ void OSD::final_init()
   r = admin_socket->register_command(
     "scrub "				\
     "name=pgid,type=CephPgid,req=false "	\
-    "name=time,type=CephInt,req=false",
+    "name=time,type=CephInt,req=false "
+    "name=force,type=CephBool,req=false",
     asok_hook,
-    "Trigger a scheduled scrub ");
+    "Trigger a scrub ");
   ceph_assert(r == 0);
   r = admin_socket->register_command(
     "deep_scrub "			\
     "name=pgid,type=CephPgid,req=false "	\
-    "name=time,type=CephInt,req=false",
+    "name=time,type=CephInt,req=false "
+    "name=force,type=CephBool,req=false",
     asok_hook,
-    "Trigger a scheduled deep scrub ");
+    "Trigger a deep scrub ");
   ceph_assert(r == 0);
 }
 
@@ -6121,9 +6131,8 @@ void OSD::tick_without_osd_lock()
   }
 
   if (is_active()) {
-    if (!scrub_random_backoff()) {
-      sched_scrub();
-    }
+    service.get_scrub_services().sched_scrub(
+      cct->_conf, service.is_recovery_active());
     service.promote_throttle_recalibrate();
     resume_creating_pg();
     bool need_send_beacon = false;
@@ -7430,130 +7439,23 @@ void OSD::handle_fast_scrub(MOSDScrub2 *m)
   m->put();
 }
 
-bool OSD::scrub_random_backoff()
+std::optional<PGLockWrapper> OSDService::get_locked_pg(spg_t pgid)
 {
-  bool coin_flip = (rand() / (double)RAND_MAX >=
-		    cct->_conf->osd_scrub_backoff_ratio);
-  if (!coin_flip) {
-    dout(20) << "scrub_random_backoff lost coin flip, randomly backing off (ratio: "
-	     << cct->_conf->osd_scrub_backoff_ratio << ")" << dendl;
-    return true;
+  auto pg = osd->lookup_lock_pg(pgid);
+  if (pg) {
+    return PGLockWrapper{pg};
+  } else {
+    return std::nullopt;
   }
-  return false;
 }
 
-
-void OSD::sched_scrub()
+void OSDService::send_sched_recalc_to_pg(spg_t pgid)
 {
-  auto& scrub_scheduler = service.get_scrub_services();
-
-  if (auto blocked_pgs = scrub_scheduler.get_blocked_pgs_count();
-      blocked_pgs > 0) {
-    // some PGs managed by this OSD were blocked by a locked object during
-    // scrub. This means we might not have the resources needed to scrub now.
-    dout(10)
-      << fmt::format(
-	   "{}: PGs are blocked while scrubbing due to locked objects ({} PGs)",
-	   __func__,
-	   blocked_pgs)
-      << dendl;
+  auto locked_pg = get_locked_pg(pgid);
+  if (locked_pg) {
+    queue_scrub_recalc_schedule(
+	&(*(locked_pg->pg())), Scrub::scrub_prio_t::low_priority);
   }
-
-  // fail fast if no resources are available
-  if (!scrub_scheduler.can_inc_scrubs()) {
-    dout(20) << __func__ << ": OSD cannot inc scrubs" << dendl;
-    return;
-  }
-
-  // if there is a PG that is just now trying to reserve scrub replica resources -
-  // we should wait and not initiate a new scrub
-  if (scrub_scheduler.is_reserving_now()) {
-    dout(20) << __func__ << ": scrub resources reservation in progress" << dendl;
-    return;
-  }
-
-  Scrub::ScrubPreconds env_conditions;
-
-  if (service.is_recovery_active() && !cct->_conf->osd_scrub_during_recovery) {
-    if (!cct->_conf->osd_repair_during_recovery) {
-      dout(15) << __func__ << ": not scheduling scrubs due to active recovery"
-	       << dendl;
-      return;
-    }
-    dout(10) << __func__
-      << " will only schedule explicitly requested repair due to active recovery"
-      << dendl;
-    env_conditions.allow_requested_repair_only = true;
-  }
-
-  if (g_conf()->subsys.should_gather<ceph_subsys_osd, 20>()) {
-    dout(20) << __func__ << " sched_scrub starts" << dendl;
-    auto all_jobs = scrub_scheduler.list_registered_jobs();
-    for (const auto& sj : all_jobs) {
-      dout(20) << "sched_scrub scrub-queue jobs: " << *sj << dendl;
-    }
-  }
-
-  auto was_started = scrub_scheduler.select_pg_and_scrub(env_conditions);
-  dout(20) << "sched_scrub done (" << ScrubQueue::attempt_res_text(was_started)
-	   << ")" << dendl;
-}
-
-Scrub::schedule_result_t OSDService::initiate_a_scrub(spg_t pgid,
-						      bool allow_requested_repair_only)
-{
-  dout(20) << __func__ << " trying " << pgid << dendl;
-
-  // we have a candidate to scrub. We need some PG information to know if scrubbing is
-  // allowed
-
-  PGRef pg = osd->lookup_lock_pg(pgid);
-  if (!pg) {
-    // the PG was dequeued in the short timespan between creating the candidates list
-    // (collect_ripe_jobs()) and here
-    dout(5) << __func__ << " pg  " << pgid << " not found" << dendl;
-    return Scrub::schedule_result_t::no_such_pg;
-  }
-
-  // This has already started, so go on to the next scrub job
-  if (pg->is_scrub_queued_or_active()) {
-    pg->unlock();
-    dout(20) << __func__ << ": already in progress pgid " << pgid << dendl;
-    return Scrub::schedule_result_t::already_started;
-  }
-  // Skip other kinds of scrubbing if only explicitly requested repairing is allowed
-  if (allow_requested_repair_only && !pg->get_planned_scrub().must_repair) {
-    pg->unlock();
-    dout(10) << __func__ << " skip " << pgid
-	     << " because repairing is not explicitly requested on it" << dendl;
-    return Scrub::schedule_result_t::preconditions;
-  }
-
-  auto scrub_attempt = pg->sched_scrub();
-  pg->unlock();
-  return scrub_attempt;
-}
-
-void OSD::resched_all_scrubs()
-{
-  dout(10) << __func__ << ": start" << dendl;
-  auto all_jobs = service.get_scrub_services().list_registered_jobs();
-  for (auto& e : all_jobs) {
-
-    auto& job = *e;
-    dout(20) << __func__ << ": examine " << job.pgid << dendl;
-
-    PGRef pg = _lookup_lock_pg(job.pgid);
-    if (!pg)
-      continue;
-
-    if (!pg->get_planned_scrub().must_scrub && !pg->get_planned_scrub().need_auto) {
-      dout(15) << __func__ << ": reschedule " << job.pgid << dendl;
-      pg->reschedule_scrub();
-    }
-    pg->unlock();
-  }
-  dout(10) << __func__ << ": done" << dendl;
 }
 
 MPGStats* OSD::collect_pg_stats()
@@ -9634,7 +9536,8 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_object_clean_region_max_num_intervals",
     "osd_scrub_min_interval",
     "osd_scrub_max_interval",
-    NULL
+    "osd_deep_scrub_interval",
+    nullptr
   };
   return KEYS;
 }
@@ -9748,9 +9651,15 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
   }
 
   if (changed.count("osd_scrub_min_interval") ||
-      changed.count("osd_scrub_max_interval")) {
-    resched_all_scrubs();
-    dout(0) << __func__ << ": scrub interval change" << dendl;
+      changed.count("osd_scrub_max_interval") ||
+      changed.count("osd_deep_scrub_interval")) {
+    service.get_scrub_services().on_config_times_change();
+    dout(0) << fmt::format(
+		   "{}: scrub interval change (min:{} deep:{} max:{})",
+		   __func__, cct->_conf->osd_scrub_min_interval,
+		   cct->_conf->osd_deep_scrub_interval,
+		   cct->_conf->osd_scrub_max_interval)
+	    << dendl;
   }
   check_config();
   if (changed.count("osd_asio_thread_count")) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -26,6 +26,7 @@
 #include "include/types.h"
 #include "include/stringify.h"
 #include "osd_types.h"
+#include "osd_types_fmt.h"
 #include "include/xlist.h"
 #include "SnapMapper.h"
 #include "Session.h"
@@ -63,6 +64,8 @@ typedef OpRequest::Ref OpRequestRef;
 class DynamicPerfStats;
 class PgScrubber;
 class ScrubBackend;
+
+class ScrubQueue;
 
 namespace Scrub {
   class Store;
@@ -170,6 +173,7 @@ class PG : public DoutPrefixProvider,
   friend class PeeringState;
   friend class PgScrubber;
   friend class ScrubBackend;
+  friend class ScrubQueue;
 
 public:
   const pg_shard_t pg_whoami;
@@ -178,13 +182,6 @@ public:
   /// the 'scrubber'. Will be allocated in the derivative (PrimaryLogPG) ctor,
   /// and be removed only in the PrimaryLogPG destructor.
   std::unique_ptr<ScrubPgIF> m_scrubber;
-
-  /// flags detailing scheduling/operation characteristics of the next scrub 
-  requested_scrub_t m_planned_scrub;
-
-  const requested_scrub_t& get_planned_scrub() const {
-    return m_planned_scrub;
-  }
 
   /// scrubbing state for both Primary & replicas
   bool is_scrub_active() const { return m_scrubber->is_scrub_active(); }
@@ -458,6 +455,12 @@ public:
 			"ReservationFailure");
   }
 
+  void scrub_send_recalc_schedule(epoch_t queued, ThreadPool::TPHandle& handle)
+  {
+    forward_scrub_event(&ScrubPgIF::recalc_schedule, queued,
+			"RecalcSchedule");
+  }
+
   void scrub_send_scrub_resched(epoch_t queued, ThreadPool::TPHandle& handle)
   {
     forward_scrub_event(&ScrubPgIF::send_scrub_resched, queued, "InternalSchedScrub");
@@ -541,8 +544,6 @@ public:
   void on_info_history_change() override;
 
   void on_primary_status_change(bool was_primary, bool now_primary) override;
-
-  void reschedule_scrub() override;
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;
 
@@ -706,48 +707,32 @@ public:
   void shutdown();
   virtual void on_shutdown() = 0;
 
-  bool get_must_scrub() const;
-  Scrub::schedule_result_t sched_scrub();
+  /**
+   * Start a scrub operation.
+   *
+   * @param [in] scrub_clock_now time now (unless under unit-test)
+   * @param [in] level Level of scrub (deep or shallow)
+   * @param [in] preconds a set of flags determined based on environment
+   *       conditions (time & load) that might restrict some scrubs
+   * @returns either 'scrub_initiated' or 'failure'
+   */
+  Scrub::schedule_result_t start_scrubbing(
+      utime_t scrub_clock_now,
+      scrub_level_t level,
+      const Scrub::ScrubPreconds preconds);
 
-  unsigned int scrub_requeue_priority(Scrub::scrub_prio_t with_priority, unsigned int suggested_priority) const;
+  unsigned int scrub_requeue_priority(
+    Scrub::scrub_prio_t with_priority,
+    unsigned int suggested_priority) const;
   /// the version that refers to flags_.priority
   unsigned int scrub_requeue_priority(Scrub::scrub_prio_t with_priority) const;
-private:
-  // auxiliaries used by sched_scrub():
-  double next_deepscrub_interval() const;
 
-  /// should we perform deep scrub?
-  bool is_time_for_deep(bool allow_deep_scrub,
-                        bool allow_shallow_scrub,
-                        bool has_deep_errors,
-                        const requested_scrub_t& planned) const;
-
-  /**
-   * Validate the various 'next scrub' flags in m_planned_scrub against configuration
-   * and scrub-related timestamps.
-   *
-   * @returns an updated copy of the m_planned_flags (or nothing if no scrubbing)
-   */
-  std::optional<requested_scrub_t> validate_scrub_mode() const;
-
-  std::optional<requested_scrub_t> validate_periodic_mode(
-    bool allow_deep_scrub,
-    bool try_to_auto_repair,
-    bool allow_shallow_scrub,
-    bool time_for_deep,
-    bool has_deep_errors,
-    const requested_scrub_t& planned) const;
-
-  std::optional<requested_scrub_t> validate_initiated_scrub(
-    bool allow_deep_scrub,
-    bool try_to_auto_repair,
-    bool time_for_deep,
-    bool has_deep_errors,
-    const requested_scrub_t& planned) const;
-
+ private:
+  /// forwarding scrub events to the scrubber
   using ScrubAPI = void (ScrubPgIF::*)(epoch_t epoch_queued);
   void forward_scrub_event(ScrubAPI fn, epoch_t epoch_queued, std::string_view desc);
-  // and for events that carry a meaningful 'activation token'
+
+  /// forwarding scrub events that carry a meaningful 'activation token'
   using ScrubSafeAPI = void (ScrubPgIF::*)(epoch_t epoch_queued,
 					   Scrub::act_token_t act_token);
   void forward_scrub_event(ScrubSafeAPI fn,
@@ -765,7 +750,7 @@ public:
 
   virtual void snap_trimmer(epoch_t epoch_queued) = 0;
   virtual void do_command(
-    const std::string_view& prefix,
+    std::string_view prefix,
     const cmdmap_t& cmdmap,
     const ceph::buffer::list& idata,
     std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) = 0;
@@ -1234,8 +1219,6 @@ public:
 
   // -- scrub --
 protected:
-  bool scrub_after_recovery;
-
   int active_pushes;
 
   [[nodiscard]] bool ops_blocked_by_scrub() const;
@@ -1369,7 +1352,7 @@ protected:
   virtual void snap_trimmer_scrub_complete() = 0;
 
   void queue_recovery();
-  void queue_scrub_after_repair();
+  void notify_scrub_on_recovery_finish();
   unsigned int get_scrub_priority();
 
   bool try_flush_or_schedule_async() override;
@@ -1420,10 +1403,6 @@ public:
 
  OSDService* get_pg_osd(ScrubberPasskey) const { return osd; }
 
- requested_scrub_t& get_planned_scrub(ScrubberPasskey)
- {
-   return m_planned_scrub;
- }
 
  void force_object_missing(ScrubberPasskey,
                            const std::set<pg_shard_t>& peer,
@@ -1437,6 +1416,15 @@ public:
  {
    return get_pgbackend()->be_get_ondisk_size(logical_size);
  }
+};
+
+class PGLockWrapper {
+ public:
+  PGLockWrapper(PGRef locked_pg) : m_pg{locked_pg} {}
+  PGRef pg() const { return m_pg; }
+  ~PGLockWrapper();
+ private:
+  PGRef m_pg;
 };
 
 #endif

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -736,10 +736,6 @@ void PeeringState::start_peering_interval(
     }
   }
 
-  if (is_primary() && was_old_primary) {
-    pl->reschedule_scrub();
-  }
-
   if (acting.empty() && !up.empty() && up_primary == pg_whoami) {
     psdout(10) << " acting empty, but i am up[0], clearing pg_temp" << dendl;
     pl->queue_want_pg_temp(acting);
@@ -3984,7 +3980,6 @@ void PeeringState::update_stats(
   if (f(info.history, info.stats)) {
     pl->publish_stats_to_osd();
   }
-  pl->reschedule_scrub();
 
   if (t) {
     dirty_info = true;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -285,9 +285,6 @@ public:
     /// Notify PG that Primary/Replica status has changed (to update scrub registration)
     virtual void on_primary_status_change(bool was_primary, bool now_primary) = 0;
 
-    /// Need to reschedule next scrub. Assuming no change in role
-    virtual void reschedule_scrub() = 0;
-
     /// Notify that a scrub has been requested
     virtual void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) = 0;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -994,7 +994,7 @@ PrimaryLogPG::get_pgls_filter(bufferlist::const_iterator& iter)
 // ==========================================================
 
 void PrimaryLogPG::do_command(
-  const string_view& orig_prefix,
+  string_view orig_prefix,
   const cmdmap_t& cmdmap,
   const bufferlist& idata,
   std::function<void(int,const std::string&,bufferlist&)> on_finish)
@@ -1028,7 +1028,7 @@ void PrimaryLogPG::do_command(
     f->close_section();
 
     if (is_primary() && is_active() && m_scrubber) {
-      m_scrubber->dump_scrubber(f.get(), m_planned_scrub);
+      m_scrubber->dump_scrubber(f.get());
     }
 
     f->open_object_section("agent_state");
@@ -1154,39 +1154,19 @@ void PrimaryLogPG::do_command(
     f->close_section();
   }
 
-  else if (prefix == "scrub" ||
-	   prefix == "deep_scrub") {
-    bool deep = (prefix == "deep_scrub");
+  else if (prefix == "scrub" || prefix == "deep_scrub") {
+
+    scrub_level_t deep =
+	(prefix == "deep_scrub") ? scrub_level_t::deep : scrub_level_t::shallow;
     int64_t time = cmd_getval_or<int64_t>(cmdmap, "time", 0);
+    bool as_must = cmd_getval_or<bool>(cmdmap, "force", false);
 
     if (is_primary()) {
-      const pg_pool_t *p = &pool.info;
-      double pool_scrub_max_interval = 0;
-      double scrub_max_interval;
-      if (deep) {
-        p->opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL, &pool_scrub_max_interval);
-        scrub_max_interval = pool_scrub_max_interval > 0 ?
-          pool_scrub_max_interval : g_conf()->osd_deep_scrub_interval;
+      if (as_must) {
+	m_scrubber->on_operator_forced_scrub(f.get(), deep);
       } else {
-        p->opts.get(pool_opts_t::SCRUB_MAX_INTERVAL, &pool_scrub_max_interval);
-        scrub_max_interval = pool_scrub_max_interval > 0 ?
-          pool_scrub_max_interval : g_conf()->osd_scrub_max_interval;
+        m_scrubber->on_operator_periodic_cmd(f.get(), deep, time);
       }
-      // Instead of marking must_scrub force a schedule scrub
-      utime_t stamp = ceph_clock_now();
-      if (time == 0)
-        stamp -= scrub_max_interval;
-      else
-        stamp -=  (float)time;
-      stamp -= 100.0;  // push back last scrub more for good measure
-      if (deep) {
-        set_last_deep_scrub_stamp(stamp);
-      }
-      set_last_scrub_stamp(stamp); // for 'deep' as well, as we use this value to order scrubs
-      f->open_object_section("result");
-      f->dump_bool("deep", deep);
-      f->dump_stream("stamp") << stamp;
-      f->close_section();
     } else {
       ss << "Not primary";
       ret = -EPERM;
@@ -1194,23 +1174,17 @@ void PrimaryLogPG::do_command(
     outbl.append(ss.str());
   }
 
-  else if (prefix == "block" || prefix == "unblock" || prefix == "set" ||
-           prefix == "unset") {
+  else if (orig_prefix == "scrubdebug" ||
+      prefix == "block" || prefix == "unblock" || prefix == "set" ||
+      prefix == "unset") {
     string value;
     cmd_getval(cmdmap, "value", value);
-
-    if (is_primary()) {
-      ret = m_scrubber->asok_debug(prefix, value, f.get(), ss);
-      f->open_object_section("result");
-      f->dump_bool("success", true);
-      f->close_section();
-    } else {
-      ss << "Not primary";
-      ret = -EPERM;
+    ret = do_scrub_debug(f.get(), orig_prefix, prefix, value);
+    if (ret) {
+      ss << "do_scrub_debug returned " << ret;
     }
     outbl.append(ss.str());
-  }
-  else {
+  } else {
     ret = -ENOSYS;
     ss << "prefix '" << prefix << "' not implemented";
   }
@@ -1220,6 +1194,23 @@ void PrimaryLogPG::do_command(
     f->flush(outbl);
   }
   on_finish(ret, ss.str(), outbl);
+}
+
+int PrimaryLogPG::do_scrub_debug(
+    Formatter *f,
+    std::string_view prefix,
+    std::string_view cmd,
+    std::string_view val)
+{
+  dout(10) << fmt::format("do_scrub_debug: {} / {} / {}", prefix, cmd, val)
+	   << dendl;
+  if (!m_scrubber) {
+    dout(10) << "do_scrub_debug: no scrubber object" << dendl;
+    return -EPERM;
+  }
+
+  stringstream ss;
+  return m_scrubber->asok_debug(prefix, cmd, val, f, ss);
 }
 
 
@@ -1760,11 +1751,13 @@ PrimaryLogPG::PrimaryLogPG(OSDService *o, OSDMapRef curmap,
     pgbackend->get_is_recoverable_predicate());
   snap_trimmer_machine.initiate();
 
-  m_scrubber = make_unique<PrimaryLogScrub>(this);
+  m_scrubber = make_unique<PrimaryLogScrub>(this, o->get_scrub_services());
 }
 
 PrimaryLogPG::~PrimaryLogPG()
 {
+  // making sure the scrubber is deleted here, in the 'derived' class, and not
+  // in the PG destructor:
   m_scrubber.reset();
 }
 
@@ -12316,7 +12309,8 @@ int PrimaryLogPG::recover_missing(
   int priority,
   PGBackend::RecoveryHandle *h)
 {
-  dout(10) << __func__ << " sar: " << scrub_after_recovery << dendl;
+  dout(10) << __func__ << " sar: " << m_scrubber->is_after_repair_required()
+	   << dendl;
 
   if (recovery_state.get_missing_loc().is_unfound(soid)) {
     dout(7) << __func__ << " " << soid
@@ -12347,7 +12341,7 @@ int PrimaryLogPG::recover_missing(
 	 if (!object_missing) {
 	   object_stat_sum_t stat_diff;
 	   stat_diff.num_objects_recovered = 1;
-	   if (scrub_after_recovery)
+	   if (m_scrubber->is_after_repair_required())
 	     stat_diff.num_objects_repaired = 1;
 	   on_global_recover(soid, stat_diff, true);
 	 } else {
@@ -13145,7 +13139,7 @@ void PrimaryLogPG::_clear_recovery_state()
 #ifdef DEBUG_RECOVERY_OIDS
   recovering_oids.clear();
 #endif
-  dout(15) << __func__ << " flags: " << m_planned_scrub << dendl;
+  dout(15) << __func__ << dendl;
 
   last_backfill_started = hobject_t();
   set<hobject_t>::iterator i = backfills_in_flight.begin();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1477,7 +1477,7 @@ public:
   ~PrimaryLogPG() override;
 
   void do_command(
-    const std::string_view& prefix,
+    std::string_view prefix,
     const cmdmap_t& cmdmap,
     const ceph::buffer::list& idata,
     std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) override;
@@ -1523,7 +1523,12 @@ public:
 
 private:
   int do_scrub_ls(const MOSDOp *op, OSDOp *osd_op);
-  bool check_src_targ(const hobject_t& soid, const hobject_t& toid) const;
+  int do_scrub_debug(
+      Formatter *f,
+      std::string_view prefix,
+      std::string_view cmd,
+      std::string_view par);
+  bool check_src_targ(const hobject_t &soid, const hobject_t &toid) const;
 
   uint64_t temp_seq; ///< last id for naming temp objects
   /// generate a new temp object name

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2944,22 +2944,29 @@ std::string pg_stat_t::dump_scrub_schedule() const
 	scrub_sched_status.m_duration_seconds);
     }
   }
+  // not scrubbing at this time:
   switch (scrub_sched_status.m_sched_status) {
     case pg_scrub_sched_status_t::unknown:
       // no reported scrub schedule yet
       return "--"s;
     case pg_scrub_sched_status_t::not_queued:
       return "no scrub is scheduled"s;
-    case pg_scrub_sched_status_t::scheduled:
-      return fmt::format(
-        "{} {}scrub scheduled @ {}",
-        (scrub_sched_status.m_is_periodic ? "periodic" : "user requested"),
-        ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""),
-        scrub_sched_status.m_scheduled_at);
     case pg_scrub_sched_status_t::queued:
       return fmt::format(
         "queued for {}scrub",
         ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""));
+    case pg_scrub_sched_status_t::scheduled:
+      return fmt::format(
+        "{} {}scrub scheduled to {:s}",
+        (scrub_sched_status.m_is_periodic ? "periodic" : "priority"),
+        ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""),
+        scrub_sched_status.m_scheduled_at);
+    case pg_scrub_sched_status_t::delayed:
+      return fmt::format(
+        "{} {}scrub will be retried not before {:s}",
+        (scrub_sched_status.m_is_periodic ? "periodic" : "priority"),
+        ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""),
+        scrub_sched_status.m_scheduled_at);
     default:
       // a bug!
       return "SCRUB STATE MISMATCH!"s;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2138,12 +2138,13 @@ enum class scrub_type_t : bool { not_repair = false, do_repair = true };
 
 /// is there a scrub in our future?
 enum class pg_scrub_sched_status_t : uint16_t {
-  unknown,         ///< status not reported yet
-  not_queued,	   ///< not in the OSD's scrub queue. Probably not active.
-  active,          ///< scrubbing
-  scheduled,	   ///< scheduled for a scrub at an already determined time
-  queued,	   ///< queued to be scrubbed
-  blocked	   ///< blocked waiting for objects to be unlocked
+  unknown,     ///< status not reported yet
+  not_queued,  ///< not in the OSD's scrub queue
+  active,      ///< scrubbing
+  queued,     ///< ready and queued to be scrubbed
+  scheduled,  ///< queued to be scrubbed once our 'not before' time is reached
+  delayed,    ///< past scheduled time, but previous attempt to scrub failed
+  blocked     ///< blocked waiting for objects to be unlocked
 };
 
 struct pg_scrubbing_status_t {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -395,7 +395,7 @@ struct pg_t {
   uint32_t m_seed;
 
   pg_t() : m_pool(0), m_seed(0) {}
-  pg_t(ps_t seed, uint64_t pool) :
+  constexpr pg_t(ps_t seed, uint64_t pool) :
     m_pool(pool), m_seed(seed) {}
   // cppcheck-suppress noExplicitConstructor
   pg_t(const ceph_pg& cpg) :
@@ -513,7 +513,7 @@ struct spg_t {
   pg_t pgid;
   shard_id_t shard;
   spg_t() : shard(shard_id_t::NO_SHARD) {}
-  spg_t(pg_t pgid, shard_id_t shard) : pgid(pgid), shard(shard) {}
+  constexpr spg_t(pg_t pgid, shard_id_t shard) : pgid(pgid), shard(shard) {}
   explicit spg_t(pg_t pgid) : pgid(pgid), shard(shard_id_t::NO_SHARD) {}
   auto operator<=>(const spg_t&) const = default;
   unsigned get_split_bits(unsigned pg_num) const {

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -328,6 +328,19 @@ struct fmt::formatter<ScrubMap> {
   bool debug_log{false};
 };
 
+template <>
+struct fmt::formatter<scrub_level_t> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(scrub_level_t lvl, FormatContext& ctx)
+  {
+    if (lvl == scrub_level_t::shallow) {
+      return formatter<string_view>::format("shallow", ctx);
+    }
+    // else
+    return formatter<string_view>::format("deep", ctx);
+  }
+};
+
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<ObjectRecoveryInfo> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<ObjectRecoveryProgress> : fmt::ostream_formatter {};

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -95,6 +95,15 @@ void PGScrubDenied::run(OSD* osd,
   pg->unlock();
 }
 
+void PGScrubRecalcSchedule::run(OSD* osd,
+			OSDShard* sdata,
+			PGRef& pg,
+			ThreadPool::TPHandle& handle)
+{
+  pg->scrub_send_recalc_schedule(epoch_queued, handle);
+  pg->unlock();
+}
+
 void PGScrubPushesUpdate::run(OSD* osd,
 			      OSDShard* sdata,
 			      PGRef& pg,

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -427,6 +427,17 @@ class PGScrubDenied : public PGScrubItem {
 };
 
 /**
+ *  should recompute scrub schedule following a configuration change
+ */
+class PGScrubRecalcSchedule : public PGScrubItem {
+ public:
+  PGScrubRecalcSchedule(spg_t pg, epoch_t epoch_queued)
+      : PGScrubItem{pg, epoch_queued, "PGScrubRecalcSchedule"}
+  {}
+  void run(OSD* osd, OSDShard* sdata, PGRef& pg, ThreadPool::TPHandle& handle) final;
+};
+
+/**
  *  called when a repair process completes, to initiate scrubbing. No local/remote
  *  resources are allocated.
  */

--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -63,10 +63,6 @@ void PrimaryLogScrub::submit_digest_fixes(const digests_fixes_t& fixes)
       num_digest_updates_pending--;
       continue;
     }
-    dout(15) << fmt::format(
-		  "{}: {}, pg[{}] {}/{}", __func__, num_digest_updates_pending,
-		  m_pg_id, obj, dgs)
-	     << dendl;
     if (obc->obs.oi.soid != obj) {
       m_osds->clog->error()
 	<< m_pg_id << " " << m_mode_desc << " " << obj
@@ -226,11 +222,14 @@ void PrimaryLogScrub::_scrub_finish()
     m_pl_pg->object_contexts.clear();
 }
 
-PrimaryLogScrub::PrimaryLogScrub(PrimaryLogPG* pg) : PgScrubber{pg}, m_pl_pg{pg}
+PrimaryLogScrub::PrimaryLogScrub(PrimaryLogPG* pg, ScrubQueue& osd_scrubq)
+    : PgScrubber{pg, osd_scrubq}
+    , m_pl_pg{pg}
 {}
 
 void PrimaryLogScrub::_scrub_clear_state()
 {
+  dout(15) << __func__ << dendl;
   m_scrub_cstat = object_stat_collection_t();
 }
 

--- a/src/osd/scrubber/PrimaryLogScrub.h
+++ b/src/osd/scrubber/PrimaryLogScrub.h
@@ -24,7 +24,7 @@ class PrimaryLogPG;
  */
 class PrimaryLogScrub : public PgScrubber {
  public:
-  explicit PrimaryLogScrub(PrimaryLogPG* pg);
+  explicit PrimaryLogScrub(PrimaryLogPG* pg, ScrubQueue& osd_scrubq);
 
   void _scrub_finish() final;
 

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -2,816 +2,935 @@
 // vim: ts=8 sw=2 smarttab
 #include "./osd_scrub_sched.h"
 
+#include <compare>
+#include <shared_mutex>
+
 #include "osd/OSD.h"
 
 #include "pg_scrubber.h"
+#include "scrub_queue.h"
 
-using namespace ::std::literals;
+using namespace std::chrono;
+using namespace std::chrono_literals;
+using namespace std::literals;
+
 
 // ////////////////////////////////////////////////////////////////////////// //
-// ScrubJob
+// SchedEntry
 
+namespace Scrub {
+
+std::weak_ordering cmp_ripe_entries(
+    const Scrub::SchedEntry& l,
+    const Scrub::SchedEntry& r)
+{
+  // for 'higher is better' sub elements - the 'r.' is on the left
+  if (auto cmp = r.urgency <=> l.urgency; cmp != 0) {
+    return cmp;
+  }
+  // the 'utime_t' operator<=> is 'partial_ordering', it seems.
+  if (auto cmp = std::weak_order(double(l.target), double(r.target));
+      cmp != 0) {
+    return cmp;
+  }
+  if (auto cmp = std::weak_order(double(l.not_before), double(r.not_before));
+      cmp != 0) {
+    return cmp;
+  }
+  if (l.level < r.level) {
+    return std::weak_ordering::less;
+  }
+  return std::weak_ordering::greater;
+}
+
+std::weak_ordering cmp_future_entries(
+    const Scrub::SchedEntry& l,
+    const Scrub::SchedEntry& r)
+{
+  if (auto cmp = std::weak_order(double(l.not_before), double(r.not_before));
+      cmp != 0) {
+    return cmp;
+  }
+  // for 'higher is better' sub elements - the 'r.' is on the left
+  if (auto cmp = r.urgency <=> l.urgency; cmp != 0) {
+    return cmp;
+  }
+  if (auto cmp = std::weak_order(double(l.target), double(r.target));
+      cmp != 0) {
+    return cmp;
+  }
+  if (l.level < r.level) {
+    return std::weak_ordering::less;
+  }
+  return std::weak_ordering::greater;
+}
+
+std::weak_ordering
+cmp_entries(utime_t t, const Scrub::SchedEntry& l, const Scrub::SchedEntry& r)
+{
+  bool l_ripe = l.is_ripe(t);
+  bool r_ripe = r.is_ripe(t);
+  if (l_ripe) {
+    if (r_ripe) {
+      return cmp_ripe_entries(l, r);
+    }
+    return std::weak_ordering::less;
+  }
+  if (r_ripe) {
+    return std::weak_ordering::greater;
+  }
+  return cmp_future_entries(l, r);
+}
+
+}  // namespace Scrub
+
+
+using SchedTarget = Scrub::SchedTarget;
+using urgency_t = Scrub::urgency_t;
+using delay_cause_t = Scrub::delay_cause_t;
+using ScrubPreconds = Scrub::ScrubPreconds;
+
+namespace {
+utime_t add_double(utime_t t, double d)
+{
+  return utime_t{t.sec() + static_cast<int>(d), t.nsec()};
+}
+}  // namespace
+
+namespace Scrub {
+// both targets compared are assumed to be 'ripe', i.e. not_before is in the past
+std::weak_ordering cmp_ripe_targets(
+    const Scrub::SchedTarget& l,
+    const Scrub::SchedTarget& r)
+{
+  return cmp_ripe_entries(l.queued_element(), r.queued_element());
+}
+
+std::weak_ordering cmp_future_targets(
+    const Scrub::SchedTarget& l,
+    const Scrub::SchedTarget& r)
+{
+  return cmp_ripe_entries(l.queued_element(), r.queued_element());
+}
+
+std::weak_ordering
+cmp_targets(utime_t t, const Scrub::SchedTarget& l, const Scrub::SchedTarget& r)
+{
+  return cmp_entries(t, l.queued_element(), r.queued_element());
+}
+}  // namespace Scrub
+
+bool Scrub::SchedEntry::is_ripe(utime_t now_is) const
+{
+  return urgency > urgency_t::off && now_is >= not_before;
+}
+
+void Scrub::SchedEntry::dump(std::string_view sect_name, ceph::Formatter* f)
+    const
+{
+  f->open_object_section(sect_name);
+  /// \todo improve the performance of u_time dumps here
+  f->dump_stream("pg") << pgid;
+  f->dump_stream("level")
+      << (level == scrub_level_t::deep ? "deep" : "shallow");
+  f->dump_stream("urgency") << fmt::format("{}", urgency);
+  f->dump_stream("target") << target;
+  f->dump_stream("not_before") << not_before;
+  f->dump_stream("deadline") << deadline;
+  f->close_section();
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// SchedTarget
+
+
+// 'dout' definitions for SchedTarget & ScrubJob
 #define dout_context (cct)
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
-#define dout_prefix *_dout << "osd." << whoami << " "
+#define dout_prefix _prefix_target(_dout, this)
 
-ScrubQueue::ScrubJob::ScrubJob(CephContext* cct, const spg_t& pg, int node_id)
-    : RefCountedObject{cct}
-    , pgid{pg}
+template <class T>
+static ostream& _prefix_target(std::ostream* _dout, T* t)
+{
+  return t->gen_prefix(*_dout);
+}
+
+/**
+ * A SchedTarget names both a PG to scrub and the level (deepness) of scrubbing
+ */
+SchedTarget::SchedTarget(
+    spg_t pg_id,
+    scrub_level_t scrub_level,
+    int osd_num,
+    CephContext* cct)
+    : sched_info{pg_id, scrub_level}
+    , cct{cct}
+    , whoami{osd_num}
+{
+  ceph_assert(cct);
+  m_log_prefix = fmt::format("osd.{} pg[{}] ScrubTrgt: ", whoami, pg_id.pgid);
+}
+
+std::ostream& SchedTarget::gen_prefix(std::ostream& out) const
+{
+  return out << m_log_prefix;
+}
+
+void SchedTarget::reset()
+{
+  // a bit convoluted, but the standard way to guarantee we keep the
+  // same set of member defaults as the constructor
+  *this = SchedTarget{sched_info.pgid, sched_info.level, whoami, cct};
+}
+
+bool SchedTarget::over_deadline(utime_t now_is) const
+{
+  return sched_info.urgency > urgency_t::off && now_is >= sched_info.deadline;
+}
+
+bool SchedTarget::is_periodic() const
+{
+  return sched_info.urgency == urgency_t::periodic_regular ||
+	 sched_info.urgency == urgency_t::overdue;
+}
+
+utime_t SchedTarget::sched_time() const
+{
+  return sched_info.not_before;
+}
+
+void SchedTarget::depenalize()
+{
+  up_urgency_to(urgency_t::periodic_regular);
+}
+
+void SchedTarget::up_urgency_to(urgency_t u)
+{
+  sched_info.urgency = std::max(sched_info.urgency, u);
+}
+
+void SchedTarget::set_oper_shallow_target(
+    scrub_type_t rpr,
+    utime_t scrub_clock_now)
+{
+  ceph_assert(sched_info.level == scrub_level_t::shallow);
+  ceph_assert(rpr != scrub_type_t::do_repair);
+  ceph_assert(!in_queue);
+
+  up_urgency_to(urgency_t::operator_requested);
+  sched_info.target = std::min(scrub_clock_now, sched_info.target);
+  sched_info.not_before = std::min(sched_info.not_before, scrub_clock_now);
+  auto_repairing = false;
+  last_issue = delay_cause_t::none;
+}
+
+void SchedTarget::set_oper_deep_target(
+    scrub_type_t rpr,
+    utime_t scrub_clock_now)
+{
+  ceph_assert(sched_info.level == scrub_level_t::deep);
+  ceph_assert(!in_queue);
+
+  if (rpr == scrub_type_t::do_repair) {
+    up_urgency_to(urgency_t::must);
+    do_repair = true;
+  } else {
+    up_urgency_to(urgency_t::operator_requested);
+  }
+  sched_info.target = std::min(scrub_clock_now, sched_info.target);
+  sched_info.not_before = std::min(sched_info.not_before, scrub_clock_now);
+  auto_repairing = false;
+  last_issue = delay_cause_t::none;
+  dout(20) << fmt::format(
+		  "{}: repair?{} final:{}", __func__,
+		  ((rpr == scrub_type_t::do_repair) ? "+" : "-"), *this)
+	   << dendl;
+}
+
+
+void SchedTarget::update_as_shallow(
+    const pg_info_t& pg_info,
+    const Scrub::sched_conf_t& config,
+    utime_t time_now)
+{
+  ceph_assert(sched_info.level == scrub_level_t::shallow);
+  ceph_assert(!in_queue);
+
+  if (is_required()) {
+    // shouldn't be called for high-urgency scrubs
+    return;
+  }
+
+  if (pg_info.stats.stats_invalid && config.mandatory_on_invalid) {
+    sched_info.urgency = urgency_t::must;
+    sched_info.target = time_now;
+    sched_info.not_before = time_now;
+    // we will force a deadline in this case
+    if (config.max_shallow && *config.max_shallow > 0.1) {
+      sched_info.deadline = add_double(time_now, *config.max_shallow);
+    } else {
+      sched_info.deadline = add_double(time_now, config.shallow_interval);
+    }
+  } else {
+    auto base = pg_info.stats.stats_invalid ? time_now
+					    : pg_info.history.last_scrub_stamp;
+    sched_info.target = add_double(base, config.shallow_interval);
+    // if in the past - do not delay. Otherwise - add a random delay
+    if (sched_info.target > time_now) {
+      double r = rand() / (double)RAND_MAX;
+      sched_info.target +=
+	  config.shallow_interval * config.interval_randomize_ratio * r;
+    }
+    sched_info.not_before = sched_info.target;
+    sched_info.urgency = urgency_t::periodic_regular;
+
+    if (config.max_shallow && *config.max_shallow > 0.1) {
+      sched_info.deadline = add_double(sched_info.target, *config.max_shallow);
+
+      if (time_now > sched_info.deadline) {
+	sched_info.urgency = urgency_t::overdue;
+      }
+    } else {
+      sched_info.deadline = utime_t::max();
+    }
+  }
+
+  // does not match the original logic, but seems to be required
+  // for testing (standalone/scrub-test):
+  /// \todo fix the tests and remove this
+  sched_info.deadline = add_double(sched_info.target, config.max_deep);
+}
+
+void SchedTarget::update_as_deep(
+    const pg_info_t& pg_info,
+    const Scrub::sched_conf_t& config,
+    utime_t time_now)
+{
+  ceph_assert(sched_info.level == scrub_level_t::deep);
+  ceph_assert(!in_queue);
+  if (is_required()) {
+    // shouldn't be called for high-urgency scrubs
+    return;
+  }
+
+  // note that (based on existing code) we do not require an immediate
+  // deep scrub if no stats are available (only a shallow one)
+  auto base = pg_info.stats.stats_invalid
+		  ? time_now
+		  : pg_info.history.last_deep_scrub_stamp;
+
+  sched_info.target = add_double(base, config.deep_interval);
+  // if in the past - do not delay. Otherwise - add a random delay
+  if (sched_info.target > time_now) {
+    double r = rand() / (double)RAND_MAX;
+    sched_info.target +=
+	config.deep_interval * config.interval_randomize_ratio * r;
+  }
+  sched_info.not_before = sched_info.target;
+  sched_info.deadline = add_double(sched_info.target, config.max_deep);
+
+  sched_info.urgency = (time_now > sched_info.deadline)
+			   ? urgency_t::overdue
+			   : urgency_t::periodic_regular;
+  auto_repairing = false;
+}
+
+void SchedTarget::push_nb_out(
+    std::chrono::seconds delay,
+    delay_cause_t delay_cause,
+    utime_t scrub_clock_now)
+{
+  sched_info.not_before =
+      std::max(scrub_clock_now, sched_info.not_before) + utime_t{delay};
+  last_issue = delay_cause;
+}
+
+void SchedTarget::delay_on_pg_state(utime_t scrub_clock_now)
+{
+  // if not in a state to be scrubbed (active & clean) - we won't retry it
+  // for some time
+  const seconds delay =
+      seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_pg_state"));
+  push_nb_out(delay, delay_cause_t::pg_state, scrub_clock_now);
+}
+
+void SchedTarget::delay_on_level_not_allowed(utime_t scrub_clock_now)
+{
+  const seconds delay =
+      seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_delay"));
+  push_nb_out(delay, delay_cause_t::flags, scrub_clock_now);
+}
+
+/// \todo time the delay based on the wait for
+/// the end of the forbidden hours.
+void SchedTarget::delay_on_wrong_time(utime_t scrub_clock_now)
+{
+  // wrong time / day / load
+  const seconds delay =
+      seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_wrong_time"));
+  push_nb_out(delay, delay_cause_t::time, scrub_clock_now);
+}
+
+void SchedTarget::delay_on_no_local_resrc(utime_t scrub_clock_now)
+{
+  // too many scrubs on our own OSD. The delay we introduce should be
+  // minimal: after all, we expect all other PG tried to fail as well.
+  // This should be revisited once we separate the resource-counters for
+  // deep and shallow scrubs.
+  push_nb_out(2s, delay_cause_t::local_resources, scrub_clock_now);
+}
+
+void SchedTarget::dump(std::string_view sect_name, ceph::Formatter* f) const
+{
+  f->open_object_section(sect_name);
+  /// \todo improve the performance of u_time dumps here
+  f->dump_stream("pg") << sched_info.pgid;
+  f->dump_stream("level")
+      << (sched_info.level == scrub_level_t::deep ? "deep" : "shallow");
+  f->dump_stream("urgency") << fmt::format("{}", sched_info.urgency);
+  f->dump_stream("target") << sched_info.target;
+  f->dump_stream("not_before") << sched_info.not_before;
+  f->dump_stream("deadline") << sched_info.deadline;
+  f->dump_bool("auto_rpr", auto_repairing);
+  f->dump_bool("forced", is_required());
+  f->dump_stream("last_delay") << fmt::format("{}", last_issue);
+  f->close_section();
+}
+
+
+// /////////////////////////////////////////////////////////////////////////
+// ScrubJob
+
+using ScrubJob = Scrub::ScrubJob;
+
+ScrubJob::ScrubJob(
+    ScrubQueueOps& osd_queue,
+    CephContext* cct,
+    const spg_t& pg,
+    int node_id)
+    : pgid{pg}
     , whoami{node_id}
     , cct{cct}
-{}
+    , scrub_queue{osd_queue}
+    , shallow_target{pg, scrub_level_t::shallow, node_id, cct}
+    , deep_target{pg, scrub_level_t::deep, node_id, cct}
+{
+  m_log_msg_prefix = fmt::format("osd.{} pg[{}] ScrubJob:", whoami, pgid.pgid);
+}
 
 // debug usage only
-ostream& operator<<(ostream& out, const ScrubQueue::ScrubJob& sjob)
+ostream& operator<<(ostream& out, const ScrubJob& sjob)
 {
-  out << sjob.pgid << ",  " << sjob.schedule.scheduled_at
-      << " dead: " << sjob.schedule.deadline << " - "
-      << sjob.registration_state() << " / failure: " << sjob.resources_failure
-      << " / pen. t.o.: " << sjob.penalty_timeout
-      << " / queue state: " << ScrubQueue::qu_state_text(sjob.state);
-
-  return out;
+  return out << fmt::format("{}", sjob);
 }
 
-void ScrubQueue::ScrubJob::update_schedule(
-  const ScrubQueue::scrub_schedule_t& adjusted)
+std::ostream& ScrubJob::gen_prefix(std::ostream& out) const
 {
-  schedule = adjusted;
-  penalty_timeout = utime_t(0, 0);  // helps with debugging
-
-  // 'updated' is changed here while not holding jobs_lock. That's OK, as
-  // the (atomic) flag will only be cleared by select_pg_and_scrub() after
-  // scan_penalized() is called and the job was moved to the to_scrub queue.
-  updated = true;
-  dout(10) << fmt::format("{}: pg[{}] adjusted: {:s} ({})", __func__, pgid,
-                          schedule.scheduled_at, registration_state()) << dendl;
+  return out << m_log_msg_prefix;
 }
 
-std::string ScrubQueue::ScrubJob::scheduling_state(utime_t now_is,
-						   bool is_deep_expected) const
+void ScrubJob::dump(ceph::Formatter* f) const
 {
-  // if not in the OSD scheduling queues, not a candidate for scrubbing
-  if (state != qu_state_t::registered) {
+  auto now_is = scrub_queue.scrub_clock_now();
+  f->open_object_section("scheduling");
+  f->dump_stream("pgid") << pgid;
+  f->dump_stream("sched_time") << get_sched_time(now_is);
+  auto& nearest = closest_target(now_is);
+  f->dump_stream("deadline") << nearest.sched_info.deadline;
+
+  nearest.dump("nearest", f);
+  shallow_target.dump("shallow_target", f);
+  deep_target.dump("deep_target", f);
+  f->dump_bool("forced", nearest.is_required());
+  f->dump_bool("blocked", blocked);
+  f->close_section();
+}
+
+scrub_level_t ScrubJob::the_other_level(scrub_level_t l)
+{
+  return (l == scrub_level_t::deep) ? scrub_level_t::shallow
+				    : scrub_level_t::deep;
+}
+
+
+SchedTarget& ScrubJob::closest_target(utime_t scrub_clock_now)
+{
+  if (cmp_targets(scrub_clock_now, shallow_target, deep_target) < 0) {
+    return shallow_target;
+  } else {
+    return deep_target;
+  }
+}
+
+const SchedTarget& ScrubJob::closest_target(utime_t scrub_clock_now) const
+{
+  if (cmp_targets(scrub_clock_now, shallow_target, deep_target) < 0) {
+    return shallow_target;
+  } else {
+    return deep_target;
+  }
+}
+
+bool ScrubJob::in_queue() const
+{
+  return shallow_target.in_queue || deep_target.in_queue;
+}
+
+
+SchedTarget ScrubJob::get_moved_target(scrub_level_t s_or_d)
+{
+  auto& moved_trgt = get_target(s_or_d);
+  SchedTarget cp = moved_trgt;
+  ceph_assert(!cp.in_queue);
+  moved_trgt.reset();
+  return cp;
+}
+
+void ScrubJob::dequeue_entry(scrub_level_t lvl)
+{
+  scrub_queue.remove_entry(pgid, lvl);
+  get_target(lvl).clear_queued();
+}
+
+int ScrubJob::dequeue_targets()
+{
+  const int in_q_count =
+      (shallow_target.is_queued() ? 1 : 0) + (deep_target.is_queued() ? 1 : 0);
+  scrub_queue.remove_entry(pgid, scrub_level_t::shallow);
+  shallow_target.clear_queued();
+  scrub_queue.remove_entry(pgid, scrub_level_t::deep);
+  deep_target.clear_queued();
+  return in_q_count;
+}
+
+SchedTarget& ScrubJob::dequeue_target(scrub_level_t s_or_d)
+{
+  auto& target = get_target(s_or_d);
+  scrub_queue.remove_entry(pgid, s_or_d);
+  target.clear_queued();
+  return target;
+}
+
+/*
+ * Note:
+ * - this is the only targets-manipulating function that accepts disabled
+ *   (urgency == off) targets;
+ * - and (partially because of that), here is where we may decide to 'upgrade'
+ *   the next shallow scrub to a deep scrub.
+ */
+void ScrubJob::init_and_queue_targets(
+    const pg_info_t& info,
+    const Scrub::sched_conf_t& aconf,
+    utime_t scrub_clock_now)
+{
+  const int in_q_count = dequeue_targets();
+
+  shallow_target.depenalize();
+  shallow_target.update_as_shallow(info, aconf, scrub_clock_now);
+  deep_target.depenalize();
+  deep_target.update_as_deep(info, aconf, scrub_clock_now);
+
+  // if 'randomly selected', we will modify the deep target to coincide
+  // with the shallow one
+  std::string log_as_updated = "";
+  const bool upgrade_to_deep = (in_q_count == 0) &&
+			       shallow_target.is_periodic() &&
+			       deep_target.is_periodic() &&
+			       (rand() / RAND_MAX) < aconf.deep_randomize_ratio;
+  if (upgrade_to_deep && (deep_target.sched_info.not_before >
+			  shallow_target.sched_info.not_before)) {
+    deep_target.sched_info.target = std::min(
+	shallow_target.sched_info.target, deep_target.sched_info.target);
+    deep_target.sched_info.not_before = shallow_target.sched_info.not_before;
+    shallow_target.sched_info.not_before = add_double(
+	shallow_target.sched_info.not_before, aconf.shallow_interval);
+    log_as_updated = " (updated)";
+  }
+
+  if (scrub_queue.queue_entries(
+	  pgid, shallow_target.queued_element(),
+	  deep_target.queued_element())) {
+    shallow_target.set_queued();
+    deep_target.set_queued();
+    dout(15) << fmt::format(
+		    "{}: {} targets removed from queue; added {} & {}{}",
+		    __func__, in_q_count, shallow_target, deep_target,
+		    log_as_updated)
+	     << dendl;
+  }
+}
+
+
+void ScrubJob::remove_from_osd_queue()
+{
+  const int in_q_count = dequeue_targets();
+  shallow_target.disable();
+  deep_target.disable();
+  dout(15) << fmt::format(
+		  "{}: {} targets removed and disabled", __func__, in_q_count)
+	   << dendl;
+}
+
+
+void ScrubJob::mark_for_after_repair()
+{
+  auto now_is = scrub_queue.scrub_clock_now();
+
+  //dequeue, then manipulate, the deep target
+  scrub_queue.remove_entry(pgid, scrub_level_t::deep);
+  deep_target.sched_info.urgency = urgency_t::after_repair;
+  deep_target.sched_info.target = {0, 0};
+  deep_target.sched_info.not_before = now_is;
+
+  // requeue
+  requeue_entry(scrub_level_t::deep);
+}
+
+
+/// \todo consider replacing with a call to 'PgScrubber::get_schedule()'
+/// followed by the code in 'pg_stat_t::dump_scrub_schedule()'
+std::string ScrubJob::scheduling_state() const
+{
+  auto now_is = scrub_queue.scrub_clock_now();
+  auto& nearest = closest_target(now_is);
+  if (!nearest.is_queued()) {
     return "no scrub is scheduled";
   }
 
-  // if the time has passed, we are surely in the queue
-  // (note that for now we do not tell client if 'penalized')
-  if (now_is > schedule.scheduled_at) {
-    // we are never sure that the next scrub will indeed be shallow:
-    return fmt::format("queued for {}scrub", (is_deep_expected ? "deep " : ""));
+  if (nearest.is_ripe(now_is)) {
+    return fmt::format(
+	"queued for {}scrub", (nearest.is_deep() ? "deep " : ""));
   }
 
-  return fmt::format("{}scrub scheduled @ {:s}",
-		     (is_deep_expected ? "deep " : ""),
-		     schedule.scheduled_at);
+  return fmt::format(
+      "{}scrub scheduled @ {}", (nearest.is_deep() ? "deep " : ""),
+      nearest.sched_time());
+}
+
+utime_t ScrubJob::get_sched_time(utime_t scrub_clock_now) const
+{
+  return closest_target(scrub_clock_now).sched_time();
+}
+
+void ScrubJob::requeue_entry(scrub_level_t level)
+{
+  if (scrubbing) {
+    return;
+  }
+  auto& target = get_target(level);
+  if (target.is_off()) {
+    // which means that the PG is no longer "scrubable"
+    return;
+  }
+  scrub_queue.cp_and_queue_target(target.queued_element());
+  target.in_queue = true;
 }
 
 
-// ////////////////////////////////////////////////////////////////////////// //
-// ScrubQueue
-
-#undef dout_context
-#define dout_context (cct)
-#undef dout_prefix
-#define dout_prefix                                                            \
-  *_dout << "osd." << osd_service.get_nodeid() << " scrub-queue::" << __func__ \
-	 << " "
-
-
-ScrubQueue::ScrubQueue(CephContext* cct, Scrub::ScrubSchedListener& osds)
-    : cct{cct}
-    , osd_service{osds}
+void ScrubJob::operator_forced_targets(
+    scrub_level_t level,
+    scrub_type_t scrub_type,
+    utime_t now_is)
 {
-  // initialize the daily loadavg with current 15min loadavg
-  if (double loadavgs[3]; getloadavg(loadavgs, 3) == 3) {
-    daily_loadavg = loadavgs[2];
+  // the dequeue might fail, as we might be scrubbing that same target now,
+  // but that's OK
+  dequeue_target(level);
+  if (level == scrub_level_t::shallow) {
+    shallow_target.set_oper_shallow_target(scrub_type, now_is);
   } else {
-    derr << "OSD::init() : couldn't read loadavgs\n" << dendl;
-    daily_loadavg = 1.0;
+    deep_target.set_oper_deep_target(scrub_type, now_is);
   }
+  requeue_entry(level);
 }
 
-std::optional<double> ScrubQueue::update_load_average()
+
+void ScrubJob::operator_periodic_targets(
+    scrub_level_t level,
+    utime_t upd_stamp,
+    const pg_info_t& info,
+    const Scrub::sched_conf_t& aconf,
+    utime_t scrub_clock_now)
 {
-  int hb_interval = conf()->osd_heartbeat_interval;
-  int n_samples = 60 * 24 * 24;
-  if (hb_interval > 1) {
-    n_samples /= hb_interval;
-    if (n_samples < 1)
-      n_samples = 1;
+  // the 'stamp' was "faked" to trigger a "periodic" scrub.
+  auto& trgt = get_target(level);
+
+  // if the target is in the queue, and has 'must' urgency - we are done
+  if (trgt.is_queued() && trgt.is_required()) {
+    dout(10) << fmt::format(
+		    "{}: there is a higher urgency scrub in the queue",
+		    __func__)
+	     << dendl;
+    return;
   }
 
-  // get CPU load avg
-  double loadavg;
-  if (getloadavg(&loadavg, 1) == 1) {
-    daily_loadavg = (daily_loadavg * (n_samples - 1) + loadavg) / n_samples;
-    dout(17) << "heartbeat: daily_loadavg " << daily_loadavg << dendl;
-    return 100 * loadavg;
-  }
+  scrub_queue.remove_entry(pgid, level);
+  trgt.clear_queued();
 
-  return std::nullopt;
-}
-
-/*
- * Modify the scrub job state:
- * - if 'registered' (as expected): mark as 'unregistering'. The job will be
- *   dequeued the next time sched_scrub() is called.
- * - if already 'not_registered': shouldn't really happen, but not a problem.
- *   The state will not be modified.
- * - same for 'unregistering'.
- *
- * Note: not holding the jobs lock
- */
-void ScrubQueue::remove_from_osd_queue(ScrubJobRef scrub_job)
-{
-  dout(15) << "removing pg[" << scrub_job->pgid << "] from OSD scrub queue"
-	   << dendl;
-
-  qu_state_t expected_state{qu_state_t::registered};
-  auto ret =
-    scrub_job->state.compare_exchange_strong(expected_state,
-					     qu_state_t::unregistering);
-
-  if (ret) {
-
-    dout(10) << "pg[" << scrub_job->pgid << "] sched-state changed from "
-	     << qu_state_text(expected_state) << " to "
-	     << qu_state_text(scrub_job->state) << dendl;
-
+  trgt.up_urgency_to(urgency_t::periodic_regular);
+  if (level == scrub_level_t::shallow) {
+    trgt.sched_info.target = add_double(upd_stamp, aconf.shallow_interval);
+    // we do set a deadline for the operator-induced scrubbing. That will
+    // allow us to avoid some limiting preconditions.
+    trgt.sched_info.deadline = add_double(
+	upd_stamp, aconf.max_shallow.value_or(aconf.shallow_interval));
   } else {
-
-    // job wasn't in state 'registered' coming in
-    dout(5) << "removing pg[" << scrub_job->pgid
-	    << "] failed. State was: " << qu_state_text(expected_state)
-	    << dendl;
-  }
-}
-
-void ScrubQueue::register_with_osd(
-  ScrubJobRef scrub_job,
-  const ScrubQueue::sched_params_t& suggested)
-{
-  qu_state_t state_at_entry = scrub_job->state.load();
-  dout(20) << fmt::format(
-		"pg[{}] state at entry: <{:.14}>", scrub_job->pgid,
-		state_at_entry)
-	   << dendl;
-
-  switch (state_at_entry) {
-    case qu_state_t::registered:
-      // just updating the schedule?
-      update_job(scrub_job, suggested);
-      break;
-
-    case qu_state_t::not_registered:
-      // insertion under lock
-      {
-	std::unique_lock lck{jobs_lock};
-
-	if (state_at_entry != scrub_job->state) {
-	  lck.unlock();
-	  dout(5) << " scrub job state changed. Retrying." << dendl;
-	  // retry
-	  register_with_osd(scrub_job, suggested);
-	  break;
-	}
-
-	update_job(scrub_job, suggested);
-	to_scrub.push_back(scrub_job);
-	scrub_job->in_queues = true;
-	scrub_job->state = qu_state_t::registered;
-      }
-      break;
-
-    case qu_state_t::unregistering:
-      // restore to the to_sched queue
-      {
-	// must be under lock, as the job might be removed from the queue
-	// at any minute
-	std::lock_guard lck{jobs_lock};
-
-	update_job(scrub_job, suggested);
-	if (scrub_job->state == qu_state_t::not_registered) {
-	  dout(5) << " scrub job state changed to 'not registered'" << dendl;
-	  to_scrub.push_back(scrub_job);
-	}
-	scrub_job->in_queues = true;
-	scrub_job->state = qu_state_t::registered;
-      }
-      break;
+    trgt.sched_info.target = add_double(upd_stamp, aconf.deep_interval);
+    trgt.sched_info.deadline = add_double(upd_stamp, aconf.deep_interval);
   }
 
-  dout(10) << fmt::format(
-		"pg[{}] sched-state changed from <{:.14}> to <{:.14}> (@{:s})",
-		scrub_job->pgid, state_at_entry, scrub_job->state.load(),
-		scrub_job->schedule.scheduled_at)
-	   << dendl;
-}
-
-// look mommy - no locks!
-void ScrubQueue::update_job(ScrubJobRef scrub_job,
-			    const ScrubQueue::sched_params_t& suggested)
-{
-  // adjust the suggested scrub time according to OSD-wide status
-  auto adjusted = adjust_target_time(suggested);
-  scrub_job->update_schedule(adjusted);
-}
-
-ScrubQueue::sched_params_t ScrubQueue::determine_scrub_time(
-  const requested_scrub_t& request_flags,
-  const pg_info_t& pg_info,
-  const pool_opts_t& pool_conf) const
-{
-  ScrubQueue::sched_params_t res;
-
-  if (request_flags.must_scrub || request_flags.need_auto) {
-
-    // Set the smallest time that isn't utime_t()
-    res.proposed_time = PgScrubber::scrub_must_stamp();
-    res.is_must = ScrubQueue::must_scrub_t::mandatory;
-    // we do not need the interval data in this case
-
-  } else if (pg_info.stats.stats_invalid && conf()->osd_scrub_invalid_stats) {
-    res.proposed_time = time_now();
-    res.is_must = ScrubQueue::must_scrub_t::mandatory;
-
-  } else {
-    res.proposed_time = pg_info.history.last_scrub_stamp;
-    res.min_interval = pool_conf.value_or(pool_opts_t::SCRUB_MIN_INTERVAL, 0.0);
-    res.max_interval = pool_conf.value_or(pool_opts_t::SCRUB_MAX_INTERVAL, 0.0);
+  trgt.sched_info.not_before =
+      std::min(trgt.sched_info.not_before, scrub_clock_now);
+  trgt.last_issue = delay_cause_t::none;
+  if (scrub_clock_now > trgt.sched_info.deadline) {
+    trgt.up_urgency_to(urgency_t::overdue);
   }
-
-  dout(15) << fmt::format(
-		"suggested: {:s} hist: {:s} v:{}/{} must:{} pool-min:{} {}",
-		res.proposed_time, pg_info.history.last_scrub_stamp,
-		(bool)pg_info.stats.stats_invalid,
-		conf()->osd_scrub_invalid_stats,
-		(res.is_must == must_scrub_t::mandatory ? "y" : "n"),
-		res.min_interval, request_flags)
-	   << dendl;
-  return res;
+  requeue_entry(level);
 }
 
-
-// used under jobs_lock
-void ScrubQueue::move_failed_pgs(utime_t now_is)
-{
-  int punished_cnt{0};	// for log/debug only
-
-  for (auto job = to_scrub.begin(); job != to_scrub.end();) {
-    if ((*job)->resources_failure) {
-      auto sjob = *job;
-
-      // last time it was scheduled for a scrub, this PG failed in securing
-      // remote resources. Move it to the secondary scrub queue.
-
-      dout(15) << "moving " << sjob->pgid
-	       << " state: " << ScrubQueue::qu_state_text(sjob->state) << dendl;
-
-      // determine the penalty time, after which the job should be reinstated
-      utime_t after = now_is;
-      after += conf()->osd_scrub_sleep * 2 + utime_t{300'000ms};
-
-      // note: currently - not taking 'deadline' into account when determining
-      // 'penalty_timeout'.
-      sjob->penalty_timeout = after;
-      sjob->resources_failure = false;
-      sjob->updated = false;  // as otherwise will be pardoned immediately
-
-      // place in the penalty list, and remove from the to-scrub group
-      penalized.push_back(sjob);
-      job = to_scrub.erase(job);
-      punished_cnt++;
-    } else {
-      job++;
-    }
-  }
-
-  if (punished_cnt) {
-    dout(15) << "# of jobs penalized: " << punished_cnt << dendl;
-  }
-}
-
-// clang-format off
-/*
- * Implementation note:
- * Clang (10 & 11) produces here efficient table-based code, comparable to using
- * a direct index into an array of strings.
- * Gcc (11, trunk) is almost as efficient.
- */
-std::string_view ScrubQueue::attempt_res_text(Scrub::schedule_result_t v)
-{
-  switch (v) {
-    case Scrub::schedule_result_t::scrub_initiated: return "scrubbing"sv;
-    case Scrub::schedule_result_t::none_ready: return "no ready job"sv;
-    case Scrub::schedule_result_t::no_local_resources: return "local resources shortage"sv;
-    case Scrub::schedule_result_t::already_started: return "denied as already started"sv;
-    case Scrub::schedule_result_t::no_such_pg: return "pg not found"sv;
-    case Scrub::schedule_result_t::bad_pg_state: return "prevented by pg state"sv;
-    case Scrub::schedule_result_t::preconditions: return "preconditions not met"sv;
-  }
-  // g++ (unlike CLANG), requires an extra 'return' here
-  return "(unknown)"sv;
-}
-
-std::string_view ScrubQueue::qu_state_text(qu_state_t st)
-{
-  switch (st) {
-    case qu_state_t::not_registered: return "not registered w/ OSD"sv;
-    case qu_state_t::registered: return "registered"sv;
-    case qu_state_t::unregistering: return "unregistering"sv;
-  }
-  // g++ (unlike CLANG), requires an extra 'return' here
-  return "(unknown)"sv;
-}
-// clang-format on
 
 /**
- *  a note regarding 'to_scrub_copy':
- *  'to_scrub_copy' is a sorted set of all the ripe jobs from to_copy.
- *  As we usually expect to refer to only the first job in this set, we could
- *  consider an alternative implementation:
- *  - have collect_ripe_jobs() return the copied set without sorting it;
- *  - loop, performing:
- *    - use std::min_element() to find a candidate;
- *    - try that one. If not suitable, discard from 'to_scrub_copy'
+ * Handle a scrub aborted mid-execution.
+ * State on entry:
+ * - no target is in the queue (both were dequeued when the scrub started);
+ * - both 'shallow' & 'deep' targets are valid - set for the next scrub;
+ * Process:
+ * - merge the failing target with the corresponding 'next' target;
+ * - make sure 'not-before' is somewhat in the future;
+ * - requeue both targets.
+ *
+ * \todo use the number of ripe jobs to determine the delay
  */
-Scrub::schedule_result_t ScrubQueue::select_pg_and_scrub(
-  Scrub::ScrubPreconds& preconds)
+void ScrubJob::on_abort(
+    SchedTarget&& aborted_target,
+    delay_cause_t issue,
+    utime_t now_is)
 {
-  dout(10) << " reg./pen. sizes: " << to_scrub.size() << " / "
-	   << penalized.size() << dendl;
+  scrubbing = false;
+  auto& nxt_target = get_target(aborted_target.level());
+  ++consec_aborts;
+  const seconds delay = seconds(
+      consec_aborts * cct->_conf.get_val<int64_t>("osd_scrub_retry_delay"));
 
-  utime_t now_is = time_now();
+  dout(15) << fmt::format(
+		  "{}: pre-abort:{} next:{}", __func__, aborted_target,
+		  nxt_target)
+	   << dendl;
 
-  preconds.time_permit = scrub_time_permit(now_is);
-  preconds.load_is_low = scrub_load_below_threshold();
-  preconds.only_deadlined = !preconds.time_permit || !preconds.load_is_low;
+  // merge the targets:
+  auto sched_to = std::min(
+      aborted_target.queued_element().target,
+      nxt_target.queued_element().target);
+  auto delay_to = now_is + utime_t{delay};
 
-  //  create a list of candidates (copying, as otherwise creating a deadlock):
-  //  - possibly restore penalized
-  //  - (if we didn't handle directly) remove invalid jobs
-  //  - create a copy of the to_scrub (possibly up to first not-ripe)
-  //  - same for the penalized (although that usually be a waste)
-  //  unlock, then try the lists
-
-  std::unique_lock lck{jobs_lock};
-
-  // pardon all penalized jobs that have deadlined (or were updated)
-  scan_penalized(restore_penalized, now_is);
-  restore_penalized = false;
-
-  // remove the 'updated' flag from all entries
-  std::for_each(to_scrub.begin(),
-		to_scrub.end(),
-		[](const auto& jobref) -> void { jobref->updated = false; });
-
-  // add failed scrub attempts to the penalized list
-  move_failed_pgs(now_is);
-
-  //  collect all valid & ripe jobs from the two lists. Note that we must copy,
-  //  as when we use the lists we will not be holding jobs_lock (see
-  //  explanation above)
-
-  auto to_scrub_copy = collect_ripe_jobs(to_scrub, now_is);
-  auto penalized_copy = collect_ripe_jobs(penalized, now_is);
-  lck.unlock();
-
-  // try the regular queue first
-  auto res = select_from_group(to_scrub_copy, preconds, now_is);
-
-  // in the sole scenario in which we've gone over all ripe jobs without success
-  // - we will try the penalized
-  if (res == Scrub::schedule_result_t::none_ready && !penalized_copy.empty()) {
-    res = select_from_group(penalized_copy, preconds, now_is);
-    dout(10) << "tried the penalized. Res: "
-	     << ScrubQueue::attempt_res_text(res) << dendl;
-    restore_penalized = true;
+  if (aborted_target.queued_element().urgency >
+      nxt_target.queued_element().urgency) {
+    nxt_target = aborted_target;
   }
+  nxt_target.sched_info.target = sched_to;
+  nxt_target.sched_info.not_before = delay_to;
+  nxt_target.last_issue = issue;
 
-  dout(15) << dendl;
-  return res;
+  if (scrub_queue.queue_entries(
+	  pgid, shallow_target.queued_element(),
+	  deep_target.queued_element())) {
+    shallow_target.set_queued();
+    deep_target.set_queued();
+  }
+  dout(10) << fmt::format(
+		  "{}: post [c.target/base:{}] [c.target/abrtd:{}] {}s delay",
+		  __func__, nxt_target, aborted_target, delay.count())
+	   << dendl;
 }
 
-// must be called under lock
-void ScrubQueue::rm_unregistered_jobs(ScrubQContainer& group)
+/**
+ * Handle a failure to secure the replicas' scrub resources.
+ * State on entry:
+ * - no target is in the queue (both were dequeued when the scrub started);
+ * - both 'shallow' & 'deep' targets are valid - set for the next scrub;
+ */
+bool ScrubJob::on_reservation_failure(
+    std::chrono::seconds penalty_period,
+    SchedTarget&& aborted_target)
 {
-  std::for_each(group.begin(), group.end(), [](auto& job) {
-    if (job->state == qu_state_t::unregistering) {
-      job->in_queues = false;
-      job->state = qu_state_t::not_registered;
-    } else if (job->state == qu_state_t::not_registered) {
-      job->in_queues = false;
-    }
-  });
+  bool trgts_demoted = false;
 
-  group.erase(std::remove_if(group.begin(), group.end(), invalid_state),
-	      group.end());
+  ceph_assert(scrubbing);
+  ceph_assert(!deep_target.in_queue);
+  ceph_assert(!shallow_target.in_queue);
+
+  const seconds delay =
+      seconds{cct->_conf.get_val<int64_t>("osd_scrub_retry_busy_replicas")};
+
+  scrubbing = false;
+  auto& nxt_target = get_target(aborted_target.level());
+  ++consec_aborts;
+
+  dout(10) << fmt::format(
+		  "{}: delay:{}s offending:{} planned:{}", __func__,
+		  delay.count(), aborted_target, nxt_target)
+	   << dendl;
+
+  // merge the targets:
+  auto sched_to =
+      std::min(aborted_target.sched_info.target, nxt_target.sched_info.target);
+  auto now_is = scrub_queue.scrub_clock_now();
+  auto delay_to = now_is + utime_t{delay};
+
+  if (aborted_target.sched_info.urgency > nxt_target.sched_info.urgency) {
+    nxt_target = aborted_target;
+  }
+  nxt_target.sched_info.target = sched_to;
+  nxt_target.sched_info.not_before = delay_to;
+  nxt_target.last_issue = delay_cause_t::replicas;
+  ceph_assert(!nxt_target.is_off());
+
+  // now - if both targets are periodic, the
+  // scrub_job will be penalized: its urgency will be demoted for a while.
+  if (penalty_period.count() > 0 && shallow_target.is_periodic() &&
+      deep_target.is_periodic()) {
+    shallow_target.sched_info.urgency = urgency_t::penalized;
+    deep_target.sched_info.urgency = urgency_t::penalized;
+    penalized = true;
+    penalized_until = now_is + utime_t{penalty_period};
+    trgts_demoted = true;
+  }
+  scrub_queue.queue_entries(
+      pgid, shallow_target.queued_element(), deep_target.queued_element());
+  shallow_target.set_queued();
+  deep_target.set_queued();
+  dout(10) << fmt::format(
+		  "{}: post [c.target/base:{}] [c.target/abrtd:{}] {}s delay",
+		  __func__, nxt_target, aborted_target, delay.count())
+	   << dendl;
+  return trgts_demoted;
 }
 
-namespace {
-struct cmp_sched_time_t {
-  bool operator()(const ScrubQueue::ScrubJobRef& lhs,
-		  const ScrubQueue::ScrubJobRef& rhs) const
-  {
-    return lhs->schedule.scheduled_at < rhs->schedule.scheduled_at;
-  }
-};
-}  // namespace
-
-// called under lock
-ScrubQueue::ScrubQContainer ScrubQueue::collect_ripe_jobs(
-  ScrubQContainer& group,
-  utime_t time_now)
+void ScrubJob::un_penalize()
 {
-  rm_unregistered_jobs(group);
+  if (!penalized) {
+    return;
+  }
+  // dequeue & requeue the targets:
+  const int in_q_count = dequeue_targets();
+  shallow_target.depenalize();
+  deep_target.depenalize();
 
-  // copy ripe jobs
-  ScrubQueue::ScrubQContainer ripes;
-  ripes.reserve(group.size());
-
-  std::copy_if(group.begin(),
-	       group.end(),
-	       std::back_inserter(ripes),
-	       [time_now](const auto& jobref) -> bool {
-		 return jobref->schedule.scheduled_at <= time_now;
-	       });
-  std::sort(ripes.begin(), ripes.end(), cmp_sched_time_t{});
-
-  if (g_conf()->subsys.should_gather<ceph_subsys_osd, 20>()) {
-    for (const auto& jobref : group) {
-      if (jobref->schedule.scheduled_at > time_now) {
-	dout(20) << " not ripe: " << jobref->pgid << " @ "
-		 << jobref->schedule.scheduled_at << dendl;
-      }
-    }
+  if (scrub_queue.queue_entries(
+	  pgid, shallow_target.queued_element(),
+	  deep_target.queued_element())) {
+    shallow_target.set_queued();
+    deep_target.set_queued();
   }
 
-  return ripes;
+  penalized = false;
+  penalized_until = utime_t{0, 0};
+  dout(15) << fmt::format(
+		  "{}: {} targets dequeued. Now: {}", __func__, in_q_count,
+		  *this)
+	   << dendl;
 }
 
-// not holding jobs_lock. 'group' is a copy of the actual list.
-Scrub::schedule_result_t ScrubQueue::select_from_group(
-  ScrubQContainer& group,
-  const Scrub::ScrubPreconds& preconds,
-  utime_t now_is)
+std::string_view ScrubJob::registration_state() const
 {
-  dout(15) << "jobs #: " << group.size() << dendl;
-
-  for (auto& candidate : group) {
-
-    // we expect the first job in the list to be a good candidate (if any)
-
-    dout(20) << "try initiating scrub for " << candidate->pgid << dendl;
-
-    if (preconds.only_deadlined && (candidate->schedule.deadline.is_zero() ||
-				    candidate->schedule.deadline >= now_is)) {
-      dout(15) << " not scheduling scrub for " << candidate->pgid << " due to "
-	       << (preconds.time_permit ? "high load" : "time not permitting")
-	       << dendl;
-      continue;
-    }
-
-    // we have a candidate to scrub. We turn to the OSD to verify that the PG
-    // configuration allows the specified type of scrub, and to initiate the
-    // scrub.
-    switch (
-      osd_service.initiate_a_scrub(candidate->pgid,
-				   preconds.allow_requested_repair_only)) {
-
-      case Scrub::schedule_result_t::scrub_initiated:
-	// the happy path. We are done
-	dout(20) << " initiated for " << candidate->pgid << dendl;
-	return Scrub::schedule_result_t::scrub_initiated;
-
-      case Scrub::schedule_result_t::already_started:
-      case Scrub::schedule_result_t::preconditions:
-      case Scrub::schedule_result_t::bad_pg_state:
-	// continue with the next job
-	dout(20) << "failed (state/cond/started) " << candidate->pgid << dendl;
-	break;
-
-      case Scrub::schedule_result_t::no_such_pg:
-	// The pg is no longer there
-	dout(20) << "failed (no pg) " << candidate->pgid << dendl;
-	break;
-
-      case Scrub::schedule_result_t::no_local_resources:
-	// failure to secure local resources. No point in trying the other
-	// PGs at this time. Note that this is not the same as replica resources
-	// failure!
-	dout(20) << "failed (local) " << candidate->pgid << dendl;
-	return Scrub::schedule_result_t::no_local_resources;
-
-      case Scrub::schedule_result_t::none_ready:
-	// can't happen. Just for the compiler.
-	dout(5) << "failed !!! " << candidate->pgid << dendl;
-	return Scrub::schedule_result_t::none_ready;
-    }
-  }
-
-  dout(20) << " returning 'none ready'" << dendl;
-  return Scrub::schedule_result_t::none_ready;
+  return in_queue() ? "in-queue" : "not-queued";
 }
 
-ScrubQueue::scrub_schedule_t ScrubQueue::adjust_target_time(
-  const sched_params_t& times) const
+
+/**
+ * mark for a deep-scrub after the current scrub ended with errors.
+ * Note that no need to requeue the target, as it will be requeued
+ * when the scrub ends.
+ */
+void ScrubJob::mark_for_rescrubbing()
 {
-  ScrubQueue::scrub_schedule_t sched_n_dead{
-    times.proposed_time, times.proposed_time};
+  ceph_assert(scrubbing);
+  ceph_assert(!deep_target.in_queue);
+  deep_target.auto_repairing = true;
+  // no need to take existing deep_target contents into account,
+  // as the only higher priority is 'after_repair', and we know no
+  // repair took place while we were scrubbing.
+  deep_target.sched_info.target = scrub_queue.scrub_clock_now();
+  deep_target.sched_info.not_before = deep_target.sched_info.target;
+  deep_target.sched_info.urgency = urgency_t::must;  // no need to use max(...)
 
-  if (times.is_must == ScrubQueue::must_scrub_t::not_mandatory) {
-    // unless explicitly requested, postpone the scrub with a random delay
-    double scrub_min_interval = times.min_interval > 0
-				  ? times.min_interval
-				  : conf()->osd_scrub_min_interval;
-    double scrub_max_interval = times.max_interval > 0
-				  ? times.max_interval
-				  : conf()->osd_scrub_max_interval;
+  dout(10) << fmt::format(
+		  "{}: need deep+a.r. after scrub errors. Target set to {}",
+		  __func__, deep_target)
+	   << dendl;
+}
 
-    sched_n_dead.scheduled_at += scrub_min_interval;
-    double r = rand() / (double)RAND_MAX;
-    sched_n_dead.scheduled_at +=
-      scrub_min_interval * conf()->osd_scrub_interval_randomize_ratio * r;
 
-    if (scrub_max_interval <= 0) {
-      sched_n_dead.deadline = utime_t{};
-    } else {
-      sched_n_dead.deadline += scrub_max_interval;
-    }
-    // note: no specific job can be named in the log message
-    dout(20) << fmt::format(
-		  "not-must. Was:{:s} {{min:{}/{} max:{}/{} ratio:{}}} "
-		  "Adjusted:{:s} ({:s})",
-		  times.proposed_time, fmt::group_digits(times.min_interval),
-		  fmt::group_digits(conf()->osd_scrub_min_interval),
-		  fmt::group_digits(times.max_interval),
-		  fmt::group_digits(conf()->osd_scrub_max_interval),
-		  conf()->osd_scrub_interval_randomize_ratio,
-		  sched_n_dead.scheduled_at, sched_n_dead.deadline)
+void ScrubJob::at_scrub_completion(
+    const pg_info_t& pg_info,
+    const sched_conf_t& aconf,
+    utime_t scrub_clock_now)
+{
+  ceph_assert(!in_queue());
+
+  shallow_target.depenalize();
+  shallow_target.update_as_shallow(pg_info, aconf, scrub_clock_now);
+
+  deep_target.depenalize();
+  deep_target.update_as_deep(pg_info, aconf, scrub_clock_now);
+
+  if (scrub_queue.queue_entries(
+	  pgid, shallow_target.queued_element(),
+	  deep_target.queued_element())) {
+    shallow_target.set_queued();
+    deep_target.set_queued();
+    dout(10) << fmt::format(
+		    "{}: requeued {} and {}", __func__, shallow_target,
+		    deep_target)
 	     << dendl;
   }
-  // else - no log needed. All relevant data will be logged by the caller
-  return sched_n_dead;
 }
 
-double ScrubQueue::scrub_sleep_time(bool must_scrub) const
+
+SchedTarget& ScrubJob::get_target(scrub_level_t lvl)
 {
-  double regular_sleep_period = conf()->osd_scrub_sleep;
-
-  if (must_scrub || scrub_time_permit(time_now())) {
-    return regular_sleep_period;
-  }
-
-  // relevant if scrubbing started during allowed time, but continued into
-  // forbidden hours
-  double extended_sleep = conf()->osd_scrub_extended_sleep;
-  dout(20) << "w/ extended sleep (" << extended_sleep << ")" << dendl;
-  return std::max(extended_sleep, regular_sleep_period);
+  return (lvl == scrub_level_t::deep) ? deep_target : shallow_target;
 }
 
-bool ScrubQueue::scrub_load_below_threshold() const
+void ScrubJob::on_periods_change(
+    const pg_info_t& info,
+    const Scrub::sched_conf_t& aconf,
+    utime_t scrub_clock_now)
 {
-  double loadavgs[3];
-  if (getloadavg(loadavgs, 3) != 3) {
-    dout(10) << __func__ << " couldn't read loadavgs\n" << dendl;
-    return false;
-  }
-
-  // allow scrub if below configured threshold
-  long cpus = sysconf(_SC_NPROCESSORS_ONLN);
-  double loadavg_per_cpu = cpus > 0 ? loadavgs[0] / cpus : loadavgs[0];
-  if (loadavg_per_cpu < conf()->osd_scrub_load_threshold) {
-    dout(20) << "loadavg per cpu " << loadavg_per_cpu << " < max "
-	     << conf()->osd_scrub_load_threshold << " = yes" << dendl;
-    return true;
-  }
-
-  // allow scrub if below daily avg and currently decreasing
-  if (loadavgs[0] < daily_loadavg && loadavgs[0] < loadavgs[2]) {
-    dout(20) << "loadavg " << loadavgs[0] << " < daily_loadavg "
-	     << daily_loadavg << " and < 15m avg " << loadavgs[2] << " = yes"
-	     << dendl;
-    return true;
-  }
-
-  dout(20) << "loadavg " << loadavgs[0] << " >= max "
-	   << conf()->osd_scrub_load_threshold << " and ( >= daily_loadavg "
-	   << daily_loadavg << " or >= 15m avg " << loadavgs[2] << ") = no"
+  dout(10) << fmt::format(
+		  "{}: before: {} and {} scrubbing:{}", __func__,
+		  shallow_target, deep_target, scrubbing)
 	   << dendl;
-  return false;
-}
+  if (scrubbing) {
+    // both targets will be updated at the end of the scrub
+    return;
+  }
 
+  bool should_unpenalize = penalized && (penalized_until < scrub_clock_now);
 
-// note: called with jobs_lock held
-void ScrubQueue::scan_penalized(bool forgive_all, utime_t time_now)
-{
-  dout(20) << time_now << (forgive_all ? " all " : " - ") << penalized.size()
+  if (shallow_target.is_periodic()) {
+    if (shallow_target.is_queued()) {
+      dequeue_target(scrub_level_t::shallow);
+    }
+    if (should_unpenalize) {
+      shallow_target.depenalize();
+    }
+    shallow_target.update_as_shallow(info, aconf, scrub_clock_now);
+    requeue_entry(scrub_level_t::shallow);
+  }
+
+  if (deep_target.is_periodic()) {
+    if (deep_target.is_queued()) {
+      dequeue_target(scrub_level_t::deep);
+    }
+    if (should_unpenalize) {
+      deep_target.depenalize();
+    }
+    deep_target.update_as_deep(info, aconf, scrub_clock_now);
+    requeue_entry(scrub_level_t::deep);
+  }
+  dout(10) << fmt::format(
+		  "{}: after: {} and {}", __func__, shallow_target, deep_target)
 	   << dendl;
-
-  // clear dead entries (deleted PGs, or those PGs we are no longer their
-  // primary)
-  rm_unregistered_jobs(penalized);
-
-  if (forgive_all) {
-
-    std::copy(penalized.begin(), penalized.end(), std::back_inserter(to_scrub));
-    penalized.clear();
-
-  } else {
-
-    auto forgiven_last = std::partition(
-      penalized.begin(),
-      penalized.end(),
-      [time_now](const auto& e) {
-	return (*e).updated || ((*e).penalty_timeout <= time_now);
-      });
-
-    std::copy(penalized.begin(), forgiven_last, std::back_inserter(to_scrub));
-    penalized.erase(penalized.begin(), forgiven_last);
-    dout(20) << "penalized after screening: " << penalized.size() << dendl;
-  }
-}
-
-// checks for half-closed ranges. Modify the (p<till)to '<=' to check for
-// closed.
-static inline bool isbetween_modulo(int64_t from, int64_t till, int p)
-{
-  // the 1st condition is because we have defined from==till as "always true"
-  return (till == from) || ((till >= from) ^ (p >= from) ^ (p < till));
-}
-
-bool ScrubQueue::scrub_time_permit(utime_t now) const
-{
-  tm bdt;
-  time_t tt = now.sec();
-  localtime_r(&tt, &bdt);
-
-  bool day_permit = isbetween_modulo(conf()->osd_scrub_begin_week_day,
-				     conf()->osd_scrub_end_week_day,
-				     bdt.tm_wday);
-  if (!day_permit) {
-    dout(20) << "should run between week day "
-	     << conf()->osd_scrub_begin_week_day << " - "
-	     << conf()->osd_scrub_end_week_day << " now " << bdt.tm_wday
-	     << " - no" << dendl;
-    return false;
-  }
-
-  bool time_permit = isbetween_modulo(conf()->osd_scrub_begin_hour,
-				      conf()->osd_scrub_end_hour,
-				      bdt.tm_hour);
-  dout(20) << "should run between " << conf()->osd_scrub_begin_hour << " - "
-	   << conf()->osd_scrub_end_hour << " now (" << bdt.tm_hour
-	   << ") = " << (time_permit ? "yes" : "no") << dendl;
-  return time_permit;
-}
-
-void ScrubQueue::ScrubJob::dump(ceph::Formatter* f) const
-{
-  f->open_object_section("scrub");
-  f->dump_stream("pgid") << pgid;
-  f->dump_stream("sched_time") << schedule.scheduled_at;
-  f->dump_stream("deadline") << schedule.deadline;
-  f->dump_bool("forced",
-	       schedule.scheduled_at == PgScrubber::scrub_must_stamp());
-  f->close_section();
-}
-
-void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
-{
-  ceph_assert(f != nullptr);
-  std::lock_guard lck(jobs_lock);
-
-  f->open_array_section("scrubs");
-
-  std::for_each(to_scrub.cbegin(), to_scrub.cend(), [&f](const ScrubJobRef& j) {
-    j->dump(f);
-  });
-
-  std::for_each(penalized.cbegin(),
-		penalized.cend(),
-		[&f](const ScrubJobRef& j) { j->dump(f); });
-
-  f->close_section();
-}
-
-ScrubQueue::ScrubQContainer ScrubQueue::list_registered_jobs() const
-{
-  ScrubQueue::ScrubQContainer all_jobs;
-  all_jobs.reserve(to_scrub.size() + penalized.size());
-  dout(20) << " size: " << all_jobs.capacity() << dendl;
-
-  std::lock_guard lck{jobs_lock};
-
-  std::copy_if(to_scrub.begin(),
-	       to_scrub.end(),
-	       std::back_inserter(all_jobs),
-	       registered_job);
-  std::copy_if(penalized.begin(),
-	       penalized.end(),
-	       std::back_inserter(all_jobs),
-	       registered_job);
-
-  return all_jobs;
-}
-
-// ////////////////////////////////////////////////////////////////////////// //
-// ScrubQueue - scrub resource management
-
-bool ScrubQueue::can_inc_scrubs() const
-{
-  // consider removing the lock here. Caller already handles delayed
-  // inc_scrubs_local() failures
-  std::lock_guard lck{resource_lock};
-
-  if (scrubs_local + scrubs_remote < conf()->osd_max_scrubs) {
-    return true;
-  }
-
-  dout(20) << " == false. " << scrubs_local << " local + " << scrubs_remote
-	   << " remote >= max " << conf()->osd_max_scrubs << dendl;
-  return false;
-}
-
-bool ScrubQueue::inc_scrubs_local()
-{
-  std::lock_guard lck{resource_lock};
-
-  if (scrubs_local + scrubs_remote < conf()->osd_max_scrubs) {
-    ++scrubs_local;
-    return true;
-  }
-
-  dout(20) << ": " << scrubs_local << " local + " << scrubs_remote
-	   << " remote >= max " << conf()->osd_max_scrubs << dendl;
-  return false;
-}
-
-void ScrubQueue::dec_scrubs_local()
-{
-  std::lock_guard lck{resource_lock};
-  dout(20) << ": " << scrubs_local << " -> " << (scrubs_local - 1) << " (max "
-	   << conf()->osd_max_scrubs << ", remote " << scrubs_remote << ")"
-	   << dendl;
-
-  --scrubs_local;
-  ceph_assert(scrubs_local >= 0);
-}
-
-bool ScrubQueue::inc_scrubs_remote()
-{
-  std::lock_guard lck{resource_lock};
-
-  if (scrubs_local + scrubs_remote < conf()->osd_max_scrubs) {
-    dout(20) << ": " << scrubs_remote << " -> " << (scrubs_remote + 1)
-	     << " (max " << conf()->osd_max_scrubs << ", local "
-	     << scrubs_local << ")" << dendl;
-    ++scrubs_remote;
-    return true;
-  }
-
-  dout(20) << ": " << scrubs_local << " local + " << scrubs_remote
-	   << " remote >= max " << conf()->osd_max_scrubs << dendl;
-  return false;
-}
-
-void ScrubQueue::dec_scrubs_remote()
-{
-  std::lock_guard lck{resource_lock};
-  dout(20) << ": " << scrubs_remote << " -> " << (scrubs_remote - 1) << " (max "
-	   << conf()->osd_max_scrubs << ", local " << scrubs_local << ")"
-	   << dendl;
-  --scrubs_remote;
-  ceph_assert(scrubs_remote >= 0);
-}
-
-void ScrubQueue::dump_scrub_reservations(ceph::Formatter* f) const
-{
-  std::lock_guard lck{resource_lock};
-  f->dump_int("scrubs_local", scrubs_local);
-  f->dump_int("scrubs_remote", scrubs_remote);
-  f->dump_int("osd_max_scrubs", conf()->osd_max_scrubs);
-}
-
-void ScrubQueue::clear_pg_scrub_blocked(spg_t blocked_pg)
-{
-  dout(5) << fmt::format(": pg {} is unblocked", blocked_pg) << dendl;
-  --blocked_scrubs_cnt;
-  ceph_assert(blocked_scrubs_cnt >= 0);
-}
-
-void ScrubQueue::mark_pg_scrub_blocked(spg_t blocked_pg)
-{
-  dout(5) << fmt::format(": pg {} is blocked on an object", blocked_pg)
-	  << dendl;
-  ++blocked_scrubs_cnt;
-}
-
-int ScrubQueue::get_blocked_pgs_count() const
-{
-  return blocked_scrubs_cnt;
 }

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -4,550 +4,742 @@
 #pragma once
 // clang-format off
 /*
-┌───────────────────────┐
-│ OSD                   │
-│ OSDService           ─┼───┐
-│                       │   │
-│                       │   │
-└───────────────────────┘   │   Ownes & uses the following
-                            │   ScrubQueue interfaces:
-                            │
-                            │
-                            │   - resource management (*1)
-                            │
-                            │   - environment conditions (*2)
-                            │
-                            │   - scrub scheduling (*3)
-                            │
-                            │
-                            │
-                            │
-                            │
-                            │
- ScrubQueue                 │
-┌───────────────────────────▼────────────┐
-│                                        │
-│                                        │
-│  ScrubQContainer    to_scrub <>────────┼────────┐
-│  ScrubQContainer    penalized          │        │
-│                                        │        │
-│                                        │        │
-│  OSD_wide resource counters            │        │
-│                                        │        │
-│                                        │        │
-│  "env scrub conditions" monitoring     │        │
-│                                        │        │
-│                                        │        │
-│                                        │        │
-│                                        │        │
-└─▲──────────────────────────────────────┘        │
-  │                                               │
-  │                                               │
-  │uses interface <4>                             │
-  │                                               │
-  │                                               │
-  │            ┌──────────────────────────────────┘
-  │            │                 shared ownership of jobs
-  │            │
-  │      ┌─────▼──────┐
-  │      │ScrubJob    │
-  │      │            ├┐
-  │      │            ││
-  │      │            │┼┐
-  │      │            │┼│
-  └──────┤            │┼┤◄──────┐
-         │            │┼│       │
-         │            │┼│       │
-         │            │┼│       │
-         └┬───────────┼┼│       │shared ownership
-          └─┼┼┼┼┼┼┼┼┼┼┼┼│       │
-            └───────────┘       │
-                                │
-                                │
-                                │
-                                │
-┌───────────────────────────────┼─┐
-│                               <>│
-│PgScrubber                       │
-│                                 │
-│                                 │
-│                                 │
-│                                 │
-│                                 │
-└─────────────────────────────────┘
 
+        PgScrubber
+        ┌───────────────────────────────────┐
+        │       ScrubJob                    │
+        │    ┌──────────────────────────────┤
+        │    │          S target            │
+        │    │        ┌────────────────────┐│
+        │    │        │                    ││
+        │    │        │     ┌───────────── ││
+        │    │        │     │ sched info   ││
+        │    │        │     │              ││
+        │    │        └─────┴──────────────┘│
+        │    │                              │
+        │    │          D target            │
+        │    │        ┌────────────────────┐│
+        │    │        │                    ││
+        │    │        │     ┌───────────── ││
+        │    │        │     │ sched info   ││
+        │    │        │     │              ││
+        │    │        └─────┴──────────────┘│
+        │    │                              │
+        └────┴──────────────────────────────┘
 
-ScrubQueue interfaces (main functions):
+ (some of the possible) Scenarios:
 
-<1> - OSD/PG resources management:
+   * PG instance becomes Primary:
+     - S & D targets are initialized based on configuration & PG info;
+     - copies of their 'sched info' sub-objects are pushed into the scrub queue;
 
-  - can_inc_scrubs()
-  - {inc/dec}_scrubs_{local/remote}()
-  - dump_scrub_reservations()
-  - {set/clear/is}_reserving_now()
+   * A specific SchedEntry (the sched-info object as appearing the scrub queue)
+     is selected for scrubbing:
+     - the entry is deleted from the queue;
+     - the PgScrubber performs some preliminary checks;
+       - failing those - the entry is updated (pushed backwards in time) and
+         returned to the queue;
+     - a scrub session is initiated;
+     - the 2'nd queue entry corresponding to this PG is also removed from the
+        queue;
+     - the ScrubJob's S & D targets are "decoupled" from the OSD's scrub queue,
+       and can be updated, if needed(*), with the new scheduling information;
+       (*) mostly following operator requests
 
-<2> - environment conditions:
-
-  - update_loadavg()
-
-  - scrub_load_below_threshold()
-  - scrub_time_permit()
-
-<3> - scheduling scrubs:
-
-  - select_pg_and_scrub()
-  - dump_scrubs()
-
-<4> - manipulating a job's state:
-
-  - register_with_osd()
-  - remove_from_osd_queue()
-  - update_job()
-
+   * A scrub session is completed:
+     - 'last-' timestamps are updated;
+     - both targets are updated, combining possible new scheduling information
+       in them with the schedule suggested by the new timestamps;
+     - the sched-info objects are pushed to the queue;
  */
 // clang-format on
 
 #include <atomic>
 #include <chrono>
+#include <compare>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
 
-#include "common/RefCountedObj.h"
 #include "common/ceph_atomic.h"
-#include "osd/osd_types.h"
-#include "osd/scrubber_common.h"
+#include "include/expected.hpp"
 #include "include/utime_fmt.h"
+#include "osd/osd_types.h"
 #include "osd/osd_types_fmt.h"
+#include "osd/scrubber_common.h"
+
 #include "utime.h"
 
 class PG;
+class PgScrubber;
+class OSDService;
+template <>
+struct fmt::formatter<Scrub::SchedTarget>;
 
 namespace Scrub {
 
 using namespace ::std::literals;
 
-// possible outcome when trying to select a PG and scrub it
-enum class schedule_result_t {
-  scrub_initiated,     // successfully started a scrub
-  none_ready,	       // no pg to scrub
-  no_local_resources,  // failure to secure local OSD scrub resource
-  already_started,     // failed, as already started scrubbing this pg
-  no_such_pg,	       // can't find this pg
-  bad_pg_state,	       // pg state (clean, active, etc.)
-  preconditions	       // time, configuration, etc.
+
+/**
+ * Possible urgency levels for a specific scheduling target (shallow or deep):
+ *
+ * 'off' - the target is not scheduled for scrubbing. This is the initial state,
+ * 	and is also the state for a target that is not eligible for scrubbing
+ * 	(e.g. before removing from the OSD).
+ *
+ * periodic scrubs:
+ * ---------------
+ *
+ * 'penalized' - our last attempt to scrub the specific PG has failed due to
+ *      reservation issues. We are still queued to be scrubbed, but - for a
+ *      time - our priority is lower than any other target.
+ *      This state is time-limited by the penalized_until field in the
+ *      owning ScrubJob.
+ *
+ * 'periodic_regular' - the "standard" shallow/deep scrub performed
+ *      periodically on each PG.
+ *
+ * 'overdue' - the target is eligible for periodic scrubbing, but has not been
+ *      scrubbed for a while, and the time now is past its deadline.
+ *      Overdue scrubs are allowed to run even if the OSD is overloaded, and in
+ *      the wrong time or day.
+ *      Also - their target time is not modified upon a configuration change.
+ *
+ *
+ * priority scrubs (termed 'required' or 'must' in the legacy code):
+ * ---------------------------------------------------------------
+ * Priority scrubs:
+ * - are not subject to times/days/load limitations;
+ * - cannot be aborted by 'noscrub'/'nodeep-scrub' flags;
+ * - are never marked 'penalized' (even if failing to reserve replicas);
+ * - do not have random delays added to their target time;
+ * - never have their target time modified by a configuration change;
+ * - never subject to 'extended sleep time' (see scrub_sleep_time());
+ *
+ *
+ * 'operator_requested' - the target was manually requested for scrubbing by
+ *      an administrator.
+ *
+ * 'must' - the target is required to be scrubbed, as:
+ *      - the scrub was initiated by a message specifying 'do_repair'; or
+ *      - the PG info is not valid (i.e. we do not have a valid 'last-scrub' stamp)
+ *   or - a deep scrub is required after the previous scrub ended with errors.
+ *      'must' scrubs are similar to 'operator_requested', but have a higher
+ *      priority (and have a repair flag set).
+ *
+ * 'after_repair' - triggered immediately after a recovery process
+ *      ('m_after_repair_scrub_required' was set). The highest urgency assigned
+ *      in this case assure we are not racing against any other type of scrub
+ *      (and helps clarifying the PG/scrub status in the logs).
+ *      This type of scrub is always deep.
+ */
+enum class urgency_t {
+  off,
+  penalized,
+  periodic_regular,
+  overdue,
+  operator_requested,
+  must,
+  after_repair,
 };
 
-// the OSD services provided to the scrub scheduler
+/**
+ * the result of the last attempt to schedule a scrub for a specific PG.
+ * The enum value itself is mostly used for logging purposes.
+ * For a discussion of the handling of scrub initiation issues and scrub
+ * aborts - see for example ScrubJob::delay_on*() & ScrubJob::on_abort()
+ */
+enum class delay_cause_t {
+  none,		    ///< scrub attempt was successful
+  replicas,	    ///< failed to reserve replicas
+  flags,	    ///< noscrub or nodeep-scrub
+  pg_state,	    ///< e.g. snap-trimming
+  time,		    ///< time restrictions or busy CPU
+  local_resources,  ///< too many scrubbing PGs
+  aborted,	    ///< scrub was aborted on no(deep)-scrub
+};
+
+struct sched_conf_t {
+  /// the desired interval between shallow scrubs
+  double shallow_interval{0.0};
+
+  /// the desired interval between deep scrubs
+  double deep_interval{0.0};
+
+  /**
+   * the maximum interval between shallow scrubs, as determined by either the
+   * OSD or the pool configuration. Empty if no limit is configured.
+   */
+  std::optional<double> max_shallow;
+
+  /**
+   * the maximum interval between deep scrubs.
+   * For deep scrubs - there is no equivalent of scrub_max_interval. Per the
+   * documentation, once deep_scrub_interval has passed, we are already
+   * "overdue", at least as far as the "ignore allowed load" window is
+   * concerned. \todo based on users complaints (and the fact that the
+   * interaction between the configuration parameters is clear to no one),
+   * this will be revised shortly.
+   * \todo consider using conf()->mon_warn_not_deep_scrubbed for now;
+   */
+  double max_deep{0.0};
+
+  /**
+   * interval_randomize_ratio
+   *
+   * We add an extra random duration to the configured times when doing
+   * scheduling. An event configured with an interval of <interval> will
+   * actually be scheduled at a time selected uniformly from
+   * [<interval>, (1+<interval_randomize_ratio>) * <interval>)
+   */
+  double interval_randomize_ratio{0.0};
+
+  /**
+   * a randomization factor aimed at preventing 'thundering herd' problems
+   * upon deep-scrubs common intervals. If polling a random number smaller
+   * than that percentage, the next shallow scrub is upgraded to deep.
+   */
+  double deep_randomize_ratio{0.0};
+
+  /**
+   * must we schedule a scrub with high urgency if we do not have a valid
+   * last scrub stamp?
+   */
+  bool mandatory_on_invalid{true};
+};
+
+class ScrubJob;
+
+/*
+ * There are two versions of the scheduling-target (the object detailing one
+ * of the two scrub types (deep or shallow) for a specific PG):
+ * 'SchedEntry' is maintained by the ScrubQueue, and holds just
+ *   the scheduling details.
+ * 'SchedTarget' is maintained by the PgScrubber, and
+ *   holds the same set of scheduling details plus additional information
+ *   about the scrub to be performed.
+ */
+
+struct SchedEntry {
+  constexpr SchedEntry(spg_t pgid, scrub_level_t level)
+      : pgid{pgid}
+      , level{level}
+  {}
+
+  spg_t pgid;
+  scrub_level_t level;
+
+  /**
+   * 'white-out' support: if false, the entry was logically removed from
+   * the queue
+   */
+  bool is_valid{true};
+
+  urgency_t urgency{urgency_t::off};
+
+  /**
+   * the time at which we are allowed to start the scrub. Never
+   * decreasing after 'target' is set.
+   */
+  utime_t not_before{utime_t::max()};
+
+  /**
+   * the 'deadline' is the time by which we expect the periodic scrub to
+   * complete. It is determined by the SCRUB_MAX_INTERVAL pool configuration
+   * and by osd_scrub_max_interval;
+   * Once passed, the scrub will be allowed to run even if the OSD is overloaded
+   * or during no-scrub hours.
+   */
+  utime_t deadline{utime_t::max()};
+
+  /**
+   * the 'target' is the time at which we intended the scrub to be scheduled.
+   * For periodic (regular) scrubs, it is set to the time of the last scrub
+   * plus the scrub interval (plus some randomization). Priority scrubs
+   * have their own specific rules for the target time:
+   * - for operator-initiated scrubs: 'target' is set to 'now';
+   * - same for re-scrubbing (deep scrub after a shallow scrub that ended with
+   *   errors;
+   * - when requesting a scrub after a repair (the highest priority scrub):
+   *   the target is set to '0' (beginning of time);
+   */
+  utime_t target{utime_t::max()};
+
+  /**
+   * a SchedEntry is 'ripe' for scrubbing if the current time is past its
+   * 'not_before' time (which guarantees it is also past its 'target').
+   * And - it must not be 'inactive'. i.e. must not have urgency 'off'.
+   */
+  bool is_ripe(utime_t now_is) const;
+
+  void dump(std::string_view sect_name, ceph::Formatter* f) const;
+};
+
+std::weak_ordering cmp_ripe_entries(
+    const Scrub::SchedEntry& l,
+    const Scrub::SchedEntry& r);
+
+std::weak_ordering cmp_future_entries(
+    const Scrub::SchedEntry& l,
+    const Scrub::SchedEntry& r);
+
+
+class SchedTarget {
+ public:
+  friend ScrubJob;
+  friend struct fmt::formatter<Scrub::SchedTarget>;
+
+  SchedTarget(
+      spg_t pg_id,
+      scrub_level_t scrub_level,
+      int osd_num,
+      CephContext* cct);
+
+  std::ostream& gen_prefix(std::ostream& out) const;
+
+  utime_t sched_time() const;
+
+  /// access that part of the SchedTarget that is queued in the scrub queue
+  const SchedEntry& queued_element() const { return sched_info; }
+
+  bool is_deep() const { return sched_info.level == scrub_level_t::deep; }
+
+  bool is_shallow() const { return sched_info.level == scrub_level_t::shallow; }
+
+  scrub_level_t level() const { return sched_info.level; }
+
+  /**
+   * periodic scrubs are those with urgency of either periodic_regular or
+   * overdue
+   */
+  bool is_periodic() const;
+
+  /// 'required' is the legacy term for high-priority (non-periodic) scrubs
+  bool is_required() const { return sched_info.urgency > urgency_t::overdue; }
+
+  /**
+   * urgency==off is only expected for SchedTarget objects belonging to
+   * PGs that are not eligible for scrubbing (not Primaries, not clean, not
+   * active)
+   */
+  bool is_off() const { return sched_info.urgency == urgency_t::off; }
+
+  bool is_queued() const { return in_queue; }
+
+  delay_cause_t delay_cause() const { return last_issue; }
+
+  bool was_delayed() const { return last_issue != delay_cause_t::none; }
+
+  /**
+   * a SchedTarget is 'ripe' for scrubbing if the current time is past its
+   * 'not_before' time (which guarantees it is also past its 'target').
+   * And - it must not be 'inactive'. i.e. must not have urgency 'off'.
+   */
+  bool is_ripe(utime_t now_is) const { return sched_info.is_ripe(now_is); }
+
+  bool over_deadline(utime_t now_is) const;
+
+  urgency_t urgency() const { return sched_info.urgency; }
+
+  // following scrub-initiation failures:
+
+  /// sets 'not-before' to 'now+delay'; updates 'last_issue'
+  void push_nb_out(
+      std::chrono::seconds delay,
+      delay_cause_t delay_cause,
+      utime_t scrub_clock_now);
+
+  /// push_nb_out() w/ delay=osd_scrub_retry_pg_state
+  void delay_on_pg_state(utime_t scrub_clock_now);
+
+  /// push_nb_out() w/ delay=osd_scrub_retry_delay
+  void delay_on_level_not_allowed(utime_t scrub_clock_now);
+
+  /// push_nb_out() w/ delay=osd_scrub_retry_wrong_time
+  void delay_on_wrong_time(utime_t scrub_clock_now);
+
+  void delay_on_no_local_resrc(utime_t scrub_clock_now);
+
+  void dump(std::string_view sect_name, ceph::Formatter* f) const;
+
+  void clear_queued() { in_queue = false; }
+  void set_queued() { in_queue = true; }
+
+  // scrub flags
+  bool get_auto_repair() const { return auto_repairing; }
+  bool get_do_repair() const { return do_repair; }
+
+ private:
+  /// our ID and scheduling parameters
+  SchedEntry sched_info;
+
+  /**
+   * is this target (meaning - a copy of his specific combination of
+   * PG and scrub type) currently in the queue?
+   */
+  bool in_queue{false};
+
+  /// the reason for the latest failure/delay (for logging/reporting purposes)
+  delay_cause_t last_issue{delay_cause_t::none};
+
+  // the flags affecting the scrub that will result from this target
+
+  /**
+   * (deep-scrub entries only:)
+   * Supporting the equivalent of 'need-auto', which translated into:
+   * - performing a deep scrub (taken care of by raising the priority of the
+   *   deep target);
+   * - marking that scrub as 'do_repair' (the next flag here);
+   */
+  bool auto_repairing{false};
+
+  /**
+   * (deep-scrub entries only:)
+   * Set for scrub_requested() scrubs with the 'repair' flag set.
+   * Translated (in set_op_parameters()) into a deep scrub with
+   * m_is_repair & PG_REPAIR_SCRUB.
+   */
+  bool do_repair{false};
+
+  // -----       logging support
+
+  CephContext* cct;
+
+  int whoami;  ///< the OSD id
+
+ private:
+  /// resets to the after-construction state
+  void reset();
+
+  void disable() { sched_info.urgency = urgency_t::off; }
+
+  void set_oper_deep_target(scrub_type_t rpr, utime_t scrub_clock_now);
+  void set_oper_shallow_target(scrub_type_t rpr, utime_t scrub_clock_now);
+
+  void up_urgency_to(urgency_t u);
+
+  void depenalize();
+
+  // updating periodic targets:
+
+  void update_as_shallow(
+      const pg_info_t& info,
+      const sched_conf_t& aconf,
+      utime_t now_is);
+
+  void update_as_deep(
+      const pg_info_t& info,
+      const sched_conf_t& aconf,
+      utime_t now_is);
+
+  std::string m_log_prefix;
+};
+
+// Queue-manipulation by a PG:
+struct ScrubQueueOps;
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// ScrubJob -- scrub scheduling & parameters for a specific PG (PgScrubber)
+
+class ScrubJob {
+ public:
+  ScrubJob(
+      ScrubQueueOps& osd_queue,
+      CephContext* cct,
+      const spg_t& pg,
+      int node_id);
+
+  /// switch between the two scrub types
+  static scrub_level_t the_other_level(scrub_level_t l);
+
+  /**
+   * dequeue and disable both shallow and deep targets
+   */
+  void remove_from_osd_queue();
+
+  // push a target back to the queue (after having it modified)
+  void requeue_entry(scrub_level_t tid);
+
+  /**
+   * returns a copy of the named target, and resets the 'left behind'
+   * copy (which is either 'shallow_target' or 'deep_target')
+   */
+  SchedTarget get_moved_target(scrub_level_t s_or_d);
+
+  void dequeue_entry(scrub_level_t s_or_d);
+
+  bool in_queue() const;
+
+  void
+  on_abort(SchedTarget&& aborted_target, delay_cause_t issue, utime_t now_is);
+
+  bool on_reservation_failure(
+      std::chrono::seconds period,
+      SchedTarget&& aborted_target);
+
+  void mark_for_after_repair();
+
+  SchedTarget& closest_target(utime_t scrub_clock_now);
+  const SchedTarget& closest_target(utime_t scrub_clock_now) const;
+
+
+ public:
+  /// pg to be scrubbed
+  spg_t pgid;
+
+  /// the OSD id (for the log)
+  int whoami;
+
+  CephContext* cct;
+
+  ScrubQueueOps& scrub_queue;
+
+  SchedTarget shallow_target;
+  SchedTarget deep_target;
+
+  SchedTarget& get_target(scrub_level_t lvl);
+
+  /**
+   * this PG (this ScrubJob) is being scrubbed now.
+   * Set to true immediately after set_op_parameters() committed us
+   * to a scrub.
+   */
+  bool scrubbing{false};
+
+  // failures/issues/aborts-related information
+
+  /**
+   * the scrubber is waiting for locked objects to be unlocked.
+   * Set after a grace period has passed.
+   */
+  bool blocked{false};
+  utime_t blocked_since{};
+
+  bool penalized{false};
+
+  /*
+   * if the PG is 'penalized' (after failing to secure replicas), this is the
+   * time at which the penalty is lifted.
+   */
+  utime_t penalized_until{0, 0};
+
+  /**
+   * the more consecutive failures - the longer we will delay before
+   * retrying the scrub job
+   */
+  int consec_aborts{0};
+
+  utime_t get_sched_time(utime_t scrub_clock_now) const;
+
+  /**
+   * the operator faked the timestamp. Reschedule the
+   * relevant target.
+   */
+  void operator_periodic_targets(
+      scrub_level_t level,
+      utime_t upd_stamp,
+      const pg_info_t& pg_info,
+      const sched_conf_t& sched_configs,
+      utime_t now_is);
+
+  /**
+   * the operator instructed us to scrub. The urgency is set to (at least)
+   * 'operator_requested', or (if the request is for a repair-scrub) - to
+   * 'must'
+   */
+  void operator_forced_targets(
+      scrub_level_t level,
+      scrub_type_t scrub_type,
+      utime_t now_is);
+
+  // deep scrub is marked for the next scrub cycle for this PG
+  // The equivalent of must_scrub & must_deep_scrub
+  void mark_for_rescrubbing();
+
+  void init_and_queue_targets(
+      const pg_info_t& info,
+      const sched_conf_t& aconf,
+      utime_t now_is);
+
+  void at_scrub_completion(
+      const pg_info_t& info,
+      const sched_conf_t& aconf,
+      utime_t now_is);
+
+  /**
+   * Following a change in the 'scrub period' parameters -
+   * recomputing the targets.
+   */
+  void on_periods_change(
+      const pg_info_t& info,
+      const sched_conf_t& aconf,
+      utime_t now_is);
+
+  void un_penalize();
+
+  void dump(ceph::Formatter* f) const;
+
+  std::string_view registration_state() const;
+
+  /**
+   * a text description of the "scheduling intentions" of this PG:
+   * are we already scheduled for a scrub/deep scrub? when?
+   */
+  std::string scheduling_state() const;
+
+  friend std::ostream& operator<<(std::ostream& out, const ScrubJob& pg);
+  std::ostream& gen_prefix(std::ostream& out) const;
+  std::string m_log_msg_prefix;
+
+ protected:  // made public in u-tests
+  // aux - dequeue targets
+  // returns the number of targets that were previously marked as "in queue"
+
+  /**
+   * dequeues both targets, marking them as 'not in queue'.
+   * returns the number of targets that were previously marked as "in queue".
+   */
+  int dequeue_targets();
+
+  /**
+   * dequeues the named target, marking it as 'not in queue'.
+   * returns a ref to the modified target.
+   */
+  SchedTarget& dequeue_target(scrub_level_t lvl);
+};
+}  // namespace Scrub
+
+
+class PGLockWrapper;
+
+namespace Scrub {
+
 class ScrubSchedListener {
  public:
   virtual int get_nodeid() const = 0;  // returns the OSD number ('whoami')
 
-  /**
-   * A callback used by the ScrubQueue object to initiate a scrub on a specific
-   * PG.
-   *
-   * The request might fail for multiple reasons, as ScrubQueue cannot by its
-   * own check some of the PG-specific preconditions and those are checked here.
-   * See attempt_t definition.
-   *
-   * @return a Scrub::attempt_t detailing either a success, or the failure
-   * reason.
-   */
-  virtual schedule_result_t initiate_a_scrub(
-    spg_t pgid,
-    bool allow_requested_repair_only) = 0;
+  virtual std::optional<PGLockWrapper> get_locked_pg(spg_t pgid) = 0;
+
+  virtual void send_sched_recalc_to_pg(spg_t pgid) = 0;
 
   virtual ~ScrubSchedListener() {}
 };
 
 }  // namespace Scrub
 
-/**
- * the queue of PGs waiting to be scrubbed.
- * Main operations are scheduling/unscheduling a PG to be scrubbed at a certain
- * time.
- *
- * A "penalty" queue maintains those PGs that have failed to reserve the
- * resources of their replicas. The PGs in this list will be reinstated into the
- * scrub queue when all eligible PGs were already handled, or after a timeout
- * (or if their deadline has passed [[disabled at this time]]).
- */
-class ScrubQueue {
- public:
-  enum class must_scrub_t { not_mandatory, mandatory };
-
-  enum class qu_state_t {
-    not_registered,  // not a primary, thus not considered for scrubbing by this
-		     // OSD (also the temporary state when just created)
-    registered,	     // in either of the two queues ('to_scrub' or 'penalized')
-    unregistering    // in the process of being unregistered. Will be finalized
-		     // under lock
-  };
-
-  ScrubQueue(CephContext* cct, Scrub::ScrubSchedListener& osds);
-  virtual ~ScrubQueue() = default;
-
-  struct scrub_schedule_t {
-    utime_t scheduled_at{};
-    utime_t deadline{0, 0};
-  };
-
-  struct sched_params_t {
-    utime_t proposed_time{};
-    double min_interval{0.0};
-    double max_interval{0.0};
-    must_scrub_t is_must{ScrubQueue::must_scrub_t::not_mandatory};
-  };
-
-  struct ScrubJob final : public RefCountedObject {
-
-    /**
-     *  a time scheduled for scrub, and a deadline: The scrub could be delayed
-     * if system load is too high (but not if after the deadline),or if trying
-     * to scrub out of scrub hours.
-     */
-    scrub_schedule_t schedule;
-
-    /// pg to be scrubbed
-    const spg_t pgid;
-
-    /// the OSD id (for the log)
-    const int whoami;
-
-    ceph::atomic<qu_state_t> state{qu_state_t::not_registered};
-
-    /**
-     * the old 'is_registered'. Set whenever the job is registered with the OSD,
-     * i.e. is in either the 'to_scrub' or the 'penalized' vectors.
-     */
-    std::atomic_bool in_queues{false};
-
-    /// last scrub attempt failed to secure replica resources
-    bool resources_failure{false};
-
-    /**
-     *  'updated' is a temporary flag, used to create a barrier after
-     *  'sched_time' and 'deadline' (or any other job entry) were modified by
-     *  different task.
-     *  'updated' also signals the need to move a job back from the penalized
-     *  queue to the regular one.
-     */
-    std::atomic_bool updated{false};
-
-    /**
-     * the scrubber is waiting for locked objects to be unlocked.
-     * Set after a grace period has passed.
-     */
-    bool blocked{false};
-    utime_t blocked_since{};
-
-    utime_t penalty_timeout{0, 0};
-
-    CephContext* cct;
-
-    ScrubJob(CephContext* cct, const spg_t& pg, int node_id);
-
-    utime_t get_sched_time() const { return schedule.scheduled_at; }
-
-    /**
-     * relatively low-cost(*) access to the scrub job's state, to be used in
-     * logging.
-     *  (*) not a low-cost access on x64 architecture
-     */
-    std::string_view state_desc() const
-    {
-      return ScrubQueue::qu_state_text(state.load(std::memory_order_relaxed));
-    }
-
-    void update_schedule(const ScrubQueue::scrub_schedule_t& adjusted);
-
-    void dump(ceph::Formatter* f) const;
-
-    /*
-     * as the atomic 'in_queues' appears in many log prints, accessing it for
-     * display-only should be made less expensive (on ARM. On x86 the _relaxed
-     * produces the same code as '_cs')
-     */
-    std::string_view registration_state() const
-    {
-      return in_queues.load(std::memory_order_relaxed) ? "in-queue"
-						       : "not-queued";
-    }
-
-    /**
-     * a text description of the "scheduling intentions" of this PG:
-     * are we already scheduled for a scrub/deep scrub? when?
-     */
-    std::string scheduling_state(utime_t now_is, bool is_deep_expected) const;
-
-    friend std::ostream& operator<<(std::ostream& out, const ScrubJob& pg);
-  };
-
-  friend class TestOSDScrub;
-  friend class ScrubSchedTestWrapper; ///< unit-tests structure
-
-  using ScrubJobRef = ceph::ref_t<ScrubJob>;
-  using ScrubQContainer = std::vector<ScrubJobRef>;
-
-  static std::string_view qu_state_text(qu_state_t st);
-
-  /**
-   * called periodically by the OSD to select the first scrub-eligible PG
-   * and scrub it.
-   *
-   * Selection is affected by:
-   * - time of day: scheduled scrubbing might be configured to only happen
-   *   during certain hours;
-   * - same for days of the week, and for the system load;
-   *
-   * @param preconds: what types of scrub are allowed, given system status &
-   *                  config. Some of the preconditions are calculated here.
-   * @return Scrub::attempt_t::scrubbing if a scrub session was successfully
-   *         initiated. Otherwise - the failure cause.
-   *
-   * locking: locks jobs_lock
-   */
-  Scrub::schedule_result_t select_pg_and_scrub(Scrub::ScrubPreconds& preconds);
-
-  /**
-   * Translate attempt_ values into readable text
-   */
-  static std::string_view attempt_res_text(Scrub::schedule_result_t v);
-
-  /**
-   * remove the pg from set of PGs to be scanned for scrubbing.
-   * To be used if we are no longer the PG's primary, or if the PG is removed.
-   */
-  void remove_from_osd_queue(ScrubJobRef sjob);
-
-  /**
-   * @return the list (not std::set!) of all scrub jobs registered
-   *   (apart from PGs in the process of being removed)
-   */
-  ScrubQContainer list_registered_jobs() const;
-
-  /**
-   * Add the scrub job to the list of jobs (i.e. list of PGs) to be periodically
-   * scrubbed by the OSD.
-   * The registration is active as long as the PG exists and the OSD is its
-   * primary.
-   *
-   * See update_job() for the handling of the 'suggested' parameter.
-   *
-   * locking: might lock jobs_lock
-   */
-  void register_with_osd(ScrubJobRef sjob, const sched_params_t& suggested);
-
-  /**
-   * modify a scrub-job's scheduled time and deadline
-   *
-   * There are 3 argument combinations to consider:
-   * - 'must' is asserted, and the suggested time is 'scrub_must_stamp':
-   *   the registration will be with "beginning of time" target, making the
-   *   scrub-job eligible to immediate scrub (given that external conditions
-   *   do not prevent scrubbing)
-   *
-   * - 'must' is asserted, and the suggested time is 'now':
-   *   This happens if our stats are unknown. The results are similar to the
-   *   previous scenario.
-   *
-   * - not a 'must': we take the suggested time as a basis, and add to it some
-   *   configuration / random delays.
-   *
-   *  ('must' is sched_params_t.is_must)
-   *
-   *  locking: not using the jobs_lock
-   */
-  void update_job(ScrubJobRef sjob, const sched_params_t& suggested);
-
-  sched_params_t determine_scrub_time(const requested_scrub_t& request_flags,
-				      const pg_info_t& pg_info,
-				      const pool_opts_t& pool_conf) const;
-
- public:
-  void dump_scrubs(ceph::Formatter* f) const;
-
-  /**
-   * No new scrub session will start while a scrub was initiated on a PG,
-   * and that PG is trying to acquire replica resources.
-   */
-  void set_reserving_now() { a_pg_is_reserving = true; }
-  void clear_reserving_now() { a_pg_is_reserving = false; }
-  bool is_reserving_now() const { return a_pg_is_reserving; }
-
-  bool can_inc_scrubs() const;
-  bool inc_scrubs_local();
-  void dec_scrubs_local();
-  bool inc_scrubs_remote();
-  void dec_scrubs_remote();
-  void dump_scrub_reservations(ceph::Formatter* f) const;
-
-  /// counting the number of PGs stuck while scrubbing, waiting for objects
-  void mark_pg_scrub_blocked(spg_t blocked_pg);
-  void clear_pg_scrub_blocked(spg_t blocked_pg);
-  int get_blocked_pgs_count() const;
-
-  /**
-   * Pacing the scrub operation by inserting delays (mostly between chunks)
-   *
-   * Special handling for regular scrubs that continued into "no scrub" times.
-   * Scrubbing will continue, but the delays will be controlled by a separate
-   * (read - with higher value) configuration element
-   * (osd_scrub_extended_sleep).
-   */
-  double scrub_sleep_time(bool must_scrub) const;  /// \todo (future) return
-						   /// milliseconds
-
-  /**
-   *  called every heartbeat to update the "daily" load average
-   *
-   *  @returns a load value for the logger
-   */
-  [[nodiscard]] std::optional<double> update_load_average();
-
- private:
-  CephContext* cct;
-  Scrub::ScrubSchedListener& osd_service;
-
-#ifdef WITH_SEASTAR
-  auto& conf() const { return local_conf(); }
-#else
-  auto& conf() const { return cct->_conf; }
-#endif
-
-  /**
-   *  jobs_lock protects the job containers and the relevant scrub-jobs state
-   *  variables. Specifically, the following are guaranteed:
-   *  - 'in_queues' is asserted only if the job is in one of the queues;
-   *  - a job will only be in state 'registered' if in one of the queues;
-   *  - no job will be in the two queues simultaneously;
-   *
-   *  Note that PG locks should not be acquired while holding jobs_lock.
-   */
-  mutable ceph::mutex jobs_lock = ceph::make_mutex("ScrubQueue::jobs_lock");
-
-  ScrubQContainer to_scrub;   ///< scrub jobs (i.e. PGs) to scrub
-  ScrubQContainer penalized;  ///< those that failed to reserve remote resources
-  bool restore_penalized{false};
-
-  double daily_loadavg{0.0};
-
-  static inline constexpr auto registered_job = [](const auto& jobref) -> bool {
-    return jobref->state == qu_state_t::registered;
-  };
-
-  static inline constexpr auto invalid_state = [](const auto& jobref) -> bool {
-    return jobref->state == qu_state_t::not_registered;
-  };
-
-  /**
-   * Are there scrub jobs that should be reinstated?
-   */
-  void scan_penalized(bool forgive_all, utime_t time_now);
-
-  /**
-   * clear dead entries (unregistered, or belonging to removed PGs) from a
-   * queue. Job state is changed to match new status.
-   */
-  void rm_unregistered_jobs(ScrubQContainer& group);
-
-  /**
-   * the set of all scrub jobs in 'group' which are ready to be scrubbed
-   * (ready = their scheduled time has passed).
-   * The scrub jobs in the new collection are sorted according to
-   * their scheduled time.
-   *
-   * Note that the returned container holds independent refs to the
-   * scrub jobs.
-   */
-  ScrubQContainer collect_ripe_jobs(ScrubQContainer& group, utime_t time_now);
-
-
-  /// scrub resources management lock (guarding scrubs_local & scrubs_remote)
-  mutable ceph::mutex resource_lock =
-    ceph::make_mutex("ScrubQueue::resource_lock");
-
-  /// the counters used to manage scrub activity parallelism:
-  int scrubs_local{0};
-  int scrubs_remote{0};
-
-  /**
-   * The scrubbing of PGs might be delayed if the scrubbed chunk of objects is
-   * locked by some other operation. A bug might cause this to be an infinite
-   * delay. If that happens, the OSDs "scrub resources" (i.e. the
-   * counters that limit the number of concurrent scrub operations) might
-   * be exhausted.
-   * We do issue a cluster-log warning in such occasions, but that message is
-   * easy to miss. The 'some pg is blocked' global flag is used to note the
-   * existence of such a situation in the scrub-queue log messages.
-   */
-  std::atomic_int_fast16_t blocked_scrubs_cnt{0};
-
-  std::atomic_bool a_pg_is_reserving{false};
-
-  [[nodiscard]] bool scrub_load_below_threshold() const;
-  [[nodiscard]] bool scrub_time_permit(utime_t now) const;
-
-  /**
-   * If the scrub job was not explicitly requested, we postpone it by some
-   * random length of time.
-   * And if delaying the scrub - we calculate, based on pool parameters, a
-   * deadline we should scrub before.
-   *
-   * @return a pair of values: the determined scrub time, and the deadline
-   */
-  scrub_schedule_t adjust_target_time(
-    const sched_params_t& recomputed_params) const;
-
-  /**
-   * Look for scrub jobs that have their 'resources_failure' set. These jobs
-   * have failed to acquire remote resources last time we've initiated a scrub
-   * session on them. They are now moved from the 'to_scrub' queue to the
-   * 'penalized' set.
-   *
-   * locking: called with job_lock held
-   */
-  void move_failed_pgs(utime_t now_is);
-
-  Scrub::schedule_result_t select_from_group(
-    ScrubQContainer& group,
-    const Scrub::ScrubPreconds& preconds,
-    utime_t now_is);
-
-protected: // used by the unit-tests
-  /**
-   * unit-tests will override this function to return a mock time
-   */
-  virtual utime_t time_now() const { return ceph_clock_now(); }
-};
-
+// clang-format off
 template <>
-struct fmt::formatter<ScrubQueue::qu_state_t>
+struct fmt::formatter<Scrub::urgency_t>
     : fmt::formatter<std::string_view> {
   template <typename FormatContext>
-  auto format(const ScrubQueue::qu_state_t& s, FormatContext& ctx)
+  auto format(Scrub::urgency_t urg, FormatContext& ctx)
   {
-    auto out = ctx.out();
-    out = fmt::formatter<string_view>::format(
-      std::string{ScrubQueue::qu_state_text(s)}, ctx);
-    return out;
+    using enum Scrub::urgency_t;
+    std::string_view desc;
+    switch (urg) {
+      case after_repair:        desc = "after-repair"; break;
+      case must:                desc = "must"; break;
+      case operator_requested:  desc = "operator-requested"; break;
+      case overdue:             desc = "overdue"; break;
+      case periodic_regular:    desc = "periodic-regular"; break;
+      case penalized:           desc = "reservation-failure"; break;
+      case off:                 desc = "off"; break;
+      // better to not have a default case, so that the compiler will warn
+    }
+    return formatter<string_view>::format(desc, ctx);
+  }
+};
+// clang-format on
+
+// clang-format off
+template <>
+struct fmt::formatter<Scrub::delay_cause_t> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(Scrub::delay_cause_t cause, FormatContext& ctx)
+  {
+    using enum Scrub::delay_cause_t;
+    std::string_view desc;
+    switch (cause) {
+      case none:        desc = "ok"; break;
+      case replicas:    desc = "replicas"; break;
+      case flags:       desc = "flags"; break;	 // no-scrub etc'
+      case pg_state:    desc = "pg-state"; break;
+      case time:        desc = "time"; break;
+      case local_resources: desc = "local-cnt"; break;
+      case aborted:     desc = "aborted"; break;
+      // better to not have a default case, so that the compiler will warn
+    }
+    return formatter<string_view>::format(desc, ctx);
+  }
+};
+// clang-format on
+
+template <>
+struct fmt::formatter<Scrub::SchedEntry> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const Scrub::SchedEntry& st, FormatContext& ctx)
+  {
+    return format_to(
+	ctx.out(), "{}/{},nb:{:s},({},tr:{:s},dl:{:s})", st.pgid,
+	(st.level == scrub_level_t::deep ? "dp" : "sh"), st.not_before,
+	st.urgency, st.target, st.deadline);
   }
 };
 
 template <>
-struct fmt::formatter<ScrubQueue::ScrubJob> {
+struct fmt::formatter<Scrub::SchedTarget> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const Scrub::SchedTarget& st, FormatContext& ctx)
+  {
+    return format_to(
+	ctx.out(), "{},q:{},ar:{},issue:{}", st.sched_info,
+	st.in_queue ? "+" : "-", st.auto_repairing ? "+" : "-", st.last_issue);
+  }
+};
+
+template <>
+struct fmt::formatter<Scrub::ScrubJob> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx)
+  {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it == 's') {
+      shortened = true;
+      ++it;
+    }
+    return it;
+  }
 
   template <typename FormatContext>
-  auto format(const ScrubQueue::ScrubJob& sjob, FormatContext& ctx)
+  auto format(const Scrub::ScrubJob& sjob, FormatContext& ctx)
   {
+    if (shortened) {
+      return fmt::format_to(
+	  ctx.out(), "pg[{}]:reg:{}", sjob.pgid, sjob.registration_state());
+    }
     return fmt::format_to(
-      ctx.out(),
-      "pg[{}] @ {:s} (dl:{:s}) - <{}> / failure: {} / pen. t.o.: {:s} / queue "
-      "state: {:.7}",
-      sjob.pgid, sjob.schedule.scheduled_at, sjob.schedule.deadline,
-      sjob.registration_state(), sjob.resources_failure, sjob.penalty_timeout,
-      sjob.state.load(std::memory_order_relaxed));
+	ctx.out(), "pg[{}]:[t/s:{},t/d:{}],reg:{}", sjob.pgid,
+	sjob.shallow_target, sjob.deep_target, sjob.registration_state());
+  }
+  bool shortened{false};  ///< no 'nearest target' info
+};
+
+template <>
+struct fmt::formatter<Scrub::sched_conf_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const Scrub::sched_conf_t& cf, FormatContext& ctx)
+  {
+    return format_to(
+	ctx.out(),
+	"periods: s:{}/{} d:{}/{} iv-ratio:{} deep-rand:{} on-inv:{}",
+	cf.shallow_interval, cf.max_shallow.value_or(-1.0), cf.deep_interval,
+	cf.max_deep, cf.interval_randomize_ratio, cf.deep_randomize_ratio,
+	cf.mandatory_on_invalid);
   }
 };

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -134,7 +134,7 @@ sc::result ReservingReplicas::react(const ReservationFailure&)
   dout(10) << "ReservingReplicas::react(const ReservationFailure&)" << dendl;
 
   // the Scrubber must release all resources and abort the scrubbing
-  scrbr->clear_pgscrub_state();
+  scrbr->on_repl_reservation_failure();
   return transit<NotActive>();
 }
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -65,6 +65,9 @@ MEV(RemotesReserved)
 /// a reservation request has failed
 MEV(ReservationFailure)
 
+/// configuration changes might affect our scrub-queue entries
+MEV(RecalcSchedule)
+
 /// initiate a new scrubbing session (relevant if we are a Primary)
 MEV(StartScrub)
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -107,6 +107,8 @@ struct ScrubMachineListener {
 
   virtual void replica_handling_done() = 0;
 
+  virtual void on_repl_reservation_failure() = 0;
+
   /// the version of 'scrub_clear_state()' that does not try to invoke FSM
   /// services (thus can be called from FSM reactions)
   virtual void clear_pgscrub_state() = 0;

--- a/src/osd/scrubber/scrub_queue.cc
+++ b/src/osd/scrubber/scrub_queue.cc
@@ -1,0 +1,570 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "osd/OSD.h"
+#include "osd/osd_types_fmt.h"
+
+#include "osd_scrub_sched.h"
+#include "scrub_queue.h"
+
+using namespace std::chrono;
+using namespace std::chrono_literals;
+using namespace std::literals;
+
+#define dout_context (cct)
+#define dout_subsys ceph_subsys_osd
+#undef dout_prefix
+#define dout_prefix _prefix_target(_dout, this)
+
+template <class T>
+static ostream& _prefix_target(std::ostream* _dout, T* t)
+{
+  return t->gen_prefix(*_dout);
+}
+
+ScrubQueue::ScrubQueue(CephContext* cct, Scrub::ScrubSchedListener& osds)
+    : cct{cct}
+    , osd_service{osds}
+    , m_osd_resources{
+	  [this](std::string msg) { log_fwd(msg); },
+	  cct->_conf}
+{
+  log_prefix = fmt::format("osd.{} scrub-queue::", osd_service.get_nodeid());
+
+  // initialize the daily loadavg with current 15min loadavg
+  if (double loadavgs[3]; getloadavg(loadavgs, 3) == 3) {
+    daily_loadavg = loadavgs[2];
+  } else {
+    derr << "OSD::init() : couldn't read loadavgs\n" << dendl;
+    daily_loadavg = 1.0;
+  }
+}
+
+std::ostream& ScrubQueue::gen_prefix(std::ostream& out) const
+{
+  return out << log_prefix;
+}
+
+utime_t ScrubQueue::scrub_clock_now() const
+{
+  return ceph_clock_now();
+}
+
+// ////////////////////////////////////////////////////////////////////////// //
+// CPU load tracking and related
+
+std::optional<double> ScrubQueue::update_load_average()
+{
+  int hb_interval = conf()->osd_heartbeat_interval;
+  int n_samples = 60 * 24 * 24;
+  if (hb_interval > 1) {
+    n_samples /= hb_interval;
+    if (n_samples < 1)
+      n_samples = 1;
+  }
+
+  // get CPU load avg
+  double loadavg;
+  if (getloadavg(&loadavg, 1) == 1) {
+    daily_loadavg = (daily_loadavg * (n_samples - 1) + loadavg) / n_samples;
+    dout(17) << "heartbeat: daily_loadavg " << daily_loadavg << dendl;
+    return 100 * loadavg;
+  }
+
+  return std::nullopt;
+}
+
+bool ScrubQueue::scrub_load_below_threshold() const
+{
+  double loadavgs[3];
+  if (getloadavg(loadavgs, 3) != 3) {
+    dout(10) << fmt::format("{}: couldn't read loadavgs", __func__) << dendl;
+    return false;
+  }
+
+  // allow scrub if below configured threshold
+  long cpus = sysconf(_SC_NPROCESSORS_ONLN);
+  double loadavg_per_cpu = cpus > 0 ? loadavgs[0] / cpus : loadavgs[0];
+  if (loadavg_per_cpu < conf()->osd_scrub_load_threshold) {
+    dout(20) << fmt::format(
+		    "loadavg per cpu {} < max {} = yes", loadavg_per_cpu,
+		    conf()->osd_scrub_load_threshold)
+	     << dendl;
+    return true;
+  }
+
+  // allow scrub if below daily avg and currently decreasing
+  if (loadavgs[0] < daily_loadavg && loadavgs[0] < loadavgs[2]) {
+    dout(20) << fmt::format(
+		    "loadavg {} < daily_loadavg {} and < 15m avg {} = yes",
+		    loadavgs[0], daily_loadavg, loadavgs[2])
+	     << dendl;
+    return true;
+  }
+
+  dout(20) << fmt::format(
+		  "loadavg {} >= max {} and ( >= daily_loadavg {} or >= 15m "
+		  "avg {} ) = no",
+		  loadavgs[0], conf()->osd_scrub_load_threshold, daily_loadavg,
+		  loadavgs[2])
+	   << dendl;
+  return false;
+}
+
+
+// checks for half-closed ranges. Modify the (p<till)to '<=' to check for
+// closed.
+static inline bool isbetween_modulo(int64_t from, int64_t till, int p)
+{
+  // the 1st condition is because we have defined from==till as "always true"
+  return (till == from) || ((till >= from) ^ (p >= from) ^ (p < till));
+}
+
+bool ScrubQueue::scrub_time_permit() const
+{
+  utime_t now = scrub_clock_now();
+  time_t tt = now.sec();
+  tm bdt;
+  localtime_r(&tt, &bdt);
+
+  bool day_permit = isbetween_modulo(
+      conf()->osd_scrub_begin_week_day, conf()->osd_scrub_end_week_day,
+      bdt.tm_wday);
+  if (!day_permit) {
+    dout(20) << fmt::format(
+		    "{}: should run between week day {} - {} now {} - no",
+		    __func__, conf()->osd_scrub_begin_week_day,
+		    conf()->osd_scrub_end_week_day, bdt.tm_wday)
+	     << dendl;
+    return false;
+  }
+
+  bool time_permit = isbetween_modulo(
+      conf()->osd_scrub_begin_hour, conf()->osd_scrub_end_hour, bdt.tm_hour);
+  dout(20) << fmt::format(
+		  "{}: should run between {} - {} now {} = {}", __func__,
+		  conf()->osd_scrub_begin_hour, conf()->osd_scrub_end_hour,
+		  bdt.tm_hour, (time_permit ? "yes" : "no"))
+	   << dendl;
+  return time_permit;
+}
+
+milliseconds ScrubQueue::required_sleep_time(bool high_priority_scrub) const
+{
+  milliseconds regular_sleep_period =
+      milliseconds{int64_t(1000 * conf()->osd_scrub_sleep)};
+
+  if (high_priority_scrub || scrub_time_permit()) {
+    return regular_sleep_period;
+  }
+
+  // relevant if scrubbing started during allowed time, but continued into
+  // forbidden hours
+  milliseconds extended_sleep =
+      milliseconds{int64_t(1000 * conf()->osd_scrub_extended_sleep)};
+  dout(20)
+      << fmt::format(
+	     "{}: scrubbing started during allowed time, but continued into "
+	     "forbidden hours. regular_sleep_period {} extended_sleep {}",
+	     __func__, regular_sleep_period, extended_sleep)
+      << dendl;
+  return std::max(extended_sleep, regular_sleep_period);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// queue manipulation - implementing the ScrubQueueOps interface
+
+using SchedEntry = Scrub::SchedEntry;
+using urgency_t = Scrub::urgency_t;
+
+namespace {
+
+// the 'identification' function for the 'to_scrub' queue
+// (would have been a key in a map, where we not sorting the entries
+// by different fields)
+auto same_key(const SchedEntry& t, spg_t pgid, scrub_level_t s_or_d)
+{
+  return t.is_valid && t.pgid == pgid && t.level == s_or_d;
+}
+}  // namespace
+
+
+bool ScrubQueue::queue_entries(spg_t pgid, SchedEntry shallow, SchedEntry deep)
+{
+  dout(20) << fmt::format(
+		  "{}: pg[{}]: queuing <{}> & <{}>", __func__, pgid, shallow,
+		  deep)
+	   << dendl;
+  ceph_assert(shallow.pgid == pgid && deep.pgid == pgid);
+
+  if (shallow.urgency == urgency_t::off || deep.urgency == urgency_t::off) {
+    dout(20) << fmt::format(
+		    "{}: pg[{}]: one of the entries is 'off' - not queuing",
+		    __func__, pgid)
+	     << dendl;
+    return false;
+  }
+
+  shallow.is_valid = true;
+  deep.is_valid = true;
+
+  std::unique_lock l{jobs_lock};
+  // now - add the new targets
+  to_scrub.push_back(shallow);
+  to_scrub.push_back(deep);
+  return true;
+}
+
+void ScrubQueue::remove_entry(spg_t pgid, scrub_level_t s_or_d)
+{
+  dout(20) << fmt::format(
+		  "{}: removing {}/{} from the scrub-queue", __func__, pgid,
+		  s_or_d)
+	   << dendl;
+  std::unique_lock l{jobs_lock};
+  auto i = std::find_if(
+      to_scrub.begin(), to_scrub.end(), [pgid, s_or_d](const SchedEntry& t) {
+	return same_key(t, pgid, s_or_d);
+      });
+  if (i != to_scrub.end()) {
+    i->is_valid = false;
+  }
+}
+
+
+void ScrubQueue::cp_and_queue_target(SchedEntry t)
+{
+  dout(20) << fmt::format("{}: restoring {} to the scrub-queue", __func__, t)
+	   << dendl;
+  ceph_assert(t.urgency > urgency_t::off);
+  std::unique_lock l{jobs_lock};
+  t.is_valid = true;
+  to_scrub.push_back(t);
+}
+
+void ScrubQueue::dump_scrubs(ceph::Formatter* f)
+{
+  std::lock_guard lck(jobs_lock);
+  normalize_the_queue();
+
+  f->open_array_section("scrubs");
+  std::for_each(to_scrub.cbegin(), to_scrub.cend(), [&f](const auto& j) {
+    j.dump("sched-target", f);
+  });
+  f->close_section();
+}
+
+Scrub::ScrubResources& ScrubQueue::resource_bookkeeper()
+{
+  return m_osd_resources;
+}
+
+const Scrub::ScrubResources& ScrubQueue::resource_bookkeeper() const
+{
+  return m_osd_resources;
+}
+
+void ScrubQueue::log_fwd(std::string_view text)
+{
+  dout(20) << text << dendl;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// initiating a scrub
+
+using ScrubPreconds = Scrub::ScrubPreconds;
+using schedule_result_t = Scrub::schedule_result_t;
+
+void ScrubQueue::sched_scrub(
+    const ceph::common::ConfigProxy& config,
+    bool is_recovery_active)
+{
+  utime_t scrub_tick_time = scrub_clock_now();
+  dout(10) << fmt::format(
+		  "time now:{}, is_recovery_active:{}", scrub_tick_time,
+		  is_recovery_active)
+	   << dendl;
+
+  // do the OSD-wide environment conditions, and the availability of scrub
+  // resources, allow us to start a scrub?
+  auto maybe_env_cond =
+      preconditions_to_scrubbing(config, is_recovery_active, scrub_tick_time);
+  if (!maybe_env_cond) {
+    return;
+  }
+  auto preconds = maybe_env_cond.value();
+
+  std::unique_lock l{jobs_lock};
+
+  // partition and sort the queue
+  if (bool not_empty = normalize_the_queue(); !not_empty) {
+    dout(10) << fmt::format("{}: no eligible scrub targets", __func__) << dendl;
+    return;
+  }
+
+  // pop the first job from the queue, as a candidate
+  auto cand = to_scrub.front();
+  to_scrub.pop_front();
+  l.unlock();
+
+  auto locked_g = osd_service.get_locked_pg(cand.pgid);
+  if (!locked_g) {
+    // the PG was deleted in the short time since unlocking the queue
+    dout(5) << fmt::format("{}: pg[{}] not found", __func__, cand.pgid)
+	    << dendl;
+    return;
+  }
+  locked_g->pg()->start_scrubbing(scrub_tick_time, cand.level, preconds);
+}
+
+
+tl::expected<ScrubPreconds, schedule_result_t>
+ScrubQueue::preconditions_to_scrubbing(
+    const ceph::common::ConfigProxy& config,
+    bool is_recovery_active,
+    utime_t scrub_clock_now) const
+{
+  if (auto blocked_pgs = get_blocked_pgs_count(); blocked_pgs > 0) {
+    // some PGs managed by this OSD were blocked by a locked object during
+    // scrub. This means we might not have the resources needed to scrub now.
+    dout(10) << fmt::format(
+		    "{}: PGs are blocked while scrubbing due to locked objects "
+		    "({} PGs)",
+		    __func__, blocked_pgs)
+	     << dendl;
+  }
+
+  // sometimes we just skip the scrubbing
+  if ((rand() / (double)RAND_MAX) < config->osd_scrub_backoff_ratio) {
+    dout(20) << fmt::format(
+		    "{}: lost coin flip, randomly backing off (ratio: {:f})",
+		    __func__, config->osd_scrub_backoff_ratio)
+	     << dendl;
+    return tl::unexpected(schedule_result_t::failure);
+  }
+
+  // fail fast if no resources are available
+  if (!resource_bookkeeper().can_inc_scrubs()) {
+    dout(10) << fmt::format("{}: OSD cannot inc scrubs", __func__) << dendl;
+    return tl::unexpected(schedule_result_t::failure);
+  }
+
+  // if there is a PG that is just now trying to reserve scrub replica resources
+  // - we should wait and not initiate a new scrub
+  if (is_reserving_now()) {
+    dout(10) << fmt::format(
+		    "{}: scrub resources reservation in progress", __func__)
+	     << dendl;
+    return tl::unexpected(schedule_result_t::failure);
+  }
+
+  Scrub::ScrubPreconds env_conditions;
+  env_conditions.time_permit = scrub_time_permit();
+  env_conditions.load_is_low = scrub_load_below_threshold();
+  env_conditions.only_deadlined =
+      !env_conditions.time_permit || !env_conditions.load_is_low;
+
+  if (is_recovery_active && !config->osd_scrub_during_recovery) {
+    if (!config->osd_repair_during_recovery) {
+      dout(15) << fmt::format(
+		      "{}: not scheduling scrubs due to active recovery",
+		      __func__)
+	       << dendl;
+      return tl::unexpected(schedule_result_t::failure);
+    }
+
+    dout(10) << fmt::format(
+		    "{}: will only schedule explicitly requested repair due to "
+		    "active recovery",
+		    __func__)
+	     << dendl;
+    env_conditions.allow_requested_repair_only = true;
+  }
+
+  return env_conditions;
+}
+
+/**
+ * the refactored "OSD::sched_all_scrubs()"
+ *
+ * Scans the queue for entries that are "periodic", and messages the PGs
+ * named in those entries to recalculate their scrub scheduling
+ */
+void ScrubQueue::on_config_times_change()
+{
+  std::set<spg_t> to_notify;
+  std::unique_lock l{jobs_lock};
+  for (const auto& e : to_scrub) {
+    if (e.is_valid && e.urgency == urgency_t::periodic_regular) {
+      to_notify.insert(e.pgid);
+    }
+  }
+  l.unlock();
+
+  for (const auto& p : to_notify) {
+    dout(15) << fmt::format("{}: rescheduling {}", __func__, p) << dendl;
+    osd_service.send_sched_recalc_to_pg(p);
+  }
+}
+
+// ////////////////////////////////////////////////////////////////////////// //
+// auxiliaries
+
+Scrub::sched_conf_t ScrubQueue::populate_config_params(
+    const pool_opts_t& pool_conf) const
+{
+  Scrub::sched_conf_t configs;
+
+  // deep-scrub optimal interval
+  configs.deep_interval =
+      pool_conf.value_or(pool_opts_t::DEEP_SCRUB_INTERVAL, 0.0);
+  if (configs.deep_interval <= 0.0) {
+    configs.deep_interval = conf()->osd_deep_scrub_interval;
+  }
+
+  // shallow-scrub interval
+  configs.shallow_interval =
+      pool_conf.value_or(pool_opts_t::SCRUB_MIN_INTERVAL, 0.0);
+  if (configs.shallow_interval <= 0.0) {
+    configs.shallow_interval = conf()->osd_scrub_min_interval;
+  }
+
+  // the max allowed delay between scrubs.
+  // For deep scrubs - there is no equivalent of scrub_max_interval. Per the
+  // documentation, once deep_scrub_interval has passed, we are already
+  // "overdue", at least as far as the "ignore allowed load" window is
+  // concerned.
+
+  configs.max_deep = configs.deep_interval + configs.shallow_interval;
+
+  auto max_shallow = pool_conf.value_or(pool_opts_t::SCRUB_MAX_INTERVAL, 0.0);
+  if (max_shallow <= 0.0) {
+    max_shallow = conf()->osd_scrub_max_interval;
+  }
+  if (max_shallow > 0.0) {
+    configs.max_shallow = max_shallow;
+    // otherwise - we're left with the default nullopt
+  }
+
+  // but seems like our tests require: \todo fix!
+  configs.max_deep =
+      std::max(configs.max_shallow.value_or(0.0), configs.deep_interval);
+
+  configs.interval_randomize_ratio = conf()->osd_scrub_interval_randomize_ratio;
+  configs.deep_randomize_ratio = conf()->osd_deep_scrub_randomize_ratio;
+  configs.mandatory_on_invalid = conf()->osd_scrub_invalid_stats;
+
+  dout(15) << fmt::format("updated config:{}", configs) << dendl;
+  return configs;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// container low-level operations. Will be extracted, and implemented by a
+// dedicated container class
+
+// used in ut/debug logs
+constexpr int ordering_as_int(std::weak_ordering cmp) noexcept
+{
+  return (cmp < 0) ? -1 : ((cmp == 0) ? 0 : 1);
+}
+
+// must be called under the lock
+bool ScrubQueue::normalize_the_queue()
+{
+  // erase all 'invalid' entries
+  to_scrub.erase(
+      std::remove_if(
+	  to_scrub.begin(), to_scrub.end(),
+	  [](const auto& sched_entry) { return !sched_entry.is_valid; }),
+      to_scrub.end());
+
+  auto nowis = scrub_clock_now();
+  // partition into 'ripe' and to those not eligible for scrubbing
+  auto not_ripe = std::stable_partition(
+      to_scrub.begin(), to_scrub.end(),
+      [nowis](const auto& sched_entry) { return sched_entry.is_ripe(nowis); });
+
+  // sort the 'ripe' entries by their specific criteria
+  std::sort(to_scrub.begin(), not_ripe, [](const auto& lhs, const auto& rhs) {
+#ifdef DEBUG
+    std::cout << fmt::format(
+	"-r- comparing {} / {} -> {}\n", lhs, rhs,
+	ordering_as_int(cmp_ripe_entries(lhs, rhs)));
+#endif
+    return cmp_ripe_entries(lhs, rhs) < 0;
+  });
+
+  // sort those with not-before in the future - mostly by their 'not-before'
+  // time
+  std::sort(not_ripe, to_scrub.end(), [](const auto& lhs, const auto& rhs) {
+#ifdef DEBUG
+    std::cout << fmt::format(
+	"-x- comparing {} / {} -> {}\n", lhs, rhs,
+	ordering_as_int(cmp_future_entries(lhs, rhs)));
+#endif
+    return cmp_future_entries(lhs, rhs) < 0;
+  });
+
+  const int ready_cnt = std::distance(to_scrub.begin(), not_ripe);
+  const int future_cnt = std::distance(not_ripe, to_scrub.end());
+  dout(10) << fmt::format(
+		  "{}: ready: {}, future: {} total queue size: {}", __func__,
+		  ready_cnt, future_cnt, to_scrub.size())
+	   << dendl;
+
+  // dump the queue
+  {
+    static const int max_to_log = 10;
+
+    // top of the ready-queue
+    int ready_n = std::min(ready_cnt, max_to_log);
+    if (ready_n && g_conf()->subsys.should_gather<ceph_subsys_osd, 10>()) {
+      dout(10) << fmt::format(
+		      "{}: top ({} of {}) of the ready-queue:", __func__,
+		      ready_n, ready_cnt)
+	       << dendl;
+      for (int i = 0; i < ready_n; ++i) {
+	dout(10) << fmt::format(" ready:  {}", to_scrub[i]) << dendl;
+      }
+    }
+
+    // and some of the targets with 'not-before' in the future
+    int future_n = std::min(future_cnt, max_to_log);
+    if (future_n && g_conf()->subsys.should_gather<ceph_subsys_osd, 20>()) {
+      dout(10) << fmt::format(
+		      "{}: top ({} of {}) of the future targets:", __func__,
+		      future_n, future_cnt)
+	       << dendl;
+      int k = future_n;
+      for (auto e = not_ripe; k > 0; --k, ++e) {
+	dout(20) << fmt::format(" future: {}", *e) << dendl;
+      }
+    }
+  }
+  return not_ripe != to_scrub.begin();
+}
+
+
+void ScrubQueue::clear_pg_scrub_blocked(spg_t blocked_pg)
+{
+  dout(5) << fmt::format("{}: pg[{}] is unblocked", __func__, blocked_pg)
+	  << dendl;
+  --blocked_scrubs_cnt;
+  ceph_assert(blocked_scrubs_cnt >= 0);
+}
+
+void ScrubQueue::mark_pg_scrub_blocked(spg_t blocked_pg)
+{
+  dout(5) << fmt::format(
+		 "{}: pg[{}] is blocked on an object", __func__, blocked_pg)
+	  << dendl;
+  ++blocked_scrubs_cnt;
+}
+
+int ScrubQueue::get_blocked_pgs_count() const
+{
+  return blocked_scrubs_cnt;
+}

--- a/src/osd/scrubber/scrub_queue.h
+++ b/src/osd/scrubber/scrub_queue.h
@@ -1,0 +1,205 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "include/expected.hpp"
+#include "include/utime.h"
+#include "include/utime_fmt.h"
+#include "osd/osd_types.h"
+#include "osd/osd_types_fmt.h"
+#include "osd/scrubber/scrub_queue_if.h"
+#include "osd/scrubber/scrub_resources.h"
+#include "osd/scrubber_common.h"
+
+namespace Scrub {
+class ScrubSchedListener;
+class ScrubJob;
+class SchedEntry;
+}  // namespace Scrub
+
+/**
+ * The 'ScrubQueue' is a "sub-component" of the OSD. It is responsible (mainly)
+ * for selecting the PGs to be scrubbed, and initiating the scrub operation.
+ * 
+ * Other responsibilities "traditionally" associated with the scrub-queue are:
+ * - monitoring system load, and
+ * - monitoring the number of scrubs performed by the OSD, as either a primary or
+ *   replica.
+ * 
+ * The object's main functionality is implemented inn two layers:
+ * - an upper layer (the 'ScrubQueue' class) is responsible for initiating a
+ *   scrub on the top-most (priority-wise) eligible PG;
+ * - a prioritized container of "scrub targets". A target conveys both the
+ *   PG to be scrubbed, and the scrub type (deep or shallow). It contains the
+ *   information required in order to prioritize the specific scrub request
+ *   compared to all other requests.
+ * 
+ * In this version, the lower layer is trivially implemented as a standard
+ * std::deque, and its interface to the upper layer is trivial. Thus, for
+ * this version, I chose to not extract that interface as a separate class.
+*/
+
+/**
+ * the following invariants hold:
+ * - there are at most two objects for each PG (one for each scrub type) in
+ *   the queue.
+ * - if a queue element is removed or white-out, the corresponding object held
+ *   by the PgScrubber will (not necessarily immediately) be marked as
+ *   'not in the queue'.
+ * - 'white-out' queue elements are never reported to the queue users.
+ */
+class ScrubQueue : public Scrub::ScrubQueueOps {
+ public:
+  ScrubQueue(CephContext* cct, Scrub::ScrubSchedListener& osds);
+  virtual ~ScrubQueue() = default;
+
+  friend class TestOSDScrub;
+  friend class ScrubQueueTestWrapper;  ///< unit-tests structure
+
+  using SchedEntry = Scrub::SchedEntry;
+  using SchedulingQueue = std::deque<SchedEntry>;
+
+  std::ostream& gen_prefix(std::ostream& out) const;
+
+  // ///////////////////////////////////////////////////
+  // the ScrubQueueOps interface:
+
+  utime_t scrub_clock_now() const override;
+
+  Scrub::sched_conf_t populate_config_params(
+      const pool_opts_t& pool_conf) const override;
+
+  void remove_entry(spg_t pgid, scrub_level_t s_or_d) final;
+
+  void cp_and_queue_target(SchedEntry t) final;
+
+  bool queue_entries(spg_t pgid, SchedEntry shallow, SchedEntry deep) final;
+
+
+  // ///////////////////////////////////////////////////
+  // outside the scope of the I/F used by the ScrubJob:
+
+  /**
+   * the main entry point for the OSD. Called in OSD::tick_without_osd_lock()
+   * to determine if there are PGs that are ready to be scrubbed, and to
+   * initiate a scrub of one of those that are ready.
+   */
+  void sched_scrub(
+      const ceph::common::ConfigProxy& config,
+      bool is_recovery_active);
+
+  /*
+   * handles a change to the configuration parameters affecting the scheduling
+   * of scrubs.
+   */
+  void on_config_times_change();
+
+ public:
+  void dump_scrubs(ceph::Formatter* f);
+
+  /**
+   * No new scrub session will start while a scrub was initiated on a PG,
+   * and that PG is trying to acquire replica resources.
+   */
+  void set_reserving_now() { a_pg_is_reserving = true; }
+  void clear_reserving_now() { a_pg_is_reserving = false; }
+  bool is_reserving_now() const { return a_pg_is_reserving; }
+
+  // resource reservation management
+
+  Scrub::ScrubResources& resource_bookkeeper();
+  const Scrub::ScrubResources& resource_bookkeeper() const;
+  /// and the logger function used by that bookkeeper:
+  void log_fwd(std::string_view text);
+  
+  /// counting the number of PGs stuck while scrubbing, waiting for objects
+  void mark_pg_scrub_blocked(spg_t blocked_pg);
+  void clear_pg_scrub_blocked(spg_t blocked_pg);
+
+ private:
+  int get_blocked_pgs_count() const;
+
+ public:
+  /**
+   * Pacing the scrub operation by inserting delays (mostly between chunks)
+   *
+   * Special handling for regular scrubs that continued into "no scrub" times.
+   * Scrubbing will continue, but the delays will be controlled by a separate
+   * (read - with higher value) configuration element
+   * (osd_scrub_extended_sleep).
+   */
+  std::chrono::milliseconds required_sleep_time(bool high_priority_scrub) const;
+
+  /**
+   *  called every heartbeat to update the "daily" load average
+   *
+   *  @returns a load value for the logger
+   */
+  [[nodiscard]] std::optional<double> update_load_average();
+
+ private:
+  CephContext* cct;
+  Scrub::ScrubSchedListener& osd_service;
+  Scrub::ScrubResources m_osd_resources;
+
+#ifdef WITH_SEASTAR
+  auto& conf() const
+  {
+    return local_conf();
+  }
+#else
+  auto& conf() const
+  {
+    return cct->_conf;
+  }
+#endif
+
+  mutable ceph::mutex jobs_lock = ceph::make_mutex("ScrubQueue::jobs_lock");
+
+  SchedulingQueue to_scrub;
+
+  double daily_loadavg{0.0};
+
+  std::string log_prefix;
+
+  tl::expected<Scrub::ScrubPreconds, Scrub::schedule_result_t>
+  preconditions_to_scrubbing(
+      const ceph::common::ConfigProxy& config,
+      bool is_recovery_active,
+      utime_t scrub_clock_now) const;
+
+  /**
+   *  Clean up the queue from entries that are no longer relevant.
+   *  Then - sort the 'ripe' entries (those with 'not earlier than' time
+   *  in the past) and the future entries separately.
+   *  \returns true if there are eligible entries in the 'ripe' list
+   */
+  bool normalize_the_queue();
+
+  /**
+   * The scrubbing of PGs might be delayed if the scrubbed chunk of objects is
+   * locked by some other operation. A bug might cause this to be an infinite
+   * delay. If that happens, the OSDs "scrub resources" (i.e. the
+   * counters that limit the number of concurrent scrub operations) might
+   * be exhausted.
+   * We do issue a cluster-log warning in such occasions, but that message is
+   * easy to miss. The 'some pg is blocked' global flag is used to note the
+   * existence of such a situation in the scrub-queue log messages.
+   */
+  std::atomic_int_fast16_t blocked_scrubs_cnt{0};
+
+  std::atomic_bool a_pg_is_reserving{false};
+
+  [[nodiscard]] bool scrub_load_below_threshold() const;
+  [[nodiscard]] bool scrub_time_permit() const;
+
+ public:  // used by the unit-tests
+  /**
+   * unit-tests will override this function to return a mock time
+   */
+  virtual utime_t time_now() const
+  {
+    return ceph_clock_now();
+  }
+};

--- a/src/osd/scrubber/scrub_queue_if.h
+++ b/src/osd/scrubber/scrub_queue_if.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "include/utime_fmt.h"
+#include "osd/osd_types.h"
+#include "osd/scrubber_common.h"
+
+#include "utime.h"
+
+namespace Scrub {
+class ScrubSchedListener;
+class SchedEntry;
+
+/**
+ *  the interface used by ScrubJob (a component of the PgScrubber) to access
+ *  the scrub scheduling functionality.
+ *  Separated from the actual implementation mostly due to cyclic dependencies.
+ */
+struct ScrubQueueOps {
+
+  // a mockable ceph_clock_now(), to allow unit-testing of the scrub scheduling
+  virtual utime_t scrub_clock_now() const = 0;
+
+  virtual sched_conf_t populate_config_params(
+      const pool_opts_t& pool_conf) const = 0;
+
+  virtual void remove_entry(spg_t pgid, scrub_level_t s_or_d) = 0;
+
+  /**
+   * add both targets to the queue (but only if urgency>off)
+   * Note: modifies the entries (setting 'is_valid') before queuing them.
+   * \retval false if the targets were disabled (and were not added to
+   * the queue)
+   * \todo when implementing a queue w/o the need for white-out support -
+   * restore to const&.
+   */
+  virtual bool
+  queue_entries(spg_t pgid, SchedEntry shallow, SchedEntry deep) = 0;
+
+  virtual void cp_and_queue_target(SchedEntry t) = 0;
+
+  virtual ~ScrubQueueOps() = default;
+};
+
+}  // namespace Scrub

--- a/src/osd/scrubber/scrub_resources.cc
+++ b/src/osd/scrubber/scrub_resources.cc
@@ -1,0 +1,95 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "./scrub_resources.h"
+
+#include <fmt/format.h>
+
+#include <iostream>
+
+#include "common/debug.h"
+
+#include "include/ceph_assert.h"
+
+
+using ScrubResources = Scrub::ScrubResources;
+
+Scrub::ScrubResources::ScrubResources(
+    log_upwards_t log_access,
+    const ceph::common::ConfigProxy& config)
+    : log_upwards(log_access)
+    , conf(config)
+
+{}
+
+// conf.get_val<milliseconds>("osd_scrub_reservation_timeout")
+
+bool Scrub::ScrubResources::can_inc_scrubs() const
+{
+  std::lock_guard lck{resource_lock};
+  if (scrubs_local + scrubs_remote < conf->osd_max_scrubs) {
+    return true;
+  }
+  log_upwards(fmt::format(
+      "{}== false. {} (local) + {} (remote) >= max ({})", __func__,
+      scrubs_local, scrubs_remote, conf->osd_max_scrubs));
+  return false;
+}
+
+bool ScrubResources::inc_scrubs_local()
+{
+  std::lock_guard lck{resource_lock};
+  if (scrubs_local + scrubs_remote < conf->osd_max_scrubs) {
+    ++scrubs_local;
+    return true;
+  }
+  log_upwards(fmt::format(
+      "{}: {} (local) + {} (remote) >= max ({})", __func__, scrubs_local,
+      scrubs_remote, conf->osd_max_scrubs));
+  return false;
+}
+
+void ScrubResources::dec_scrubs_local()
+{
+  std::lock_guard lck{resource_lock};
+  log_upwards(fmt::format(
+      "{}: {} -> {} (max {}, remote {})", __func__, scrubs_local,
+      (scrubs_local - 1), conf->osd_max_scrubs, scrubs_remote));
+  --scrubs_local;
+  ceph_assert(scrubs_local >= 0);
+}
+
+bool ScrubResources::inc_scrubs_remote()
+{
+  std::lock_guard lck{resource_lock};
+  if (scrubs_local + scrubs_remote < conf->osd_max_scrubs) {
+    log_upwards(fmt::format(
+	"{}: {} -> {} (max {}, local {})", __func__, scrubs_remote,
+	(scrubs_remote + 1), conf->osd_max_scrubs, scrubs_local));
+    ++scrubs_remote;
+    return true;
+  }
+
+  log_upwards(fmt::format(
+      "{}: {} (local) + {} (remote) >= max ({})", __func__, scrubs_local,
+      scrubs_remote, conf->osd_max_scrubs));
+  return false;
+}
+
+void ScrubResources::dec_scrubs_remote()
+{
+  std::lock_guard lck{resource_lock};
+  log_upwards(fmt::format(
+      "{}: {} -> {} (max {}, local {})", __func__, scrubs_remote,
+      (scrubs_remote - 1), conf->osd_max_scrubs, scrubs_local));
+  --scrubs_remote;
+  ceph_assert(scrubs_remote >= 0);
+}
+
+void ScrubResources::dump_scrub_reservations(ceph::Formatter* f) const
+{
+  std::lock_guard lck{resource_lock};
+  f->dump_int("scrubs_local", scrubs_local);
+  f->dump_int("scrubs_remote", scrubs_remote);
+  f->dump_int("osd_max_scrubs", conf->osd_max_scrubs);
+}

--- a/src/osd/scrubber/scrub_resources.h
+++ b/src/osd/scrubber/scrub_resources.h
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+
+#include "common/Formatter.h"
+#include "common/config_proxy.h"
+
+
+namespace Scrub {
+
+/**
+ * an interface allowing the ScrubResources to log directly into its
+ * owner's log. This way, we do not need the full dout() mechanism
+ * (prefix func, OSD id, etc.)
+ */
+using log_upwards_t = std::function<void(std::string msg)>;
+
+/**
+ * The number of concurrent scrub operations performed on an OSD is limited
+ * by a configuration parameter. The 'ScrubResources' class is responsible for
+ * maintaining a count of the number of scrubs currently performed, both
+ * acting as primary and acting as a replica, and for enforcing the limit.
+ */
+class ScrubResources {
+  /// the number of concurrent scrubs performed by Primaries on this OSD
+  int scrubs_local{0};
+
+  /// the number of active scrub reservations granted by replicas
+  int scrubs_remote{0};
+
+  mutable ceph::mutex resource_lock =
+      ceph::make_mutex("ScrubQueue::resource_lock");
+
+  log_upwards_t log_upwards;  ///< access into the owner's dout()
+
+  const ceph::common::ConfigProxy& conf;
+
+ public:
+  explicit ScrubResources(
+      log_upwards_t log_access,
+      const ceph::common::ConfigProxy& config);
+
+  /**
+   * \returns true if the number of concurrent scrubs is
+   *  below osd_scrub_load_threshold
+   */
+  bool can_inc_scrubs() const;
+
+  /// increments the number of scrubs acting as a Primary
+  bool inc_scrubs_local();
+
+  /// decrements the number of scrubs acting as a Primary
+  void dec_scrubs_local();
+
+  /// increments the number of scrubs acting as a Replica
+  bool inc_scrubs_remote();
+
+  /// decrements the number of scrubs acting as a Replica
+  void dec_scrubs_remote();
+
+  void dump_scrub_reservations(ceph::Formatter* f) const;
+};
+}  // namespace Scrub

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -5,6 +5,7 @@
 #include <fmt/ranges.h>
 
 #include "common/scrub_types.h"
+#include "include/expected.hpp"
 #include "include/types.h"
 #include "os/ObjectStore.h"
 
@@ -17,16 +18,27 @@ class Formatter;
 struct PGPool;
 
 namespace Scrub {
-  class ReplicaReservations;
-}
+class ReplicaReservations;
 
-/// Facilitating scrub-realated object access to private PG data
+// possible outcome when trying to select a PG and scrub it
+enum class schedule_result_t {
+  scrub_initiated,     // successfully started a scrub
+  none_ready,	       // no pg to scrub
+  failure,
+};
+
+class SchedTarget;
+struct SchedEntry;
+}  // namespace Scrub
+
+/// Facilitating scrub-related object access to private PG data
 class ScrubberPasskey {
 private:
   friend class Scrub::ReplicaReservations;
   friend class PrimaryLogScrub;
   friend class PgScrubber;
   friend class ScrubBackend;
+  friend class ScrubQueue;
   ScrubberPasskey() {}
   ScrubberPasskey(const ScrubberPasskey&) = default;
   ScrubberPasskey& operator=(const ScrubberPasskey&) = delete;
@@ -49,6 +61,53 @@ struct ScrubPreconds {
   bool only_deadlined{false};
 };
 
+// concise passing of PG state re scrubbing to the
+// scrubber at initiation of a scrub
+struct ScrubPGPreconds {
+  bool allow_shallow{true};
+  bool allow_deep{true};
+  bool has_deep_errors{false};
+  bool can_autorepair{false};
+};
+}
+
+template <>
+struct fmt::formatter<Scrub::ScrubPreconds> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const Scrub::ScrubPreconds& conds, FormatContext& ctx)
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "overdue-only:{} load:{} time:{} repair-only:{}",
+        conds.only_deadlined,
+        conds.load_is_low ? "ok" : "high",
+        conds.time_permit ? "ok" : "no",
+        conds.allow_requested_repair_only);
+  }
+};
+
+template <>
+struct fmt::formatter<Scrub::ScrubPGPreconds> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const Scrub::ScrubPGPreconds& conds, FormatContext& ctx)
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "allowed:{}/{} err:{} autorp:{}",
+        conds.allow_shallow ? "+" : "-",
+        conds.allow_deep ? "+" : "-",
+        conds.has_deep_errors ? "+" : "-",
+        conds.can_autorepair ? "+" : "-");
+  }
+};
+
+
+namespace Scrub {
+
 /// PG services used by the scrubber backend
 struct PgScrubBeListener {
   virtual ~PgScrubBeListener() = default;
@@ -64,124 +123,12 @@ struct PgScrubBeListener {
   // query the PG backend for the on-disk size of an object
   virtual uint64_t logical_to_ondisk_size(uint64_t logical_size) const = 0;
 
-  // used to verify our "cleaness" before scrubbing
+  // used to verify our "cleanliness" before scrubbing
   virtual bool is_waiting_for_unreadable_object() const = 0;
 };
 
 }  // namespace Scrub
 
-
-/**
- * Flags affecting the scheduling and behaviour of the *next* scrub.
- *
- * we hold two of these flag collections: one
- * for the next scrub, and one frozen at initiation (i.e. in pg::queue_scrub())
- */
-struct requested_scrub_t {
-
-  // flags to indicate explicitly requested scrubs (by admin):
-  // bool must_scrub, must_deep_scrub, must_repair, need_auto;
-
-  /**
-   * 'must_scrub' is set by an admin command (or by need_auto).
-   *  Affects the priority of the scrubbing, and the sleep periods
-   *  during the scrub.
-   */
-  bool must_scrub{false};
-
-  /**
-   * scrub must not be aborted.
-   * Set for explicitly requested scrubs, and for scrubs originated by the
-   * pairing process with the 'repair' flag set (in the RequestScrub event).
-   *
-   * Will be copied into the 'required' scrub flag upon scrub start.
-   */
-  bool req_scrub{false};
-
-  /**
-   * Set from:
-   *  - scrub_requested() with need_auto param set, which only happens in
-   *  - scrub_finish() - if deep_scrub_on_error is set, and we have errors
-   *
-   * If set, will prevent the OSD from casually postponing our scrub. When
-   * scrubbing starts, will cause must_scrub, must_deep_scrub and auto_repair to
-   * be set.
-   */
-  bool need_auto{false};
-
-  /**
-   * Set for scrub-after-recovery just before we initiate the recovery deep
-   * scrub, or if scrub_requested() was called with either need_auto ot repair.
-   * Affects PG_STATE_DEEP_SCRUB.
-   */
-  bool must_deep_scrub{false};
-
-  /**
-   * (An intermediary flag used by pg::sched_scrub() on the first time
-   * a planned scrub has all its resources). Determines whether the next
-   * repair/scrub will be 'deep'.
-   *
-   * Note: 'dumped' by PgScrubber::dump() and such. In reality, being a
-   * temporary that is set and reset by the same operation, will never
-   * appear externally to be set
-   */
-  bool time_for_deep{false};
-
-  bool deep_scrub_on_error{false};
-
-  /**
-   * If set, we should see must_deep_scrub & must_scrub, too
-   *
-   * - 'must_repair' is checked by the OSD when scheduling the scrubs.
-   * - also checked & cleared at pg::queue_scrub()
-   */
-  bool must_repair{false};
-
-  /*
-   * the value of auto_repair is determined in sched_scrub() (once per scrub.
-   * previous value is not remembered). Set if
-   * - allowed by configuration and backend, and
-   * - must_scrub is not set (i.e. - this is a periodic scrub),
-   * - time_for_deep was just set
-   */
-  bool auto_repair{false};
-
-  /**
-   * indicating that we are scrubbing post repair to verify everything is fixed.
-   * Otherwise - PG_STATE_FAILED_REPAIR will be asserted.
-   */
-  bool check_repair{false};
-
-  /**
-   * Used to indicate, both in client-facing listings and internally, that
-   * the planned scrub will be a deep one.
-   */
-  bool calculated_to_deep{false};
-};
-
-std::ostream& operator<<(std::ostream& out, const requested_scrub_t& sf);
-
-template <>
-struct fmt::formatter<requested_scrub_t> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-  template <typename FormatContext>
-  auto format(const requested_scrub_t& rs, FormatContext& ctx)
-  {
-    return fmt::format_to(ctx.out(),
-                          "(plnd:{}{}{}{}{}{}{}{}{}{})",
-                          rs.must_repair ? " must_repair" : "",
-                          rs.auto_repair ? " auto_repair" : "",
-                          rs.check_repair ? " check_repair" : "",
-                          rs.deep_scrub_on_error ? " deep_scrub_on_error" : "",
-                          rs.must_deep_scrub ? " must_deep_scrub" : "",
-                          rs.must_scrub ? " must_scrub" : "",
-                          rs.time_for_deep ? " time_for_deep" : "",
-                          rs.need_auto ? " need_auto" : "",
-                          rs.req_scrub ? " req_scrub" : "",
-                          rs.calculated_to_deep ? " deep" : "");
-  }
-};
 
 /**
  *  The interface used by the PG when requesting scrub-related info or services
@@ -192,10 +139,10 @@ struct ScrubPgIF {
 
   friend std::ostream& operator<<(std::ostream& out, const ScrubPgIF& s)
   {
-    return s.show(out);
+    return s.show_concise(out);
   }
 
-  virtual std::ostream& show(std::ostream& out) const = 0;
+  virtual std::ostream& show_concise(std::ostream& out) const = 0;
 
   // --------------- triggering state-machine events:
 
@@ -241,10 +188,31 @@ struct ScrubPgIF {
 
   // --------------------------------------------------
 
-  [[nodiscard]] virtual bool are_callbacks_pending() const = 0;	 // currently
-								 // only used
-								 // for an
-								 // assert
+  /**
+   * Start a scrub operation.
+   *
+   * @param [in] scrub_clock_now time now (unless under unit-test)
+   * @param [in] level Level of scrub (deep or shallow)
+   * @param [in] pg_cond conveying the PG state re scrubbing
+   * @param [in] preconds a set of flags determined based on environment
+   *       conditions (time & load) that might restrict scrub's level/urgency
+   * @returns either 'scrub_initiated' or 'failure'
+   */
+  virtual Scrub::schedule_result_t start_scrubbing(
+    utime_t scrub_clock_now,
+    scrub_level_t level,
+    const Scrub::ScrubPGPreconds& pg_cond,
+    const Scrub::ScrubPreconds& preconds) = 0;
+
+  /**
+   * let the scrubber know that a recovery operation has completed.
+   * This might trigger an 'after repair' scrub.
+   */
+  virtual void recovery_completed() = 0;
+  virtual bool is_after_repair_required() const = 0;
+
+  // currently only used for an assertion:
+  [[nodiscard]] virtual bool are_callbacks_pending() const = 0;	
 
   /**
    * the scrubber is marked 'active':
@@ -258,7 +226,7 @@ struct ScrubPgIF {
    * and scrubbing is completely cleaned-up.
    *
    * In other words - holds longer than is_scrub_active(), thus preventing
-   * a rescrubbing of the same PG while the previous scrub has not fully
+   * a re-scrubbing of the same PG while the previous scrub has not fully
    * terminated.
    */
   [[nodiscard]] virtual bool is_queued_or_active() const = 0;
@@ -280,16 +248,22 @@ struct ScrubPgIF {
 
   virtual void replica_scrub_op(OpRequestRef op) = 0;
 
-  virtual void set_op_parameters(const requested_scrub_t&) = 0;
-
   virtual void scrub_clear_state() = 0;
-
-  virtual void handle_query_state(ceph::Formatter* f) = 0;
 
   virtual pg_scrubbing_status_t get_schedule() const = 0;
 
-  virtual void dump_scrubber(ceph::Formatter* f,
-			     const requested_scrub_t& request_flags) const = 0;
+  //// perform 'scrub'/'deep_scrub' asok commands
+  virtual void on_operator_periodic_cmd(
+    ceph::Formatter* f,
+    scrub_level_t scrub_level,
+    int64_t offset) = 0;
+
+  virtual void on_operator_forced_scrub(
+    ceph::Formatter* f,
+    scrub_level_t scrub_level
+    ) = 0;
+
+  virtual void dump_scrubber(ceph::Formatter* f) const = 0;
 
   /**
    * Return true if soid is currently being scrubbed and pending IOs should
@@ -340,6 +314,13 @@ struct ScrubPgIF {
    */
   virtual void send_reservation_failure(epoch_t epoch_queued) = 0;
 
+  /**
+   * scrub scheduling configuration has changed. Update our scrub-queue
+   * entries accordingly.
+   */
+  virtual void recalc_schedule(epoch_t epoch_queued) = 0;
+
+
   virtual void cleanup_store(ObjectStore::Transaction* t) = 0;
 
   virtual bool get_store_errors(const scrub_ls_arg_t& arg,
@@ -386,17 +367,9 @@ struct ScrubPgIF {
    *
    * Following our status as Primary or replica.
    */
-  virtual void on_primary_change(
-    std::string_view caller,
-    const requested_scrub_t& request_flags) = 0;
+  virtual void on_primary_change(std::string_view caller) = 0;
 
-  /**
-   * Recalculate the required scrub time.
-   *
-   * This function assumes that the queue registration status is up-to-date,
-   * i.e. the OSD "knows our name" if-f we are the Primary.
-   */
-  virtual void update_scrub_job(const requested_scrub_t& request_flags) = 0;
+  virtual void on_maybe_registration_change() = 0;
 
   // on the replica:
   virtual void handle_scrub_reserve_request(OpRequestRef op) = 0;
@@ -409,14 +382,18 @@ struct ScrubPgIF {
 
   virtual void rm_from_osd_scrubbing() = 0;
 
-  virtual void scrub_requested(scrub_level_t scrub_level,
-			       scrub_type_t scrub_type,
-			       requested_scrub_t& req_flags) = 0;
+  /// returns the requested scrub's level (which is shallow
+  /// only if scrub_level is shallow *and* no repair is requested)
+  virtual scrub_level_t scrub_requested(
+      scrub_level_t scrub_level,
+      scrub_type_t scrub_type) = 0;
 
   // --------------- debugging via the asok ------------------------------
 
-  virtual int asok_debug(std::string_view cmd,
-			 std::string param,
-			 Formatter* f,
-			 std::stringstream& ss) = 0;
+  virtual int asok_debug(
+      std::string_view prefix,
+      std::string_view cmd,
+      std::string_view param,
+      Formatter* f,
+      std::stringstream& ss) = 0;
 };

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -83,6 +83,13 @@ add_executable(unittest_scrub_sched
 add_ceph_unittest(unittest_scrub_sched)
 target_link_libraries(unittest_scrub_sched osd os global ${CMAKE_DL_LIBS} mon ${BLKID_LIBRARIES})
 
+# unittest_scrub_schedjob
+add_executable(unittest_scrub_schedjob
+  test_scrub_schedjob.cc
+  )
+add_ceph_unittest(unittest_scrub_schedjob)
+target_link_libraries(unittest_scrub_schedjob osd os global ${CMAKE_DL_LIBS} mon ${BLKID_LIBRARIES})
+
 # unittest_pglog
 add_executable(unittest_pglog
   TestPGLog.cc

--- a/src/test/osd/test_scrub_sched.h
+++ b/src/test/osd/test_scrub_sched.h
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/// \file common objects used in scrub scheduling tests
+
+#include <optional>
+
+#include "osd/osd_types.h"
+#include "osd/osd_types_fmt.h"
+#include "osd/scrubber/osd_scrub_sched.h"
+#include "osd/scrubber/scrub_queue_if.h"
+#include "osd/scrubber_common.h"
+
+struct expected_entry_t {
+
+  std::optional<bool> tst_is_valid;
+  std::optional<bool> tst_is_ripe;
+  std::optional<scrub_level_t> tst_level;
+  std::optional<Scrub::urgency_t> tst_urgency;
+  std::optional<utime_t> tst_target_time;
+  std::optional<utime_t> tst_target_time_min;
+  std::optional<utime_t> tst_target_time_max;
+  std::optional<utime_t> tst_nb_time;
+  std::optional<utime_t> tst_nb_time_min;
+  std::optional<utime_t> tst_nb_time_max;
+};
+
+struct expected_target_t {
+
+  std::optional<expected_entry_t> tst_sched_info;
+  std::optional<bool> tst_in_queue;
+  std::optional<bool> tst_is_viable;
+  std::optional<bool> tst_is_overdue;
+  std::optional<Scrub::delay_cause_t> tst_delay_cause;
+};
+
+struct level_config_t {
+  utime_t history_stamp;
+  // more to come (for planned tests)
+};
+
+struct sjob_config_t {
+  spg_t spg;
+  bool are_stats_valid;
+  Scrub::sched_conf_t sched_cnf;
+
+  std::array<level_config_t, 2> levels;	 // 0=shallow, 1=deep
+};
+
+struct schedentry_blueprint_t {
+  spg_t spg;
+  scrub_level_t level;
+  Scrub::urgency_t urgency;
+  utime_t not_before;
+  utime_t deadline;
+  utime_t target;
+
+  Scrub::SchedEntry make_entry() const
+  {
+    Scrub::SchedEntry e{spg, level};
+    e.urgency = urgency;
+    e.not_before = not_before;
+    e.deadline = deadline;
+    e.target = target;
+    return e;
+  }
+
+  bool is_equiv(const Scrub::SchedEntry& e) const
+  {
+    return spg == e.pgid && level == e.level && urgency == e.urgency &&
+	   not_before == e.not_before && deadline == e.deadline &&
+	   target == e.target;
+  }
+  bool is_equiv(std::optional<Scrub::SchedEntry> maybe_e) const
+  {
+    return maybe_e && spg == maybe_e->pgid && level == maybe_e->level &&
+	   urgency == maybe_e->urgency && not_before == maybe_e->not_before &&
+	   deadline == maybe_e->deadline && target == maybe_e->target;
+  }
+};
+
+struct poolopts_blueprint_t {
+  std::optional<double> min_interval;
+  std::optional<double> deep_interval;
+  std::optional<double> max_interval;
+  pool_opts_t make_conf()
+  {
+    pool_opts_t c;
+    if (min_interval) {
+      c.set(pool_opts_t::SCRUB_MIN_INTERVAL, *min_interval);
+    }
+    if (deep_interval) {
+      c.set(pool_opts_t::DEEP_SCRUB_INTERVAL, *deep_interval);
+    }
+    if (max_interval) {
+      c.set(pool_opts_t::SCRUB_MAX_INTERVAL, *max_interval);
+    }
+    return c;
+  }
+};

--- a/src/test/osd/test_scrub_schedjob.cc
+++ b/src/test/osd/test_scrub_schedjob.cc
@@ -1,0 +1,509 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/// \file testing the ScrubJob object (and the ScrubQueue indirectly)
+
+#include "./test_scrub_sched.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <deque>
+#include <map>
+#include <string>
+
+#include "common/async/context_pool.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "include/utime_fmt.h"
+#include "mon/MonClient.h"
+#include "msg/Messenger.h"
+#include "os/ObjectStore.h"
+#include "osd/PG.h"
+#include "osd/osd_types.h"
+#include "osd/osd_types_fmt.h"
+#include "osd/scrubber/osd_scrub_sched.h"
+#include "osd/scrubber/scrub_queue_if.h"
+#include "osd/scrubber_common.h"
+
+using namespace std::chrono;
+using namespace std::chrono_literals;
+using namespace std::literals;
+
+int main(int argc, char** argv)
+{
+  std::map<std::string, std::string> defaults = {
+      // make sure we have 3 copies, or some tests won't work
+      {"osd_pool_default_size", "3"},
+      // our map is flat, so just try and split across OSDs, not hosts or
+      // whatever
+      {"osd_crush_chooseleaf_type", "0"},
+      {"osd_scrub_retry_busy_replicas", "10"},
+  };
+  std::vector<const char*> args(argv, argv + argc);
+  auto cct = global_init(
+      &defaults, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+using sched_conf_t = Scrub::sched_conf_t;
+using SchedEntry = Scrub::SchedEntry;
+using ScrubJob = Scrub::ScrubJob;
+using urgency_t = Scrub::urgency_t;
+using delay_cause_t = Scrub::delay_cause_t;
+using string = std::string;
+
+
+/**
+ *  implementing the ScrubQueue services used by the ScrubJob
+ *
+ *  Note - in this unit-testing implementation, elements are erased
+ * forthwith, not whited-out.
+ */
+struct ScrubQueueOpsImp : public Scrub::ScrubQueueOps {
+  ~ScrubQueueOpsImp() override = default;
+
+  // clock issues
+
+  void set_time_for_testing(long faked_now)
+  {
+    m_time_for_testing = utime_t{timeval{faked_now}};
+  }
+
+  void clear_time_for_testing() { m_time_for_testing.reset(); }
+
+  mutable std::optional<utime_t> m_time_for_testing;
+
+  utime_t scrub_clock_now() const final
+  {
+    if (m_time_for_testing) {
+      m_time_for_testing->tv.tv_nsec += 1'000'000;
+    }
+    return m_time_for_testing.value_or(ceph_clock_now());
+  }
+
+
+  sched_conf_t populate_config_params(
+      const pool_opts_t& pool_conf) const override
+  {
+    return m_config;
+  }
+
+  void remove_entry(spg_t pgid, scrub_level_t s_or_d)
+  {
+    auto it = std::find_if(
+	m_queue.begin(), m_queue.end(), [pgid, s_or_d](const SchedEntry& e) {
+	  return e.pgid == pgid && e.level == s_or_d;
+	});
+    if (it != m_queue.end()) {
+      m_queue.erase(it);
+    }
+  }
+
+  /**
+   * add both targets to the queue (but only if urgency>off)
+   * Note: modifies the entries (setting 'is_valid') before queuing them.
+   * \todo when implementing a queue w/o the need for white-out support -
+   * restore to const&.
+   */
+  bool queue_entries(spg_t pgid, SchedEntry shallow, SchedEntry deep) override
+  {
+    EXPECT_TRUE(shallow.level == scrub_level_t::shallow);
+    EXPECT_TRUE(deep.level == scrub_level_t::deep);
+
+    if (shallow.urgency == urgency_t::off || deep.urgency == urgency_t::off) {
+      return false;
+    }
+
+    // we should not have these entries in the queue already
+    EXPECT_TRUE(!is_in_queue(pgid, scrub_level_t::shallow));
+    EXPECT_TRUE(!is_in_queue(pgid, scrub_level_t::deep));
+
+    // set the 'is_valid' flag
+    shallow.is_valid = true;
+    deep.is_valid = true;
+
+    // and queue
+    m_queue.push_back(shallow);
+    m_queue.push_back(deep);
+    return true;
+  }
+
+  void cp_and_queue_target(SchedEntry t) override
+  {
+    EXPECT_TRUE(t.urgency != urgency_t::off);
+    t.is_valid = true;
+    m_queue.push_back(t);
+  }
+
+  // test support
+
+  void set_sched_conf(const sched_conf_t& conf) { m_config = conf; }
+  const sched_conf_t& get_sched_conf() const { return m_config; }
+  int get_queue_size() const { return m_queue.size(); }
+
+ private:
+  std::deque<SchedEntry> m_queue;
+
+  sched_conf_t m_config;
+
+  bool is_in_queue(spg_t pgid, scrub_level_t level)
+  {
+    auto it = std::find_if(
+	m_queue.begin(), m_queue.end(), [pgid, level](const SchedEntry& e) {
+	  return e.pgid == pgid && e.level == level && e.is_valid;
+	});
+    return it != m_queue.end();
+  }
+};
+
+
+// ///////////////////////////////////////////////////
+// ScrubJob
+
+class ScrubJobTestWrapper : public ScrubJob {
+ public:
+  ScrubJobTestWrapper(ScrubQueueOpsImp& qops, const spg_t& pg, int osd_num)
+      : ScrubJob(qops, g_ceph_context, pg, osd_num)
+  {}
+
+  int dequeue_targets() { return ScrubJob::dequeue_targets(); }
+  Scrub::SchedTarget& dequeue_target(scrub_level_t lvl)
+  {
+    return ScrubJob::dequeue_target(lvl);
+  }
+
+  void verify_sched_entry(const SchedEntry& e, const expected_entry_t& tst)
+  {
+    auto now_is = scrub_queue.scrub_clock_now();
+    EXPECT_EQ(tst.tst_is_valid.value_or(e.is_valid), e.is_valid);
+    EXPECT_EQ(tst.tst_is_ripe.value_or(e.is_ripe(now_is)), e.is_ripe(now_is));
+    EXPECT_EQ(tst.tst_level.value_or(e.level), e.level);
+    EXPECT_EQ(tst.tst_urgency.value_or(e.urgency), e.urgency);
+    EXPECT_EQ(tst.tst_target_time.value_or(e.target), e.target);
+    EXPECT_LE(tst.tst_target_time_min.value_or(e.target), e.target);
+    EXPECT_GE(tst.tst_target_time_max.value_or(e.target), e.target);
+    EXPECT_EQ(tst.tst_nb_time.value_or(e.not_before), e.not_before);
+    EXPECT_LE(tst.tst_nb_time_min.value_or(e.not_before), e.not_before);
+    EXPECT_GE(tst.tst_nb_time_max.value_or(e.not_before), e.not_before);
+  }
+
+  void verify_target(scrub_level_t selector, const expected_target_t tst)
+  {
+    const auto& e = get_target(selector);
+    if (tst.tst_sched_info) {
+      verify_sched_entry(e.queued_element(), tst.tst_sched_info.value());
+    }
+    EXPECT_EQ(tst.tst_in_queue.value_or(e.is_queued()), e.is_queued());
+    EXPECT_EQ(tst.tst_is_viable.value_or(!e.is_off()), !e.is_off());
+    auto now_is = scrub_queue.scrub_clock_now();
+    EXPECT_EQ(
+	tst.tst_is_overdue.value_or(e.over_deadline(now_is)),
+	e.over_deadline(now_is));
+    EXPECT_EQ(tst.tst_delay_cause.value_or(e.delay_cause()), e.delay_cause());
+  }
+
+  template <typename T>
+  T get_conf_val(std::string c_name) const
+  {
+    return g_conf().get_val<T>(c_name);
+  }
+};
+
+
+class TestScrubSchedJob : public ::testing::Test {
+ public:
+  TestScrubSchedJob() = default;
+
+  void init(const sjob_config_t& dt, utime_t starting_at)
+  {
+    // the pg-info is queried for stats validity and for the last-scrub-stamp
+    pg_info = create_pg_info(dt);
+
+    m_qops.set_sched_conf(dt.sched_cnf);
+    m_qops.set_time_for_testing(starting_at);
+
+    // the scrub-job is created with the initial configuration
+    m_sjob = std::make_unique<ScrubJobTestWrapper>(m_qops, dt.spg, 1);
+  }
+
+  void set_initial_targets()
+  {
+    ASSERT_TRUE(m_sjob);
+    m_sjob->init_and_queue_targets(
+	pg_info, m_qops.get_sched_conf(), m_qops.scrub_clock_now());
+  }
+
+  pg_info_t create_pg_info(const sjob_config_t& s)
+  {
+    pg_info_t pginf;
+    pginf.pgid = s.spg;
+    pginf.history.last_scrub_stamp = s.levels[0].history_stamp;
+    pginf.stats.last_scrub_stamp = s.levels[0].history_stamp;
+    pginf.history.last_deep_scrub_stamp = s.levels[1].history_stamp;
+    pginf.stats.last_deep_scrub_stamp = s.levels[1].history_stamp;
+    pginf.stats.stats_invalid = !s.are_stats_valid;
+    return pginf;
+  }
+
+ protected:
+  int m_num_osds{3};
+  int my_osd_id{1};
+
+  spg_t tested_pg;
+  ScrubQueueOpsImp m_qops;
+  std::unique_ptr<ScrubJobTestWrapper> m_sjob;
+
+  /// the pg-info is queried for stats validity and for the last-scrub-stamp
+  pg_info_t pg_info{};
+
+  /// the pool configuration holds some per-pool scrub timing settings
+  pool_opts_t pool_opts{};
+};
+
+
+// ///////////////////////////////////////////////////////////////////////////
+// test data.
+
+namespace {
+
+// the times used during the tests are offset to 1.1.2000, so that
+// utime_t formatting will treat them as absolute (not as a relative time)
+static const auto epoch_2000 = 946'684'800;
+
+
+sched_conf_t t1{
+    .shallow_interval = 24 * 3600.0,
+    .deep_interval = 7 * 24 * 3600.0,
+    .max_shallow = 2 * 24 * 3600.0,
+    .max_deep = 7 * 24 * 3600.0,
+    .interval_randomize_ratio = 0.2};
+
+sjob_config_t sjob_config_1{
+    spg_t{pg_t{1, 1}},
+    true,	    // PG has valid stats
+    t1,		    // sched_conf_t
+    {level_config_t{// shallow
+		    utime_t{std::time_t(epoch_2000 + 1'050'000), 0}},
+
+     level_config_t{						       // deep
+		    utime_t{std::time_t(epoch_2000 + 1'000'000), 0}}}  // fmt
+};
+
+expected_entry_t for_t1_shallow{
+    .tst_is_valid = true,
+    .tst_is_ripe = true,
+    .tst_level = scrub_level_t::shallow,
+    .tst_urgency = urgency_t::periodic_regular,
+    .tst_target_time_min = utime_t{std::time_t(epoch_2000 + 1'050'000), 0}
+    // for fmt
+};
+
+static const auto t2_base_time = epoch_2000 + 10'000'000;
+
+// invalid stats
+sjob_config_t sjob_config_2{
+    spg_t{pg_t{3, 1}},
+    false,	    // invalid stats
+    t1,		    // sched_conf_t
+    {level_config_t{// shallow
+		    utime_t{std::time_t(epoch_2000 + 1'050'000), 0}},
+
+     level_config_t{						       // deep
+		    utime_t{std::time_t(epoch_2000 + 1'000'000), 0}}}  // fmt
+};
+
+static const expected_entry_t for_t2_deep{
+    .tst_is_valid = true,
+    .tst_is_ripe = false,
+    .tst_level = scrub_level_t::deep,
+    .tst_urgency = urgency_t::periodic_regular,
+    .tst_target_time_min =
+	utime_t{std::time_t(t2_base_time + 3 * t1.shallow_interval), 0},
+    .tst_nb_time_max = utime_t{std::time_t(t2_base_time + 1'050'000), 0}
+    // line-break for fmt
+};
+
+static const expected_entry_t for_t2_shallow{
+    .tst_is_valid = true,
+    .tst_is_ripe = true,
+    .tst_level = scrub_level_t::shallow,
+    .tst_urgency = urgency_t::must,
+    .tst_target_time_min = utime_t{std::time_t(t2_base_time), 0},
+    .tst_nb_time_max =
+	utime_t{std::time_t(t2_base_time + 3 * t1.shallow_interval), 0}
+    // line-break for fmt
+};
+
+}  // anonymous namespace
+
+
+// //////////////////////////// tests ////////////////////////////////////////
+
+
+TEST_F(TestScrubSchedJob, targets_creation)
+{
+  utime_t t_at_start{epoch_2000 + 1'000'000, 0};
+  init(sjob_config_1, t_at_start);
+  std::cout << "\ntime is now: " << m_qops.scrub_clock_now() << std::endl;
+
+  set_initial_targets();
+  auto f = Formatter::create_unique("json-pretty");
+
+  m_sjob->dump(f.get());
+  f.get()->flush(std::cout);
+
+  EXPECT_EQ(m_qops.get_queue_size(), 2);
+
+  // set a time after both targets are due
+  utime_t t_after{epoch_2000 + 1'600'000, 0};
+  m_qops.set_time_for_testing(t_after);
+  std::cout << "\ntime is now: " << m_qops.scrub_clock_now() << std::endl;
+
+  // the scheduling state should be:
+  std::string exp1 = "queued for scrub";
+  EXPECT_EQ(exp1, m_sjob->scheduling_state());
+
+  m_sjob->verify_sched_entry(
+      m_sjob->shallow_target.queued_element(), for_t1_shallow);
+}
+
+
+TEST_F(TestScrubSchedJob, invalid_history)
+{
+  utime_t t_at_start{t2_base_time, 0};
+  init(sjob_config_2, t_at_start);
+  std::cout << "\ntime is now: " << m_qops.scrub_clock_now() << std::endl;
+
+  set_initial_targets();
+  auto f = Formatter::create_unique("json-pretty");
+
+  m_sjob->dump(f.get());
+  f.get()->flush(std::cout);
+
+  EXPECT_EQ(m_qops.get_queue_size(), 2);
+
+  utime_t t_after{t2_base_time + 100, 0};
+  m_qops.set_time_for_testing(t_after);
+  std::cout << "\ntime is now: " << m_qops.scrub_clock_now() << std::endl;
+
+  auto nrst = m_sjob->closest_target(m_qops.scrub_clock_now());
+  m_sjob->verify_sched_entry(nrst.queued_element(), for_t2_shallow);
+  m_sjob->verify_sched_entry(m_sjob->deep_target.queued_element(), for_t2_deep);
+
+  // the scheduling state should be:
+  std::string exp1 = "queued for scrub";
+  EXPECT_EQ(exp1, m_sjob->scheduling_state());
+}
+
+namespace {
+
+sched_conf_t no_rand_conf{
+    .shallow_interval = 24 * 3600.0,
+    .deep_interval = 7 * 24 * 3600.0,
+    .max_shallow = 2 * 24 * 3600.0,
+    .max_deep = 7 * 24 * 3600.0,
+    .interval_randomize_ratio = 0.0};
+
+static const auto resfail_base_time = epoch_2000 + 31 * 24 * 3600;
+
+static const sjob_config_t sjob_config_resfail{
+    spg_t{pg_t{5, 1}},
+    true,  // the stats are valid
+    no_rand_conf,
+    {level_config_t{// shallow
+		    utime_t{std::time_t(resfail_base_time - 3'600), 0}},
+
+     level_config_t{
+	 // deep
+	 utime_t{std::time_t(resfail_base_time + 100'000), 0}}}	 // fmt
+};
+
+static const expected_entry_t exp_resfail_b4_dp{
+    .tst_is_valid = true,
+    .tst_is_ripe = false,
+    .tst_level = scrub_level_t::deep,
+    .tst_urgency = urgency_t::periodic_regular,
+    .tst_target_time_min =
+	utime_t{std::time_t(resfail_base_time + 3 * t1.shallow_interval), 0},
+    .tst_nb_time_max = utime_t{std::time_t(resfail_base_time + 1'050'000), 0}
+    // line-break for fmt
+};
+
+static const expected_entry_t exp_resfail_shl_penlzd{
+    .tst_is_valid = true,
+    .tst_is_ripe = false,
+    .tst_level = scrub_level_t::shallow,
+    .tst_urgency = urgency_t::penalized,
+    .tst_nb_time_min = utime_t{std::time_t(resfail_base_time + 10), 0},
+    .tst_nb_time_max = utime_t{std::time_t(resfail_base_time + 20), 0},
+    // for fmt
+};
+
+static const expected_target_t for_resfail_shallow{
+    .tst_sched_info = exp_resfail_shl_penlzd,
+    .tst_in_queue = true,
+    .tst_is_viable = true,
+    .tst_is_overdue = false,
+    .tst_delay_cause = delay_cause_t::replicas
+    //
+};
+
+}  // namespace
+
+TEST_F(TestScrubSchedJob, reservationFail)
+{
+  utime_t t_at_start{resfail_base_time, 0};
+  init(sjob_config_resfail, t_at_start);
+  std::cout << "\ntime is now: " << m_qops.scrub_clock_now() << std::endl;
+
+  set_initial_targets();
+#ifdef DEV_EXTRA
+  {
+    auto f = Formatter::create_unique("json-pretty");
+    m_sjob->dump(f.get());
+    f.get()->flush(std::cout);
+  }
+#endif
+
+  EXPECT_EQ(m_qops.get_queue_size(), 2);
+  m_sjob->scrubbing = true;  // required by the Scrub-Sched code
+  m_sjob->dequeue_target(scrub_level_t::shallow);
+  m_sjob->dequeue_target(scrub_level_t::deep);
+
+  // suppose a shallow scrub was initiated, and failed repl reservation:
+  EXPECT_EQ(m_qops.get_queue_size(), 0);
+
+#ifdef DEV_EXTRA
+  std::cout << "conf: "
+	    << m_sjob->get_conf_val<int64_t>("osd_scrub_retry_busy_replicas")
+	    << std::endl;
+#endif
+
+  auto active_target = m_sjob->get_moved_target(scrub_level_t::shallow);
+  {
+    std::cout << fmt::format("active: {}\n", active_target);
+    auto f = Formatter::create_unique("json-pretty");
+    m_sjob->dump(f.get());
+    f.get()->flush(std::cout);
+  }
+
+  auto was_penl =
+      m_sjob->on_reservation_failure(200s, std::move(active_target));
+
+#ifdef DEV_EXTRA
+  {
+    auto f = Formatter::create_unique("json-pretty");
+    m_sjob->dump(f.get());
+    f.get()->flush(std::cout);
+  }
+#endif
+
+  // the target wasn't a priority one, thus:
+  EXPECT_EQ(true, was_penl);
+  m_sjob->verify_target(scrub_level_t::shallow, for_resfail_shallow);
+}


### PR DESCRIPTION

REPLACED BY 51869
 


Main changes:
- instead of the OSD managing a queue of scrub-jobs (one per PG),
  now queuing a "scheduling target" (job + shallow/deep);
- when being scrubbed, the sched-target is shadowed by a modifiable
  "next deep scrub" (or "next shallow") sched target;
- the "requested scrub" flags (need-auto, auto-repair, etc') are
  folded into the specific behavior of the target. Specifically -
  a target have 'urgency' - spanning the desired scrub priorities
  from 'regular periodic scrub' to 'must scrub now after a repair'.
- the 'penalized' state (faulting PGs that failed to reserve their
  replicas) is implemented as one of the urgency levels;

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>