### PR TITLE
quincy: mgr/cephadm: some master -> main cleanup

### DIFF
--- a/doc/dev/cephadm/developing-cephadm.rst
+++ b/doc/dev/cephadm/developing-cephadm.rst
@@ -32,7 +32,7 @@ cephadm/cephadm script into memory.)
   for mon or mgr.
 - You'll see health warnings from cephadm about stray daemons--that's because
   the vstart-launched daemons aren't controlled by cephadm.
-- The default image is ``quay.io/ceph-ci/ceph:master``, but you can change
+- The default image is ``quay.io/ceph-ci/ceph:main``, but you can change
   this by passing ``-o container_image=...`` or ``ceph config set global container_image ...``.
 
 

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -9,10 +9,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
-IMAGE_MASTER=${IMAGE_MASTER:-'quay.ceph.io/ceph-ci/ceph:master'}
+IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
+IMAGE_QUINCY=${IMAGE_QUINCY:-'quay.ceph.io/ceph-ci/ceph:quincy'}
 IMAGE_PACIFIC=${IMAGE_PACIFIC:-'quay.ceph.io/ceph-ci/ceph:pacific'}
 #IMAGE_OCTOPUS=${IMAGE_OCTOPUS:-'quay.ceph.io/ceph-ci/ceph:octopus'}
-IMAGE_DEFAULT=${IMAGE_MASTER}
+IMAGE_DEFAULT=${IMAGE_QUINCY}
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"
 OSD_IMAGE_SIZE='6G'
@@ -168,7 +169,7 @@ $SUDO CEPHADM_IMAGE=$IMAGE_PACIFIC $CEPHADM_BIN version \
 #$SUDO CEPHADM_IMAGE=$IMAGE_OCTOPUS $CEPHADM_BIN version
 #$SUDO CEPHADM_IMAGE=$IMAGE_OCTOPUS $CEPHADM_BIN version \
 #    | grep 'ceph version 15'
-$SUDO $CEPHADM_BIN --image $IMAGE_MASTER version | grep 'ceph version'
+$SUDO $CEPHADM_BIN --image $IMAGE_MAIN version | grep 'ceph version'
 
 # try force docker; this won't work if docker isn't installed
 systemctl status docker > /dev/null && ( $CEPHADM --docker version | grep 'ceph version' ) || echo "docker not installed"

--- a/src/cephadm/box/box.py
+++ b/src/cephadm/box/box.py
@@ -17,7 +17,7 @@ from util import (
     run_shell_command,
 )
 
-CEPH_IMAGE = 'quay.ceph.io/ceph-ci/ceph:master'
+CEPH_IMAGE = 'quay.ceph.io/ceph-ci/ceph:main'
 BOX_IMAGE = 'cephadm-box:latest'
 
 # NOTE: this image tar is a trickeroo so cephadm won't pull the image everytime
@@ -112,11 +112,11 @@ class Cluster(Target):
 
         run_shell_command('docker load < /cephadm/box/docker/ceph/image/quay.ceph.image.tar')
         # cephadm guid error because it sometimes tries to use quay.ceph.io/ceph-ci/ceph:<none>
-        # instead of master's tag
+        # instead of main branch's tag
         run_shell_command('export CEPH_SOURCE_FOLDER=/ceph')
-        run_shell_command('export CEPHADM_IMAGE=quay.ceph.io/ceph-ci/ceph:master')
+        run_shell_command('export CEPHADM_IMAGE=quay.ceph.io/ceph-ci/ceph:main')
         run_shell_command(
-            'echo "export CEPHADM_IMAGE=quay.ceph.io/ceph-ci/ceph:master" >> ~/.bashrc'
+            'echo "export CEPHADM_IMAGE=quay.ceph.io/ceph-ci/ceph:main" >> ~/.bashrc'
         )
 
         extra_args = []

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -441,7 +441,7 @@ class TestCephAdm(object):
                                  '514e6a882f6e74806a5856468489eeff8d7106095557578da96935e4d0ba4d9d',
                                  '2022-04-19 13:45:20.97146228 +0000 UTC',
                                  '')
-        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|master|2022-03-23 16:29:19 +0000 UTC
+        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
         quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
         docker.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
         with mock.patch('cephadm.call_throws', return_value=(out, '', '')):
@@ -450,7 +450,7 @@ class TestCephAdm(object):
                 assert image == 'quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e'
 
         # make sure first valid image is used when no container_info is found
-        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|master|2022-03-23 16:29:19 +0000 UTC
+        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
         quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
         docker.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
         with mock.patch('cephadm.call_throws', return_value=(out, '', '')):

--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -283,7 +283,7 @@
       "service_type": "mds",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 2,
@@ -309,7 +309,7 @@
       "service_type": "mgr",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T05:44:40.978366",
         "last_refresh": "2020-04-16T06:51:42.412919",
         "running": 2,
@@ -336,7 +336,7 @@
       "service_type": "nfs",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 1,
@@ -366,7 +366,7 @@
       "service_type": "iscsi",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 1,
@@ -378,7 +378,7 @@
     {
       "container_id": "87d84858109d",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:39:40.394999",
       "daemon_id": "xx.mgr0.nkchxn",
       "daemon_type": "mds",
@@ -392,7 +392,7 @@
     {
       "container_id": "07ff9b56bcb9",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:39:41.318155",
       "daemon_id": "xx.osd0.ouawlt",
       "daemon_type": "mds",
@@ -406,7 +406,7 @@
     {
       "container_id": "459a982152c6",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:36:31.577976",
       "daemon_id": "mgr0.gvlxbw",
       "daemon_type": "mgr",
@@ -420,7 +420,7 @@
     {
       "container_id": "37b7fc67390a",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "osd0.mnsbeq",
       "daemon_type": "mgr",
@@ -434,7 +434,7 @@
     {
       "container_id": "aeba86ca1655",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "vstart.osd0",
       "daemon_type": "nfs",
@@ -448,7 +448,7 @@
     {
       "container_id": "e695cd698d8a",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "iscsi.osd0.abc123",
       "daemon_type": "iscsi",

--- a/src/script/cpatch
+++ b/src/script/cpatch
@@ -9,7 +9,7 @@ if [ ! -e Makefile ] && [ ! -e build.ninja ] || [ ! -e ../do_cmake.sh ]; then
     exit 1
 fi
 
-base="quay.ceph.io/ceph-ci/ceph:master"
+base="quay.ceph.io/ceph-ci/ceph:main"
 target=""
 push=0
 strip=1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58147

---

backport of https://github.com/ceph/ceph/pull/46539
parent tracker: https://tracker.ceph.com/issues/58146

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh