### PR TITLE
quincy: mds: do not acquire xlock in xlockdone state

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1925,8 +1925,13 @@ bool Locker::xlock_start(SimpleLock *lock, MDRequestRef& mut)
       }
 
       if (!lock->is_stable() && (lock->get_state() != LOCK_XLOCKDONE ||
-				 lock->get_xlock_by_client() != client ||
-				 lock->is_waiter_for(SimpleLock::WAIT_STABLE)))
+                                lock->get_xlock_by_client() != client ||
+                                lock->is_waiter_for(SimpleLock::WAIT_STABLE)))
+	break;
+      // Avoid unstable XLOCKDONE state reset,
+      // see: https://tracker.ceph.com/issues/49132
+      if (lock->get_state() == LOCK_XLOCKDONE &&
+          lock->get_type() == CEPH_LOCK_IFILE)
 	break;
 
       if (lock->get_state() == LOCK_LOCK || lock->get_state() == LOCK_XLOCKDONE) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58322

backport of https://github.com/ceph/ceph/pull/48743
parent tracker: https://tracker.ceph.com/issues/49132

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>
(cherry picked from commit 2e37d1e3c4af071d4e09df603c141f38cadda69f)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
