### PR TITLE
mgr/dashboard: rbd-mirror improvements

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -185,6 +185,16 @@ class Rbd(RESTController):
             if size and size != image.size():
                 image.resize(size)
 
+            mirror_image_info = image.mirror_image_get_info()
+            if enable_mirror and mirror_image_info['state'] == rbd.RBD_MIRROR_IMAGE_DISABLED:
+                RbdMirroringService.enable_image(
+                    image_name, pool_name, namespace,
+                    MIRROR_IMAGE_MODE[mirror_mode])
+            elif (enable_mirror is False
+                  and mirror_image_info['state'] == rbd.RBD_MIRROR_IMAGE_ENABLED):
+                RbdMirroringService.disable_image(
+                    image_name, pool_name, namespace)
+
             # check enable/disable features
             if features is not None:
                 curr_features = format_bitmask(image.features())
@@ -207,16 +217,6 @@ class Rbd(RESTController):
 
             RbdConfiguration(pool_ioctx=ioctx, image_name=image_name).set_configuration(
                 configuration)
-
-            mirror_image_info = image.mirror_image_get_info()
-            if enable_mirror and mirror_image_info['state'] == rbd.RBD_MIRROR_IMAGE_DISABLED:
-                RbdMirroringService.enable_image(
-                    image_name, pool_name, namespace,
-                    MIRROR_IMAGE_MODE[mirror_mode])
-            elif (enable_mirror is False
-                  and mirror_image_info['state'] == rbd.RBD_MIRROR_IMAGE_ENABLED):
-                RbdMirroringService.disable_image(
-                    image_name, pool_name, namespace)
 
             if primary and not mirror_image_info['primary']:
                 RbdMirroringService.promote_image(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
@@ -59,7 +59,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       icon: Icons.download,
       click: () => this.importBootstrapModal(),
       name: $localize`Import Bootstrap Token`,
-      disable: () => this.peersExist
+      disable: () => false
     };
     this.tableActions = [createBootstrapAction, importBootstrapAction];
   }
@@ -70,7 +70,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.rbdMirroringService.subscribeSummary((data) => {
         this.status = data.content_data.status;
-
         this.peersExist = !!data.content_data.pools.find((o: Pool) => o['peer_uuids'].length > 0);
       })
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -132,6 +132,7 @@
         <cd-rbd-snapshot-list [snapshots]="selection.snapshots"
                               [featuresName]="selection.features_name"
                               [poolName]="selection.pool_name"
+                              [primary]="selection.primary"
                               [namespace]="selection.namespace"
                               [mirroring]="selection.mirror_mode"
                               [rbdName]="selection.name"></cd-rbd-snapshot-list>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -281,7 +281,7 @@
           <label class="cd-col-form-label"
                  i18n>Schedule Interval
           <cd-helper i18n-html
-                     html="Create Mirror-Snapshots automatically on a periodic basis. The interval can be specified in days, hours, or minutes using d, h, m suffix respectively.">
+                     html="Create Mirror-Snapshots automatically on a periodic basis. The interval can be specified in days, hours, or minutes using d, h, m suffix respectively. To create mirror snapshots, you must import or create and have available peers to mirror">
           </cd-helper></label>
           <div class="cd-col-form-input">
             <input id="schedule"
@@ -291,7 +291,7 @@
                    formControlName="schedule"
                    i18n-placeholder
                    placeholder="e.g., 12h or 1d or 10m"
-                   [attr.disabled]="(mode === rbdFormMode.editing) ? true : null">
+                   [attr.disabled]="(peerConfigured === false) ? true : null">
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -452,6 +452,9 @@ describe('RbdFormComponent', () => {
 
       it('should set and disable exclusive-lock only for the journal mode', () => {
         component.poolMirrorMode = 'pool';
+        component.mirroring = true;
+        const journal = fixture.debugElement.query(By.css('#journal')).nativeElement;
+        journal.click();
         fixture.detectChanges();
         const exclusiveLocks = fixture.debugElement.query(By.css('#exclusive-lock')).nativeElement;
         expect(exclusiveLocks.checked).toBe(true);
@@ -462,6 +465,7 @@ describe('RbdFormComponent', () => {
         component.mirroring = true;
         fixture.detectChanges();
         const journal = fixture.debugElement.query(By.css('#journal')).nativeElement;
+        journal.click();
         expect(journal.checked).toBe(true);
         const request = component.createRequest();
         expect(request.features).toContain('journaling');
@@ -471,6 +475,7 @@ describe('RbdFormComponent', () => {
         component.mirroring = true;
         fixture.detectChanges();
         const journal = fixture.debugElement.query(By.css('#journal')).nativeElement;
+        journal.click();
         expect(journal.checked).toBe(true);
         const request = component.editRequest();
         expect(request.features).toContain('journaling');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -65,8 +65,7 @@
   <span *ngIf="value.length === 3; else probb"
         class="badge badge-info">{{ value[0] }}</span>&nbsp;
   <span *ngIf="value.length === 3"
-        class="badge badge-info"
-        [ngbTooltip]="'Next scheduled snapshot on' + ' ' + (value[2] | cdDate)">{{ value[1] }}</span>
+        class="badge badge-info">{{ value[1] }}</span>&nbsp;
   <span *ngIf="row.primary === true"
         class="badge badge-info"
         i18n>primary</span>
@@ -76,6 +75,13 @@
   <ng-template #probb>
     <span class="badge badge-info">{{ value }}</span>
   </ng-template>
+</ng-template>
+
+<ng-template #ScheduleTpl
+             let-value="value"
+             let-row="row">
+  <span *ngIf="value.length === 3"
+        class="badge badge-info">{{ value[2] | cdDate  }}</span>
 </ng-template>
 
 <ng-template #flattenTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -53,6 +53,8 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   parentTpl: TemplateRef<any>;
   @ViewChild('nameTpl')
   nameTpl: TemplateRef<any>;
+  @ViewChild('ScheduleTpl', { static: true })
+  ScheduleTpl: TemplateRef<any>;
   @ViewChild('mirroringTpl', { static: true })
   mirroringTpl: TemplateRef<any>;
   @ViewChild('flattenTpl', { static: true })
@@ -305,6 +307,13 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         flexGrow: 3,
         sortable: false,
         cellTemplate: this.mirroringTpl
+      },
+      {
+        name: $localize`Next Scheduled Snapshot`,
+        prop: 'mirror_mode',
+        flexGrow: 3,
+        sortable: false,
+        cellTemplate: this.ScheduleTpl
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -7,6 +7,7 @@ import { NgbModalModule, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { MockComponent } from 'ng-mocks';
 import { ToastrModule } from 'ngx-toastr';
 import { Subject, throwError as observableThrowError } from 'rxjs';
+import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { ComponentsModule } from '~/app/shared/components/components.module';
@@ -85,6 +86,7 @@ describe('RbdSnapshotListComponent', () => {
   describe('api delete request', () => {
     let called: boolean;
     let rbdService: RbdService;
+    let rbdMirroringService: RbdMirroringService;
     let notificationService: NotificationService;
     let authStorageService: AuthStorageService;
 
@@ -93,6 +95,7 @@ describe('RbdSnapshotListComponent', () => {
       const modalService = TestBed.inject(ModalService);
       const actionLabelsI18n = TestBed.inject(ActionLabelsI18n);
       called = false;
+      rbdMirroringService = new RbdMirroringService(null, null);
       rbdService = new RbdService(null, null);
       notificationService = new NotificationService(null, null, null);
       authStorageService = new AuthStorageService();
@@ -103,6 +106,7 @@ describe('RbdSnapshotListComponent', () => {
         null,
         null,
         rbdService,
+        rbdMirroringService,
         null,
         notificationService,
         null,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.ts
@@ -94,6 +94,10 @@ export class RbdMirroringService {
     return this.http.get(`api/block/mirroring/pool/${poolName}/peer/${peerUUID}`);
   }
 
+  getPeerForPool(poolName: string) {
+    return this.http.get(`api/block/mirroring/pool/${poolName}/peer`);
+  }
+
   addPeer(poolName: string, request: any) {
     return this.http.post(`api/block/mirroring/pool/${poolName}/peer`, request, {
       observe: 'response'


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58297
This PR intends to solve the below mentioned workflow issues-

1. RBD images in dashboard shows default mirroring as journal which should not be the case
2. snapshot based mirroring schedule Interval got disabled to edit which should not be the case
3. unable to create snapshot of an image using dashboard which should not be the case
4. provide snapshot schedule info in a new column
5. dashboard doesn't allow importing peer bootstrap key to be imported for subsequent pools which should not be the case

![Screenshot from 2022-12-07 13-28-58](https://user-images.githubusercontent.com/66050535/206122064-70390ba7-32d5-4cb5-bbe3-273c4e7e3862.png)




<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
