### PR TITLE
mgr/rook: Replace hardcoded namespace

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -509,9 +509,14 @@ class DefaultRemover():
         self.rook_env = rook_env
 
         self.inventory = inventory
-        self.osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod, namespace='rook-ceph', label_selector='app=rook-ceph-osd')
-        self.jobs: KubernetesResource = KubernetesResource(self.batchV1_api.list_namespaced_job, namespace='rook-ceph', label_selector='app=rook-ceph-osd-prepare')
-        self.pvcs: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_persistent_volume_claim, namespace='rook-ceph')
+        self.osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod,
+                                                               namespace=self.rook_env.namespace,
+                                                               label_selector='app=rook-ceph-osd')
+        self.jobs: KubernetesResource = KubernetesResource(self.batchV1_api.list_namespaced_job,
+                                                           namespace=self.rook_env.namespace,
+                                                           label_selector='app=rook-ceph-osd-prepare')
+        self.pvcs: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_persistent_volume_claim,
+                                                           namespace=self.rook_env.namespace)
 
 
     def remove_device_sets(self) -> str:
@@ -560,11 +565,9 @@ class DefaultRemover():
 
     def scale_deployments(self) -> None:
         for osd_id in self.osd_ids:
-            self.appsV1_api.patch_namespaced_deployment_scale(namespace='rook-ceph', name='rook-ceph-osd-{}'.format(osd_id), body=client.V1Scale(
-                spec=client.V1ScaleSpec(
-                    replicas=0
-                )
-            ))
+            self.appsV1_api.patch_namespaced_deployment_scale(namespace=self.rook_env.namespace,
+                                                              name='rook-ceph-osd-{}'.format(osd_id),
+                                                              body=client.V1Scale(spec=client.V1ScaleSpec(replicas=0)))
 
     def set_osds_out(self) -> None:
         out_flag_args = {
@@ -577,13 +580,18 @@ class DefaultRemover():
             
     def delete_deployments(self) -> None:
         for osd_id in self.osd_ids:
-            self.appsV1_api.delete_namespaced_deployment(namespace='rook-ceph', name='rook-ceph-osd-{}'.format(osd_id), propagation_policy='Foreground')
+            self.appsV1_api.delete_namespaced_deployment(namespace=self.rook_env.namespace,
+                                                         name='rook-ceph-osd-{}'.format(osd_id),
+                                                         propagation_policy='Foreground')
 
     def clean_up_prepare_jobs_and_pvc(self) -> None:
         for job in self.jobs.items:
             if job.metadata.labels['ceph.rook.io/pvc'] in self.pvc_to_remove:
-                self.batchV1_api.delete_namespaced_job(name=job.metadata.name, namespace='rook-ceph', propagation_policy='Foreground')
-                self.coreV1_api.delete_namespaced_persistent_volume_claim(name=job.metadata.labels['ceph.rook.io/pvc'], namespace='rook-ceph', propagation_policy='Foreground')
+                self.batchV1_api.delete_namespaced_job(name=job.metadata.name, namespace=self.rook_env.namespace,
+                                                       propagation_policy='Foreground')
+                self.coreV1_api.delete_namespaced_persistent_volume_claim(name=job.metadata.labels['ceph.rook.io/pvc'],
+                                                                          namespace=self.rook_env.namespace,
+                                                                          propagation_policy='Foreground')
 
     def purge_osds(self) -> None:
         for id in self.osd_ids:
@@ -665,9 +673,9 @@ class RookCluster(object):
         self.storage_classes : KubernetesResource = KubernetesResource(self.storageV1_api.list_storage_class)
 
         self.rook_pods: KubernetesResource[client.V1Pod] = KubernetesResource(self.coreV1_api.list_namespaced_pod,
-                                            namespace=self.rook_env.namespace,
-                                            label_selector="rook_cluster={0}".format(
-                                                self.rook_env.namespace))
+                                                                              namespace=self.rook_env.namespace,
+                                                                              label_selector="rook_cluster={0}".format(
+                                                                                  self.rook_env.namespace))
         self.nodes: KubernetesResource[client.V1Node] = KubernetesResource(self.coreV1_api.list_node)
         
     def rook_url(self, path: str) -> str:
@@ -720,7 +728,9 @@ class RookCluster(object):
         return self.fetcher.devices()
         
     def get_osds(self) -> List:
-        osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod, namespace='rook-ceph', label_selector='app=rook-ceph-osd')
+        osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod,
+                                                          namespace=self.rook_env.namespace,
+                                                          label_selector='app=rook-ceph-osd')
         return list(osd_pods.items)
         
     def get_nfs_conf_url(self, nfs_cluster: str, instance: str) -> Optional[str]:
@@ -1070,12 +1080,18 @@ class RookCluster(object):
                 _update_nfs, _create_nfs)
 
     def rm_service(self, rooktype: str, service_id: str) -> str:
-        self.customObjects_api.delete_namespaced_custom_object(group="ceph.rook.io", version="v1", namespace="rook-ceph", plural=rooktype, name=service_id)
+        self.customObjects_api.delete_namespaced_custom_object(group="ceph.rook.io", version="v1",
+                                                               namespace=self.rook_env.namespace,
+                                                               plural=rooktype, name=service_id)
         objpath = "{0}/{1}".format(rooktype, service_id)
         return f'Removed {objpath}'
 
     def get_resource(self, resource_type: str) -> Iterable:
-        custom_objects: KubernetesCustomResource = KubernetesCustomResource(self.customObjects_api.list_namespaced_custom_object, group="ceph.rook.io", version="v1", namespace="rook-ceph", plural=resource_type)
+        custom_objects: KubernetesCustomResource = KubernetesCustomResource(self.customObjects_api.list_namespaced_custom_object,
+                                                                            group="ceph.rook.io",
+                                                                            version="v1",
+                                                                            namespace=self.rook_env.namespace,
+                                                                            plural=resource_type)
         return custom_objects.items
 
     def can_create_osd(self) -> bool:
@@ -1154,7 +1170,7 @@ class RookCluster(object):
             api_version="batch/v1",
             metadata=client.V1ObjectMeta(
                 name="rook-ceph-device-zap",
-                namespace="rook-ceph"
+                namespace=self.rook_env.namespace
             ),
             spec=client.V1JobSpec(
                 template=client.V1PodTemplateSpec(
@@ -1229,7 +1245,7 @@ class RookCluster(object):
                 )
             )
         )
-        self.batchV1_api.create_namespaced_job('rook-ceph', body)
+        self.batchV1_api.create_namespaced_job(self.rook_env.namespace, body)
 
     def rbd_mirror(self, spec: ServiceSpec) -> None:
         service_id = spec.service_id or "default-rbd-mirror"


### PR DESCRIPTION
The namespace used by a rook cluster can be different form the default (rook-ceph) that was hardcoded in several places in the rook_cluster module.

If the rook cluster has been installed in any different workspace from "rook-ceph", several of the RookCluster methods fail because they try to execute in a  namespace which does not exist.

Example:
```
bash-4.4$ ceph orch ls
Error EINVAL: Traceback (most recent call last):
  File "/usr/share/ceph/mgr/mgr_module.py", line 1755, in _handle_command
    return self.handle_command(inbuf, cmd)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 171, in handle_command
    return dispatch[cmd['prefix']].call(self, cmd, inbuf)
  File "/usr/share/ceph/mgr/mgr_module.py", line 462, in call
    return self.func(mgr, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 107, in <lambda>
    wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)  # noqa: E731
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 96, in wrapper
    return func(*args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 589, in _list_services
    services = raise_if_exception(completion)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 228, in raise_if_exception
    raise e
kubernetes.client.rest.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '04cc1beb-3d01-4446-8cbf-f1136a6651b0', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': 'a35d8a39-5adf-45bc-a2a4-e5f9f2461a52', 'X-Kubernetes-Pf-Prioritylevel-Uid': '00958480-dc5d-4759-923b-e219549de5f9', 'Date': 'Wed, 14 Dec 2022 16:26:53 GMT', 'Content-Length': '372'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"cephfilesystems.ceph.rook.io is forbidden: User \"system:serviceaccount:rook-jmo:rook-ceph-mgr\" cannot list resource \"cephfilesystems\" in API group \"ceph.rook.io\" in the namespace \"rook-ceph\"","reason":"Forbidden","details":{"group":"ceph.rook.io","kind":"cephfilesystems"},"code":403}
```



fixes: https://tracker.ceph.com/issues/58210

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests


