### PR TITLE
quincy: doc/rbd: refine "Listing Block Device Images"

### DIFF
--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -87,33 +87,47 @@ the default pool ``rbd``, execute the following::
 Listing Block Device Images
 ===========================
 
-To list block devices in the ``rbd`` pool, execute the following
-(i.e., ``rbd`` is the default pool name):: 
+To list block devices in the ``rbd`` pool, run the following command:
 
-	rbd ls
+.. prompt:: bash $
 
-To list block devices in a particular pool, execute the following,
-but replace ``{poolname}`` with the name of the pool:: 
+   rbd ls
 
-	rbd ls {poolname}
+.. note:: ``rbd`` is the default pool name, and ``rbd ls`` lists the commands
+   in the default pool.
+
+To list block devices in a particular pool, run the following command, but
+replace ``{poolname}`` with the name of the pool: 
+
+.. prompt:: bash $
+
+   rbd ls {poolname}
 	
-For example::
+For example:
 
-	rbd ls swimmingpool
+.. prompt:: bash $
 
-To list deferred delete block devices in the ``rbd`` pool, execute the 
-following:: 
+   rbd ls swimmingpool
 
-        rbd trash ls
+To list "deferred delete" block devices in the ``rbd`` pool, run the
+following command:
 
-To list deferred delete block devices in a particular pool, execute the 
-following, but replace ``{poolname}`` with the name of the pool:: 
+.. prompt:: bash $
 
-        rbd trash ls {poolname}
+   rbd trash ls
 
-For example::
+To list "deferred delete" block devices in a particular pool, run the 
+following command, but replace ``{poolname}`` with the name of the pool:
 
-        rbd trash ls swimmingpool
+.. prompt:: bash $
+
+   rbd trash ls {poolname}
+
+For example:
+
+.. prompt:: bash $
+
+   rbd trash ls swimmingpool
 
 Retrieving Image Information
 ============================


### PR DESCRIPTION
Refine the text and prompts in "Listing Block Device Images" in doc/rbd/rados-rbd-cmds.rst.

https://tracker.ceph.com/issues/57001

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit ad3c93535fbb614d593f74806fdfccdd60a1696f)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
