### PR TITLE
quincy: rgw: Fix truncated ListBuckets response.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2397,6 +2397,8 @@ void RGWListBuckets::execute(optional_yield y)
       break;
     }
 
+    is_truncated = buckets.is_truncated();
+
     /* We need to have stats for all our policies - even if a given policy
      * isn't actually used in a given account. In such situation its usage
      * stats would be simply full of zeros. */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58233

---

backport of https://github.com/ceph/ceph/pull/48559
parent tracker: https://tracker.ceph.com/issues/57901

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh