### PR TITLE
octopus: qa: switch to https protocol for repos' server

### DIFF
--- a/qa/run_xfstests-obsolete.sh
+++ b/qa/run_xfstests-obsolete.sh
@@ -33,7 +33,7 @@ PROGNAME=$(basename $0)
 
 # xfstests is downloaded from this git repository and then built.
 # XFSTESTS_REPO="git://oss.sgi.com/xfs/cmds/xfstests.git"
-XFSTESTS_REPO="git://git.ceph.com/xfstests.git"
+XFSTESTS_REPO="https://git.ceph.com/xfstests-dev.git"
 
 # Default command line option values
 COUNT="1"
@@ -277,7 +277,7 @@ function install_xfstests() {
 
 	git clone "${XFSTESTS_REPO}"
 
-	cd xfstests
+	cd xfstests-dev
 
 	# FIXME: use an older version before the tests were rearranged!
 	git reset --hard e5f1a13792f20cfac097fef98007610b422f2cac
@@ -296,7 +296,7 @@ function install_xfstests() {
 function remove_xfstests() {
 	arg_count 0 $#
 
-	rm -rf "${TESTDIR}/xfstests"
+	rm -rf "${TESTDIR}/xfstests-dev"
 	rm -rf "${XFSTESTS_DIR}"
 }
 

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -42,12 +42,11 @@ class XFSTestsDev(CephFSTestCase):
 
         # TODO: make sure that repo is not cloned for every test. it should
         # happen only once.
-        remoteurl = 'git://git.ceph.com/xfstests-dev.git'
+        remoteurl = 'https://git.ceph.com/xfstests-dev.git'
         self.repo_path = self.mount_a.client_remote.mkdtemp(suffix=
                                                             'xfstests-dev')
-        self.mount_a.run_shell(['git', 'archive', '--remote=' + remoteurl,
-                                'HEAD', run.Raw('|'),
-                                'tar', '-C', self.repo_path, '-x', '-f', '-'])
+        self.mount_a.run_shell(['git', 'clone', remoteurl, '--depth', '1',
+                                self.repo_path])
 
     def get_admin_key(self):
         import configparser

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -38,8 +38,6 @@ class XFSTestsDev(CephFSTestCase):
         """
         Clone xfstests_dev repository. If already present, update it.
         """
-        from teuthology.orchestra import run
-
         # TODO: make sure that repo is not cloned for every test. it should
         # happen only once.
         remoteurl = 'https://git.ceph.com/xfstests-dev.git'

--- a/qa/tasks/restart.py
+++ b/qa/tasks/restart.py
@@ -3,6 +3,7 @@ Daemon restart
 """
 import logging
 import pipes
+import os
 
 from teuthology import misc as teuthology
 from teuthology.orchestra import run as tor
@@ -48,16 +49,15 @@ def get_tests(ctx, config, role, remote, testdir):
             'mkdir', '--', srcdir,
             run.Raw('&&'),
             'git',
-            'archive',
-            '--remote=git://git.ceph.com/ceph.git',
-            '%s:qa/workunits' % refspec,
-            run.Raw('|'),
-            'tar',
-            '-C', srcdir,
-            '-x',
-            '-f-',
+            'clone',
+            'https://git.ceph.com/ceph.git',
+            srcdir,
             run.Raw('&&'),
             'cd', '--', srcdir,
+            run.Raw('&&'),
+            'git', 'checkout', '-b', 'restart_test', str(refspec),
+            run.Raw('&&'),
+            'cd', '--', 'qa/workunits',
             run.Raw('&&'),
             'if', 'test', '-e', 'Makefile', run.Raw(';'), 'then', 'make', run.Raw(';'), 'fi',
             run.Raw('&&'),
@@ -68,7 +68,7 @@ def get_tests(ctx, config, role, remote, testdir):
     restarts = sorted(teuthology.get_file(
                         remote,
                         '{tdir}/restarts.list'.format(tdir=testdir)).split('\0'))
-    return (srcdir, restarts)
+    return (os.path.join(srcdir, 'qa/workunits'), restarts)
 
 def task(ctx, config):
     """

--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -4,7 +4,7 @@ set -e
 
 ceph fs set cephfs allow_new_snaps true --yes-i-really-mean-it
 
-git clone git://git.ceph.com/ceph.git
+git clone https://git.ceph.com/ceph.git
 cd ceph
 
 versions=`seq 1 21`

--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-git clone git://git.ceph.com/xfstests.git
-cd xfstests
+git clone https://git.ceph.com/xfstests-dev.git
+cd xfstests-dev
 git checkout 12973fc04fd10d4af086901e10ffa8e48866b735
 make -j4
 cd ..
-cp xfstests/ltp/fsx .
+cp xfstests-dev/ltp/fsx .
 
 OPTIONS="-z"  # don't use zero range calls; not supported by cephfs
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58291

---

backport of https://github.com/ceph/ceph/pull/49021 and two commits of https://github.com/ceph/ceph/pull/48628
parent tracker: https://tracker.ceph.com/issues/58290 and https://tracker.ceph.com/issues/58133

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
