### PR TITLE
rgw: Give useful errors when policies fail to parse

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,9 @@
 >=18.0.0
 
+* The RGW policy parser now rejects unknown principals by default. If you are
+  mirroring policies between RGW and AWS, you may wish to set
+  "rgw policy reject invalid principals" to "false". This affects only newly set
+  policies, not policies that are already in place.
 * RGW's default backend for `rgw_enable_ops_log` changed from RADOS to file.
   The default value of `rgw_ops_log_rados` is now false, and `rgw_ops_log_file_path`
   defaults to "/var/log/ceph/ops-log-$cluster-$name.log".

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2129,7 +2129,9 @@ fi
 %{_bindir}/rgw-gap-list
 %{_bindir}/rgw-gap-list-comparator
 %{_bindir}/rgw-orphan-list
+%{_bindir}/rgw-policy-check
 %{_mandir}/man8/radosgw.8*
+%{_mandir}/man8/rgw-policy-check.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -37,6 +37,7 @@ usr/share/man/man8/crushdiff.8
 usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
 usr/share/man/man8/radosgw-admin.8
+usr/share/man/man8/rgw-policy-check.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -59,6 +59,7 @@ if(WITH_RADOSGW)
 	radosgw.rst
 	radosgw-admin.rst
 	rgw-orphan-list.rst
+	rgw-policy-check.rst
 	ceph-diff-sorted.rst)
 endif()
 

--- a/doc/man/8/rgw-policy-check.rst
+++ b/doc/man/8/rgw-policy-check.rst
@@ -1,0 +1,55 @@
+:orphan:
+
+===================================================
+rgw-policy-check -- verify syntax of bucket policy
+===================================================
+
+.. program:: rgw-policy-check
+
+Synopsis
+========
+
+| **rgw-policy-check**
+   -t *tenant* [ *filename* ... ]
+
+
+Description
+===========
+
+This program reads one or more files containing bucket policy
+and determines if it is syntactically correct.
+It does not check to see if the policy makes sense;
+it only checks to see if the file would be accepted
+by the policy parsing logic inside
+:program:`radsogw`.
+
+More than one filename may be specified.  If no files are
+given, the program will read from stdin.
+
+On success, the program will say nothing.  On failure,
+the program will emit a error message indicating the
+problem.  The program will terminate with non-zero exit
+status if one or more policies could not be read or parsed.
+
+Options
+=======
+
+.. option: -t *tenant*
+
+   Specify *tenant* as the tenant.  This is required by the
+   policy parsing logic and is used to construct the internal
+   state representation of the policy.
+
+Availability
+============
+
+**rgw-policy-check** is part of Ceph, a massively scalable, open-source,
+distributed storage system.  Please refer to the Ceph documentation at
+http://ceph.com/docs for more information.
+
+See also
+========
+
+:doc:`radosgw <radosgw>`\(8)
+
+.. _Bucket Policies: ../../radosgw/bucketpolicy.rst

--- a/doc/man_index.rst
+++ b/doc/man_index.rst
@@ -47,3 +47,4 @@
    man/8/rgw-orphan-list
    man/8/ceph-immutable-object-cache
    man/8/ceph-diff-sorted
+   man/8/rgw-policy-check

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3701,3 +3701,14 @@ options:
   default: tank
   services:
   - rgw
+- name: rgw_policy_reject_invalid_principals
+  type: bool
+  level: basic
+  desc: Whether to reject policies with invalid principals
+  long_desc: If true, policies with invalid principals will be
+    rejected. We don't support Canonical User identifiers or some
+    other form of policies that Amazon does, so if you are mirroring
+    policies between RGW and AWS, you may wish to set this to false.
+  default: true
+  services:
+  - rgw

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -459,6 +459,12 @@ target_link_libraries(radosgw-object-expirer ${rgw_libs} librados
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES})
 install(TARGETS radosgw-object-expirer DESTINATION bin)
 
+set(radosgw_polparser_srcs
+  rgw_polparser.cc)
+add_executable(rgw-policy-check ${radosgw_polparser_srcs})
+target_link_libraries(rgw-policy-check ${rgw_libs})
+install(TARGETS rgw-policy-check DESTINATION bin)
+
 set(librgw_srcs
   librgw.cc)
 add_library(rgw SHARED ${librgw_srcs})

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6785,7 +6785,10 @@ int main(int argc, const char **argv)
       }
       bufferlist bl = bufferlist::static_from_string(assume_role_doc);
       try {
-        const rgw::IAM::Policy p(g_ceph_context, tenant, bl);
+        const rgw::IAM::Policy p(
+	  g_ceph_context, tenant, bl,
+	  g_ceph_context->_conf.get_val<bool>(
+	    "rgw_policy_reject_invalid_principals"));
       } catch (rgw::IAM::PolicyParseException& e) {
         cerr << "failed to parse policy: " << e.what() << std::endl;
         return -EINVAL;
@@ -6840,7 +6843,9 @@ int main(int argc, const char **argv)
 
       bufferlist bl = bufferlist::static_from_string(assume_role_doc);
       try {
-        const rgw::IAM::Policy p(g_ceph_context, tenant, bl);
+        const rgw::IAM::Policy p(g_ceph_context, tenant, bl,
+				 g_ceph_context->_conf.get_val<bool>(
+				   "rgw_policy_reject_invalid_principals"));
       } catch (rgw::IAM::PolicyParseException& e) {
         cerr << "failed to parse policy: " << e.what() << std::endl;
         return -EINVAL;
@@ -6898,7 +6903,9 @@ int main(int argc, const char **argv)
         bl = bufferlist::static_from_string(perm_policy_doc);
       }
       try {
-        const rgw::IAM::Policy p(g_ceph_context, tenant, bl);
+        const rgw::IAM::Policy p(g_ceph_context, tenant, bl,
+				 g_ceph_context->_conf.get_val<bool>(
+				   "rgw_policy_reject_invalid_principals"));
       } catch (rgw::IAM::PolicyParseException& e) {
         cerr << "failed to parse perm policy: " << e.what() << std::endl;
         return -EINVAL;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -871,7 +871,7 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   for (auto it: role.role_policies) {
     try {
       bufferlist bl = bufferlist::static_from_string(it);
-      const rgw::IAM::Policy p(s->cct, role.tenant, bl);
+      const rgw::IAM::Policy p(s->cct, role.tenant, bl, false);
       s->iam_user_policies.push_back(std::move(p));
     } catch (rgw::IAM::PolicyParseException& e) {
       //Control shouldn't reach here as the policy has already been
@@ -884,7 +884,7 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
     try {
       string policy = this->token_attrs.token_policy;
       bufferlist bl = bufferlist::static_from_string(policy);
-      const rgw::IAM::Policy p(s->cct, role.tenant, bl);
+      const rgw::IAM::Policy p(s->cct, role.tenant, bl, false);
       s->session_policies.push_back(std::move(p));
     } catch (rgw::IAM::PolicyParseException& e) {
       //Control shouldn't reach here as the policy has already been

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -21,25 +21,18 @@ namespace {
 constexpr int dout_subsys = ceph_subsys_rgw;
 }
 
-using std::bitset;
 using std::dec;
-using std::find;
 using std::hex;
 using std::int64_t;
-using std::move;
-using std::pair;
 using std::size_t;
 using std::string;
 using std::stringstream;
 using std::ostream;
 using std::uint16_t;
 using std::uint64_t;
-using std::unordered_map;
 
 using boost::container::flat_set;
 using std::regex;
-using std::regex_constants::ECMAScript;
-using std::regex_constants::optimize;
 using std::regex_match;
 using std::smatch;
 
@@ -50,7 +43,6 @@ using rapidjson::Reader;
 using rapidjson::kParseCommentsFlag;
 using rapidjson::kParseNumbersAsStringsFlag;
 using rapidjson::StringStream;
-using rapidjson::ParseResult;
 
 using rgw::auth::Principal;
 
@@ -165,10 +157,10 @@ static const actpair actpairs[] =
 
 struct PolicyParser;
 
-const Keyword top[1]{"<Top>", TokenKind::pseudo, TokenID::Top, 0, false,
-    false};
-const Keyword cond_key[1]{"<Condition Key>", TokenKind::cond_key,
-    TokenID::CondKey, 0, true, false};
+const Keyword top[1]{{"<Top>", TokenKind::pseudo, TokenID::Top, 0, false,
+			false}};
+const Keyword cond_key[1]{{"<Condition Key>", TokenKind::cond_key,
+			     TokenID::CondKey, 0, true, false}};
 
 struct ParseState {
   PolicyParser* pp;
@@ -442,15 +434,13 @@ bool ParseState::key(const char* s, size_t l) {
 // which will make all of this ever so much nicer.
 static boost::optional<Principal> parse_principal(CephContext* cct, TokenID t,
 						  string&& s) {
-  // Wildcard!
   if ((t == TokenID::AWS) && (s == "*")) {
+    // Wildcard!
     return Principal::wildcard();
-
-    // Do nothing for now.
   } else if (t == TokenID::CanonicalUser) {
-
-  }  // AWS and Federated ARNs
-   else if (t == TokenID::AWS || t == TokenID::Federated) {
+    // Do nothing for now.
+  } else if (t == TokenID::AWS || t == TokenID::Federated) {
+    // AWS and Federated ARNs
     if (auto a = ARN::parse(s)) {
       if (a->resource == "root") {
 	return Principal::tenant(std::move(a->account));

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -523,8 +523,14 @@ struct Policy {
 
   std::vector<Statement> statements;
 
+  // reject_invalid_principals should be set to
+  // `cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals")`
+  // when executing operations that *set* a bucket policy, but should
+  // be false when reading a stored bucket policy so as not to break
+  // backwards configuration.
   Policy(CephContext* cct, const std::string& tenant,
-	 const bufferlist& text);
+	 const bufferlist& text,
+	 bool reject_invalid_principals);
 
   Effect eval(const Environment& e,
 	      boost::optional<const rgw::auth::Identity&> ida,

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8132,8 +8132,9 @@ void RGWPutBucketPolicy::execute(optional_yield y)
 	return op_ret;
       });
   } catch (rgw::IAM::PolicyParseException& e) {
-    ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
+    ldpp_dout(this, 5) << "failed to parse policy: " << e.what() << dendl;
     op_ret = -EINVAL;
+    s->err.message = e.what();
   }
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -293,7 +293,7 @@ static boost::optional<Policy> get_iam_policy_from_attr(CephContext* cct,
 							const string& tenant) {
   auto i = attrs.find(RGW_ATTR_IAM_POLICY);
   if (i != attrs.end()) {
-    return Policy(cct, tenant, i->second);
+    return Policy(cct, tenant, i->second, false);
   } else {
     return none;
   }
@@ -326,7 +326,7 @@ vector<Policy> get_iam_user_policy_from_attr(CephContext* cct,
    decode(policy_map, out_bl);
    for (auto& it : policy_map) {
      bufferlist bl = bufferlist::static_from_string(it.second);
-     Policy p(cct, tenant, bl);
+     Policy p(cct, tenant, bl, false);
      policies.push_back(std::move(p));
    }
   }
@@ -8114,7 +8114,9 @@ void RGWPutBucketPolicy::execute(optional_yield y)
   }
 
   try {
-    const Policy p(s->cct, s->bucket_tenant, data);
+    const Policy p(
+      s->cct, s->bucket_tenant, data,
+      s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     rgw::sal::Attrs attrs(s->bucket_attrs);
     if (s->bucket_access_conf &&
         s->bucket_access_conf->block_public_policy() &&

--- a/src/rgw/rgw_polparser.cc
+++ b/src/rgw/rgw_polparser.cc
@@ -1,0 +1,105 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "include/buffer.h"
+
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+
+#include "global/global_init.h"
+
+#include "rgw/rgw_iam_policy.h"
+
+// Returns true on success
+bool parse(CephContext* cct, const std::string& tenant,
+           const std::string& fname, std::istream& in) noexcept
+{
+  bufferlist bl;
+  bl.append(in);
+  try {
+    auto p = rgw::IAM::Policy(
+      cct, tenant, bl,
+      cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
+  } catch (const rgw::IAM::PolicyParseException& e) {
+    std::cerr << fname << ": " << e.what() << std::endl;
+    return false;
+  } catch (const std::exception& e) {
+    std::cerr << fname << ": caught exception: " << e.what() << std::endl;;
+    return false;
+  }
+  return true;
+}
+
+void helpful_exit(std::string_view cmdname)
+{
+  std::cerr << cmdname << "-h for usage" << std::endl;
+  exit(1);
+}
+
+void usage(std::string_view cmdname)
+{
+  std::cout << "usage: " << cmdname << " -t <tenant> [filename]"
+	    << std::endl;
+}
+
+int main(int argc, const char** argv)
+{
+  std::string_view cmdname = argv[0];
+  std::string tenant;
+
+  auto args = argv_to_vec(argc, argv);
+  if (ceph_argparse_need_usage(args)) {
+    usage(cmdname);
+    exit(0);
+  }
+
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DAEMON_ACTIONS |
+			 CINIT_FLAG_NO_MON_CONFIG);
+  common_init_finish(cct.get());
+  std::string val;
+  for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
+    if (ceph_argparse_double_dash(args, i)) {
+      break;
+    } else if (ceph_argparse_witharg(args, i, &val, "--tenant", "-t",
+				     (char*)nullptr)) {
+      tenant = std::move(val);
+    } else {
+      ++i;
+    }
+  }
+
+  if (tenant.empty()) {
+    std::cerr << cmdname << ": must specify tenant name" << std::endl;
+    helpful_exit(cmdname);
+  }
+
+  bool success = true;
+
+  if (args.empty()) {
+    success = parse(cct.get(), tenant, "(stdin)", std::cin);
+  } else {
+    for (const auto& file : args) {
+      std::ifstream in;
+      in.open(file, std::ifstream::in);
+      if (!in.is_open()) {
+	std::cerr << "Can't read " << file << std::endl;
+	success = false;
+      }
+      if (!parse(cct.get(), tenant, file, in)) {
+	success = false;
+      }
+    }
+  }
+
+  return success ? 0 : 1;
+}

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -169,7 +169,8 @@ int RGWCreateRole::get_params()
       s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
   }
   catch (rgw::IAM::PolicyParseException& e) {
-    ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
+    ldpp_dout(this, 5) << "failed to parse policy: " << e.what() << dendl;
+    s->err.message = e.what();
     return -ERR_MALFORMED_DOC;
   }
 
@@ -576,6 +577,7 @@ int RGWPutRolePolicy::get_params()
   }
   catch (rgw::IAM::PolicyParseException& e) {
     ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
+    s->err.message = e.what();
     return -ERR_MALFORMED_DOC;
   }
   return 0;

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -164,7 +164,9 @@ int RGWCreateRole::get_params()
 
   bufferlist bl = bufferlist::static_from_string(trust_policy);
   try {
-    const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl);
+    const rgw::IAM::Policy p(
+      s->cct, s->user->get_tenant(), bl,
+      s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
   }
   catch (rgw::IAM::PolicyParseException& e) {
     ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
@@ -568,7 +570,9 @@ int RGWPutRolePolicy::get_params()
   }
   bufferlist bl = bufferlist::static_from_string(perm_policy);
   try {
-    const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl);
+    const rgw::IAM::Policy p(
+      s->cct, s->user->get_tenant(), bl,
+      s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
   }
   catch (rgw::IAM::PolicyParseException& e) {
     ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -526,7 +526,7 @@ int RGWREST_STS::verify_permission(optional_yield y)
   //Parse the policy
   //TODO - This step should be part of Role Creation
   try {
-    const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl);
+    const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl, false);
     if (!s->principal_tags.empty()) {
       auto res = p.eval(s->env, *s->auth.identity, rgw::IAM::stsTagSession, boost::none);
       if (res != rgw::IAM::Effect::Allow) {
@@ -644,7 +644,9 @@ int RGWSTSAssumeRoleWithWebIdentity::get_params()
   if (! policy.empty()) {
     bufferlist bl = bufferlist::static_from_string(policy);
     try {
-      const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl);
+      const rgw::IAM::Policy p(
+	s->cct, s->user->get_tenant(), bl,
+	s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     }
     catch (rgw::IAM::PolicyParseException& e) {
       ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << "policy" << policy << dendl;
@@ -703,7 +705,9 @@ int RGWSTSAssumeRole::get_params()
   if (! policy.empty()) {
     bufferlist bl = bufferlist::static_from_string(policy);
     try {
-      const rgw::IAM::Policy p(s->cct, s->user->get_tenant(), bl);
+      const rgw::IAM::Policy p(
+	s->cct, s->user->get_tenant(), bl,
+	s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     }
     catch (rgw::IAM::PolicyParseException& e) {
       ldpp_dout(this, 0) << "failed to parse policy: " << e.what() << "policy" << policy << dendl;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -649,7 +649,8 @@ int RGWSTSAssumeRoleWithWebIdentity::get_params()
 	s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     }
     catch (rgw::IAM::PolicyParseException& e) {
-      ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << "policy" << policy << dendl;
+      ldpp_dout(this, 5) << "failed to parse policy: " << e.what() << "policy" << policy << dendl;
+      s->err.message = e.what();
       return -ERR_MALFORMED_DOC;
     }
   }
@@ -711,6 +712,7 @@ int RGWSTSAssumeRole::get_params()
     }
     catch (rgw::IAM::PolicyParseException& e) {
       ldpp_dout(this, 0) << "failed to parse policy: " << e.what() << "policy" << policy << dendl;
+      s->err.message = e.what();
       return -ERR_MALFORMED_DOC;
     }
   }

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -141,7 +141,9 @@ void RGWPutUserPolicy::execute(optional_yield y)
   }
 
   try {
-    const Policy p(s->cct, s->user->get_tenant(), bl);
+    const Policy p(
+      s->cct, s->user->get_tenant(), bl,
+      s->cct->_conf.get_val<bool>("rgw_policy_reject_invalid_principals"));
     map<string, string> policies;
     if (auto it = user->get_attrs().find(RGW_ATTR_USER_POLICY); it != user->get_attrs().end()) {
       bufferlist out_bl = it->second;

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -162,7 +162,8 @@ void RGWPutUserPolicy::execute(optional_yield y)
     ldpp_dout(this, 0) << "ERROR: failed to decode user policies" << dendl;
     op_ret = -EIO;
   } catch (rgw::IAM::PolicyParseException& e) {
-    ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
+    ldpp_dout(this, 5) << "failed to parse policy: " << e.what() << dendl;
+    s->err.message = e.what();
     op_ret = -ERR_MALFORMED_DOC;
   }
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -166,7 +166,8 @@ TEST_F(PolicyTest, Parse1) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example1)));
+			     bufferlist::static_from_string(example1),
+			     true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, example1);
@@ -195,7 +196,7 @@ TEST_F(PolicyTest, Parse1) {
 
 TEST_F(PolicyTest, Eval1) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example1));
+		   bufferlist::static_from_string(example1), true);
   Environment e;
 
   ARN arn1(Partition::aws, Service::s3,
@@ -219,7 +220,8 @@ TEST_F(PolicyTest, Parse2) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example2)));
+			     bufferlist::static_from_string(example2),
+			     true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, example2);
@@ -261,7 +263,7 @@ TEST_F(PolicyTest, Parse2) {
 
 TEST_F(PolicyTest, Eval2) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example2));
+		   bufferlist::static_from_string(example2), true);
   Environment e;
 
   auto trueacct = FakeIdentity(
@@ -302,7 +304,7 @@ TEST_F(PolicyTest, Parse3) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example3)));
+			     bufferlist::static_from_string(example3), true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, example3);
@@ -416,7 +418,7 @@ TEST_F(PolicyTest, Parse3) {
 
 TEST_F(PolicyTest, Eval3) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example3));
+		   bufferlist::static_from_string(example3), true);
   Environment em;
   Environment tr = { { "aws:MultiFactorAuthPresent", "true" } };
   Environment fa = { { "aws:MultiFactorAuthPresent", "false" } };
@@ -527,7 +529,7 @@ TEST_F(PolicyTest, Parse4) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example4)));
+			     bufferlist::static_from_string(example4), true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, example4);
@@ -556,7 +558,7 @@ TEST_F(PolicyTest, Parse4) {
 
 TEST_F(PolicyTest, Eval4) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example4));
+		   bufferlist::static_from_string(example4), true);
   Environment e;
 
   ARN arn1(Partition::aws, Service::iam,
@@ -574,7 +576,7 @@ TEST_F(PolicyTest, Parse5) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example5)));
+			     bufferlist::static_from_string(example5), true));
   ASSERT_TRUE(p);
   EXPECT_EQ(p->text, example5);
   EXPECT_EQ(p->version, Version::v2012_10_17);
@@ -603,7 +605,7 @@ TEST_F(PolicyTest, Parse5) {
 
 TEST_F(PolicyTest, Eval5) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example5));
+		   bufferlist::static_from_string(example5), true);
   Environment e;
 
   ARN arn1(Partition::aws, Service::iam,
@@ -626,7 +628,7 @@ TEST_F(PolicyTest, Parse6) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example6)));
+			     bufferlist::static_from_string(example6), true));
   ASSERT_TRUE(p);
   EXPECT_EQ(p->text, example6);
   EXPECT_EQ(p->version, Version::v2012_10_17);
@@ -655,7 +657,7 @@ TEST_F(PolicyTest, Parse6) {
 
 TEST_F(PolicyTest, Eval6) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example6));
+		   bufferlist::static_from_string(example6), true);
   Environment e;
 
   ARN arn1(Partition::aws, Service::iam,
@@ -673,7 +675,7 @@ TEST_F(PolicyTest, Parse7) {
   boost::optional<Policy> p;
 
   ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(example7)));
+			     bufferlist::static_from_string(example7), true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, example7);
@@ -705,7 +707,7 @@ TEST_F(PolicyTest, Parse7) {
 
 TEST_F(PolicyTest, Eval7) {
   auto p  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(example7));
+		   bufferlist::static_from_string(example7), true);
   Environment e;
 
   auto subacct = FakeIdentity(
@@ -950,8 +952,9 @@ TEST_F(IPPolicyTest, IPEnvironment) {
 TEST_F(IPPolicyTest, ParseIPAddress) {
   boost::optional<Policy> p;
 
-  ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
-			     bufferlist::static_from_string(ip_address_full_example)));
+  ASSERT_NO_THROW(
+    p = Policy(cct.get(), arbitrary_tenant,
+	       bufferlist::static_from_string(ip_address_full_example), true));
   ASSERT_TRUE(p);
 
   EXPECT_EQ(p->text, ip_address_full_example);
@@ -1007,12 +1010,15 @@ TEST_F(IPPolicyTest, ParseIPAddress) {
 }
 
 TEST_F(IPPolicyTest, EvalIPAddress) {
-  auto allowp  = Policy(cct.get(), arbitrary_tenant,
-			bufferlist::static_from_string(ip_address_allow_example));
-  auto denyp  = Policy(cct.get(), arbitrary_tenant,
-		       bufferlist::static_from_string(ip_address_deny_example));
-  auto fullp  = Policy(cct.get(), arbitrary_tenant,
-		   bufferlist::static_from_string(ip_address_full_example));
+  auto allowp =
+    Policy(cct.get(), arbitrary_tenant,
+	   bufferlist::static_from_string(ip_address_allow_example), true);
+  auto denyp =
+    Policy(cct.get(), arbitrary_tenant,
+	   bufferlist::static_from_string(ip_address_deny_example), true);
+  auto fullp =
+    Policy(cct.get(), arbitrary_tenant,
+	   bufferlist::static_from_string(ip_address_full_example), true);
   Environment e;
   Environment allowedIP, blocklistedIP, allowedIPv6, blocklistedIPv6;
   allowedIP.emplace("aws:SourceIp","192.168.1.2");


### PR DESCRIPTION
This gives useful error messages when policies fail to parse and adds an option that (when true) will reject policies with invalid principals rather than logging them and moving on.

We can now get error messages like:

```
$ rgw-policy-check -t foo test*.json      
test1.json: At offset 467: `2022-10-17` is not a valid version. Valid versions are `2008-10-17` and `2012-10-17`.
test2.json: At offset 345: Policy owned by tenant `foo` cannot grant access to resource owned by tenant `bar`.
test3.json: At offset 158: `s3:GetObjectVersio` is not a valid action.
test4.json: At offset 336: `arn:aws:s3:::foo:ourdata/*` is not a valid ARN. Resource ARNs should have a format like `arn:aws:s3::tenant:resource' or `arn:aws:s3:::resource`.
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
