### PR TITLE
mon: try to realase forward op which is dropped by leader mon

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4153,7 +4153,8 @@ void Monitor::send_reply(MonOpRequestRef op, Message *reply)
   if (session->proxy_con) {
     dout(15) << "send_reply routing reply to " << con->get_peer_addr()
 	     << " via " << session->proxy_con->get_peer_addr()
-	     << " for request " << *req << dendl;
+	     << " for request " << *req
+             << " tid " << session->proxy_tid << dendl;
     session->proxy_con->send_message(new MRoute(session->proxy_tid, reply));
     op->mark_event("reply: send routed request");
   } else {
@@ -4170,7 +4171,8 @@ void Monitor::no_reply(MonOpRequestRef op)
   if (session->proxy_con) {
     dout(10) << "no_reply to " << req->get_source_inst()
 	     << " via " << session->proxy_con->get_peer_addr()
-	     << " for request " << *req << dendl;
+	     << " for request " << *req
+             << " tid " << session->proxy_tid << dendl;
     session->proxy_con->send_message(new MRoute(session->proxy_tid, NULL));
     op->mark_event("no_reply: send routed request");
   } else {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3897,6 +3897,10 @@ bool OSDMonitor::preprocess_alive(MonOpRequestRef op)
   return false;
 
  ignore:
+  if (session && session->proxy_con) {
+    dout(10) << __func__ << " reply forward op tid " << session->proxy_tid << dendl;
+    session->proxy_con->send_message(new MRoute(session->proxy_tid, nullptr));
+  }
   return true;
 }
 


### PR DESCRIPTION
when leader mon drop a osd_alive forward op，the src mon will always wait for the forwarded op. 
need reply to the src mon to release the forwarded op.

Fixes: https://tracker.ceph.com/issues/58194

Signed-off-by: yanqiang-ux <yanqiang_ux@163.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
