### PR TITLE
mgr/rbd_support: remove localized schedule option during module startup

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -369,15 +369,13 @@ class MirrorSnapshotScheduleHandler:
         self.queue: Dict[str, List[ImageSpec]] = {}
         # pool_id => {namespace => image_id}
         self.images: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self.schedules = Schedules(self)
         self.refresh_images()
         self.log.debug("MirrorSnapshotScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
         self.log.info("MirrorSnapshotScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load(namespace_validator, image_validator)
-        self.schedules = schedules
+        self.schedules.load(namespace_validator, image_validator)
 
     def refresh_images(self) -> float:
         elapsed = (datetime.now() - self.last_refresh_images).total_seconds()

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -378,18 +378,10 @@ class Schedules:
         self.level_specs: Dict[str, LevelSpec] = {}
         self.schedules: Dict[str, Schedule] = {}
 
-    def __len__(self) -> int:
-        return len(self.schedules)
-
-    def load(self,
-             namespace_validator: Optional[Callable] = None,
-             image_validator: Optional[Callable] = None) -> None:
-
-        schedule_cfg = self.handler.module.get_module_option(
-            self.handler.MODULE_OPTION_NAME, '')
-
         # Previous versions incorrectly stored the global config in
         # the localized module option. Check the config is here and fix it.
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if not schedule_cfg:
             schedule_cfg = self.handler.module.get_localized_module_option(
                 self.handler.MODULE_OPTION_NAME, '')
@@ -399,6 +391,17 @@ class Schedules:
         self.handler.module.set_localized_module_option(
             self.handler.MODULE_OPTION_NAME, None)
 
+    def __len__(self) -> int:
+        return len(self.schedules)
+
+    def load(self,
+             namespace_validator: Optional[Callable] = None,
+             image_validator: Optional[Callable] = None) -> None:
+        self.level_specs = {}
+        self.schedules = {}
+
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if schedule_cfg:
             try:
                 level_spec = LevelSpec.make_global()

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -62,15 +62,13 @@ class TrashPurgeScheduleHandler:
         self.queue: Dict[str, List[Tuple[str, str]]] = {}
         # pool_id => {namespace => pool_name}
         self.pools: Dict[str, Dict[str, str]] = {}
+        self.schedules = Schedules(self)
         self.refresh_pools()
         self.log.debug("TrashPurgeScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
         self.log.info("TrashPurgeScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load()
-        self.schedules = schedules
+        self.schedules.load()
 
     def refresh_pools(self) -> float:
         elapsed = (datetime.now() - self.last_refresh_pools).total_seconds()


### PR DESCRIPTION
```
The localized schedule option was removed during every load of a
scheduler handler. This occured multiple times during a mgr process's
lifespan. Instead, remove the localized schedule module option when the
rbd_support module starts up.

Fixes: https://tracker.ceph.com/issues/57726
Signed-off-by: Ramana Raja <rraja@redhat.com>
```

For more context, you can see the discussion here, https://github.com/ceph/ceph/pull/37864/commits/8e9e2a73f5b8abd743933e59a3b986598765a681#r513533495

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
