### PR TITLE
mgr/dashboard: allow Origin url for CORS if present in config 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -246,16 +246,19 @@ class CherryPyConfig(object):
         resp_head = cherrypy.response.headers
 
         # Always set response headers necessary for 'simple' CORS.
-        req_header_origin_url = req_head.get('Access-Control-Allow-Origin')
+        req_header_cross_origin_url = req_head.get('Access-Control-Allow-Origin')
         cross_origin_urls = mgr.get_localized_module_option('cross_origin_url', '')
         cross_origin_url_list = [url.strip() for url in cross_origin_urls.split(',')]
-        if req_header_origin_url in cross_origin_url_list:
-            resp_head['Access-Control-Allow-Origin'] = req_header_origin_url
+        if req_header_cross_origin_url in cross_origin_url_list:
+            resp_head['Access-Control-Allow-Origin'] = req_header_cross_origin_url
         resp_head['Access-Control-Expose-Headers'] = 'GET, POST'
         resp_head['Access-Control-Allow-Credentials'] = 'true'
 
         # Non-simple CORS preflight request; short-circuit the normal handler.
         if cherrypy.request.method == 'OPTIONS':
+            req_header_origin_url = req_head.get('Origin')
+            if req_header_origin_url in cross_origin_url_list:
+                resp_head['Access-Control-Allow-Origin'] = req_header_origin_url
             ac_method = req_head.get('Access-Control-Request-Method', None)
 
             allowed_methods = ['GET', 'POST']


### PR DESCRIPTION
By default the browser will not set `Access-Control-Allow-Origin` header in Request headers. So allow the CORS for the origins which uses browser to access the url and are mentioned in config key `cross_origin_url`.

Fixes: https://tracker.ceph.com/issues/58245
Signed-off-by: Avan Thakkar <athakkar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
