### PR TITLE
osd: fix suicide when osd bootup timeout

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6183,6 +6183,14 @@ options:
   min: 0
   flags:
   - runtime
+- name: osd_bootup_timeout
+  type: secs
+  level: advanced
+  desc: timeout for osd bootup (0 is unlimited)
+  default: 300
+  min: 300
+  flags:
+  - runtime
 # true if LTTng-UST tracepoints should be enabled
 - name: rados_tracing
   type: bool

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1129,6 +1129,7 @@ protected:
   PerfCounters* create_recoverystate_perf();
   void tick();
   void tick_without_osd_lock();
+  void bootup_timeout(int s, int t);
   void _dispatch(Message *m);
 
   void check_osdmap_features();
@@ -1241,6 +1242,8 @@ public:
 private:
   class C_Tick;
   class C_Tick_WithoutOSDLock;
+  class C_Bootup_Timeout;
+  Context *bootup_timeout_callback = nullptr;
 
   // -- config settings --
   float m_osd_pg_epoch_max_lag_factor;
@@ -1286,9 +1289,7 @@ public:
   int get_state() const {
     return state;
   }
-  void set_state(int s) {
-    state = s;
-  }
+  void set_state(int s);
   bool is_initializing() const {
     return state == STATE_INITIALIZING;
   }


### PR DESCRIPTION
osd: suicide when osd bootup timeout
Fixes: https://tracker.ceph.com/issues/58182





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
