### PR TITLE
pacific: rados: fix extra tabs on warning for pool copy

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3102,7 +3102,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
 
     cerr << "WARNING: pool copy does not preserve user_version, which some "
-	 << "    apps may rely on." << std::endl;
+	 << "apps may rely on." << std::endl;
 
     if (rados.get_pool_is_selfmanaged_snaps_mode(src_pool)) {
       cerr << "WARNING: pool " << src_pool << " has selfmanaged snaps, which are not preserved\n"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58260

---

backport of https://github.com/ceph/ceph/pull/49251
parent tracker: https://tracker.ceph.com/issues/58165

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh