### PR TITLE
pacific: mgr/dashboard: allow Origin url for CORS if present in config 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -248,16 +248,19 @@ class CherryPyConfig(object):
         resp_head = cherrypy.response.headers
 
         # Always set response headers necessary for 'simple' CORS.
-        req_header_origin_url = req_head.get('Access-Control-Allow-Origin')
+        req_header_cross_origin_url = req_head.get('Access-Control-Allow-Origin')
         cross_origin_urls = mgr.get_localized_module_option('cross_origin_url', '')
         cross_origin_url_list = [url.strip() for url in cross_origin_urls.split(',')]
-        if req_header_origin_url in cross_origin_url_list:
-            resp_head['Access-Control-Allow-Origin'] = req_header_origin_url
+        if req_header_cross_origin_url in cross_origin_url_list:
+            resp_head['Access-Control-Allow-Origin'] = req_header_cross_origin_url
         resp_head['Access-Control-Expose-Headers'] = 'GET, POST'
         resp_head['Access-Control-Allow-Credentials'] = 'true'
 
         # Non-simple CORS preflight request; short-circuit the normal handler.
         if cherrypy.request.method == 'OPTIONS':
+            req_header_origin_url = req_head.get('Origin')
+            if req_header_origin_url in cross_origin_url_list:
+                resp_head['Access-Control-Allow-Origin'] = req_header_origin_url
             ac_method = req_head.get('Access-Control-Request-Method', None)
 
             allowed_methods = ['GET', 'POST']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58268

---

backport of https://github.com/ceph/ceph/pull/49329
parent tracker: https://tracker.ceph.com/issues/58245

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh