### PR TITLE
pacific: mds: avoid ~mdsdir's scrubbing and reporting damage health status

### DIFF
--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -176,3 +176,12 @@ class TestScrub(CephFSTestCase):
 
     def test_scrub_dup_inode(self):
         self._scrub(DupInodeWorkload(self, self.fs, self.mount_a))
+
+    def test_mdsdir_scrub_backtrace(self):
+        damage_count = self._get_damage_count()
+        self.assertNotIn("MDS_DAMAGE", self.mds_cluster.mon_manager.get_mon_health()['checks'])
+
+        out_json = self.fs.run_scrub(["start", "~mdsdir", "recursive"])
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
+        self.assertEqual(self._get_damage_count(), damage_count)
+        self.assertNotIn("MDS_DAMAGE", self.mds_cluster.mon_manager.get_mon_health()['checks'])

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4693,6 +4693,10 @@ void CInode::validate_disk_state(CInode::validated_data *results,
         results->backtrace.error_str << "failed to read off disk; see retval";
         // we probably have a new unwritten file!
         // so skip the backtrace scrub for this entry and say that all's well
+        if (in->is_mdsdir()){
+          dout(20) << "forcing backtrace as passed since mdsdir actually doesn't have backtrace" << dendl;
+          results->backtrace.passed = true;
+        }
         if (in->is_dirty_parent()) {
           dout(20) << "forcing backtrace as passed since inode is dirty parent" << dendl;
           results->backtrace.passed = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58250

---

backport of https://github.com/ceph/ceph/pull/48450
parent tracker: https://tracker.ceph.com/issues/58030

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh