### PR TITLE
mgr/nfs: disallow non-existent paths when creating export

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -744,3 +744,17 @@ class TestNFS(MgrTestCase):
         except CommandFailedError as e:
             if e.exitstatus != errno.ENOENT:
                 raise
+
+    def test_nfs_export_with_invalid_path(self):
+        """
+        Test that nfs exports can't be created with invalid path
+        """
+        self._test_create_cluster()
+        try:
+            self._create_export(export_id='123',
+                                extra_cmd=['--pseudo-path', self.pseudo_path,
+                                           '--path', '/non_existent_dir'])
+        except CommandFailedError as e:
+            if e.exitstatus != errno.ENOENT:
+                raise
+        self._test_delete_cluster()

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -112,13 +112,12 @@ class TestNFS(MgrTestCase):
         :param expected_status: Status to be verified
         :param fail_msg: Message to be printed if test failed
         '''
-        # Wait for two minutes as ganesha daemon takes some time to be deleted/created
-        wait_time = 10
-        while wait_time <= 120:
-            time.sleep(wait_time)
-            if expected_status in self._fetch_nfs_daemons_details():
-                return
-            wait_time += 10
+        # Wait for a minute as ganesha daemon takes some time to be
+        # deleted/created
+        with contextutil.safe_while(sleep=6, tries=10, _raise=False) as proceed:
+            while proceed():
+                if expected_status in self._fetch_nfs_daemons_details():
+                    return
         self.fail(fail_msg)
 
     def _check_auth_ls(self, export_id=1, check_in=False):

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -334,6 +334,49 @@ class TestNFS(MgrTestCase):
         else:
             self.fail('expected write to a read-only export to fail')
 
+    def _create_cluster_with_fs(self, fs_name, mnt_pt=None):
+        """
+        create a cluster along with fs and mount it to the path supplied
+        :param fs_name: name of CephFS volume to be created
+        :param mnt_pt: mount fs to the path
+        """
+        self._test_create_cluster()
+        self._cmd('fs', 'volume', 'create', fs_name)
+        with contextutil.safe_while(sleep=5, tries=30) as proceed:
+            while proceed():
+                output = self._cmd(
+                    'orch', 'ls', '-f', 'json',
+                    '--service-name', f'mds.{fs_name}'
+                )
+                j = json.loads(output)
+                if j[0]['status']['running']:
+                    break
+        if mnt_pt:
+            with contextutil.safe_while(sleep=3, tries=3) as proceed:
+                while proceed():
+                    try:
+                        self.ctx.cluster.run(args=['sudo', 'ceph-fuse', mnt_pt])
+                        break
+                    except CommandFailedError as e:
+                        log.warning(f'{e}, retrying')
+            self.ctx.cluster.run(args=['sudo', 'chmod', '1777', mnt_pt])
+
+    def _delete_cluster_with_fs(self, fs_name, mnt_pt=None, mode=None):
+        """
+        delete cluster along with fs and unmount it from the path supplied
+        :param fs_name: name of CephFS volume to be deleted
+        :param mnt_pt: unmount fs from the path
+        :param mode: revert to this mode
+        """
+        if mnt_pt:
+            self.ctx.cluster.run(args=['sudo', 'umount', mnt_pt])
+            if mode:
+                if isinstance(mode, bytes):
+                    mode = mode.decode().strip()
+                self.ctx.cluster.run(args=['sudo', 'chmod', mode, mnt_pt])
+        self._cmd('fs', 'volume', 'rm', fs_name, '--yes-i-really-mean-it')
+        self._test_delete_cluster()
+
     def test_create_and_delete_cluster(self):
         '''
         Test successful creation and deletion of the nfs cluster.
@@ -758,3 +801,45 @@ class TestNFS(MgrTestCase):
             if e.exitstatus != errno.ENOENT:
                 raise
         self._test_delete_cluster()
+
+    def test_nfs_export_creation_at_filepath(self):
+        """
+        Test that nfs exports can't be created at a filepath
+        """
+        mnt_pt = '/mnt'
+        preserve_mode = self._sys_cmd(['stat', '-c', '%a', mnt_pt])
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
+        self.ctx.cluster.run(args=['touch', f'{mnt_pt}/testfile'])
+        try:
+            self._create_export(export_id='123', extra_cmd=['--pseudo-path',
+                                                            self.pseudo_path,
+                                                            '--path',
+                                                            '/testfile'])
+        except CommandFailedError as e:
+            # NotADirectoryError is raised as EINVAL
+            if e.exitstatus != errno.EINVAL:
+                raise
+        self.ctx.cluster.run(args=['rm', '-rf', '/mnt/testfile'])
+        self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)
+
+    def test_nfs_export_creation_at_symlink(self):
+        """
+        Test that nfs exports can't be created at a symlink path
+        """
+        mnt_pt = '/mnt'
+        preserve_mode = self._sys_cmd(['stat', '-c', '%a', mnt_pt])
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
+        self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir'])
+        self.ctx.cluster.run(args=['ln', '-s', 'testdir', 'testdir_symlink'],
+                             cwd=f'{mnt_pt}')
+        try:
+            self._create_export(export_id='123',
+                                extra_cmd=['--pseudo-path',
+                                           self.pseudo_path,
+                                           '--path',
+                                           f'{mnt_pt}/testdir_symlink'])
+        except CommandFailedError as e:
+            if e.exitstatus != errno.ENOENT:
+                raise
+        self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}/*'])
+        self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -36,7 +36,7 @@ from .utils import (
     conf_obj_name,
     available_clusters,
     check_fs,
-    restart_nfs_service)
+    restart_nfs_service, check_cephfs_path)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -658,6 +658,9 @@ class ExportMgr:
                              access_type: str,
                              clients: list = [],
                              sectype: Optional[List[str]] = None) -> Dict[str, Any]:
+
+        check_cephfs_path(self.mgr, fs_name, path)
+
         pseudo_path = normalize_path(pseudo_path)
 
         if not self._fetch_export(cluster_id, pseudo_path):

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -251,7 +251,8 @@ EXPORT {
                 mock.patch('nfs.export.check_fs', return_value=True), \
                 mock.patch('nfs.ganesha_conf.check_fs', return_value=True), \
                 mock.patch('nfs.export.ExportMgr._create_user_key',
-                           return_value='thekeyforclientabc'):
+                           return_value='thekeyforclientabc'), \
+                mock.patch('nfs.export.check_cephfs_path'):
 
             rados.open_ioctx.return_value.__enter__.return_value = self.io_mock
             rados.open_ioctx.return_value.__exit__ = mock.Mock(return_value=None)

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -1,7 +1,13 @@
+import errno
+import functools
+import logging
+import stat
 from typing import List, Tuple, TYPE_CHECKING
 
 from object_format import ErrorResponseBase
 import orchestrator
+import cephfs
+from mgr_util import CephfsClient, open_filesystem
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -9,6 +15,8 @@ if TYPE_CHECKING:
 EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
+
+log = logging.getLogger(__name__)
 
 
 class NonFatalError(ErrorResponseBase):
@@ -82,3 +90,25 @@ def check_fs(mgr: 'Module', fs_name: str) -> bool:
     '''
     fs_map = mgr.get('fs_map')
     return fs_name in [fs['mdsmap']['fs_name'] for fs in fs_map['filesystems']]
+
+
+def check_cephfs_path(mgr: 'Module', fs: str, path: str) -> None:
+    @functools.lru_cache(maxsize=1)
+    def _get_cephfs_client() -> CephfsClient:
+        return CephfsClient(mgr)
+    try:
+        cephfs_client = _get_cephfs_client()
+        with open_filesystem(cephfs_client, fs) as fs_handle:
+            stx = fs_handle.statx(path.encode('utf-8'),
+                                  cephfs.CEPH_STATX_MODE, 0)
+            if not stat.S_ISDIR(stx.get('mode')):
+                raise NotADirectoryError(f"{path} is not a dir")
+    except cephfs.ObjectNotFound as e:
+        log.exception(f"{-errno.ENOENT}: {e.args[1]}")
+        raise e
+    except cephfs.Error as e:
+        log.exception(f"{e.args[0]}: {e.args[1]}")
+        raise e
+    except Exception as e:
+        log.exception(f"unknown exception occurred: {e}")
+        raise e


### PR DESCRIPTION
Fixes: 
- https://tracker.ceph.com/issues/58228
- https://tracker.ceph.com/issues/58744
- https://tracker.ceph.com/issues/58758
- helper function `_check_nfs_cluster_status()` in `test_nfs.py`

Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
