### PR TITLE
qa/workunits/rados/test_crash: chown crash files to ceph user

### DIFF
--- a/qa/workunits/rados/test_crash.sh
+++ b/qa/workunits/rados/test_crash.sh
@@ -24,6 +24,11 @@ for f in $(find $TESTDIR/archive/coredump -type f); do
 	fi
 done
 
+# ceph-crash runs as the unprivileged "ceph" user, but when under test
+# the ceph osd daemons are running as root, so their crash files aren't
+# readable.  let's chown them so they behave as they would in real life.
+sudo chown -R ceph:ceph /var/lib/ceph/crash
+
 # let daemon find crashdumps on startup
 sudo systemctl restart ceph-crash
 sleep 30

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -66,6 +66,9 @@ def post_crash(path):
 def scrape_path(path):
     for p in os.listdir(path):
         crashpath = os.path.join(path, p)
+        if not os.access(crashpath, os.R_OK):
+            log.warning('unable to read crash path %s' % (crashpath))
+            continue
         metapath = os.path.join(crashpath, 'meta')
         donepath = os.path.join(crashpath, 'done')
         if os.path.isfile(metapath):


### PR DESCRIPTION
This PR also makes ceph-crash log a warning if it can't read any of the crash directories.

Fixes: https://tracker.ceph.com/issues/58098


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
