### PR TITLE
dokan: Made file/dir access mode configurable

### DIFF
--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -111,7 +111,7 @@ static NTSTATUS WinCephCreateDirectory(
     return 0;
   }
 
-  int ret = ceph_mkdir(cmount, path.c_str(), 0755);
+  int ret = ceph_mkdir(cmount, path.c_str(), g_cfg->dir_mode);
   if (ret < 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_mkdir failed. Error: " << ret << dendl;
@@ -166,13 +166,14 @@ static NTSTATUS WinCephCreateFile(
         return STATUS_OBJECT_NAME_COLLISION;
       case TRUNCATE_EXISTING:
         // open O_TRUNC & return 0
-        return do_open_file(path, O_CREAT | O_TRUNC | O_RDWR, 0755, fdc);
+        return do_open_file(path, O_CREAT | O_TRUNC | O_RDWR,
+                            g_cfg->file_mode, fdc);
       case OPEN_ALWAYS:
         // open & return STATUS_OBJECT_NAME_COLLISION
         if (!WRITE_ACCESS_REQUESTED(AccessMode))
           fdc->read_only = 1;
         if ((st = do_open_file(path, fdc->read_only ? O_RDONLY : O_RDWR,
-                               0755, fdc)))
+                               g_cfg->file_mode, fdc)))
           return st;
         return STATUS_OBJECT_NAME_COLLISION;
       case OPEN_EXISTING:
@@ -180,12 +181,13 @@ static NTSTATUS WinCephCreateFile(
         if (!WRITE_ACCESS_REQUESTED(AccessMode))
           fdc->read_only = 1;
         if ((st = do_open_file(path, fdc->read_only ? O_RDONLY : O_RDWR,
-                               0755, fdc)))
+                               g_cfg->file_mode, fdc)))
           return st;
         return 0;
       case CREATE_ALWAYS:
         // open O_TRUNC & return STATUS_OBJECT_NAME_COLLISION
-        if ((st = do_open_file(path, O_CREAT | O_TRUNC | O_RDWR, 0755, fdc)))
+        if ((st = do_open_file(path, O_CREAT | O_TRUNC | O_RDWR,
+                               g_cfg->file_mode, fdc)))
           return st;
         return STATUS_OBJECT_NAME_COLLISION;
       }
@@ -204,7 +206,7 @@ static NTSTATUS WinCephCreateFile(
         return 0;
       case OPEN_ALWAYS:
       case OPEN_EXISTING:
-        return do_open_file(path, O_RDONLY, 0755, fdc);
+        return do_open_file(path, O_RDONLY, g_cfg->file_mode, fdc);
       case CREATE_ALWAYS:
         return STATUS_OBJECT_NAME_COLLISION;
       }
@@ -220,18 +222,21 @@ static NTSTATUS WinCephCreateFile(
       if ((st = WinCephCreateDirectory(FileName, DokanFileInfo)))
         return st;
       // Dokan expects a file handle even when creating new directories.
-      return do_open_file(path, O_RDONLY, 0755, fdc);
+      return do_open_file(path, O_RDONLY, g_cfg->file_mode, fdc);
     }
     dout(20) << __func__ << " " << path << ". New file." << dendl;
     switch (CreationDisposition) {
       case CREATE_NEW:
         // create & return 0
-        return do_open_file(path, O_CREAT | O_RDWR | O_EXCL, 0755, fdc);
+        return do_open_file(path, O_CREAT | O_RDWR | O_EXCL,
+                            g_cfg->file_mode, fdc);
       case CREATE_ALWAYS:
         // create & return 0
-        return do_open_file(path, O_CREAT | O_TRUNC | O_RDWR, 0755, fdc);
+        return do_open_file(path, O_CREAT | O_TRUNC | O_RDWR,
+                            g_cfg->file_mode, fdc);
       case OPEN_ALWAYS:
-        return do_open_file(path, O_CREAT | O_RDWR, 0755, fdc);
+        return do_open_file(path, O_CREAT | O_RDWR,
+                            g_cfg->file_mode, fdc);
       case OPEN_EXISTING:
       case TRUNCATE_EXISTING:
         dout(2) << __func__ << " " << path << ": Not found." << dendl;

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -34,6 +34,8 @@ struct Config {
   std::wstring win_vol_name = L"";
   unsigned long win_vol_serial = 0;
   unsigned long max_path_len = 256;
+  mode_t file_mode = 0755;
+  mode_t dir_mode = 0755;
 };
 
 extern Config *g_cfg;


### PR DESCRIPTION
By default, when mounting a filesystem using ceph-dokan, the file and directory access modes were hardcoded as 755.

Now, both the file and directory access modes are configurable using the --file-mode and --dir-mode optargs, accepting values ranging from 001 to 777.

If no value is specified, the default value of 755 will be used.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
