### PR TITLE
rgw/sal: get_notification() takes optional_yield

### DIFF
--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -970,7 +970,8 @@ reservation_t::reservation_t(const DoutPrefixProvider* _dpp,
 			     const req_state* _s,
 			     rgw::sal::Object* _object,
 			     rgw::sal::Object* _src_object,
-			     const std::string* _object_name) :
+			     const std::string* _object_name,
+			     optional_yield y) :
   dpp(_s), store(_store), s(_s), size(0) /* XXX */,
   object(_object), src_object(_src_object), bucket(_s->bucket.get()),
   object_name(_object_name),
@@ -980,7 +981,7 @@ reservation_t::reservation_t(const DoutPrefixProvider* _dpp,
   user_id(_s->user->get_id().id),
   user_tenant(_s->user->get_id().tenant),
   req_id(_s->req_id),
-  yield(_s->yield)
+  yield(y)
 {}
 
 reservation_t::reservation_t(const DoutPrefixProvider* _dpp,

--- a/src/rgw/driver/rados/rgw_notify.h
+++ b/src/rgw/driver/rados/rgw_notify.h
@@ -76,7 +76,8 @@ struct reservation_t {
 		const req_state* _s,
 		rgw::sal::Object* _object,
 		rgw::sal::Object* _src_object,
-		const std::string* _object_name);
+		const std::string* _object_name,
+		optional_yield y);
 
   /* ctor for non-request caller (e.g., lifecycle) */
   reservation_t(const DoutPrefixProvider* _dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1273,9 +1273,9 @@ std::unique_ptr<Completions> RadosStore::get_completions(void)
 }
 
 std::unique_ptr<Notification> RadosStore::get_notification(
-  rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, const std::string* object_name)
+  rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name)
 {
-  return std::make_unique<RadosNotification>(s, this, obj, src_obj, s, event_type, object_name);
+  return std::make_unique<RadosNotification>(s, this, obj, src_obj, s, event_type, y, object_name);
 }
 
 std::unique_ptr<Notification> RadosStore::get_notification(const DoutPrefixProvider* dpp, rgw::sal::Object* obj, rgw::sal::Object* src_obj, rgw::notify::EventType event_type, rgw::sal::Bucket* _bucket, std::string& _user_id, std::string& _user_tenant, std::string& _req_id, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -747,7 +747,7 @@ class RadosNotification : public StoreNotification {
 
   public:
     RadosNotification(const DoutPrefixProvider* _dpp, RadosStore* _store, Object* _obj, Object* _src_obj, req_state* _s, rgw::notify::EventType _type, const std::string* object_name=nullptr) :
-      StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _s, _obj, _src_obj, object_name) { }
+      StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _s, _obj, _src_obj, object_name, _s->yield) { }
 
     RadosNotification(const DoutPrefixProvider* _dpp, RadosStore* _store, Object* _obj, Object* _src_obj, rgw::notify::EventType _type, rgw::sal::Bucket* _bucket, std::string& _user_id, std::string& _user_tenant, std::string& _req_id, optional_yield y) :
       StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _obj, _src_obj, _bucket, _user_id, _user_tenant, _req_id, y) {}

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -164,7 +164,7 @@ class RadosStore : public StoreDriver {
     virtual int cluster_stat(RGWClusterStat& stats) override;
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
     virtual std::unique_ptr<Completions> get_completions(void) override;
-    virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, const std::string* object_name=nullptr) override;
+    virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name=nullptr) override;
     virtual std::unique_ptr<Notification> get_notification(
     const DoutPrefixProvider* dpp, rgw::sal::Object* obj, rgw::sal::Object* src_obj, 
     rgw::notify::EventType event_type, rgw::sal::Bucket* _bucket, std::string& _user_id, std::string& _user_tenant,
@@ -746,8 +746,8 @@ class RadosNotification : public StoreNotification {
   rgw::notify::reservation_t res;
 
   public:
-    RadosNotification(const DoutPrefixProvider* _dpp, RadosStore* _store, Object* _obj, Object* _src_obj, req_state* _s, rgw::notify::EventType _type, const std::string* object_name=nullptr) :
-      StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _s, _obj, _src_obj, object_name, _s->yield) { }
+    RadosNotification(const DoutPrefixProvider* _dpp, RadosStore* _store, Object* _obj, Object* _src_obj, req_state* _s, rgw::notify::EventType _type, optional_yield y, const std::string* object_name) :
+      StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _s, _obj, _src_obj, object_name, y) { }
 
     RadosNotification(const DoutPrefixProvider* _dpp, RadosStore* _store, Object* _obj, Object* _src_obj, rgw::notify::EventType _type, rgw::sal::Bucket* _bucket, std::string& _user_id, std::string& _user_tenant, std::string& _req_id, optional_yield y) :
       StoreNotification(_obj, _src_obj, _type), store(_store), res(_dpp, _store, _obj, _src_obj, _bucket, _user_id, _user_tenant, _req_id, y) {}

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3969,7 +3969,7 @@ void RGWPutObj::execute(optional_yield y)
   std::unique_ptr<rgw::sal::Notification> res
 		     = driver->get_notification(
 		       s->object.get(), s->src_object.get(), s,
-		       rgw::notify::ObjectCreatedPut);
+		       rgw::notify::ObjectCreatedPut, y);
   if(!multipart) {
     op_ret = res->publish_reserve(this, obj_tags.get());
     if (op_ret < 0) {
@@ -4377,7 +4377,7 @@ void RGWPostObj::execute(optional_yield y)
 
   // make reservation for notification if needed
   std::unique_ptr<rgw::sal::Notification> res
-    = driver->get_notification(s->object.get(), s->src_object.get(), s, rgw::notify::ObjectCreatedPost);
+    = driver->get_notification(s->object.get(), s->src_object.get(), s, rgw::notify::ObjectCreatedPost, y);
   op_ret = res->publish_reserve(this);
   if (op_ret < 0) {
     return;
@@ -5062,7 +5062,7 @@ void RGWDeleteObj::execute(optional_yield y)
       rgw::notify::ObjectRemovedDelete;
     std::unique_ptr<rgw::sal::Notification> res
       = driver->get_notification(s->object.get(), s->src_object.get(), s,
-				event_type);
+				event_type, y);
     op_ret = res->publish_reserve(this);
     if (op_ret < 0) {
       return;
@@ -5466,7 +5466,7 @@ void RGWCopyObj::execute(optional_yield y)
   std::unique_ptr<rgw::sal::Notification> res
 				   = driver->get_notification(
 				     s->object.get(), s->src_object.get(),
-				     s, rgw::notify::ObjectCreatedCopy);
+				     s, rgw::notify::ObjectCreatedCopy, y);
   op_ret = res->publish_reserve(this);
   if (op_ret < 0) {
     return;
@@ -6430,7 +6430,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
 
   // make reservation for notification if needed
   std::unique_ptr<rgw::sal::Notification> res
-    = driver->get_notification(meta_obj.get(), nullptr, s, rgw::notify::ObjectCreatedCompleteMultipartUpload, &s->object->get_name());
+    = driver->get_notification(meta_obj.get(), nullptr, s, rgw::notify::ObjectCreatedCompleteMultipartUpload, y, &s->object->get_name());
   op_ret = res->publish_reserve(this);
   if (op_ret < 0) {
     return;
@@ -6964,7 +6964,7 @@ void RGWDeleteMultiObj::handle_individual_object(const rgw_obj_key& o, optional_
                           rgw::notify::ObjectRemovedDeleteMarkerCreated :
                           rgw::notify::ObjectRemovedDelete;
   std::unique_ptr<rgw::sal::Notification> res
-          = driver->get_notification(obj.get(), s->src_object.get(), s, event_type);
+          = driver->get_notification(obj.get(), s->src_object.get(), s, event_type, y);
   op_ret = res->publish_reserve(this);
   if (op_ret < 0) {
     send_partial_response(o, false, "", op_ret, formatter_flush_cond);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -330,7 +330,7 @@ class Driver {
       * management/tracking software */
     /** RGWOp variant */
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s,
-        rgw::notify::EventType event_type, const std::string* object_name=nullptr) = 0;
+        rgw::notify::EventType event_type, optional_yield y, const std::string* object_name=nullptr) = 0;
     /** No-req_state variant (e.g., rgwlc) */
     virtual std::unique_ptr<Notification> get_notification(
     const DoutPrefixProvider* dpp, rgw::sal::Object* obj, rgw::sal::Object* src_obj, 

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -935,7 +935,7 @@ class DaosStore : public StoreDriver {
   virtual std::unique_ptr<Completions> get_completions(void) override;
   virtual std::unique_ptr<Notification> get_notification(
       rgw::sal::Object* obj, rgw::sal::Object* src_obj, struct req_state* s,
-      rgw::notify::EventType event_type,
+      rgw::notify::EventType event_type, optional_yield y,
       const std::string* object_name = nullptr) override;
   virtual std::unique_ptr<Notification> get_notification(
       const DoutPrefixProvider* dpp, rgw::sal::Object* obj,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1826,7 +1826,8 @@ namespace rgw::sal {
 
   std::unique_ptr<Notification> DBStore::get_notification(
     rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s,
-    rgw::notify::EventType event_type, const std::string* object_name)
+    rgw::notify::EventType event_type, optional_yield y,
+    const std::string* object_name)
   {
     return std::make_unique<DBNotification>(obj, src_obj, event_type);
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -814,7 +814,7 @@ public:
 
   virtual std::unique_ptr<Notification> get_notification(
     rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s,
-    rgw::notify::EventType event_type, const std::string* object_name) override;
+    rgw::notify::EventType event_type, optional_yield y, const std::string* object_name) override;
 
   virtual std::unique_ptr<Notification> get_notification(
     const DoutPrefixProvider* dpp, rgw::sal::Object* obj,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -275,12 +275,12 @@ std::unique_ptr<Completions> FilterDriver::get_completions(void)
 
 std::unique_ptr<Notification> FilterDriver::get_notification(rgw::sal::Object* obj,
 				rgw::sal::Object* src_obj, req_state* s,
-				rgw::notify::EventType event_type,
+				rgw::notify::EventType event_type, optional_yield y,
 				const std::string* object_name)
 {
   std::unique_ptr<Notification> n = next->get_notification(nextObject(obj),
 							   nextObject(src_obj),
-							   s, event_type,
+							   s, event_type, y,
 							   object_name);
   return std::make_unique<FilterNotification>(std::move(n));
 }

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -202,7 +202,7 @@ public:
 
   virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj,
 				 rgw::sal::Object* src_obj, struct req_state* s,
-				 rgw::notify::EventType event_type,
+				 rgw::notify::EventType event_type, optional_yield y,
 				 const std::string* object_name=nullptr) override;
   virtual std::unique_ptr<Notification> get_notification(
     const DoutPrefixProvider* dpp, rgw::sal::Object* obj, rgw::sal::Object* src_obj, 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -953,7 +953,7 @@ class MotrStore : public StoreDriver {
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
     virtual std::unique_ptr<Completions> get_completions(void) override;
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj,
-        req_state* s, rgw::notify::EventType event_type, const std::string* object_name=nullptr) override;
+        req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name=nullptr) override;
     virtual std::unique_ptr<Notification> get_notification(const DoutPrefixProvider* dpp, rgw::sal::Object* obj,
         rgw::sal::Object* src_obj, rgw::notify::EventType event_type, rgw::sal::Bucket* _bucket,
         std::string& _user_id, std::string& _user_tenant, std::string& _req_id, optional_yield y) override;


### PR DESCRIPTION
not all calls use `s->yield`, so pass in the `optional_yield` argument separately

Fixes: https://tracker.ceph.com/issues/58231

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
