### PR TITLE
quincy: mgr/dashboard: fix server side encryption config error

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -209,7 +209,7 @@ class RgwBucket(RgwRESTController):
 
         CephService.set_encryption_config(encryption_type, kms_provider, auth_method,
                                           secret_engine, secret_path, namespace, address,
-                                          token, ssl_cert, client_cert, client_key)
+                                          token, daemon_name, ssl_cert, client_cert, client_key)
 
     def _get_encryption(self, bucket_name, daemon_name, owner):
         rgw_client = RgwClient.instance(owner, daemon_name)
@@ -390,8 +390,8 @@ class RgwBucket(RgwRESTController):
 
     @RESTController.Collection(method='GET', path='/getEncryptionConfig')
     @allow_empty_body
-    def get_encryption_config(self):
-        return CephService.get_encryption_config()
+    def get_encryption_config(self, daemon_name=None, owner=None):
+        return CephService.get_encryption_config(daemon_name)
 
 
 @APIRouter('/rgw/user', Scope.RGW)

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -186,8 +186,8 @@ export class RgwBucketService extends ApiClient {
   }
 
   getEncryptionConfig() {
-    return this.rgwDaemonService.request(() => {
-      return this.http.get(`${this.url}/getEncryptionConfig`);
+    return this.rgwDaemonService.request((params: HttpParams) => {
+      return this.http.get(`${this.url}/getEncryptionConfig`, { params: params });
     });
   }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -7738,7 +7738,17 @@ paths:
       - RgwBucket
   /api/rgw/bucket/getEncryptionConfig:
     get:
-      parameters: []
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: daemon_name
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: owner
+        schema:
+          type: string
       responses:
         '200':
           content:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58302

---

backport of https://github.com/ceph/ceph/pull/49173
parent tracker: https://tracker.ceph.com/issues/58296

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh