### PR TITLE
mds: remove unused declaraion

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2212,7 +2212,6 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
   auto p = bl.cbegin();
 
   DECODE_START(1, p);
-  utime_t tm;
 
   snapid_t newfirst;
   using ceph::decode;


### PR DESCRIPTION
as some Jenkins builds are set to treat warnings as errors, and complain.
(and - because the variable is indeed unused)

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
