### PR TITLE
osd: fix couples of bugs with similar error log of bug 52657.

### DIFF
--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -549,22 +549,22 @@ public:
    */
   virtual ConnectionRef connect_to(
     int type, const entity_addrvec_t& dest,
-    bool anon=false, bool not_local_dest=false) = 0;
+    bool anon=false, bool not_local_dest=false, bool must_connected=false) = 0;
   ConnectionRef connect_to_mon(const entity_addrvec_t& dest,
-      bool anon=false, bool not_local_dest=false) {
-	return connect_to(CEPH_ENTITY_TYPE_MON, dest, anon, not_local_dest);
+      bool anon=false, bool not_local_dest=false, bool must_connected=false) {
+	return connect_to(CEPH_ENTITY_TYPE_MON, dest, anon, not_local_dest, must_connected);
   }
   ConnectionRef connect_to_mds(const entity_addrvec_t& dest,
-      bool anon=false, bool not_local_dest=false) {
-	return connect_to(CEPH_ENTITY_TYPE_MDS, dest, anon, not_local_dest);
+      bool anon=false, bool not_local_dest=false, bool must_connected=false) {
+	return connect_to(CEPH_ENTITY_TYPE_MDS, dest, anon, not_local_dest, must_connected);
   }
   ConnectionRef connect_to_osd(const entity_addrvec_t& dest,
-      bool anon=false, bool not_local_dest=false) {
-	return connect_to(CEPH_ENTITY_TYPE_OSD, dest, anon, not_local_dest);
+      bool anon=false, bool not_local_dest=false, bool must_connected=false) {
+	return connect_to(CEPH_ENTITY_TYPE_OSD, dest, anon, not_local_dest, must_connected);
   }
   ConnectionRef connect_to_mgr(const entity_addrvec_t& dest,
-      bool anon=false, bool not_local_dest=false) {
-	return connect_to(CEPH_ENTITY_TYPE_MGR, dest, anon, not_local_dest);
+      bool anon=false, bool not_local_dest=false, bool must_connected=false) {
+	return connect_to(CEPH_ENTITY_TYPE_MGR, dest, anon, not_local_dest, must_connected);
   }
 
   /**

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -494,6 +494,10 @@ bool AsyncConnection::is_connected() {
   return protocol->is_connected();
 }
 
+int AsyncConnection::wait_for_ready() {
+  return protocol->wait_for_ready();
+}
+
 void AsyncConnection::connect(const entity_addrvec_t &addrs, int type,
                               entity_addr_t &target) {
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -114,6 +114,7 @@ private:
   bool unregistered = false;
 public:
   void maybe_start_delay_thread();
+  int wait_for_ready();
 
   std::ostream& _conn_prefix(std::ostream *_dout);
 

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -150,7 +150,7 @@ public:
    */
   ConnectionRef connect_to(int type,
 			   const entity_addrvec_t& addrs,
-			   bool anon, bool not_local_dest=false) override;
+			   bool anon, bool not_local_dest=false, bool must_connected=false) override;
   ConnectionRef get_loopback_connection() override;
   void mark_down(const entity_addr_t& addr) override {
     mark_down_addrs(entity_addrvec_t(addr));

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1301,11 +1301,13 @@ CtPtr ProtocolV2::ready() {
 
   {
     std::lock_guard<std::mutex> l(connection->write_lock);
+    std::lock_guard<std::mutex> l2(ready_lock);
     can_write = true;
     if (!out_queue.empty()) {
       connection->center->dispatch_event_external(connection->write_handler);
     }
   }
+  ready_cond.notify_all();
 
   connection->maybe_start_delay_thread();
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1059,10 +1059,15 @@ void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epo
     peer_con = osd->cluster_messenger->get_loopback_connection();
   } else {
     peer_con = osd->cluster_messenger->connect_to_osd(
-	next_map->get_cluster_addrs(peer), false, true);
+	next_map->get_cluster_addrs(peer), false, true, true);
   }
-  maybe_share_map(peer_con.get(), next_map);
-  peer_con->send_message(m);
+  if(peer_con) {
+    maybe_share_map(peer_con.get(), next_map);
+    peer_con->send_message(m);
+  }
+  else {
+    dout(5) << __func__ << ": getting a NULL connection. abort sending message." << dendl;
+  }
   release_map(next_map);
 }
 
@@ -1083,10 +1088,15 @@ void OSDService::send_message_osd_cluster(std::vector<std::pair<int, Message*>>&
       peer_con = osd->cluster_messenger->get_loopback_connection();
     } else {
       peer_con = osd->cluster_messenger->connect_to_osd(
-	  next_map->get_cluster_addrs(iter.first), false, true);
+	  next_map->get_cluster_addrs(iter.first), false, true, true);
     }
-    maybe_share_map(peer_con.get(), next_map);
-    peer_con->send_message(iter.second);
+    if(peer_con) {
+      maybe_share_map(peer_con.get(), next_map);
+      peer_con->send_message(iter.second);
+    }
+    else {
+      dout(5) << __func__ << ": getting a NULL connection. abort sending message." << dendl;
+    }
   }
   release_map(next_map);
 }
@@ -1106,7 +1116,7 @@ ConnectionRef OSDService::get_con_osd_cluster(int peer, epoch_t from_epoch)
     con = osd->cluster_messenger->get_loopback_connection();
   } else {
     con = osd->cluster_messenger->connect_to_osd(
-	next_map->get_cluster_addrs(peer), false, true);
+	next_map->get_cluster_addrs(peer), false, true, true);
   }
   release_map(next_map);
   return con;


### PR DESCRIPTION
an effort for fixing issues with log errors like MOSDPGLog::encode_payload(uint64_t): Assertion `HAVE_FEATURE(features, SERVER_NAUTILUS)'

calling AsyncMessenger::connect_to is asynchronous and just set in state of START_CONNECT; a sequence of handshakes frame(including server identity frame) is pending to be exchanged before the connection is in ready state. The race condition is then sending message by the connection should not be allowed. it should wait for readiness if a connection be used instantly after its creation.

Since the issue is hard to reproduce, only with some sort of race condition, it would be better to bring up a live cluster in lab with the commit to see how it works for us.

this should fix the folowing similar issues:
https://tracker.ceph.com/issues/57845
https://tracker.ceph.com/issues/52657
https://tracker.ceph.com/issues/52694
https://tracker.ceph.com/issues/57845
https://tracker.ceph.com/issues/53685

Signed-off-by: Ben Gao <bengao168@msn.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
