### PR TITLE
quincy: pybind/mgr: tox and test fixes 

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/tests/test_cal_final_pg_target.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_cal_final_pg_target.py
@@ -18,7 +18,7 @@ class RootMapItem:
 
 class TestPgAutoscaler(object):
 
-    def setup(self):
+    def setup_method(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
 

--- a/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
@@ -42,7 +42,7 @@ class CRUSH:
 
 class TestPgAutoscaler(object):
 
-    def setup(self):
+    def setup_method(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
 

--- a/src/pybind/mgr/progress/test_progress.py
+++ b/src/pybind/mgr/progress/test_progress.py
@@ -13,7 +13,7 @@ from progress import module
 class TestPgRecoveryEvent(object):
     # Testing PgRecoveryEvent class
 
-    def setup(self):
+    def setup_method(self):
         # Creating the class and Mocking 
         # a bunch of attributes for testing
         module._module = mock.Mock() # just so Event._refresh() works
@@ -90,7 +90,7 @@ class OSDMap:
 class TestModule(object):
     # Testing Module Class
     
-    def setup(self):
+    def setup_method(self):
         # Creating the class and Mocking a
         # bunch of attributes for testing
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,6 +1,6 @@
 import cherrypy
 from collections import defaultdict
-from distutils.version import StrictVersion
+from packaging.version import Version
 import json
 import math
 import os
@@ -32,10 +32,10 @@ DEFAULT_PORT = 9283
 # ipv6 isn't yet configured / supported and CherryPy throws an uncaught
 # exception.
 if cherrypy is not None:
-    v = StrictVersion(cherrypy.__version__)
+    v = Version(cherrypy.__version__)
     # the issue was fixed in 3.2.3. it's present in 3.2.2 (current version on
     # centos:7) and back to at least 3.0.0.
-    if StrictVersion("3.1.2") <= v < StrictVersion("3.2.3"):
+    if Version("3.1.2") <= v < Version("3.2.3"):
         # https://github.com/cherrypy/cherrypy/issues/1100
         from cherrypy.process import servers
         servers.wait_for_occupied_port = lambda host, port: None


### PR DESCRIPTION
Backport of: #49490

Similar failures can be seen in Q makecheck runs: 
https://jenkins.ceph.com/job/ceph-pull-requests/108549/consoleFull#2123650961e840cee4-f4a4-4183-81dd-42855615f2c1


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
