### PR TITLE
pybind/rados: fix missed changes for PEP484 style type annotations

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1047,10 +1047,10 @@ Rados object in state %s." % self.state)
         # NOTE(sileht): looks weird but test_monmap_dump pass int
             target = str(target)
 
-        target = cstr(target, 'target', opt=True)
+        target_raw = cstr(target, 'target', opt=True)
 
         cdef:
-            char *_target = opt_str(target)
+            char *_target = opt_str(target_raw)
             char **_cmd = to_bytes_array(cmds)
             size_t _cmdlen = len(cmds)
 
@@ -1063,7 +1063,7 @@ Rados object in state %s." % self.state)
             size_t _outs_len
 
         try:
-            if target:
+            if target_raw:
                 with nogil:
                     ret = rados_mon_command_target(self.cluster, _target,
                                                 <const char **>_cmd, _cmdlen,
@@ -1148,10 +1148,10 @@ Rados object in state %s." % self.state)
         self.require_state("connected")
 
         cmds = [cstr(cmd, 'cmd')]
-        target = cstr(target, 'target', opt=True)
+        target_raw = cstr(target, 'target', opt=True)
 
         cdef:
-            char *_target = opt_str(target)
+            char *_target = opt_str(target_raw)
 
             char **_cmd = to_bytes_array(cmds)
             size_t _cmdlen = len(cmds)
@@ -1165,7 +1165,7 @@ Rados object in state %s." % self.state)
             size_t _outs_len
 
         try:
-            if target is not None:
+            if target_raw is not None:
                 with nogil:
                     ret = rados_mgr_command_target(self.cluster,
 		                            <const char*>_target,
@@ -3779,9 +3779,9 @@ returned %d, but should return zero on success." % (self.name, ret))
         :para max_return: list no more than max_return key/value pairs
         :returns: an iterator over the requested omap values, return value from this action
         """
-        start_after = cstr(start_after, 'start_after') if start_after else None
+        start_after_raw = cstr(start_after, 'start_after') if start_after else None
         cdef:
-            char *_start_after = opt_str(start_after)
+            char *_start_after = opt_str(start_after_raw)
             ReadOp _read_op = read_op
             rados_omap_iter_t iter_addr = NULL
             int _max_return = max_return

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -556,6 +556,11 @@ class TestIoctx(object):
             eq(ret, 0)
             with assert_raises(ObjectNotFound):
                 self.ioctx.operate_read_op(read_op, "no_such")
+        with ReadOpCtx() as read_op:
+            iter, ret = self.ioctx.get_omap_keys(read_op,"2",2)
+            eq(ret, 0)
+            self.ioctx.operate_read_op(read_op, "hw")
+            eq(list(iter), [("3", None)])
 
     def test_clear_omap(self):
         keys = ("1", "2", "3")


### PR DESCRIPTION
originally brought by https://github.com/ceph/ceph/pull/36918

As a result improper (unicode string is assigned with byte one) assignment causes assertion in Ioctx.get_omap_keys (defined at src/pybind/rados/rados.pyx) when start_after parameter is non-empty. AFAIU this is bound specifically to Cython since pure Python apparently permits such assignments

Fixes: https://tracker.ceph.com/issues/58304
Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
