### PR TITLE
quincy: src/valgrind.supp: Adding know leaks unrelated to ceph

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -290,6 +290,15 @@
 	...
 }
 {
+	dl-init.c possible lost init
+	Memcheck:Leak
+	...
+	fun:__trans_list_add
+	fun:call_init.part.0
+	fun:call_init
+	...
+}
+{
 	weird thing from libc
 	Memcheck:Leak
 	...
@@ -392,6 +401,13 @@
 	Memcheck:Leak
 	...
 	fun:*BGThreadWrapper*
+	...
+}
+{
+	rocksdb VersionStorageInfo
+	Memcheck:Leak
+	...
+	fun:*VersionStorageInfo
 	...
 }
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58315

---

backport of https://github.com/ceph/ceph/pull/48641
parent tracker: https://tracker.ceph.com/issues/52136

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh