### PR TITLE
*: s/whitelist_externals/allowlist_externals/

### DIFF
--- a/monitoring/ceph-mixin/tox.ini
+++ b/monitoring/ceph-mixin/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skipsdist = true
 
 [testenv:jsonnet-bundler-{install,update}]
-whitelist_externals =
+allowlist_externals =
     jb
 description =
     install: Install the jsonnet dependencies
@@ -19,7 +19,7 @@ commands =
 
 [testenv:jsonnet-{check,fix,lint}]
 basepython = python3
-whitelist_externals =
+allowlist_externals =
     find
     jb
     jsonnet
@@ -56,7 +56,7 @@ deps =
     -rrequirements-lint.txt
 depends = grafonnet-check
 setenv =
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     behave tests_dashboards/features 
@@ -66,7 +66,7 @@ deps =
     -rrequirements-alerts.txt
     pytest
 depends = grafonnet-check
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     fix: jsonnet -J vendor -S alerts.jsonnet -o prometheus_alerts.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/shell_tox.ini
+++ b/src/ceph-volume/shell_tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 
 [testenv]
 passenv=*
-whitelist_externals=
+allowlist_externals=
   bash
   grep
   mktemp

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ envlist =
     fix
     flake8
 skipsdist = true
-requires = cython
 
 [flake8]
 max-line-length = 100

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -8,7 +8,6 @@ envlist =
     jinjalint
     nooptional
 skipsdist = true
-requires = cython
 skip_missing_interpreters = true
 
 [pytest]
@@ -51,7 +50,6 @@ setenv =
     UNITTEST = true
     PYTHONPATH = $PYTHONPATH:..
 deps =
-    cython
     -rrequirements.txt
     -rrook/requirements.txt
 commands =
@@ -62,7 +60,6 @@ setenv =
     UNITTEST = true
     PYTHONPATH = $PYTHONPATH:..
 deps =
-    cython
     -rrequirements-required.txt
 commands =
     pytest {posargs:cephadm/tests/test_ssh.py}
@@ -107,7 +104,6 @@ mypy_args = --config-file=../../mypy.ini
            -m volumes
            -m zabbix
 deps =
-    cython
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt
     mypy


### PR DESCRIPTION
as we started using tox 4.0 and up (v4.0.2 in specific). tox complains and fails like:

alerts-lint: failed with promtool is not allowed, use allowlist_externals to allow it
  alerts-lint: FAIL code 1 (9.25 seconds)

see https://tox.wiki/en/latest/faq.html#tox-4-removed-tox-ini-keys and https://tox.wiki/en/latest/config.html#allowlist_externals

it'd be nice to use a more inclusive language also. so, in this change, s/whitelist_externals/allowlist_externals/ in all tox.ini in this project.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
