### PR TITLE
mon/OSDMontior: Simplify check_pg_num()

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8332,9 +8332,12 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "crush rule " << p.get_crush_rule() << " type does not match pool";
       return -EINVAL;
     }
-    int r = check_pg_num(pool, p.get_pg_num(), n, p.get_crush_rule(), &ss);
-    if (r < 0) {
-      return r;
+    if (n > p.size) {
+      // only when increasing pool size
+      int r = check_pg_num(pool, p.get_pg_num(), n, p.get_crush_rule(), &ss);
+      if (r < 0) {
+        return r;
+      }
     }
     p.size = n;
     p.min_size = g_conf().get_osd_pool_default_min_size(p.size);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -516,6 +516,7 @@ private:
 				const std::string &erasure_code_profile,
 				unsigned *stripe_width,
 				std::ostream *ss);
+  uint32_t get_osd_num_by_crush(int crush_rule);
   int check_pg_num(int64_t pool, int pg_num, int size, int crush_rule, std::ostream* ss);
   int prepare_new_pool(std::string& name,
 		       int crush_rule,

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -247,16 +247,6 @@ private:
 	row[4 + size + i] = up[i];
       }
     }
-
-    uint64_t get_num_acting_pgs() const {
-      uint64_t num_acting_pgs = 0;
-      const size_t row_size = this->row_size();
-      for (size_t ps = 0; ps < pg_num; ++ps) {
-        const int32_t *row = &table[row_size * ps];
-        num_acting_pgs += row[2];
-      }
-      return num_acting_pgs;
-    }
   };
 
   mempool::osdmap_mapping::map<int64_t,PoolMapping> pools;
@@ -338,12 +328,6 @@ public:
   const mempool::osdmap_mapping::vector<pg_t>& get_osd_acting_pgs(unsigned osd) { 
     ceph_assert(osd < acting_rmap.size());
     return acting_rmap[osd];
-  }
-
-  uint64_t get_num_acting_pgs(int64_t pool) const {
-    auto p = pools.find(pool);
-    ceph_assert(p != pools.end());
-    return p->second.get_num_acting_pgs();
   }
 
   void update(const OSDMap& map, pg_t pgid);


### PR DESCRIPTION
* See: https://tracker.ceph.com/issues/47062.
  Originally, `check_pg_num()` did not take into account the root
  osds used by the crush rule.
  This behavior resulted in an inaccurate pg num per osd count.
  #39062 has addressed this issue.
  However, an underflow was caused when the 
  new pg num specified was less than the pg num 
  calculated from pg info.
  The underflow proposed fix: #44430.

This PR includes a refactor to `OSDMonitor::check_pg_num()` and a usage fix which is introduced: a7c09bb82cc7749b05a0f60477c9407a177086d1.

* The key point of the refactoring is to avoid summing all of the projected 
   pg num and **only later on** subtracting the pg num if the pool did exist.
   (Accumulating un-needed pg num and then subtracting those 
   caused the underflow.)

* With this change, we only count the projected pg num which
  are part of the pools affected by the crush rule.
  Same for number of osds, instead of dividing the projected
  pg number total by all of the osdmap's osds, divide only by
  the osds used by the crush rule.

* Avoid differentiating between whether the mapping epoch
  is later than the osdmap epoch or not. Always check the pg
  num according to the crush rule.

Fixes: https://tracker.ceph.com/issues/57105
Fixes: https://tracker.ceph.com/issues/54188

### **Example:**
Only 3 osds are added as root in `osd_test` crush rule:
```
ID  CLASS  WEIGHT   TYPE NAME         STATUS  REWEIGHT  PRI-AFF
-5         0.19717  root osd_test
0    ssd  0.09859      osd.0             up   1.00000  1.00000
1    ssd  0.09859      osd.1             up   1.00000  1.00000
2    ssd  0.09859      osd.2             up   1.00000  1.00000
-1         0.59151  root default
-3         0.59151      host folio03
0    ssd  0.09859          osd.0         up   1.00000  1.00000
1    ssd  0.09859          osd.1         up   1.00000  1.00000
2    ssd  0.09859          osd.2         up   1.00000  1.00000
3    ssd  0.09859          osd.3         up   1.00000  1.00000
4    ssd  0.09859          osd.4         up   1.00000  1.00000
5    ssd  0.09859          osd.5         up   1.00000  1.00000
```
Create a pool with the **specified rule** `ceph osd pool create pool_test 256 256 test_rule`:
```
Error ERANGE: pg_num 256 size 3 for this pool would result in 256 cumulative PGs per OSD (768 total PG replicas on 3 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250
```
Notice `on 3 'in' root OSDs by crush rule`.

Create a pool with the **default** rule `ceph osd pool create pool_test 256 256 `:
```
pool 'pool_test ' created
```
Since default rule has 6 `in` osds  the `mon_max_pg_per_osd` does not exceed and we create the pool successfully.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
