### PR TITLE
pacific: mgr/cephadm: some master -> main cleanup

### DIFF
--- a/doc/dev/cephadm/developing-cephadm.rst
+++ b/doc/dev/cephadm/developing-cephadm.rst
@@ -32,7 +32,7 @@ cephadm/cephadm script into memory.)
   for mon or mgr.
 - You'll see health warnings from cephadm about stray daemons--that's because
   the vstart-launched daemons aren't controlled by cephadm.
-- The default image is ``quay.io/ceph-ci/ceph:master``, but you can change
+- The default image is ``quay.io/ceph-ci/ceph:main``, but you can change
   this by passing ``-o container_image=...`` or ``ceph config set global container_image ...``.
 
 

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
-IMAGE_MASTER=${IMAGE_MASTER:-'quay.ceph.io/ceph-ci/ceph:master'}
+IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
 IMAGE_PACIFIC=${IMAGE_PACIFIC:-'quay.ceph.io/ceph-ci/ceph:pacific'}
 #IMAGE_OCTOPUS=${IMAGE_OCTOPUS:-'quay.ceph.io/ceph-ci/ceph:octopus'}
 IMAGE_DEFAULT=${IMAGE_PACIFIC}
@@ -168,7 +168,7 @@ $SUDO CEPHADM_IMAGE=$IMAGE_PACIFIC $CEPHADM_BIN version \
 #$SUDO CEPHADM_IMAGE=$IMAGE_OCTOPUS $CEPHADM_BIN version
 #$SUDO CEPHADM_IMAGE=$IMAGE_OCTOPUS $CEPHADM_BIN version \
 #    | grep 'ceph version 15'
-$SUDO $CEPHADM_BIN --image $IMAGE_MASTER version | grep 'ceph version'
+$SUDO $CEPHADM_BIN --image $IMAGE_MAIN version | grep 'ceph version'
 
 # try force docker; this won't work if docker isn't installed
 systemctl status docker > /dev/null && ( $CEPHADM --docker version | grep 'ceph version' ) || echo "docker not installed"

--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -283,7 +283,7 @@
       "service_type": "mds",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 2,
@@ -309,7 +309,7 @@
       "service_type": "mgr",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T05:44:40.978366",
         "last_refresh": "2020-04-16T06:51:42.412919",
         "running": 2,
@@ -336,7 +336,7 @@
       "service_type": "nfs",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 1,
@@ -366,7 +366,7 @@
       "service_type": "iscsi",
       "status": {
         "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "container_image_name": "quay.io/ceph-ci/ceph:main",
         "created": "2020-04-16T03:39:39.512721",
         "last_refresh": "2020-04-16T06:51:42.412980",
         "running": 1,
@@ -378,7 +378,7 @@
     {
       "container_id": "87d84858109d",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:39:40.394999",
       "daemon_id": "xx.mgr0.nkchxn",
       "daemon_type": "mds",
@@ -392,7 +392,7 @@
     {
       "container_id": "07ff9b56bcb9",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:39:41.318155",
       "daemon_id": "xx.osd0.ouawlt",
       "daemon_type": "mds",
@@ -406,7 +406,7 @@
     {
       "container_id": "459a982152c6",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T03:36:31.577976",
       "daemon_id": "mgr0.gvlxbw",
       "daemon_type": "mgr",
@@ -420,7 +420,7 @@
     {
       "container_id": "37b7fc67390a",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "osd0.mnsbeq",
       "daemon_type": "mgr",
@@ -434,7 +434,7 @@
     {
       "container_id": "aeba86ca1655",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "vstart.osd0",
       "daemon_type": "nfs",
@@ -448,7 +448,7 @@
     {
       "container_id": "e695cd698d8a",
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
-      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "container_image_name": "quay.io/ceph-ci/ceph:main",
       "created": "2020-04-16T05:44:41.551646",
       "daemon_id": "iscsi.osd0.abc123",
       "daemon_type": "iscsi",

--- a/src/script/cpatch
+++ b/src/script/cpatch
@@ -9,7 +9,7 @@ if [ ! -e Makefile ] || [ ! -e ../do_cmake.sh ]; then
     exit 1
 fi
 
-base="quay.ceph.io/ceph-ci/ceph:master"
+base="quay.ceph.io/ceph-ci/ceph:main"
 target=""
 push=0
 strip=1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58148

---

backport of https://github.com/ceph/ceph/pull/46539
parent tracker: https://tracker.ceph.com/issues/58146

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh