### PR TITLE
quincy: doc/rados: add prompts to ceph-conf.rst

### DIFF
--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -486,17 +486,26 @@ The following CLI commands are used to configure the cluster:
 Help
 ====
 
-You can get help for a particular option with::
+You can get help for a particular option with:
 
-  ceph config help <option>
+.. prompt:: bash $
 
-Note that this will use the configuration schema that is compiled into the running monitors.  If you have a mixed-version cluster (e.g., during an upgrade), you might also want to query the option schema from a specific running daemon::
+   ceph config help <option>
 
-  ceph daemon <name> config help [option]
+Note that this will use the configuration schema that is compiled into the running monitors.  If you have a mixed-version cluster (e.g., during an upgrade), you might also want to query the option schema from a specific running daemon:
 
-For example,::
+.. prompt:: bash $
 
-  $ ceph config help log_file
+   ceph daemon <name> config help [option]
+
+For example:
+
+.. prompt:: bash $
+
+   ceph config help log_file
+
+:: 
+
   log_file - path to log file
     (std::string, basic)
     Default (non-daemon):
@@ -504,9 +513,14 @@ For example,::
     Can update at runtime: false
     See also: [log_to_stderr,err_to_stderr,log_to_syslog,err_to_syslog]
 
-or::
+or:
 
-  $ ceph config help log_file -f json-pretty
+.. prompt:: bash $
+
+   ceph config help log_file -f json-pretty
+
+::
+
   {
       "name": "log_file",
       "type": "std::string",
@@ -543,9 +557,11 @@ increasing/decreasing logging output, enabling/disabling debug
 settings, and even for runtime optimization.
 
 Generally speaking, configuration options can be updated in the usual
-way via the ``ceph config set`` command.  For example, do enable the debug log level on a specific OSD,::
+way via the ``ceph config set`` command.  For example, do enable the debug log level on a specific OSD:
 
-  ceph config set osd.123 debug_ms 20
+.. prompt:: bash $
+
+   ceph config set osd.123 debug_ms 20
 
 Note that if the same option is also customized in a local
 configuration file, the monitor setting will be ignored (it has a
@@ -561,28 +577,38 @@ the daemon or process restarts.
 
 Override values can be set in two ways:
 
-#. From any host, we can send a message to a daemon over the network with::
+#. From any host, we can send a message to a daemon over the network with:
+   
+   .. prompt:: bash $
 
-     ceph tell <name> config set <option> <value>
+      ceph tell <name> config set <option> <value>
 
-   For example,::
+   For example:
+   
+   .. prompt:: bash $
 
-     ceph tell osd.123 config set debug_osd 20
+      ceph tell osd.123 config set debug_osd 20
 
    The `tell` command can also accept a wildcard for the daemon
    identifier.  For example, to adjust the debug level on all OSD
-   daemons,::
+   daemons:
+   
+   .. prompt:: bash $
 
-     ceph tell osd.* config set debug_osd 20
+      ceph tell osd.* config set debug_osd 20
 
 #. From the host the process is running on, we can connect directly to
-   the process via a socket in ``/var/run/ceph`` with::
+   the process via a socket in ``/var/run/ceph`` with:
 
-     ceph daemon <name> config set <option> <value>
+   .. prompt:: bash $
 
-   For example,::
+      ceph daemon <name> config set <option> <value>
 
-     ceph daemon osd.4 config set debug_osd 20
+   For example:
+   
+   .. prompt:: bash $
+
+      ceph daemon osd.4 config set debug_osd 20
 
 Note that in the ``ceph config show`` command output these temporary
 values will be shown with a source of ``override``.
@@ -591,29 +617,41 @@ values will be shown with a source of ``override``.
 Viewing runtime settings
 ========================
 
-You can see the current options set for a running daemon with the ``ceph config show`` command.  For example,::
+You can see the current options set for a running daemon with the ``ceph config show`` command.  For example:
 
-  ceph config show osd.0
+.. prompt:: bash $
 
-will show you the (non-default) options for that daemon.  You can also look at a specific option with::
+   ceph config show osd.0
 
-  ceph config show osd.0 debug_osd
+will show you the (non-default) options for that daemon.  You can also look at a specific option with:
 
-or view all options (even those with default values) with::
+.. prompt:: bash $
 
-  ceph config show-with-defaults osd.0
+   ceph config show osd.0 debug_osd
 
-You can also observe settings for a running daemon by connecting to it from the local host via the admin socket.  For example,::
+or view all options (even those with default values) with:
 
-  ceph daemon osd.0 config show
+.. prompt:: bash $
 
-will dump all current settings,::
+   ceph config show-with-defaults osd.0
 
-  ceph daemon osd.0 config diff
+You can also observe settings for a running daemon by connecting to it from the local host via the admin socket.  For example:
 
-will show only non-default settings (as well as where the value came from: a config file, the monitor, an override, etc.), and::
+.. prompt:: bash $
 
-  ceph daemon osd.0 config get debug_osd
+   ceph daemon osd.0 config show
+
+will dump all current settings:
+
+.. prompt:: bash $
+
+   ceph daemon osd.0 config diff
+
+will show only non-default settings (as well as where the value came from: a config file, the monitor, an override, etc.), and:
+
+.. prompt:: bash $
+
+   ceph daemon osd.0 config get debug_osd
 
 will report the value of a single option.
 


### PR DESCRIPTION
Add unselectable prompts to doc/rados/ceph-conf.rst.

https://tracker.ceph.com/issues/57108

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 874152535c5f8ca4a447b68040d62d1c34c3c24e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
