### PR TITLE
cmake: add 1.79 and 1.80 to known versions

### DIFF
--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -381,12 +381,14 @@ Set ``Boost_NO_BOOST_CMAKE`` to ``ON``, to disable the search for boost-cmake.
 
 # The FPHSA helper provides standard way of reporting final search results to
 # the user including the version and component checks.
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(FindPackageHandleStandardArgs)
 
 # Save project's policies
 cmake_policy(PUSH)
 cmake_policy(SET CMP0057 NEW) # if IN_LIST
-cmake_policy(SET CMP0102 NEW) # if mark_as_advanced(non_cache_var)
+if(POLICY CMP0102)
+  cmake_policy(SET CMP0102 NEW) # if mark_as_advanced(non_cache_var)
+endif()
 
 function(_boost_get_existing_target component target_var)
   set(names "${component}")
@@ -584,19 +586,17 @@ if (NOT Boost_NO_BOOST_CMAKE)
   # Do the same find_package call but look specifically for the CMake version.
   # Note that args are passed in the Boost_FIND_xxxxx variables, so there is no
   # need to delegate them to this find_package call.
+  cmake_policy(PUSH)
   if(BOOST_ROOT AND NOT Boost_ROOT)
     # Honor BOOST_ROOT by setting Boost_ROOT with CMP0074 NEW behavior.
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0074 NEW)
+    if(POLICY CMP0074)
+      cmake_policy(SET CMP0074 NEW)
+    endif()
     set(Boost_ROOT "${BOOST_ROOT}")
     set(_Boost_ROOT_FOR_CONFIG 1)
   endif()
   find_package(Boost QUIET NO_MODULE ${_boost_FIND_PACKAGE_ARGS})
-  if(_Boost_ROOT_FOR_CONFIG)
-    unset(_Boost_ROOT_FOR_CONFIG)
-    unset(Boost_ROOT)
-    cmake_policy(POP)
-  endif()
+  cmake_policy(POP)
   if (DEFINED Boost_DIR)
     mark_as_advanced(Boost_DIR)
   endif ()
@@ -1693,11 +1693,13 @@ _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
 _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_ADDITIONAL_VERSIONS")
 _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_NO_SYSTEM_PATHS")
 
-cmake_policy(GET CMP0074 _Boost_CMP0074)
-if(NOT "x${_Boost_CMP0074}x" STREQUAL "xNEWx")
-  _Boost_CHECK_SPELLING(Boost_ROOT)
+if(POLICY CMP0074)
+  cmake_policy(GET CMP0074 _Boost_CMP0074)
+  if(NOT "x${_Boost_CMP0074}x" STREQUAL "xNEWx")
+    _Boost_CHECK_SPELLING(Boost_ROOT)
+  endif()
+  unset(_Boost_CMP0074)
 endif()
-unset(_Boost_CMP0074)
 _Boost_CHECK_SPELLING(Boost_LIBRARYDIR)
 _Boost_CHECK_SPELLING(Boost_INCLUDEDIR)
 
@@ -1846,11 +1848,16 @@ if(Boost_INCLUDE_DIR)
   set(Boost_VERSION_STRING "${Boost_VERSION_MAJOR}.${Boost_VERSION_MINOR}.${Boost_VERSION_PATCH}")
 
   # Define final Boost_VERSION
-  cmake_policy(GET CMP0093 _Boost_CMP0093
-    PARENT_SCOPE # undocumented, do not use outside of CMake
-  )
-  if("x${_Boost_CMP0093}x" STREQUAL "xNEWx")
-    set(Boost_VERSION ${Boost_VERSION_STRING})
+  if(POLICY CMP0093)
+    cmake_policy(GET CMP0093 _Boost_CMP0093
+      PARENT_SCOPE # undocumented, do not use outside of CMake
+    )
+    if("x${_Boost_CMP0093}x" STREQUAL "xNEWx")
+      set(Boost_VERSION ${Boost_VERSION_STRING})
+    else()
+      set(Boost_VERSION ${Boost_VERSION_MACRO})
+    endif()
+    unset(_Boost_CMP0093)
   else()
     set(Boost_VERSION ${Boost_VERSION_MACRO})
   endif()


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
