### PR TITLE
 mgr/pybind: fix mypy and autopep8 arg parsing

### DIFF
--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -1,4 +1,4 @@
--e../../python-common
+-e ../../python-common
 asyncmock
 cherrypy
 cryptography

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -28,20 +28,20 @@ ignore =
     E501,
     W503,
 exclude =
-    .tox,
-    .vagrant,
-    __pycache__,
-    *.pyc,
-    templates,
+    .tox \
+    .vagrant \
+    __pycache__ \
+    *.pyc \
+    templates \
     .eggs
 statistics = True
 
 [autopep8]
 addopts =
-    --max-line-length {[flake8]max-line-length}
-    --exclude "{[flake8]exclude}"
-    --in-place
-    --recursive
+    --max-line-length {[flake8]max-line-length} \
+    --exclude "{[flake8]exclude}" \
+    --in-place \
+    --recursive \
     --ignore-local-config
 
 [testenv]
@@ -157,19 +157,19 @@ basepython = python3
 deps =
     autopep8
 modules =
-    alerts
-    balancer
-    cephadm
-    cli_api
-    crash
-    devicehealth
-    diskprediction_local
-    insights
-    iostat
-    nfs
-    orchestrator
-    prometheus
-    status
+    alerts \
+    balancer \
+    cephadm \
+    cli_api \
+    crash \
+    devicehealth \
+    diskprediction_local \
+    insights \
+    iostat \
+    nfs \
+    orchestrator \
+    prometheus \
+    status \
     telemetry
 commands =
     python --version

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -70,6 +70,39 @@ setenv =
 passenv =
     MYPYPATH
 basepython = python3
+mypy_args =
+           --config-file=../../mypy.ini \
+           -m alerts \
+           -m balancer \
+           -m cephadm \
+           -m crash \
+           -m dashboard \
+           -m devicehealth \
+           -m diskprediction_local \
+           -m hello \
+           -m influx \
+           -m iostat \
+           -m localpool \
+           -m mds_autoscaler \
+           -m mgr_module \
+           -m mgr_util \
+           -m mirroring \
+           -m nfs \
+           -m orchestrator \
+           -m pg_autoscaler \
+           -m progress \
+           -m prometheus \
+           -m rbd_support \
+           -m rook \
+           -m snap_schedule \
+           -m selftest \
+           -m stats \
+           -m status \
+           -m telegraf \
+           -m telemetry \
+           -m test_orchestrator \
+           -m volumes \
+           -m zabbix
 deps =
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt


### PR DESCRIPTION
On the new tox version it is treating each line as a new command
so it will do something like "mypy --config-file=../../mypy.ini"
as one command and then "-m balancer" as a totally separate command.
The first one immediately fails as it doesn't include any modules
to test. Adding backslashes to the ends of the lines gets it to
handle the lines as one long command

Similar to mypy, we now need a backslash to signal
a newline doesn't mean to start a new command for autopep8 args

Signed-off-by: Adam King <adking@redhat.com>

I think the flake8 check is also broken in that it seems to just run the unit tests instead of actually running flake8, but it technically should pass still so leaving that for a separate PR.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
