### PR TITLE
mon: avoid daemons crashing with mal-formatted cmd input

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -222,7 +222,13 @@ bool HealthMonitor::prepare_update(MonOpRequestRef op)
   case MSG_MON_HEALTH_CHECKS:
     return prepare_health_checks(op);
   case MSG_MON_COMMAND:
-    return prepare_command(op);
+    try {
+      return prepare_command(op);
+    } catch (const bad_cmd_get& e) {
+      bufferlist bl;
+      mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
+      return true;
+    }
   default:
     return false;
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -911,7 +911,13 @@ public:
         std::ostringstream ds;
         std::string prefix;
         cmdmap_from_json(m->cmd, &cmdmap, ds);
-        cmd_getval(cmdmap, "prefix", prefix);
+        try {
+          cmd_getval(cmdmap, "prefix", prefix);
+        } catch (bad_cmd_get& e){
+          mon.reply_command(op, -EINVAL, e.what(), 0);
+          return;
+        }
+
         if (prefix != "config set" && prefix != "config-key set")
           ss << "cmd='" << m->cmd << "': finished";
 


### PR DESCRIPTION
From a complete code analysis,code under src/common, src/messages, src/mon and src/osd get reviewed to make sure all cmd_getval stuff are running safe with these commits.
in fact, there are 364 calling locations altogether as below:
src/common(14)
src/messages(6)
src/mon(308)
src/osd(29)

Most of them above had been handled well with try/catch. This PR just created a full coverage with the latest code in order to strengthen ceph cluster from DOS attacks. please help review for better.

bug to fix:https://tracker.ceph.com/issues/57890
related bug: https://tracker.ceph.com/issues/54558

Signed-off-by: Ben Gao <bengao168@msn.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
