### PR TITLE
cls/fifo: specialize fmt::formater<> for rados::cls::fifo::info

### DIFF
--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -25,7 +25,9 @@
 #undef FMT_HEADER_ONLY
 #define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
-
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "include/types.h"
@@ -522,3 +524,10 @@ inline std::ostream& operator <<(std::ostream& m, const part_header& p) {
 	   << "max_time: " << p.max_time;
 }
 } // namespace rados::cls::fifo
+
+#if FMT_VERSION >= 90000
+template<>
+struct fmt::formatter<rados::cls::fifo::info> : fmt::ostream_formatter {};
+template<>
+struct fmt::formatter<rados::cls::fifo::part_header> : fmt::ostream_formatter {};
+#endif

--- a/src/test/cls_fifo/bench_cls_fifo.cc
+++ b/src/test/cls_fifo/bench_cls_fifo.cc
@@ -49,6 +49,11 @@ namespace fifo = rados::cls::fifo;
 namespace s = spawn;
 namespace sc = std::chrono;
 
+#if FMT_VERSION >= 90000
+template<>
+struct fmt::formatter<bpo::options_description> : fmt::ostream_formatter {};
+#endif
+
 namespace {
 static constexpr auto PUSH = 0x01 << 0;
 static constexpr auto PULL = 0x01 << 1;


### PR DESCRIPTION
since fmt v9, fmt::formatter<> is not specialized for the types with operator<<(ostream&, ...) anymore. so we need to specialize it manually. in this change, fmt::formatter<rados::cls::fifo::info> is defined so the tree can compile with fmt v9.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
