### PR TITLE
mgr/rbd_support: don't try to remove localized option on every scheduler load

### DIFF
--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -390,14 +390,15 @@ class Schedules:
 
         # Previous versions incorrectly stored the global config in
         # the localized module option. Check the config is here and fix it.
-        if not schedule_cfg:
-            schedule_cfg = self.handler.module.get_localized_module_option(
-                self.handler.MODULE_OPTION_NAME, '')
-            if schedule_cfg:
+        loc_schedule_cfg = self.handler.module.get_localized_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
+        if loc_schedule_cfg:
+            if not schedule_cfg:
+                schedule_cfg = loc_schedule_cfg
                 self.handler.module.set_module_option(
                     self.handler.MODULE_OPTION_NAME, schedule_cfg)
-        self.handler.module.set_localized_module_option(
-            self.handler.MODULE_OPTION_NAME, None)
+            self.handler.module.set_localized_module_option(
+                self.handler.MODULE_OPTION_NAME, None)
 
         if schedule_cfg:
             try:


### PR DESCRIPTION
Do this only once if it exists.

Fixes: https://tracker.ceph.com/issues/58192
Signed-off-by: Mykola Golub <mgolub@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
