### PR TITLE
crimson/net: refactors to encapsulate ProtocolV2 message read and write paths and event dispatching

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -176,11 +176,11 @@ set(crimson_net_srcs
   ${PROJECT_SOURCE_DIR}/src/msg/async/frames_v2.cc
   net/Errors.cc
   net/FrameAssemblerV2.cc
+  net/io_handler.cc
   net/Messenger.cc
   net/SocketConnection.cc
   net/SocketMessenger.cc
   net/Socket.cc
-  net/Protocol.cc
   net/ProtocolV2.cc
   net/chained_dispatchers.cc)
 add_library(crimson STATIC

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -175,6 +175,7 @@ set(crimson_net_srcs
   ${PROJECT_SOURCE_DIR}/src/msg/async/compression_onwire.cc
   ${PROJECT_SOURCE_DIR}/src/msg/async/frames_v2.cc
   net/Errors.cc
+  net/FrameAssemblerV2.cc
   net/Messenger.cc
   net/SocketConnection.cc
   net/SocketMessenger.cc

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -465,7 +465,7 @@ void Client::tick()
   gate.dispatch_in_background(__func__, *this, [this] {
     if (active_con) {
       return seastar::when_all_succeed(wait_for_send_log(),
-                                       active_con->get_conn()->keepalive(),
+                                       active_con->get_conn()->send_keepalive(),
                                        active_con->renew_tickets(),
                                        active_con->renew_rotating_keyring()).discard_result();
     } else {

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -76,14 +76,14 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   virtual seastar::future<> send(MessageURef msg) = 0;
 
   /**
-   * keepalive
+   * send_keepalive
    *
    * Send a keepalive message over a connection that has completed its
    * handshake.
    *
    * May be invoked from any core.
    */
-  virtual seastar::future<> keepalive() = 0;
+  virtual seastar::future<> send_keepalive() = 0;
 
   virtual clock_t::time_point get_last_keepalive() const = 0;
 

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -289,4 +289,9 @@ void FrameAssemblerV2::log_main_preamble(const ceph::bufferlist &bl)
                  (int)main_preamble->num_segments, main_preamble->crc);
 }
 
+FrameAssemblerV2Ref FrameAssemblerV2::create(SocketConnection &conn)
+{
+  return std::make_unique<FrameAssemblerV2>(conn);
+}
+
 } // namespace crimson::net

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -1,0 +1,264 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "FrameAssemblerV2.h"
+
+#include "Errors.h"
+#include "SocketConnection.h"
+
+using ceph::msgr::v2::FrameAssembler;
+using ceph::msgr::v2::FrameError;
+using ceph::msgr::v2::preamble_block_t;
+using ceph::msgr::v2::segment_t;
+using ceph::msgr::v2::Tag;
+
+namespace {
+
+seastar::logger& logger() {
+  return crimson::get_logger(ceph_subsys_ms);
+}
+
+} // namespace anonymous
+
+namespace crimson::net {
+
+FrameAssemblerV2::FrameAssemblerV2(SocketConnection &_conn)
+  : conn{_conn}
+{}
+
+void FrameAssemblerV2::set_is_rev1(bool _is_rev1)
+{
+  is_rev1 = _is_rev1;
+  tx_frame_asm.set_is_rev1(_is_rev1);
+  rx_frame_asm.set_is_rev1(_is_rev1);
+}
+
+void FrameAssemblerV2::create_session_stream_handlers(
+  const AuthConnectionMeta &auth_meta,
+  bool crossed)
+{
+  session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
+      nullptr, auth_meta, is_rev1, crossed);
+}
+
+void FrameAssemblerV2::reset_handlers()
+{
+  session_stream_handlers = { nullptr, nullptr };
+  session_comp_handlers = { nullptr, nullptr };
+}
+
+FrameAssemblerV2::mover_t
+FrameAssemblerV2::to_replace()
+{
+  assert(has_socket());
+  socket = nullptr;
+  return mover_t{
+      std::move(conn.socket),
+      std::move(session_stream_handlers),
+      std::move(session_comp_handlers)};
+}
+
+void FrameAssemblerV2::replace_by(FrameAssemblerV2::mover_t &&mover)
+{
+  set_socket(std::move(mover.socket));
+  record_io = false;
+  rxbuf.clear();
+  txbuf.clear();
+  session_stream_handlers = std::move(mover.session_stream_handlers);
+  session_comp_handlers = std::move(mover.session_comp_handlers);
+}
+
+void FrameAssemblerV2::start_recording()
+{
+  record_io = true;
+  rxbuf.clear();
+  txbuf.clear();
+}
+
+FrameAssemblerV2::record_bufs_t
+FrameAssemblerV2::stop_recording()
+{
+  ceph_assert_always(record_io == true);
+  record_io = false;
+  return record_bufs_t{std::move(rxbuf), std::move(txbuf)};
+}
+
+bool FrameAssemblerV2::has_socket() const
+{
+  assert((socket && conn.socket) || (!socket && !conn.socket));
+  return socket != nullptr;
+}
+
+void FrameAssemblerV2::set_socket(SocketRef &&_socket)
+{
+  assert(!has_socket());
+  ceph_assert_always(!conn.socket);
+  socket = _socket.get();
+  conn.socket = std::move(_socket);
+  assert(has_socket());
+}
+
+void FrameAssemblerV2::learn_socket_ephemeral_port_as_connector(uint16_t port)
+{
+  assert(has_socket());
+  socket->learn_ephemeral_port_as_connector(port);
+}
+
+void FrameAssemblerV2::shutdown_socket()
+{
+  if (has_socket()) {
+    socket->shutdown();
+  }
+}
+
+seastar::future<> FrameAssemblerV2::reset_and_close_socket(bool do_reset)
+{
+  if (!has_socket()) {
+    return seastar::now();
+  }
+  if (do_reset) {
+    socket = nullptr;
+    return conn.socket->close(
+    ).then([sock = std::move(conn.socket)] {});
+  } else {
+    return socket->close();
+  }
+}
+
+seastar::future<Socket::tmp_buf>
+FrameAssemblerV2::read_exactly(std::size_t bytes)
+{
+  assert(has_socket());
+  if (unlikely(record_io)) {
+    return socket->read_exactly(bytes
+    ).then([this](auto bl) {
+      rxbuf.append(buffer::create(bl.share()));
+      return bl;
+    });
+  } else {
+    return socket->read_exactly(bytes);
+  };
+}
+
+seastar::future<ceph::bufferlist>
+FrameAssemblerV2::read(std::size_t bytes)
+{
+  assert(has_socket());
+  if (unlikely(record_io)) {
+    return socket->read(bytes
+    ).then([this](auto buf) {
+      rxbuf.append(buf);
+      return buf;
+    });
+  } else {
+    return socket->read(bytes);
+  }
+}
+
+seastar::future<>
+FrameAssemblerV2::write(ceph::bufferlist &&buf)
+{
+  assert(has_socket());
+  if (unlikely(record_io)) {
+    txbuf.append(buf);
+  }
+  return socket->write(std::move(buf));
+}
+
+seastar::future<>
+FrameAssemblerV2::flush()
+{
+  assert(has_socket());
+  return socket->flush();
+}
+
+seastar::future<>
+FrameAssemblerV2::write_flush(ceph::bufferlist &&buf)
+{
+  assert(has_socket());
+  if (unlikely(record_io)) {
+    txbuf.append(buf);
+  }
+  return socket->write_flush(std::move(buf));
+}
+
+seastar::future<FrameAssemblerV2::read_main_t>
+FrameAssemblerV2::read_main_preamble()
+{
+  rx_preamble.clear();
+  return read_exactly(rx_frame_asm.get_preamble_onwire_len()
+  ).then([this](auto bl) {
+    try {
+      rx_preamble.append(buffer::create(std::move(bl)));
+      const Tag tag = rx_frame_asm.disassemble_preamble(rx_preamble);
+      return read_main_t{tag, &rx_frame_asm};
+    } catch (FrameError& e) {
+      logger().warn("{} read_main_preamble: {}", conn, e.what());
+      throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
+    }
+  });
+}
+
+seastar::future<FrameAssemblerV2::read_payload_t*>
+FrameAssemblerV2::read_frame_payload()
+{
+  rx_segments_data.clear();
+  return seastar::do_until(
+    [this] {
+      return rx_frame_asm.get_num_segments() == rx_segments_data.size();
+    },
+    [this] {
+      // TODO: create aligned and contiguous buffer from socket
+      const size_t seg_idx = rx_segments_data.size();
+      if (uint16_t alignment = rx_frame_asm.get_segment_align(seg_idx);
+          alignment != segment_t::DEFAULT_ALIGNMENT) {
+        logger().trace("{} cannot allocate {} aligned buffer at segment desc index {}",
+                       conn, alignment, rx_segments_data.size());
+      }
+      uint32_t onwire_len = rx_frame_asm.get_segment_onwire_len(seg_idx);
+      // TODO: create aligned and contiguous buffer from socket
+      return read_exactly(onwire_len
+      ).then([this](auto tmp_bl) {
+        logger().trace("{} RECV({}) frame segment[{}]",
+                       conn, tmp_bl.size(), rx_segments_data.size());
+        bufferlist segment;
+        segment.append(buffer::create(std::move(tmp_bl)));
+        rx_segments_data.emplace_back(std::move(segment));
+      });
+    }
+  ).then([this] {
+    return read_exactly(rx_frame_asm.get_epilogue_onwire_len());
+  }).then([this](auto bl) {
+    logger().trace("{} RECV({}) frame epilogue", conn, bl.size());
+    bool ok = false;
+    try {
+      bufferlist rx_epilogue;
+      rx_epilogue.append(buffer::create(std::move(bl)));
+      ok = rx_frame_asm.disassemble_segments(rx_preamble, rx_segments_data.data(), rx_epilogue);
+    } catch (FrameError& e) {
+      logger().error("read_frame_payload: {} {}", conn, e.what());
+      throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
+    } catch (ceph::crypto::onwire::MsgAuthError&) {
+      logger().error("read_frame_payload: {} bad auth tag", conn);
+      throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
+    }
+    // we do have a mechanism that allows transmitter to start sending message
+    // and abort after putting entire data field on wire. This will be used by
+    // the kernel client to avoid unnecessary buffering.
+    if (!ok) {
+      ceph_abort("TODO");
+    }
+    return &rx_segments_data;
+  });
+}
+
+void FrameAssemblerV2::log_main_preamble(const ceph::bufferlist &bl)
+{
+  const auto main_preamble =
+    reinterpret_cast<const preamble_block_t*>(bl.front().c_str());
+  logger().trace("{} SEND({}) frame: tag={}, num_segments={}, crc={}",
+                 conn, bl.length(), (int)main_preamble->tag,
+                 (int)main_preamble->num_segments, main_preamble->crc);
+}
+
+} // namespace crimson::net

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -83,7 +83,12 @@ seastar::future<> FrameAssemblerV2::replace_by(FrameAssemblerV2::mover_t &&mover
   txbuf.clear();
   session_stream_handlers = std::move(mover.session_stream_handlers);
   session_comp_handlers = std::move(mover.session_comp_handlers);
-  return replace_shutdown_socket(std::move(mover.socket));
+  if (has_socket()) {
+    return replace_shutdown_socket(std::move(mover.socket));
+  } else {
+    set_socket(std::move(mover.socket));
+    return seastar::now();
+  }
 }
 
 void FrameAssemblerV2::start_recording()

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -1,0 +1,158 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "msg/async/frames_v2.h"
+#include "msg/async/crypto_onwire.h"
+#include "msg/async/compression_onwire.h"
+
+#include "crimson/net/Socket.h"
+
+namespace crimson::net {
+
+class SocketConnection;
+
+class FrameAssemblerV2 {
+public:
+  FrameAssemblerV2(SocketConnection &conn);
+
+  ~FrameAssemblerV2() = default;
+
+  FrameAssemblerV2(const FrameAssemblerV2 &) = delete;
+
+  FrameAssemblerV2(FrameAssemblerV2 &&) = delete;
+
+  void set_is_rev1(bool is_rev1);
+
+  void create_session_stream_handlers(
+      const AuthConnectionMeta &auth_meta,
+      bool crossed);
+
+  void reset_handlers();
+
+  /*
+   * replacing
+   */
+
+  struct mover_t {
+    SocketRef socket;
+    ceph::crypto::onwire::rxtx_t session_stream_handlers;
+    ceph::compression::onwire::rxtx_t session_comp_handlers;
+  };
+
+  mover_t to_replace();
+
+  void replace_by(mover_t &&);
+
+  /*
+   * auth signature interfaces
+   */
+
+  void start_recording();
+
+  struct record_bufs_t {
+    ceph::bufferlist rxbuf;
+    ceph::bufferlist txbuf;
+  };
+  record_bufs_t stop_recording();
+
+  /*
+   * socket maintainence interfaces
+   */
+
+  bool has_socket() const;
+
+  void set_socket(SocketRef &&);
+
+  void learn_socket_ephemeral_port_as_connector(uint16_t port);
+
+  void shutdown_socket();
+
+  seastar::future<> reset_and_close_socket(bool do_reset=true);
+
+  /*
+   * socket read and write interfaces
+   */
+
+  seastar::future<Socket::tmp_buf> read_exactly(std::size_t bytes);
+
+  seastar::future<ceph::bufferlist> read(std::size_t bytes);
+
+  seastar::future<> write(ceph::bufferlist &&);
+
+  seastar::future<> flush();
+
+  seastar::future<> write_flush(ceph::bufferlist &&);
+
+  /*
+   * frame read and write interfaces
+   */
+
+  /// may throw negotiation_failure as fault
+  struct read_main_t {
+    ceph::msgr::v2::Tag tag;
+    const ceph::msgr::v2::FrameAssembler *rx_frame_asm;
+  };
+  seastar::future<read_main_t> read_main_preamble();
+
+  /// may throw negotiation_failure as fault
+  using read_payload_t = ceph::msgr::v2::segment_bls_t;
+  // FIXME: read_payload_t cannot be no-throw move constructible
+  seastar::future<read_payload_t*> read_frame_payload();
+
+  template <class F>
+  ceph::bufferlist get_buffer(F &tx_frame) {
+    auto bl = tx_frame.get_buffer(tx_frame_asm);
+    log_main_preamble(bl);
+    return bl;
+  }
+
+  template <class F>
+  seastar::future<> write_flush_frame(F &tx_frame) {
+    auto bl = get_buffer(tx_frame);
+    return write_flush(std::move(bl));
+  }
+
+private:
+  void log_main_preamble(const ceph::bufferlist &bl);
+
+  SocketConnection &conn;
+
+  Socket *socket = nullptr;
+
+  /*
+   * auth signature
+   */
+
+  bool record_io = false;
+
+  ceph::bufferlist rxbuf;
+
+  ceph::bufferlist txbuf;
+
+  /*
+   * frame data and handlers
+   */
+
+  ceph::crypto::onwire::rxtx_t session_stream_handlers = { nullptr, nullptr };
+
+  // TODO
+  ceph::compression::onwire::rxtx_t session_comp_handlers = { nullptr, nullptr };
+
+  bool is_rev1 = false;
+
+  ceph::msgr::v2::FrameAssembler tx_frame_asm{
+    &session_stream_handlers, is_rev1, common::local_conf()->ms_crc_data,
+    &session_comp_handlers};
+
+  ceph::msgr::v2::FrameAssembler rx_frame_asm{
+    &session_stream_handlers, is_rev1, common::local_conf()->ms_crc_data,
+    &session_comp_handlers};
+
+  ceph::bufferlist rx_preamble;
+
+  read_payload_t rx_segments_data;
+};
+
+} // namespace crimson::net

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -43,7 +43,7 @@ public:
 
   mover_t to_replace();
 
-  void replace_by(mover_t &&);
+  seastar::future<> replace_by(mover_t &&);
 
   /*
    * auth signature interfaces
@@ -61,15 +61,15 @@ public:
    * socket maintainence interfaces
    */
 
-  bool has_socket() const;
-
   void set_socket(SocketRef &&);
 
   void learn_socket_ephemeral_port_as_connector(uint16_t port);
 
   void shutdown_socket();
 
-  seastar::future<> reset_and_close_socket(bool do_reset=true);
+  seastar::future<> replace_shutdown_socket(SocketRef &&);
+
+  seastar::future<> close_shutdown_socket();
 
   /*
    * socket read and write interfaces
@@ -115,6 +115,10 @@ public:
   }
 
 private:
+  bool has_socket() const;
+
+  bool is_socket_valid() const;
+
   void log_main_preamble(const ceph::bufferlist &bl);
 
   SocketConnection &conn;

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -12,6 +12,8 @@
 namespace crimson::net {
 
 class SocketConnection;
+class FrameAssemblerV2;
+using FrameAssemblerV2Ref = std::unique_ptr<FrameAssemblerV2>;
 
 class FrameAssemblerV2 {
 public:
@@ -119,6 +121,8 @@ public:
     auto bl = get_buffer(tx_frame);
     return write_flush(std::move(bl));
   }
+
+  static FrameAssemblerV2Ref create(SocketConnection &conn);
 
 private:
   bool has_socket() const;

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -103,6 +103,9 @@ public:
 
   template <class F>
   ceph::bufferlist get_buffer(F &tx_frame) {
+#ifdef UNIT_TESTS_BUILT
+    intercept_frame(F::tag, true);
+#endif
     auto bl = tx_frame.get_buffer(tx_frame_asm);
     log_main_preamble(bl);
     return bl;
@@ -120,6 +123,10 @@ private:
   bool is_socket_valid() const;
 
   void log_main_preamble(const ceph::bufferlist &bl);
+
+#ifdef UNIT_TESTS_BUILT
+  void intercept_frame(ceph::msgr::v2::Tag, bool is_write);
+#endif
 
   SocketConnection &conn;
 

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -61,6 +61,9 @@ public:
    * socket maintainence interfaces
    */
 
+  // the socket exists and not shutdown
+  bool is_socket_valid() const;
+
   void set_socket(SocketRef &&);
 
   void learn_socket_ephemeral_port_as_connector(uint16_t port);
@@ -119,8 +122,6 @@ public:
 
 private:
   bool has_socket() const;
-
-  bool is_socket_valid() const;
 
   void log_main_preamble(const ceph::bufferlist &bl);
 

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -269,6 +269,31 @@ void Protocol::reset_out()
   ack_left = 0;
 }
 
+void Protocol::dispatch_accept()
+{
+  dispatchers.ms_handle_accept(
+    seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
+}
+
+void Protocol::dispatch_connect()
+{
+  dispatchers.ms_handle_connect(
+    seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
+}
+
+void Protocol::dispatch_reset(bool is_replace)
+{
+  dispatchers.ms_handle_reset(
+    seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
+    is_replace);
+}
+
+void Protocol::dispatch_remote_reset()
+{
+  dispatchers.ms_handle_remote_reset(
+    seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
+}
+
 void Protocol::ack_out_sent(seq_num_t seq)
 {
   if (conn.policy.lossy) {  // lossy connections don't keep sent messages

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -245,6 +245,16 @@ seastar::future<FrameAssemblerV2Ref> Protocol::wait_io_exit_dispatching()
   });
 }
 
+void Protocol::reset_session(bool full)
+{
+  // reset in
+  in_seq = 0;
+  if (full) {
+    reset_out();
+    dispatch_remote_reset();
+  }
+}
+
 void Protocol::requeue_out_sent()
 {
   assert(io_state != io_state_t::open);

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -479,7 +479,7 @@ void Protocol::notify_out_dispatch()
      [[fallthrough]];
    case out_state_t::delay:
     assert(!gate.is_closed());
-    gate.dispatch_in_background("do_out_dispatch", *this, [this] {
+    gate.dispatch_in_background("do_out_dispatch", conn, [this] {
       return do_out_dispatch();
     });
     return;
@@ -607,7 +607,7 @@ void Protocol::do_in_dispatch()
 {
   ceph_assert_always(!in_exit_dispatching.has_value());
   in_exit_dispatching = seastar::promise<>();
-  gate.dispatch_in_background("do_in_dispatch", *this, [this] {
+  gate.dispatch_in_background("do_in_dispatch", conn, [this] {
     return seastar::keep_doing([this] {
       return frame_assembler->read_main_preamble(
       ).then([this](auto ret) {

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -28,7 +28,7 @@ Protocol::Protocol(ChainedDispatchers& dispatchers,
 Protocol::~Protocol()
 {
   ceph_assert(gate.is_closed());
-  assert(!exit_open);
+  assert(!out_exit_dispatching);
 }
 
 void Protocol::close(bool dispatch_reset,
@@ -53,7 +53,7 @@ void Protocol::close(bool dispatch_reset,
   if (conn.socket) {
     conn.socket->shutdown();
   }
-  set_write_state(write_state_t::drop);
+  set_out_state(out_state_t::drop);
   assert(!gate.is_closed());
   auto gate_closed = gate.close();
 
@@ -86,139 +86,143 @@ void Protocol::close(bool dispatch_reset,
   });
 }
 
-ceph::bufferlist Protocol::sweep_messages_and_move_to_sent(
+ceph::bufferlist Protocol::sweep_out_pending_msgs_to_sent(
       size_t num_msgs,
       bool require_keepalive,
-      std::optional<utime_t> keepalive_ack,
+      std::optional<utime_t> maybe_keepalive_ack,
       bool require_ack)
 {
-  ceph::bufferlist bl = do_sweep_messages(out_q,
+  ceph::bufferlist bl = do_sweep_messages(out_pending_msgs,
                                           num_msgs,
                                           require_keepalive,
-                                          keepalive_ack,
+                                          maybe_keepalive_ack,
                                           require_ack);
   if (!conn.policy.lossy) {
-    sent.insert(sent.end(),
-                std::make_move_iterator(out_q.begin()),
-                std::make_move_iterator(out_q.end()));
+    out_sent_msgs.insert(
+        out_sent_msgs.end(),
+        std::make_move_iterator(out_pending_msgs.begin()),
+        std::make_move_iterator(out_pending_msgs.end()));
   }
-  out_q.clear();
+  out_pending_msgs.clear();
   return bl;
 }
 
 seastar::future<> Protocol::send(MessageURef msg)
 {
-  if (write_state != write_state_t::drop) {
-    out_q.push_back(std::move(msg));
-    write_event();
+  if (out_state != out_state_t::drop) {
+    out_pending_msgs.push_back(std::move(msg));
+    notify_out_dispatch();
   }
   return seastar::now();
 }
 
-seastar::future<> Protocol::keepalive()
+seastar::future<> Protocol::send_keepalive()
 {
   if (!need_keepalive) {
     need_keepalive = true;
-    write_event();
+    notify_out_dispatch();
   }
   return seastar::now();
 }
 
-void Protocol::notify_keepalive_ack(utime_t _keepalive_ack)
+void Protocol::notify_keepalive_ack(utime_t keepalive_ack)
 {
-  logger().trace("{} got keepalive ack {}", conn, _keepalive_ack);
-  keepalive_ack = _keepalive_ack;
-  write_event();
+  logger().trace("{} got keepalive ack {}", conn, keepalive_ack);
+  next_keepalive_ack = keepalive_ack;
+  notify_out_dispatch();
 }
 
 void Protocol::notify_ack()
 {
   if (!conn.policy.lossy) {
     ++ack_left;
-    write_event();
+    notify_out_dispatch();
   }
 }
 
-void Protocol::requeue_sent()
+void Protocol::requeue_out_sent()
 {
-  assert(write_state != write_state_t::open);
-  if (sent.empty()) {
+  assert(out_state != out_state_t::open);
+  if (out_sent_msgs.empty()) {
     return;
   }
 
-  out_seq -= sent.size();
+  out_seq -= out_sent_msgs.size();
   logger().debug("{} requeue {} items, revert out_seq to {}",
-                 conn, sent.size(), out_seq);
-  for (MessageURef& msg : sent) {
+                 conn, out_sent_msgs.size(), out_seq);
+  for (MessageURef& msg : out_sent_msgs) {
     msg->clear_payload();
     msg->set_seq(0);
   }
-  out_q.insert(out_q.begin(),
-               std::make_move_iterator(sent.begin()),
-               std::make_move_iterator(sent.end()));
-  sent.clear();
-  write_event();
+  out_pending_msgs.insert(
+      out_pending_msgs.begin(),
+      std::make_move_iterator(out_sent_msgs.begin()),
+      std::make_move_iterator(out_sent_msgs.end()));
+  out_sent_msgs.clear();
+  notify_out_dispatch();
 }
 
-void Protocol::requeue_up_to(seq_num_t seq)
+void Protocol::requeue_out_sent_up_to(seq_num_t seq)
 {
-  assert(write_state != write_state_t::open);
-  if (sent.empty() && out_q.empty()) {
+  assert(out_state != out_state_t::open);
+  if (out_sent_msgs.empty() && out_pending_msgs.empty()) {
     logger().debug("{} nothing to requeue, reset out_seq from {} to seq {}",
                    conn, out_seq, seq);
     out_seq = seq;
     return;
   }
-  logger().debug("{} discarding sent items by seq {} (sent_len={}, out_seq={})",
-                 conn, seq, sent.size(), out_seq);
-  while (!sent.empty()) {
-    auto cur_seq = sent.front()->get_seq();
+  logger().debug("{} discarding sent msgs by seq {} (sent_len={}, out_seq={})",
+                 conn, seq, out_sent_msgs.size(), out_seq);
+  while (!out_sent_msgs.empty()) {
+    auto cur_seq = out_sent_msgs.front()->get_seq();
     if (cur_seq == 0 || cur_seq > seq) {
       break;
     } else {
-      sent.pop_front();
+      out_sent_msgs.pop_front();
     }
   }
-  requeue_sent();
+  requeue_out_sent();
 }
 
-void Protocol::reset_write()
+void Protocol::reset_out()
 {
-  assert(write_state != write_state_t::open);
+  assert(out_state != out_state_t::open);
   out_seq = 0;
-  out_q.clear();
-  sent.clear();
+  out_pending_msgs.clear();
+  out_sent_msgs.clear();
   need_keepalive = false;
-  keepalive_ack = std::nullopt;
+  next_keepalive_ack = std::nullopt;
   ack_left = 0;
 }
 
-void Protocol::ack_writes(seq_num_t seq)
+void Protocol::ack_out_sent(seq_num_t seq)
 {
   if (conn.policy.lossy) {  // lossy connections don't keep sent messages
     return;
   }
-  while (!sent.empty() && sent.front()->get_seq() <= seq) {
+  while (!out_sent_msgs.empty() &&
+         out_sent_msgs.front()->get_seq() <= seq) {
     logger().trace("{} got ack seq {} >= {}, pop {}",
-                   conn, seq, sent.front()->get_seq(), *sent.front());
-    sent.pop_front();
+                   conn, seq, out_sent_msgs.front()->get_seq(),
+                   *out_sent_msgs.front());
+    out_sent_msgs.pop_front();
   }
 }
 
-seastar::future<stop_t> Protocol::try_exit_sweep() {
-  assert(!is_queued());
+seastar::future<stop_t> Protocol::try_exit_out_dispatch() {
+  assert(!is_out_queued());
   return conn.socket->flush().then([this] {
-    if (!is_queued()) {
+    if (!is_out_queued()) {
       // still nothing pending to send after flush,
       // the dispatching can ONLY stop now
-      ceph_assert(write_dispatching);
-      write_dispatching = false;
-      if (unlikely(exit_open.has_value())) {
-        exit_open->set_value();
-        exit_open = std::nullopt;
-        logger().info("{} write_event: nothing queued at {},"
-                      " set exit_open",
-                      conn, write_state);
+      ceph_assert(out_dispatching);
+      out_dispatching = false;
+      if (unlikely(out_exit_dispatching.has_value())) {
+        out_exit_dispatching->set_value();
+        out_exit_dispatching = std::nullopt;
+        logger().info("{} do_out_dispatch: nothing queued at {},"
+                      " set out_exit_dispatching",
+                      conn, out_state);
       }
       return seastar::make_ready_future<stop_t>(stop_t::yes);
     } else {
@@ -228,56 +232,57 @@ seastar::future<stop_t> Protocol::try_exit_sweep() {
   });
 }
 
-seastar::future<> Protocol::do_write_dispatch_sweep()
+seastar::future<> Protocol::do_out_dispatch()
 {
   return seastar::repeat([this] {
-    switch (write_state) {
-     case write_state_t::open: {
-      size_t num_msgs = out_q.size();
-      bool still_queued = is_queued();
+    switch (out_state) {
+     case out_state_t::open: {
+      size_t num_msgs = out_pending_msgs.size();
+      bool still_queued = is_out_queued();
       if (unlikely(!still_queued)) {
-        return try_exit_sweep();
+        return try_exit_out_dispatch();
       }
-      auto acked = ack_left;
-      assert(acked == 0 || in_seq > 0);
-      // sweep all pending writes with the concrete Protocol
-      return conn.socket->write(sweep_messages_and_move_to_sent(
-          num_msgs, need_keepalive, keepalive_ack, acked > 0)
-      ).then([this, prv_keepalive_ack=keepalive_ack, acked] {
+      auto to_ack = ack_left;
+      assert(to_ack == 0 || in_seq > 0);
+      // sweep all pending out with the concrete Protocol
+      return conn.socket->write(
+        sweep_out_pending_msgs_to_sent(
+          num_msgs, need_keepalive, next_keepalive_ack, to_ack > 0)
+      ).then([this, prv_keepalive_ack=next_keepalive_ack, to_ack] {
         need_keepalive = false;
-        if (keepalive_ack == prv_keepalive_ack) {
-          keepalive_ack = std::nullopt;
+        if (next_keepalive_ack == prv_keepalive_ack) {
+          next_keepalive_ack = std::nullopt;
         }
-        assert(ack_left >= acked);
-        ack_left -= acked;
-        if (!is_queued()) {
-          return try_exit_sweep();
+        assert(ack_left >= to_ack);
+        ack_left -= to_ack;
+        if (!is_out_queued()) {
+          return try_exit_out_dispatch();
         } else {
           // messages were enqueued during socket write
           return seastar::make_ready_future<stop_t>(stop_t::no);
         }
       });
      }
-     case write_state_t::delay:
-      // delay dispatching writes until open
-      if (exit_open) {
-        exit_open->set_value();
-        exit_open = std::nullopt;
-        logger().info("{} write_event: delay and set exit_open ...", conn);
+     case out_state_t::delay:
+      // delay out dispatching until open
+      if (out_exit_dispatching) {
+        out_exit_dispatching->set_value();
+        out_exit_dispatching = std::nullopt;
+        logger().info("{} do_out_dispatch: delay and set out_exit_dispatching ...", conn);
       } else {
-        logger().info("{} write_event: delay ...", conn);
+        logger().info("{} do_out_dispatch: delay ...", conn);
       }
-      return state_changed.get_shared_future()
-      .then([] { return stop_t::no; });
-     case write_state_t::drop:
-      ceph_assert(write_dispatching);
-      write_dispatching = false;
-      if (exit_open) {
-        exit_open->set_value();
-        exit_open = std::nullopt;
-        logger().info("{} write_event: dropped and set exit_open", conn);
+      return out_state_changed.get_shared_future(
+      ).then([] { return stop_t::no; });
+     case out_state_t::drop:
+      ceph_assert(out_dispatching);
+      out_dispatching = false;
+      if (out_exit_dispatching) {
+        out_exit_dispatching->set_value();
+        out_exit_dispatching = std::nullopt;
+        logger().info("{} do_out_dispatch: dropped and set out_exit_dispatching", conn);
       } else {
-        logger().info("{} write_event: dropped", conn);
+        logger().info("{} do_out_dispatch: dropped", conn);
       }
       return seastar::make_ready_future<stop_t>(stop_t::yes);
      default:
@@ -287,42 +292,42 @@ seastar::future<> Protocol::do_write_dispatch_sweep()
     if (e.code() != std::errc::broken_pipe &&
         e.code() != std::errc::connection_reset &&
         e.code() != error::negotiation_failure) {
-      logger().error("{} write_event(): unexpected error at {} -- {}",
-                     conn, write_state, e);
+      logger().error("{} do_out_dispatch(): unexpected error at {} -- {}",
+                     conn, out_state, e);
       ceph_abort();
     }
     conn.socket->shutdown();
-    if (write_state == write_state_t::open) {
-      logger().info("{} write_event(): fault at {}, going to delay -- {}",
-                    conn, write_state, e);
-      write_state = write_state_t::delay;
+    if (out_state == out_state_t::open) {
+      logger().info("{} do_out_dispatch(): fault at {}, going to delay -- {}",
+                    conn, out_state, e);
+      out_state = out_state_t::delay;
     } else {
-      logger().info("{} write_event(): fault at {} -- {}",
-                    conn, write_state, e);
+      logger().info("{} do_out_dispatch(): fault at {} -- {}",
+                    conn, out_state, e);
     }
-    return do_write_dispatch_sweep();
+    return do_out_dispatch();
   });
 }
 
-void Protocol::write_event()
+void Protocol::notify_out_dispatch()
 {
-  notify_write();
-  if (write_dispatching) {
+  notify_out();
+  if (out_dispatching) {
     // already dispatching
     return;
   }
-  write_dispatching = true;
-  switch (write_state) {
-   case write_state_t::open:
+  out_dispatching = true;
+  switch (out_state) {
+   case out_state_t::open:
      [[fallthrough]];
-   case write_state_t::delay:
+   case out_state_t::delay:
     assert(!gate.is_closed());
-    gate.dispatch_in_background("do_write_dispatch_sweep", *this, [this] {
-      return do_write_dispatch_sweep();
+    gate.dispatch_in_background("do_out_dispatch", *this, [this] {
+      return do_out_dispatch();
     });
     return;
-   case write_state_t::drop:
-    write_dispatching = false;
+   case out_state_t::drop:
+    out_dispatching = false;
     return;
    default:
     ceph_assert(false);

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -242,8 +242,15 @@ seastar::future<> Protocol::do_out_dispatch()
                      conn, out_state, e);
       ceph_abort();
     }
-    ceph_assert_always(frame_assembler.has_socket());
-    frame_assembler.shutdown_socket();
+
+    std::exception_ptr eptr;
+    try {
+      throw e;
+    } catch(...) {
+      eptr = std::current_exception();
+    }
+    notify_out_fault(eptr);
+
     if (out_state == out_state_t::open) {
       logger().info("{} do_out_dispatch(): fault at {}, going to delay -- {}",
                     conn, out_state, e);

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -173,7 +173,7 @@ void Protocol::set_out_state(
   if (out_state != new_state) {
     out_state = new_state;
     out_state_changed.set_value();
-    out_state_changed = seastar::shared_promise<>();
+    out_state_changed = seastar::promise<>();
   }
 
   // The above needs to be atomic
@@ -335,7 +335,7 @@ seastar::future<> Protocol::do_out_dispatch()
       } else {
         logger().info("{} do_out_dispatch: delay ...", conn);
       }
-      return out_state_changed.get_shared_future(
+      return out_state_changed.get_future(
       ).then([] { return stop_t::no; });
      case out_state_t::drop:
       ceph_assert(out_dispatching);

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -5,6 +5,7 @@
 
 #include "auth/Auth.h"
 
+#include "crimson/common/formatter.h"
 #include "crimson/common/log.h"
 #include "crimson/net/Errors.h"
 #include "crimson/net/chained_dispatchers.h"
@@ -12,10 +13,32 @@
 #include "crimson/net/SocketMessenger.h"
 #include "msg/Message.h"
 
+using namespace ceph::msgr::v2;
+using crimson::common::local_conf;
+
 namespace {
 
 seastar::logger& logger() {
   return crimson::get_logger(ceph_subsys_ms);
+}
+
+[[noreturn]] void abort_in_fault() {
+  throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
+}
+
+[[noreturn]] void abort_protocol() {
+  throw std::system_error(make_error_code(crimson::net::error::protocol_aborted));
+}
+
+std::size_t get_msg_size(const FrameAssembler &rx_frame_asm)
+{
+  ceph_assert(rx_frame_asm.get_num_segments() > 0);
+  size_t sum = 0;
+  // we don't include SegmentIndex::Msg::HEADER.
+  for (size_t idx = 1; idx < rx_frame_asm.get_num_segments(); idx++) {
+    sum += rx_frame_asm.get_segment_logical_len(idx);
+  }
+  return sum;
 }
 
 } // namespace anonymous
@@ -125,13 +148,22 @@ void Protocol::set_out_state(
     (new_state != out_state_t::drop && out_state == out_state_t::drop)
   ));
 
+  bool dispatch_in = false;
   if (out_state != out_state_t::open &&
       new_state == out_state_t::open) {
     // to open
     ceph_assert_always(frame_assembler.is_socket_valid());
+    dispatch_in = true;
+#ifdef UNIT_TESTS_BUILT
+    if (conn.interceptor) {
+      conn.interceptor->register_conn_ready(conn);
+    }
+#endif
   } else if (out_state == out_state_t::open &&
              new_state != out_state_t::open) {
     // from open
+    ceph_assert_always(frame_assembler.is_socket_valid());
+    frame_assembler.shutdown_socket();
     if (out_dispatching) {
       ceph_assert_always(!out_exit_dispatching.has_value());
       out_exit_dispatching = seastar::shared_promise<>();
@@ -143,21 +175,33 @@ void Protocol::set_out_state(
     out_state_changed.set_value();
     out_state_changed = seastar::shared_promise<>();
   }
-}
 
-void Protocol::notify_keepalive_ack(utime_t keepalive_ack)
-{
-  logger().trace("{} got keepalive ack {}", conn, keepalive_ack);
-  next_keepalive_ack = keepalive_ack;
-  notify_out_dispatch();
-}
-
-void Protocol::notify_ack()
-{
-  if (!conn.policy.lossy) {
-    ++ack_left;
-    notify_out_dispatch();
+  // The above needs to be atomic
+  if (dispatch_in) {
+    do_in_dispatch();
   }
+}
+
+seastar::future<> Protocol::wait_io_exit_dispatching()
+{
+  ceph_assert_always(out_state != out_state_t::open);
+  ceph_assert_always(!frame_assembler.is_socket_valid());
+  return seastar::when_all(
+    [this] {
+      if (out_exit_dispatching) {
+        return out_exit_dispatching->get_shared_future();
+      } else {
+        return seastar::now();
+      }
+    }(),
+    [this] {
+      if (in_exit_dispatching) {
+        return in_exit_dispatching->get_shared_future();
+      } else {
+        return seastar::now();
+      }
+    }()
+  ).discard_result();
 }
 
 void Protocol::requeue_out_sent()
@@ -326,7 +370,7 @@ seastar::future<> Protocol::do_out_dispatch()
         eptr = std::current_exception();
       }
       set_out_state(out_state_t::delay);
-      notify_out_fault(eptr);
+      notify_out_fault("do_out_dispatch", eptr);
     } else {
       logger().info("{} do_out_dispatch(): fault at {} -- {}",
                     conn, out_state, e);
@@ -359,6 +403,220 @@ void Protocol::notify_out_dispatch()
    default:
     ceph_assert(false);
   }
+}
+
+seastar::future<>
+Protocol::read_message(utime_t throttle_stamp, std::size_t msg_size)
+{
+  return frame_assembler.read_frame_payload(
+  ).then([this, throttle_stamp, msg_size](auto payload) {
+    if (unlikely(out_state != out_state_t::open)) {
+      logger().debug("{} triggered {} during read_message()",
+                     conn, out_state);
+      abort_protocol();
+    }
+
+    utime_t recv_stamp{seastar::lowres_system_clock::now()};
+
+    // we need to get the size before std::moving segments data
+    auto msg_frame = MessageFrame::Decode(*payload);
+    // XXX: paranoid copy just to avoid oops
+    ceph_msg_header2 current_header = msg_frame.header();
+
+    logger().trace("{} got {} + {} + {} byte message,"
+                   " envelope type={} src={} off={} seq={}",
+                   conn, msg_frame.front_len(), msg_frame.middle_len(),
+                   msg_frame.data_len(), current_header.type, conn.get_peer_name(),
+                   current_header.data_off, current_header.seq);
+
+    ceph_msg_header header{current_header.seq,
+                           current_header.tid,
+                           current_header.type,
+                           current_header.priority,
+                           current_header.version,
+                           ceph_le32(msg_frame.front_len()),
+                           ceph_le32(msg_frame.middle_len()),
+                           ceph_le32(msg_frame.data_len()),
+                           current_header.data_off,
+                           conn.get_peer_name(),
+                           current_header.compat_version,
+                           current_header.reserved,
+                           ceph_le32(0)};
+    ceph_msg_footer footer{ceph_le32(0), ceph_le32(0),
+                           ceph_le32(0), ceph_le64(0), current_header.flags};
+
+    auto conn_ref = seastar::static_pointer_cast<SocketConnection>(
+        conn.shared_from_this());
+    Message *message = decode_message(nullptr, 0, header, footer,
+        msg_frame.front(), msg_frame.middle(), msg_frame.data(), conn_ref);
+    if (!message) {
+      logger().warn("{} decode message failed", conn);
+      abort_in_fault();
+    }
+
+    // store reservation size in message, so we don't get confused
+    // by messages entering the dispatch queue through other paths.
+    message->set_dispatch_throttle_size(msg_size);
+
+    message->set_throttle_stamp(throttle_stamp);
+    message->set_recv_stamp(recv_stamp);
+    message->set_recv_complete_stamp(utime_t{seastar::lowres_system_clock::now()});
+
+    // check received seq#.  if it is old, drop the message.
+    // note that incoming messages may skip ahead.  this is convenient for the
+    // client side queueing because messages can't be renumbered, but the (kernel)
+    // client will occasionally pull a message out of the sent queue to send
+    // elsewhere.  in that case it doesn't matter if we "got" it or not.
+    uint64_t cur_seq = get_in_seq();
+    if (message->get_seq() <= cur_seq) {
+      logger().error("{} got old message {} <= {} {}, discarding",
+                     conn, message->get_seq(), cur_seq, *message);
+      if (HAVE_FEATURE(conn.features, RECONNECT_SEQ) &&
+          local_conf()->ms_die_on_old_message) {
+        ceph_assert(0 == "old msgs despite reconnect_seq feature");
+      }
+      return seastar::now();
+    } else if (message->get_seq() > cur_seq + 1) {
+      logger().error("{} missed message? skipped from seq {} to {}",
+                     conn, cur_seq, message->get_seq());
+      if (local_conf()->ms_die_on_skipped_message) {
+        ceph_assert(0 == "skipped incoming seq");
+      }
+    }
+
+    // note last received message.
+    in_seq = message->get_seq();
+    if (conn.policy.lossy) {
+      logger().debug("{} <== #{} === {} ({})",
+                     conn,
+                     message->get_seq(),
+                     *message,
+                     message->get_type());
+    } else {
+      logger().debug("{} <== #{},{} === {} ({})",
+                     conn,
+                     message->get_seq(),
+                     current_header.ack_seq,
+                     *message,
+                     message->get_type());
+    }
+
+    // notify ack
+    if (!conn.policy.lossy) {
+      ++ack_left;
+      notify_out_dispatch();
+    }
+
+    ack_out_sent(current_header.ack_seq);
+
+    // TODO: change MessageRef with seastar::shared_ptr
+    auto msg_ref = MessageRef{message, false};
+    assert(out_state == out_state_t::open);
+    // throttle the reading process by the returned future
+    return dispatchers.ms_dispatch(conn_ref, std::move(msg_ref));
+  });
+}
+
+void Protocol::do_in_dispatch()
+{
+  ceph_assert_always(!in_exit_dispatching.has_value());
+  in_exit_dispatching = seastar::shared_promise<>();
+  gate.dispatch_in_background("do_in_dispatch", *this, [this] {
+    return seastar::keep_doing([this] {
+      return frame_assembler.read_main_preamble(
+      ).then([this](auto ret) {
+        switch (ret.tag) {
+          case Tag::MESSAGE: {
+            size_t msg_size = get_msg_size(*ret.rx_frame_asm);
+            return seastar::futurize_invoke([this] {
+              // throttle_message() logic
+              if (!conn.policy.throttler_messages) {
+                return seastar::now();
+              }
+              // TODO: message throttler
+              ceph_assert(false);
+              return seastar::now();
+            }).then([this, msg_size] {
+              // throttle_bytes() logic
+              if (!conn.policy.throttler_bytes) {
+                return seastar::now();
+              }
+              if (!msg_size) {
+                return seastar::now();
+              }
+              logger().trace("{} wants {} bytes from policy throttler {}/{}",
+                             conn, msg_size,
+                             conn.policy.throttler_bytes->get_current(),
+                             conn.policy.throttler_bytes->get_max());
+              return conn.policy.throttler_bytes->get(msg_size);
+            }).then([this, msg_size] {
+              // TODO: throttle_dispatch_queue() logic
+              utime_t throttle_stamp{seastar::lowres_system_clock::now()};
+              return read_message(throttle_stamp, msg_size);
+            });
+          }
+          case Tag::ACK:
+            return frame_assembler.read_frame_payload(
+            ).then([this](auto payload) {
+              // handle_message_ack() logic
+              auto ack = AckFrame::Decode(payload->back());
+              logger().debug("{} GOT AckFrame: seq={}", conn, ack.seq());
+              ack_out_sent(ack.seq());
+            });
+          case Tag::KEEPALIVE2:
+            return frame_assembler.read_frame_payload(
+            ).then([this](auto payload) {
+              // handle_keepalive2() logic
+              auto keepalive_frame = KeepAliveFrame::Decode(payload->back());
+              logger().debug("{} GOT KeepAliveFrame: timestamp={}",
+                             conn, keepalive_frame.timestamp());
+              // notify keepalive ack
+              next_keepalive_ack = keepalive_frame.timestamp();
+              notify_out_dispatch();
+
+              last_keepalive = seastar::lowres_system_clock::now();
+            });
+          case Tag::KEEPALIVE2_ACK:
+            return frame_assembler.read_frame_payload(
+            ).then([this](auto payload) {
+              // handle_keepalive2_ack() logic
+              auto keepalive_ack_frame = KeepAliveFrameAck::Decode(payload->back());
+              auto _last_keepalive_ack =
+                seastar::lowres_system_clock::time_point{keepalive_ack_frame.timestamp()};
+              set_last_keepalive_ack(_last_keepalive_ack);
+              logger().debug("{} GOT KeepAliveFrameAck: timestamp={}",
+                             conn, _last_keepalive_ack);
+            });
+          default: {
+            logger().warn("{} do_in_dispatch() received unexpected tag: {}",
+                          conn, static_cast<uint32_t>(ret.tag));
+            abort_in_fault();
+          }
+        }
+      });
+    }).handle_exception([this](std::exception_ptr eptr) {
+      const char *e_what;
+      try {
+        std::rethrow_exception(eptr);
+      } catch (std::exception &e) {
+        e_what = e.what();
+      }
+
+      if (out_state == out_state_t::open) {
+        logger().info("{} do_in_dispatch(): fault at {}, going to delay -- {}",
+                      conn, out_state, e_what);
+        set_out_state(out_state_t::delay);
+        notify_out_fault("do_in_dispatch", eptr);
+      } else {
+        logger().info("{} do_in_dispatch(): fault at {} -- {}",
+                      conn, out_state, e_what);
+      }
+    }).finally([this] {
+      ceph_assert_always(in_exit_dispatching.has_value());
+      in_exit_dispatching->set_value();
+      in_exit_dispatching = std::nullopt;
+    });
+  });
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -129,8 +129,6 @@ class Protocol {
 
   ChainedDispatchers& dispatchers;
 
-  SocketConnection &conn;
-
  private:
   bool is_out_queued() const {
     return (!out_pending_msgs.empty() ||
@@ -155,6 +153,8 @@ class Protocol {
   seastar::future<> read_message(utime_t throttle_stamp, std::size_t msg_size);
 
   void do_in_dispatch();
+
+  SocketConnection &conn;
 
   crimson::common::Gated gate;
 

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -11,6 +11,7 @@
 #include "crimson/common/log.h"
 #include "Fwd.h"
 #include "SocketConnection.h"
+#include "FrameAssemblerV2.h"
 
 namespace crimson::net {
 
@@ -141,13 +142,6 @@ class Protocol {
     in_seq = 0;
   }
 
-  bool is_out_queued() const {
-    return (!out_pending_msgs.empty() ||
-            ack_left > 0 ||
-            need_keepalive ||
-            next_keepalive_ack.has_value());
-  }
-
   bool is_out_queued_or_sent() const {
     return is_out_queued() || !out_sent_msgs.empty();
   }
@@ -174,7 +168,16 @@ class Protocol {
 
   SocketConnection &conn;
 
+  FrameAssemblerV2 frame_assembler;
+
  private:
+  bool is_out_queued() const {
+    return (!out_pending_msgs.empty() ||
+            ack_left > 0 ||
+            need_keepalive ||
+            next_keepalive_ack.has_value());
+  }
+
   seastar::future<stop_t> try_exit_out_dispatch();
 
   seastar::future<> do_out_dispatch();

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -21,8 +21,6 @@ class Protocol {
   Protocol(Protocol&&) = delete;
   virtual ~Protocol();
 
-  virtual bool is_connected() const = 0;
-
   virtual void close() = 0;
 
   virtual seastar::future<> close_clean_yielded() = 0;
@@ -52,6 +50,10 @@ class Protocol {
 // the write state-machine
  public:
   using clock_t = seastar::lowres_system_clock;
+
+  bool is_connected() const {
+    return protocol_is_connected;
+  }
 
   seastar::future<> send(MessageURef msg);
 
@@ -167,6 +169,8 @@ class Protocol {
   crimson::common::Gated gate;
 
   FrameAssemblerV2Ref frame_assembler;
+
+  bool protocol_is_connected = false;
 
   /*
    * out states for writing

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -35,8 +35,6 @@ class Protocol {
   virtual void start_accept(SocketRef&& socket,
                             const entity_addr_t& peer_addr) = 0;
 
-  virtual void print_conn(std::ostream&) const = 0;
-
  protected:
   Protocol(ChainedDispatchers& dispatchers,
            SocketConnection& conn);
@@ -209,11 +207,6 @@ class Protocol {
   clock_t::time_point last_keepalive_ack;
 };
 
-inline std::ostream& operator<<(std::ostream& out, const Protocol& proto) {
-  proto.print_conn(out);
-  return out;
-}
-
 inline std::ostream& operator<<(
     std::ostream& out, Protocol::io_stat_printer stat) {
   stat.protocol.print_io_stat(out);
@@ -246,7 +239,3 @@ struct fmt::formatter<crimson::net::Protocol::out_state_t>
     return formatter<string_view>::format(name, ctx);
   }
 };
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::net::Protocol> : fmt::ostream_formatter {};
-#endif

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -90,6 +90,11 @@ class Protocol {
 
 // TODO: encapsulate a SessionedSender class
  protected:
+  seastar::future<> close_out() {
+    assert(!gate.is_closed());
+    return gate.close();
+  }
+
   /**
    * out_state_t
    *
@@ -165,8 +170,6 @@ class Protocol {
     return ++out_seq;
   }
 
-  crimson::common::Gated gate;
-
   ChainedDispatchers& dispatchers;
 
   SocketConnection &conn;
@@ -183,6 +186,8 @@ class Protocol {
       bool require_ack);
 
   void notify_out_dispatch();
+
+  crimson::common::Gated gate;
 
   /*
    * out states for writing

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -54,6 +54,8 @@ class Protocol {
 
   virtual void notify_out() = 0;
 
+  virtual void notify_out_fault(std::exception_ptr) = 0;
+
 // the write state-machine
  public:
   using clock_t = seastar::lowres_system_clock;

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -167,7 +167,7 @@ class Protocol {
   out_state_t out_state = out_state_t::none;
 
   // wait until current out_state changed
-  seastar::shared_promise<> out_state_changed;
+  seastar::promise<> out_state_changed;
 
   bool out_dispatching = false;
 

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -75,9 +75,6 @@ class Protocol {
       std::optional<utime_t> keepalive_ack,
       bool require_ack); 
 
- public:
-  SocketRef socket;
-
  protected:
   ChainedDispatchers& dispatchers;
   SocketConnection &conn;

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -127,7 +127,13 @@ class Protocol {
     return in_seq;
   }
 
-  ChainedDispatchers& dispatchers;
+  void dispatch_accept();
+
+  void dispatch_connect();
+
+  void dispatch_reset(bool is_replace);
+
+  void dispatch_remote_reset();
 
  private:
   bool is_out_queued() const {
@@ -153,6 +159,8 @@ class Protocol {
   seastar::future<> read_message(utime_t throttle_stamp, std::size_t msg_size);
 
   void do_in_dispatch();
+
+  ChainedDispatchers &dispatchers;
 
   SocketConnection &conn;
 

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -460,7 +460,7 @@ ProtocolV2::banner_exchange(bool is_connect)
       //5. read peer HelloFrame
       return frame_assembler->read_main_preamble();
     }).then([this](auto ret) {
-      expect_tag(Tag::HELLO, ret.tag, conn, __func__);
+      expect_tag(Tag::HELLO, ret.tag, conn, "read_hello_frame");
       return frame_assembler->read_frame_payload();
     }).then([this](auto payload) {
       // 6. process peer HelloFrame
@@ -544,7 +544,7 @@ seastar::future<> ProtocolV2::handle_auth_reply()
           return finish_auth();
         });
       default: {
-        unexpected_tag(ret.tag, conn, __func__);
+        unexpected_tag(ret.tag, conn, "handle_auth_reply");
         return seastar::now();
       }
     }
@@ -959,7 +959,7 @@ seastar::future<> ProtocolV2::_handle_auth_request(bufferlist& auth_payload, boo
     ).then([this] {
       return frame_assembler->read_main_preamble();
     }).then([this](auto ret) {
-      expect_tag(Tag::AUTH_REQUEST_MORE, ret.tag, conn, __func__);
+      expect_tag(Tag::AUTH_REQUEST_MORE, ret.tag, conn, "read_auth_request_more");
       return frame_assembler->read_frame_payload();
     }).then([this](auto payload) {
       auto auth_more = AuthRequestMoreFrame::Decode(payload->back());
@@ -984,7 +984,7 @@ seastar::future<> ProtocolV2::server_auth()
 {
   return frame_assembler->read_main_preamble(
   ).then([this](auto ret) {
-    expect_tag(Tag::AUTH_REQUEST, ret.tag, conn, __func__);
+    expect_tag(Tag::AUTH_REQUEST, ret.tag, conn, "read_auth_request");
     return frame_assembler->read_frame_payload();
   }).then([this](auto payload) {
     // handle_auth_request() logic
@@ -1280,7 +1280,7 @@ ProtocolV2::read_reconnect()
 {
   return frame_assembler->read_main_preamble(
   ).then([this](auto ret) {
-    expect_tag(Tag::SESSION_RECONNECT, ret.tag, conn, "read_reconnect");
+    expect_tag(Tag::SESSION_RECONNECT, ret.tag, conn, "read_session_reconnect");
     return server_reconnect();
   });
 }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -166,12 +166,6 @@ ProtocolV2::ProtocolV2(ChainedDispatchers& dispatchers,
 
 ProtocolV2::~ProtocolV2() {}
 
-bool ProtocolV2::is_connected() const {
-  return state == state_t::READY ||
-         state == state_t::ESTABLISHING ||
-         state == state_t::REPLACING;
-}
-
 void ProtocolV2::start_connect(const entity_addr_t& _peer_addr,
                                const entity_name_t& _peer_name)
 {

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1862,7 +1862,7 @@ void ProtocolV2::execute_server_wait()
 
 // CLOSING state
 
-void ProtocolV2::close()
+void ProtocolV2::notify_mark_down()
 {
   do_close(false);
 }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -156,10 +156,10 @@ seastar::future<> ProtocolV2::Timer::backoff(double seconds)
 }
 
 ProtocolV2::ProtocolV2(ChainedDispatchers& dispatchers,
-                       SocketConnection& conn,
-                       SocketMessenger& messenger)
+                       SocketConnection& conn)
   : Protocol(dispatchers, conn),
-    messenger{messenger},
+    conn{conn},
+    messenger{conn.messenger},
     frame_assembler{FrameAssemblerV2::create(conn)},
     auth_meta{seastar::make_lw_shared<AuthConnectionMeta>()},
     protocol_timer{conn}

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1527,9 +1527,15 @@ void ProtocolV2::execute_accepting()
            default:
             ceph_abort("impossible next step");
           }
-        }).handle_exception([this] (std::exception_ptr eptr) {
+        }).handle_exception([this](std::exception_ptr eptr) {
+          const char *e_what;
+          try {
+            std::rethrow_exception(eptr);
+          } catch (std::exception &e) {
+            e_what = e.what();
+          }
           logger().info("{} execute_accepting(): fault at {}, going to CLOSING -- {}",
-                        conn, get_state_name(state), eptr);
+                        conn, get_state_name(state), e_what);
           do_close(false);
         });
     });
@@ -1834,9 +1840,15 @@ void ProtocolV2::execute_wait(bool max_backoff)
       }
       logger().info("{} execute_wait(): going to CONNECTING", conn);
       execute_connecting();
-    }).handle_exception([this] (std::exception_ptr eptr) {
+    }).handle_exception([this](std::exception_ptr eptr) {
+      const char *e_what;
+      try {
+        std::rethrow_exception(eptr);
+      } catch (std::exception &e) {
+        e_what = e.what();
+      }
       logger().info("{} execute_wait(): protocol aborted at {} -- {}",
-                    conn, get_state_name(state), eptr);
+                    conn, get_state_name(state), e_what);
       assert(state == state_t::REPLACING ||
              state == state_t::CLOSING);
     });
@@ -1854,9 +1866,15 @@ void ProtocolV2::execute_server_wait()
     ).then([this](auto bl) {
       logger().warn("{} SERVER_WAIT got read, abort", conn);
       abort_in_fault();
-    }).handle_exception([this] (std::exception_ptr eptr) {
+    }).handle_exception([this](std::exception_ptr eptr) {
+      const char *e_what;
+      try {
+        std::rethrow_exception(eptr);
+      } catch (std::exception &e) {
+        e_what = e.what();
+      }
       logger().info("{} execute_server_wait(): fault at {}, going to CLOSING -- {}",
-                    conn, get_state_name(state), eptr);
+                    conn, get_state_name(state), e_what);
       do_close(false);
     });
   });

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1640,7 +1640,9 @@ void ProtocolV2::trigger_replacing(bool reconnect,
     return wait_out_exit_dispatching(
     ).then([this] {
       protocol_timer.cancel();
-      return execution_done.get_future();
+      auto done = std::move(execution_done);
+      execution_done = seastar::now();
+      return done;
     }).then([this,
              reconnect,
              do_reset,

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1716,9 +1716,9 @@ void ProtocolV2::trigger_replacing(bool reconnect,
                                    uint64_t new_connect_seq,
                                    uint64_t new_msg_seq)
 {
-  trigger_state(state_t::REPLACING, io_state_t::delay, false);
-  ceph_assert_always(has_socket);
+  ceph_assert_always(has_socket || state == state_t::CONNECTING);
   ceph_assert_always(!mover.socket->is_shutdown());
+  trigger_state(state_t::REPLACING, io_state_t::delay, false);
   if (is_socket_valid) {
     frame_assembler->shutdown_socket();
     is_socket_valid = false;
@@ -1775,6 +1775,7 @@ void ProtocolV2::trigger_replacing(bool reconnect,
         }
       );
       is_socket_valid = true;
+      has_socket = true;
 
       if (reconnect) {
         connect_seq = new_connect_seq;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1166,6 +1166,7 @@ ProtocolV2::handle_existing_connection(SocketConnectionRef existing_conn)
     // each other at the same time.
     if (existing_proto->client_cookie != client_cookie) {
       if (existing_conn->peer_wins()) {
+        // acceptor (this connection, the peer) wins
         logger().warn("{} server_connect: connection race detected (cs={}, e_cs={}, ss=0)"
                       " and win, reusing existing {} {}",
                       conn,
@@ -1175,6 +1176,7 @@ ProtocolV2::handle_existing_connection(SocketConnectionRef existing_conn)
                       *existing_conn);
         return reuse_connection(existing_proto);
       } else {
+        // acceptor (this connection, the peer) loses
         logger().warn("{} server_connect: connection race detected (cs={}, e_cs={}, ss=0)"
                       " and lose to existing {}, ask client to wait",
                       conn, client_cookie, existing_proto->client_cookie, *existing_conn);
@@ -1446,6 +1448,7 @@ ProtocolV2::server_reconnect()
     } else if (existing_proto->connect_seq == reconnect.connect_seq()) {
       // reconnect race: both peers are sending reconnect messages
       if (existing_conn->peer_wins()) {
+        // acceptor (this connection, the peer) wins
         logger().warn("{} server_reconnect: reconnect race detected (cs={})"
                       " and win, reusing existing {} {}",
                       conn,
@@ -1456,6 +1459,7 @@ ProtocolV2::server_reconnect()
             existing_proto, false,
             true, reconnect.connect_seq(), reconnect.msg_seq());
       } else {
+        // acceptor (this connection, the peer) loses
         logger().warn("{} server_reconnect: reconnect race detected (cs={})"
                       " and lose to existing {}, ask client to wait",
                       conn, reconnect.connect_seq(), *existing_conn);

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -253,7 +253,7 @@ class ProtocolV2 final : public Protocol {
 
   // CLOSING
   // reentrant
-  void do_close(bool dispatch_reset,
+  void do_close(bool is_dispatch_reset,
                 std::optional<std::function<void()>> f_accept_new=std::nullopt);
 };
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -107,7 +107,7 @@ class ProtocolV2 final : public Protocol {
     return statenames[static_cast<int>(state)];
   }
 
-  void trigger_state(state_t state, out_state_t out_state, bool reentrant);
+  void trigger_state(state_t state, io_state_t io_state, bool reentrant);
 
   uint64_t peer_supported_features = 0;
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -20,7 +20,8 @@ class ProtocolV2 final : public Protocol {
              SocketConnection& conn,
              SocketMessenger& messenger);
   ~ProtocolV2() override;
-  void print(std::ostream&) const final;
+  void print_conn(std::ostream&) const final;
+
  private:
   void on_closed() override;
   bool is_connected() const override;
@@ -144,7 +145,7 @@ class ProtocolV2 final : public Protocol {
 
  private:
   void fault(bool backoff, const char* func_name, std::exception_ptr eptr);
-  void reset_session(bool full);
+  void reset_session(bool is_full);
   seastar::future<std::tuple<entity_type_t, entity_addr_t>>
   banner_exchange(bool is_connect);
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -62,6 +62,8 @@ class ProtocolV2 final : public Protocol {
 
   AuthConnectionMetaRef auth_meta;
 
+  crimson::common::Gated gate;
+
   bool closed = false;
 
   // become valid only after closed == true

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -19,8 +19,6 @@ class ProtocolV2 final : public Protocol {
 
 // public to SocketConnection, but private to the others
  private:
-  void close() override;
-
   seastar::future<> close_clean_yielded() override;
 
 #ifdef UNIT_TESTS_BUILT
@@ -45,6 +43,8 @@ class ProtocolV2 final : public Protocol {
   void notify_out() override;
 
   void notify_out_fault(const char *, std::exception_ptr) override;
+
+  void notify_mark_down() override;
 
   seastar::future<> wait_exit_io() {
     if (exit_io.has_value()) {

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -19,8 +19,6 @@ class ProtocolV2 final : public Protocol {
 
 // public to SocketConnection, but private to the others
  private:
-  bool is_connected() const override;
-
   void close() override;
 
   seastar::future<> close_clean_yielded() override;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -45,13 +45,6 @@ class ProtocolV2 final : public Protocol {
   void print_conn(std::ostream&) const final;
 
  private:
-  ceph::bufferlist do_sweep_messages(
-      const std::deque<MessageURef>& msgs,
-      size_t num_msgs,
-      bool require_keepalive,
-      std::optional<utime_t> keepalive_ack,
-      bool require_ack) override;
-
   void notify_out() override;
 
   void notify_out_fault(std::exception_ptr) override;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -166,14 +166,6 @@ class ProtocolV2 final : public Protocol {
   Timer protocol_timer;
 
  private:
-  seastar::future<FrameAssemblerV2::read_main_t> read_main_preamble();
-
-  template <class F>
-  ceph::bufferlist get_buffer(F &tx_frame);
-
-  template <class F>
-  seastar::future<> write_flush_frame(F &tx_frame);
-
   void fault(state_t expected_state,
              const char *where,
              std::exception_ptr eptr);

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -49,6 +49,14 @@ class ProtocolV2 final : public Protocol {
 
   void notify_out_fault(const char *, std::exception_ptr) override;
 
+  seastar::future<> wait_exit_io() {
+    if (exit_io.has_value()) {
+      return exit_io->get_shared_future();
+    } else {
+      return seastar::now();
+    }
+  }
+
  private:
   SocketMessenger &messenger;
 
@@ -56,6 +64,10 @@ class ProtocolV2 final : public Protocol {
 
   // the socket exists and it is not shutdown
   bool is_socket_valid = false;
+
+  FrameAssemblerV2Ref frame_assembler;
+
+  std::optional<seastar::shared_promise<>> exit_io;
 
   AuthConnectionMetaRef auth_meta;
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -243,7 +243,7 @@ class ProtocolV2 final : public Protocol {
 
   // READY
   seastar::future<> read_message(utime_t throttle_stamp, std::size_t msg_size);
-  void execute_ready(bool dispatch_connect);
+  void execute_ready();
 
   // STANDBY
   void execute_standby();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -14,8 +14,7 @@ class ProtocolV2 final : public Protocol {
 
  public:
   ProtocolV2(ChainedDispatchers& dispatchers,
-             SocketConnection& conn,
-             SocketMessenger& messenger);
+             SocketConnection& conn);
   ~ProtocolV2() override;
 
 // public to SocketConnection, but private to the others
@@ -58,6 +57,8 @@ class ProtocolV2 final : public Protocol {
   }
 
  private:
+  SocketConnection &conn;
+
   SocketMessenger &messenger;
 
   bool has_socket = false;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -47,7 +47,7 @@ class ProtocolV2 final : public Protocol {
  private:
   void notify_out() override;
 
-  void notify_out_fault(std::exception_ptr) override;
+  void notify_out_fault(const char *, std::exception_ptr) override;
 
  private:
   SocketMessenger &messenger;
@@ -107,14 +107,6 @@ class ProtocolV2 final : public Protocol {
   uint64_t global_seq = 0;
   uint64_t peer_global_seq = 0;
   uint64_t connect_seq = 0;
-
-  std::optional<seastar::shared_promise<>> in_exit_dispatching;
-  seastar::future<> wait_in_exit_dispatching() {
-    if (in_exit_dispatching.has_value()) {
-      return in_exit_dispatching->get_shared_future();
-    }
-    return seastar::now();
-  }
 
   seastar::future<> execution_done = seastar::now();
 
@@ -235,7 +227,6 @@ class ProtocolV2 final : public Protocol {
                          uint64_t new_msg_seq);
 
   // READY
-  seastar::future<> read_message(utime_t throttle_stamp, std::size_t msg_size);
   void execute_ready();
 
   // STANDBY

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -41,7 +41,7 @@ class ProtocolV2 final : public Protocol {
       std::optional<utime_t> keepalive_ack,
       bool require_ack) override;
 
-  void notify_write() override;
+  void notify_out() override;
 
  private:
   SocketMessenger &messenger;
@@ -76,7 +76,7 @@ class ProtocolV2 final : public Protocol {
     return statenames[static_cast<int>(state)];
   }
 
-  void trigger_state(state_t state, write_state_t write_state, bool reentrant);
+  void trigger_state(state_t state, out_state_t out_state, bool reentrant);
 
   uint64_t peer_supported_features = 0;
 

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -157,9 +157,7 @@ seastar::future<> Socket::close() {
 seastar::future<> Socket::inject_delay () {
   if (float delay_period = local_conf()->ms_inject_internal_delays;
       delay_period) {
-    logger().debug("{}: sleep for {}",
-                  __func__,
-                  delay_period);
+    logger().debug("Socket::inject_delay: sleep for {}", delay_period);
     return seastar::sleep(
       std::chrono::milliseconds((int)(delay_period * 1000.0)));
   }
@@ -171,9 +169,9 @@ void Socket::inject_failure()
   if (local_conf()->ms_inject_socket_failures) {
     uint64_t rand =
       ceph::util::generate_random_number<uint64_t>(1, RAND_MAX);
-      if (rand % local_conf()->ms_inject_socket_failures == 0) {
+    if (rand % local_conf()->ms_inject_socket_failures == 0) {
       if (true) {
-        logger().warn("{} injecting socket failure", __func__);
+        logger().warn("Socket::inject_failure: injecting socket failure");
 	throw std::system_error(make_error_code(
 	  crimson::net::error::negotiation_failure));
       }

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -119,6 +119,7 @@ Socket::read_exactly(size_t bytes) {
 }
 
 void Socket::shutdown() {
+  socket_is_shutdown = true;
   socket.shutdown_input();
   socket.shutdown_output();
 }
@@ -210,7 +211,7 @@ seastar::future<> Socket::try_trap_post(bp_action_t& trap) {
     break;
    case bp_action_t::STALL:
     logger().info("[Test] got STALL and block");
-    shutdown();
+    force_shutdown();
     return blocker->block();
    default:
     ceph_abort("unexpected action from trap");

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -42,6 +42,7 @@ class Socket
       // the default buffer size 8192 is too small that may impact our write
       // performance. see seastar::net::connected_socket::output()
       out(socket.output(65536)),
+      socket_is_shutdown(false),
       side(_side),
       ephemeral_port(e_port) {}
 
@@ -109,6 +110,10 @@ class Socket
 #endif
   }
 
+  bool is_shutdown() const {
+    return socket_is_shutdown;
+  }
+
   // preemptively disable further reads or writes, can only be shutdown once.
   void shutdown();
 
@@ -118,6 +123,12 @@ class Socket
   static seastar::future<> inject_delay();
 
   static void inject_failure();
+
+  // shutdown for tests
+  void force_shutdown() {
+    socket.shutdown_input();
+    socket.shutdown_output();
+  }
 
   // shutdown input_stream only, for tests
   void force_shutdown_in() {
@@ -155,6 +166,7 @@ class Socket
   seastar::connected_socket socket;
   seastar::input_stream<char> in;
   seastar::output_stream<char> out;
+  bool socket_is_shutdown;
   side_t side;
   uint16_t ephemeral_port;
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -57,7 +57,7 @@ bool SocketConnection::is_closed() const
 bool SocketConnection::is_closed_clean() const
 {
   assert(seastar::this_shard_id() == shard_id());
-  return protocol->is_closed_clean;
+  return protocol->is_closed_clean();
 }
 
 #endif
@@ -104,7 +104,7 @@ void SocketConnection::set_last_keepalive_ack(clock_t::time_point when)
 void SocketConnection::mark_down()
 {
   assert(seastar::this_shard_id() == shard_id());
-  protocol->close(false);
+  protocol->close();
 }
 
 void
@@ -122,9 +122,9 @@ SocketConnection::start_accept(SocketRef&& sock,
 }
 
 seastar::future<>
-SocketConnection::close_clean(bool dispatch_reset)
+SocketConnection::close_clean_yielded()
 {
-  return protocol->close_clean(dispatch_reset);
+  return protocol->close_clean_yielded();
 }
 
 seastar::shard_id SocketConnection::shard_id() const {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -134,19 +134,19 @@ seastar::shard_id SocketConnection::shard_id() const {
 }
 
 seastar::socket_address SocketConnection::get_local_address() const {
-  return protocol->socket->get_local_address();
+  return socket->get_local_address();
 }
 
 void SocketConnection::print(ostream& out) const {
     out << (void*)this << " ";
     messenger.print(out);
-    if (!protocol->socket) {
+    if (!socket) {
       out << " >> " << get_peer_name() << " " << peer_addr;
-    } else if (protocol->socket->get_side() == Socket::side_t::acceptor) {
+    } else if (socket->get_side() == Socket::side_t::acceptor) {
       out << " >> " << get_peer_name() << " " << peer_addr
-          << "@" << protocol->socket->get_ephemeral_port();
-    } else { // protocol->socket->get_side() == Socket::side_t::connector
-      out << "@" << protocol->socket->get_ephemeral_port()
+          << "@" << socket->get_ephemeral_port();
+    } else { // socket->get_side() == Socket::side_t::connector
+      out << "@" << socket->get_ephemeral_port()
           << " >> " << get_peer_name() << " " << peer_addr;
     }
 }

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -29,7 +29,7 @@ SocketConnection::SocketConnection(SocketMessenger& messenger,
                                    ChainedDispatchers& dispatchers)
   : core(messenger.shard_id()),
     messenger(messenger),
-    protocol(std::make_unique<ProtocolV2>(dispatchers, *this, messenger))
+    protocol(std::make_unique<ProtocolV2>(dispatchers, *this))
 {
 #ifdef UNIT_TESTS_BUILT
   if (messenger.interceptor) {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -75,12 +75,12 @@ seastar::future<> SocketConnection::send(MessageURef msg)
     });
 }
 
-seastar::future<> SocketConnection::keepalive()
+seastar::future<> SocketConnection::send_keepalive()
 {
   return seastar::smp::submit_to(
     shard_id(),
     [this] {
-      return protocol->keepalive();
+      return protocol->send_keepalive();
     });
 }
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -84,29 +84,27 @@ seastar::future<> SocketConnection::keepalive()
     });
 }
 
+SocketConnection::clock_t::time_point
+SocketConnection::get_last_keepalive() const
+{
+  return protocol->get_last_keepalive();
+}
+
+SocketConnection::clock_t::time_point
+SocketConnection::get_last_keepalive_ack() const
+{
+  return protocol->get_last_keepalive_ack();
+}
+
+void SocketConnection::set_last_keepalive_ack(clock_t::time_point when)
+{
+  protocol->set_last_keepalive_ack(when);
+}
+
 void SocketConnection::mark_down()
 {
   assert(seastar::this_shard_id() == shard_id());
   protocol->close(false);
-}
-
-bool SocketConnection::update_rx_seq(seq_num_t seq)
-{
-  if (seq <= in_seq) {
-    if (HAVE_FEATURE(features, RECONNECT_SEQ) &&
-        local_conf()->ms_die_on_old_message) {
-      ceph_abort_msg("old msgs despite reconnect_seq feature");
-    }
-    return false;
-  } else if (seq > in_seq + 1) {
-    if (local_conf()->ms_die_on_skipped_message) {
-      ceph_abort_msg("skipped incoming seq");
-    }
-    return false;
-  } else {
-    in_seq = seq;
-    return true;
-  }
 }
 
 void

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -104,7 +104,7 @@ void SocketConnection::set_last_keepalive_ack(clock_t::time_point when)
 void SocketConnection::mark_down()
 {
   assert(seastar::this_shard_id() == shard_id());
-  protocol->close();
+  protocol->mark_down();
 }
 
 void

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -37,6 +37,8 @@ class SocketConnection : public Connection {
   SocketMessenger& messenger;
   std::unique_ptr<Protocol> protocol;
 
+  SocketRef socket;
+
   entity_name_t peer_name = {0, entity_name_t::NEW};
 
   entity_addr_t peer_addr;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -120,7 +120,7 @@ class SocketConnection : public Connection {
   void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr);
 
-  seastar::future<> close_clean(bool dispatch_reset);
+  seastar::future<> close_clean_yielded();
 
   seastar::socket_address get_local_address() const;
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -82,7 +82,7 @@ class SocketConnection : public Connection {
 
   seastar::future<> send(MessageURef msg) override;
 
-  seastar::future<> keepalive() override;
+  seastar::future<> send_keepalive() override;
 
   clock_t::time_point get_last_keepalive() const override;
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -180,6 +180,7 @@ private:
 
   friend class Protocol;
   friend class ProtocolV2;
+  friend class FrameAssemblerV2;
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -209,10 +209,12 @@ private:
 
   bool is_closed() const override;
 
+  // peer wins if myaddr > peeraddr
   bool peer_wins() const override;
 
   Interceptor *interceptor = nullptr;
 #else
+  // peer wins if myaddr > peeraddr
   bool peer_wins() const;
 #endif
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -43,7 +43,7 @@ SocketMessenger::SocketMessenger(const entity_name_t& myname,
 
 SocketMessenger::~SocketMessenger()
 {
-  logger().debug("{}: {}", __func__, logic_name);
+  logger().debug("~SocketMessenger: {}", logic_name);
   ceph_assert(!listener);
 }
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -262,16 +262,16 @@ seastar::future<> SocketMessenger::shutdown()
   // close all connections
   }).then([this] {
     return seastar::parallel_for_each(accepting_conns, [] (auto conn) {
-      return conn->close_clean(false);
+      return conn->close_clean_yielded();
     });
   }).then([this] {
     ceph_assert(accepting_conns.empty());
     return seastar::parallel_for_each(connections, [] (auto conn) {
-      return conn.second->close_clean(false);
+      return conn.second->close_clean_yielded();
     });
   }).then([this] {
     return seastar::parallel_for_each(closing_conns, [] (auto conn) {
-      return conn->close_clean(false);
+      return conn->close_clean_yielded();
     });
   }).then([this] {
     ceph_assert(connections.empty());

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -450,13 +450,13 @@ seastar::future<> IOHandler::do_out_dispatch()
         e.code() != std::errc::connection_reset &&
         e.code() != error::negotiation_failure) {
       logger().error("{} do_out_dispatch(): unexpected error at {} -- {}",
-                     conn, io_state, e);
+                     conn, io_state, e.what());
       ceph_abort();
     }
 
     if (io_state == io_state_t::open) {
       logger().info("{} do_out_dispatch(): fault at {}, going to delay -- {}",
-                    conn, io_state, e);
+                    conn, io_state, e.what());
       std::exception_ptr eptr;
       try {
         throw e;
@@ -467,7 +467,7 @@ seastar::future<> IOHandler::do_out_dispatch()
       handshake_listener->notify_out_fault("do_out_dispatch", eptr);
     } else {
       logger().info("{} do_out_dispatch(): fault at {} -- {}",
-                    conn, io_state, e);
+                    conn, io_state, e.what());
     }
 
     return do_out_dispatch();

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -11,6 +11,7 @@
 #include "crimson/net/chained_dispatchers.h"
 #include "crimson/net/SocketMessenger.h"
 #include "msg/Message.h"
+#include "msg/msg_fmt.h"
 
 using namespace ceph::msgr::v2;
 using crimson::common::local_conf;
@@ -519,9 +520,14 @@ IOHandler::read_message(utime_t throttle_stamp, std::size_t msg_size)
 
     logger().trace("{} got {} + {} + {} byte message,"
                    " envelope type={} src={} off={} seq={}",
-                   conn, msg_frame.front_len(), msg_frame.middle_len(),
-                   msg_frame.data_len(), current_header.type, conn.get_peer_name(),
-                   current_header.data_off, current_header.seq);
+                   conn,
+                   msg_frame.front_len(),
+                   msg_frame.middle_len(),
+                   msg_frame.data_len(),
+                   current_header.type,
+                   conn.get_peer_name(),
+                   current_header.data_off,
+                   current_header.seq);
 
     ceph_msg_header header{current_header.seq,
                            current_header.tid,

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -267,3 +267,7 @@ struct fmt::formatter<crimson::net::IOHandler::io_state_t>
     return formatter<string_view>::format(name, ctx);
   }
 };
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::net::IOHandler::io_stat_printer> : fmt::ostream_formatter {};
+#endif

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -406,7 +406,6 @@ void Heartbeat::Connection::replaced()
   racing_detected = true;
   logger().warn("Heartbeat::Connection::replaced(): {} racing", *this);
   assert(conn != replaced_conn);
-  assert(conn->is_connected());
 }
 
 void Heartbeat::Connection::reset()

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -197,7 +197,7 @@ static seastar::future<> test_echo(unsigned rounds,
             [this, conn, &count_ping, &count_keepalive] {
               return seastar::repeat([this, conn, &count_ping, &count_keepalive] {
                   if (keepalive_dist(rng)) {
-                    return conn->keepalive()
+                    return conn->send_keepalive()
                       .then([&count_keepalive] {
                         count_keepalive += 1;
                         return seastar::make_ready_future<seastar::stop_iteration>(
@@ -1155,7 +1155,7 @@ class FailoverSuite : public Dispatcher {
   seastar::future<> keepalive_peer() {
     logger().info("[Test] keepalive_peer()");
     ceph_assert(tracked_conn);
-    return tracked_conn->keepalive();
+    return tracked_conn->send_keepalive();
   }
 
   seastar::future<> try_send_peer() {
@@ -1524,7 +1524,7 @@ class FailoverSuitePeer : public Dispatcher {
   seastar::future<> keepalive_peer() {
     logger().info("[TestPeer] keepalive_peer()");
     ceph_assert(tracked_conn);
-    return tracked_conn->keepalive();
+    return tracked_conn->send_keepalive();
   }
 
   seastar::future<> markdown() {

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -36,7 +36,7 @@ using crimson::common::local_conf;
 namespace {
 
 seastar::logger& logger() {
-  return crimson::get_logger(ceph_subsys_ms);
+  return crimson::get_logger(ceph_subsys_test);
 }
 
 static std::random_device rd;

--- a/src/test/crimson/test_messenger.h
+++ b/src/test/crimson/test_messenger.h
@@ -13,7 +13,7 @@ constexpr uint64_t TEST_NONCE = 2;
 constexpr int64_t TEST_OSD = 2;
 constexpr uint64_t CMD_SRV_NONCE = 3;
 constexpr int64_t CMD_SRV_OSD = 3;
-constexpr uint64_t TEST_PEER_NONCE = 4;
+constexpr uint64_t TEST_PEER_NONCE = 2;
 constexpr int64_t TEST_PEER_OSD = 4;
 
 inline entity_addr_t get_test_peer_addr(

--- a/src/test/crimson/test_messenger.h
+++ b/src/test/crimson/test_messenger.h
@@ -3,7 +3,26 @@
 
 #pragma once
 
+#include "msg/msg_types.h"
+
 namespace ceph::net::test {
+
+constexpr uint64_t CMD_CLI_NONCE = 1;
+constexpr int64_t CMD_CLI_OSD = 1;
+constexpr uint64_t TEST_NONCE = 2;
+constexpr int64_t TEST_OSD = 2;
+constexpr uint64_t CMD_SRV_NONCE = 3;
+constexpr int64_t CMD_SRV_OSD = 3;
+constexpr uint64_t TEST_PEER_NONCE = 4;
+constexpr int64_t TEST_PEER_OSD = 4;
+
+inline entity_addr_t get_test_peer_addr(
+    const entity_addr_t &cmd_peer_addr) {
+  entity_addr_t test_peer_addr = cmd_peer_addr;
+  test_peer_addr.set_port(cmd_peer_addr.get_port() + 1);
+  test_peer_addr.set_nonce(TEST_PEER_NONCE);
+  return test_peer_addr;
+}
 
 enum class cmd_t : char {
   none = '\0',

--- a/src/test/crimson/test_messenger_peer.cc
+++ b/src/test/crimson/test_messenger_peer.cc
@@ -14,14 +14,13 @@
 #include "msg/Dispatcher.h"
 #include "msg/Messenger.h"
 
-#include "test_cmds.h"
+#include "test_messenger.h"
 
 namespace {
 
 #define dout_subsys ceph_subsys_test
 
-using ceph::net::test::cmd_t;
-using ceph::net::test::policy_t;
+using namespace ceph::net::test;
 using SocketPolicy = Messenger::Policy;
 
 constexpr int CEPH_OSD_PROTOCOL = 10;
@@ -105,7 +104,11 @@ class FailoverSuitePeer : public Dispatcher {
 
  private:
   void init(entity_addr_t test_peer_addr, SocketPolicy policy) {
-    peer_msgr.reset(Messenger::create(cct, "async", entity_name_t::OSD(4), "TestPeer", 4));
+    peer_msgr.reset(Messenger::create(
+      cct, "async",
+      entity_name_t::OSD(TEST_PEER_OSD),
+      "TestPeer",
+      TEST_PEER_NONCE));
     dummy_auth.auth_registry.refresh_config();
     peer_msgr->set_cluster_protocol(CEPH_OSD_PROTOCOL);
     peer_msgr->set_default_policy(policy);
@@ -361,7 +364,11 @@ class FailoverTestPeer : public Dispatcher {
   }
 
   void init(entity_addr_t cmd_peer_addr) {
-    cmd_msgr.reset(Messenger::create(cct, "async", entity_name_t::OSD(3), "CmdSrv", 3));
+    cmd_msgr.reset(Messenger::create(
+      cct, "async",
+      entity_name_t::OSD(CMD_SRV_OSD),
+      "CmdSrv",
+      CMD_SRV_NONCE));
     dummy_auth.auth_registry.refresh_config();
     cmd_msgr->set_cluster_protocol(CEPH_OSD_PROTOCOL);
     cmd_msgr->set_default_policy(Messenger::Policy::stateless_server(0));
@@ -384,11 +391,12 @@ class FailoverTestPeer : public Dispatcher {
   void wait() { cmd_msgr->wait(); }
 
   static std::unique_ptr<FailoverTestPeer>
-  create(CephContext* cct, entity_addr_t cmd_peer_addr, bool nonstop) {
-    // suite bind to cmd_peer_addr, with port + 1
-    entity_addr_t test_peer_addr = cmd_peer_addr;
-    test_peer_addr.set_port(cmd_peer_addr.get_port() + 1);
-    auto test_peer = std::make_unique<FailoverTestPeer>(cct, test_peer_addr, nonstop);
+  create(CephContext* cct,
+         entity_addr_t cmd_peer_addr,
+         entity_addr_t test_peer_addr,
+         bool nonstop) {
+    auto test_peer = std::make_unique<FailoverTestPeer>(
+        cct, test_peer_addr, nonstop);
     test_peer->init(cmd_peer_addr);
     ldout(cct, 0) << "[CmdSrv] ready" << dendl;
     return test_peer;
@@ -404,7 +412,7 @@ int main(int argc, char** argv)
   desc.add_options()
     ("help,h", "show help message")
     ("addr", po::value<std::string>()->default_value("v2:127.0.0.1:9013"),
-     "CmdSrv address, and TestPeer address with port+=1")
+     "This is CmdSrv address, and TestPeer address is at port+=1")
     ("nonstop", po::value<bool>()->default_value(false),
      "Do not shutdown TestPeer when all tests are successful");
   po::variables_map vm;
@@ -426,12 +434,6 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  auto addr = vm["addr"].as<std::string>();
-  entity_addr_t cmd_peer_addr;
-  cmd_peer_addr.parse(addr.c_str(), nullptr);
-  ceph_assert_always(cmd_peer_addr.is_msgr2());
-  auto nonstop = vm["nonstop"].as<bool>();
-
   std::vector<const char*> args(argv, argv + argc);
   auto cct = global_init(nullptr, args,
                          CEPH_ENTITY_TYPE_CLIENT,
@@ -439,6 +441,22 @@ int main(int argc, char** argv)
                          CINIT_FLAG_NO_MON_CONFIG);
   common_init_finish(cct.get());
 
-  auto test_peer = FailoverTestPeer::create(cct.get(), cmd_peer_addr, nonstop);
+  auto addr = vm["addr"].as<std::string>();
+  entity_addr_t cmd_peer_addr;
+  cmd_peer_addr.parse(addr.c_str(), nullptr);
+  cmd_peer_addr.set_nonce(CMD_SRV_NONCE);
+  ceph_assert_always(cmd_peer_addr.is_msgr2());
+  auto test_peer_addr = get_test_peer_addr(cmd_peer_addr);
+  auto nonstop = vm["nonstop"].as<bool>();
+  ldout(cct, 0) << "test configuration: cmd_peer_addr=" << cmd_peer_addr
+                << ", test_peer_addr=" << test_peer_addr
+                << ", nonstop=" << nonstop
+                << dendl;
+
+  auto test_peer = FailoverTestPeer::create(
+      cct.get(),
+      cmd_peer_addr,
+      test_peer_addr,
+      nonstop);
   test_peer->wait();
 }

--- a/src/test/crimson/test_messenger_peer.cc
+++ b/src/test/crimson/test_messenger_peer.cc
@@ -411,7 +411,7 @@ int main(int argc, char** argv)
   po::options_description desc{"Allowed options"};
   desc.add_options()
     ("help,h", "show help message")
-    ("addr", po::value<std::string>()->default_value("v2:127.0.0.1:9013"),
+    ("addr", po::value<std::string>()->default_value("v2:127.0.0.1:9012"),
      "This is CmdSrv address, and TestPeer address is at port+=1")
     ("nonstop", po::value<bool>()->default_value(false),
      "Do not shutdown TestPeer when all tests are successful");


### PR DESCRIPTION
This is an intermediate step towards multi-core messenger. There should be no impact to the msgr users yet.

The goal of this step is about introducing an `IOHandler` class that is responsible to the executions in `ProtocolV2::READY` state, as well as event dispatching in all states. Changes are including:
* Move IO related logic into `Protocol` and move IO unrelated logic out of `Protocol`.
* Clean up and categorize in and out logic in `Protocol`.
* Break the inheritance relationship from `ProtocolV2` to `Protocol`.
* Introduce `FrameAssemblerV2` to be shared by both `IOHandler` and `ProtocolV2` for the low level protocol-v2 frame processings, and to be responsible for the `Socket` ownership.
* Rename `Protocol` to `IOHandler`.
* Major refactors about how to hand over the `READY` state from `ProtocolV2` to `IOHandler`, and how `IOHandler` to notify `ProtocolV2` to exit the `READY` state in various scenarios.
* Other fixes and cleanups.

The next step(s) will include:
* Design `Socket` and `ServerSocket` to manage seastar sockets in multiple cores.
* Design Dispatcher interfaces for multi-core event dispatching, especially about how to notify the user about the connection core changes.
* Further refactor the interactions between `IOHandler` and `ProtocolV2` for the inevitable cross-core communications.
* How to make the design compatible to both single-shard and multiple-shard use cases.

The basic idea is to:
* Distribute the messenger IO workload to multiple cores. 
* Make sure the IO core and the socket core are the same for a connection (as the connection core from user perspective), to prevent unnecessary cross-core in the IO path.
* Hide the user from the complexity that connection handshake may be on a different core.
* User still needs to call `Messenger` interfaces from core-0, such as `connect()`.

The architecture now looks:
![multi-core msgr](https://user-images.githubusercontent.com/7736006/207512024-74b440a9-42b8-4d2c-96b9-25a944694d50.jpg)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
