### PR TITLE
mgr/dashboard: linked dist dashboard folder

### DIFF
--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -46,7 +46,7 @@ else:
     mgr = mock.Mock()
     mgr.get_frontend_path.return_value = os.path.abspath(os.path.join(
         os.path.dirname(__file__),
-        'frontend/dist'))
+        'frontend/dist/dist-link'))
 
     import rbd
 

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -45,7 +45,7 @@ class LanguageMixin(object):
                     'lang': self.LANGUAGES_PATH_MAP[lang]['lang'],
                     'path': self.LANGUAGES_PATH_MAP[lang]['path']
                 }
-        with open(os.path.normpath("{}/../package.json".format(mgr.get_frontend_path())),
+        with open(os.path.normpath(mgr.get_frontend_package_json_path()),
                   "r") as f:
             config = json.load(f)
         self.DEFAULT_LANGUAGE = config['config']['locale']

--- a/src/pybind/mgr/dashboard/frontend/.gitignore
+++ b/src/pybind/mgr/dashboard/frontend/.gitignore
@@ -1,7 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
+/dist/upstream
 /tmp
 /out-tsc
 

--- a/src/pybind/mgr/dashboard/frontend/angular.json
+++ b/src/pybind/mgr/dashboard/frontend/angular.json
@@ -75,7 +75,7 @@
               "lodash"
             ],
             "i18nMissingTranslation": "ignore",
-            "outputPath": "dist",
+            "outputPath": "dist/upstream",
             "index": "src/index.html",
             "main": "src/main.ts",
             "tsConfig": "tsconfig.app.json",

--- a/src/pybind/mgr/dashboard/frontend/dist/dist-link
+++ b/src/pybind/mgr/dashboard/frontend/dist/dist-link
@@ -1,0 +1,1 @@
+upstream

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -372,16 +372,33 @@ class Module(MgrModule, CherryPyConfig):
         return True, ""
 
     @classmethod
-    def get_frontend_path(cls):
+    def get_frontend_package_json_path(cls):
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        path = os.path.join(current_dir, 'frontend/dist')
+        # dist-link is a link to the dist folder to distribute. By default,
+        # we link to the build produced in upstream which is created under dist/upstream.
+        path = os.path.join(current_dir, 'frontend/package.json')
         if os.path.exists(path):
             return path
         else:
             path = os.path.join(current_dir,
                                 '../../../../build',
                                 'src/pybind/mgr/dashboard',
-                                'frontend/dist')
+                                'frontend/package.json')
+            return os.path.abspath(path)
+
+    @classmethod
+    def get_frontend_path(cls):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        # dist-link is a link to the dist folder to distribute. By default,
+        # we link to the build produced in upstream which is created under dist/upstream.
+        path = os.path.join(current_dir, 'frontend/dist/dist-link')
+        if os.path.exists(path):
+            return path
+        else:
+            path = os.path.join(current_dir,
+                                '../../../../build',
+                                'src/pybind/mgr/dashboard',
+                                'frontend/dist/dist-link')
             return os.path.abspath(path)
 
     def serve(self):


### PR DESCRIPTION
With this pr we change the default dist folder to be built in `frontend/dist/upstream` instead of `frontend/dist`. `frontend/dist-link` is a symbolic link which points to upstream by default and it increases the flexibility to add new flavors to the dashboard by just changing the link to another folder.

This PR will make jenkins job fail as rpms are built based on the previous dist folder.

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
