### PR TITLE
qa: set locale to C.UTF-8 in tox.ini

### DIFF
--- a/qa/CMakeLists.txt
+++ b/qa/CMakeLists.txt
@@ -5,5 +5,5 @@ endif()
 
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(qa TOX_ENVS py3 flake8 mypy deadsymlinks)
+  add_tox_test(qa TOX_ENVS flake8 mypy deadsymlinks)
 endif()

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -32,6 +32,7 @@ basepython = python3
 deps =
   {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[coverage,orchestra,test]
   httplib2
+  pytest
 commands =
   pytest --assert=plain test_import.py
   pytest tasks/tests --suite-dir {toxinidir}/suites {posargs}

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -2,6 +2,11 @@
 envlist = flake8, mypy, pytest, deadsymlinks
 skipsdist = True
 
+[testenv]
+setenv =
+  LC_ALL = C.UTF-8
+  LANG = C
+
 [testenv:flake8]
 basepython = python3
 deps=

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py3,
-    py37,
     mypy,
     fix
     flake8
@@ -71,38 +70,6 @@ setenv =
 passenv =
     MYPYPATH
 basepython = python3
-mypy_args = --config-file=../../mypy.ini
-           -m alerts
-           -m balancer
-           -m cephadm
-           -m crash
-           -m dashboard
-           -m devicehealth
-           -m diskprediction_local
-           -m hello
-           -m influx
-           -m iostat
-           -m localpool
-           -m mds_autoscaler
-           -m mgr_module
-           -m mgr_util
-           -m mirroring
-           -m nfs
-           -m orchestrator
-           -m pg_autoscaler
-           -m progress
-           -m prometheus
-           -m rbd_support
-           -m rook
-           -m snap_schedule
-           -m selftest
-           -m stats
-           -m status
-           -m telegraf
-           -m telemetry
-           -m test_orchestrator
-           -m volumes
-           -m zabbix
 deps =
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt
@@ -114,9 +81,38 @@ deps =
     types-PyYAML
     types-jwt
 commands =
-    mypy {[testenv:mypy]mypy_args}
-    mypy --python-version 3.7 {[testenv:mypy]mypy_args}
-
+    mypy --config-file=../../mypy.ini \
+           -m alerts \
+           -m balancer \
+           -m cephadm \
+           -m crash \
+           -m dashboard \
+           -m devicehealth \
+           -m diskprediction_local \
+           -m hello \
+           -m influx \
+           -m iostat \
+           -m localpool \
+           -m mds_autoscaler \
+           -m mgr_module \
+           -m mgr_util \
+           -m mirroring \
+           -m nfs \
+           -m orchestrator \
+           -m pg_autoscaler \
+           -m progress \
+           -m prometheus \
+           -m rbd_support \
+           -m rook \
+           -m snap_schedule \
+           -m selftest \
+           -m stats \
+           -m status \
+           -m telegraf \
+           -m telemetry \
+           -m test_orchestrator \
+           -m volumes \
+           -m zabbix
 
 [testenv:test]
 setenv = {[testenv]setenv}


### PR DESCRIPTION
as ansible is using UTF-8 encoded characters in the file names, so, to avoid failures like:

  File "/home/jenkins-build/build/workspace/ceph-pull-requests/qa/.tox/py3/lib/python3.10/site-packages/pip/_internal/utils/unpacking.py", line 217, in untar_file
    with open(path, "wb") as destfp:
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 137-140: ordinal not in range(256)

we have to set a locale which is able to handle UTF-8.

see also https://github.com/ceph/teuthology/pull/1671

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
