### PR TITLE
quincy: doc/rados: add prompts to placement-groups.rst

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -540,9 +540,11 @@ Set the Number of Placement Groups
 
 To set the number of placement groups in a pool, you must specify the
 number of placement groups at the time you create the pool.
-See `Create a Pool`_ for details.  Even after a pool is created you can also change the number of placement groups with::
+See `Create a Pool`_ for details.  Even after a pool is created you can also change the number of placement groups with:
 
-        ceph osd pool set {pool-name} pg_num {pg_num}
+.. prompt:: bash # 
+
+   ceph osd pool set {pool-name} pg_num {pg_num}
 
 After you increase the number of placement groups, you must also
 increase the number of placement groups for placement (``pgp_num``)
@@ -552,9 +554,11 @@ algorithm. Increasing ``pg_num`` splits the placement groups but data
 will not be migrated to the newer placement groups until placement
 groups for placement, ie. ``pgp_num`` is increased. The ``pgp_num``
 should be equal to the ``pg_num``.  To increase the number of
-placement groups for placement, execute the following::
+placement groups for placement, execute the following:
 
-        ceph osd pool set {pool-name} pgp_num {pgp_num}
+.. prompt:: bash #
+
+   ceph osd pool set {pool-name} pgp_num {pgp_num}
 
 When decreasing the number of PGs, ``pgp_num`` is adjusted
 automatically for you.
@@ -562,9 +566,11 @@ automatically for you.
 Get the Number of Placement Groups
 ==================================
 
-To get the number of placement groups in a pool, execute the following::
+To get the number of placement groups in a pool, execute the following:
 
-        ceph osd pool get {pool-name} pg_num
+.. prompt:: bash #
+   
+   ceph osd pool get {pool-name} pg_num
 
 
 Get a Cluster's PG Statistics


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/placement-groups.rst. (2 of 3)

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 8574cfb847bb555bc724a6bd44a815f83e3dd364)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
