### PR TITLE
rbd-mirror: add information about the last snapshot sync to image status

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -298,6 +298,9 @@ bool Replayer<I>::get_replay_status(std::string* description,
     m_bytes_per_snapshot);
   root_obj["bytes_per_snapshot"] = round_to_two_places(bytes_per_snapshot);
 
+  root_obj["last_snapshot_sync_seconds"] = m_last_snapshot_sync_seconds;
+  root_obj["last_snapshot_bytes"] = m_last_snapshot_bytes;
+
   auto pending_bytes = bytes_per_snapshot * m_pending_snapshots;
   if (bytes_per_second > 0 && m_pending_snapshots > 0) {
     std::uint64_t seconds_until_synced = round_to_two_places(
@@ -1110,21 +1113,23 @@ void Replayer<I>::handle_copy_image(int r) {
 
   {
     std::unique_lock locker{m_lock};
+    m_last_snapshot_bytes = m_snapshot_bytes;
     m_bytes_per_snapshot(m_snapshot_bytes);
-    auto time = ceph_clock_now() - m_snapshot_replay_start;
+    utime_t duration = ceph_clock_now() - m_snapshot_replay_start;
+    m_last_snapshot_sync_seconds = duration.sec();
+
     if (g_snapshot_perf_counters) {
       g_snapshot_perf_counters->inc(l_rbd_mirror_snapshot_replay_bytes,
                                     m_snapshot_bytes);
       g_snapshot_perf_counters->inc(l_rbd_mirror_snapshot_replay_snapshots);
       g_snapshot_perf_counters->tinc(
-        l_rbd_mirror_snapshot_replay_snapshots_time, time);
+        l_rbd_mirror_snapshot_replay_snapshots_time, duration);
     }
     if (m_perf_counters) {
       m_perf_counters->inc(l_rbd_mirror_snapshot_replay_bytes, m_snapshot_bytes);
       m_perf_counters->inc(l_rbd_mirror_snapshot_replay_snapshots);
-      m_perf_counters->tinc(l_rbd_mirror_snapshot_replay_snapshots_time, time);
+      m_perf_counters->tinc(l_rbd_mirror_snapshot_replay_snapshots_time, duration);
     }
-    m_snapshot_bytes = 0;
   }
 
   apply_image_state();

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
@@ -238,8 +238,11 @@ private:
   DeepCopyHandler* m_deep_copy_handler = nullptr;
 
   TimeRollingMean m_bytes_per_second;
+  uint64_t m_last_snapshot_sync_seconds = 0;
 
   uint64_t m_snapshot_bytes = 0;
+  uint64_t m_last_snapshot_bytes = 0;
+
   boost::accumulators::accumulator_set<
     uint64_t, boost::accumulators::stats<
       boost::accumulators::tag::rolling_mean>> m_bytes_per_snapshot{


### PR DESCRIPTION

Currently, the rbd mirror status command does not include information about the time taken to sync and bytes in the last snapshot, making it difficult to monitor and troubleshoot the mirroring process. This feature request is to add "last_snapshot_bytes" and "last_snapshot_seconds" fields to the rbd mirror status command, providing administrators with valuable information about the performance of the mirroring process.

Use case:
In snapshot-based mirroring, it's important to know how long it took to sync the last snapshot and how many bytes were transferred during the sync process. This information is useful for monitoring the performance of the mirroring process and identifying any issues that may arise. By adding these fields to the rbd mirror status command, administrators will be able to quickly and easily retrieve this information and use it to optimize the mirroring process.

Fixes: https://tracker.ceph.com/issues/58755
