### PR TITLE
pybind/mgr: partial reversion of #49359

### DIFF
--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -70,39 +70,6 @@ setenv =
 passenv =
     MYPYPATH
 basepython = python3
-mypy_args =
-           --config-file=../../mypy.ini \
-           -m alerts \
-           -m balancer \
-           -m cephadm \
-           -m crash \
-           -m dashboard \
-           -m devicehealth \
-           -m diskprediction_local \
-           -m hello \
-           -m influx \
-           -m iostat \
-           -m localpool \
-           -m mds_autoscaler \
-           -m mgr_module \
-           -m mgr_util \
-           -m mirroring \
-           -m nfs \
-           -m orchestrator \
-           -m pg_autoscaler \
-           -m progress \
-           -m prometheus \
-           -m rbd_support \
-           -m rook \
-           -m snap_schedule \
-           -m selftest \
-           -m stats \
-           -m status \
-           -m telegraf \
-           -m telemetry \
-           -m test_orchestrator \
-           -m volumes \
-           -m zabbix
 deps =
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt


### PR DESCRIPTION
When creating #49359 I was testing on an outdated
branch and didn't realize part of what I was fixing had already been fixed in #49321. Basically ended up changing what a variable "mypy_args" is set to but that variable is no longer being used. It has no actual effect but we should remove the extraneous code.

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
