### PR TITLE
pacific: ceph-volume: fix a bug in get_all_devices_vgs()

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -794,7 +794,7 @@ def get_all_devices_vgs(name_prefix=''):
         verbose_on_failure=False
     )
     vgs = _output_parser(stdout, vg_fields)
-    return [VolumeGroup(**vg) for vg in vgs]
+    return [VolumeGroup(**vg) for vg in vgs if vg['vg_name']]
 
 #################################
 #


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58279

---

backport of https://github.com/ceph/ceph/pull/48707
parent tracker: https://tracker.ceph.com/issues/57918

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh