### PR TITLE
quincy: osd: Reset mClock's OSD capacity config option for inactive device type

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -102,9 +102,11 @@ void mClockScheduler::set_max_osd_capacity()
   if (is_rotational) {
     max_osd_capacity =
       cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_hdd");
+    cct->_conf.set_val("osd_mclock_max_capacity_iops_ssd", "0");
   } else {
     max_osd_capacity =
       cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_ssd");
+    cct->_conf.set_val("osd_mclock_max_capacity_iops_hdd", "0");
   }
   // Set per op-shard iops limit
   max_osd_capacity /= num_shards;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58186

---

backport of https://github.com/ceph/ceph/pull/48708
parent tracker: https://tracker.ceph.com/issues/57963

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh