### PR TITLE
rgw: fix signed to unsigned comparisson warning

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -151,11 +151,9 @@ void RGWPutUserPolicy::execute(optional_yield y)
     }
     bufferlist in_bl;
     policies[policy_name] = policy;
-#define USER_POLICIES_MAX_NUM 100
-    int max_num = s->cct->_conf->rgw_user_policies_max_num;
-    if (max_num < 0) {
-      max_num = USER_POLICIES_MAX_NUM;
-    }
+    constexpr unsigned int USER_POLICIES_MAX_NUM = 100;
+    const unsigned int max_num = s->cct->_conf->rgw_user_policies_max_num < 0 ? 
+      USER_POLICIES_MAX_NUM : s->cct->_conf->rgw_user_policies_max_num;
     if (policies.size() > max_num) {
       ldpp_dout(this, 4) << "IAM user policies has reached the num config: "
                          << max_num << ", cant add another" << dendl;


### PR DESCRIPTION
warning:
rgw_rest_user_policy.cc:159:25: warning: comparison of integer expressions of different signedness: ‘std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} and ‘int’

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
