### PR TITLE
crimson/os: fix compile error by delete packed attribute

### DIFF
--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -25,7 +25,7 @@ struct device_spec_t {
     denc(v.id, p);
     DENC_FINISH(p);
   }
-} __attribute__ ((packed));
+};
 
 std::ostream& operator<<(std::ostream&, const device_spec_t&);
 


### PR DESCRIPTION
Compiling crimson with gcc 11 get errors like:
> error: cannot bind packed field 'v.crimson::os::seastore::device_spec_t::magic' to 'long unsigned int&'

As before to fix runtime error in pr https://github.com/ceph/ceph/pull/49408 introduce the compile error.
> runtime error: reference binding to misaligned address 0x610000008395
for type 'device_type_t', which requires 4 byte alignment

As define `enum class device_type_t {`, without the underlying type (in this case, the underlying type is
an implementation-defined integral type that can represent all enumerator values), so `device_type_t` is
a 4 byte wide type, in func `get_pos_add` `i` is `list::contiguous_appender `type when encoding, and the return
value `i.get_pos_add(sizeof(T))` is a byte algined address possibly, the runtime error happens in reinterpret_cast
process. We have already define `enum class device_type_t : uint8_t {`, so just delete the packed attribute
to fix the compile error.

Signed-off-by: luo rixin <luorixin@huawei.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
