### PR TITLE
cmake: add common-options-objs as a dependency of common-msg-objs, rados_snap_set_diff_obj and krbd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -614,6 +614,7 @@ add_subdirectory(osdc)
 add_subdirectory(perfglue)
 
 add_library(rados_snap_set_diff_obj OBJECT librados/snap_set_diff.cc)
+add_dependencies(rados_snap_set_diff_obj common-options-objs)
 
 option(WITH_LIBRADOSSTRIPER "build with libradosstriper support" ON)
 
@@ -867,6 +868,7 @@ add_subdirectory(journal)
 if(WITH_RBD)
   if(WITH_KRBD)
     add_library(krbd STATIC krbd.cc
+      $<TARGET_OBJECTS:common-options-objs>
       $<TARGET_OBJECTS:parse_secret_objs>)
     target_link_libraries(krbd keyutils::keyutils)
   endif()

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(common-msg-objs OBJECT ${msg_srcs})
 target_compile_definitions(common-msg-objs PRIVATE
   $<TARGET_PROPERTY:fmt::fmt,INTERFACE_COMPILE_DEFINITIONS>)
 target_include_directories(common-msg-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
+add_dependencies(common-msg-objs common-options-objs)
 
 if(WITH_DPDK)
   set(async_dpdk_srcs


### PR DESCRIPTION
This PR fixes two compilation issues with `common-options-objs`, found on Gentoo.

1. https://bugs.gentoo.org/866449
  `src/msg/Messenger.h:723:30: error: ‘class ConfigValues’ has no member named ‘ms_die_on_unhandled_msg’`

2. https://bugs.gentoo.org/868891
  `global_legacy_options.h: No such file or directory`
```
                 from /var/tmp/portage/sys-cluster/ceph-17.2.5-r1/work/ceph-17.2.5/src/librados/snap_set_diff.cc:7:
/var/tmp/portage/sys-cluster/ceph-17.2.5-r1/work/ceph-17.2.5/src/common/options/legacy_config_opts.h:1:10: fatal error: global_legacy_options.h: No such file or directory

                 from /var/tmp/portage/sys-cluster/ceph-17.2.5-r1/work/ceph-17.2.5/src/krbd.cc:44:
/var/tmp/portage/sys-cluster/ceph-17.2.5-r1/work/ceph-17.2.5/src/common/options/legacy_config_opts.h:1:10: fatal error: global_legacy_options.h: No such file or directory
```

Add common-options-objs as a dependency of common-msg-objs, rados_snap_set_diff_obj and krbd to fix them.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
