### PR TITLE
rbd: alternative LSVD block device (not suitable for merging)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -874,6 +874,7 @@ if(WITH_RBD)
   if(WITH_FUSE)
     add_subdirectory(rbd_fuse)
   endif()
+  add_subdirectory(liblsvd)
 
   install(PROGRAMS
     ceph-rbdnamer


### PR DESCRIPTION
Log Structured Virtual Disk (LSVD) technology preview see "Beating the I/O Bottleneck - a Case for Log-Structured Virtual Disks" Hajkazemi et al, EuroSys 2022 https://dl.acm.org/doi/10.1145/3492321.3524271

This adds a new library, liblsvd.so, which "pirates" the librbd interface and can be used via LD_PRELOAD; it's been tested with QEMU and fio.

See README.md for more details. Note that this needs re-writing to conform to Ceph coding guidelines, as well as a lot of discussion to figure out how it can live alongside RBD, use Ceph async completion and buffer lists so it can use the internal RADOS interface, etc.

Signed-off-by: Peter Desnoyers <p.desnoyers@northeastern.edu>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

Includes unit tests, but they aren't integrated into Ceph make check or teuthology
