### PR TITLE
quincy: qa: wait for scrub to finish

### DIFF
--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -139,8 +139,7 @@ done
 
         # resume and verify
         self._resume_scrub(0)
-        out_json = self.fs.get_scrub_status()
-        self.assertTrue("no active" in out_json['status'])
+        self.assertTrue(self.fs.wait_until_scrub_complete(sleep=5, timeout=30))
 
         checked = self._check_task_status_na()
         self.assertTrue(checked)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57760

---

backport of https://github.com/ceph/ceph/pull/48218
parent tracker: https://tracker.ceph.com/issues/48812

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh