### PR TITLE
pacific: pybind/mgr: fixup after upgrading tox versions

### DIFF
--- a/monitoring/ceph-mixin/tox.ini
+++ b/monitoring/ceph-mixin/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skipsdist = true
 
 [testenv:jsonnet-bundler-{install,update}]
-whitelist_externals =
+allowlist_externals =
     jb
 description =
     install: Install the jsonnet dependencies
@@ -19,7 +19,7 @@ commands =
 
 [testenv:jsonnet-{check,fix,lint}]
 basepython = python3
-whitelist_externals =
+allowlist_externals =
     find
     jb
     jsonnet
@@ -56,7 +56,7 @@ deps =
     -rrequirements-lint.txt
 depends = grafonnet-check
 setenv =
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     python -m doctest tests_dashboards/util.py
@@ -67,7 +67,7 @@ deps =
     -rrequirements-alerts.txt
     pytest
 depends = grafonnet-check
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     fix: jsonnet -J vendor -S alerts.jsonnet -o prometheus_alerts.yml

--- a/qa/CMakeLists.txt
+++ b/qa/CMakeLists.txt
@@ -5,5 +5,5 @@ endif()
 
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(qa TOX_ENVS py3 flake8 import-tasks)
+  add_tox_test(qa TOX_ENVS py3 flake8)
 endif()

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -2,6 +2,11 @@
 envlist = flake8, mypy, pytest
 skipsdist = True
 
+[testenv]
+setenv =
+  LC_ALL = C.UTF-8
+  LANG = C
+
 [testenv:flake8]
 basepython = python3
 deps=

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -28,6 +28,6 @@ commands = python test_import.py {posargs:tasks/**/*.py}
 [testenv:pytest]
 basepython = python3
 deps =
-  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[test]
+  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[test]
   httplib2
-commands = pytest -vv tasks/tests
+commands = pytest -vvv tasks/tests

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -20,7 +20,9 @@ commands = mypy {posargs:.}
 
 [testenv:import-tasks]
 basepython = python3
-deps = {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[coverage,orchestra,test]
+deps =
+  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[coverage,orchestra,test]
+  pytest
 commands = python test_import.py {posargs:tasks/**/*.py}
 
 [testenv:pytest]

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/shell_tox.ini
+++ b/src/ceph-volume/shell_tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 
 [testenv]
 passenv=*
-whitelist_externals=
+allowlist_externals=
   bash
   grep
   mktemp

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ envlist =
     fix
     flake8
 skipsdist = true
-requires = cython
 
 [flake8]
 max-line-length = 100

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,5 +1,5 @@
 pytest-cov==2.7.1
--e../../python-common
+-e ../../python-common
 kubernetes
 requests-mock
 pyyaml

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -28,20 +28,20 @@ ignore =
     E501,
     W503,
 exclude =
-    .tox,
-    .vagrant,
-    __pycache__,
-    *.pyc,
-    templates,
+    .tox \
+    .vagrant \
+    __pycache__ \
+    *.pyc \
+    templates \
     .eggs
 statistics = True
 
 [autopep8]
 addopts =
-    --max-line-length {[flake8]max-line-length}
-    --exclude "{[flake8]exclude}"
-    --in-place
-    --recursive
+    --max-line-length {[flake8]max-line-length} \
+    --exclude "{[flake8]exclude}" \
+    --in-place \
+    --recursive \
     --ignore-local-config
 
 [testenv]

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -9,7 +9,6 @@ envlist =
     flake8
     jinjalint
 skipsdist = true
-requires = cython
 
 [pytest]
 log_level=NOTSET
@@ -50,7 +49,6 @@ setenv =
     UNITTEST = true
     PYTHONPATH = $PYTHONPATH:..
 deps =
-    cython
     -rrequirements.txt
 commands =
     pytest --doctest-modules {posargs: \
@@ -72,7 +70,6 @@ passenv =
     MYPYPATH
 basepython = python3
 deps =
-    cython
     -rrequirements.txt
     mypy==0.790
 commands =


### PR DESCRIPTION
We upgraded the tox version on the Jenkins machines and some changes are needed in order for make check to pass now.

Backport of https://github.com/ceph/ceph/pull/49322, https://github.com/ceph/ceph/pull/49321, partially https://github.com/ceph/ceph/pull/49359 (included some unnecessary things I've removed here and will revert in main later)

A lot more merge conflicts in this one than the quincy backport. Hopefully all handled correctly and make check still passes. 
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
