### PR TITLE
quincy: doc/rados: add prompts to stretch-mode.rst

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -65,15 +65,19 @@ just as susceptible to netsplit issues, but are much more tolerant of
 component availability outages than 2-site clusters are.
 
 To enter stretch mode, you must set the location of each monitor, matching
-your CRUSH map. For instance, to place ``mon.a`` in your first data center ::
+your CRUSH map. For instance, to place ``mon.a`` in your first data center:
 
-  $ ceph mon set_location a datacenter=site1
+.. prompt:: bash $
+
+   ceph mon set_location a datacenter=site1
 
 Next, generate a CRUSH rule which will place 2 copies in each data center. This
-will require editing the CRUSH map directly::
+will require editing the CRUSH map directly:
 
-  $ ceph osd getcrushmap > crush.map.bin
-  $ crushtool -d crush.map.bin -o crush.map.txt
+.. prompt:: bash $
+
+   ceph osd getcrushmap > crush.map.bin
+   crushtool -d crush.map.bin -o crush.map.txt
 
 Now edit the ``crush.map.txt`` file to add a new rule. Here
 there is only one other rule, so this is ID 1, but you may need
@@ -93,10 +97,12 @@ named ``site1`` and ``site2``::
           step emit
   }
 
-Finally, inject the CRUSH map to make the rule available to the cluster::
+Finally, inject the CRUSH map to make the rule available to the cluster:
 
-  $ crushtool -c crush.map.txt -o crush2.map.bin
-  $ ceph osd setcrushmap -i crush2.map.bin
+.. prompt:: bash $
+
+   crushtool -c crush.map.txt -o crush2.map.bin
+   ceph osd setcrushmap -i crush2.map.bin
 
 If you aren't already running your monitors in connectivity mode, do so with
 the instructions in `Changing Monitor Elections`_.
@@ -107,10 +113,12 @@ And lastly, tell the cluster to enter stretch mode. Here, ``mon.e`` is the
 tiebreaker and we are splitting across data centers. ``mon.e`` should be also
 set a datacenter, that will differ from ``site1`` and ``site2``. For this
 purpose you can create another datacenter bucket named ```site3`` in your
-CRUSH and place ``mon.e`` there ::
+CRUSH and place ``mon.e`` there:
 
-  $ ceph mon set_location e datacenter=site3
-  $ ceph mon enable_stretch_mode e stretch_rule datacenter
+.. prompt:: bash $
+
+   ceph mon set_location e datacenter=site3
+   ceph mon enable_stretch_mode e stretch_rule datacenter
 
 When stretch mode is enabled, the OSDs will only take PGs active when
 they peer across data centers (or whatever other CRUSH bucket type
@@ -163,9 +171,11 @@ running with more than 2 full sites.
 Other commands
 ==============
 If your tiebreaker monitor fails for some reason, you can replace it. Turn on
-a new monitor and run ::
+a new monitor and run:
 
-  $ ceph mon set_new_tiebreaker mon.<new_mon_name>
+.. prompt:: bash $
+
+   ceph mon set_new_tiebreaker mon.<new_mon_name>
 
 This command will protest if the new monitor is in the same location as existing
 non-tiebreaker monitors. This command WILL NOT remove the previous tiebreaker
@@ -180,9 +190,11 @@ bucket type you specified when running ``enable_stretch_mode``.
 
 When in stretch degraded mode, the cluster will go into "recovery" mode automatically
 when the disconnected data center comes back. If that doesn't work, or you want to
-enable recovery mode early, you can invoke ::
+enable recovery mode early, you can invoke:
 
-  $ ceph osd force_recovery_stretch_mode --yes-i-really-mean-it
+.. prompt:: bash $
+
+   ceph osd force_recovery_stretch_mode --yes-i-really-mean-it
 
 But this command should not be necessary; it is included to deal with
 unanticipated situations.
@@ -191,9 +203,11 @@ When in recovery mode, the cluster should go back into normal stretch mode
 when the PGs are healthy. If this doesn't happen, or you want to force the
 cross-data-center peering early and are willing to risk data downtime (or have
 verified separately that all the PGs can peer, even if they aren't fully
-recovered), you can invoke ::
+recovered), you can invoke:
 
-  $ ceph osd force_healthy_stretch_mode --yes-i-really-mean-it
+.. prompt:: bash $
+
+   ceph osd force_healthy_stretch_mode --yes-i-really-mean-it
 
 This command should not be necessary; it is included to deal with
 unanticipated situations. But you might wish to invoke it to remove


### PR DESCRIPTION
Add unselectable prompts to doc/rados/operations/stretch-mode.rst.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit bafe76c20488006ced7d9a2f6b82a54540dd7a89)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
