### PR TITLE
pacific: doc/rbd: refine "Removing a Block Device Image"

### DIFF
--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -199,53 +199,82 @@ Decreasing the Size of a Block Device Image
 Removing a Block Device Image
 =============================
 
-To remove a block device, execute the following, but replace ``{image-name}``
-with the name of the image you want to remove:: 
+To remove a block device, run the following command, but replace
+``{image-name}`` with the name of the image you want to remove:
 
-	rbd rm {image-name}
+.. prompt:: bash $
 
-For example:: 
+   rbd rm {image-name}
 
-	rbd rm foo
- 
-To remove a block device from a pool, execute the following, but replace 
-``{image-name}`` with the name of the image to remove and replace 
-``{pool-name}`` with the name of the pool:: 
+For example:
 
-	rbd rm {pool-name}/{image-name}
+.. prompt:: bash $
 
-For example:: 
+   rbd rm foo
 
-	rbd rm swimmingpool/bar
+Removing a Block Device from a Pool
+-----------------------------------
 
-To defer delete a block device from a pool, execute the following, but 
-replace ``{image-name}`` with the name of the image to move and replace 
-``{pool-name}`` with the name of the pool:: 
+To remove a block device from a pool, run the following command but replace
+``{image-name}`` with the name of the image to be removed, and replace
+``{pool-name}`` with the name of the pool from which the image is to be
+removed:
 
-        rbd trash mv {pool-name}/{image-name}
+.. prompt:: bash $
 
-For example:: 
+   rbd rm {pool-name}/{image-name}
 
-        rbd trash mv swimmingpool/bar
+For example:
 
-To remove a deferred block device from a pool, execute the following, but 
-replace ``{image-id}`` with the id of the image to remove and replace 
-``{pool-name}`` with the name of the pool:: 
+.. prompt:: bash $
 
-        rbd trash rm {pool-name}/{image-id}
+   rbd rm swimmingpool/bar
 
-For example:: 
+"Defer Deleting" a Block Device from a Pool
+-------------------------------------------
 
-        rbd trash rm swimmingpool/2bf4474b0dc51
+To defer delete a block device from a pool (which entails moving it to the
+"trash" and deleting it later), run the following command but replace
+``{image-name}`` with the name of the image to be moved to the trash and
+replace ``{pool-name}`` with the name of the pool:
+
+.. prompt:: bash $
+
+   rbd trash mv {pool-name}/{image-name}
+
+For example:
+
+.. prompt:: bash $
+
+   rbd trash mv swimmingpool/bar
+
+Removing a Deferred Block Device from a Pool
+--------------------------------------------
+
+To remove a deferred block device from a pool, run the following command but
+replace ``{image-}`` with the ID of the image to be removed, and replace
+``{pool-name}`` with the name of the pool from which the image is to be
+removed:
+
+.. prompt:: bash $
+
+   rbd trash rm {pool-name}/{image-}
+
+For example:
+
+.. prompt:: bash $
+   
+   rbd trash rm swimmingpool/2bf4474b0dc51
 
 .. note::
 
-  * You can move an image to the trash even it has snapshot(s) or actively 
-    in-use by clones, but can not be removed from trash.
+  * You can move an image to the trash even if it has snapshot(s) or is
+    actively in use by clones. However, you cannot remove it from the trash
+    under those conditions.
 
-  * You can use *--expires-at* to set the defer time (default is ``now``), 
-    and if its deferment time has not expired, it can not be removed unless 
-    you use *--force*.
+  * You can use ``--expires-at`` to set the deferment time (default is
+    ``now``). If the deferment time has not yet arrived, you cannot remove the
+    image unless you use ``--force``.
 
 Restoring a Block Device Image
 ==============================


### PR DESCRIPTION
Refine and add unselectable prompts to "Removing a Block Device Image" in doc/rbd/rados-rbd-cmds.

https://tracker.ceph.com/issues/57001

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 3a6284a49bf41030bb20a5714b0dfce92928438b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
