### PR TITLE
log: fix stderr handling on Windows

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -71,6 +71,7 @@ Log::~Log()
 
 void Log::_configure_stderr()
 {
+#ifndef _WIN32
   struct stat info;
   if (int rc = fstat(m_fd_stderr, &info); rc == -1) {
     std::cerr << "failed to stat stderr: " << cpp_strerror(errno) << std::endl;
@@ -81,6 +82,8 @@ void Log::_configure_stderr()
     /* Set O_NONBLOCK on FIFO stderr file. We want to ensure atomic debug log
      * writes so they do not get partially read by e.g. buggy container
      * runtimes. See also IEEE Std 1003.1-2017 and Log::_log_stderr below.
+     *
+     * This isn't required on Windows.
      */
     int flags = fcntl(m_fd_stderr, F_GETFL);
     if (flags == -1) {
@@ -97,6 +100,7 @@ void Log::_configure_stderr()
     }
     do_stderr_poll = true;
   }
+#endif // !_WIN32
 }
 
 


### PR DESCRIPTION
log: fix stderr handling on Windows

A recent commit configured stderr to use non-blocking IO in order to avoid partial writes with container runtimes.

This broke the Windows build:

```
ceph/src/log/Log.cc:85:36: error: 'F_GETFL' was not declared in this scope
   85 |     int flags = fcntl(m_fd_stderr, F_GETFL);
      |                                    ^~~~~~~
ceph/src/log/Log.cc:85:17: error: 'fcntl' was not declared in this scope
   85 |     int flags = fcntl(m_fd_stderr, F_GETFL);
      |                 ^~~~~
ceph/src/log/Log.cc:90:19: error: 'O_NONBLOCK' was not declared in this scope
   90 |     if (!(flags & O_NONBLOCK)) {
      |                   ^~~~~~~~~~
ceph/src/log/Log.cc:92:34: error: 'F_SETFL' was not declared in this scope
   92 |       flags = fcntl(m_fd_stderr, F_SETFL, flags);
```

We're going to skip this since we don't actually need to use non-blocking IO with stderr on Windows.

Fixes: 2551130bcc12c55ddaa879b4f5b77c81890b51b2

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
