### PR TITLE
quincy: mgr/dashboard: display real health in rbd mirroring pools

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -108,14 +108,15 @@ class GetDaemonAndPoolsTest(unittest.TestCase):
         mock_rbd_instance = mock_rbd.return_value
         mock_rbd_instance.mirror_peer_list.return_value = []
         test_cases = self._get_pool_test_cases()
-        for new_status, mirror_mode, expected_output in test_cases:
+        for new_status, pool_mirror_mode, images_summary, expected_output in test_cases:
             _status[1].update(new_status)
             daemon_status = {
                 'json': json.dumps(_status)
             }
             mgr.get_daemon_status.return_value = daemon_status
             daemons = get_daemons()
-            mock_rbd_instance.mirror_mode_get.return_value = mirror_mode
+            mock_rbd_instance.mirror_mode_get.return_value = pool_mirror_mode
+            mock_rbd_instance.mirror_image_status_summary.return_value = images_summary
             res = get_pools(daemons)
             for k, v in expected_output.items():
                 self.assertTrue(v == res['rbd'][k])
@@ -123,11 +124,16 @@ class GetDaemonAndPoolsTest(unittest.TestCase):
 
     def _get_pool_test_cases(self):
         test_cases = [
+            # 1. daemon status
+            # 2. Pool mirror mock_get_daemon_status
+            # 3. Image health summary
+            # 4. Pool health output
             (
                 {
                     'image_error_count': 7,
                 },
                 rbd.RBD_MIRROR_MODE_IMAGE,
+                [(rbd.MIRROR_IMAGE_STATUS_STATE_UNKNOWN, None)],
                 {
                     'health_color': 'warning',
                     'health': 'Warning'
@@ -137,7 +143,8 @@ class GetDaemonAndPoolsTest(unittest.TestCase):
                 {
                     'image_error_count': 7,
                 },
-                rbd.RBD_MIRROR_MODE_DISABLED,
+                rbd.RBD_MIRROR_MODE_POOL,
+                [(rbd.MIRROR_IMAGE_STATUS_STATE_ERROR, None)],
                 {
                     'health_color': 'error',
                     'health': 'Error'
@@ -150,6 +157,7 @@ class GetDaemonAndPoolsTest(unittest.TestCase):
                     'leader_id': 1
                 },
                 rbd.RBD_MIRROR_MODE_DISABLED,
+                [],
                 {
                     'health_color': 'info',
                     'health': 'Disabled'
@@ -280,7 +288,7 @@ class RbdMirroringSummaryControllerTest(ControllerTestCase):
         self.assertStatus(200)
 
         summary = self.json_body()['rbd_mirroring']
-        self.assertEqual(summary, {'errors': 0, 'warnings': 1})
+        self.assertEqual(summary, {'errors': 0, 'warnings': 2})
 
 
 class RbdMirroringStatusControllerTest(ControllerTestCase):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58317

---

backport of https://github.com/ceph/ceph/pull/47276
parent tracker: https://tracker.ceph.com/issues/57615

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh