### PR TITLE
crimson/os: define device_spec_t as packed

### DIFF
--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -14,7 +14,7 @@ namespace crimson::os::seastore {
 
 using magic_t = uint64_t;
 
-struct device_spec_t{
+struct device_spec_t {
   magic_t magic = 0;
   device_type_t dtype = device_type_t::NONE;
   device_id_t id = DEVICE_ID_NULL;
@@ -25,7 +25,7 @@ struct device_spec_t{
     denc(v.id, p);
     DENC_FINISH(p);
   }
-};
+} __attribute__ ((packed));
 
 std::ostream& operator<<(std::ostream&, const device_spec_t&);
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -871,7 +871,7 @@ constexpr auto PLACEMENT_HINT_NULL = placement_hint_t::NUM_HINTS;
 
 std::ostream& operator<<(std::ostream& out, placement_hint_t h);
 
-enum class alignas(4) device_type_t : uint_fast8_t {
+enum class device_type_t : uint8_t {
   NONE = 0,
   HDD,
   SSD,


### PR DESCRIPTION
per C++ standard 20, alignas cannot be applied to scoped enum. despite that there is a resolution to address this, see
https://cplusplus.github.io/CWG/issues/2354.html, it's not included in C++20. so we have to use a different way to address

> runtime error: reference binding to misaligned address 0x610000008395
> for type 'device_type_t', which requires 4 byte alignment

otherwise the code would fail to compile with Clang-15, like:

> <source>:3:13: error: 'alignas' attribute cannot be applied to an enumeration

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
