### PR TITLE
rbd: alternative LSVD block device (not suitable for merging)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -874,6 +874,7 @@ if(WITH_RBD)
   if(WITH_FUSE)
     add_subdirectory(rbd_fuse)
   endif()
+  add_subdirectory(liblsvd)
 
   install(PROGRAMS
     ceph-rbdnamer

--- a/src/liblsvd/CMakeLists.txt
+++ b/src/liblsvd/CMakeLists.txt
@@ -1,0 +1,52 @@
+set(lsvd_srcs
+      liblsvd.cc  
+      config.cc
+      file_backend.cc
+      io.cc
+      lsvd_debug.cc
+      mkcache.cc
+      nvme.cc
+      objects.cc
+      rados_backend.cc
+      read_cache.cc
+      translate.cc
+      write_cache.cc)
+ 
+set(lsvd_libs
+     librados
+     pthread
+     rt
+     aio
+     uuid
+     z)
+
+add_library(liblsvd SHARED
+  ${lsvd_srcs})
+target_link_libraries(liblsvd PRIVATE ${lsvd_libs}) 
+
+if(ENABLE_SHARED)
+  set_target_properties(liblsvd PROPERTIES
+    OUTPUT_NAME lsvd
+    VERSION 0.0.1
+    SOVERSION 0
+    SONAME rbd
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+endif(ENABLE_SHARED)
+install(TARGETS liblsvd DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+add_executable(lsvd_imgtool
+    lsvd_imgtool.cc
+    ${lsvd_srcs})
+target_link_libraries(lsvd_imgtool ${lsvd_libs}) 
+
+add_executable(lsvd_rnd_test
+    lsvd_rnd_test.cc
+    ${lsvd_srcs})  
+target_link_libraries(lsvd_rnd_test ${lsvd_libs}) 
+
+add_executable(lsvd_crash_test
+    lsvd_crash_test.cc
+    ${lsvd_srcs}) 
+
+target_link_libraries(lsvd_crash_test ${lsvd_libs}) 

--- a/src/liblsvd/README.md
+++ b/src/liblsvd/README.md
@@ -1,0 +1,263 @@
+# LSVD - Log-Structured Virtual Disk
+
+Original paper [here](https://dl.acm.org/doi/10.1145/3492321.3524271)
+
+This is a re-write with a number of differences:
+- supported backends are RADOS and local files (for debugging), no S3 support yet
+- user-space implementation, with no kernel component. Among other things, no need for individual partitions for the cache, since you can use a regular file
+- reasonable metadata with versions, IDs, extensibility - the previous version was grad student code...
+
+It's not quite as fast as the the version in the paper, but on my old machines (IvyBridge) and Ceph 17.2.0 I'm getting about 100K write IOPS against an erasure-coded pool on SATA SSDs with moderate CPU load on the backend (~30% CPU * 32 OSDs) vs maybe 5x that for half as many IOPS with straight RBD and a replicated pool.
+
+Note that although individual disk performance is important, the main goal is to be able to support higher aggregate client IOPS against a given backend OSD pool.
+
+## what's here
+
+This builds `liblsvd.so`, which provides most of the basic RBD API; you can use `LD_PRELOAD` to use this in place of RBD with `fio`, KVM/QEMU, and a few other tools. It also includes some tests and tools described below.
+
+## stability
+
+As of Dec 22 it still suffers from occasional lost completions - I did a download and full build of Ceph on a 16-VCPU VM, and I had to restart QEMU half a dozen times when dropped I/Os caused hung processes.
+
+## Configuration
+
+LSVD is not yet merged into the Ceph configuration framework, and uses its own system. 
+It reads from a configuration file (`lsvd.conf` or `/usr/local/etc/lsvd.conf`) or from environment variables of the form `LSVD_<NAME>`, where NAME is the upper-case version of the config file variable.
+Default values can be found in `config.h`
+
+Parameters are:
+
+- `batch_size`, `LSVD_BATCH_SIZE`: size of objects written to the backend, in bytes (K/M recognized as 1024, 1024\*1024). Default: 8MiB
+- `wcache_batch`: write cache batching (see below)
+- `wcache_chunk': maximum size of atomic write, in bytes - larger writes will be split and may be non-atomic.
+- `cache_dir` - directory used for cache file and GC temporary files. Note that `lsvd_imgtool` can format a partition for cache and symlink it into this directory, although the performance improvement seems limited.
+- `xlate_window`: max writes (i.e. objects) in flight to the backend. Note that this value is coupled to the size of the write cache, which must be big enough to hold all outstanding writes in case of a crash.
+- `hard_sync` (untested): "flush" forces all batched writes to the backend.
+- `backend`: "file" or "rados" (default rados). The "file" backend is for testing only
+- `cache_size` (bytes, K/M/G): total size of the cache file. Currently split 1/3 write, 2/3 read. Ignored if the cache file already exists.
+- `ckpt_interval` N: limits the number of objects to be examined during crash recovery by flushing metadata every N objects.
+- `flush_msec`: timeout for flushing batched writes
+- `gc_threshold` (percent): described below
+
+Typically the only parameters that need to be set are `cache_dir` and `cache_size`.
+Parameters may be added or removed as we tune things and/or figure out how to optimize at runtime instead of bothering the user for a value.
+
+## Using LSVD with fio and QEMU
+
+First create a volume:
+```
+build$ sudo bin/lsvd_imgtool --create --rados \
+	--cache-dir=/mnt/nvme/lsvd --size=20g ec83b_pool/ubuntu_3
+```
+
+Then you can start QEMU:
+```
+build$ sudo env LSVD_CACHE_DIR=/mnt/nvme/lsvd \
+         LSVD_CACHE_SIZE=1000m \
+         LD_PRELOAD=$PWD/lib/liblsvd.so \
+		 LD_LIBRARY_PATH=$PWD/lib \
+         XAUTHORITY=$HOME/.Xauthority \
+   qemu-system-x86_64 -m 1024 -cdrom whatever.iso \
+    -blockdev '{"driver":"rbd","pool":"ec83b_pool",
+	           "image":"ec83b_pool/ubuntu_3",
+               "server":[{"host":"10.1.0.4","port":"6789"}],
+               "node-name":"libvirt-2-storage","auto-read-only":true,
+                "discard":"unmap"}' \
+	-device virtio-blk,drive=libvirt-2-storage \
+    -device e1000,netdev=net0 \
+	-netdev user,id=net0,hostfwd=tcp::5555-:22 \
+    -k en-us -machine accel=kvm -smp 2 -m 1024
+```
+
+Or you can fun `fio` like this:
+```
+build$ cat > rbd-w.fio <<EOF
+[global]
+ioengine=rbd
+clientname=admin
+pool=ec83b_pool
+rbdname=ec83b_pool/fio-target
+busy_poll=0
+
+rw=randwrite
+#rw=randread
+bs=4k
+runtime=100
+time_based
+direct=1
+
+[rbd_lsvd]
+iodepth=128
+EOF
+
+build$ sudo bin/lsvd_imgtool --create --rados \
+	--cache-dir=/mnt/nvme/lsvd --size=10g ec83b_pool/fio-target
+
+build$ sudo env LD_PRELOAD=$PWD/lib/liblsvd.so \
+    LSVD_CACHE_DIR=/mnt/nvme/test fio rbd-w.fio
+```
+
+Note that FIO random write throughput varies widely depending on which version you use.
+The 2.38-1 package in Ubuntu 22.04 performs fairly poorly; when compiled with default options it does a lot better, and better still if you build it without `rbd_poll` support. 
+(it's not a config option, so you have to hack things)
+
+Do not use multiple fio jobs on the same image - currently there's no protection and they'll stomp all over each other. 
+RBD performs horribly in that case, but AFAIK it doesn't compromise correctness.
+
+[TODO - use RADOS locking to prevent multiple opens, maybe use refcounts to allow multiple threads to "open" and access the same image]
+
+## Image and object names
+
+Currently the name of an image is *pool/name*; LSVD will ignore the ioctx passed in the API and open the pool named in the image name. [TODO]
+
+Given an image name of `mypool/disk_x`, LSVD stores a *superblock* in the object `disk_x`, and a series of *data objects* and *checkpoint objects* in `disk_x.00000001`, etc. using hexadecimal 32-bit sequence numbers. 
+
+- superblock - holds volume size, clone linkage, [TBD snapshot info], and clean shutdown info / pointer to roll-forward point.
+- data objects - data blocks and metadata (i.e. list of LBAs) for log recovery
+- checkpoints - full map, persisted at shutdown and periodically to limit the amount of log recovery needed after a crash
+
+[TODO - use a larger sequence number - at 100K IOPS, 2^32 gives us a bit less than 3 years]
+
+[TODO - checkpoints can be large for large volumes, although we don't have good data points for realistic workloads. (The GC does defragmentation, and the map uses length encoded extents, so unless you run pure random writes it's hard to calculate the map size) 
+We probably need to split the checkpoint into multiple objects and write it incrementally to handle multi-TB volumes]
+
+## How it works
+
+There's a more detailed (although possibly out-of-date) description of the internals in [review-notes.md](review-notes.md)
+
+Writes: Incoming writes are optionally batched, if there's a queue for the NVMe device, and written in journal records to NVMe from within the calling thread.
+A libaio completion thread passes the data to the translation layer, where it gets copied into a batch buffer, and then notifies callers.
+Full batches are tossed on a queue for another thread, as lock delays in the translation layer tend to be a lot longer than in the write cache. 
+They get written out and the new LBA to object/offset mapping is recorded in the object map.
+
+Reads: this is more complicated, and described in some detail in [review-notes.md](review-notes.md).
+We iterate over the requested address range, finding extents which are resident in the write cache, passing any other mapped extents to the read cache, and zeroing any unmapped extents, aggregating all the individual requests we've broken it up into.
+Then we launch all the requests and wait for them to complete.
+
+Completions come from the write cache libaio callback thread, the read cache callback thread, or RADOS aio notification.
+
+(note that heavily fragmented reads are atypical, but of course have to be handled properly for correctness)
+
+## Garbage collection
+
+LSVD currently uses a fairly straightforward greedy garbage collector, selecting objects with utilization (i.e. fraction of live sectors) below a certain threshold and cleaning them.
+This threshold can be set (as a percent, out of 100) with the `gc_threshold` parameter.
+Higher values will reduce wasted space, while lower values will decrease 
+As a rough guide, overall volume utilization will be halfway between this threshold and 100% - e.g. a value of 60 should give an overall utilization of about 80%, or a space expansion of 25% (i.e. 100/80). 
+
+Raising this value above about 70 is not recommended, and we would suggest instead using lower-rate erasure codes - e.g. an 8,2 code plus 25% overhead (i.e. gc=60) gives an overall space expansion of 1.56x, vs 3x for triple replication.
+
+The GC algorithm runs in fairly large batches, and stores data in a temporary file in the cache directory rather than buffering it in memory.
+At the moment we don't have any controls on the size of this file or mechanism for limiting it, although in practice it's been reasonably small compared to the cache itself. [TODO]
+
+## Cache consistency
+
+The write cache can't be decoupled from the virtual disk, but there are a number of mechanisms to ensure consistency and some parameters to tweak them.
+
+1. Write ordering - write order is maintained through to the backend, which is important for some of the recovery mechanisms below
+1. Post-crash cache recovery - the write cache is a journal, and after recovery we replay any writes which didn't make it to the backend.
+1. Cache loss - *prefix consistency* is maintained - if any write is visible in the image, all writes preceding that are visible. This ensures file system consistency, but may lose data.
+1. Write atomicity - writes up to 2MB are guaranteed to be atomic. Larger ones are split into 2MB chunks, and it's possible that the tail of such a sequence could be lost while the first chunks are recorded. 
+
+The `hard_flush` configuration option will cause flush operations to push all data to the backend, at a substantial loss in performance for sync-heavy workloads. Alternately the `flush_msec` option (default 2s) can be used to bound the duration of possible data loss.
+
+Note that `lsvd_crash_test` simulates crashes by killing a subprocess while it's writing, and optionally deletes the cache before recovery.
+To verify consistency writes are stamped with sequence numbers, and the test finds the last sequence number present in the image and verifies that all preceding writes are fully present as well.
+
+## Erasure code notes
+
+The write logic creates large objects (default 8MB), so it works pretty well on pretty much any pool.
+The read cache typically fetches 64K blocks, so there may be a bit of extra load on the backend if you use the default 4KB stripe size instead of an  erasure code with a stripe size of 64K; however I haven't really tested how much of a difference this makes.
+Most of the testing to date has been with an 8,3 code with 64K stripe size.
+
+## Tools
+`lsvd_imgtool` mostly just calls the LSVD versions of `rbd_create` and `rbd_remove`, although it can also format a cache file (e.g. if you're using a raw partition) 
+```
+build$ bin/lsvd_imgtool --help
+Usage: lsvd_imgtool [OPTION...]
+IMAGE
+
+  -C, --create               create image
+  -d, --cache-dir=DIR        cache directory
+  -D, --delete               delete image
+  -I, --info                 show image information
+  -k, --mkcache=DEV          use DEV as cache
+  -O, --rados                use RADOS
+  -z, --size=SIZE            size in bytes (M/G=2^20,2^30)
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+```
+
+Other tools live in the `tools` subdirectory - see the README there for more details.
+
+## Tests
+
+There are two tests included: `lsvd_rnd_test` and `lsvd_crash_test`. 
+They do random writes of various sizes, with random data, and each 512-byte sector is "stamped" with its LBA and a sequence number for the write.
+CRCs are saved for each sector, and after a bunch of writes we read everything back and verify that the CRCs match.
+
+## `lsvd_rnd_test`
+
+```
+build$ bin/lsvd_rnd_test --help
+Usage: lsvd_rnd_test [OPTION...] RUNS
+
+  -c, --close                close and re-open
+  -d, --cache-dir=DIR        cache directory
+  -D, --delay                add random backend delays
+  -k, --keep                 keep data between tests
+  -l, --len=N                run length
+  -O, --rados                use RADOS
+  -p, --prefix=PREFIX        object prefix
+  -r, --reads=FRAC           fraction reads (0.0-1.0)
+  -R, --reverse              reverse NVMe completion order
+  -s, --seed=S               use this seed (one run)
+  -v, --verbose              print LBAs and CRCs
+  -w, --window=W             write window
+  -x, --existing             don't delete existing cache
+  -z, --size=S               volume size (e.g. 1G, 100M)
+  -Z, --cache-size=N         cache size (K/M/G)
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+```
+
+Unlike the normal library, it defaults to storing objects on the filesystem; the image name is just the path to the superblock object (the --prefix argument), and other objects live in the same directory.
+If you use this, you probably want to use the `--delay` flag, to have object read/write requests subject to random delays.
+It creates a volume of --size bytes, does --len random writes of random lengths, and then reads it all back and checks CRCs. 
+It can do multiple runs; if you don't specify --keep it will delete and recreate the volume between runs. 
+The --close flag causes it to close and re-open the image between runs; otherwise it stays open.
+
+### `lsvd_rnd_test`
+
+This is pretty similar, except that does the writes in a subprocess which kills itself with `_exit` rather than finishing gracefully, and it has an option to delete the cache before restarting.
+
+This one needs to be run with the file backend, because some of the test options crash the writer, recover the image to read and verify it, then restore it back to its crashed state before starting the writer up again.
+
+It uses the write sequence numbers to figure out which writes made it to disk before the crash, scanning all the sectors to find the highest sequence number stamp, then it veries that the image matches what you would get if you apply all writes up to and including that sequence number.
+
+```
+build$ bin/lsvd_crash_test --help
+Usage: lsvd_crash_test [OPTION...] RUNS
+
+  -2, --seed2                seed-generating seed
+  -d, --cache-dir=DIR        cache directory
+  -D, --delay                add random backend delays
+  -k, --keep                 keep data between tests
+  -l, --len=N                run length
+  -L, --lose-writes=N        delete some of last N cache writes
+  -n, --no-wipe              don't clear image between runs
+  -o, --lose-objs=N          delete some of last N objects
+  -p, --prefix=PREFIX        object prefix
+  -r, --reads=FRAC           fraction reads (0.0-1.0)
+  -R, --reverse              reverse NVMe completion order
+  -s, --seed=S               use this seed (one run)
+  -S, --sleep                child sleeps for debug attach
+  -v, --verbose              print LBAs and CRCs
+  -w, --window=W             write window
+  -W, --wipe-cache           delete cache on restart
+  -x, --existing             don't delete existing cache
+  -z, --size=S               volume size (e.g. 1G, 100M)
+  -Z, --cache-size=N         cache size (K/M/G)
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+```

--- a/src/liblsvd/README.md
+++ b/src/liblsvd/README.md
@@ -17,7 +17,9 @@ This builds `liblsvd.so`, which provides most of the basic RBD API; you can use 
 
 ## stability
 
-As of Dec 22 it still suffers from occasional lost completions - I did a download and full build of Ceph on a 16-VCPU VM, and I had to restart QEMU half a dozen times when dropped I/Os caused hung processes.
+[fixed] As of Dec 22 it still suffers from occasional lost completions - I did a download and full build of Ceph on a 16-VCPU VM, and I had to restart QEMU half a dozen times when dropped I/Os caused hung processes.
+
+Full Ceph compile runs without incident.
 
 ## Configuration
 

--- a/src/liblsvd/backend.h
+++ b/src/liblsvd/backend.h
@@ -1,0 +1,44 @@
+/* This file is the header file for the backend for lsvd which simply uses definitions from sys/uio.h
+ * in order to have base functions for write and read operations for IO
+ */
+
+#ifndef BACKEND_H
+#define BACKEND_H
+
+#include <sys/uio.h>
+#include <string>
+
+#include "fake_rbd.h"
+
+class request;
+
+class backend {
+public:
+    virtual ~backend(){}
+    
+    /* synchronous I/O methods, return 0 / -1 for success/error
+     */
+    virtual int write_object(const char *name, iovec *iov, int iovcnt) = 0;
+    virtual int write_object(const char *name, char *buf, size_t len) = 0;
+    virtual int read_object(const char *name, iovec *iov, int iovcnt,
+                            size_t offset) = 0;
+    virtual int read_object(const char *name, char *buf, size_t len,
+                            size_t offset) = 0;
+    virtual int delete_object(const char *name) = 0;
+    virtual request *delete_object_req(const char *name) = 0;
+    
+    /* async I/O
+     */
+    virtual request *make_write_req(const char *name,
+                                    iovec *iov, int iovcnt) = 0;
+    virtual request *make_write_req(const char *name, char *buf, size_t len) = 0;
+    virtual request *make_read_req(const char *name, size_t offset,
+                                    iovec *iov, int iovcnt) = 0;
+    virtual request *make_read_req(const char *name, size_t offset,
+                                   char *buf, size_t len) = 0;
+};
+
+extern backend *make_file_backend(const char *prefix);
+extern backend *make_rados_backend(rados_ioctx_t io);
+
+#endif

--- a/src/liblsvd/config.cc
+++ b/src/liblsvd/config.cc
@@ -1,0 +1,132 @@
+/*
+ * file:        config.cc
+ * description: quick and dirty config file parser
+ *              env var overrides modeled on github.com/spf13/viper
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <stdlib.h>
+#include <ctype.h>
+#include <uuid/uuid.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <filesystem>
+namespace fs = std::filesystem;
+
+#include "config.h"
+
+std::vector<std::string> cfg_path(
+    {"lsvd.conf", "/usr/local/etc/lsvd.conf"});
+
+static void split(std::string s, std::vector<std::string> &words) {
+    std::string w = "";
+    for (auto c : s) {
+	if (!isspace(c))
+	    w = w + c;
+	else {
+	    words.push_back(w);
+	    w = "";
+	}
+    }
+    if (w.size() > 0)
+	words.push_back(w);
+}
+
+static std::map<std::string,cfg_backend> m = {{"file", BACKEND_FILE},
+					      {"rados", BACKEND_RADOS}};
+
+
+/* fancy-ass macros to parse config file lines. 
+ *   config keyword = field name
+ *   environment var = LSVD_ + uppercase(field name)
+ *   skips blank lines and lines that don't match a keyword
+ */
+#include "config_macros.h"
+
+int lsvd_config::read() {
+    auto explicit_cfg = getenv("LSVD_CONFIG_FILE");
+    if (explicit_cfg) {
+	std::string f(explicit_cfg);
+	cfg_path.insert(cfg_path.begin(), f);
+    }
+    for (auto f : cfg_path) {
+	std::ifstream fp(f);
+	if (!fp.is_open())
+	    continue;
+	std::string line;
+	while (getline(fp, line)) {
+	    if (line[0] == '#')
+		continue;
+	    std::vector<std::string> words;
+	    split(line, words);
+	    if (words.size() != 2)
+		continue;
+	    F_CONFIG_H_INT(words[0], words[1], batch_size);
+	    F_CONFIG_INT(words[0], words[1], wcache_batch);
+	    F_CONFIG_H_INT(words[0], words[1], wcache_chunk);
+	    F_CONFIG_STR(words[0], words[1], cache_dir);
+	    F_CONFIG_INT(words[0], words[1], xlate_window);
+	    F_CONFIG_TABLE(words[0], words[1], backend, m);
+	    F_CONFIG_H_INT(words[0], words[1], cache_size);
+	    F_CONFIG_INT(words[0], words[1], hard_sync);
+	    F_CONFIG_INT(words[0], words[1], ckpt_interval);
+	    F_CONFIG_INT(words[0], words[1], flush_msec);
+	    F_CONFIG_INT(words[0], words[1], gc_threshold);
+	}
+	fp.close();
+	break;
+    }
+    
+    ENV_CONFIG_H_INT(batch_size);
+    ENV_CONFIG_INT(wcache_batch);
+    ENV_CONFIG_H_INT(wcache_chunk);
+    ENV_CONFIG_STR(cache_dir);
+    ENV_CONFIG_INT(xlate_window);
+    ENV_CONFIG_TABLE(backend, m);
+    ENV_CONFIG_H_INT(cache_size);
+    ENV_CONFIG_INT(hard_sync);
+    ENV_CONFIG_INT(ckpt_interval);
+    ENV_CONFIG_INT(flush_msec);
+    ENV_CONFIG_INT(gc_threshold);
+
+    return 0;			// success
+}
+
+std::string lsvd_config::cache_filename(uuid_t &uuid, const char *name) {
+    char buf[256]; // PATH_MAX
+    std::string file(name);
+    file = fs::path(file).filename();
+    
+    sprintf(buf, "%s/%s.cache", cache_dir.c_str(), file.c_str());
+    if (access(buf, R_OK|W_OK) == 0)
+	return std::string((const char*)buf);
+
+    char uuid_s[64];
+    uuid_unparse(uuid, uuid_s);
+    sprintf(buf, "%s/%s.cache", cache_dir.c_str(), uuid_s);
+    return std::string((const char*)buf);
+}
+
+#if 0
+int main(int argc, char **argv) {
+    auto cfg = new lsvd_config;
+    cfg->read();
+
+    printf("batch: %d\n", cfg->batch_size); // h_int
+    printf("wc batch %d\n", cfg->wcache_batch); // int
+    printf("cache: %s\n", cfg->cache_dir.c_str()); // str
+    printf("backend: %d\n", (int)cfg->backend);	   // table
+
+    uuid_t uu;
+    std::cout << cfg->cache_filename(uu, "foobar") << "\n";
+}
+#endif

--- a/src/liblsvd/config.h
+++ b/src/liblsvd/config.h
@@ -1,0 +1,38 @@
+/*
+ * file:        config.h
+ * description: quick and dirty config file parser
+ *              env var overrides modeled on github.com/spf13/viper
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+enum cfg_backend { BACKEND_FILE = 1, BACKEND_RADOS = 2 };
+
+class lsvd_config {
+public:
+
+    int         batch_size = 8*1024*1024;   // in bytes
+    int         wcache_batch = 8;           // requests
+    int         wcache_chunk = 2*1024*1024; // bytes
+    std::string cache_dir = "/tmp";
+    int         xlate_window = 8;
+    int         hard_sync = 0;
+    enum cfg_backend backend = BACKEND_RADOS;
+    long        cache_size = 500*1024*1024; // in bytes
+    int         ckpt_interval = 500;        // objects 
+    int         flush_msec = 2000;          // flush timeout
+    int         gc_threshold = 60;          // GC threshold, percent
+
+    lsvd_config(){}
+    ~lsvd_config(){ }
+    int read();
+    std::string cache_filename(uuid_t &uuid, const char *name);
+};
+
+#endif

--- a/src/liblsvd/config_macros.h
+++ b/src/liblsvd/config_macros.h
@@ -1,0 +1,88 @@
+/*
+ * file:        config_macros.h
+ * description: really simple config file / env var parsing
+ *
+ * config file keyword = variable name
+ * environment variable = LSVD_(uppercase keyword)
+ * handles four types of values:
+ *   - string
+ *   - int
+ *   - human-readable int (e.g. 10m, 20G)
+ *   - table (actually std::map<char,...>) lookup
+ *
+ * to use: 
+ *   F_CONFIG_XXX(input, arg, name) - if input==name, set name=arg
+ *   ENV_CONFIG_XXX(name) - if LSVD_<name> is set, set name=<val>
+ *
+ */
+
+#include <algorithm>
+#include <cctype>
+
+static long parseint(const char *_s)
+{
+    char *s = (char*)_s;
+    long val = strtol(s, &s, 0);
+    if (toupper(*s) == 'G')
+        val *= (1024*1024*1024);
+    if (toupper(*s) == 'M')
+        val *= (1024*1024);
+    if (toupper(*s) == 'K')
+        val *= 1024;
+    return val;
+}
+
+static long parseint(std::string &s)
+{
+    return parseint(s.c_str());
+}
+
+#define CONFIG_HDR(name)    \
+    const char *val = NULL; \
+    std::string env = "LSVD_" #name; \
+    std::transform(env.begin(), env.end(), env.begin(), \
+		   [](unsigned char c){ return std::toupper(c);});
+
+#define F_CONFIG_STR(input, arg, name) { \
+    if (input == #name) \
+	name = arg; \
+    }
+
+#define ENV_CONFIG_STR(name) { \
+    CONFIG_HDR(name) \
+    if ((val = getenv(env.c_str()))) \
+	name = std::string(val); \
+    }
+
+#define F_CONFIG_INT(input, arg, name) { \
+    if (input == #name) \
+	name = atoi(arg.c_str()); \
+    }
+
+#define ENV_CONFIG_INT(name) { \
+    CONFIG_HDR(name) \
+    if ((val = getenv(env.c_str()))) \
+	name = atoi(val); \
+    }
+
+#define F_CONFIG_H_INT(input, arg, name) { \
+    if (input == #name) \
+	name = parseint(arg); \
+    }
+
+#define ENV_CONFIG_H_INT(name) { \
+    CONFIG_HDR(name) \
+    if ((val = getenv(env.c_str()))) \
+	name = parseint(val); \
+    }
+
+#define F_CONFIG_TABLE(input, arg, name, table) { \
+    if (input == #name) \
+	name = table[arg]; \
+    }
+
+#define ENV_CONFIG_TABLE(name, table) { \
+    CONFIG_HDR(name) \
+    if ((val = getenv(env.c_str()))) \
+	name = table[std::string(val)]; \
+    }

--- a/src/liblsvd/design-notes.md
+++ b/src/liblsvd/design-notes.md
@@ -1,0 +1,570 @@
+# new-lsvd
+
+### 3/23/22
+
+- the whole idea of putting checkpoints inline with the rest of the write cache may be flawed. Maybe we should reserve a section - worst case is 20B for 8KB. (well, worst case is a bit more than that, since in theory we could have a bunch of single-sector writes. Worst is actually 12*8+8 = 104B per 8k, but that's still less than 2%)
+
+### 3/21/22
+
+- fixed the bug that was overwriting the read cache map
+- added clean shutdown stuff to `rbd_close`, but now fio read seems to hang when it's done
+- some cleanup of cache.py
+- added some synchronization so that translate::flush actually waits until stuff has been written. (more importantly, until it's been updated in the map so we can do a checkpoint)
+
+### 3/20/22
+
+weird things to fix and add to tests:
+- write cache is overwriting the read cache map, I think, with PAD record.
+- read cache only registers 200 misses, but replacing the cache line fetch logic with straight read doubles the throughput
+- not getting misses despite random read of 1GB volume with 100MB cache
+
+## stuff
+thread pool:
+
+took a stab at using https://github.com/DeveloperPaul123/thread-pool,
+which seems to be a nice header-only thread pool, but it's a pain in
+the ass to compile.
+
+Instead think I'll use:
+https://github.com/fbastos1/thread_pool_cpp17
+
+from
+https://codereview.stackexchange.com/questions/221626/c17-thread-pool
+
+# basic design
+
+Need to implement lots of the functions from [librbd.h](https://github.com/ceph/ceph/blob/master/src/include/rbd/librbd.h)
+
+This seems to be a list of most of the methods that we should implement - note that in a lot of cases we probably have to figure out which version (e.g. create/create2/create3/...) the tools are using
+
+- `rbd_list2` - list images
+- `rbd_create`, `rbd_create2`, `rbd_create3`, `rbd_create4` - various ways of creating image, we should pick one?
+- `rbd_clone`, `rbd_clone2`, `rbd_clone3` - create a clone; again, pick 1?
+- `rbd_remove`
+- `rbd_open`, `rbd_open_by_id`, `rbd_aio_open`, `rbd_aio_open_by_id`
+- `rbd_close`, `rbd_aio_close`
+- `rbd_get_size` - [maybe]
+- `rbd_copy`, `rbd_copy2` .. 4 - [maybe]
+- `rbd_snap_list`, `rbd_snap_list_end`, `rbd_snap_exists`
+- `rbd_snap_create`, `rbd_snap_create2`
+- `rbd_snap_remove`, `rbd_snap_remove2`, `rbd_snap_remove_by_id`
+- `rbd_snap_rollback`
+- `rbd_list_children` - not sure we can do this (list children of clones)
+- `rbd_read`, `rbd_read2`, `rbd_read_iterate`, `rbd_read_iterate2`
+- `rbd_write`, `rbd_write2`
+- `rbd_discard`, `rbd_aio_discard`
+- `rbd_aio_write`, `rbd_aio_write2`, `rbd_aio_writev`
+- `rbd_aio_read`, `rbd_aio_read2`, `rbd_aio_readv`
+- `rbd_aio_create_completion`, `rbd_aio_is_complete`, `rbd_aio_wait_for_complete`, `rbd_aio_get_return_value`, `rbd_aio_release`
+- `rbd_flush`, `rbd_aio_flush`
+
+
+### Phases of development
+
+1. basic read/write functionality, with working garbage collection. Image creation via external utility
+
+2. logging of journal map, local journal recovery
+
+3. incremental checkpointing of backend map, failure recovery.
+
+4. clone - read/write support in library, creation via external utility
+
+5. snapshot - creation by external utility while volume is quiesced, add deferred GC delete to library
+
+6. fancy GC / defragmentation
+
+7. roll snap/clone external support into the library??? not sure how important this is
+
+### Journal and local cache format
+
+Need to specify detailed format of the journal:
+
+- individual records
+- allocation (bitmap?)
+- how do incoming writes and cached reads go together?
+- eviction algorithm
+- map persistence
+- crash recovery process
+
+Note that we can do 1-ahead allocation so that we can link journal records both forwards and backwards.
+
+Hmm, we can allocate in fairly big chunks (makes the journal header a bit more complex) which means that the bitmap can be smaller. E.g. 4KB = 32MB bitmap for 1TB, but 64KB = 2MB bitmap.
+
+But that's also problematic, since it means we may need to do GC to free blocks, so maybe we're stuck with 32MB/TB.
+
+### Object format / header
+
+This needs to handle a bunch of stuff for recovery, snap&clone, incremental map persistence, etc.
+
+I've got some notes somewhere about it.
+
+### Software structure
+
+Each virtual disk instance has:
+
+- LBA -> (obj,offset) map, for all complete write batches
+- LBA -> ptr map for any writes currently being batched
+- (obj,offset) -> LBA map to find cached data
+- current write batch (process when we hit size or timeout limit)
+- outstanding writes to backend
+- outstanding reads to backend
+
+I've been thinking that there's a single write batch buffered in memory. That means when it fills we need to atomically:
+- sort and merge it
+- assign an object number, put extents into LBA->(obj,offset) map
+- wait for NVMe writes to complete
+- set new empty buffer, map
+
+We need NVMe writes to complete, since the only way here to access new data after it's no longer in the newest buffer is to get it from the NVMe.
+
+Actually I think it would be better to have a list of buffer/map pairs, and we can remove a pair from the list and recycle them when all their NVMe writes complete.
+
+We don't need to worry about new writes after that point, since they should last in the journaled cache until after they've been successfully written to back-end S3.
+
+So the order of checking things for a read is:
+- incoming buffer+map (LBA->ptr)
+- list of buffer+map with NVMe writes pending (LBA->ptr)
+- backend map (LBA->(obj,offset))
+    - now check cache map (obj,offset)->LBA
+        if found, read from cache; otherwise fetch remote
+
+Incoming buffer+map needs a reader/writer lock, as it's shared between reads and writes. The buffer+map pairs waiting on NVMe write are read-only, but we need a reader/writer lock on the list so that they don't get deleted while we're looking at them.
+
+The backend map and cache maps can both have single reader/writer locks, writes should update cache map before backend map, one at a time, for consistency.
+
+### "Instantaneous garbage collection"
+
+1. calculate all the data to garbage collection
+2. read it in, save a copy in NVMe
+3. atomically update it in the backend map and the cache map
+4. write it to the back end
+
+Step 3 will lock the backend map for a while, since we have to re-check all the calculations from steps 1 and 2, but it's still in-memory. If it's all written to NVMe cache, then step 4 can happen **after** the map update and we're still OK.
+
+Note that the data written to NVMe might be quite cold, so once the writeback in step 4 is finished we may want to prioritize it for eviction.
+
+### Cache replacement
+
+The extent map implements A and D bits; D is set implicitly by update operations, while A is set explicitly by the application.
+
+This allows us to do rolling checkpoints for the object map, as long as we don't support discard. Discard is tricker - we could probably implement it by mapping to a sentinel value, e.g. object = MAX, offset = LBA. Not sure if we should ever remove these from the map - with 24 bits for the length field, max extent size = 2GB so it won't add many extra extents. 
+
+A single A  bit restricts us in the replacement algorithms we can use. One possibility is 2Q/CLOCK, maintaining 2 maps:
+
+- CLOCK on first map moves cold extents to 2nd map
+- CLOCK on 2nd map chooses extents for eviction
+- update trims from 2nd map and inserts into first map
+- lookup has to check both maps and merge the results. 
+
+### lazy GC writes
+
+Data objects need to have pointer to last "real" data object, so we can ignore missing GC writes
+
+### object headers
+
+Standard header
+```
+magic
+version
+volume UUID
+object type: superblock / data / checkpoint
+header len (sectors?)
+data len (sectors?)
+```
+
+Superblock
+```
+<standard header>
+volume size
+number of objects?
+total storage?
+checkpoints: list of obj#
+clone info - list of {name, UUID, seq#}
+snapshots - list of {UUID, seq#}
+pad to 4KB ???
+```
+Do we want a list of all the outstanding checkpoints? or just the last one?
+
+Data object
+```
+<standard header>
+active checkpoints: list of seq#
+last real data object (see GC comment)
+objects cleaned: list of {seq#, deleted?)
+extents: list of {LBA, len, ?offset?}
+pad to sector or 4KB
+<data>
+```
+
+Checkpoint
+```
+<standard header>
+active checkpoints: list of seq#
+map: list of {LBA, len, seq#, offset}
+objects: list of {seq#, data_sectors, live_sectors}
+deferred deletes: list of {seq#, delete time}
+```
+
+### random thoughts
+
+GC - fetch live data object-at-a-time and store it in local SSD. Note that we have to flag those locations as being temporary allocations, so they don't get marked as "allocated" in a checkpoint.
+
+If we allocate blocks of size X (8KB, 16KB etc) then we free blocks of that size. With X>=8KB we don't need to worry about bookkeeping for headers. Freeing is complicated, because we have to check that the adjacent map entry isn't still pointing to part of the block, but at least we don't need to keep counters for each block. For now stick with 4KB, as it's probably small compared to the extent map.
+
+(hmm, if we allocated 64KB blocks and kept 4-bit counters of the number of live 4K blocks in each 64KB, we could reduce the bitmap size by 4. Then again, just going to 16KB would do that, and we could still use bitmap ops and other good stuff)
+
+1TB / 16KB mean extent size would be 128M extents, or 2GB RAM. Note that we can probably structure the code to merge a lot of writes going to NVMe - post the write to a list, each worker thread grabs all the writes currently on the list.
+
+objects.cc - need an object that takes a memory buffer and can return pointers to header, other parts, and iterators for the various structures.
+It should also be able to serialize a set of vectors etc. Probably need std::string versions of the data structures that have names in them.
+
+Need a convention for how to handle buckets. I think including them in the name - "bucket/key" - is fine. Remember that this is going to also have to work for files and RADOS.
+
+How do we structure the local storage?
+
+superblock has
+- timestamp
+- remote volume UUID
+- pointer to last chunk written
+- <bitmap info>
+- <map info>
+
+note that temporary allocations are going to need some sort of journal header. Actually, can just flag them as such, and they get freed on replay.
+
+Bitmap and map are stored in the same way - a count (of bits or map entries) and a list of block numbers containing the data. (if we use 4KB block numbers we can use 32 bits for everything and still handle 16TB local SSDs)
+
+actual format in the superblock is probably
+- int64 count
+- int32 block count
+- int32 data block 
+- int32 indirect block 
+- int32 double indirect block
+- int32 triple indirect
+
+Use convention that only one of data / indirect / double indirect are used. 
+
+- data block: 4KB of data
+- indirect: 1K 4KB blocks
+- double: 1M 4KB blocks = 4GB
+- triple: 4TB, i.e. more than enough
+
+So maybe:
+
+- int32 count
+- int32 tree level (1, 2, 3 or 4 for direct / single..triple indirect)
+- int32 block count
+- int32 block
+
+Allocate storage and write all the data for bitmap and map before writing the superblock. Keep 2 copies of the superblock, write the first synchronously before writing the 2nd. On restart take the one with the most recent timestamp.
+
+Keep superblocks in blocks 0 and 1?
+
+Block allocator needs to return the block number for the next one that will be allocated, so we can do forward linking for log replay.
+
+SEQUENCE NUMBER. That's what the timestamp is - it's a counter that's incremented with every write. We need that in the journal header.
+
+Keep the CRC in the journal header, note that we only have to check it on log replay.
+
+Should there be a "clean" flag, or just recover every time we remount? Also should we store pointer to last chunk written, or pointer to next chunk? (which initializes the allocator if we're in the clean state)
+
+Need a reader for the tree-structured data, so that we can iterate through it.
+
+### actual journal format
+
+old format, from `dm-disbd.c`
+```
+struct _disheader {
+        uint32_t magic;
+        uint32_t seq;
+        uint32_t crc32;
+        uint16_t n_extents;
+        uint16_t n_sectors;
+} __attribute__((packed));
+
+struct _ext_local {
+        uint64_t lba : 47;
+        uint64_t len : 16;
+        uint64_t dirty : 1;
+} __attribute__((packed));
+
+#define HDR_EXTS ((DIS_HDR_SIZE - sizeof(struct _disheader)) / sizeof(struct _ext_local))
+
+struct dis_header {
+        struct _disheader h;
+        struct _ext_local extents[HDR_EXTS];
+};
+```
+
+NOTE - how much performance does the CRC cost? Would a checksum be better?
+
+Header needs to have:
+- magic number
+- sequence number
+- (block number? verify written in the right place)
+- list of blocks - need to mark as allocated on replay
+- pointer to next block
+- checksum / CRC. probably.
+- flag for whether it contains data or not.  [more complicated...]
+- list of extents
+
+On replay we put the data into the map and flag the header blocks as free. If it's a non-data entry, it's one of several things:
+
+- superblock-related data. if the sequence number
+    - precedes the current superblock, it stays allocated and we free the header
+    - is after the current superblock, we free the whole thing
+- temporary storage for GC. free unconditionally
+- checkpoint-related data. we wouldn't be reading it if the checkpoint were complete - free it
+
+Need to keep track of the header blocks for data writes and checkpoint data (bitmap, map) - when the checkpoint is complete we free them. Or rather, free them in the in-memory bitmap before writing it to disk.
+
+wait a minute, the superblock *is* the checkpoint. So any committed checkpoint will have a write frontier that is after any of its data. 
+
+progress:
+- wrote simple bitmap allocator
+maybe we need a sequence number class? for journal and backend
+
+parts of the whole thing:
+- (1) queue Q1 for writes
+- (2) thread pool reading from Q1 and writing to NVMe
+- (3) NVMe complete posts to queue Q2
+- (4) thread pool takes batch
+
+Easiest way to do batching is after (3), NVMe completion. We haven't replied to the write yet, so it's OK for reads to return older information. This means the NVMe writer:
+1. writes to NVMe
+2. on write completion, copy to batch buffer and map
+3. send write completion
+
+Probably better to have write threads to NVMe rather than async I/O, as it's more likely to use multiple CPUs? It's easier, anyway.
+
+items at the first queue:
+- LBA, len
+- iovec, count
+- async callback info
+
+thread takes a list of these, crafts a single NVMe write, sends it out. Maybe max I/O size? Use blktrace to see where they get split, probably 256K is OK.
+
+block-to-LBA and block-to-offset macros.
+
+## Possible problems
+
+`int64_t` vs `uint64_t` - we're losing a bit of precision in a bunch of places because of this. I think we need to move to unsigned integers for the bitfields, but I'm worried about signed/unsigned problems.
+
+- **DONE** changed to unsigned. In particular, signed bitfields of length 1 don't work very well...
+
+extent length - what happens if we try to merge two adjacent extents that overflow the length field?
+TODO - need to check for this; maybe modify the `adjacent` test so it fails on overflow.
+
+extent length -  what happens if we try to insert a range that's too large? This should only happen if we're implementing discard with a tombstone sentinel, as we're not going to create objects large enough or allocate memory or NVMe space large enough. In that case we have to loop and insert multiple.
+
+## Schedule
+
+1. finish extent map, unit tests
+1. basic non-GC device, using librbd? BDUS?. Need simple "mkdisk" utility. File backend?
+1. superblock 
+1. startup / recovery code
+1. simple (full) checkpoints
+1. simple GC
+1. incremental checkpoints
+1. clone
+1. snapshots
+1. backends: S3 / file / RADOS
+1. better GC
+
+How to set up unit/integration tests?
+- read tests with prefab data
+- write tests
+- python tools for generating / parsing object data
+- python driver script? Or use libcheck?
+
+### notes on recovery algorithm
+
+- after a crash we have to (a) recover the cache, (b) recover the back end, and then (c) find any writes in the cache which aren't present in the back end and replay them. To deal with that, the object header should include the sequence number of the newest write reflected in it, so we can rewind the cache log to that point and replay it.
+- after cache recovery, there might be writes that completed somewhere beyond the end of the log. (e.g. writes to locations 1, 2, and 4 completed, we detect end of log after 2) There's a tiny chance that we could write to location 3, then crash, and then come back up and think that 4 was part of the log. There are a few ways to deal with this, but it's not very likely so think about it later. (and maybe look up what ext4/jbd does?)
+
+### notes on GC
+
+We need to be able to perform GC without blocking incoming reads.
+- strategy 1: incoming writes check the list of LBA ranges being copied by a running GC cycle, and block if they interfere
+- strategy 2: keep a list of writes during the GC copy process. When it's done, subtract those ranges from the GC map updates.
+
+### Cache sharing
+
+In theory multiple virtual disks based on the same clone image ought to be able to share locally cached blocks from the base image. In practice it's a bit tricky because each virtual disk is in a separate QEMU process.
+
+Proposal - separate cache daemon for caching clone base images. Use shared memory to communicate with individual virtual disks:
+- communicate via unix socket
+- pass read-only file descriptor for cache partition
+- cache map in shared memory - see shm\_overview(7)
+- sequence number in shared memory
+- clients send usage information over socket
+
+Sequence number is even when map is valid, odd when it's being updated. To use the cache:
+- check that map is valid, sequence number S
+- translate with local copy of map
+- fetch from cache
+- check that map sequence is still S. If not, bail and fetch directly
+
+The shared cache should update the map infrequently, and take a decent amount of time in doing so. (1 second?)
+
+### Write and read cache
+
+If the read cache uses 64K chunks, then 1TB/64k = 16M entries, or 64MB at 4 bytes each.
+32+16 = 48 = 256TB max volume size for 4 byte entries. Note that current extent.cc has 128TB limit, although it could get bigger if I reduced the max extent length, which is currently 24 bits (= 2^33 bytes).
+
+It wouldn't be a big deal to serialize 5-byte entries, which would give a max size of 64PB or something. If we drop the max extent length to 1GB (21 bit sector number) then we would be able to get 1PB into the object map, or 8PB if we move to 4KB block addressing. (with 8GB max chunk again - 64PB if we drop extent length to 18 bits) Of course at that point the memory usage for the object map is kind of crazy - 1PB with 1M extents is a billion entries. Actually, 24GB for the map isn't horribly excessive - that's about $100, and 1PB of bare disks costs maybe $15K.
+
+How do we do LRU ordering or whatever? Assign order to each entry, truncate it to 8 bits, store it. Or if we're using saturating LFU or something like that, just store those values.
+
+**Important:** need version number for map, replacement state info because it's going to change. It's probably useful to provide a small region for version-specific metadata, too. E.g.:
+- length in blocks
+- type
+- type-specific data (32B? 64B?)
+- start block <- assumes sequential allocation
+
+For the simple map, type-specific data would only be the count of entries. (or equivalently the total length in bytes)
+
+For write cache, journal needs entry types for checkpoint and pad
+
+Note that we can add the write cache first and test it, then add the read cache.
+
+**Direct I/O** - I really think we should be using direct i/o to the cache device, as otherwise we don't have any guarantees about when data goes to the NVMe drive. This means we're going to have to copy everything into aligned buffers, probably. Which in turn means that we probably don't have to copy in the translation layer, but we need some way of notifying the cache that we're done with a specific buffer.
+
+### notes on migrating data from write cache to read cache
+
+1. same logic as garbage collection - read journal headers and double-check against map to filter out stale data
+2. how to handle sending random chunks of data to read cache indexed by object ID / offset?
+
+Tag each block in read cache with a bitmap indicating which blocks are valid. Assume 4KB blocks, don't store any finer granularity in read cache -> 16 bits per 64KB block. Send LBA/data to read cache, which looks up obj/offset mapping and either allocates new 64K block or overwrites contents of an existing one.
+
+Start out by using random replacement in the read cache, fix it later.
+
+How do we tie together read cache and backend? There's something of a locking and mapping problem if we encapsulate the write cache, read cache, and translation layer separately.
+- write cache - this can have its own lock, maybe a reader/write lock
+- translation layer lock - again maybe a reader/writer lock?
+- read cache - reader/writer?
+
+The read cache needs read-only access to the translation layer object map. Or do we connect the read cache to the translation layer? Write cache has interface for garbage collection, returns list of LBA extents and block pointers, plus a token to pass back when the data has been copied. write cache GC sends this info to read cache, 
+
+Solution:
+- read cache and write cache each have their own mutex and map
+- object map + shared\_mutex are separate and shared by read cache and translation layer.
+so 4 mutexes in total.
+
+### Read cache
+
+The read cache keeps a bitmap of the valid pages in each block. This is basically only used when we recycle data from the write cache to the read cache - this way we can just accept the data without worrying if it makes up a full block. If we try to read from the cache block and come across an invalid page, we just fetch the whole damn block.
+
+Note that we just check the pages that are being referenced, so it's ok if the surrounding pages in the object are garbage - we'll never check the corresponding bits, so we'll never fetch the garbage
+
+### valgrind
+To run Gdb with `valgrind`:
+```
+valgrind --vgdb-error=1 --vgdb=full --vgdb-stop-at=all ./unit-test
+```
+
+Example of running Python-based tests under `valgrind` with Gdb:
+```
+valgrind --vgdb-error=1 --vgdb=full --vgdb-stop-at=all --suppressions=valgrind-python.supp python3 test1.py
+```
+
+### more gc, as I'm writing the read cache
+
+need a flag to rcache->add to indicate that it's low priority, also another call to check whether something's already in cache. (and to maybe lock it?) Use that for GC - after getting the list of candidate objects, go through the list (not holding map lock) and fetch any data not already in cache. 
+
+### left to do (Mon Mar 7)
+
+- fix header length issues **DONE**
+- tests for the read cache
+    - test basic add and read **DONE**
+    - test eviction
+    - refactor eviction for easier testing?
+- log cleaner for the write cache
+- garbage collector
+    - some sort of priority/depriority for GC blocks?
+- librbd interface
+
+- `io_uring` implementation (wait until everything else works)
+- proper eviction algorithm for read cache (maybe d-choices w/ sequence #s)
+- progressive checkpoints
+- snapshot
+- clone
+
+Note that we can keep a read sequence number, save its value for each cache block, and do pseudo-LRU by choosing d random blocks and taking the oldest sequence number. For now 32 bits should work - 4G / 10K IOPS = 400K seconds, close to a week. 
+Later we may want to use 64 bits per block, which lets us do either a sequence number or LFUDA. (possibly a d-choices version)
+
+TODO: add sequencing, d-choices LRU, persist the eviction status. **add fields to superblock [DONE]**
+
+### Oh No, object offsets are broken [nvm, fixed]
+
+If the read cache is going to use the object map directly, it either needs access to header lengths, or offsets in the map entries need to include the object headers. The problem is that I'd like to keep the in-memory access to batches in the translation layer, so that current unit tests continue to work. Maybe it can be optional based on a runtime parameter?
+
+I think the best approach is:
+- if in-memory is enabled, keep `in_mem_objects` and update the objmap immediately on write; offsets will not include header length, as the header doesn't exist yet
+- otherwise just leave the extents in the batch. (write cache will have them anyway)
+- when a batch is complete, (a) coalesce writes, (b) write the object, and (c) update the map, with offsets inclusive of header length
+
+specific changes:
+
+`translate.writev`
+- add cache/nocache mode on init
+- in nocache mode, add batches to `in_mem_objects`, add extents to objmap immediately. (with 0 hdrlen)
+
+`translate.worker_thread`
+- coalesce writes in batch
+- update objmap, including hdrlen
+
+`translate.read`
+- don't add in hdrlen
+
+### status
+
+**Fri Mar 11 22:00:00 2022**
+
+- read on a null disk seems to work on fio
+- write crashes immediately with iovec problems
+
+test setup:
+```
+rm /mnt/nvme/lsvd/*
+dd if=/dev/zero bs=1024k count=100 of=/mnt/nvme/lsvd/SSD status=none
+python3 mkdisk.py --uuid 7cf1fca0-a182-11ec-8abf-37d9345adf42 --size 1g /mnt/nvme/lsvd/obj
+python3 mkcache.py --uuid 7cf1fca0-a182-11ec-8abf-37d9345adf42 /mnt/nvme/lsvd/SSD
+```
+
+**Mon Mar 7 13:50:00 2022**
+- write cache write logic is done
+- TODO: tail cleaning for write cache
+- read cache is started
+- TODO: fix nomenclature - sector=512 / page=4K / unit=64K (or cache "line"?)
+
+**Sun Feb 27 23:55:50 2022**
+- init from superblock (sort of)
+- started some unit tests using python unittest framework and ctypes
+
+**Sun Feb 27 10:03:23 2022** Basic functionality seems to be working under BDUS.
+- file only, no objects yet
+- starts up with empty disk - no map recovery
+- no cache
+
+Things to do now:
+1. basic python unit tests
+2. write coalescing, in-memory map
+3. map recovery on startup
+4. cache writes, change in-memory map to cache map
+5. object backend
+
+**Mon Jan 31 23:48:00 2022** object headers seem to be mostly done. Journal headers for writes are done, but need to figure out the superblock. Steps from here:
+1. get read/write working with librbd interface and null operations
+2. add journal writes to NVMe, with allocator and map
+3. add checkpoint code
+4. test recovery
+
+After that I can start writing backend objects
+
+```
+Local Variables:
+mode: Markdown
+eval: (auto-fill-mode -1)
+eval: (visual-line-mode 1)
+End:
+```

--- a/src/liblsvd/extent.h
+++ b/src/liblsvd/extent.h
@@ -1,0 +1,690 @@
+// file:        extent.h
+// description: Extent map for S3 Block Device
+// author:      Peter Desnoyers, Northeastern University
+//              Copyright 2021, 2022 Peter Desnoyers
+// license:     GNU LGPL v2.1 or newer
+//              LGPL-2.1-or-later
+//
+
+// There may be an elegant way to do this in C++; this isn't it.
+
+// Defines four types of map:
+//  objmap (int64_t => obj_offset)   - maps LBA to obj+offset
+//  cachemap (obj_offset => int64_t) - maps obj+offset to LBA
+//  cachemap2 (int64_t => int64_t)   - maps vLBA to pLBA
+//  bufmap (int64_t => sector_ptr)   - maps LBA to char*
+//
+// Update/trim takes a pointer to a vector for discarded extents, so
+// we don't have to search the map twice, and we can use read-only
+// iterators for lookup
+//
+// extents have A and D bits:
+//   set - access() / dirty() - set
+//   get - a() / d()
+// note that D bit is set internally, while A bit is set by the user
+#ifndef EXTENT_H
+#define EXTENT_H
+
+#include <cstddef>
+#include <stdint.h>
+#include <stdlib.h>
+#include <vector>
+#include <set>
+#include <tuple>
+#include <cassert>
+
+namespace extmap {
+
+    // we support three map outputs:
+    // LBA        - just an int64_t
+    // obj_offset - sequence number + LBA offset
+    // sector_ptr - points into a memory buffer. ptr increments by 512
+    //
+    struct obj_offset {
+	int64_t obj    : 36;
+	int64_t offset : 28;	// 128GB
+    public:
+	obj_offset operator+=(int val) {
+	    offset += val;
+	    return *this;
+	}
+	bool operator==(const obj_offset other) const {
+	    return (obj == other.obj) && (offset == other.offset);
+	}
+	bool operator<(const obj_offset other) const {
+	    return (obj == other.obj) ? (offset < other.offset) : (obj < other.obj);
+	}
+	bool operator>(const obj_offset other) const {
+	    return (obj == other.obj) ? (offset > other.offset) : (obj > other.obj);
+	}
+	bool operator>=(const obj_offset other) const {
+	    return (obj == other.obj) ? (offset >= other.offset) : (obj >= other.obj);
+	}
+	bool operator<=(const obj_offset other) const {
+	    return (obj == other.obj) ? (offset <= other.offset) : (obj <= other.obj);
+	}
+	obj_offset operator+(int val) {
+	    return (obj_offset){.obj = obj, .offset = offset + val};
+	}
+	int operator-(const obj_offset other) {
+	    return offset - other.offset; // meaningless if obj != other.obj
+	}
+    };
+
+    struct sector_ptr {
+	char *buf;
+    public:
+	sector_ptr(char *ptr) {
+	    buf = ptr;
+	}
+	sector_ptr() {}
+	sector_ptr operator+=(int val) {
+	    buf += val*512;
+	    return *this;
+	}
+	bool operator<(const sector_ptr other) const {
+	    return buf < other.buf;
+	}
+	bool operator>(const sector_ptr other) const {
+	    return buf > other.buf;
+	}
+	bool operator==(const sector_ptr other) const {
+	    return buf == other.buf;
+	}
+	sector_ptr operator+(int val) {
+	    sector_ptr p(buf + val*512);
+	    return p;
+	}
+	int operator-(const sector_ptr val) {
+	    return (buf - val.buf) / 512;
+	}
+    };
+    
+    // These are the three map types we support. There's probably a way to 
+    // do this with a template, but I don't think it's worth the effort
+    // these are the actual structures stored in the map
+    //
+    struct _lba2buf {
+	uint64_t    a    : 1;
+	uint64_t    d    : 1;
+	uint64_t    base : 38;
+	uint64_t    len  : 24;
+	sector_ptr ptr;
+    };
+	
+    struct _obj2lba {
+	obj_offset base;
+	uint64_t   a   : 1;
+	uint64_t   d   : 1;
+	uint64_t   len : 24;
+	int64_t    ptr : 38;	// LBA
+    };
+
+    struct _lba2lba {		// TODO: any way to do this in 12 bytes?
+	int64_t  a    : 1;
+	int64_t  d    : 1;
+	int64_t  base : 38;	// LBA
+	int64_t  len  : 24;
+	int64_t  ptr  : 40;	// LBA
+	int64_t  pad  : 24;
+    };
+	
+    struct _lba2obj {
+	int64_t    a    : 1;
+	int64_t    d    : 1;
+	int64_t    base : 38;	// 128TB max
+	int64_t    len  : 24;
+	obj_offset ptr;
+    };
+
+    // Here's the wrapper around those types, so that we can use the same
+    // map logic for all three of them
+    //
+    // Note that new extents are created with D=1, and rebase/relimit set D=1, so
+    // the update logic never has to worry about dirty bits.
+    //
+    template <class T, class T_in, class T_out> 
+    struct _extent {
+	T s;
+    public:
+	_extent(T_in _base, int64_t _len, T_out _ptr) {
+	    s.base = _base;
+	    s.len = _len;
+	    s.ptr = _ptr;
+	    s.a = 0;
+	    s.d = 1;		// new extents are dirty
+	}
+	_extent(T_in _base) {
+	    s.base = _base;
+	}
+	_extent() {}
+
+	// extents all get implemented as [base .. base+len) but the logic 
+	// using them a lot easier if we work with [base .. limit)
+	// 
+	T_in base(void) { return s.base; }
+	T_in limit(void) { return s.base + s.len; }
+	T_out ptr(void) { return s.ptr; }
+	void relimit(T_in _limit) {
+	    s.len = _limit - s.base;
+	    s.d = 1;		// dirty
+	}
+
+	// if we change the base, we need to update the pointer by the same amount
+	//
+	void rebase(T_in _base) {
+	    auto delta = _base - s.base;
+	    s.ptr += delta;
+	    s.len -= delta;
+	    s.base = _base;
+	    s.d = 1;		// dirty
+	}
+	
+	_extent operator+=(int val) {
+	    s.ptr += val;
+	    return *this;
+	}
+	bool operator<(const _extent &other) const {
+	    return s.base < other.s.base;
+	}
+
+	// can't use a bitfield directly in make_tuple - need +0
+	std::tuple<T_in, T_in, T_out> vals(void) {
+            auto _ptr = s.ptr;
+	    return std::make_tuple(s.base+0, s.base+s.len, _ptr);
+	}
+
+	std::tuple<T_in, T_in, T_out> vals(T_in _base, T_in _limit) {
+	    auto _ptr = s.ptr;
+	    if (s.base < _base)
+		_ptr += (_base - s.base);
+	    else
+		_base = s.base;
+	    _limit = std::min(limit(), _limit);
+	    return std::make_tuple(_base, _limit, _ptr);
+	}
+
+	void access(bool val) {
+	    s.a = (val ? 1 : 0);
+	}
+	void dirty(bool val) {
+	    s.d = (val ? 1 : 0);
+	}
+	bool a(void) {
+	    return s.a != 0;
+	}
+	bool d(void) {
+	    return s.d != 0;
+	}
+    };
+
+    // template <class T, class T_in, class T_out> 
+    typedef _extent<_lba2buf,int64_t,sector_ptr> lba2buf;
+    typedef _extent<_obj2lba,obj_offset,int64_t> obj2lba;
+    typedef _extent<_lba2obj,int64_t,obj_offset> lba2obj;
+    typedef _extent<_lba2lba,int64_t,int64_t>    lba2lba;
+
+    // an extent map with entries of type T, which map from T_in to T_out
+    //
+    template <class T, class T_in, class T_out, int load = 256>
+    struct extmap {
+	static const int _load = load;
+
+    public:
+	typedef std::vector<T>      extent_vector;
+	std::vector<extent_vector*> lists;
+	std::vector<T_in>           maxes;
+	int                         count;
+
+	extmap(){ count = 0; }
+	~extmap(){
+	    for (auto l : lists)
+		delete l;
+	}
+	
+	// debug code
+	//
+	void verify_max(void) {
+	}
+
+	void first(T _e) {
+	    auto vec = new extent_vector();
+	    vec->reserve(_load);
+	    vec->push_back(_e);
+	    lists.push_back(vec);
+	    maxes.push_back(_e.limit());
+	    count = 1;
+	}
+
+	// iterator gets used both internally and externally
+	// (returned by lookup function)
+	//
+	class iterator {
+	    
+	public:
+	    extmap *m;
+	    int     i;
+	    typename extent_vector::iterator it;
+	    
+	    using iterator_category = std::random_access_iterator_tag;
+	    using value_type = T;
+	    using difference_type = std::ptrdiff_t;
+	    using pointer = T*;
+	    using reference = T&;
+
+	    iterator() {}
+	    
+	    bool  operator==(const iterator &other) const {
+		return m == other.m && i == other.i && it == other.it;
+	    }
+
+	    bool operator!=(const iterator &other) const {
+		return m != other.m || i != other.i || it != other.it;
+	    }
+	    
+	    iterator(extmap *m, int i, typename extent_vector::iterator it) {
+		this->m = m;
+		this->i = i;
+		this->it = it;
+	    }
+	    
+	    reference operator*() const {
+		return *it;
+	    }
+
+	    pointer operator->() {
+		return &(*it);
+	    }
+	    iterator& operator++(int) {
+		assert(it < m->lists[i]->end());
+		it++;
+		if (it == m->lists[i]->end()) {
+		    if (i+1 <  (int)m->lists.size()) {
+			i++;
+			it = m->lists[i]->begin();
+		    }
+		}
+		return *this;
+	    }
+	    
+	    // TODO: (begin()--)++ doesn't work correctly
+	    iterator& operator--(int) {
+		if (it == m->lists[i]->begin()) {
+		    if (i > 0) {
+			i--;
+			it = m->lists[i]->end() - 1;
+		    }
+		}
+		else
+		    it--;
+		return *this;
+	    }
+
+	    // it+1 / it-1 is useful in several cases. We never need to
+	    // add/subtract more than 1, so the overhead of recursive solution
+	    // isn't a big deal
+	    //
+	    iterator operator-(std::ptrdiff_t n) {
+		if (n > 1)
+		    return (*this + 1) + (n-1);
+		if (it == m->lists[i]->begin() && i == 0)
+		    return m->begin();
+		if ((it == m->lists[i]->begin()))
+		    return iterator(m, i-1, m->lists[i-1]->end() - 1);
+		return iterator(m, i, it-1);
+	    }
+	    iterator operator+(std::ptrdiff_t n) {
+		if (n > 1)
+		   return (*this + 1) + (n-1);
+		if (it+1 == m->lists[i]->end()) {
+		    if (i+1 == (int)m->lists.size())
+			return m->end();
+		    else
+			return iterator(m, i+1, m->lists[i+1]->begin());
+		}
+		return iterator(m, i, it+1);
+	    }
+
+//	    bool operator<(T_in val) const {
+//		return (*this == m->end() || it->base < val);
+//	    }
+	};
+	
+	extent_vector _tmp; // HACK! HACK!
+	iterator begin() {
+            if (lists.size() == 0)
+                return iterator(this, 0, _tmp.begin());
+	    return iterator(this, 0, lists[0]->begin());
+	}
+
+	iterator end() {
+	    if (lists.size() == 0) 
+		return iterator(this, 0, _tmp.end());
+	    int n = lists.size()-1;
+	    return iterator(this, n, lists[n]->end());
+	}
+	
+	iterator lower_bound(T_in base) {
+	    if (lists.size() == 0) 	// should never get called in this case?
+		return end();
+
+	    // search maxes to find the list containing @base
+	    // remember that max is 1+highest legal addr
+	    //
+	    auto max_iter = std::lower_bound(maxes.begin(), maxes.end(), base);
+	    if (max_iter != maxes.end() && base == *max_iter)
+		max_iter++; // TODO delete? search base+1?
+	    if (max_iter == maxes.end())
+		return end();
+
+	    // find lowest entry with base >= @base
+	    //
+	    auto i = max_iter - maxes.begin();
+	    T _key(base);
+	    auto list_iter = std::lower_bound(lists[i]->begin(), lists[i]->end(), _key);
+
+	    // whoops, previous entry could have limit > @base...
+	    //
+	    if (list_iter != lists[i]->begin()) {
+		auto prev = list_iter - 1;
+		if (prev->base() <= base && prev->limit() > base)
+		    return iterator(this, i, prev);
+	    }
+
+	    // this shouldn't happen??? because we searched max
+	    //
+	    if (i < (int)(lists.size()-1) && list_iter == lists[i]->end())
+		return iterator(this, i+1, lists[i+1]->begin());
+
+	    return iterator(this, i, list_iter);
+	}
+
+	// Following logic from Python sorted containers, by Grant Jenks.
+	// https://github.com/grantjenks/python-sortedcontainers
+	// sortedlist.py in particular
+	//
+	
+	// Python-style list slicing - remove [len]..[end] and return it
+	//
+	static std::vector<T> *_slice(std::vector<T> *A, int len) {
+	    auto half = new std::vector<T>();
+	    half->reserve(_load);
+	    for (auto it = A->begin()+len; it != A->end(); it++)
+		half->push_back(*it);
+	    A->resize(len);
+	    return half;
+	}
+
+	// sortedlist._expand(self, pos)
+	//
+	iterator _expand(iterator it) {
+	    if (lists[it.i]->size() >= _load * 2) {
+		int j = it.it - lists[it.i]->begin();
+		auto half = _slice(lists[it.i], _load);
+		maxes[it.i] = lists[it.i]->back().limit();
+		lists.insert(lists.begin()+it.i+1, half);
+		maxes.insert(maxes.begin()+it.i+1, half->back().limit());
+		if (j >= _load) {
+		    j -= _load;
+		    it.i++;
+		}
+		it.it = lists[it.i]->begin()+j;
+	    }
+	    return it;
+	}
+
+	// insert just before iterator 'it', return pointer to inserted value
+	//
+	iterator _insert(iterator it, T _e) {
+	    if (count == 0) {
+		first(_e);
+		return begin();
+	    }
+	    it.it = lists[it.i]->insert(it.it, _e);
+	    maxes[it.i] = lists[it.i]->back().limit();
+	    count++;
+	    return _expand(it);
+	}
+	
+	// sortedlist._delete
+	//
+	iterator _erase(iterator it) {
+	    it.it = lists[it.i]->erase(it.it);
+
+	    // if there's only one list, this might delete it down to zero
+	    if (lists[it.i]->size() > 0) 
+		maxes[it.i] = lists[it.i]->back().limit();
+	    else {
+		delete lists[it.i];
+		lists.erase(lists.begin()+it.i);
+		maxes.erase(maxes.begin()+it.i);
+	    }
+	    count--;
+	    if (lists.size() == 0)
+		return end();
+	    
+	    if (lists[it.i]->size() > _load / 2)
+		;
+	    else if (lists.size() > 1) {
+		int j = it.it - lists[it.i]->begin();
+		int pos = (it.i > 0) ? it.i : it.i+1;
+		int prev = pos-1;
+		if (pos == it.i)
+		    j += lists[prev]->size();
+
+		lists[prev]->insert(lists[prev]->end(),
+				    lists[pos]->begin(), lists[pos]->end());
+		maxes[prev] = lists[prev]->back().limit();
+
+		delete lists[pos];
+		lists.erase(lists.begin()+pos);
+		maxes.erase(maxes.begin()+pos);
+
+		it = _expand(iterator(this, prev, lists[prev]->begin() + j));
+	    }
+	    else if (lists[it.i]->size() > 0)
+		maxes[it.i] = lists[it.i]->back().limit();
+
+	    if (it.it == lists[it.i]->end() && it.i != (int)lists.size()-1) {
+		it.i++;
+		it.it = lists[it.i]->begin();
+	    }
+	    return it;
+	}
+
+	// helper - can we merge these two extents?
+	//
+	static bool adjacent(T left, T right) {
+	    return left.limit() == right.base() &&
+		left.s.ptr + (left.limit() - left.base()) == right.s.ptr;
+	}
+
+	// update the map
+	//    trim=T : just unmap [@base..@limit)
+	//    trim=F : replace with [@base..@limit) -> [@e..@e+len)
+	// removed extents are returned in del[] (if non-null) for GC tracking
+	//
+	void _update(T_in base, T_in limit, T_out e, bool trim, extent_vector *del) {
+	    //= {.base = base, .limit = limit, .ext = e};
+	    T _e(base, limit-base, e);
+
+	    verify_max();
+
+	    // special case inserting the first entry
+	    //
+	    if (maxes.size() == 0) {
+		first(_e);
+		return;
+	    }
+
+	    // TODO - old fixit() function?
+	    verify_max();
+
+	    // find the first extent with base >= @base
+	    //
+	    auto it = lower_bound(base);
+
+	    if (it != end()) {
+		// we bisect an extent
+		//   [-----------------]       *it          _new
+		//          [+++++]       -> [-----][+++++][----]
+		//
+		if (it->base() < base && it->limit() > limit) {
+		    if (del != nullptr) {
+			T _old(base,		    // base
+			       limit - base,	    // len
+			       it->s.ptr + (base - it->base())); // ptr
+			del->push_back(_old);
+		    }
+		    T _new(limit, /* base */
+			   it->limit() - limit, /* len */
+			   it->s.ptr + (limit - it->base()));
+		    it->relimit(base);
+		    maxes[it.i] = lists[it.i]->back().limit();
+		    it = _insert(it+1, _new);
+		    verify_max();
+		}
+		
+		// left-hand overlap
+		//   [---------]
+		//       [++++++++++]  ->  [----][++++++++++]
+		//
+		else if (it->base() < base && it->limit() > base) {
+		    if (del != nullptr) {
+			T _old(base,		    // base
+			       it->limit() - base,  // len
+			       it->s.ptr + (base - it->base())); // ptr
+			del->push_back(_old);
+		    }
+		    it->relimit(base);
+		    maxes[it.i] = lists[it.i]->back().limit();
+		    it++;
+		    verify_max();
+		}
+
+		// erase any extents fully overlapped
+		//       [----] [---] 
+		//   [+++++++++++++++++] -> [+++++++++++++++++]
+		//
+		while (it != end()) {
+		    if (it->base() >= base && it->limit() <= limit) {
+			if (del != nullptr) 
+			    del->push_back(*it);
+			it = _erase(it);
+		    } else
+			break;
+		}
+
+		// update right-hand overlap
+		//        [---------]
+		//   [++++++++++]        -> [++++++++++][----]
+		//
+		if (it != end() && limit > it->base()) {
+		    if (del != nullptr) {
+			T _old(it->base(),	   // base
+			       limit - it->base(),  // len
+			       it->s.ptr);
+			del->push_back(_old);
+		    }
+		    //it->s.ptr += (limit - it->base()); // TODO is this right???
+		    it->rebase(limit);
+		    verify_max();
+		}
+	    }
+
+	    // insert before 'it'
+	    if (!trim) {
+		if (count == 0) { // avoid valgrind error on (it-1)
+		    _insert(it, _e);
+		    return;
+		}
+		auto prev = it-1;
+		if (it != begin() && adjacent(*prev, _e)) {
+		    // we can merge with the previous extent
+		    //
+		    prev->relimit(limit);
+		    maxes[prev.i] = lists[prev.i]->back().limit();
+		    if (it != end() && adjacent(*prev, *it)) {
+			// we plug a hole, and can merge with the next extent
+			//
+			prev->relimit(it->limit());
+			maxes[prev.i] = lists[prev.i]->back().limit();
+			_erase(it);
+			verify_max();
+			return;
+		    }
+		}
+		else if (it != end() && adjacent(_e, *it)) {
+		    // we can merge with the next extent
+		    //
+		    //it->s.ptr += (base - limit); // subtract
+		    it->rebase(base);
+		}
+		else {
+		    // no merging, just insert the damn thing
+		    //
+		    _insert(it, _e);
+		    verify_max();
+		}
+	    }
+	}
+
+//    public:
+	int size() {
+	    return count;
+	}
+
+	int capacity() {
+	    int sum = 0;
+	    for (auto list : lists)
+		sum += list->capacity();
+	    return sum;
+	}
+	
+	// lookup - returns iterator pointing to one of:
+	// - extent containing @base
+	// - lowest extent with base > @base
+	// - end()
+
+	// usage:
+	// for (auto it = lookup(base); it != end() && it->base < limit; it++) 
+	//    auto [base, limit, ptr] = it->vals(base, limit);
+	//
+	iterator lookup(T_in base) {
+	    return lower_bound(base);
+	}
+
+	// various ways of calling _update...
+	//
+	void update(T_in base, T_in limit, T_out e, std::vector<T> *del) {
+	    _update(base, limit, e, false, del);
+	}
+	void update(T_in base, T_in limit, T_out e) {
+	    _update(base, limit, e, false, nullptr);
+	}
+
+	void trim(T_in base, T_in limit, std::vector<T> *del) {
+	    static T_out unused;
+	    _update(base, limit, unused, true, del);
+	}
+	void trim(T_in base, T_in limit) {
+	    static T_out unused; // get rid of that damn "ininitialized message"
+	    _update(base, limit, unused, true, nullptr);
+	}
+	void reset(void) {
+	    for (auto l : lists)
+		delete l;
+	    lists.resize(0);
+	    maxes.resize(0);
+	    count = 0;
+	}
+    };
+
+    // template <class T, class T_in, class T_out>
+    typedef extmap<lba2obj,int64_t,obj_offset> objmap;
+    typedef extmap<obj2lba,obj_offset,int64_t> cachemap;
+    typedef extmap<lba2buf,int64_t,sector_ptr> bufmap;
+    typedef extmap<lba2lba,int64_t,int64_t>    cachemap2;
+}
+
+#endif

--- a/src/liblsvd/fake_rbd.h
+++ b/src/liblsvd/fake_rbd.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <sys/uio.h>
-#include <rados/librados.h>
+#include "include/rados/librados.h"
 
 /* the following types have to be compatible with the real librbd.h
  */

--- a/src/liblsvd/fake_rbd.h
+++ b/src/liblsvd/fake_rbd.h
@@ -1,0 +1,281 @@
+/*
+ * file:        fake_rbd.h
+ * description: replacement for <rbd/librbd.h>
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef __FAKE_RBD_H__
+#define __FAKE_RBD_H__
+
+#if __GNUC__ >= 4
+  #define CEPH_RBD_API          __attribute__ ((visibility ("default")))
+  #define CEPH_RBD_DEPRECATED   __attribute__((deprecated))
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+  #define CEPH_RBD_API
+  #define CEPH_RBD_DEPRECATED
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/uio.h>
+#include <rados/librados.h>
+
+/* the following types have to be compatible with the real librbd.h
+ */
+enum {
+    EVENT_TYPE_PIPE = 1,
+    EVENT_TYPE_EVENTFD = 2
+};
+
+typedef void *rbd_image_t;
+typedef void *rbd_image_options_t;
+typedef void *rbd_pool_stats_t;
+
+typedef void *rbd_completion_t;
+typedef void (*rbd_callback_t)(rbd_completion_t cb, void *arg);
+
+#define RBD_MAX_BLOCK_NAME_SIZE 24
+#define RBD_MAX_IMAGE_NAME_SIZE 96
+
+/* fio only looks at 'size' */
+typedef struct {
+    uint64_t size;
+    uint64_t obj_size;
+    uint64_t num_objs;
+    int order;
+    char block_name_prefix[RBD_MAX_BLOCK_NAME_SIZE]; /* deprecated */
+    int64_t parent_pool;                             /* deprecated */
+    char parent_name[RBD_MAX_IMAGE_NAME_SIZE];       /* deprecated */
+} rbd_image_info_t;
+
+typedef struct {
+    uint64_t id;
+    uint64_t size;
+    const char *name;
+} rbd_snap_info_t;
+
+extern "C" CEPH_RBD_API int rbd_poll_io_events(rbd_image_t image,
+                                               rbd_completion_t *comps, int numcomp);
+
+extern "C" CEPH_RBD_API int rbd_set_image_notification(rbd_image_t image, int fd, int type);
+
+extern "C" CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,
+                                                      rbd_callback_t complete_cb,
+                                                      rbd_completion_t *c);
+
+extern "C" CEPH_RBD_API void rbd_aio_release(rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off,
+                                            uint64_t len, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_flush(rbd_image_t image, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_flush(rbd_image_t image);
+
+extern "C" CEPH_RBD_API void *rbd_aio_get_arg(rbd_completion_t c);
+
+extern "C" CEPH_RBD_API ssize_t rbd_aio_get_return_value(rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_read(rbd_image_t image, uint64_t offset,
+                                         size_t len, char *buf, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_readv(rbd_image_t image, const iovec *iov,
+                                          int iovcnt, uint64_t off, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_writev(rbd_image_t image, const struct iovec *iov,
+                                           int iovcnt, uint64_t off, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off,
+                                          size_t len, const char *buf, rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_read(rbd_image_t image, uint64_t off, size_t len, char *buf);
+
+extern "C" CEPH_RBD_API int rbd_write(rbd_image_t image, uint64_t off, size_t len,
+                                      const char *buf);
+
+extern "C" CEPH_RBD_API int rbd_aio_writesame(rbd_image_t image, uint64_t off,
+                                              size_t len,
+                                              const char *buf, size_t data_len,
+                                              rbd_completion_t c, int op_flags);
+
+extern "C" CEPH_RBD_API int rbd_aio_write_zeroes(rbd_image_t image,
+                                                 uint64_t off,
+                                                 size_t len, rbd_completion_t c,
+                                                 int zero_flags, int op_flags);
+
+extern "C" CEPH_RBD_API int rbd_aio_wait_for_complete(rbd_completion_t c);
+
+extern "C" CEPH_RBD_API int rbd_stat(rbd_image_t image, rbd_image_info_t *info,
+                                     size_t infosize);
+
+extern "C" CEPH_RBD_API int rbd_get_size(rbd_image_t image, uint64_t *size);
+
+extern "C" CEPH_RBD_API int rbd_open(rados_ioctx_t io, const char *name,
+                                     rbd_image_t *image, const char *snap_name);
+extern "C" CEPH_RBD_API int rbd_close(rbd_image_t image);
+extern "C" CEPH_RBD_API int rbd_invalidate_cache(rbd_image_t image);
+
+extern "C" CEPH_RBD_API int rbd_create(rados_ioctx_t io, const char *name, uint64_t size, int *order);
+extern "C" CEPH_RBD_API int rbd_remove(rados_ioctx_t io, const char *name);
+
+typedef int (*librbd_progress_fn_t)(uint64_t offset, uint64_t total, void *ptr);
+extern "C" CEPH_RBD_API int rbd_remove_with_progress(rados_ioctx_t io, const char *name,
+                                                     librbd_progress_fn_t cb, void *cbdata);
+
+/* These RBD functions are unimplemented and return errors
+ */
+extern "C" CEPH_RBD_API int rbd_resize(rbd_image_t image, uint64_t size);
+extern "C" CEPH_RBD_API int rbd_snap_create(rbd_image_t image, const char *snapname);
+extern "C" CEPH_RBD_API int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
+extern "C" CEPH_RBD_API void rbd_snap_list_end(rbd_snap_info_t *snaps);
+extern "C" CEPH_RBD_API int rbd_snap_remove(rbd_image_t image, const char *snapname);
+extern "C" CEPH_RBD_API int rbd_snap_rollback(rbd_image_t image, const char *snapname);
+
+extern "C" CEPH_RBD_API int rbd_diff_iterate2(rbd_image_t image,
+                                   const char *fromsnapname,
+                                   uint64_t ofs, uint64_t len,
+                                   uint8_t include_parent, uint8_t whole_object,
+                                   int (*cb)(uint64_t, size_t, int, void *),
+                                   void *arg);
+
+typedef enum {
+    RBD_ENCRYPTION_FORMAT_LUKS1 = 0,
+    RBD_ENCRYPTION_FORMAT_LUKS2 = 1,
+    RBD_ENCRYPTION_FORMAT_LUKS  = 2
+} rbd_encryption_format_t;
+
+typedef void *rbd_encryption_options_t;
+extern "C" CEPH_RBD_API int rbd_encryption_format(rbd_image_t image,
+                                       rbd_encryption_format_t format,
+                                       rbd_encryption_options_t opts,
+                                       size_t opts_size);
+
+extern "C" CEPH_RBD_API int rbd_encryption_load(rbd_image_t image,
+                                     rbd_encryption_format_t format,
+                                     rbd_encryption_options_t opts,
+                                     size_t opts_size);
+extern "C" CEPH_RBD_API int rbd_get_features(rbd_image_t image, uint64_t *features);
+extern "C" CEPH_RBD_API int rbd_get_flags(rbd_image_t image, uint64_t *flags);
+
+typedef struct {
+  char *id;
+  char *name;
+} rbd_image_spec_t;
+
+extern "C" CEPH_RBD_API void rbd_image_spec_cleanup(rbd_image_spec_t *image);
+
+typedef struct {
+  int64_t pool_id;
+  char *pool_name;
+  char *pool_namespace;
+  char *image_id;
+  char *image_name;
+  bool trash;
+} rbd_linked_image_spec_t;
+
+extern "C" CEPH_RBD_API void rbd_linked_image_spec_cleanup(rbd_linked_image_spec_t *image);
+extern "C" CEPH_RBD_API int rbd_mirror_image_enable(rbd_image_t image) CEPH_RBD_DEPRECATED;
+
+typedef enum {
+  RBD_MIRROR_IMAGE_MODE_JOURNAL  = 0,
+  RBD_MIRROR_IMAGE_MODE_SNAPSHOT = 1,
+} rbd_mirror_image_mode_t;
+
+extern "C" CEPH_RBD_API int rbd_mirror_image_enable2(rbd_image_t image,
+                                          rbd_mirror_image_mode_t mode);
+typedef enum {
+  RBD_MIRROR_IMAGE_DISABLING = 0,
+  RBD_MIRROR_IMAGE_ENABLED = 1,
+  RBD_MIRROR_IMAGE_DISABLED = 2
+} rbd_mirror_image_state_t;
+
+typedef struct {
+  char *global_id;
+  rbd_mirror_image_state_t state;
+  bool primary;
+} rbd_mirror_image_info_t;
+
+extern "C" CEPH_RBD_API void rbd_mirror_image_get_info_cleanup(
+    rbd_mirror_image_info_t *mirror_image_info);
+
+typedef enum {
+  MIRROR_IMAGE_STATUS_STATE_UNKNOWN         = 0,
+  MIRROR_IMAGE_STATUS_STATE_ERROR           = 1,
+  MIRROR_IMAGE_STATUS_STATE_SYNCING         = 2,
+  MIRROR_IMAGE_STATUS_STATE_STARTING_REPLAY = 3,
+  MIRROR_IMAGE_STATUS_STATE_REPLAYING       = 4,
+  MIRROR_IMAGE_STATUS_STATE_STOPPING_REPLAY = 5,
+  MIRROR_IMAGE_STATUS_STATE_STOPPED         = 6,
+} rbd_mirror_image_status_state_t;
+
+typedef struct {
+  char *mirror_uuid;
+  rbd_mirror_image_status_state_t state;
+  char *description;
+  time_t last_update;
+  bool up;
+} rbd_mirror_image_site_status_t;
+
+typedef struct {
+  char *name;
+  rbd_mirror_image_info_t info;
+  uint32_t site_statuses_count;
+  rbd_mirror_image_site_status_t *site_statuses;
+} rbd_mirror_image_global_status_t;
+
+extern "C" CEPH_RBD_API void rbd_mirror_image_global_status_cleanup(
+    rbd_mirror_image_global_status_t *mirror_image_global_status);
+
+typedef enum {
+  RBD_MIRROR_PEER_DIRECTION_RX    = 0,
+  RBD_MIRROR_PEER_DIRECTION_TX    = 1,
+  RBD_MIRROR_PEER_DIRECTION_RX_TX = 2
+} rbd_mirror_peer_direction_t;
+
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_add(
+    rados_ioctx_t io_ctx, char *uuid, size_t uuid_max_length,
+    rbd_mirror_peer_direction_t direction, const char *site_name,
+    const char *client_name);
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_get_attributes(
+    rados_ioctx_t p, const char *uuid, char *keys, size_t *max_key_len,
+    char *values, size_t *max_value_len, size_t *key_value_count);
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_remove(
+    rados_ioctx_t io_ctx, const char *uuid);
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_set_attributes(
+    rados_ioctx_t p, const char *uuid, const char *keys, const char *values,
+    size_t key_value_count);
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_set_name(
+    rados_ioctx_t io_ctx, const char *uuid, const char *site_name);
+extern "C" CEPH_RBD_API int rbd_mirror_peer_site_set_client_name(
+    rados_ioctx_t io_ctx, const char *uuid, const char *client_name);
+
+typedef void *rbd_pool_stats_t;
+extern "C" CEPH_RBD_API void rbd_pool_stats_create(rbd_pool_stats_t *stats);
+extern "C" CEPH_RBD_API void rbd_pool_stats_destroy(rbd_pool_stats_t stats);
+extern "C" CEPH_RBD_API int rbd_pool_stats_option_add_uint64(rbd_pool_stats_t stats,
+                                                  int stat_option,
+                                                  uint64_t* stat_val);
+typedef enum {
+  RBD_TRASH_IMAGE_SOURCE_USER = 0,
+  RBD_TRASH_IMAGE_SOURCE_MIRRORING = 1,
+  RBD_TRASH_IMAGE_SOURCE_MIGRATION = 2,
+  RBD_TRASH_IMAGE_SOURCE_REMOVING = 3,
+  RBD_TRASH_IMAGE_SOURCE_USER_PARENT = 4,
+} rbd_trash_image_source_t;
+typedef struct {
+  char *id;
+  char *name;
+  rbd_trash_image_source_t source;
+  time_t deletion_time;
+  time_t deferment_end_time;
+} rbd_trash_image_info_t;
+
+extern "C" CEPH_RBD_API void rbd_trash_get_cleanup(rbd_trash_image_info_t *info);
+extern "C" CEPH_RBD_API void rbd_version(int *major, int *minor, int *extra);
+
+#endif

--- a/src/liblsvd/file_backend.cc
+++ b/src/liblsvd/file_backend.cc
@@ -1,0 +1,315 @@
+/*
+ * file:        file_backend.cc
+ * description: local filesystem-based object backend
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/uio.h>
+#include <libaio.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#include <map>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <random>
+#include <algorithm>
+
+#include "lsvd_types.h"
+#include "backend.h"
+#include "request.h"
+#include "smartiov.h"
+#include "io.h"
+#include "misc_cache.h"
+#include "objects.h"
+
+extern void do_log(const char *, ...);
+
+bool __lsvd_dbg_be_delay = false;
+long __lsvd_dbg_be_seed = 1;
+int __lsvd_dbg_be_threads = 10;
+int __lsvd_dbg_be_delay_ms = 5;
+bool __lsvd_dbg_rename = false;
+static std::mt19937_64 rng;
+
+class file_backend_req;
+
+void verify_obj(iovec *iov, int iovcnt) {
+    auto h = (obj_hdr*)iov[0].iov_base;
+    if (h->type != LSVD_DATA)
+	return;
+    auto dh = (obj_data_hdr*)(h+1);
+    auto map = (data_map*)((char*)h + dh->data_map_offset);
+    int n_map = dh->data_map_len / sizeof(data_map);
+    uint32_t sum = 0;
+    for (int i = 0; i < n_map; i++)
+	sum += map[i].len;
+    assert(sum == h->data_sectors);
+}
+
+class file_backend : public backend {
+    void worker(thread_pool<file_backend_req*> *p);
+    std::mutex m;
+    
+public:
+    file_backend(const char *prefix);
+    ~file_backend();
+
+    /* see backend.h 
+     */
+    int write_object(const char *name, iovec *iov, int iovcnt);
+    int write_object(const char *name, char *buf, size_t len);
+    int read_object(const char *name, iovec *iov, int iovcnt, size_t offset);
+    int read_object(const char *name, char *buf, size_t len, size_t offset);
+    int delete_object(const char *name);
+    request *delete_object_req(const char *name);
+    
+    /* async I/O
+     */
+    request *make_write_req(const char *name, iovec *iov, int iovcnt);
+    request *make_write_req(const char *name, char *buf, size_t len);
+    request *make_read_req(const char *name, size_t offset,
+                           iovec *iov, int iovcnt);
+    request *make_read_req(const char *name, size_t offset,
+                           char *buf, size_t len);
+    thread_pool<file_backend_req*> workers;
+};
+
+#include <zlib.h>
+/* trivial methods 
+ */
+int file_backend::write_object(const char *name, iovec *iov, int iovcnt) {
+    int fd;
+    if ((fd = open(name, O_RDWR | O_CREAT | O_TRUNC, 0777)) < 0)
+	return -1;
+    auto val = writev(fd, iov, iovcnt);
+    close(fd);
+    return val < 0 ? -1 : val;
+}
+
+int file_backend::write_object(const char *name, char *buf, size_t len) {
+    iovec iov = {buf, len};
+    return write_object(name, &iov, 1);
+}
+
+int file_backend::read_object(const char *name, iovec *iov, int iovcnt,
+				  size_t offset) {
+    int fd;
+    if ((fd = open(name, O_RDONLY)) < 0)
+       return -1;
+    if (fd < 0)
+       return -1;
+    auto val = preadv(fd, iov, iovcnt, offset);
+    close(fd);
+    return val < 0 ? -1 : val;
+}
+
+int file_backend::read_object(const char *name, char *buf, size_t len,
+			      size_t offset) {
+    iovec iov = {buf, len};
+    return read_object(name, &iov, 1, offset);
+}
+
+int file_backend::delete_object(const char *name) {
+    int rv;
+    if (__lsvd_dbg_rename) {
+	std::string newname = std::string(name) + ".bak";
+	rv = rename(name, newname.c_str());
+    }
+    else
+	rv = unlink(name);
+    return rv < 0 ? -1 : 0;
+}
+
+/* this only gets used for deleting images
+ * the async nature is obviously fraudulent
+ */
+class f_delete_req : public request {
+    int rv;
+public:
+    f_delete_req(const char *name) { rv = unlink(name); }
+    ~f_delete_req() {}
+    void wait() { delete this; }
+    void run(request *parent) {}
+    void notify(request *child) {}
+    void release() { }
+};
+
+request *file_backend::delete_object_req(const char *name) {
+    return (request*)new f_delete_req(name);
+}
+
+void trim_partial(const char *_prefix) {
+    auto prefix = std::string(_prefix);
+    auto stem = fs::path(prefix).filename();
+    auto parent = fs::path(prefix).parent_path();
+    size_t stem_len = strlen(stem.c_str());
+    int rv;
+    
+    for (auto const& dir_entry : fs::directory_iterator{parent}) {
+	std::string entry{dir_entry.path().filename()};
+	if (strncmp(entry.c_str(), stem.c_str(), stem_len) == 0 &&
+	    entry.size() == stem_len + 9) {
+	    char buf[512];
+	    auto h = (obj_hdr *)buf;
+	    int fd = open(dir_entry.path().c_str(), O_RDONLY);
+	    struct stat sb;
+	    if (fstat(fd, &sb) < 0) {
+		close(fd);
+		continue;
+	    }
+	    rv = read(fd, buf, sizeof(buf));
+	    if (rv < 512 || h->magic != LSVD_MAGIC ||
+		(h->hdr_sectors + h->data_sectors)*512 != sb.st_size) {
+		printf("deleting partial object: %s (%d vs %d)\n",
+		       dir_entry.path().c_str(), (int)sb.st_size,
+		       (int)(h->hdr_sectors + h->data_sectors));
+		rename(dir_entry.path().c_str(),
+		       (std::string(dir_entry.path()) + ".bak").c_str());
+	    }
+	    close(fd);
+	}
+    }
+}
+
+int iov_sum(iovec *iov, int niov) {
+    int sum = 0;
+    for (int i = 0; i < niov; i++)
+	sum += iov[i].iov_len;
+    return sum;
+}
+
+class file_backend_req : public request {
+    enum lsvd_op    op;
+    smartiov        _iovs;
+    size_t          offset;
+    char            name[64];
+    request        *parent = NULL;
+    file_backend   *be;
+    int             fd = -1;
+    int             retval;
+    
+public:
+    file_backend_req(enum lsvd_op op_, const char *name_,
+		     iovec *iov, int iovcnt, size_t offset_,
+		     file_backend *be_) : _iovs(iov, iovcnt) {
+	op = op_;
+	offset = offset_;
+	be = be_;
+	strcpy(name, name_);
+    }
+    file_backend_req(enum lsvd_op op_, const char *name_,
+		     char *buf, size_t len, size_t offset_,
+		     file_backend *be_) {
+	op = op_;
+	offset = offset_;
+	be = be_;
+	strcpy(name, name_);
+	iovec iov = {buf, len};
+	_iovs.push_back(iov);
+    }
+    ~file_backend_req() {}
+
+    void      wait() {}		   // TODO: ?????
+    void      run(request *parent);
+    void      notify(request *child);
+    void      release() {};
+
+    void exec(void) {
+	auto [iov,niovs] = _iovs.c_iov();
+	if (op == OP_READ) {
+	    if ((fd = open(name, O_RDONLY)) < 0)
+		retval = fd;
+	    else {
+		retval = preadv(fd, iov, niovs, offset);
+		close(fd);
+	    }
+	}
+	else {
+	    if ((fd = open(name, O_RDWR | O_CREAT | O_TRUNC, 0777)) < 0)
+		retval = fd;
+	    else {
+		retval = pwritev(fd, iov, niovs, offset);
+		close(fd);
+	    }
+	}
+	notify(NULL);
+    }
+};
+
+
+/* methods that depend on file_backend_req
+ */
+file_backend::file_backend(const char *prefix) : workers(&m) {
+    if (prefix)
+	trim_partial(prefix);
+    rng.seed(__lsvd_dbg_be_seed);
+    for (int i = 0; i < __lsvd_dbg_be_threads; i++) 
+	workers.pool.push(std::thread(&file_backend::worker, this, &workers));
+}
+
+file_backend::~file_backend() {
+}
+
+void file_backend::worker(thread_pool<file_backend_req*> *p) {
+    pthread_setname_np(pthread_self(), "file_worker");
+    while (p->running) {
+	file_backend_req *req;
+	if (!p->get(req)) 
+	    return;
+	if (__lsvd_dbg_be_delay) {
+	    std::uniform_int_distribution<int> uni(0,__lsvd_dbg_be_delay_ms*1000);
+	    useconds_t usecs = uni(rng);
+	    usleep(usecs);
+	}
+	req->exec();
+    }
+}
+
+/* TODO: run() ought to return error/success
+ */
+void file_backend_req::run(request *parent_) {
+    parent = parent_;
+    be->workers.put(this);
+}
+
+/* TODO: this assumes no use of wait/release
+ */
+void file_backend_req::notify(request *unused) {
+    parent->notify(this);
+    delete this;
+}
+
+request *file_backend::make_write_req(const char*name, iovec *iov, int niov) {
+    assert(access(name, F_OK) != 0);
+    verify_obj(iov, niov);
+    return new file_backend_req(OP_WRITE, name, iov, niov, 0, this);
+}
+request *file_backend::make_write_req(const char *name, char *buf, size_t len) {
+    assert(access(name, F_OK) != 0);
+    return new file_backend_req(OP_WRITE, name, buf, len, 0, this);
+}
+    
+
+
+request *file_backend::make_read_req(const char *name, size_t offset,
+				     iovec *iov, int iovcnt) {
+    return new file_backend_req(OP_READ, name, iov, iovcnt, offset, this);
+}
+
+request *file_backend::make_read_req(const char *name, size_t offset,
+				     char *buf, size_t len) {
+    iovec iov = {buf, len};
+    return new file_backend_req(OP_READ, name, &iov, 1, offset, this);
+}
+
+backend *make_file_backend(const char *prefix) {
+    return new file_backend(prefix);
+}

--- a/src/liblsvd/image.h
+++ b/src/liblsvd/image.h
@@ -1,0 +1,77 @@
+/*
+ * file:        image.h
+ * description: the fake RBD image. 
+ *
+ * TODO: fix up lsvd_debug.cc and move this into lsvd.cc
+ */
+
+#ifndef __IMAGE_H__
+#define __IMAGE_H__
+
+struct event_socket {
+    int socket;
+    int type;
+public:
+    event_socket(): socket(-1), type(0) {}
+    bool is_valid() const { return socket != -1; }
+    int init(int fd, int t) {
+	socket = fd;
+	type = t;
+	return 0;
+    }
+    int notify() {
+	int rv;
+	switch (type) {
+	case EVENT_TYPE_PIPE:
+	{
+	    char buf[1] = {'i'}; // why 'i'???
+	    rv = write(socket, buf, 1);
+	    rv = (rv < 0) ? -errno : 0;
+	    break;
+	}
+	case EVENT_TYPE_EVENTFD:
+	{
+	    uint64_t value = 1;
+	    rv = write(socket, &value, sizeof (value));
+	    rv = (rv < 0) ? -errno : 0;
+	    break;
+	}
+	default:
+	    rv = -1;
+	}
+	return rv;
+    }
+};
+
+struct rbd_image {
+    lsvd_config  cfg;
+    ssize_t      size;          // bytes
+
+    std::shared_mutex map_lock;
+    extmap::objmap    map;
+
+    backend     *objstore;
+    translate   *xlate;
+    write_cache *wcache;
+    read_cache  *rcache;
+    int          fd;            /* cache file */
+    
+    std::mutex   m;             /* protects completions */
+    event_socket ev;
+    std::queue<rbd_completion_t> completions;
+
+    int          refcount = 0;
+
+    std::thread  dbg;
+    bool         done = false;
+
+    rbd_image() {}
+    ~rbd_image() {}
+
+    int image_open(rados_ioctx_t io, const char *name);
+    int image_close(void);
+    int poll_io_events(rbd_completion_t *comps, int numcomp);
+    void notify(rbd_completion_t c);
+};
+
+#endif

--- a/src/liblsvd/io.cc
+++ b/src/liblsvd/io.cc
@@ -1,0 +1,157 @@
+/*
+ * file:        io.cc
+ * description: implementation of libaio-based async I/O
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <libaio.h>
+#include <sys/uio.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+
+#include <shared_mutex>
+#include <condition_variable>
+#include <thread>
+
+#include "lsvd_types.h"
+#include "smartiov.h"
+#include "extent.h"
+
+#include <unistd.h>
+#include "io.h"
+#include "misc_cache.h"
+
+#include <valgrind/drd.h>
+
+size_t getsize64(int fd)
+{
+    struct stat sb;
+    size_t size;
+    
+    if (fstat(fd, &sb) < 0)
+	throw_fs_error("stat");
+    if (S_ISBLK(sb.st_mode)) {
+	if (ioctl(fd, BLKGETSIZE64, &size) < 0)
+	    throw_fs_error("ioctl");
+    }
+    else
+	size = sb.st_size;
+    return size;
+}
+
+/* libaio helpers */
+
+void e_iocb_cb(io_context_t ctx, iocb *io, long res, long res2)
+{
+    assert(res2 == 0);
+    auto iocb = (e_iocb*)io;
+    iocb->cb(iocb->ptr, res);
+}
+
+int io_queue_wait(io_context_t ctx, struct timespec *timeout)
+{
+    return io_getevents(ctx, 1, 10, NULL, timeout);
+}
+
+bool __lsvd_dbg_reverse = false;
+
+/* https://lwn.net/Articles/39285/
+ */
+#define IO_BATCH_EVENTS 8               /* number of events to batch up */
+int io_queue_run2(io_context_t ctx, struct timespec *timeout)
+{
+    struct io_event events[IO_BATCH_EVENTS];
+    //struct io_event *ep;
+    int ret = 0;                /* total number of events processed */
+    int n;
+
+    /*
+     * Process io events and call the callbacks.
+     * Try to batch the events up to IO_BATCH_EVENTS at a time.
+     * Loop until we have read all the available events and called the callbacks.
+     */
+    do {
+        int i;
+
+        if ((n = io_getevents(ctx, 1, IO_BATCH_EVENTS, events, timeout)) < 0)
+            break;
+        ret += n;
+        //for (ep = events, i = n; i-- > 0; ep++) {
+	struct io_event *ep = events;
+	if (__lsvd_dbg_reverse) 
+	    for (i = n-1; i >= 0; i--) {
+		io_callback_t cb = (io_callback_t)ep[i].data;
+		struct iocb *iocb = ep[i].obj;
+		ANNOTATE_HAPPENS_AFTER(iocb);
+		cb(ctx, iocb, ep[i].res, ep[i].res2);
+	    }
+	else
+	    for (i = 0; i < n; i++) {
+		io_callback_t cb = (io_callback_t)ep[i].data;
+		struct iocb *iocb = ep[i].obj;
+		ANNOTATE_HAPPENS_AFTER(iocb);
+		cb(ctx, iocb, ep[i].res, ep[i].res2);
+	    }
+    } while (n >= 0);
+
+    return ret ? ret : n;               /* return number of events or error */
+}
+
+void e_iocb_runner(io_context_t ctx, bool *running, const char *name)
+{
+    struct timespec timeout = {0, 1000*100}; // 100 microseconds
+    pthread_setname_np(pthread_self(), name);
+    while (*running) 
+	io_queue_run2(ctx, &timeout);
+}
+
+void e_io_prep_pwrite(e_iocb *io, int fd, void *buf, size_t len, size_t offset,
+		      void (*cb)(void*,long), void *arg)
+{
+    io_prep_pwrite(&io->io, fd, buf, len, offset);
+    io->cb = cb;
+    io->ptr = arg;
+    io_set_callback(&io->io, e_iocb_cb);
+}
+
+void e_io_prep_pread(e_iocb *io, int fd, void *buf, size_t len, size_t offset,
+		     void (*cb)(void*,long), void *arg)
+{
+    io_prep_pread(&io->io, fd, buf, len, offset);
+    io->cb = cb;
+    io->ptr = arg;
+    io_set_callback(&io->io, e_iocb_cb);
+}
+
+void e_io_prep_pwritev(e_iocb *io, int fd, const struct iovec *iov, int iovcnt,
+		       size_t offset, void (*cb)(void*,long), void *arg)
+{
+    io_prep_pwritev(&io->io, fd, iov, iovcnt, offset);
+    io->cb = cb;
+    io->ptr = arg;
+    io_set_callback(&io->io, e_iocb_cb);
+}
+
+void e_io_prep_preadv(e_iocb *eio, int fd, const struct iovec *iov, int iovcnt,
+		      size_t offset, void (*cb)(void*,long), void *arg)
+{
+    io_prep_preadv(&eio->io, fd, iov, iovcnt, offset);
+    eio->cb = cb;
+    eio->ptr = arg;
+    io_set_callback(&eio->io, e_iocb_cb);
+}
+
+// see https://chromium.googlesource.com/chromium/src/base/+/
+//  f86dd125dc43d6dba04b61e73ac8a2bd4636c3f8/dynamic_annotations.h
+
+int e_io_submit(io_context_t ctx, e_iocb *eio)
+{
+    iocb *io = &eio->io;
+    ANNOTATE_HAPPENS_BEFORE(&eio->io);
+    return io_submit(ctx, 1, &io);
+}
+

--- a/src/liblsvd/io.cc
+++ b/src/liblsvd/io.cc
@@ -82,20 +82,11 @@ int io_queue_run2(io_context_t ctx, struct timespec *timeout)
         ret += n;
         //for (ep = events, i = n; i-- > 0; ep++) {
 	struct io_event *ep = events;
-	if (__lsvd_dbg_reverse) 
-	    for (i = n-1; i >= 0; i--) {
-		io_callback_t cb = (io_callback_t)ep[i].data;
-		struct iocb *iocb = ep[i].obj;
-		ANNOTATE_HAPPENS_AFTER(iocb);
-		cb(ctx, iocb, ep[i].res, ep[i].res2);
-	    }
-	else
-	    for (i = 0; i < n; i++) {
-		io_callback_t cb = (io_callback_t)ep[i].data;
-		struct iocb *iocb = ep[i].obj;
-		ANNOTATE_HAPPENS_AFTER(iocb);
-		cb(ctx, iocb, ep[i].res, ep[i].res2);
-	    }
+	for (i = 0; i < n; i++) {
+	    io_callback_t cb = (io_callback_t)ep[i].data;
+	    struct iocb *iocb = ep[i].obj;
+	    cb(ctx, iocb, ep[i].res, ep[i].res2);
+	}
     } while (n >= 0);
 
     return ret ? ret : n;               /* return number of events or error */

--- a/src/liblsvd/io.h
+++ b/src/liblsvd/io.h
@@ -1,0 +1,54 @@
+/*
+ * file:        io.h
+ * description: interface for libaio-based async I/O
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef IO_H
+#define IO_H
+
+#include <stddef.h>
+#include <libaio.h>
+
+/* TODO: why is this here???
+ */
+size_t getsize64(int fd);
+
+
+
+/* adapt libaio for generic callbacks
+ */
+//void e_iocb_cb(io_context_t ctx, iocb *io, long res, long res2);
+struct e_iocb {
+    iocb io;
+    void (*cb)(void*,long) = NULL;
+    void *ptr = NULL;
+    e_iocb() {}
+};
+
+/* this is *supposed* to be implemented in libaio
+ */
+int io_queue_wait(io_context_t ctx, struct timespec *timeout);
+
+/* sets thread name, runs queue. Polls with 100uS timeout, since
+ * blocking doesn't seem to work correctly
+ */
+void e_iocb_runner(io_context_t ctx, bool *running, const char *name);
+
+/* each e_io_xyz corresponds io_prep_xyz in libaio.h
+ * see man page for more info
+ */
+void e_io_prep_pwrite(e_iocb *io, int fd, void *buf, size_t len, size_t offset,
+		      void (*cb)(void*,long), void *arg);
+void e_io_prep_pread(e_iocb *io, int fd, void *buf, size_t len, size_t offset,
+		     void (*cb)(void*,long), void *arg);
+void e_io_prep_pwritev(e_iocb *io, int fd, const struct iovec *iov, int iovcnt,
+                       size_t offset, void (*cb)(void*,long), void *arg);
+void e_io_prep_preadv(e_iocb *eio, int fd, const struct iovec *iov, int iovcnt,
+                      size_t offset, void (*cb)(void*,long), void *arg);
+int e_io_submit(io_context_t ctx, e_iocb *eio);
+
+#endif

--- a/src/liblsvd/journal.h
+++ b/src/liblsvd/journal.h
@@ -1,0 +1,134 @@
+/* 
+This file, journal2.h, features structures which are used for the each of the
+logging systems used in the lsvd system, including structures of superblocks for
+both the write and read caches, and the connecting structures between them and 
+the how they fit together with rados and s3
+*/
+#ifndef JOURNAL2_H
+#define JOURNAL2_H
+
+#include <stdint.h>
+#include <vector>
+#include <uuid/uuid.h>
+
+struct j_extent {
+    uint64_t lba : 40;		// volume LBA (in sectors)
+    uint64_t len : 24;		// length (sectors)
+} __attribute__((packed));
+
+// could do a horrible hack to make this 14 bytes, but not worth it
+struct j_map_extent {
+    uint64_t lba : 40;		// volume LBA (in sectors)
+    uint64_t len : 24;		// length (sectors)
+    uint64_t plba;		// on-SSD LBA
+} __attribute__((packed));
+
+struct j_length {
+    int32_t page;		// in pages
+    int32_t len;		// in pages
+    bool operator<(const j_length &other) const { // for sorting
+        return page < other.page;
+    }
+} __attribute__((packed));
+
+enum {LSVD_J_DATA    = 10,
+      LSVD_J_CKPT    = 11,
+      LSVD_J_PAD     = 12,
+      LSVD_J_SUPER   = 13,
+      LSVD_J_W_SUPER = 14,
+      LSVD_J_R_SUPER = 15};
+
+/* for now we'll assume that all entries are contiguous
+ */
+struct j_hdr {
+    uint32_t magic;
+    uint32_t type;		// LSVD_J_DATA
+    uint32_t version;		// 1
+    int32_t  len;		// in 4KB blocks, including header
+    uint64_t seq;
+    uint32_t crc32;		// TODO: implement this
+    int32_t  extent_offset;	// in bytes
+    int32_t  extent_len;        // in bytes
+    int32_t  prev;              // reverse link for recovery
+} __attribute__((packed));
+
+/* probably in the second 4KB block of the parition
+ * this gets overwritten every time we re-write the map. We assume the 4KB write is
+ * atomic, and write out the new map before updating the superblock.
+ */
+struct j_write_super {
+    uint32_t magic;
+    uint32_t type;		// LSVD_J_W_SUPER
+    uint32_t version;		// 1
+
+    uint32_t clean;
+    uint64_t seq;		// next write sequence (if clean)
+
+    /* all values are in 4KB block units. */
+    
+    /* Map and length checkpoints live in this region. Allocation within this
+     * range is arbitrary, just set {map/len}_{start/blocks/entries} properly
+     */
+    int32_t meta_base;
+    int32_t meta_limit;
+    
+    /* FIFO range is [base,limit), 
+     *  valid range accounting for wraparound is [oldest,next)
+     *  'wrapped' 
+     */
+    int32_t base;
+    int32_t limit;
+    int32_t next;
+    
+    int32_t map_start;		// type: j_map_extent
+    int32_t map_blocks;
+    int32_t map_entries;
+
+    int32_t len_start;	// type: j_length
+    int32_t len_blocks;
+    int32_t len_entries;
+} __attribute__((packed));
+
+/* probably in the third 4KB block, never gets overwritten (overwrite map in place)
+ * uses a fixed map with 1 entry per 64KB block
+ * to update atomically:
+ * - reclaim batch of blocks, then write map. (free entries: obj=0)
+ * - allocate blocks, then write map
+ * - recover free list to memory on startup
+ */
+struct j_read_super {
+    uint32_t magic;
+    uint32_t type;		// LSVD_J_R_SUPER
+    uint32_t version;		// 1
+
+    int32_t unit_size;		// cache unit size, in sectors
+
+    /* note that the cache is not necessarily unit-aligned
+     */
+    int32_t base;		// the cache itself
+    int32_t units;		// length, in @unit_size segments
+
+    /* each has @cache_segments entries
+     */
+    int32_t map_start;		// extmap::obj_offset
+    int32_t map_blocks;
+} __attribute__((packed));
+
+      
+/* this goes in the first 4KB block in the cache partition, and never
+ * gets modified
+ */
+struct j_super {
+    uint32_t magic;
+    uint32_t type;		// LSVD_J_SUPER
+    uint32_t version;		// 1
+
+    /* both are single blocks, so we only need a block number
+     */
+    uint32_t write_super;
+    uint32_t read_super;
+
+    uuid_t   vol_uuid;
+} __attribute__((packed));
+
+#endif

--- a/src/liblsvd/liblsvd.cc
+++ b/src/liblsvd/liblsvd.cc
@@ -1,0 +1,928 @@
+/*
+ * file:        lsvd.cc
+ * description: userspace block-on-object layer with librbd interface
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <uuid/uuid.h>
+
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <atomic>
+#include <thread>
+
+#include <algorithm>
+
+#include <stack>
+#include <queue>
+#include <vector>
+#include <map>
+
+#include <string>
+#include <cassert>
+
+#include "journal.h"
+#include "smartiov.h"
+#include "extent.h"
+
+#include "lsvd_types.h"
+#include "backend.h"
+#include "misc_cache.h"
+#include "translate.h"
+#include "request.h"
+#include "nvme.h"
+#include "read_cache.h"
+#include "write_cache.h"
+
+#include "fake_rbd.h"
+#include "config.h"
+#include "image.h"
+
+extern void do_log(const char *, ...);
+extern void fp_log(const char *, ...);
+
+extern void check_crc(sector_t sector, iovec *iov, int niovs, const char *msg);
+extern void add_crc(sector_t sector, iovec *iov, int niovs);
+
+/* RBD "image" and completions are only used in this file, so we
+ * don't break them out into a .h
+ */
+
+extern int make_cache(int fd, uuid_t &uuid, int n_pages);
+
+bool __lsvd_dbg_no_gc = false;
+
+backend *get_backend(lsvd_config *cfg, rados_ioctx_t io, const char *name) {
+
+    if (cfg->backend == BACKEND_FILE)
+	return make_file_backend(name);
+    if (cfg->backend == BACKEND_RADOS)
+	return make_rados_backend(io);
+    return NULL;
+}
+
+int rbd_image::image_open(rados_ioctx_t io, const char *name) {
+
+    if (cfg.read() < 0)
+	return -1;
+    objstore = get_backend(&cfg, io, name);
+
+    /* read superblock and initialize translation layer
+     */
+    xlate = make_translate(objstore, &cfg, &map, &map_lock);
+    size = xlate->init(name, true);
+
+    /* figure out cache file name, create it if necessary
+     */
+    std::string cache = cfg.cache_filename(xlate->uuid, name);
+    if (access(cache.c_str(), R_OK|W_OK) < 0) {
+	int cache_pages = cfg.cache_size / 4096;
+	int fd = open(cache.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0777);
+	if (fd < 0)
+	    return fd;
+	if (make_cache(fd, xlate->uuid, cache_pages) < 0)
+	    return -1;
+	close(fd);
+    }
+
+    fd = open(cache.c_str(), O_RDWR | O_DIRECT);
+    if (fd < 0)
+	return -1;
+
+    j_super *js =  (j_super*)aligned_alloc(512, 4096);
+    if (pread(fd, (char*)js, 4096, 0) < 0)
+	return -1;
+    if (js->magic != LSVD_MAGIC || js->type != LSVD_J_SUPER)
+	return -1;
+    if (memcmp(js->vol_uuid, xlate->uuid, sizeof(uuid_t)) != 0)
+	throw("object and cache UUIDs don't match");
+
+    wcache = make_write_cache(js->write_super, fd, xlate, &cfg);
+    rcache = make_read_cache(js->read_super, fd, false,
+			     xlate, &map, &map_lock, objstore);
+    free(js);
+
+    if (!__lsvd_dbg_no_gc)
+	xlate->start_gc();
+
+    return 0;
+}
+
+void rbd_image::notify(rbd_completion_t c) {
+    std::unique_lock lk(m);
+    if (ev.is_valid()) {
+	completions.push(c);
+	ev.notify();
+    }
+}
+
+/* for debug use
+ */
+rbd_image *make_rbd_image(backend *b, translate *t, write_cache *w,
+			  read_cache *r) {
+    auto img = new rbd_image;
+    img->objstore = b;
+    img->xlate = t;
+    img->wcache = w;
+    img->rcache = r;
+    return img;
+}
+
+translate *image_2_xlate(rbd_image_t image) {
+    auto img = (rbd_image*)image;
+    return img->xlate;
+}
+
+rbd_image_t __lsvd_dbg_img;
+
+extern "C" int rbd_open(rados_ioctx_t io, const char *name,
+			rbd_image_t *image, const char *snap_name) {
+    auto img = new rbd_image;
+    if (img->image_open(io, name) < 0) {
+	delete img;
+	return -1;
+    }
+    *image = __lsvd_dbg_img = (void*)img;
+    return 0;
+}
+
+int rbd_image::image_close(void) {
+    rcache->write_map();
+    delete rcache;
+    wcache->flush();
+    wcache->do_write_checkpoint();
+    delete wcache;
+    xlate->stop_gc();
+    xlate->checkpoint();
+    delete xlate;
+    delete objstore;
+    close(fd);
+    return 0;
+}
+
+extern "C" int rbd_close(rbd_image_t image)
+{
+    rbd_image *img = (rbd_image*)image;
+    img->image_close();
+    delete img;
+    return 0;
+}
+
+/* RBD-level completion structure
+ */
+struct lsvd_completion {
+public:
+    int magic = LSVD_MAGIC;
+    rbd_image *img;
+    rbd_callback_t cb;
+    void *arg;
+    int retval;
+    std::mutex m;
+    std::condition_variable cv;
+    /* done: += 1
+     * released: += 10
+     * caller waiting: += 20
+     */
+    std::atomic<int> done_released = 0;
+    request *req;
+
+    lsvd_completion(rbd_callback_t cb_, void *arg_) : cb(cb_), arg(arg_) {}
+
+    /* see Ceph AioCompletion::complete
+     */
+    void complete(int val) {
+	retval = val;
+	if (cb)
+	    cb((rbd_completion_t)this, arg);
+	img->notify((rbd_completion_t)this);
+
+	std::unique_lock lk(m);
+	int x = (done_released += 1);
+	cv.notify_all();
+	if (x == 11) {
+	    lk.unlock();
+	    delete this;
+	}
+    }
+
+    void release() {
+	int x = (done_released += 10);
+	if (x == 11)
+	    delete this;
+    }
+};
+
+int rbd_image::poll_io_events(rbd_completion_t *comps, int numcomp) {
+    std::unique_lock lk(m);
+    int i;
+    for (i = 0; i < numcomp && !completions.empty(); i++) {
+	auto p = (lsvd_completion *)completions.front();
+	assert(p->magic == LSVD_MAGIC);
+	comps[i] = p;
+	completions.pop();
+    }
+    return i;
+}
+
+extern "C" int rbd_poll_io_events(rbd_image_t image,
+				  rbd_completion_t *comps, int numcomp)
+{
+    rbd_image *img = (rbd_image*)image;
+    int rv = img->poll_io_events(comps, numcomp);
+    return rv;
+}
+
+extern "C" int rbd_set_image_notification(rbd_image_t image, int fd, int type)
+{
+    rbd_image *img = (rbd_image*)image;
+    assert(type == EVENT_TYPE_EVENTFD);
+    return img->ev.init(fd, type);
+}
+
+extern "C" int rbd_aio_create_completion(void *cb_arg,
+					 rbd_callback_t complete_cb,
+					 rbd_completion_t *c)
+{
+    lsvd_completion *p = new lsvd_completion(complete_cb, cb_arg);
+    *c = (rbd_completion_t)p;
+    return 0;
+}
+
+extern "C" void rbd_aio_release(rbd_completion_t c)
+{
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->release();
+}
+
+extern "C" int rbd_aio_discard(rbd_image_t image, uint64_t off,
+			       uint64_t len, rbd_completion_t c)
+{
+    //do_log("rbd_aio_discard\n");
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->img = (rbd_image*)image;
+
+    /* TODO: implement
+     */
+
+    p->complete(0);
+    return 0;
+}
+
+extern "C" int rbd_aio_flush(rbd_image_t image, rbd_completion_t c)
+{
+    //do_log("'f', 0, 0, []\n");
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    auto img = p->img = (rbd_image*)image;
+
+    if (img->cfg.hard_sync)
+	img->xlate->flush();
+
+    p->complete(0);		// TODO - make asynchronous
+    return 0;
+}
+
+extern "C" int rbd_flush(rbd_image_t image)
+{
+    //do_log("rbd_flush\n");
+    auto img = (rbd_image*)image;
+    if (img->cfg.hard_sync)
+	img->xlate->flush();
+    return 0;
+}
+
+extern "C" void *rbd_aio_get_arg(rbd_completion_t c)
+{
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    return p->arg;
+}
+
+extern "C" ssize_t rbd_aio_get_return_value(rbd_completion_t c)
+{
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    return p->retval;
+}
+
+static std::atomic<int> __reqs;
+
+enum rbd_req_status {
+    REQ_NOWAIT = 0,
+    REQ_COMPLETE = 1,
+    REQ_LAUNCHED = 2,
+    REQ_WAIT = 4
+};
+
+/* rbd_aio_req - state machine for rbd_aio_read, rbd_aio_write
+ *
+ * TODO: fix this. I merged separate read & write classes in the
+ * ugliest possible way, but it works...
+ */
+class rbd_aio_req : public request {
+    rbd_image        *img;
+    lsvd_completion  *p;
+    char             *aligned_buf = NULL;
+    uint64_t          offset;	// in bytes
+    sector_t          _sector;
+    lsvd_op           op;
+    smartiov          iovs;
+    smartiov          aligned_iovs;
+    sector_t          sectors = 0;
+    std::vector<smartiov*> to_free;
+
+    std::atomic<int>  n_req = 0;
+    std::atomic<int>  status = 0;
+    std::mutex        m;
+    std::condition_variable cv;
+
+
+    std::set<void*> wc_work;
+    std::set<request*> rc_work;
+
+    void notify_parent(void) {
+	//assert(!m.try_lock());
+        if (p != NULL)
+            p->complete(sectors*512L);
+	if (status & REQ_WAIT)
+	    cv.notify_all();
+    }
+
+    void notify_w(request *req) {
+	std::unique_lock lk(m);
+	wc_work.erase((void*)req);
+	auto z = --n_req;
+	if (z > 0)
+	    return;
+
+        img->wcache->release_room(sectors);
+
+	auto x = (status |= REQ_COMPLETE);
+	if (x & REQ_LAUNCHED) {
+	    lk.unlock();
+	    notify_parent();
+	    if (! (x & REQ_WAIT))
+		delete this;
+	}
+    }
+
+    void run_w() {
+	if (aligned_buf)	// copy to aligned *before* write
+	    iovs.copy_out(aligned_buf);
+
+	img->wcache->get_room(sectors);
+	img->xlate->wait_for_room();
+
+	/* split large requests into 2MB (default) chunks
+	 */
+	sector_t max_sectors = img->cfg.wcache_chunk / 512;
+	n_req += div_round_up(sectors, max_sectors);
+	// TODO: this is horribly ugly
+
+	std::unique_lock lk(m);
+
+	for (sector_t s_offset = 0; s_offset < sectors; s_offset += max_sectors) {
+	    auto _sectors = std::min(sectors - s_offset, max_sectors);
+	    smartiov tmp = aligned_iovs.slice(s_offset*512L, s_offset*512L + _sectors*512L);
+	    smartiov *_iov = new smartiov(tmp.data(), tmp.size());
+	    to_free.push_back(_iov);
+	    auto wcw = img->wcache->writev(this, offset/512, _iov);
+	    wc_work.insert((void*)wcw);
+	    offset += _sectors*512L;
+	}
+
+	auto x = (status |= REQ_LAUNCHED);
+
+	if (x == (REQ_LAUNCHED | REQ_COMPLETE)) {
+	    lk.unlock();
+	    notify_parent();
+	    delete this;
+	}
+    }
+
+    void notify_r(request *child) {
+	if (child)
+	    child->release();
+
+	std::unique_lock lk(m);
+	rc_work.erase(child);
+        if (--n_req > 0)
+	    return;
+
+	if (aligned_buf)	// copy from aligned *after* read
+	    iovs.copy_in(aligned_buf);
+
+	auto x = (status |= REQ_COMPLETE);
+
+	if (x & REQ_LAUNCHED) {
+	    lk.unlock();
+	    notify_parent();
+	    if (! (x & REQ_WAIT))
+		delete this;
+	}
+    }
+
+    void run_r() {
+	__reqs++;
+        /* we're not done until n_req == 0 && launched == true
+         */
+	size_t _offset = 0, _end = aligned_iovs.bytes();
+	std::vector<request*> requests;
+	
+        while (_offset < _end) {
+	    smartiov wcache_iov = aligned_iovs.slice(_offset,_end);
+            auto [skip,wait,req] =
+                img->wcache->async_readv(offset, &wcache_iov);
+	    if (req != NULL) {
+		requests.push_back(req);
+		rc_work.insert(req);
+	    }
+            while (skip > 0) {
+		smartiov rcache_iov = aligned_iovs.slice(_offset, _offset+skip);
+                auto [skip2, wait2, req2] =
+                    img->rcache->async_readv(offset, &rcache_iov);
+		if (req2) {
+		    requests.push_back(req2);
+		    rc_work.insert(req2);
+		}
+
+		aligned_iovs.zero(_offset, _offset+skip2);
+                skip -= (skip2 + wait2);
+                _offset += (skip2 + wait2);
+                offset += (skip2 + wait2);
+            }
+            _offset += wait;
+            offset += wait;
+	}
+
+	n_req += requests.size();
+	for (auto const & r : requests)
+	    r->run(this);
+	
+	std::unique_lock lk(m);
+	if (requests.size() == 0)
+	    status |= REQ_COMPLETE;
+	auto x = (status |= REQ_LAUNCHED);
+
+	if (x == (REQ_LAUNCHED | REQ_COMPLETE)) {
+	    lk.unlock();
+	    notify_parent();
+	    delete this;
+	}
+    }
+
+    void setup(lsvd_op op_, rbd_image *img_,
+	       lsvd_completion *p_, uint64_t offset_, int status_) {
+	op = op_;		// OP_READ or OP_WRITE
+	img = img_;
+	p = p_;
+	if (p != NULL)
+	    assert(p->magic == LSVD_MAGIC);
+	offset = offset_;	// byte offset into volume
+	_sector = offset / 512;
+	status = status_;	// 0 or REQ_WAIT
+	sectors = iovs.bytes() / 512L;
+#if 0
+	if (op == OP_WRITE) {
+	    do_log("%s %ld\n", op == OP_READ ? "R" : "W", sectors);
+	    if (iovs.size() > 10)
+		do_log(" big\n");
+	}
+#endif
+	if (iovs.aligned(512))
+	    aligned_iovs = iovs;
+	else {
+	    aligned_buf = (char*)aligned_alloc(512, iovs.bytes());
+	    iovec iov = {aligned_buf, iovs.bytes()};
+	    aligned_iovs.ingest(&iov, 1);
+	}
+    }
+
+public:
+    rbd_aio_req(lsvd_op op_, rbd_image *img_,
+		lsvd_completion *p_, uint64_t offset_, int status_,
+		const iovec *iov, size_t niov) : iovs(iov, niov) {
+	setup(op_, img_, p_, offset_, status_);
+    }
+    rbd_aio_req(lsvd_op op_, rbd_image *img_,
+		lsvd_completion *p_, uint64_t offset_, int status_,
+		char *buf_, size_t len_) : iovs(buf_, len_) {
+	setup(op_, img_, p_, offset_, status_);
+    }
+    ~rbd_aio_req() {
+	if (aligned_buf)
+	    free(aligned_buf);
+	for (auto iov : to_free)
+	    delete iov;
+    }
+
+    /* note that there's no child request until read cache is updated
+     * to use request/notify model.
+     */
+    void notify(request *child) {
+	if (op == OP_READ)
+	    notify_r(child);
+	else
+	    notify_w(child);
+    }
+
+    /* TODO: this is really gross. To properly fix it I need to integrate this
+     * with rbd_aio_completion and use its release() method
+     */
+    void wait() {
+	assert(status & REQ_WAIT);
+	std::unique_lock lk(m);
+	while (! (status & REQ_COMPLETE))
+	    cv.wait(lk);
+	lk.unlock();
+	delete this;
+    }
+
+    void release() {}
+
+    void run(request *parent /* unused */) {
+	if (op == OP_READ)
+	    run_r();
+	else
+	    run_w();
+    }
+
+    static void aio_read_cb(void *ptr) {
+	auto req = (rbd_aio_req *)ptr;
+	req->notify(NULL);
+    }
+};
+
+extern "C" int rbd_aio_read(rbd_image_t image, uint64_t offset,
+			    size_t len, char *buf, rbd_completion_t c)
+{
+    //do_log("rbd_aio_read\n");
+    rbd_image *img = (rbd_image*)image;
+    auto p = (lsvd_completion*)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->img = img;
+
+    p->req = new rbd_aio_req(OP_READ, img, p, offset, REQ_NOWAIT, buf, len);
+    p->req->run(NULL);
+    return 0;
+}
+
+
+extern "C" int rbd_aio_readv(rbd_image_t image, const iovec *iov,
+			     int iovcnt, uint64_t offset, rbd_completion_t c)
+{
+    rbd_image *img = (rbd_image*)image;
+    auto p = (lsvd_completion*)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->img = img;
+
+    p->req = new rbd_aio_req(OP_READ, img, p, offset, REQ_NOWAIT, iov, iovcnt);
+    p->req->run(NULL);
+    return 0;
+}
+
+extern "C" int rbd_aio_writev(rbd_image_t image, const struct iovec *iov,
+			      int iovcnt, uint64_t offset, rbd_completion_t c)
+{
+    rbd_image *img = (rbd_image*)image;
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->img = img;
+
+    p->req = new rbd_aio_req(OP_WRITE, img, p, offset, REQ_NOWAIT,
+			     iov, iovcnt);
+    p->req->run(NULL);
+    return 0;
+}
+
+extern "C" int rbd_aio_write(rbd_image_t image, uint64_t offset, size_t len,
+			     const char *buf, rbd_completion_t c)
+{
+    rbd_image *img = (rbd_image*)image;
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->img = img;
+
+    p->req = new rbd_aio_req(OP_WRITE, img, p, offset, REQ_NOWAIT,
+			     (char*)buf, len);
+    p->req->run(NULL);
+
+    return 0;
+}
+
+/* note that rbd_aio_read handles aligned bounce buffers for us
+ */
+extern "C" int rbd_read(rbd_image_t image, uint64_t off, size_t len, char *buf)
+{
+    //do_log("rbd_read %d\n", (int)(off / 512));
+    rbd_image *img = (rbd_image*)image;
+    auto req = new rbd_aio_req(OP_READ, img, NULL, off, REQ_WAIT, buf, len);
+
+    req->run(NULL);
+    req->wait();
+    return 0;
+}
+
+extern "C" int rbd_write(rbd_image_t image, uint64_t off, size_t len, const char *buf)
+{
+    //do_log("rbd_write\n");
+    rbd_image *img = (rbd_image*)image;
+    auto req = new rbd_aio_req(OP_WRITE, img, NULL, off, REQ_WAIT,
+			       (char*)buf, len);
+    req->run(NULL);
+    req->wait();
+    return 0;
+}
+
+extern "C" int rbd_aio_wait_for_complete(rbd_completion_t c)
+{
+    lsvd_completion *p = (lsvd_completion *)c;
+    assert(p->magic == LSVD_MAGIC);
+    p->done_released += 20;
+    std::unique_lock lk(p->m);
+    while ((p->done_released.load() & 1) == 0)
+	p->cv.wait(lk);
+    int x = (p->done_released -= 20);
+    if (x == 11) {
+	lk.unlock();
+	delete p;
+    }
+    return 0;
+}
+
+/* note that obj_size and order should match chunk size in
+ * rbd_aio_req::run_w
+ */
+extern "C" int rbd_stat(rbd_image_t image, rbd_image_info_t *info, size_t infosize)
+{
+    //do_log("rbd_stat\n");
+    rbd_image *img = (rbd_image*)image;
+    memset(info, 0, sizeof(*info));
+    info->size = img->size;
+    info->obj_size = 2*1024*1024; // 2^21 bytes
+    info->order = 21;		  // 2^21 bytes
+    return 0;
+}
+
+extern "C" int rbd_get_size(rbd_image_t image, uint64_t *size)
+{
+    //do_log("rbd_get_size\n");
+    rbd_image *img = (rbd_image*)image;
+    *size = img->size;
+    return 0;
+}
+
+std::pair<std::string,std::string> split_string(std::string s,
+						std::string delim) {
+    auto i = s.find(delim);
+    return std::pair(s.substr(0,i), s.substr(i+delim.length()));
+}
+
+
+extern "C" int rbd_create(rados_ioctx_t io, const char *name, uint64_t size,
+                            int *order)
+{
+    lsvd_config  cfg;
+    if (cfg.read() < 0)
+	return -1;
+    auto objstore = get_backend(&cfg, io, NULL);
+    auto rv = translate_create_image(objstore, name, size);
+    delete objstore;
+    return rv;
+}
+
+/* remove all objects and cache file.
+ * this only removes objects pointed to by the last checkpoint, plus
+ * a small range of following ones - there may be dangling objects after
+ * removing a deeply corrupted image
+ */
+extern "C" int rbd_remove(rados_ioctx_t io, const char *name) {
+    lsvd_config  cfg;
+    auto rv = cfg.read();
+    if (rv < 0)
+	return rv;
+    auto objstore = get_backend(&cfg, io, NULL);
+    uuid_t uu;
+    if ((rv = translate_get_uuid(objstore, name, uu)) < 0)
+	return rv;
+    auto cache_file = cfg.cache_filename(uu, name);
+    unlink(cache_file.c_str());
+    rv = translate_remove_image(objstore, name);
+    delete objstore;
+    return rv;
+}
+
+extern "C" void rbd_uuid(rbd_image_t image, uuid_t *uuid) {
+    rbd_image *img = (rbd_image*)image;
+    memcpy(uuid, img->xlate->uuid, sizeof(uuid_t));
+}
+
+extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off,
+				 size_t len,
+				 const char *buf, size_t data_len,
+				 rbd_completion_t c, int op_flags)
+{
+    int n = div_round_up(len, data_len);
+    iovec iov[n];
+    int niovs = 0;
+    while (len > 0) {
+	size_t bytes = std::min(len, data_len);
+	iov[niovs++] = (iovec){(void*)buf, bytes};
+	len -= bytes;
+    }
+    return rbd_aio_writev(image, iov, niovs, off, c);
+}
+
+char zeropage[4096];
+extern "C" int rbd_aio_write_zeroes(rbd_image_t image, uint64_t off,
+                                      size_t len, rbd_completion_t c,
+                                      int zero_flags, int op_flags)
+{
+    return rbd_aio_writesame(image, off, len, zeropage, 4096, c, op_flags);
+}
+
+/* any following functions are stubs only
+ */
+extern "C" int rbd_invalidate_cache(rbd_image_t image)
+{
+    return 0;
+}
+
+/* These RBD functions are unimplemented and return errors
+ */
+extern "C" int rbd_resize(rbd_image_t image, uint64_t size)
+{
+    return -1;
+}
+
+extern "C" int rbd_snap_create(rbd_image_t image, const char *snapname)
+{
+    return -1;
+}
+extern "C" int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps,
+                               int *max_snaps)
+{
+    return -1;
+}
+extern "C" void rbd_snap_list_end(rbd_snap_info_t *snaps)
+{
+}
+extern "C" int rbd_snap_remove(rbd_image_t image, const char *snapname)
+{
+    return -1;
+}
+extern "C" int rbd_snap_rollback(rbd_image_t image, const char *snapname)
+{
+    return -1;
+}
+
+/* */
+extern "C" int rbd_diff_iterate2(rbd_image_t image, const char *fromsnapname,
+				 uint64_t ofs, uint64_t len,
+				 uint8_t include_parent, uint8_t whole_object,
+				 int (*cb)(uint64_t, size_t, int, void *),
+				 void *arg)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_encryption_format(rbd_image_t image,
+				     rbd_encryption_format_t format,
+				     rbd_encryption_options_t opts,
+				     size_t opts_size)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_encryption_load(rbd_image_t image,
+				   rbd_encryption_format_t format,
+				   rbd_encryption_options_t opts,
+				   size_t opts_size)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_get_features(rbd_image_t image, uint64_t *features)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_get_flags(rbd_image_t image, uint64_t *flags)
+{
+    return *(int*)0;
+}
+
+static int _tmp;
+#define ASSERT_FAIL() _tmp += *(int*)0
+
+extern "C" void rbd_image_spec_cleanup(rbd_image_spec_t *image)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" void rbd_linked_image_spec_cleanup(rbd_linked_image_spec_t *image)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" int rbd_mirror_image_enable(rbd_image_t image)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_image_enable2(rbd_image_t image,
+                                          rbd_mirror_image_mode_t mode)
+{
+    return *(int*)0;
+}
+
+extern "C" void rbd_mirror_image_get_info_cleanup(
+    rbd_mirror_image_info_t *mirror_image_info)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" void rbd_mirror_image_global_status_cleanup(
+    rbd_mirror_image_global_status_t *mirror_image_global_status)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" int rbd_mirror_peer_site_add(
+    rados_ioctx_t io_ctx, char *uuid, size_t uuid_max_length,
+    rbd_mirror_peer_direction_t direction, const char *site_name,
+    const char *client_name)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_peer_site_get_attributes(
+    rados_ioctx_t p, const char *uuid, char *keys, size_t *max_key_len,
+    char *values, size_t *max_value_len, size_t *key_value_count)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_peer_site_remove(
+    rados_ioctx_t io_ctx, const char *uuid)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_peer_site_set_attributes(
+    rados_ioctx_t p, const char *uuid, const char *keys, const char *values,
+    size_t key_value_count)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_peer_site_set_name(
+    rados_ioctx_t io_ctx, const char *uuid, const char *site_name)
+{
+    return *(int*)0;
+}
+
+extern "C" int rbd_mirror_peer_site_set_client_name(
+    rados_ioctx_t io_ctx, const char *uuid, const char *client_name)
+{
+    return *(int*)0;
+}
+
+extern "C" void rbd_pool_stats_create(rbd_pool_stats_t *stats)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" void rbd_pool_stats_destroy(rbd_pool_stats_t stats)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" int rbd_pool_stats_option_add_uint64(rbd_pool_stats_t stats,
+						int stat_option,
+						uint64_t* stat_val)
+{
+    return *(int*)0;
+}
+
+extern "C" void rbd_trash_get_cleanup(rbd_trash_image_info_t *info)
+{
+    ASSERT_FAIL();
+}
+
+extern "C" void rbd_version(int *major, int *minor, int *extra)
+{
+    *major = 0;
+    *minor = 0;
+    *extra = 1;
+}

--- a/src/liblsvd/lsvd_crash_test.cc
+++ b/src/liblsvd/lsvd_crash_test.cc
@@ -1,0 +1,866 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <argp.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <zlib.h>
+
+#include <random>
+#include <chrono>
+#include <filesystem>
+namespace fs = std::filesystem;
+#include <iostream>
+#include <queue>
+#include <map>
+#include <mutex>
+#include <atomic>
+#include <algorithm>
+#include <fstream>
+
+#include "fake_rbd.h"
+#include "objects.h"
+#include "journal.h"
+#include "lsvd_types.h"
+#include "lsvd_debug.h"
+#include "objname.h"
+#include "extent.h"
+
+extern bool __lsvd_dbg_reverse;
+extern bool __lsvd_dbg_be_delay;
+extern bool __lsvd_dbg_be_delay_ms;
+extern bool __lsvd_dbg_be_threads;
+extern bool __lsvd_dbg_rename;
+
+std::mt19937_64 rng;
+
+struct cfg {
+    const char *cache_dir;
+    const char *cache_size;
+    const char *obj_prefix;
+    int    run_len;
+    size_t window;
+    int    image_sectors;
+    float  read_fraction;
+    int    n_runs;
+    std::vector<long> seeds;
+    bool   restart;
+    bool   verbose;
+    bool   existing;
+    int    lose_objs;
+    bool   wipe_cache;
+    size_t lose_writes;
+    bool   wipe_data;
+    bool   sleep;
+    long   seed2;
+};
+
+
+/* empirical fit to the pattern of writes in the ubuntu install,
+ * except it has lots more writes in the 128..32768 sector range
+ */
+int n_sectors(void) {
+    struct { float p; int max; } params[] = {
+	{0.5, 8},
+	{0.25, 32},
+	{0.125, 64},
+	{0.0625, 128},
+	{1.0, 4096}};
+    std::uniform_real_distribution<> uni(0.0,1.0);
+    float r = uni(rng);
+    int max = 8;
+
+    for (size_t i = 0; i < sizeof(params) / sizeof(params[0]); i++) {
+	if (r < params[i].p) {
+	    max = params[i].max;
+	    break;
+	}
+	r -= params[i].p;
+    }
+
+    std::uniform_int_distribution<int> uni_max(8/8,max/8);
+    return uni_max(rng) * 8;
+}
+
+int gen_lba(int max, int n) {
+    std::uniform_int_distribution<int> uni(0,(max-n)/8);
+    return uni(rng) * 8;
+}
+
+char *rnd_data;
+const int max_sectors = 32768;
+
+void init_random(void) {
+    size_t bytes = max_sectors * 512;
+    rnd_data = (char*)malloc(bytes);
+    for (long *p = (long*)rnd_data, *end = (long*)(rnd_data+bytes); p<end; p++)
+	*p = rng();
+}
+
+void get_random(char *buf, int lba, int sectors, int seq) {
+    int slack = (max_sectors - sectors) * 512;
+    std::uniform_int_distribution<int> uni(0,slack);
+    int offset = uni(rng);
+    memcpy(buf, rnd_data+offset, sectors*512);
+    for (auto p = (int*)buf; sectors > 0; sectors--, p += 512/4) {
+	p[0] = lba++;
+	p[1] = seq;
+    }
+}
+
+void clean_cache(std::string cache_dir) {
+    const char *suffix = ".cache";
+    for (auto const& dir_entry : fs::directory_iterator{cache_dir}) {
+	std::string entry{dir_entry.path().filename()};
+	if (!strcmp(suffix, entry.c_str() + entry.size() - strlen(suffix)))
+	    fs::remove(dir_entry.path());
+	if (!strncmp(entry.c_str(), "gc.", 3))
+	    fs::remove(dir_entry.path());
+    }
+}
+
+
+typedef std::pair<rbd_completion_t,char*> opinfo;
+
+void drain(std::queue<opinfo> &q, size_t window) {
+    while (q.size() > window) {
+	auto [c,ptr] = q.front();
+	q.pop();
+	rbd_aio_wait_for_complete(c);
+	rbd_aio_release(c);
+	free(ptr);
+    }
+}
+
+
+std::string get_cache_filename(struct cfg *cfg) {
+    char buf[4096];
+
+    std::ifstream obj_fp(std::string(cfg->obj_prefix), std::ios::binary);
+    assert(obj_fp.read(buf, sizeof(buf)));
+    auto super = (obj_hdr*)buf;
+
+    char uuid_str[64];
+    uuid_unparse(super->vol_uuid, uuid_str);
+    auto uuid_name = std::string(cfg->cache_dir) + "/" + std::string(uuid_str) + ".cache";
+    
+    auto stem = fs::path(cfg->obj_prefix).filename();
+    auto obj_name = std::string(cfg->cache_dir) + "/" + std::string(stem) + ".cache";
+
+    if (fs::exists(obj_name))
+	return obj_name;
+    if (fs::exists(uuid_name))
+	return uuid_name;
+    assert(false);
+}
+
+void obj_delete(struct cfg *cfg) {
+    std::vector<std::pair<int, std::string>> files;
+    std::string dir = fs::path(cfg->obj_prefix).parent_path();
+    auto stem = fs::path(cfg->obj_prefix).filename();
+    size_t stem_len = strlen(stem.c_str());
+    
+    for (auto const& dir_entry : fs::directory_iterator{dir}) {
+	std::string entry{dir_entry.path().filename()};
+	if (strncmp(entry.c_str(), stem.c_str(), stem_len) == 0)
+	    if (entry.size() == stem_len + 9) {
+		int seq = strtol(entry.c_str() + stem_len+1, NULL, 16);
+		files.push_back(std::make_pair(seq, entry));
+	    }
+	}
+
+    std::sort(files.begin(), files.end());
+
+    /* find the last checkpoint - we're guaranteed not to have lost
+     * that or any preceding objects
+     */
+    int last_ckpt = 0;
+    for (auto [seq, name] : files) {
+	std::string path = dir + "/" + name;
+	std::ifstream fp(path, std::ios::binary);
+	char buf[512];
+	if (fp.read(buf, sizeof(buf))) {
+	    auto _hdr = (obj_hdr*) buf;
+	    if (_hdr->type == LSVD_CKPT)
+		last_ckpt = seq;
+	}
+    }
+
+    printf("last_ckpt %08x last_file %08x\n", last_ckpt, files[files.size()-1].first);
+    
+    std::uniform_real_distribution<> uni(0.0,1.0);
+
+    for (int i = 0, j = files.size()-1; i < cfg->lose_objs; i++, j--) {
+	auto [seq, file] = files[j];
+	if (seq <= last_ckpt)
+	    break;
+	if (uni(rng) < 0.5) {
+	    fs::rename(dir + "/" + file, dir + "/" + file + ".bak");
+	    //fs::remove(dir + "/" + file);
+	    printf("rm %s\n", file.c_str());
+	}
+    }
+}
+
+void lose_writes(struct cfg *cfg) {
+    auto cache = get_cache_filename(cfg);
+    int fd = open(cache.c_str(), O_RDWR, 0777);
+    
+    char buf[4096];
+    assert(pread(fd, buf, sizeof(buf), 0) == sizeof(buf));
+    auto super = (j_super*)buf;
+    assert(super->magic == LSVD_MAGIC && super->type == LSVD_J_SUPER);
+
+    assert(pread(fd, buf, sizeof(buf), super->write_super * 4096) == 4096);
+    auto w_super = (j_write_super*)buf;
+    assert(w_super->magic == LSVD_MAGIC && w_super->type == LSVD_J_W_SUPER);
+
+    auto base = w_super->base, limit = w_super->limit;
+    std::vector<int> header_pages;
+    uint32_t seq = 0;
+    
+    for (int i = base; i < limit; ) {
+	assert(pread(fd, buf, sizeof(buf), i * 4096) == 4096);
+	auto hdr = (j_hdr*)buf;
+	if (seq == 0)
+	    seq = hdr->seq - 1;
+	if (hdr->magic != LSVD_MAGIC || hdr->type != LSVD_J_DATA || hdr->seq != seq+1)
+	    break;
+	seq++;
+	header_pages.push_back(i);
+	i += hdr->len;
+    }
+    
+    memset(buf, 0, sizeof(buf));
+
+    std::uniform_real_distribution<> uni(0.0,1.0);
+    std::reverse(header_pages.begin(), header_pages.end());
+    for (size_t i = 0; i < cfg->lose_writes && i < header_pages.size(); i++)
+	if (uni(rng) < 0.5) {
+	    int n = header_pages[i];
+	    assert(pwrite(fd, buf, sizeof(buf), n * 4096) == 4096);
+	    printf("overwriting %d\n", n);
+	}
+    close(fd);
+}
+
+int print_status(struct cfg *cfg) {
+    auto prefix = std::string(cfg->obj_prefix);
+    auto stem = fs::path(prefix).filename();
+    auto parent = fs::path(prefix).parent_path();
+    size_t stem_len = strlen(stem.c_str());
+    
+    /* find the most recent object written
+     */
+    std::vector<std::pair<int, std::string>> files;
+    for (auto const& dir_entry : fs::directory_iterator{parent}) {
+	std::string entry{dir_entry.path().filename()};
+	if (strncmp(entry.c_str(), stem.c_str(), stem_len) == 0)
+	    if (entry.size() == stem_len + 9) {
+		int seq = strtol(entry.c_str() + stem_len+1, NULL, 16);
+		files.push_back(std::make_pair(seq, entry));
+	    }
+	}
+
+    std::sort(files.begin(), files.end());
+    auto end = files.size() - 1;
+    printf("last object: %x %s\n", files[end].first, files[end].second.c_str());
+    int rv = files[end].first;
+    auto min = std::max(0, (int)files.size() - 20);
+    
+    int n = files[min].first;
+    const char *msg = "missing objects:\n";
+    for (int i = min; i < (int)files.size(); i++, n++) {
+	while (n < files[i].first) {
+	    printf("%s%s.%08x\n", msg, stem.c_str(), n++);
+	    msg = "";
+	}
+    }
+    for (int i = min; i < (int)files.size(); i++)
+	printf("%s\n", files[i].second.c_str());
+    
+    auto cache = get_cache_filename(cfg);
+    char buf[4096];
+    int fd = open(cache.c_str(), O_RDONLY);
+    pread(fd, buf, sizeof(buf), 0);
+    auto super = (j_super*)buf;
+    assert(super->magic == LSVD_MAGIC && super->type == LSVD_J_SUPER);
+    pread(fd, buf, sizeof(buf), super->write_super * 4096);
+    auto w_super = (j_write_super*)buf;
+    assert(w_super->magic == LSVD_MAGIC && w_super->type == LSVD_J_W_SUPER);
+    auto base = w_super->base, limit = w_super->limit;
+
+    int seq = 0, highest = 0;
+    for (int i = base; i < limit;) {
+	pread(fd, buf, sizeof(buf), i * 4096);
+	auto hdr = (j_hdr*)buf;
+	if (seq == 0)
+	    seq = hdr->seq - 1;
+	if (hdr->magic != LSVD_MAGIC || (int)hdr->seq != seq+1)
+	    break;
+	assert(hdr->len != 0);
+	seq++;
+	highest = i;
+	i = i + hdr->len;
+    }
+    printf("last write cache page: %d\n", highest);
+    close(fd);
+    return rv;
+}
+
+int super_n;
+char super_buf[4096];
+std::vector<std::string> ckpt_files;
+
+void save_super(struct cfg *cfg) {
+    char buf[10];
+    sprintf(buf, "%d", super_n++);
+    std::string super(cfg->obj_prefix);
+    fs::copy_file(super, super + "." + std::string(buf));
+    int fd = open(cfg->obj_prefix, O_RDONLY);
+    read(fd, super_buf, sizeof(super_buf));
+    printf("saved %s crc %08x\n", cfg->obj_prefix,
+	   (uint32_t)crc32(0, (const unsigned char*)super_buf, 4096));
+    close(fd);
+    auto h = (obj_hdr*)super_buf;
+    auto sh = (super_hdr*)(h+1);
+    auto cp = (int*)(super_buf + sh->ckpts_offset);
+    ckpt_files.clear();
+    for (int i = 0; i < sh->ckpts_len/4; i++) {
+	char buf[128];
+	sprintf(buf, "%s.%08x", cfg->obj_prefix, cp[i]);
+	ckpt_files.push_back(std::string(buf));
+	assert(access(buf, R_OK) == 0);
+    }
+}
+
+void restore_super(struct cfg *cfg) {
+    int fd = open(cfg->obj_prefix, O_WRONLY, 0);
+    printf("restoring super crc %08x\n",
+	   (uint32_t)crc32(0, (const unsigned char*)super_buf, 4096));
+    pwrite(fd, super_buf, sizeof(super_buf), 0);
+    close(fd);
+    for (auto s : ckpt_files) {
+	if (access(s.c_str(), R_OK) != 0) {
+	    printf("resurrecting %s\n", s.c_str());
+	    fs::rename(s + ".bak", s);
+	}
+    }
+}
+
+void get_obj_files(std::string prefix, std::vector<std::string> &files) {
+    auto stem = fs::path(prefix).filename();
+    auto parent = fs::path(prefix).parent_path();
+    size_t stem_len = strlen(stem.c_str());
+
+    for (auto const& dir_entry : fs::directory_iterator{parent}) {
+        std::string entry{dir_entry.path().filename()};
+        if (strncmp(entry.c_str(), stem.c_str(), stem_len) == 0)
+            if (entry.size() == stem_len + 9)
+		files.push_back(entry);
+    }
+    std::sort(files.begin(), files.end());
+}
+
+void check_rcache(struct cfg *cfg) {
+    // crc32 -> <obj#,block>
+    std::map<uint32_t,std::pair<int,int>> crcmap;
+    std::map<std::pair<int,int>,uint32_t> objmap;
+    bool failed = false;
+    
+    auto cache = get_cache_filename(cfg);
+    int fd = open(cache.c_str(), O_RDONLY);
+    char buf1[4096];
+    pread(fd, buf1, 4096, 2*4096);
+    auto r_super = (j_read_super*)buf1;
+    size_t map_bytes = r_super->map_blocks * 4096;
+    auto _flat_map = malloc(map_bytes);
+    pread(fd, _flat_map, map_bytes, r_super->map_start * 4096);
+    auto flat_map = (extmap::obj_offset*)_flat_map;
+
+    std::set<int> objects;
+
+    for (int i = 0; i < r_super->units; i++) {
+	auto oo = flat_map[i];
+	if (objects.find(oo.obj) != objects.end())
+	    continue;
+	char name[128];
+	sprintf(name, "%s.%08x", cfg->obj_prefix, (uint32_t)oo.obj);
+	int fd = open(name, O_RDONLY);
+	if (fd == -1) {
+	    sprintf(name, "%s.%08x.bak", cfg->obj_prefix, (uint32_t)oo.obj);
+	    fd = open(name, O_RDONLY);
+	}
+	
+	char buf[64*1024];
+	for (int i = 0, rv = sizeof(buf); rv == sizeof(buf); i++) {
+	    memset(buf, 0, sizeof(buf));
+	    if ((rv = read(fd, buf, sizeof(buf))) <= 0)
+		break;
+	    uint32_t crc = crc32(0, (unsigned char*)buf, sizeof(buf));
+	    auto oop = std::make_pair((int)oo.obj, (int)i);
+	    crcmap[crc] = oop;
+	    objmap[oop] = crc;
+	}
+	objects.insert(oo.obj);
+	close(fd);
+    }
+
+    // note - all-zeros 64KB CRC = d7978eeb
+    for (int i = 0; i < r_super->units; i++) {
+	auto oo = flat_map[i];
+	if (oo.obj == 0)
+	    continue;
+	auto _oo = std::make_pair((int)oo.obj, (int)oo.offset);
+	assert(objmap.find(_oo) != objmap.end());
+	auto crc1 = objmap[_oo];
+	char buf[64*1024];
+	memset(buf, 0, sizeof(buf));
+	// 16 4KB pages in a 64KB block
+	pread(fd, buf, sizeof(buf), (r_super->base + i*16) * 4096L);
+	uint32_t crc2 = crc32(0, (unsigned char*)buf, 64*1024);
+	if (crc1 != crc2) {
+	    failed = true;
+	    printf("%d (%d.%d) failed: %08x (should be %08x)\n", i,
+		   (int)oo.obj, (int)oo.offset, crc2, crc1);
+	    if (crcmap.find(crc2) != crcmap.end()) {
+		auto [obj,offset] = crcmap[crc2];
+		printf("  %08x is for %d.%d\n", crc2, obj, offset);
+	    }
+	}
+    }
+
+    assert(!failed);
+}
+
+char wcache_state_buf[4096];
+int backup_n;
+void save_wcache_state(struct cfg *cfg) {
+    auto cache = get_cache_filename(cfg);
+    char buf[10];
+    sprintf(buf, "%d", backup_n++);
+
+    fs::copy_file(cache, cache + "." + std::string(buf));
+
+    int fd = open(cache.c_str(), O_RDONLY);
+    pread(fd, wcache_state_buf, 4096, 1*4096); // assume write super is block 1
+    auto super = (j_super*)wcache_state_buf;
+    assert(super->magic == LSVD_MAGIC && super->type == LSVD_J_W_SUPER);
+    close(fd);
+}
+void restore_wcache_state(struct cfg *cfg) {
+    auto cache = get_cache_filename(cfg);
+#if 0
+    fs::copy_file(cache + ".bak", cache, fs::copy_options::overwrite_existing);
+#else
+    int fd = open(cache.c_str(), O_WRONLY, 0777);
+    pwrite(fd, wcache_state_buf, 4096, 1*4096); // assume write super is block 1
+    close(fd);
+#endif
+}
+
+extern char *p_log, *logbuf;
+
+struct triple {
+    int lba;
+    int seq;
+    uint32_t crc;
+};
+
+struct op {
+    int sector;
+    int len;
+    int seq;
+    std::vector<uint32_t> *crcs;
+};
+
+#include <sys/mman.h>
+
+extern bool __lsvd_dbg_no_gc;
+
+void run_test(struct cfg *cfg) {
+    const int buflen = 16000000;
+    auto child_logbuf = (char*) mmap(NULL, buflen, PROT_READ | PROT_WRITE, 
+				     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    rados_ioctx_t io = 0;
+    rbd_image_t img;
+    bool started = false;
+    int seq = 0;
+    std::vector<triple> should_be_crcs(cfg->image_sectors);
+    std::vector<op> op_crcs;
+
+    setenv("LSVD_CACHE_SIZE", cfg->cache_size, 1);
+    setenv("LSVD_BACKEND", "file", 1);
+    setenv("LSVD_CACHE_DIR", cfg->cache_dir, 1);
+    
+    std::vector<std::tuple<int,int>> io_list;
+
+    for (auto s : cfg->seeds) {
+#if 0
+	p_log = logbuf;
+	if (p_log)
+	    *p_log = 0;
+#endif
+	do_log("RESTART\n\n");
+
+	printf("seed: 0x%lx\n", s);
+	rng.seed(s);
+
+	init_random();
+
+	if (!started || cfg->restart) {
+	    clean_cache(cfg->cache_dir);
+	    rbd_remove(io, cfg->obj_prefix);
+	    rbd_create(io, cfg->obj_prefix, cfg->image_sectors, NULL);
+	    started = true;
+	    seq = 0;
+	    for (int i = 0; i < cfg->image_sectors; i++)
+		should_be_crcs[i] = (triple){0, 0, 0xb2aa7578};
+	    op_crcs.clear();
+	}
+
+	std::uniform_real_distribution<> uni(0.0,1.0);
+	int n_requests = cfg->run_len + (uni(rng)-0.5)*100;
+    
+
+	int start = io_list.size();
+	for (int i = 0; i < n_requests; i++) {
+	    int n = n_sectors();
+	    int lba = gen_lba(cfg->image_sectors, n);
+	    io_list.push_back(std::make_tuple(lba, n));
+	}
+
+	int pid = fork();
+	if (pid == 0) {
+	    extern char *logbuf, *p_log, *end_log;
+
+	    logbuf = child_logbuf;
+	    p_log = (char*)memchr(logbuf, 0, buflen);
+	    end_log = child_logbuf+buflen;
+	    do_log("\n\nRESTART\n\n\n");
+
+	    if (cfg->sleep) {
+		printf("pid %d\n", getpid());
+		sleep(10);
+	    }
+	    if (rbd_open(io, cfg->obj_prefix, &img, NULL) < 0)
+		printf("failed: rbd_open\n"), exit(1);
+
+	    std::queue<std::pair<rbd_completion_t,char*>> q;
+	    for (int i = 0; i < n_requests; i++) {
+		drain(q, cfg->window-1);
+		if (i % 1000 == 999)
+		    printf("+"), fflush(stdout);
+		rbd_completion_t c;
+		rbd_aio_create_completion(NULL, NULL, &c);
+
+		auto [lba, n] = io_list[start+i];
+		auto ptr = (char*)aligned_alloc(512, n*512);
+	
+		q.push(std::make_pair(c, ptr));
+		if (uni(rng) < cfg->read_fraction) {
+		    rbd_aio_read(img, 512L * lba, 512L * n, ptr, c);
+		}
+		else {
+		    auto s = ++seq;
+		    get_random(ptr, lba, n, s);
+		    rbd_aio_write(img, 512L * lba, 512L * n, ptr, c);
+		}
+	    }
+	    printf(" K\n");
+	    _exit(0);
+	}
+
+	int start2 = op_crcs.size();
+	/* this relies on the random number stream being identical in 
+	 * the parent and child processes
+	 */
+	int n_writes = 0;
+	for (int i = 0; i < n_requests; i++) {
+	    if (uni(rng) < cfg->read_fraction)
+		continue;
+	    n_writes++;
+	    auto [lba, n] = io_list[start+i];
+	    auto ptr = (char*)malloc(n*512);
+	    auto s = ++seq;
+	    get_random(ptr, lba, n, s);
+
+	    auto crc_list = new std::vector<uint32_t>();
+	    for (size_t j = 0; j < 512UL*n; j += 512) {
+		auto p = (const unsigned char*)ptr + j;
+		auto crc = (uint32_t)crc32(0, p, 512);
+		crc_list->push_back(crc);
+	    }
+	    op_crcs.push_back((op){lba, n, s, crc_list});
+	    free(ptr);
+	}
+
+	int status;
+	waitpid(pid, &status, 0);
+	int last_obj = print_status(cfg);
+
+	
+	if (cfg->lose_objs)
+	    obj_delete(cfg);
+	if (cfg->wipe_cache)
+	    clean_cache(cfg->cache_dir);
+	else if (cfg->lose_writes)
+	    lose_writes(cfg);
+
+	if (!cfg->restart) {
+	    save_wcache_state(cfg);
+	    save_super(cfg);
+	}
+	
+	//check_rcache(cfg);
+
+	extern bool __lsvd_dbg_no_gc;
+	__lsvd_dbg_no_gc = true;
+	if (rbd_open(io, cfg->obj_prefix, &img, NULL) < 0)
+	    printf("failed: rbd_open\n"), exit(1);
+
+	//check_rcache(cfg);
+	extern void do_log(const char*, ...);
+	do_log("cache checked\n");
+	auto tmp = __lsvd_dbg_be_delay;
+	__lsvd_dbg_be_delay = false;
+
+	const int bufsize = 128*1024;
+	auto buf = (char*)aligned_alloc(512, bufsize);
+	std::vector<triple> image_info(cfg->image_sectors);
+    
+	int i = 0;
+	for (int sector = 0; sector < cfg->image_sectors; sector += bufsize/512) {
+	    memset(buf, 0, bufsize);
+	    rbd_read(img, sector*512L, bufsize, buf);
+	    for (int j = 0; j < bufsize; j += 512) {
+		auto p = (const unsigned char*)buf + j;
+		assert(*(int*)p == sector + j/512 || *(int*)p == 0);
+		assert(*(int*)(p+4) >= 0);
+		uint32_t crc = crc32(0, p, 512);
+		image_info[sector + j/512] = (triple){*(int*)p,
+						      *(int*)(p+4), crc};
+		assert(*(int*)(p+4) <= (int)image_info.size()+1);
+	    }
+	    if (++i > cfg->image_sectors / (bufsize/512) / 10) {
+		printf("-"); fflush(stdout);
+		i = 0;
+	    }
+	}
+	printf("\n");
+    
+	rbd_close(img);
+	//check_rcache(cfg);
+
+	int max_seq = 0;
+	for (int i = 0; i < cfg->image_sectors; i++)
+	    if (image_info[i].seq > max_seq) {
+		max_seq = image_info[i].seq;
+		assert(max_seq <= (int)op_crcs.size()+1);
+	    }
+
+	printf("max_seq = %d start = %d start2 = %d\n", max_seq, start, start2);
+	int secs = 0;
+	for (size_t i = max_seq; i < op_crcs.size(); i++)
+	    secs += op_crcs[i].len;
+	printf("lost %d writes (%.1f MB)\n",
+	       (int)op_crcs.size() - max_seq, secs / 2.0 / 1024);
+	assert(cfg->lose_writes || (n_writes - max_seq) < (int)cfg->window);
+    
+	for (int i = start2; i < max_seq; i++) {
+	    auto [lba,len,seq,crcs] = op_crcs[i];
+	    assert(seq == i+1);
+	    assert(seq <= max_seq);
+	    int j = 0;
+	    for (auto c : *crcs) {
+		should_be_crcs[lba+j] = (triple){lba+j,seq,c};
+		j++;
+	    }
+	}
+	int failed = 0;
+	for (int i = 0; i < cfg->image_sectors && failed < 100; i++)
+	    if (should_be_crcs[i].crc != image_info[i].crc) {
+		printf("%d : %08x (seq %d) should be: %08x (%d)\n", i,
+		       image_info[i].crc, image_info[i].seq,
+		       should_be_crcs[i].crc, should_be_crcs[i].seq);
+		failed++;
+	    }
+	if (failed) {
+	    check_rcache(cfg);
+	    assert(false);
+	}
+	printf("ok\n");
+
+	__lsvd_dbg_no_gc = false;
+	
+	if (!cfg->restart) {
+	    restore_wcache_state(cfg);
+	    restore_super(cfg);
+	    for (int i = 1; i < 64; i++) {
+		char name[128];
+		sprintf(name, "%s.%08x", cfg->obj_prefix, last_obj + i);
+		if (unlink(name) >= 0)
+		    printf("removed %s\n", name);
+	    }
+	    // works fine if I do this: (or don't delete objects above)
+	    // well, almost fine.
+	    //rbd_open(io, cfg->obj_prefix, &img, NULL);
+	    //rbd_close(img);
+	}
+
+	free(buf);
+	__lsvd_dbg_be_delay = tmp;
+    }
+}
+
+
+static char args_doc[] = "RUNS";
+
+static struct argp_option options[] = {
+    {"seed",     's', "S",    0, "use this seed (one run)"},
+    {"len",      'l', "N",    0, "run length"},
+    {"window",   'w', "W",    0, "write window"},
+    {"size",     'z', "S",    0, "volume size (e.g. 1G, 100M)"},
+    {"cache-dir",'d', "DIR",  0, "cache directory"},
+    {"prefix",   'p', "PREFIX", 0, "object prefix"},
+    {"reads",    'r', "FRAC", 0, "fraction reads (0.0-1.0)"},
+    {"keep",     'k', 0,      0, "keep data between tests"},
+    {"verbose",  'v', 0,      0, "print LBAs and CRCs"},
+    {"reverse",  'R', 0,      0, "reverse NVMe completion order"},
+    {"existing", 'x', 0,      0, "don't delete existing cache"},
+    {"delay",    'D', 0,      0, "add random backend delays"},
+    {"lose-objs",'o', "N",    0, "delete some of last N objects"},
+    {"wipe-cache",'W', 0,     0, "delete cache on restart"},
+    {"lose-writes",'L', "N",    0, "delete some of last N cache writes"},
+    {"cache-size",'Z', "N",    0, "cache size (K/M/G)"},
+    {"no-wipe",  'n', 0,      0, "don't clear image between runs"},
+    {"sleep",    'S', 0,      0, "child sleeps for debug attach"},
+    {"seed2",    '2', 0,      0, "seed-generating seed"},
+    {0},
+};
+
+struct cfg _cfg = {
+    "/tmp",			// cache_dir
+    "200M",			// cache_size
+    "/tmp/bkt/obj",		// obj_prefix
+    10000, 			// run_len
+    16,				// window
+    1024*1024*2,		// image_sectors,
+    0.0,			// read_fraction
+    1,				// n_runs
+    {},				// seeds
+    true,			// restart
+    false,			// verbose
+    false,			// existing
+    0,				// lose_objs
+    false,			// wipe_cache
+    0,				// lose_writes
+    true,			// wipe_data
+    false,			// sleep
+    0};				// seed2
+
+off_t parseint(char *s)
+{
+    off_t val = strtoul(s, &s, 0);
+    if (toupper(*s) == 'G')
+        val *= (1024*1024*1024);
+    if (toupper(*s) == 'M')
+        val *= (1024*1024);
+    if (toupper(*s) == 'K')
+        val *= 1024;
+    return val;
+}
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
+{
+    switch (key) {
+    case ARGP_KEY_INIT:
+	break;
+    case ARGP_KEY_ARG:
+        _cfg.n_runs = atoi(arg);
+        break;
+    case 's':
+	_cfg.seeds.push_back(strtoul(arg, NULL, 0));
+	break;
+    case 'l':
+	_cfg.run_len = atoi(arg);
+	break;
+    case 'w':
+	_cfg.window = atoi(arg);
+	break;
+    case 'z':
+	_cfg.image_sectors = parseint(arg) / 512;
+	break;
+    case 'd':
+	_cfg.cache_dir = arg;
+	break;
+    case 'p':
+	_cfg.obj_prefix = arg;
+	break;
+    case 'r':
+	_cfg.read_fraction = atof(arg);
+	break;
+    case 'k':
+	_cfg.restart = false;
+	break;
+    case 'v':
+	_cfg.verbose = true;
+	break;
+    case 'R':
+	__lsvd_dbg_reverse = true;
+	break;
+    case 'x':
+	_cfg.existing = true;
+	break;
+    case 'D':
+	__lsvd_dbg_be_delay = true;
+	break;
+    case 'o':
+	_cfg.lose_objs = atoi(arg);
+	break;
+    case 'W':
+	_cfg.wipe_cache = true;
+	break;
+    case 'L':
+	_cfg.lose_writes = atoi(arg);
+	break;
+    case 'Z':
+	_cfg.cache_size = arg;
+	break;
+    case 'n':
+	_cfg.wipe_data = false;
+	break;
+    case 'S':
+	_cfg.sleep = true;
+	break;
+    case '2':
+	_cfg.seed2 = strtoul(arg, NULL, 0);
+	break;
+    case ARGP_KEY_END:
+        break;
+    }
+    return 0;
+}
+static struct argp argp = { options, parse_opt, NULL, args_doc};
+
+int main(int argc, char **argv) {
+    argp_parse (&argp, argc, argv, 0, 0, 0);
+    __lsvd_dbg_rename = true;
+    
+    if (_cfg.seeds.size() == 0) {
+	long seed = _cfg.seed2;
+	if (seed == 0) {
+	    auto now = std::chrono::system_clock::now();
+	    auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+	    auto value = now_ms.time_since_epoch();
+	    seed = value.count();
+	    printf("seed2: 0x%lx\n", seed);
+	}
+
+	rng.seed(seed);
+	for (int i = 0; i < _cfg.n_runs; i++)
+	    _cfg.seeds.push_back(rng());
+    }
+
+    run_test(&_cfg);
+}

--- a/src/liblsvd/lsvd_debug.cc
+++ b/src/liblsvd/lsvd_debug.cc
@@ -1,0 +1,290 @@
+#include <unistd.h>
+#include <uuid/uuid.h>
+
+#include <queue>
+#include <map>
+#include <thread>
+
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <atomic>
+
+#include "lsvd_types.h"
+#include "smartiov.h"
+#include "fake_rbd.h"
+#include "config.h"
+#include "extent.h"
+#include "backend.h"
+#include "translate.h"
+#include "read_cache.h"
+#include "journal.h"
+#include "write_cache.h"
+#include "image.h"
+
+#include "objects.h"
+#include "request.h"
+
+#include "misc_cache.h"
+#include "nvme.h"
+
+#include "config.h"
+
+// tuple :	used for retrieving maps
+struct tuple {
+    int base;
+    int limit;
+    int obj;                    // object map
+    int offset;
+    int plba;                   // write cache map
+};
+
+// getmap_s :	more helper structures
+struct getmap_s {
+    int i;
+    int max;
+    struct tuple *t;
+};
+
+extern translate *image_2_xlate(rbd_image_t image);
+
+
+// struct rbd_image;
+extern rbd_image *make_rbd_image(backend *b, translate *t,
+				 write_cache *w, read_cache *r);
+
+
+char *logbuf, *p_log, *end_log;
+#include <stdarg.h>
+std::mutex m;
+void do_log(const char *fmt, ...) {
+    std::unique_lock lk(m);
+    if (!logbuf) {
+	size_t sz = 64*1024;
+	const char *env = getenv("LSVD_DEBUG_BUF");
+	if (env)
+	    sz = atoi(env);
+	p_log = logbuf = (char*)malloc(sz);
+	end_log = p_log + sz;
+    }
+    va_list args;
+    va_start(args, fmt);
+    ssize_t max = end_log - p_log - 1;
+    if (max > 256)
+	p_log += vsnprintf(p_log, max, fmt, args);
+}
+
+FILE *_fp;
+void fp_log(const char *fmt, ...) {
+    //std::unique_lock lk(m);
+    if (_fp == NULL)
+	_fp = fopen("/tmp/lsvd.log", "w");
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(_fp, fmt, args);
+    fflush(_fp);
+}
+
+
+struct timelog {
+    uint64_t loc : 8;
+    uint64_t val : 48;
+    uint64_t time;
+};
+
+struct timelog *tl;
+std::atomic<int> tl_index;
+int tl_max = 10000000;
+
+#include <x86intrin.h>
+void log_time(uint64_t loc, uint64_t value) {
+    return;
+    if (tl == NULL)
+	tl = (struct timelog*)malloc(tl_max * sizeof(struct timelog));
+    auto t = __rdtsc();
+    auto i = tl_index++;
+    if (i < tl_max) 
+	tl[i] = {loc, value, t};
+}
+
+void save_log_time(void) {
+    return;
+    FILE *fp = fopen("/tmp/timelog", "wb");
+    size_t bytes = tl_index * sizeof(struct timelog);
+    fwrite(tl, bytes, 1, fp);
+    fclose(fp);
+}
+
+/* random run-time debugging stuff, not used at the moment...
+ */
+#if CRC_DEBUGGER
+#include <zlib.h>
+static std::map<int,uint32_t> sector_crc;
+char zbuf[512];
+static std::mutex zm;
+
+void add_crc(sector_t sector, iovec *iov, int niovs) {
+    std::unique_lock lk(zm);
+    for (int i = 0; i < niovs; i++) {
+	for (size_t j = 0; j < iov[i].iov_len; j += 512) {
+	    const unsigned char *ptr = j + (unsigned char*)iov[i].iov_base;
+	    sector_crc[sector] = (uint32_t)crc32(0, ptr, 512);
+	    sector++;
+	}
+    }
+}
+
+void check_crc(sector_t sector, iovec *iov, int niovs, const char *msg) {
+    std::unique_lock lk(zm);
+    for (int i = 0; i < niovs; i++) {
+	for (size_t j = 0; j < iov[i].iov_len; j += 512) {
+	    const unsigned char *ptr = j + (unsigned char*)iov[i].iov_base;
+	    if (sector_crc.find(sector) == sector_crc.end()) {
+		assert(memcmp(ptr, zbuf, 512) == 0);
+	    }
+	    else {
+		unsigned crc1 = 0, crc2 = 0;
+		assert((crc1 = sector_crc[sector]) == (crc2 = crc32(0, ptr, 512)));
+	    }
+	    sector++;
+	}
+    }
+}
+
+void list_crc(sector_t sector, int n) {
+    for (int i = 0; i < n; i++)
+	printf("%ld %08x\n", sector+i, sector_crc[sector+i]);
+}
+#endif
+
+#ifdef PERF_DEBUGGER
+#include <fcntl.h>
+void getcpu(int pid, int tid, int &u, int &s) {
+    if (tid == 0) 
+	return;
+    char procname[128];
+    sprintf(procname, "/proc/%d/task/%d/stat", pid, tid);
+    int fd = open(procname, O_RDONLY);
+    char buf[512], *p = buf;
+    read(fd, buf, sizeof(buf));
+    close(fd);
+    for (int i = 0; i < 13; i++)
+	p = strchr(p, ' ') + 1;
+    u = strtol(p, &p, 0);
+    s = strtol(p, &p, 0);
+}
+
+int __dbg_wc_tid;
+int __dbg_gc_tid;
+int __dbg_fio_tid;
+#include <sys/syscall.h>
+
+int get_tid(void) {
+    return syscall(SYS_gettid);
+}
+
+int __dbg_write1;		// writes launched
+int __dbg_write2;		// writes completed
+int __dbg_write3, __dbg_write4;	// objects written, completed
+
+std::mutex *__dbg_wcache_m;
+std::mutex *__dbg_xlate_m;
+const char *__dbg_gc_state = "   -";
+int __dbg_gc_reads;
+int __dbg_gc_writes;
+int __dbg_gc_deletes;
+int __dbg_gc_n;
+
+int __dbg_t_room;
+int __dbg_w_room;
+
+std::atomic<int> __dbg_in_lsvd;
+
+bool read_lock(std::mutex *m) {
+    if (!m)
+	return false;
+    bool val = m->try_lock();
+    if (val)
+	m->unlock();
+    return !val;
+}
+bool read_lock(std::shared_mutex *m) {
+    if (!m)
+	return false;
+    bool val = m->try_lock();
+    if (val)
+	m->unlock();
+    return !val;
+}
+    
+#include <sys/time.h>
+struct timeval tv0;
+double gettime(void) {
+    if (tv0.tv_sec == 0)
+	gettimeofday(&tv0, NULL);
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec - tv0.tv_sec + (tv.tv_usec - tv0.tv_usec) / 1.0e6;
+}
+
+std::atomic<int> __dbg_wq_1;
+std::atomic<int> __dbg_wq_2;
+std::atomic<int> __dbg_wq_3;
+std::atomic<int> __dbg_wq_4;
+
+void debug_thread(rbd_image *img) {
+    int pid = getpid();
+    int write1 = __dbg_write1, write2 = __dbg_write2;
+    int write3 = 0, write4 = 0;
+    int gcr = 0, gcw = 0, gcd = 0;
+    int uf=0,sf=0,uw=0,sw=0,ug=0,sg=0;
+    int t_room = 0, w_room = 0;
+    int xlate_m = 0, wcache_m = 0, obj_m = 0;
+    double time0 = gettime();
+    int in_lsvd = 0;
+    
+    while (!img->done) {
+	int t1 = __dbg_write1, t2 = __dbg_write2;
+	int t3 = __dbg_write3, t4 = __dbg_write4;
+
+	int n1 = __dbg_gc_reads, n2 = __dbg_gc_writes, n3 = __dbg_gc_deletes;
+
+	int uf_,sf_,uw_,sw_,ug_,sg_;
+	getcpu(pid, __dbg_fio_tid, uf_, sf_);
+	getcpu(pid, __dbg_wc_tid, uw_, sw_);
+	getcpu(pid, __dbg_gc_tid, ug_, sg_);
+
+	int q1 = __dbg_wq_1;
+	int q2 = __dbg_wq_2;
+	int q3 = __dbg_wq_3;
+	int q4 = __dbg_wq_4;
+	double time1 = gettime();
+	printf("%.3f %- 4d\t%- 4d\t%- 4d\t%- 4d\t%d %d %d\t%s %d\t%d %d %d\t%d %d %d %d %d %d\t%d %d\t%d\t%d %d %d %d\n",
+	       time1-time0,
+	       t1-write1, t2-write2, t3-write3, t4-write4,
+	       xlate_m, wcache_m, obj_m,
+	       __dbg_gc_state, __dbg_gc_n, 
+	       n1-gcr, n2-gcw, n3-gcd,
+	       uf_-uf, sf_-sf, uw_-uw, sw_-sw, ug_-ug, sg_-sg,
+	       w_room, t_room,
+	       in_lsvd,
+	       q1, q2, q3, q4);
+	time0 = time1;
+	write1 = t1; write2 = t2; write3 = t3; write4 = t4;
+	gcr = n1; gcw = n2; gcd = n3;
+	uf=uf_; sf=sf_; uw=uw_; sw=sw_; ug=ug_; sg=sg_;
+	t_room = w_room = 0;
+	xlate_m = wcache_m = obj_m = 0;
+	in_lsvd = 0;
+	for (int i = 0; i < 20 && !img->done; i++) {
+	    t_room += __dbg_t_room;
+	    w_room += __dbg_w_room;
+	    xlate_m += read_lock(__dbg_xlate_m);
+	    wcache_m += read_lock(__dbg_wcache_m);
+	    obj_m += read_lock(&img->map_lock);
+	    in_lsvd += (__dbg_in_lsvd > 0);
+	    usleep(10000);
+	}
+    }
+}
+#endif // PERF_DEBUGGER

--- a/src/liblsvd/lsvd_debug.h
+++ b/src/liblsvd/lsvd_debug.h
@@ -1,0 +1,14 @@
+/*
+ * file:        lsvd_debug.h
+ * description: extern functions for unit tests
+ */
+
+#ifndef __LSVD_DEBUG_H__
+#define __LSVD_DEBUG_H__
+
+/* lightweight printf to buffer, retrieve via get_logbuf or lsvd.logbuf
+ */
+extern void do_log(const char *fmt, ...);
+extern "C" int get_logbuf(char *buf);
+
+#endif

--- a/src/liblsvd/lsvd_imgtool.cc
+++ b/src/liblsvd/lsvd_imgtool.cc
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string>
+#include <uuid/uuid.h>
+#include <fcntl.h>
+
+#include "fake_rbd.h"
+#include "config.h"
+
+struct backend;
+
+extern backend *get_backend(lsvd_config *cfg, rados_ioctx_t io, const char *name);
+extern int translate_get_uuid(backend *, const char *, uuid_t &);
+
+
+
+const char *backend = "file";
+const char *image_name;
+const char *cache_dir;
+const char *cache_dev;
+enum _op {OP_CREATE = 1, OP_DELETE = 2, OP_INFO = 3, OP_MKCACHE};
+enum _op op;
+size_t size = 0;
+
+static long parseint(const char *_s)
+{
+    char *s = (char*)_s;
+    long val = strtol(s, &s, 0);
+    if (toupper(*s) == 'G')
+        val *= (1024*1024*1024);
+    if (toupper(*s) == 'M')
+        val *= (1024*1024);
+    if (toupper(*s) == 'K')
+        val *= 1024;
+    return val;
+}
+
+static struct argp_option options[] = {
+    {"cache-dir",'d', "DIR",  0, "cache directory"},
+    {"rados",    'O', 0,      0, "use RADOS"},
+    {"create",   'C', 0,      0, "create image"},
+    {"mkcache",  'k', "DEV",  0, "use DEV as cache"},
+    {"size",     'z', "SIZE", 0, "size in bytes (M/G=2^20,2^30)"},
+    {"delete",   'D', 0,      0, "delete image"},
+    {"info",     'I', 0,      0, "show image information"},
+    {0},
+};
+
+static char args_doc[] = "IMAGE";
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
+{
+    switch (key) {
+    case ARGP_KEY_ARG:
+        image_name = arg;
+        break;
+    case 'd':
+	cache_dir = arg;
+	break;
+    case 'O':
+	backend = "rados";
+        break;
+    case 'C':
+	op = OP_CREATE;
+        break;
+    case 'z':
+	size = parseint(arg);
+	break;
+    case 'D':
+	op = OP_DELETE;
+        break;
+    case 'I':
+	op = OP_INFO;
+        break;
+    case 'k':
+	op = OP_MKCACHE;
+	cache_dev = arg;
+	break;
+    case ARGP_KEY_END:
+	if (op == 0 || (op == OP_CREATE && size == 0))
+	    argp_usage(state);
+        break;
+    }
+    return 0;
+}
+
+static struct argp argp = { options, parse_opt, NULL, args_doc};
+
+void info(rados_ioctx_t io, const char *image_name) {
+    lsvd_config  cfg;
+    int rv;
+    if ((rv = cfg.read()) < 0) {
+	printf("error reading config: %d\n", rv);
+	exit(1);
+    }
+    auto objstore = get_backend(&cfg, io, NULL);
+    uuid_t uu;
+    if ((rv = translate_get_uuid(objstore, image_name, uu)) < 0) {
+	printf("error reading superblock: %d\n", rv);
+	exit(1);
+    }
+    auto cache_file = cfg.cache_filename(uu, image_name);
+    printf("image: %s\n", image_name);
+    printf("cache: %s\n", cache_file.c_str());
+}
+
+extern int make_cache(int fd, uuid_t &uuid, int n_pages);
+extern size_t getsize64(int fd);
+
+void mk_cache(rados_ioctx_t io, const char *image_name, const char *dev_name) {
+    int rv, fd = open(dev_name, O_RDWR);
+    if (fd < 0) {
+	perror("device file open");
+	exit(1);
+    }
+    auto sz = getsize64(fd);
+
+    lsvd_config  cfg;
+    if ((rv = cfg.read()) < 0) {
+	printf("error reading config: %d\n", rv);
+	exit(1);
+    }
+    auto objstore = get_backend(&cfg, io, NULL);
+    uuid_t uu;
+    if ((rv = translate_get_uuid(objstore, image_name, uu)) < 0) {
+	printf("error reading superblock: %d\n", rv);
+	exit(1);
+    }
+    auto cache_file = cfg.cache_filename(uu, image_name);
+
+    auto n_pages = sz / 4096;
+    if (make_cache(fd, uu, n_pages) < 0) {
+	printf("make_cache failed\n");
+	exit(1);
+    }
+    if ((rv = symlink(dev_name, cache_file.c_str())) < 0) {
+	perror("symbolic link");
+	exit(1);
+    }
+    close(fd);
+}
+
+int main(int argc, char **argv) {
+    argp_parse (&argp, argc, argv, 0, 0, 0);
+
+    setenv("LSVD_BACKEND", backend, 1);
+    if (cache_dir != NULL)
+	setenv("LSVD_CACHE_DIR", cache_dir, 1);
+    rados_ioctx_t io = 0;
+    if (op == OP_CREATE && size > 0)
+	rbd_create(io, image_name, size, NULL);
+    else if (op == OP_DELETE)
+	rbd_remove(io, image_name);
+    else if (op == OP_INFO)
+	info(io, image_name);
+    else if (op == OP_MKCACHE)
+	mk_cache(io, image_name, cache_dev);
+}

--- a/src/liblsvd/lsvd_rnd_test.cc
+++ b/src/liblsvd/lsvd_rnd_test.cc
@@ -1,0 +1,398 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <argp.h>
+
+#include <random>
+#include <chrono>
+#include <filesystem>
+namespace fs = std::filesystem;
+#include <iostream>
+#include <queue>
+#include <map>
+#include <mutex>
+#include <atomic>
+
+#include "fake_rbd.h"
+#include "objects.h"
+#include "lsvd_types.h"
+
+extern bool __lsvd_dbg_reverse;
+extern bool __lsvd_dbg_be_delay;
+extern bool __lsvd_dbg_be_delay_ms;
+extern bool __lsvd_dbg_be_threads;
+
+std::mt19937_64 rng;
+
+struct cfg {
+    const char *cache_dir;
+    const char *cache_size;
+    const char *obj_prefix;
+    const char *backend;
+    int    run_len;
+    size_t window;
+    int    image_sectors;
+    float  read_fraction;
+    int    n_runs;
+    std::vector<long> seeds;
+    bool   reopen;
+    bool   restart;
+    bool   verbose;
+    bool   existing;
+};
+
+
+/* empirical fit to the pattern of writes in the ubuntu install,
+ * truncated to 2MB writes max
+ */
+int n_sectors(void) {
+    struct { float p; int max; } params[] = {
+	{0.5, 8},
+	{0.25, 32},
+	{0.125, 64},
+	{0.0625, 128},
+	{1.0, 4096}};
+    std::uniform_real_distribution<> uni(0.0,1.0);
+    float r = uni(rng);
+    int max = 8;
+
+    for (size_t i = 0; i < sizeof(params) / sizeof(params[0]); i++) {
+	if (r < params[i].p) {
+	    max = params[i].max;
+	    break;
+	}
+	r -= params[i].p;
+    }
+
+    std::uniform_int_distribution<int> uni_max(8/8,max/8);
+    return uni_max(rng) * 8;
+}
+
+int gen_lba(int max, int n) {
+    std::uniform_int_distribution<int> uni(0,(max-n)/8);
+    return uni(rng) * 8;
+}
+
+char *rnd_data;
+const int max_sectors = 32768;
+
+void init_random(void) {
+    size_t bytes = max_sectors * 512;
+    rnd_data = (char*)malloc(bytes);
+    for (long *p = (long*)rnd_data, *end = (long*)(rnd_data+bytes); p<end; p++)
+	*p = rng();
+}
+
+void get_random(char *buf, int lba, int sectors, int seq) {
+    int slack = (max_sectors - sectors) * 512;
+    std::uniform_int_distribution<int> uni(0,slack);
+    int offset = uni(rng);
+    memcpy(buf, rnd_data+offset, sectors*512);
+    for (auto p = (int*)buf; sectors > 0; sectors--, p += 512/4) {
+	p[0] = lba++;
+	p[1] = seq;
+    }
+}
+
+extern "C" void rbd_uuid(rbd_image_t image, uuid_t *uuid);
+std::string get_cache_name(rbd_image_t img) {
+    uuid_t uu;
+    rbd_uuid(img, &uu);
+    char uuid_str[64];
+    uuid_unparse(uu, uuid_str);
+    return std::string(uuid_str) + ".cache";
+}
+
+void clean_cache(std::string cache_dir) {
+    const char *suffix = ".cache";
+    for (auto const& dir_entry : fs::directory_iterator{cache_dir}) {
+	std::string entry{dir_entry.path().filename()};
+	if (!strcmp(suffix, entry.c_str() + entry.size() - strlen(suffix)))
+	    fs::remove(dir_entry.path());
+	if (!strncmp(entry.c_str(), "gc.", 3))
+	    fs::remove(dir_entry.path());
+    }
+}
+
+#include <zlib.h>
+static std::map<int,uint32_t> sector_crc;
+static std::map<int,int> sector_seq;
+char _zbuf[512];
+static std::atomic<int> _seq;
+static std::mutex zm;
+
+void add_crc(sector_t sector, const char *_buf, size_t bytes, int seq, bool verbose) {
+    auto buf = (const unsigned char *)_buf;
+    std::unique_lock lk(zm);
+    if (verbose)
+	printf("%d %ld", seq, sector);
+    for (size_t i = 0; i < bytes; i += 512) {
+	const unsigned char *ptr = buf + i;
+	auto crc = sector_crc[sector] = (uint32_t)crc32(0, ptr, 512);
+	sector_seq[sector] = seq;
+	if (verbose)
+	    printf(" %x", crc);
+	sector++;
+    }
+    if (verbose)
+	printf("\n");
+}
+
+void check_crc(sector_t sector, const char *_buf, size_t bytes) {
+    auto buf = (const unsigned char *)_buf;
+    std::unique_lock lk(zm);
+    for (size_t i = 0; i < bytes; i += 512) {
+	const unsigned char *ptr = buf + i;
+	if (sector_crc.find(sector) == sector_crc.end()) {
+	    assert(memcmp(ptr, _zbuf, 512) == 0);
+	}
+	else {
+	    unsigned crc1 = 0, crc2 = 0;
+	    assert((crc1 = sector_crc[sector]) == (crc2 = crc32(0, ptr, 512)));
+	}
+	sector++;
+    }
+}
+
+unsigned show_crc(sector_t sector) {
+    return sector_crc[sector];
+}
+unsigned show_seq(sector_t sector) {
+    return sector_seq[sector];
+}
+
+typedef std::pair<rbd_completion_t,char*> opinfo;
+
+void drain(std::queue<opinfo> &q, size_t window) {
+    while (q.size() > window) {
+	auto [c,ptr] = q.front();
+	q.pop();
+	rbd_aio_wait_for_complete(c);
+	rbd_aio_release(c);
+	free(ptr);
+    }
+}
+
+bool started = false;
+
+void run_test(unsigned long seed, struct cfg *cfg) {
+    printf("seed: 0x%lx\n", seed);
+    rng.seed(seed);
+
+    init_random();
+    rados_ioctx_t io = 0;
+    rbd_image_t img;
+
+    setenv("LSVD_CACHE_SIZE", cfg->cache_size, 1);
+    setenv("LSVD_BACKEND", cfg->backend, 1);
+    setenv("LSVD_CACHE_DIR", cfg->cache_dir, 1);
+    
+    if (!started || cfg->restart) {
+	//clean_cache(cfg->cache_dir);
+	rbd_remove(io, cfg->obj_prefix);
+	rbd_create(io, cfg->obj_prefix, cfg->image_sectors, NULL);
+	sector_crc.clear();
+	started = true;
+    }
+
+    std::vector<data_map> writes;
+    
+    int rv = rbd_open(io, cfg->obj_prefix, &img, NULL);
+    assert(rv >= 0);
+
+    std::queue<std::pair<rbd_completion_t,char*>> q;
+    std::uniform_real_distribution<> uni(0.0,1.0);
+    
+    for (int i = 0; i < cfg->run_len; i++) {
+	drain(q, cfg->window-1);
+	if (i % 1000 == 999)
+	    printf("+"), fflush(stdout);
+	rbd_completion_t c;
+	rbd_aio_create_completion(NULL, NULL, &c);
+
+	int n = n_sectors();
+	int lba = gen_lba(cfg->image_sectors, n);
+	auto ptr = (char*)aligned_alloc(512, n*512);
+	
+	q.push(std::make_pair(c, ptr));
+	if (uni(rng) < cfg->read_fraction) {
+	    rbd_aio_read(img, 512L * lba, 512L * n, ptr, c);
+	}
+	else {
+	    auto s = ++_seq;
+	    get_random(ptr, lba, n, s);
+	    rbd_aio_write(img, 512L * lba, 512L * n, ptr, c);
+	    add_crc(lba, ptr, n*512L, s, cfg->verbose);
+	    writes.push_back({(uint64_t)lba,(uint64_t)n});
+	}
+    }
+    drain(q, 0);
+    printf("\n");
+
+    extern char *p_log, *end_log;
+    if (p_log && p_log+16 < end_log)
+	p_log += snprintf(p_log, end_log-p_log, "\n\nWRITE DONE\n\n");
+			 
+    if (cfg->reopen) {
+	rbd_close(img);
+	if (p_log && p_log+16 < end_log)
+	    p_log += snprintf(p_log, end_log-p_log, "\nCLOSE done\n\n");
+	if (rbd_open(io, cfg->obj_prefix, &img, NULL) < 0)
+	    printf("failed: rbd_open\n"), exit(1);
+	if (p_log && p_log+16 < end_log)
+	    p_log += snprintf(p_log, end_log-p_log, "\nREOPEN done\n\n");	
+    }
+
+    auto tmp = __lsvd_dbg_be_delay;
+    __lsvd_dbg_be_delay = false;
+    auto buf = (char*)aligned_alloc(512, 64*1024);
+    int i = 0;
+    for (int sector = 0; sector < cfg->image_sectors; sector += 64*2) {
+	rbd_read(img, sector*512L, 64*1024, buf);
+	check_crc(sector, buf, 64*1024);
+	if (++i > cfg->image_sectors / 128 / 10) {
+	    printf("-"); fflush(stdout);
+	    i = 0;
+	}
+    }
+    printf("\n");
+    free(buf);
+    rbd_close(img);
+    __lsvd_dbg_be_delay = tmp;
+    if (p_log && p_log+16 < end_log)
+	p_log += snprintf(p_log, end_log-p_log, "\n\nREAD DONE\n\n");
+}
+
+
+static char args_doc[] = "RUNS";
+
+static struct argp_option options[] = {
+    {"seed",     's', "S",    0, "use this seed (one run)"},
+    {"len",      'l', "N",    0, "run length"},
+    {"window",   'w', "W",    0, "write window"},
+    {"size",     'z', "S",    0, "volume size (e.g. 1G, 100M)"},
+    {"cache-dir",'d', "DIR",  0, "cache directory"},
+    {"prefix",   'p', "PREFIX", 0, "object prefix"},
+    {"reads",    'r', "FRAC", 0, "fraction reads (0.0-1.0)"},
+    {"close",    'c', 0,      0, "close and re-open"},
+    {"keep",     'k', 0,      0, "keep data between tests"},
+    {"verbose",  'v', 0,      0, "print LBAs and CRCs"},
+    {"reverse",  'R', 0,      0, "reverse NVMe completion order"},    
+    {"existing", 'x', 0,      0, "don't delete existing cache"},    
+    {"delay",    'D', 0,      0, "add random backend delays"},    
+    {"rados",    'O', 0,      0, "use RADOS"},
+    {"cache-size",'Z', "N",    0, "cache size (K/M/G)"},
+    {0},
+};
+
+struct cfg _cfg = {
+    "/tmp",			// cache_dir
+    "/tmp/bkt/obj",		// obj_prefix
+    "100m",                     // cache_size
+    "file",                	// backend
+    10000, 			// run_len
+    16,				// window
+    1024*1024*2,		// image_sectors,
+    0.0,			// read_fraction
+    1,				// n_runs
+    {},				// seeds
+    false,			// reopen
+    true,			// restart
+    false,			// verbose
+    false};			// existing
+
+off_t parseint(char *s)
+{
+    off_t val = strtoul(s, &s, 0);
+    if (toupper(*s) == 'G')
+        val *= (1024*1024*1024);
+    if (toupper(*s) == 'M')
+        val *= (1024*1024);
+    if (toupper(*s) == 'K')
+        val *= 1024;
+    return val;
+}
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
+{
+    switch (key) {
+    case ARGP_KEY_INIT:
+	break;
+    case ARGP_KEY_ARG:
+        _cfg.n_runs = atoi(arg);
+        break;
+    case 's':
+	_cfg.seeds.push_back(strtoul(arg, NULL, 0));
+	break;
+    case 'l':
+	_cfg.run_len = atoi(arg);
+	break;
+    case 'w':
+	_cfg.window = atoi(arg);
+	break;
+    case 'z':
+	_cfg.image_sectors = parseint(arg) / 512;
+	break;
+    case 'd':
+	_cfg.cache_dir = arg;
+	break;
+    case 'p':
+	_cfg.obj_prefix = arg;
+	break;
+    case 'r':
+	_cfg.read_fraction = atof(arg);
+	break;
+    case 'c':
+	_cfg.reopen = true;
+	break;
+    case 'k':
+	_cfg.restart = false;
+	break;
+    case 'v':
+	_cfg.verbose = true;
+	break;
+    case 'R':
+	__lsvd_dbg_reverse = true;
+	break;
+    case 'x':
+	_cfg.existing = true;
+	break;
+    case 'D':
+	__lsvd_dbg_be_delay = true;
+	break;
+    case 'O':
+	_cfg.backend = "rados";
+	break;
+    case 'Z':
+	_cfg.cache_size = arg;
+	break;
+    case ARGP_KEY_END:
+        break;
+    }
+    return 0;
+}
+static struct argp argp = { options, parse_opt, NULL, args_doc};
+
+int main(int argc, char **argv) {
+    argp_parse (&argp, argc, argv, 0, 0, 0);
+
+    if (_cfg.seeds.size() > 0) {
+	for (int i = 0; i < _cfg.n_runs; i++)
+	    for (auto s : _cfg.seeds)
+		run_test(s, &_cfg);
+    }
+    else {
+	auto now = std::chrono::system_clock::now();
+	auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+	auto value = now_ms.time_since_epoch();
+	long seed = value.count();
+
+	rng.seed(seed);
+
+	std::vector<unsigned long> seeds;
+	for (int i = 0; i < _cfg.n_runs; i++)
+	    seeds.push_back(rng());
+	for (auto s : seeds)
+	    run_test(s, &_cfg);
+    }
+}

--- a/src/liblsvd/lsvd_types.h
+++ b/src/liblsvd/lsvd_types.h
@@ -1,0 +1,63 @@
+/*
+ * file:        lsvd_types.h
+ * description: basic types, not relying on any other ones
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef __LSVD_TYPES_H__
+#define __LSVD_TYPES_H__
+
+#include <stdint.h>
+#include <vector>
+
+typedef int64_t sector_t;
+typedef int page_t;
+
+enum lsvd_op {
+    OP_READ = 2,
+    OP_WRITE = 4
+};
+
+enum { LSVD_MAGIC = 0x4456534c };
+
+/* if buf[offset]...buf[offset+len] contains an array of type T,
+ * copy them into the provided output vector
+ */
+template<class T>
+void decode_offset_len(char *buf, size_t offset, size_t len,
+                       std::vector<T> &vals) {
+    T *p = (T*)(buf + offset), *end = (T*)(buf + offset + len);
+    for (; p < end; p++)
+        vals.push_back(*p);
+}
+
+/* buf[offset ... offset+len] contains array of type T, with variable 
+ * length field name_len.
+ */
+template<class T>
+void decode_offset_len_ptr(char *buf, size_t offset, size_t len,
+                       std::vector<T*> &vals) {
+    T *p = (T*)(buf + offset), *end = (T*)(buf + offset + len);
+    for (; p < end;) {
+        vals.push_back(p);
+        p = (T*)((char*)p + sizeof(T) + p->name_len);
+    }
+}
+
+static inline int div_round_up(int n, int m) {
+    return (n + m - 1) / m;
+}
+
+static inline int round_up(int n, int m) {
+    return m * div_round_up(n, m);
+}
+
+static inline bool aligned(const void *ptr, int a) {
+    return 0 == ((long)ptr & (a-1));
+}
+
+#endif
+

--- a/src/liblsvd/misc_cache.h
+++ b/src/liblsvd/misc_cache.h
@@ -1,0 +1,113 @@
+/*
+ * file:        misc_cache.h
+ * description: grab-bag of various classes and structures:
+ *              -thread_pool
+ *		-sized_vector for caches
+ *		-objmap (map shared by translate, read_cache)
+ *
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+
+#ifndef MISC_CACHE_H
+#define MISC_CACHE_H
+
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+/* implements a thread pool with a work queue of type T
+ * to use, push threads onto thread_pool.pool
+ * - get(), get_locked() - used by worker threads to receive work
+ * - put(), put_locked() - submit work
+ */
+template <class T>
+class thread_pool {
+public:
+    std::queue<T> q;
+    bool         running;
+    std::mutex  *m;
+    std::condition_variable cv;
+    std::queue<std::thread> pool;
+    
+    thread_pool(std::mutex *_m) {
+	running = true;
+	m = _m;
+    }
+
+    void stop() {
+	std::unique_lock lk(*m);
+	running = false;
+	cv.notify_all();
+	lk.unlock();
+	while (!pool.empty()) {
+	    pool.front().join();
+	    pool.pop();
+	}
+    }
+    ~thread_pool() {
+        if (running)
+            stop();
+    }
+
+    bool get_locked(std::unique_lock<std::mutex> &lk, T &val) {
+        while (running && q.empty())
+            cv.wait(lk);
+        if (!running)
+            return false;
+        val = q.front();
+        q.pop();
+        return val;
+    }
+
+    bool get(T &val) {
+        std::unique_lock lk(*m);
+        return get_locked(lk, val);
+    }
+
+    void put_locked(T work) {
+        q.push(work);
+        cv.notify_one();
+    }
+
+    void put(T work) {
+        std::unique_lock<std::mutex> lk(*m);
+        put_locked(work);
+    }
+};
+
+/* nice error messages
+ */
+#include <filesystem>
+namespace fs = std::filesystem;
+static inline void throw_fs_error(std::string msg) {
+    throw fs::filesystem_error(msg, std::error_code(errno,
+                                                    std::system_category()));
+}
+
+/* convenience class, because we don't know cache size etc.
+ * at cache object construction time.
+ */
+template <class T>
+class sized_vector {
+    std::vector<T> *elements;
+public:
+    ~sized_vector() {
+        delete elements;
+    }
+    void init(int n) {
+        elements = new std::vector<T>(n);
+    }
+    void init(int n, T val) {
+        elements = new std::vector<T>(n, val);
+    }
+    T &operator[](int index) {
+        return (*elements)[index];
+    }
+};
+
+#endif

--- a/src/liblsvd/mkcache.cc
+++ b/src/liblsvd/mkcache.cc
@@ -1,0 +1,82 @@
+/*
+ * file:        mkcache.cc
+ * description: create file containing write+read caches
+ *
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <uuid/uuid.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "lsvd_types.h"
+#include "extent.h"
+#include "journal.h"
+
+/* translated from mkcache.py version 2a8d3060
+ */
+int make_cache(int fd, uuid_t &uuid, int n_pages) {
+    page_t r_units = 0.66 * n_pages / 16;
+    page_t r_pages = r_units * 16;
+    page_t r_meta = div_round_up(r_units * sizeof(extmap::obj_offset), 4096);
+    page_t w_pages = n_pages - r_pages - r_meta - 3;
+    
+    char buf[4096];
+    memset(buf, 0, sizeof(buf));
+    auto sup = (j_super*)buf;
+    *sup = (j_super){LSVD_MAGIC,
+		     LSVD_J_SUPER,
+		     1,   // version
+		     1,   // write superblock offset
+		     2,   // read superblock offset
+		     {0}};// uuid
+    memcpy(sup->vol_uuid, uuid, sizeof(uuid_t));
+    write(fd, buf, 4096);
+
+    page_t _map = div_round_up(w_pages, 256);
+    page_t _len = div_round_up(w_pages, 512);
+    page_t w_meta = 2 * (_map + _len); // TODO: no more 2x?
+    w_pages -= w_meta;
+    
+    memset(buf, 0, sizeof(buf));
+    auto w_super = (j_write_super*)buf;
+    *w_super = (j_write_super){LSVD_MAGIC,
+			       LSVD_J_W_SUPER,
+			       1,		   // version
+			       1,		   // clean
+			       1,		   // seq
+			       3,		   // meta_base
+			       3+w_meta,	   // meta_limit
+			       3+w_meta,	   // base
+			       3+w_meta+w_pages,   // limit
+			       3+w_meta,	   // next
+			       0,0,0,	   // map_start/blocks/entries
+			       0,0,0};	   // len_start/blocks/entries
+    write(fd, buf, 4096);
+
+    page_t r_base = 3 + w_pages + w_meta;
+
+    memset(buf, 0, sizeof(buf));
+    auto r_super = (j_read_super*)buf;
+    *r_super = (j_read_super){LSVD_MAGIC,
+			      LSVD_J_R_SUPER,
+			      1,		     // version
+			      128,		     // unit_size
+			      r_base+r_meta,	     // base
+			      r_units,		     // units
+			      r_base,		     // map_start
+			      r_meta};		     // map_blocks
+    write(fd, buf, 4096);
+
+    memset(buf, 0, 4096);
+    for (int i = 3; i < 3 + w_pages + w_meta + r_pages + r_meta; i++)
+	write(fd, buf, 4096);
+
+    return 0;
+}

--- a/src/liblsvd/nvme.cc
+++ b/src/liblsvd/nvme.cc
@@ -1,0 +1,198 @@
+/*
+ * file:        nvme.cc
+ * description: implementation of read/write requests to local SSD
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <libaio.h>
+#include <unistd.h>
+#include <sys/uio.h>
+#include <uuid/uuid.h>
+#include <signal.h>
+
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <thread>
+
+#include "lsvd_types.h"
+#include "smartiov.h"
+#include "extent.h"
+#include "misc_cache.h"
+#include "backend.h"
+#include "io.h"
+#include "request.h"
+
+#include "nvme.h"
+
+void do_log(const char*, ...);
+
+class nvme_impl;
+
+class nvme_request : public request {
+public:
+    e_iocb      eio;
+    smartiov    _iovs;
+    size_t      ofs;
+    enum lsvd_op op;
+    nvme_impl  *nvme_ptr;
+    request    *parent;
+
+    bool        released = false;
+    bool        complete = false;
+    std::mutex  m;
+    std::condition_variable cv;
+    
+public:
+    nvme_request(smartiov *iov, size_t offset, enum lsvd_op type, nvme_impl* nvme_w);
+    nvme_request(char *buf, size_t len, size_t offset, enum lsvd_op type,
+		 nvme_impl* nvme_w);
+    ~nvme_request();
+
+    void wait();
+    void run(request *parent);
+    void notify(request *child) {}
+    void notify2(long res);
+    void release();
+};
+
+class nvme_impl : public nvme {
+public:
+    int fd;
+    bool e_io_running = false;
+    std::thread e_io_th;
+    io_context_t ioctx;
+
+    static void sighandler(int sig) {
+	pthread_exit(NULL);
+    }
+    
+    nvme_impl(int fd_, const char *name_) {
+	fd = fd_;
+	e_io_running = true;
+	io_queue_init(64, &ioctx);
+	signal(SIGUSR2, sighandler);
+	e_io_th = std::thread(e_iocb_runner, ioctx, &e_io_running, name_);
+    }
+
+    ~nvme_impl() {
+	e_io_running = false;
+	//e_io_th.join();
+	//pthread_cancel(e_io_th.native_handle());
+	pthread_kill(e_io_th.native_handle(), SIGUSR2);
+	e_io_th.join();
+	io_queue_release(ioctx);
+    }
+
+    int read(void *buf, size_t count, off_t offset) {
+	return pread(fd, buf, count, offset);
+    }
+    
+    int write(const void *buf, size_t count, off_t offset) {
+	return pwrite(fd, buf, count, offset);
+    }
+
+    int writev(const struct iovec *iov, int iovcnt, off_t offset) {
+	return pwritev(fd, iov, iovcnt, offset);
+    }
+    
+    int readv(const struct iovec *iov, int iovcnt, off_t offset) {
+	return preadv(fd, iov, iovcnt, offset);
+    }
+
+    request* make_write_request(smartiov *iov, size_t offset) {
+	assert(offset != 0);
+	auto req = new nvme_request(iov, offset, OP_WRITE, this);
+	return (request*) req;
+    }
+
+    request* make_write_request(char *buf, size_t len, size_t offset) {
+	assert(offset != 0);
+	auto req = new nvme_request(buf, len, offset, OP_WRITE, this);
+	return (request*) req;
+    }
+    
+    request* make_read_request(smartiov *iov, size_t offset) {
+	auto req = new nvme_request(iov, offset, OP_READ, this);
+	return (request*) req;
+    }
+
+    request* make_read_request(char *buf, size_t len, size_t offset) {
+	auto req = new nvme_request(buf, len, offset, OP_READ, this);
+	return (request*) req;
+    }
+};
+
+nvme *make_nvme(int fd, const char* name) {
+    return (nvme*) new nvme_impl(fd, name);
+}
+
+/* ------- nvme_request implementation -------- */
+
+void call_send_request_notify(void *parent, long res)
+{
+    nvme_request *r = (nvme_request*) parent;
+    r->notify2(res);
+}
+
+nvme_request::nvme_request(smartiov *iov, size_t offset,
+			   enum lsvd_op type, nvme_impl* nvme_w) {
+    _iovs.ingest(iov->data(), iov->size());
+    ofs = offset;
+    op = type;
+    nvme_ptr = nvme_w;
+}
+
+nvme_request::nvme_request(char *buf, size_t len, size_t offset,
+			   enum lsvd_op type, nvme_impl* nvme_w) {
+    _iovs.push_back((iovec){buf, len});
+    ofs = offset;
+    op = type;
+    nvme_ptr = nvme_w;
+}
+
+void nvme_request::run(request* parent_) {
+    parent = parent_;
+    if (op == OP_WRITE) {
+	e_io_prep_pwritev(&eio, nvme_ptr->fd, _iovs.data(), _iovs.size(),
+			  ofs, call_send_request_notify, this);
+    }
+    else
+	e_io_prep_preadv(&eio, nvme_ptr->fd, _iovs.data(), _iovs.size(),
+			 ofs, call_send_request_notify, this);
+    e_io_submit(nvme_ptr->ioctx, &eio);
+}
+
+void nvme_request::notify2(long result) {
+    if (parent)
+	parent->notify(this);
+    assert((size_t)result == _iovs.bytes());
+    
+    std::unique_lock lk(m);
+    complete = true;
+    cv.notify_one();
+    if (released) {
+	lk.unlock();
+	delete this;
+    }
+}
+
+void nvme_request::wait() {
+    std::unique_lock lk(m);
+    while (!complete)
+	cv.wait(lk);
+}
+
+void nvme_request::release() {
+    std::unique_lock lk(m);
+    released = true;
+    if (complete) {		// TODO: atomic swap?
+	lk.unlock();
+	delete this;
+    }
+}
+
+nvme_request::~nvme_request() {}

--- a/src/liblsvd/nvme.h
+++ b/src/liblsvd/nvme.h
@@ -1,0 +1,33 @@
+/*
+ * file:        nvme.h
+ * description: interface for request-driven interface to local SSD
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef NVME_H
+#define NVME_H
+
+class nvme {
+public:
+    nvme() {};
+    virtual ~nvme() {};
+
+    virtual int read(void *buf, size_t count, off_t offset) = 0;
+    virtual int write(const void *buf, size_t count, off_t offset) = 0;
+
+    virtual int writev(const struct iovec *iov, int iovcnt, off_t offset) = 0;
+    virtual int readv(const struct iovec *iov, int iovcnt, off_t offset) = 0;
+
+    virtual request* make_write_request(smartiov *iov, size_t offset) = 0;
+    virtual request* make_write_request(char *buf, size_t len, size_t offset) = 0;
+    virtual request* make_read_request(smartiov *iov, size_t offset) = 0;
+
+    virtual request* make_read_request(char *buf, size_t len, size_t offset) = 0;
+};
+
+nvme *make_nvme(int fd, const char* name);
+
+#endif

--- a/src/liblsvd/objects.cc
+++ b/src/liblsvd/objects.cc
@@ -1,0 +1,176 @@
+/*
+ * file:        objects.cc
+ * description: serializers / deserializers for object format
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <sys/uio.h>
+#include <string.h>
+#include <zlib.h>
+
+#include "lsvd_types.h"
+#include "backend.h"
+#include "objects.h"
+
+extern void do_log(const char *fmt, ...);
+
+char *object_reader::read_object_hdr(const char *name, bool fast) {
+    obj_hdr *h = (obj_hdr*)malloc(4096);
+    iovec iov = {(char*)h, 4096};
+    int rv;
+    if ((rv = objstore->read_object(name, &iov, 1, 0)) < 0)
+	goto fail;
+    if (fast)
+	return (char*)h;
+    if (h->hdr_sectors > 8) {
+	size_t len = h->hdr_sectors * 512;
+	h = (obj_hdr*)realloc(h, len);
+	iovec iov = {(char*)h, len};
+	if (objstore->read_object(name, &iov, 1, 0) < 0)
+	    goto fail;
+    }
+    return (char*)h;
+fail:
+    free((char*)h);
+    return NULL;
+}
+
+/* read all info from superblock, returns a vast number of things:
+ * [super, vol_size] = f(name, &ckpts, &clones, *&snaps):
+ *  - super - pointer to buffer (must be freed)
+ *  - vol_size - in bytes (-1 on failure)
+ *  - ckpts, clones, snaps - what you'd expect
+ */
+std::pair<char*,ssize_t>
+object_reader::read_super(const char *name, std::vector<uint32_t> &ckpts,
+			  std::vector<clone_info*> &clones,
+			  std::vector<snap_info*> &snaps,
+			  uuid_t &uuid) {
+    char *super_buf = read_object_hdr(name, false);
+    auto super_h = (obj_hdr*)super_buf;
+
+    if (super_h->magic != LSVD_MAGIC || super_h->version != 1 ||
+	super_h->type != LSVD_SUPER)
+	return std::make_pair((char*)NULL,-1);
+    memcpy(uuid, super_h->vol_uuid, sizeof(uuid_t));
+
+    super_hdr *super_sh = (super_hdr*)(super_h+1);
+
+    decode_offset_len<uint32_t>(super_buf, super_sh->ckpts_offset,
+				super_sh->ckpts_len, ckpts);
+    decode_offset_len_ptr<clone_info>(super_buf, super_sh->clones_offset,
+				      super_sh->clones_len, clones);
+    decode_offset_len_ptr<snap_info>(super_buf, super_sh->snaps_offset,
+				     super_sh->snaps_len, snaps);
+
+    return std::make_pair(super_buf,super_sh->vol_size * 512);
+}
+
+/* read and decode the header of an object. Copies into arguments,
+ * frees all allocated memory
+ */
+ssize_t object_reader::read_data_hdr(const char *name, obj_hdr &h,
+				     obj_data_hdr &dh,
+				     std::vector<obj_cleaned> &cleaned,
+				     std::vector<data_map> &dmap) {
+    char *buf = read_object_hdr(name, false);
+    if (buf == NULL)
+	return -1;
+    auto tmp_h = (obj_hdr*)buf;
+    auto tmp_dh = (obj_data_hdr*)(tmp_h+1);
+    if (tmp_h->type != LSVD_DATA) {
+	free(buf);
+	return -1;
+    }
+
+    h = *tmp_h;
+    dh = *tmp_dh;
+
+    decode_offset_len<obj_cleaned>(buf, tmp_dh->objs_cleaned_offset,
+				   tmp_dh->objs_cleaned_len, cleaned);
+    decode_offset_len<data_map>(buf, tmp_dh->data_map_offset,
+				tmp_dh->data_map_len, dmap);
+
+    free(buf);
+    return 0;
+}
+
+/* read and decode a checkpoint object identified by sequence number
+ */
+ssize_t object_reader::read_checkpoint(const char *name, uint64_t &cache_seq,
+				       std::vector<uint32_t> &ckpts,
+				       std::vector<ckpt_obj> &objects, 
+				       std::vector<deferred_delete> &deletes,
+				       std::vector<ckpt_mapentry> &dmap) {
+    char *buf = read_object_hdr(name, false);
+    if (buf == NULL) {
+	do_log("buf == NULL\n");
+	return -1;
+    }
+    auto h = (obj_hdr*)buf;
+    auto ch = (obj_ckpt_hdr*)(h+1);
+    if (h->type != LSVD_CKPT) {
+	do_log("%s: WRONG TYPE %d\n", name, h->type);
+	free(buf);
+	return -1;
+    }
+    cache_seq = ch->cache_seq;
+    decode_offset_len<uint32_t>(buf, ch->ckpts_offset, ch->ckpts_len, ckpts);
+    decode_offset_len<ckpt_obj>(buf, ch->objs_offset, ch->objs_len, objects);
+    decode_offset_len<deferred_delete>(buf, ch->deletes_offset,
+				       ch->deletes_len, deletes);
+    decode_offset_len<ckpt_mapentry>(buf, ch->map_offset,
+				     ch->map_len, dmap);
+
+    free(buf);
+    return 0;
+}
+
+/* How many bytes will we need for an object header if we 
+ * have @n_entries extent entries and @n_ckpts checkpoints. 
+ */
+size_t obj_hdr_len(int n_entries) {
+    return sizeof(obj_hdr) +
+	sizeof(obj_data_hdr) +
+	n_entries * sizeof(data_map);
+}
+
+/* create header for a data object, returns size in bytes
+ * unfortunately we need the length earlier in the code, so
+ * we duplicate some of this logic in obj_hdr_len()
+ */
+size_t make_data_hdr(char *hdr, size_t bytes, uint64_t cache_seq,
+		     std::vector<data_map> *entries, uint32_t seq,
+		     uuid_t *uuid) {
+    auto h = (obj_hdr*)hdr;
+    auto dh = (obj_data_hdr*)(h+1);
+    uint32_t o1 = sizeof(*h) + sizeof(*dh),
+	o2 = o1, l2 = entries->size() * sizeof(data_map),
+	hdr_bytes = o2 + l2;
+    uint32_t hdr_sectors = div_round_up(hdr_bytes, 512);
+
+    *h = (obj_hdr){.magic = LSVD_MAGIC, .version = 1, .vol_uuid = {0},
+		   .type = LSVD_DATA, .seq = seq,
+		   .hdr_sectors = hdr_sectors,
+		   .data_sectors = (uint32_t)(bytes / 512), .crc = 0};
+    memcpy(h->vol_uuid, uuid, sizeof(uuid_t));
+
+    *dh = (obj_data_hdr){.cache_seq = cache_seq,
+			 .objs_cleaned_offset = 0, . objs_cleaned_len = 0,
+			 .data_map_offset = o2, .data_map_len = l2};
+
+    auto dm = (data_map*)(dh+1);
+    for (auto e : *entries)
+	*dm++ = e;
+
+    auto pad = hdr + hdr_bytes;	// make valgrind happy
+    memset(pad, 0, hdr_sectors*512 - hdr_bytes);
+    
+    auto ptr = (const unsigned char *)hdr;
+    h->crc = (uint32_t)crc32(0, ptr, hdr_sectors*512);
+
+    return (char*)dm - (char*)hdr;
+}

--- a/src/liblsvd/objects.h
+++ b/src/liblsvd/objects.h
@@ -1,0 +1,189 @@
+/*
+ * file:        objects.h
+ * description: back-end object format definitions and helper functions
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef OBJECTS_H
+#define OBJECTS_H
+
+#include <cstddef>
+#include <stdint.h>
+#include <stdlib.h>
+#include <vector>
+#include <tuple>
+#include <cassert>
+#include <uuid/uuid.h>
+
+#if __BYTE_ORDER != __LITTLE_ENDIAN
+#error "this code is little-endian only"
+#endif
+
+/* for now we'll use 32-bit object sequence numbers. So sue me...
+ */
+
+enum obj_type {
+    LSVD_SUPER = 1,
+    LSVD_DATA = 2,
+    LSVD_CKPT = 3
+};
+
+/* hdr - standard header for all backend objects
+ * total length is hdr_sectors + data_sectors, in 512-byte units
+ * name is <prefix> for superblock, (<prefix>.%08x % seq) otherwise
+ */
+struct obj_hdr {
+    uint32_t magic;
+    uint32_t version;		// 1
+    uuid_t   vol_uuid;
+    uint32_t type;
+    uint32_t seq;		// same as in name
+    uint32_t hdr_sectors;
+    uint32_t data_sectors;
+    uint32_t crc;               // of header only
+} __attribute__((packed));
+
+/*  super_hdr - "superblock object", describing the entire volume
+ *
+ * variable-length fields are identified by offset/length pairs; 
+ * offset, length are both in units of bytes.
+ *
+ * ckpts : array of checkpoint sequence numbers (uint32). We keep the
+ *         last 3, but we only need 1 unless we go to incremental ckpts
+ * clones : zero or one struct clone_info, followed by a name and a zero
+ *         byte to terminate the string. (chase the chain to find all)
+ * snaps : TBD
+ */
+struct super_hdr {
+    uint64_t vol_size;
+    uint32_t ckpts_offset;
+    uint32_t ckpts_len;
+    uint32_t clones_offset;	// array of struct clone
+    uint32_t clones_len;
+    uint32_t snaps_offset;
+    uint32_t snaps_len;
+} __attribute__((packed));
+
+/* ckpts: list of active checkpoints: array of uint32_t */
+
+/* variable-length structure
+ * objects @last_seq and earlier are in volume @name or its predecessors
+ */
+struct clone_info {
+    uuid_t   vol_uuid;          // of volume @name
+    uint32_t last_seq;          // of linked volume
+    uint8_t  name_len;
+    char     name[0];
+} __attribute__((packed));
+
+struct snap_info {
+    uint32_t seq;
+    uint8_t  name_len;
+    char     name[0];
+} __attribute__((packed));
+
+/* sub-header for a data object
+ *  cache_seq: lowest write cache sequence number (see source code)
+ *  objs_cleaned: TBD
+ *  data_map_offset/len: lba/len pairs for data in body of object.
+ */
+struct obj_data_hdr {
+    uint64_t cache_seq;
+    uint32_t objs_cleaned_offset;
+    uint32_t objs_cleaned_len;
+    uint32_t data_map_offset;
+    uint32_t data_map_len;
+} __attribute__((packed));
+
+struct obj_cleaned {
+    uint32_t seq;
+    uint32_t was_deleted;
+} __attribute__((packed));
+
+// we can omit the offset in a data header
+//
+struct data_map {
+    uint64_t lba : 36;          // 512-byte sectors
+    uint64_t len : 28;          // 512-byte sectors
+} __attribute__((packed));
+
+/* sub-header for a checkpoint object
+ *  TODO: get rid of ckpts_offset/len
+ *  objs_offset/len: list of live objects. For clones, does not include
+ *                   objects in clone base
+ *  deletes_offset/len: TBD
+ *  map_offset/len: LBA-to-object map at time checkpoint was written
+ *
+ * TODO: incremental checkpointing, taking advantage of dirty-bit
+ * feature in extent.h
+ */
+struct obj_ckpt_hdr {
+    uint64_t cache_seq;         // from last data object
+    uint32_t ckpts_offset;	// TODO: remove this
+    uint32_t ckpts_len;
+    uint32_t objs_offset;	// ckpt_obj[]
+    uint32_t objs_len;
+    uint32_t deletes_offset;	// deferred_delete[]
+    uint32_t deletes_len;
+    uint32_t map_offset;        // ckpt_mapentry[]
+    uint32_t map_len;
+} __attribute__((packed));
+
+struct ckpt_obj {
+    uint32_t seq;
+    uint32_t hdr_sectors;
+    uint32_t data_sectors;
+    uint32_t live_sectors;
+} __attribute__((packed));
+
+struct deferred_delete {
+    uint32_t seq;		// object deleted
+    uint32_t time;		// current write frontier when cleaned
+} __attribute__((packed));
+
+struct ckpt_mapentry {
+    int64_t lba : 36;
+    int64_t len : 28;
+    int32_t obj;
+    int32_t offset;
+} __attribute__((packed));
+
+/* ------ helper functions -------- */
+
+class backend;
+
+class object_reader {
+    backend *objstore;
+
+public:
+    object_reader(backend *be) : objstore(be) {}
+
+    char *read_object_hdr(const char *name, bool fast);
+
+    std::pair<char*,ssize_t> read_super(const char *name,
+					std::vector<uint32_t> &ckpts,
+					std::vector<clone_info*> &clones,
+					std::vector<snap_info*> &snaps,
+					uuid_t &uuid);
+
+    ssize_t read_data_hdr(const char *name, obj_hdr &h, obj_data_hdr &dh,
+			  std::vector<obj_cleaned> &cleaned,
+			  std::vector<data_map> &dmap);
+
+    ssize_t read_checkpoint(const char *name, uint64_t &cache_seq,
+			    std::vector<uint32_t> &ckpts,
+			    std::vector<ckpt_obj> &objects, 
+			    std::vector<deferred_delete> &deletes,
+			    std::vector<ckpt_mapentry> &dmap);
+};
+
+extern size_t obj_hdr_len(int n_entries);
+
+extern size_t make_data_hdr(char *hdr, size_t bytes, uint64_t cache_seq,
+                            std::vector<data_map> *entries,
+                            uint32_t seq, uuid_t *uuid);
+
+#endif

--- a/src/liblsvd/objname.h
+++ b/src/liblsvd/objname.h
@@ -1,0 +1,31 @@
+/*
+ * file:        objname.h
+ * description: string-like structure for handling object names
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef __OBJNAME_H__
+#define __OBJNAME_H__
+
+class objname {
+    char buf[128];
+public:
+    objname() {}
+    objname(const char *prefix, uint32_t seq) {
+        init(prefix, seq);
+    }
+    void init(const char *prefix, uint32_t seq) {
+        size_t len = strlen(prefix);
+        assert(len + 9 < sizeof(buf));
+        memcpy(buf, prefix, len);
+        sprintf(buf + len, ".%08x", seq);
+    }
+    const char *c_str() {
+        return buf;
+    }
+};
+        
+#endif

--- a/src/liblsvd/rados_backend.cc
+++ b/src/liblsvd/rados_backend.cc
@@ -1,0 +1,303 @@
+/*
+ * file:        rados_backend.cc
+ * description: backend interface using RADOS objects
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <rados/librados.h>
+
+#include <vector>
+#include <sstream>
+#include <iomanip>
+
+#include <condition_variable>
+#include <queue>
+#include <thread>
+
+#include "lsvd_types.h"
+
+#include "smartiov.h"
+#include "extent.h"
+#include "request.h"
+#include "backend.h"
+
+void do_log(const char*, ...);
+
+class rados_backend : public backend {
+    std::mutex m;
+    char pool[128];
+    int  pool_len = 0;
+    rados_t cluster;
+    rados_ioctx_t io_ctx;
+
+    char *pool_init(const char *pool_);
+    
+public:
+    rados_backend();
+    ~rados_backend();
+
+    int write_object(const char *name, iovec *iov, int iovcnt);
+    int write_object(const char *name, char *buf, size_t len);
+    int read_object(const char *name, iovec *iov, int iovcnt,
+                    size_t offset);
+    int read_object(const char *name, char *buf, size_t len, size_t offset);
+    int delete_object(const char *name);
+    request *delete_object_req(const char *name);
+    
+    /* async I/O
+     */
+    request *make_write_req(const char *name, iovec *iov, int iovcnt);
+    request *make_write_req(const char *name, char *buf, size_t len);
+
+    request *make_read_req(const char *name, size_t offset,
+                           iovec *iov, int iovcnt);
+    request *make_read_req(const char *name, size_t offset,
+                           char *buf, size_t len);
+
+};
+
+/* needed for implementation hiding
+ */
+backend *make_rados_backend(rados_ioctx_t io) {
+    return new rados_backend;
+}
+
+/* see https://docs.ceph.com/en/latest/rados/api/librados/
+ * for documentation on the librados API
+ */
+rados_backend::rados_backend() {
+    int r;
+    if ((r = rados_create(&cluster, NULL)) < 0) // NULL = ".client"
+	throw("rados create");
+    if ((r = rados_conf_read_file(cluster, NULL)) < 0)
+	throw("rados conf");
+    if ((r = rados_connect(cluster)) < 0)
+	throw("rados connect");
+}
+
+rados_backend::~rados_backend() {
+    if (pool_len > 0)
+	rados_ioctx_destroy(io_ctx);
+    rados_shutdown(cluster);
+    /* TODO: do we close things down? */
+}
+
+/* if pool hasn't been initialized yet, initialize the ioctx
+ * only supports one pool, exception if you try to access another one
+ * name format: <pool>/<object_prefix>
+ * HACK: returns pointer to object name, i.e. suffix after "<pool>/"
+ */
+char* rados_backend::pool_init(const char *name) {
+    if (pool_len == 0) {
+	char *dst = pool;
+	const char *src = name;
+	while (*src && *src != '/')
+	    *dst++ = *src++;
+	*dst = 0;
+	pool_len = dst - pool;
+	int r = rados_ioctx_create(cluster, pool, &io_ctx);
+	if (r < 0)
+	    throw("rados pool open");
+    }
+    assert(!memcmp(pool, name, pool_len));
+    return (char*)name + pool_len + 1;
+}
+
+int rados_backend::write_object(const char *name, iovec *iov, int iovcnt) {
+    auto oname = pool_init(name);
+    assert(*((int*)iov[0].iov_base) == LSVD_MAGIC);
+    smartiov iovs(iov, iovcnt);
+    char *buf = (char*)malloc(iovs.bytes());
+    iovs.copy_out(buf);
+
+    int r = rados_write_full(io_ctx, oname, buf, iovs.bytes());
+
+    free(buf);
+    return r;
+}
+
+int rados_backend::write_object(const char *name, char *buf, size_t len) {
+    auto oname = pool_init(name);
+    assert(*((int*)buf) == LSVD_MAGIC);
+    return rados_write_full(io_ctx, oname, buf, len);
+}
+
+int rados_backend::read_object(const char *name, iovec *iov,
+				   int iovcnt, size_t offset) {
+    auto oname = pool_init(name);
+    
+    smartiov iovs(iov, iovcnt);
+    char *buf = (char*)malloc(iovs.bytes());
+
+    int r = rados_read(io_ctx, oname, buf, iovs.bytes(), offset);
+
+    iovs.copy_in(buf);
+    free(buf);
+    return r;
+}
+
+
+int rados_backend::read_object(const char *name, char *buf, size_t len,
+			       size_t offset) {
+    iovec iov = {buf, len};
+    return read_object(name, &iov, 1, offset);
+}
+
+
+int rados_backend::delete_object(const char *name) {
+    auto oname = pool_init(name);
+    uint64_t size;
+    time_t time;
+    int rv = rados_stat(io_ctx, oname, &size, &time);
+    if (rv >= 0)
+	rv = rados_remove(io_ctx, oname);
+    return rv;
+}
+
+/* wait-only request, used for deleting images
+ */
+class r_delete_req : public request {
+    char oid[64];
+    rados_ioctx_t io_ctx;
+    rados_completion_t c;
+public:
+    r_delete_req(const char *oid_, rados_ioctx_t io) {
+	strcpy(oid, oid_);
+	io_ctx = io;
+    }
+    ~r_delete_req() {}
+    void wait() {
+	rados_aio_wait_for_complete(c);
+	rados_aio_release(c);
+	delete this;
+    }
+    void run(request *parent) {
+	rados_aio_create_completion2(this, NULL, &c);
+	rados_aio_remove(io_ctx, oid, c);
+    }
+    void notify(request *child) { }
+    void release() { }
+};
+
+request *rados_backend::delete_object_req(const char *name) {
+    auto oid = pool_init(name);
+    return (request*)new r_delete_req(oid, io_ctx);
+}
+
+class rados_be_request : public request {
+    smartiov       _iovs;
+    char          *buf = NULL;
+    char          *client_buf = NULL;
+    size_t         client_len = 0;
+    request       *parent = NULL;
+    char           oid[64];
+    //char          *oid = NULL;
+    size_t         offset = 0;
+    rados_ioctx_t  io_ctx;
+    rados_completion_t c;
+    std::mutex     *m;
+
+public:
+    enum lsvd_op   op;
+
+    rados_be_request(enum lsvd_op op_, char *obj_name,
+		     iovec *iov, int niov, size_t offset_,
+		     rados_ioctx_t io_ctx_, std::mutex *m_) : _iovs(iov, niov) {
+	offset = offset_;
+	io_ctx = io_ctx_;
+	strcpy(oid, obj_name);
+	op = op_;
+	m = m_;
+    }
+
+    rados_be_request(enum lsvd_op op_, char *obj_name,
+		     char *buf, size_t len, size_t offset_,
+		     rados_ioctx_t io_ctx_, std::mutex *m_) {
+	offset = offset_;
+	io_ctx = io_ctx_;
+	strcpy(oid, obj_name);
+	client_buf = buf;
+	client_len = len;
+	op = op_;
+	m = m_;
+    }
+    ~rados_be_request() {}
+
+    void notify(request *unused) {
+	if (op == OP_READ && buf != NULL)
+	    _iovs.copy_in(buf);
+	parent->notify(this);
+	if (buf != NULL)
+	    free(buf);
+	rados_aio_release(c);
+	delete this;
+    }
+
+    static void rados_be_notify(rados_completion_t c, void *ptr) {
+	auto req = (rados_be_request*)ptr;
+	int rv = rados_aio_get_return_value(c);
+	assert(rv >= 0);
+	req->notify(NULL);
+    }
+    
+    void run(request *parent_) {
+	parent = parent_;
+	assert(op == OP_READ || op == OP_WRITE);
+	
+	rados_aio_create_completion2(this, rados_be_notify, &c);
+
+	/* damn C interface doesn't handle iovecs
+	 */
+	if (client_buf == NULL) {
+	    char *_buf = (char*)_iovs.data()->iov_base;
+	    if (_iovs.size() > 1) {
+		_buf = buf = (char*)malloc(_iovs.bytes());
+		if (op == OP_WRITE)
+		    _iovs.copy_out(buf);
+	    }
+
+	    if (op == OP_READ)
+		rados_aio_read(io_ctx, oid, c, _buf, _iovs.bytes(), offset);
+	    else
+		rados_aio_write_full(io_ctx, oid, c, _buf, _iovs.bytes());
+	}
+	else {
+	    if (op == OP_READ)
+		rados_aio_read(io_ctx, oid, c, client_buf, client_len, offset);
+	    else
+		rados_aio_write_full(io_ctx, oid, c, client_buf, client_len);
+	}
+    }
+
+    void release() {}
+    void wait() {}
+};
+
+request *rados_backend::make_write_req(const char *name, iovec *iov,
+				       int iovcnt) {
+    auto oid = pool_init(name);
+    assert(*((int*)iov[0].iov_base) == LSVD_MAGIC);
+    return new rados_be_request(OP_WRITE, oid, iov, iovcnt, 0, io_ctx, &m);
+}
+
+request *rados_backend::make_write_req(const char *name, char *buf, size_t len) {
+    auto oid = pool_init(name);
+    assert(*((int*)buf) == LSVD_MAGIC);
+    return new rados_be_request(OP_WRITE, oid, buf, len, 0, io_ctx, &m);
+}
+
+request *rados_backend::make_read_req(const char *name, size_t offset,
+				      iovec *iov, int iovcnt) {
+    auto oid = pool_init(name);
+    return new rados_be_request(OP_READ, oid, iov, iovcnt, offset, io_ctx, &m);
+}
+
+request *rados_backend::make_read_req(const char *name, size_t offset,
+				      char *buf, size_t len) {
+    iovec iov = {buf, len};
+    auto oid = pool_init(name);
+    return new rados_be_request(OP_READ, oid, &iov, 1, offset, io_ctx, &m);
+}

--- a/src/liblsvd/rados_backend.cc
+++ b/src/liblsvd/rados_backend.cc
@@ -7,7 +7,7 @@
  *              LGPL-2.1-or-later
  */
 
-#include <rados/librados.h>
+#include "include/rados/librados.h"
 
 #include <vector>
 #include <sstream>

--- a/src/liblsvd/read_cache.cc
+++ b/src/liblsvd/read_cache.cc
@@ -1,0 +1,659 @@
+/*
+ * file:        read_cache.cc
+ * description: implementation of read cache
+ *              the read cache is:
+ *                       * 1. indexed by obj/offset[*], not LBA
+ *                       * 2. stores aligned 64KB blocks
+ *                       * [*] offset is in units of 64KB blocks
+ * author:      Peter Desnoyers, Northeastern University
+ *              Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <shared_mutex>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <cassert>
+
+
+#include <queue>
+#include <map>
+#include <stack>
+#include <vector>
+
+#include <random>
+#include <algorithm>		// std::min
+
+#include "lsvd_types.h"
+#include "backend.h"
+
+#include "smartiov.h"
+#include "extent.h"
+#include "misc_cache.h"
+
+#include "request.h"
+#include "journal.h"
+#include "config.h"
+#include "translate.h"
+#include "nvme.h"
+
+#include "read_cache.h"
+#include "objname.h"
+
+extern void do_log(const char *, ...);
+
+class read_cache_impl : public read_cache {
+    
+    std::mutex m;
+    std::map<extmap::obj_offset,int> map;
+
+    j_read_super       *super;
+    extmap::obj_offset *flat_map;
+
+    extmap::objmap     *obj_map;
+    std::shared_mutex  *obj_lock;
+    
+    translate          *be;
+    backend            *io;
+    nvme               *ssd;
+    
+    friend class rcache_req;
+    
+    int               unit_sectors;
+    std::vector<int>  free_blks;
+    bool              map_dirty = false;
+
+
+    // new idea for hit rate - require that sum(backend reads) is no
+    // more than 2 * sum(read sectors) (or 3x?), using 64bit counters 
+    //
+    struct {
+	int64_t       user = 1000; // hack to get test4/test_2_fakemap to work
+	int64_t       backend = 0;
+    } hit_stats;
+    int               outstanding_writes = 0; // NVMe writes to cache
+    int               maxbufs = 100;
+    
+    thread_pool<int> misc_threads; // eviction thread, for now
+    bool             nothreads = false;	// for debug
+
+    /* if map[obj,offset] = n:
+     *   in_use[n] - not eligible for eviction
+     *   written[n] - safe to read from cache
+     *   buffer[n] - in-memory data for block n
+     *   pending[n] - continuations to invoke when buffer[n] becomes valid
+     * buf_loc - FIFO queue of {n | buffer[n] != NULL}
+     */
+    sized_vector<std::atomic<int>>   in_use;
+    sized_vector<char>               written; // can't use vector<bool> here
+    sized_vector<char*>              buffer;
+    sized_vector<std::vector<request*>> pending;
+    std::queue<int>    buf_loc;
+
+    /* possible CLOCK implementation - queue holds <block,ojb/offset> 
+     * pairs so that we can evict blocks without having to remove them 
+     * from the CLOCK queue
+     */
+    sized_vector<char> a_bit;
+#if 0
+    sized_vector<int>  block_version;
+    std::queue<std::pair<int,extmap::obj_offset>> clock_queue;
+#endif
+    
+    /* evict 'n' blocks - random replacement
+     */
+    void evict(int n);
+    void evict_thread(thread_pool<int> *p);
+    char *get_cacheline_buf(int n);
+
+public:
+    read_cache_impl(uint32_t blkno, int _fd, bool nt,
+		    translate *_be, extmap::objmap *map,
+		    std::shared_mutex *m, backend *_io);
+    ~read_cache_impl();
+    
+    std::tuple<size_t,size_t,request*> async_readv(size_t offset,
+						   smartiov *iov);
+
+    void write_map(void);
+};
+
+/* factory function so we can hide implementation
+ */
+read_cache *make_read_cache(uint32_t blkno, int _fd, bool nt, translate *_be,
+			    extmap::objmap *map, std::shared_mutex *m,
+			    backend *_io) {
+    return new read_cache_impl(blkno, _fd, nt, _be, map, m, _io);
+}
+
+/* constructor - allocate, read the superblock and map, start threads
+ */
+read_cache_impl::read_cache_impl(uint32_t blkno, int fd_, bool nt,
+				 translate *be_, extmap::objmap *omap,
+				 std::shared_mutex *maplock,
+				 backend *io_) : misc_threads(&m) {
+    obj_map = omap;
+    obj_lock = maplock;
+    be = be_;
+    io = io_;
+    nothreads = nt;
+
+    const char *name = "read_cache_cb";
+    ssd = make_nvme(fd_, name);
+    
+    char *buf = (char*)aligned_alloc(512, 4096);
+    if (ssd->read(buf, 4096, 4096L*blkno) < 0)
+	throw("read cache superblock");
+    super = (j_read_super*)buf;
+
+    unit_sectors = super->unit_size;
+
+    in_use.init(super->units);
+    written.init(super->units);
+    buffer.init(super->units);
+    pending.init(super->units);
+    a_bit.init(super->units);
+
+    flat_map = (extmap::obj_offset*)aligned_alloc(512, super->map_blocks*4096);
+    if (ssd->read((char*)flat_map, super->map_blocks*4096,
+		  super->map_start*4096L) < 0)
+	throw("read flatmap");
+
+    for (int i = 0; i < super->units; i++) {
+	if (flat_map[i].obj != 0) {
+	    map[flat_map[i]] = i;
+	    written[i] = true;
+	}
+	else 
+	    free_blks.push_back(i);
+    }
+
+    map_dirty = false;
+
+    misc_threads.pool.push(std::thread(&read_cache_impl::evict_thread,
+				       this, &misc_threads));
+}
+
+read_cache_impl::~read_cache_impl() {
+    misc_threads.stop();	// before we free anything threads might touch
+    delete ssd;
+	
+    free((void*)flat_map);
+    for (auto i = 0; i < super->units; i++)
+	if (buffer[i] != NULL)
+	    free(buffer[i]);
+    free((void*)super);
+}
+
+#if 0
+static std::random_device rd; // to initialize RNG
+static std::mt19937 rng(rd());
+#else
+static std::mt19937 rng(17);      // for deterministic testing
+#endif
+
+/* evict 'n' blocks from cache, using random eviction
+ */
+void read_cache_impl::evict(int n) {
+    // assert(!m.try_lock());       // m must be locked
+    std::uniform_int_distribution<int> uni(0,super->units - 1);
+    for (int i = 0; i < n; i++) {
+	int j = uni(rng);
+	while (flat_map[j].obj == 0 || in_use[j] > 0)
+	    j = uni(rng);
+	auto oo = flat_map[j];
+	flat_map[j] = (extmap::obj_offset){0, 0};
+	map.erase(oo);
+	free_blks.push_back(j);
+    }
+}
+
+void read_cache_impl::evict_thread(thread_pool<int> *p) {
+    auto wait_time = std::chrono::milliseconds(500);
+    auto t0 = std::chrono::system_clock::now();
+    auto timeout = std::chrono::seconds(2);
+
+    std::unique_lock<std::mutex> lk(m);
+
+    while (p->running) {
+	p->cv.wait_for(lk, wait_time);
+	if (!p->running)
+	    return;
+
+	int n = 0;
+	if ((int)free_blks.size() < super->units / 16)
+	    n = super->units / 4 - free_blks.size();
+	if (n)
+	    evict(n);
+
+	if (!map_dirty)     // free list didn't change
+	    continue;
+
+	/* write the map (a) immediately if we evict something, or 
+	 * (b) occasionally if the map is dirty
+	 */
+	auto t = std::chrono::system_clock::now();
+	if (n > 0 || (t - t0) > timeout) {
+	    size_t bytes = 4096 * super->map_blocks;
+	    auto buf = (char*)aligned_alloc(512, bytes);
+	    memcpy(buf, flat_map, bytes);
+
+	    if (ssd->write(buf, bytes, 4096L * super->map_start) < 0)
+		throw("write flatmap");
+
+	    free(buf);
+	    t0 = t;
+	    map_dirty = false;
+	}
+    }
+}
+
+/* state machine for block obj,offset can be represented by the tuple:
+ *  map=n - i.e. exists(n) | map[obj,offset] = n
+ *  in_use[n] - 0 / >0
+ *  written[n] - n/a, F, T
+ *  buffer[n] - n/a, NULL, <p>
+ *  pending[n] - n/a, [], [...]
+ *
+ * if not cached                          -> {!map, n/a}
+ * first read will:
+ *   - add to map
+ *   - increment in_use
+ *   - launch read                        -> {map=n, >0, F, NULL, []}
+ * following reads will 
+ *   queue request to copy from buffer[n] -> {map=n, >0, F, NULL, [..]}
+ * read complete will:
+ *   - set buffer[n]
+ *   - notify requests from pending[n]
+ *   - launch write                       -> {map=n, >0, F, <p>, []}
+ * write complete will:
+ *   - set written[n] to true             -> {map=n, >0, T, <p>, []}
+ * eviction of buffer will:
+ *   - decr in_use
+ *   - remove buffer                      -> {map=n, 0, T, NULL, []}
+ * further reads will temporarily increment in_use
+ * eviction will remove from map:         -> {!map, n/a}
+ */
+
+
+/* limit the number of block buffers, using FIFO replacement via
+ * the @buf_loc queue. Note that this is only called from async_readv
+ * with the read cache mutex locked
+ *
+ * TODO: double-check written[n] and recycle if it isn't?
+ */
+char *read_cache_impl::get_cacheline_buf(int n) {
+    char *buf = NULL;
+    int len = super->unit_size * 512;
+    if (buf_loc.size() < (size_t)maxbufs) 
+	buf = (char*)aligned_alloc(512, len);
+    else {
+	for (int i = 0; i < 20; i++) {
+	    int j = buf_loc.front();
+	    buf_loc.pop();
+	    if (buffer[j] != NULL && written[j]) {
+		buf = buffer[j];
+		buffer[j] = NULL;
+		in_use[j]--;
+		break;
+	    }
+	    buf_loc.push(j);
+	}
+	if (buf == NULL) {
+	    do_log("rcache bufs: %d\n", (int)buf_loc.size()+1);
+	    buf = (char*)aligned_alloc(512, len);
+	}
+    }
+    buf_loc.push(n);
+    memset(buf, 0, len);
+    return buf;
+}
+
+enum req_type {
+    RCACHE_NONE = 0,
+
+    // we found an in-memory copy of the cache block,
+    // complete immediately
+    RCACHE_LOCAL_BUFFER = 1,
+
+    // waiting for read from block already in NVME cache
+    RCACHE_SSD_READ = 2,
+
+    // to be queued, waiting for run()
+    RCACHE_PENDING_QUEUE = 3,
+
+    // waiting for someone else to read my cache block:
+    RCACHE_QUEUED = 4,
+
+    // waiting for backend read of full cache block
+    RCACHE_BACKEND_WAIT = 5,
+
+    // waiting for block write to cache (async)
+    RCACHE_BLOCK_WRITE = 6,
+
+    // cache readaround - waiting for backend
+    RCACHE_DIRECT_READ = 7,
+
+    RCACHE_DONE = 8
+};
+
+class rcache_req : public request {
+    request *parent = NULL;
+    read_cache_impl *rci;
+
+    friend class read_cache_impl;
+
+    enum req_type state = RCACHE_NONE;
+    bool   released = false;
+    request *sub_req = NULL;	// cache or backend request
+
+    int      n = -1;		// cache block number
+    extmap::obj_offset unit;	// map key
+    
+    sector_t blk_offset = -1;	// see async_readv comments
+
+    smartiov iovs;
+    
+    off_t nvme_offset;
+    off_t buf_offset;
+    char *_buf = NULL;
+    char objname[128];
+
+    std::mutex m;
+    
+public:
+    rcache_req(read_cache_impl *rcache_) : rci(rcache_) {}
+    ~rcache_req() {}
+
+    void run(request *parent);
+    void notify(request *child);
+    void release();
+
+    void wait() {}
+};    
+
+void rcache_req::release() {
+    released = true;
+    if (state == RCACHE_DONE)
+	delete this;
+}
+
+void rcache_req::notify(request *child) {
+    std::unique_lock lk(m);
+    bool notify_parent = false;
+    enum req_type next_state = state;
+
+    if (child != NULL)
+	child->release();
+
+    /* direct read from nvme, line 375
+     */
+    if (state == RCACHE_SSD_READ) {
+	rci->in_use[n]--;
+	next_state = RCACHE_DONE;
+	notify_parent = true;
+    }
+    /* completion of a pending prior read
+     */
+    else if (state == RCACHE_QUEUED) {
+	iovs.copy_in(rci->buffer[n] + blk_offset*512);
+	notify_parent = true;
+	next_state = RCACHE_DONE;
+    }
+    /* cache block read completion
+     */
+    else if (state == RCACHE_BACKEND_WAIT) {
+	iovs.copy_in(_buf + buf_offset);
+
+	std::unique_lock lk(rci->m);
+	rci->buffer[n] = _buf;
+	lk.unlock();
+
+	/* once buffer[n] is set, pending[n] will not be modified
+	 * by any other requests and we can safely access and clear it
+	 */
+	notify_parent = true;
+	for (auto const & p : rci->pending[n]) 
+	    p->notify(NULL);	// other requests waiting on read
+	rci->pending[n].clear();
+
+	sub_req = rci->ssd->make_write_request(_buf, rci->unit_sectors*512L,
+					       nvme_offset);
+	next_state = RCACHE_BLOCK_WRITE;
+	sub_req->run(this);
+    }
+    else if (state == RCACHE_BLOCK_WRITE) {
+	std::unique_lock lk(rci->m);
+	rci->written[n] = true;
+	rci->flat_map[n] = unit;
+	rci->map_dirty = true;
+	rci->outstanding_writes--;
+	assert(rci->outstanding_writes >= 0);
+	next_state = RCACHE_DONE;
+    }
+    else if (state == RCACHE_DIRECT_READ) {
+	notify_parent = true;
+	next_state = RCACHE_DONE;
+    }
+    else
+	assert(false);
+    
+    if (notify_parent && parent != NULL) 
+	parent->notify(this);
+
+    if (next_state == RCACHE_DONE && released) {
+	lk.unlock();
+	delete this;
+	return;
+    }
+    else
+	state = next_state;
+}
+
+void rcache_req::run(request *parent_) {
+    parent = parent_;
+    if (state == RCACHE_QUEUED) {
+	/* nothing */
+    }
+    else if (state == RCACHE_PENDING_QUEUE) {
+	std::unique_lock lk(rci->m);
+	if (rci->buffer[n] != NULL) {
+	    iovs.copy_in(rci->buffer[n] + blk_offset*512);
+	    parent->notify(this);
+	    state = RCACHE_DONE;
+	    if (released)
+		delete this;
+	}
+	else {
+	    rci->pending[n].push_back(this);
+	    state = RCACHE_QUEUED;
+	}
+    }
+    else if (state == RCACHE_LOCAL_BUFFER) {
+	parent->notify(this);
+	state = RCACHE_DONE;
+	if (released)
+	    delete this;
+    }
+    else if (state == RCACHE_SSD_READ ||
+	     state == RCACHE_BACKEND_WAIT ||
+	     state == RCACHE_DIRECT_READ) {
+	sub_req->run(this);
+    }
+    else
+	assert(false);
+}
+
+std::tuple<size_t,size_t,request*>
+read_cache_impl::async_readv(size_t offset, smartiov *iov) {
+    size_t len = iov->bytes();
+    sector_t base = offset/512, sectors = len/512, limit = base+sectors;
+    sector_t read_sectors = -1, skip_sectors = -1;
+    extmap::obj_offset oo = {0, 0};
+    
+    std::shared_lock lk(*obj_lock);
+    auto it = obj_map->lookup(base);
+    if (it == obj_map->end() || it->base() >= limit) {
+	skip_sectors = sectors;
+	read_sectors = 0;
+    }
+    else {
+	auto [_base, _limit, _ptr] = it->vals(base, limit);
+	skip_sectors = (_base - base);
+	read_sectors = (_limit - _base);
+	oo = _ptr;
+    }
+    lk.unlock();
+
+    if (read_sectors == 0)
+	return std::make_tuple(skip_sectors*512L, 0, (request*)NULL);
+    
+    /* handle the small probability that it's for an object
+     * currently being GC'ed
+     */
+    if (!be->check_object_ready(oo.obj))
+	be->wait_object_ready(oo.obj);
+
+    auto r = new rcache_req(this);
+    
+    /*
+     * diagram to help explain stuff:
+     *
+     *   base                                     limit
+     *    [------------ sectors --------------------]
+     *                 [----- map entry -----]
+     *
+     *    |----------->| skip_sectors
+     *                 |-------------------->| read_sectors
+     *
+     * (a) if the unit ends before the map entry:
+     * [------- unit --------------------]
+     *  -------------->| blk_offset
+     *  -------------------------------->| blk_top_offset (update read_sectors)
+     *
+     * (b) if it ends after the map entry:
+     *          [------- unit --------------------]
+     *           ----->| blk_offset
+     *           --------------------------->| blk_top_offset
+     */
+
+    extmap::obj_offset unit = r->unit = {oo.obj, oo.offset / unit_sectors};
+    sector_t blk_base = r->unit.offset * unit_sectors;
+    sector_t blk_offset = oo.offset % unit_sectors;
+    sector_t blk_top_offset = std::min((int)(blk_offset+read_sectors),
+				       round_up(blk_offset+1,unit_sectors));
+    int n = -1;			// cache block number
+
+    /* trim read_sectors - (a) above
+     */
+    read_sectors = (blk_top_offset - blk_offset);
+
+    size_t skip_len = 512L * skip_sectors;
+    size_t read_len = 512L * read_sectors;
+
+    /* Hold the read cache instance lock through the rest of the
+     * method. The code is complicated, but doesn't do any I/O. 
+     * TODO: see about dropping the lock for buffer copy???
+     */
+    std::unique_lock lk2(m);
+    bool in_cache = false;
+    auto it2 = map.find(unit);
+    if (it2 != map.end()) {
+	r->n = n = it2->second;
+	in_cache = true;
+    }
+
+    /* protection against random reads - read-around when hit rate is too low
+     */
+    bool use_cache = free_blks.size() > 0 &&
+	hit_stats.user * 3 > hit_stats.backend * 2;
+    if (outstanding_writes > maxbufs - 10)
+	use_cache = false;
+    if (free_blks.size() < 5)
+	misc_threads.cv.notify_one();
+    
+    if (in_cache) {
+	sector_t blk_in_ssd = super->base*8 + n*unit_sectors,
+	    start = blk_in_ssd + blk_offset;
+
+	a_bit[n] = true;
+	hit_stats.user += read_sectors;
+
+	if (buffer[n] != NULL) {
+	    smartiov _iov = iov->slice(skip_len, skip_len + read_len);
+	    _iov.copy_in(buffer[n] + blk_offset*512L);
+	    r->state = RCACHE_LOCAL_BUFFER;
+	}
+	else if (written[n]) {
+	    in_use[n]++;
+	    smartiov _iov = iov->slice(skip_len, skip_len + read_len);
+	    r->sub_req = ssd->make_read_request(&_iov, 512L*start);
+	    r->state = RCACHE_SSD_READ;
+	}
+	else {              // prior read is pending
+	    r->state = RCACHE_PENDING_QUEUE;
+	    r->iovs = iov->slice(skip_len, skip_len + read_len);
+	    r->blk_offset = blk_offset;
+	}
+    }
+    else if (use_cache) {
+	/* assign a location in cache before we start reading (and while we're
+	 * still holding the lock)
+	 */
+	r->n = n = free_blks.back();
+	free_blks.pop_back();
+	written[n] = false;
+	assert(buffer[n] == NULL);
+	in_use[n]++;
+	auto _buf = get_cacheline_buf(n);
+	memset(_buf, 0, 64*1024);
+
+	/* point the map to that location, so that further requests to the 
+	 * same cache block will get queued. 
+	 * (since buffer[n] == NULL and !written[n])
+	 */
+	map[unit] = n;
+
+	hit_stats.backend += unit_sectors;
+	//sector_t sectors = std::min((sector_t)(read_len/512),
+	//			    blk_top_offset - blk_offset);
+	hit_stats.user += read_sectors;
+
+	r->nvme_offset = (super->base*8 + n*unit_sectors) * 512L;
+	r->buf_offset = blk_offset * 512L;
+
+	r->_buf = _buf;
+	r->state = RCACHE_BACKEND_WAIT;
+	r->iovs = iov->slice(skip_len, skip_len+read_len);
+	
+	objname name(be->prefix(unit.obj), unit.obj);
+	strcpy(r->objname, name.c_str());
+	r->sub_req = io->make_read_req(r->objname, 512L*blk_base,
+				       _buf, 512L*unit_sectors);
+	outstanding_writes++;	// bound # of write bufs
+    }
+    else {
+	hit_stats.user += read_sectors;
+	hit_stats.backend += read_sectors;
+
+	objname name(be->prefix(oo.obj), oo.obj);
+	auto tmp = iov->slice(skip_len, skip_len + read_len);
+	auto [_iov, _niov] = tmp.c_iov();
+	r->sub_req = io->make_read_req(name.c_str(), 512L*oo.offset,
+				       _iov, _niov);
+	r->state = RCACHE_DIRECT_READ;
+    }
+    return std::make_tuple(skip_len, read_len, r);
+}
+
+void read_cache_impl::write_map(void) {
+    if (ssd->write(flat_map, 4096 * super->map_blocks,
+                   4096L * super->map_start) < 0)
+        throw("write flatmap");
+}

--- a/src/liblsvd/read_cache.h
+++ b/src/liblsvd/read_cache.h
@@ -1,0 +1,41 @@
+/*
+ * file:        read_cache.h
+ * description: interface for read cache
+ * author:      Peter Desnoyers, Northeastern University
+ *              Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef READ_CACHE_H
+#define READ_CACHE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+#include <map>
+
+class translate;
+class objmap;
+class backend;
+class nvme;
+
+struct j_read_super;
+#include "extent.h"
+
+class read_cache {
+public:
+
+    virtual ~read_cache() {};
+    virtual std::tuple<size_t,size_t,request*>
+        async_readv(size_t offset, smartiov *iov) = 0;
+    virtual void write_map(void) = 0;
+};
+
+extern read_cache *make_read_cache(uint32_t blkno, int _fd, bool nt,
+                                   translate *_be, extmap::objmap *map,
+                                   std::shared_mutex *m, backend *_io);
+
+#endif
+

--- a/src/liblsvd/request.h
+++ b/src/liblsvd/request.h
@@ -1,0 +1,41 @@
+/*
+ * file:        request.h
+ * description: generic inter-layer request mechanism
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef REQUEST_H
+#define REQUEST_H
+
+/* generic interface for requests.
+ *  - run(parent): begin execution
+ *  - notify(rv): notification of completion
+ *  - TODO: wait(): wait for completion
+ */
+class request {
+public:
+    virtual void wait() = 0;
+    virtual void run(request *parent) = 0;
+    virtual void notify(request *child) = 0;
+    virtual void release() = 0;
+    virtual ~request(){}
+    request() {}
+};
+
+/* for callback-only request classes
+ */
+class trivial_request : public request {
+public:
+    trivial_request() {}
+    ~trivial_request() {}
+    virtual void notify(request *child) = 0;
+    void wait() {}
+    void run(request *parent) {}
+    void release() {}
+};
+
+#endif

--- a/src/liblsvd/smartiov.h
+++ b/src/liblsvd/smartiov.h
@@ -1,0 +1,146 @@
+/*
+ * file:        smartiov.h
+ * description: iovec-based buffer list
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef SMARTIOV_H
+#define SMARTIOV_H
+
+#include <sys/uio.h>
+#include <string.h>
+#include <cassert>
+#include <vector>
+
+/* this makes readv / writev a lot easier...
+ */
+class smartiov {
+    std::vector<iovec> iovs;
+public:
+    smartiov() {}
+    smartiov(const iovec *iov, int iovcnt) {
+	for (int i = 0; i < iovcnt; i++)
+	    iovs.push_back(iov[i]);
+    }
+    smartiov(char *buf, size_t len) {
+        iovs.push_back((iovec){buf, len});
+    }
+    void push_back(const iovec &iov) {
+	iovs.push_back(iov);
+    }
+    void ingest(const iovec *iov, int iovcnt) {
+	for (int i = 0; i < iovcnt; i++)
+	    iovs.push_back(iov[i]);
+    }
+    iovec *data(void) {
+	return iovs.data();
+    }
+    iovec& operator[](int i) {
+	return iovs[i];
+    }
+    int size(void) {
+	return iovs.size();
+    }
+    std::pair<iovec*,int> c_iov(void) {
+	return std::pair(iovs.data(), (int)iovs.size());
+    }
+    size_t bytes(void) {
+	size_t sum = 0;
+	for (auto i : iovs)
+	    sum += i.iov_len;
+	return sum;
+    }
+    smartiov slice(size_t off, size_t limit) {
+	assert(limit <= bytes());
+	smartiov other;
+	size_t len = limit - off;
+	for (auto it = iovs.begin(); it != iovs.end() && len > 0; it++) {
+	    if (it->iov_len < off)
+		off -= it->iov_len;
+	    else {
+		auto _len = std::min(len, it->iov_len - off);
+		other.push_back((iovec){(char*)it->iov_base + off, _len});
+		len -= _len;
+		off = 0;
+	    }
+	}
+	return other;
+    }
+    void zero(void) {
+	for (auto i : iovs)
+	    memset(i.iov_base, 0, i.iov_len);
+    }
+    void zero(size_t off, size_t limit) {
+	size_t len = limit - off;
+	for (auto it = iovs.begin(); it != iovs.end() && len > 0; it++) {
+	    if (it->iov_len < off)
+		off -= it->iov_len;
+	    else {
+		auto _len = std::min(len, it->iov_len - off);
+                memset((char*)it->iov_base + off, 0, _len);
+		len -= _len;
+		off = 0;
+	    }
+	}
+    }
+    void copy_in(char *buf) {
+	for (auto i : iovs) {
+	    memcpy((void*)i.iov_base, (void*)buf, (size_t)i.iov_len);
+	    buf += i.iov_len;
+	}
+    }
+    void copy_out(char *buf) {
+	for (auto i : iovs) {
+	    memcpy((void*)buf, (void*)i.iov_base, (size_t)i.iov_len);
+	    buf += i.iov_len;
+	}
+    }
+    bool aligned(int n) {
+	for (auto i : iovs)
+	    if (((long)i.iov_base & (n-1)) != 0)
+		return false;
+	return true;
+    }
+};
+
+#ifdef TEST
+
+#include <cassert>
+#include <cstdlib>
+
+void test1(void)
+{
+    char *buf1 = (char*)calloc(1001, 1);
+    char *buf2 = (char*)calloc(1001, 1);
+    memset(buf1, 'A', 1000);
+    iovec iov1[] = {{buf1, 117}, {buf1+117, 204}, {buf1+117+204, 412},
+		    {buf1+733, 1000-733}};
+    auto s = smartiov(iov1, 4);
+    s.copy_out(buf2);
+    assert(strlen(buf2) == 1000);
+
+    auto z = s.slice(200,500);  // 0, 83+121, 0+179
+    assert(z.bytes() == 300);
+    assert(z.size() == 2);
+    assert(z.iov()[0].iov_base == buf1+200);
+    
+    s.slice(200,500).zero();
+    assert(strlen(buf1) == 200);
+    assert(memchr(buf1+200, 'A', 800) == buf1+500);
+
+    memset(buf2, 0, 1001);
+    s.slice(400,700).copy_out(buf2);
+    assert(memchr(buf2, 'A', 300) == buf2 + 100);
+    assert(strlen(buf2+100) == 200);
+}
+
+int main(int argc, char **argv)
+{
+    test1();
+}
+#endif
+#endif

--- a/src/liblsvd/smartiov.h
+++ b/src/liblsvd/smartiov.h
@@ -24,7 +24,8 @@ public:
     smartiov() {}
     smartiov(const iovec *iov, int iovcnt) {
 	for (int i = 0; i < iovcnt; i++)
-	    iovs.push_back(iov[i]);
+            if (iov[i].iov_len > 0)
+                iovs.push_back(iov[i]);
     }
     smartiov(char *buf, size_t len) {
         iovs.push_back((iovec){buf, len});
@@ -34,7 +35,8 @@ public:
     }
     void ingest(const iovec *iov, int iovcnt) {
 	for (int i = 0; i < iovcnt; i++)
-	    iovs.push_back(iov[i]);
+            if (iov[i].iov_len > 0)
+                iovs.push_back(iov[i]);
     }
     iovec *data(void) {
 	return iovs.data();

--- a/src/liblsvd/tools/README.md
+++ b/src/liblsvd/tools/README.md
@@ -1,0 +1,80 @@
+# Random LSVD tools
+
+This is a bit of a mess right now, since it started out as a ctypes-based Python unit test framework for the library but that's all been stripped out.
+
+## cache.py - read cache contents
+Note that you might need to parse the superblock with `parse.py` to find the cache file name - it's typically "<cache dir>/<uuid>.cache"
+
+```
+usage: cache.py [-h] [--write] [--writemap] [--read] [--nowrap] device
+
+Read SSD cache
+
+positional arguments:
+  device      cache device/file
+
+options:
+  -h, --help  show this help message and exit
+  --write     print write cache details
+  --writemap  print write cache map
+  --read      print read cache details
+  --nowrap    one entry per line
+```
+
+## clone.py - create image clone
+
+(note - needs to be moved into RBD API)
+
+```
+usage: clone.py [-h] [--uuid UUID] [--rados] base image
+
+create clone of LSVD disk image
+
+positional arguments:
+  base         base image
+  image        new (clone) image
+
+options:
+  -h, --help   show this help message and exit
+  --uuid UUID  volume UUID
+```
+
+## dumpobj
+
+Translate backend objects to/from text. Note that this includes the structure definitions, rather than importing them from `lsvd_types.py`, so that it can be extended to handle different versions.
+
+```
+usage: dumpobj.py [-h] [--rados] [--encode] [--decode] src [dst]
+
+LSVD object to/from text
+
+positional arguments:
+  src         source
+  dst         destination
+
+options:
+  -h, --help  show this help message and exit
+  --rados     use RADOS
+  --encode    text -> binary
+  --decode    binary -> text
+
+```
+
+## parse.py - parse and pretty-print backend objects
+```
+usage: parse.py [-h] [--rados] [--nowrap] object
+
+Read backend object
+
+positional arguments:
+  object      object path
+
+options:
+  -h, --help  show this help message and exit
+  --rados     fetch from RADOS
+  --nowrap    one entry per line
+```
+
+## mkcache.py, mkdisk.py - historic use only
+
+These should be superceded by imgtool, which uses the RBD API plus an extension or two.

--- a/src/liblsvd/tools/blkdev.py
+++ b/src/liblsvd/tools/blkdev.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import fcntl
+import struct
+
+# adapted from https://gist.github.com/shimarin/34f05caaf75d02966a30
+
+S_IFMT  = 0o00170000
+S_IFREG =  0o0100000
+S_IFBLK =  0o0060000
+
+def S_ISBLK(m):
+    return (m & S_IFMT) == S_IFBLK
+def S_ISREG(m):
+    return (m & S_IFMT) == S_IFREG
+
+def ioctl_read_uint64(fd, req):
+    buf = bytearray(b'\0'*8)
+    fcntl.ioctl(fd, req, buf)
+    return struct.unpack('L',buf)[0]
+
+def dev_get_size(fd):
+    BLKGETSIZE64 = 0x80081272
+    return ioctl_read_uint64(fd, BLKGETSIZE64)
+    

--- a/src/liblsvd/tools/cache.py
+++ b/src/liblsvd/tools/cache.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import lsvd_types as lsvd
+import test3 as t3
+import uuid
+import blkdev
+import argparse
+import ctypes
+
+def prettyprint(p, insns):
+    for field,fmt in insns:
+        x = eval('p.' + field)
+        pad = ' ' * (10 - len(field)) + ':'
+        if type(fmt) == str:
+            print(field, pad, fmt % x)
+        elif callable(fmt):
+            print(field, pad, fmt(x))
+        elif type(fmt) == dict:
+            print(field, pad, fmt[x])
+
+fmt_uuid = lambda u: uuid.UUID(bytes=bytes(u[:]))
+
+fieldnames = dict({(10, 'DATA'),(11, 'CKPT'),(12, 'PAD'),(13, 'SUPER'),
+                       (14, 'W_SUPER'),(15, 'R_SUPER')})
+magic = lambda x: 'ok' if x == lsvd.LSVD_MAGIC else '**BAD**'
+blk_fmt = lambda x: '%d%s' % (x, '' if x < npages else ' *INVALID*')
+
+hdr_pp = [['magic', magic], ['type', fieldnames], ['vol_uuid', fmt_uuid],
+              ['write_super', blk_fmt], ['read_super', blk_fmt]]
+
+wsup_pp = [['magic', magic], ['type', fieldnames], ['clean', lambda x: "YES" if x else "NO"],
+               ['seq', '%d'], ['meta_base', '%d'], ['meta_limit', '%d'],
+               ['base', '%d'], ['limit', '%d'], ['next', '%d'], 
+               ['map_start', '%d'], ['map_entries', '%d'],
+               ['len_start', '%d'], ['len_entries', '%d']]
+
+rsup_pp = [["magic", magic], ["type", fieldnames], ["unit_size", '%d'], 
+               ["base", '%d'], ["units", '%d'], ["map_start", '%d'],["map_blocks", '%d']]
+
+parser = argparse.ArgumentParser(description='Read SSD cache')
+parser.add_argument('--write', help='print write cache details', action='store_true')
+parser.add_argument('--writemap', help='print write cache map', action='store_true')
+parser.add_argument('--read', help='print read cache details', action='store_true')
+parser.add_argument('--nowrap', help='one entry per line', action='store_true')
+parser.add_argument('device', help='cache device/file')
+args = parser.parse_args()
+
+fd = os.open(args.device, os.O_RDONLY)
+sb = os.fstat(fd)
+if blkdev.S_ISBLK(sb.st_mode):
+    npages = blkdev.dev_get_size(fd)
+else:
+    npages = sb.st_size // 4096
+
+super = t3.c_super(fd)
+print('superblock: (0)')
+prettyprint(super, hdr_pp)
+w_super = r_super = None
+print('\nwrite superblock: (%s)' % blk_fmt(super.write_super))
+if super.write_super < npages:
+    w_super = t3.c_w_super(fd, super.write_super)
+    prettyprint(w_super, wsup_pp)
+
+print('\nread superblock: (%s)' % blk_fmt(super.read_super))
+if super.read_super < npages:
+    r_super = t3.c_r_super(fd, super.read_super)
+    prettyprint(r_super, rsup_pp)
+
+def read_exts(b, npgs, n):
+    bytes = n*lsvd.sizeof_j_map_extent
+    buf = os.pread(fd, bytes, b*4096)
+    e = (lsvd.j_map_extent*n).from_buffer(bytearray(buf))
+    return [(_.lba, _.len, _.plba) for _ in e]
+
+def read_lens(b, npgs, n):
+    bytes = n*lsvd.sizeof_j_length
+    buf = os.pread(fd, bytes, b*4096)
+    l = (lsvd.j_length*n).from_buffer(bytearray(buf))
+    return [(_.page, _.len) for _ in l]
+    
+if args.write and super.write_super < npages:
+    b = w_super.base
+    while b < w_super.limit:
+        [j,e] = t3.c_hdr(fd, b)
+        if j.magic != lsvd.LSVD_MAGIC:
+            b += 1
+            continue
+
+        h_pp = [["magic", magic], ["type", fieldnames], ["seq", '%d'], ["len", '%d'], ["prev", '%d']]
+        print('\ndata: (%d)' % b)
+        prettyprint(j, h_pp)
+        print('extents    :', ' '.join(['%d+%d' % (_.lba,_.len) for _ in e]))
+        b = b + j.len
+
+def wrapjoin(prefix, linelen, items):
+    val = ''
+    line = prefix
+    for i in items:
+        if len(line)+len(i) > linelen:
+            val = val + line + '\n'
+            line = prefix
+        line = line + ' ' + i
+    if line != prefix:
+        val += line
+    return val
+        
+if args.writemap and w_super:
+    print('\nwrite cache map:')
+    e = read_exts(w_super.map_start, w_super.map_blocks, w_super.map_entries)
+    if args.nowrap:
+        print('\n'.join(['%d+%d->%d' % _ for _ in e]))
+    else:
+        print(wrapjoin(' ', 80, ['%d+%d->%d' % _ for _ in e]))
+
+    print('\nwrite cache lengths:')
+    l = read_lens(w_super.len_start, w_super.len_blocks, w_super.len_entries)
+    if args.nowrap:
+        print('\n'.join(['[%d]=%d' % _ for _ in l]))
+    else:
+        print(wrapjoin(' ', 80, ['[%d]=%d' % _ for _ in l]))
+
+if args.read and r_super:
+    nbytes = r_super.units * lsvd.sizeof_obj_offset
+    print("map start:   ", r_super.map_start)
+    buf = os.pread(fd, nbytes, r_super.map_start * 4096)
+    oos = (lsvd.obj_offset * r_super.units).from_buffer(bytearray(buf))
+    oos = [_ for _ in filter(lambda x: x.obj != 0, oos)]
+    print("\nread map:")
+    print(wrapjoin(' ', 80, ['[%d] = %d.%d' % _ for _ in
+                                 [(i, oos[i].obj, oos[i].offset) for i in range(len(oos))]]))

--- a/src/liblsvd/tools/clone.py
+++ b/src/liblsvd/tools/clone.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+
+import ctypes
+import lsvd_types as lsvd
+import os
+import re
+import argparse
+import uuid
+try:
+    import rados
+except:
+    pass
+    
+def read_obj(name):
+    if args.rados:
+        pool,oid = name.split('/')
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found: ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        obj = ioctx.read(oid)
+        h = lsvd.hdr.from_buffer(bytearray(obj[0:lsvd.sizeof_hdr]))
+        if len(obj) < 512*h.hdr_sectors:
+            obj = ioctx.read(oid, 512*h.hdr_sectors, 0)
+        ioctx.close()
+    else:
+        fp = open(name, 'rb')
+        obj = fp.read()
+        fp.close()
+    return obj
+
+def write_obj(name, data):
+    if args.rados:
+        pool,oid = name.split('/')
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found: ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        ioctx.write(oid, bytes(data))
+        ioctx.close()
+    else:
+        fd = os.open(name, os.O_WRONLY|os.O_TRUNC|os.O_CREAT)
+        os.write(fd, bytes(data))
+        os.close(fd)
+
+# we assume that the base volume is completely shut down, so the 
+# highest-numbered object is the last checkpoint
+#
+def mk_clone(old, new, uu):
+    obj = read_obj(old)
+    o2 = lsvd.sizeof_hdr
+    h = lsvd.hdr.from_buffer(bytearray(obj[0:o2]))
+
+    o3 = o2+lsvd.sizeof_super_hdr
+    sh = lsvd.super_hdr.from_buffer(bytearray(obj[o2:o3]))
+
+    # find the last checkpoint
+    _ckpts = obj[sh.ckpts_offset:sh.ckpts_offset+sh.ckpts_len]
+    ckpts = (ctypes.c_int * (len(_ckpts)//4)).from_buffer(bytearray(_ckpts))
+    seq = ckpts[-1]
+
+    # read it, and create a new one
+    ckpt_name = "%s.%08x" % (old, seq)
+    ckpt_obj = read_obj(ckpt_name)
+    print("ckpt len", len(ckpt_obj))
+    c_h = lsvd.hdr.from_buffer(bytearray(ckpt_obj))
+    c_ch = lsvd.ckpt_hdr.from_buffer(bytearray(ckpt_obj[lsvd.sizeof_hdr:]))
+
+    m_begin = c_ch.map_offset
+    m_end = m_begin + c_ch.map_len
+    ckpt_map = ckpt_obj[m_begin:m_end]
+
+    c_ckpt_num = ctypes.c_int(seq+1)
+    
+    hdr_bytes = (ctypes.sizeof(c_h) + ctypes.sizeof(c_ch) +
+                     ctypes.sizeof(c_ckpt_num) + len(ckpt_map))
+    hdr_sectors = (hdr_bytes + 511) // 512
+
+    c_ch.cache_seq = 0
+    o = ctypes.sizeof(c_h) + ctypes.sizeof(c_ch)
+    c_ch.ckpts_offset = o
+    c_ch.ckpts_len = ctypes.sizeof(c_ckpt_num)
+    o += ctypes.sizeof(c_ckpt_num)
+
+    c_ch.objs_len = 0                     # omit the object list
+    c_ch.deletes_len = 0
+
+    c_ch.map_offset = o
+    c_ch.map_len = len(ckpt_map)
+    
+    c_h.seq = seq+1
+    c_h.vol_uuid[:] = uu
+    c_h.hdr_sectors = hdr_sectors
+    c_newobj = bytearray() + c_h + c_ch + c_ckpt_num + ckpt_map
+
+    new_ckpt_name = "%s.%08x" % (new, seq+1)
+    write_obj(new_ckpt_name, c_newobj)
+    
+    # and create a superblock object
+    h2 = lsvd.hdr(magic=lsvd.LSVD_MAGIC, version=1, type=lsvd.LSVD_SUPER,
+                      hdr_sectors=8, data_sectors=0)
+    h2.vol_uuid[:] = uu
+
+    # TODO: need to create a single checkpoint, copying the map from the
+    # most recent checkpoint in the base, but omitting the object map.
+
+    b_old = bytes(old,'utf-8')
+    c = lsvd.clone_info(last_num=seq, name_len=len(b_old))
+    c.vol_uuid[:] = h.vol_uuid[:]
+    sizeof_clone = lsvd.sizeof_clone_info + len(b_old) + 1
+    offset_ckpt = lsvd.sizeof_hdr+lsvd.sizeof_super_hdr
+    offset_clone = offset_ckpt + ctypes.sizeof(c_ckpt_num)
+    
+    sh2 = lsvd.super_hdr(vol_size=sh.vol_size, ckpts_offset=offset_ckpt,
+                             ckpts_len=ctypes.sizeof(c_ckpt_num), 
+                             clones_offset=offset_clone,
+                             clones_len=sizeof_clone)
+
+    data = bytearray() + h2 + sh2 + c_ckpt_num + c + b_old
+    data += b'\0' * (4096-len(data))
+
+    write_obj(new, data)
+    
+if __name__ == '__main__':
+    _rnd_uuid = str(uuid.uuid4())
+    parser = argparse.ArgumentParser(description='create clone of LSVD disk image')
+    parser.add_argument('--uuid', help='volume UUID', default=_rnd_uuid)
+    parser.add_argument('--rados', help='use RADOS backend', action='store_true');
+    parser.add_argument('base', help='base image')
+    parser.add_argument('image', help='new (clone) image')
+    args = parser.parse_args()
+
+    _uuid = uuid.UUID(args.uuid).bytes
+
+    if args.rados:
+        cluster = rados.Rados(conffile='')
+        cluster.connect()
+
+    mk_clone(args.base, args.image, _uuid)
+
+    if args.rados:
+        cluster.shutdown()

--- a/src/liblsvd/tools/dumpobj.py
+++ b/src/liblsvd/tools/dumpobj.py
@@ -1,0 +1,331 @@
+#!/usr/bin/python3
+
+# binary/text encode and decode
+# includes object definitions, so that images can be converted if
+# encoding changes during development
+#
+
+import os
+import sys
+import uuid
+from ctypes import *
+import argparse
+import zlib
+
+#### matches commit f06dde of objects.h
+
+LSVD_SUPER = 1
+LSVD_DATA = 2
+LSVD_CKPT = 3
+LSVD_MAGIC = 0x4456534c
+
+# these match version 453d93 of objects.cc
+
+parser = argparse.ArgumentParser(description='LSVD object to/from text')
+parser.add_argument('--rados', help='use RADOS', action='store_true')
+parser.add_argument('--encode', help='text -> binary', action='store_true')
+parser.add_argument('--decode', help='binary -> text', action='store_true')
+parser.add_argument('src', help='source')
+parser.add_argument('dst', help='destination', nargs='?')
+args = parser.parse_args()
+
+ver = 1
+
+class hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",               c_uint),
+                ("version",             c_uint),
+                ("vol_uuid",            c_ubyte*16),
+                ("type",                c_uint),
+                ("seq",                 c_uint),
+                ("hdr_sectors",         c_uint),
+                ("data_sectors",        c_uint),
+                ("crc",                 c_uint)]
+
+class super_hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("vol_size",            c_ulong),
+                ("ckpts_offset",        c_uint),
+                ("ckpts_len",           c_uint),
+                ("clones_offset",       c_uint),
+                ("clones_len",          c_uint),
+                ("snaps_offset",        c_uint),
+                ("snaps_len",           c_uint)]
+
+# ckpts is array of uint32
+
+class clone_info(Structure):
+    _pack_ = 1
+    _fields_ = [("vol_uuid",            c_ubyte*16),
+                ("last_seq",            c_uint),
+                ("name_len",            c_ubyte)]   # 21 bytes
+        # followed by 'name_len' bytes of name
+
+if ver == 1:
+    class ckpt_hdr(Structure):
+        _pack_ = 1
+        _fields_ = [("cache_seq",           c_ulong),
+                    ("ckpts_offset",        c_uint),
+                    ("ckpts_len",           c_uint),
+                    ("objs_offset",         c_uint),
+                    ("objs_len",            c_uint),
+                    ("deletes_offset",      c_uint),
+                    ("deletes_len",         c_uint),
+                    ("map_offset",          c_uint),
+                    ("map_len",             c_uint)]
+
+
+class ckpt_obj(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("hdr_sectors",         c_uint),
+                ("data_sectors",        c_uint),
+                ("live_sectors",        c_uint)]
+sizeof_ckpt_obj = sizeof(ckpt_obj) # 16
+
+class deferred_delete(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("time",                c_uint)]
+sizeof_deferred_delete = sizeof(deferred_delete)
+
+class ckpt_mapentry(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("lba",                 c_ulong, 36),
+                ("len",                 c_ulong, 28),
+                ("obj",                 c_uint),
+                ("offset",              c_uint)]
+sizeof_ckpt_mapentry = sizeof(ckpt_mapentry) # 16
+
+
+if args.rados:
+    import rados
+    cluster = rados.Rados(conffile='')
+    cluster.connect()
+    
+def read_obj(name):
+    if args.rados:
+        pool,oid = name.split('/')
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found: ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        obj = ioctx.read(oid)
+        h = hdr.from_buffer(bytearray(obj[0:sizeof(hdr)]))
+        if len(obj) < 512*h.hdr_sectors:
+            obj = ioctx.read(oid, 512*h.hdr_sectors, 0)
+        ioctx.close()
+    else:
+        f = open(name, 'rb')
+        obj = f.read(None)
+        f.close()
+    return obj
+
+def write_obj(name, data):
+    if args.rados:
+        pool,oid = name.split('/')
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found: ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        ioctx.write(oid, bytes(data))
+        ioctx.close()
+    else:
+        fd = os.open(name, os.O_WRONLY|os.O_TRUNC|os.O_CREAT)
+        os.write(fd, bytes(data))
+        os.close(fd)
+
+def decode_super(obj, fp):
+    o1 = sizeof(hdr)
+    h = hdr.from_buffer(bytearray(obj[:o1]))
+    o2 = o1 + sizeof(super_hdr)
+    sh = super_hdr.from_buffer(bytearray(obj[o1:o2]))
+
+    uu = uuid.UUID(bytes=bytes(h.vol_uuid))
+    print('type SUPER', file=fp);
+    print('uuid', str(uu), file=fp)
+    assert(h.seq == 0)
+    assert(h.data_sectors == 0)
+
+    print('vol_size', sh.vol_size, file=fp)
+    
+    if sh.ckpts_len > 0:
+        _ckpts = obj[sh.ckpts_offset:sh.ckpts_offset+sh.ckpts_len]
+        ckpts = (c_int * (len(_ckpts)//4)).from_buffer(bytearray(_ckpts))
+        for c in ckpts:
+            print('ckpt', c, file=fp)
+    if sh.clones_len > 0:
+        cl = clone_info.from_buffer(bytearray(obj[sh.clones_offset:]))
+        o3 = sh.clones_offset + sizeof(cl)
+        name = obj[o3:o3+cl.name_len]
+        uu = uuid.UUID(bytes=bytes(cl.vol_uuid))
+        print('clone', str(name,'utf-8'), str(uu), cl.last_seq, file=fp)
+    
+def decode_ckpt(obj, fp):
+    o1 = sizeof(hdr)
+    h = hdr.from_buffer(bytearray(obj[:o1]))
+    o2 = o1 + sizeof(ckpt_hdr)
+    ch = ckpt_hdr.from_buffer(bytearray(obj[o1:o2]))
+
+    uu = uuid.UUID(bytes=bytes(h.vol_uuid))
+    print('type CKPT', file=fp);
+    print('uuid', str(uu), file=fp)
+    print('seq', h.seq)
+    print('cache_seq', ch.cache_seq)
+    if ch.ckpts_len > 0:
+        n = ch.ckpts_len // 4
+        o = ch.ckpts_offset
+        ckpts = (c_int * n).from_buffer(bytearray(obj[o:o+ch.ckpts_len]))
+        for c in ckpts:
+            print('ckpt', c)
+    if ch.objs_len > 0:
+        n = ch.objs_len // sizeof(ckpt_obj)
+        o = ch.objs_offset
+        objs = (ckpt_obj * n).from_buffer(bytearray(obj[o:o+ch.objs_len]))
+        for obj in objs:
+            print('obj %d,%d,%d,%d',
+                      (obj.seq, obj.hdr_sectors, obj.data_sectors, obj.live_sectors))
+    if ch.deletes_len > 0:
+        n = ch.deletes_len // sizeof(deferred_delete)
+        o = ch.deletes_offset
+        dels = (deferred_delete * n).from_buffer(bytearray(obj[o:o+ch.deletes_len]))
+        for d in dels:
+            print('delete %d,%d', (d.seq, d.time))
+    if ch.map_len > 0:
+        n = ch.map_len // sizeof(ckpt_mapentry)
+        o = ch.map_offset
+        _map = (ckpt_mapentry * n).from_buffer(bytearray(obj[o:o+ch.map_len]))
+        for m in _map:
+            print('map %d,%d,%d,%d' % (m.lba, m.len, m.obj, m.offset))
+    
+def encode_ckpt(f, name):
+    h = hdr(magic = LSVD_MAGIC, version=1, type=LSVD_CKPT,
+                     seq=int(f['seq']), hdr_sectors=0, data_sectors=0)
+    h.vol_uuid[:] = uuid.UUID(f['uuid']).bytes
+
+    ckpts_data = b''
+    objs_data = b''
+    deletes_data = b''
+    map_data = b''
+    
+    ch = ckpt_hdr(cache_seq = int(f['cache_seq']))
+    offset = sizeof(h) + sizeof(ch)
+    
+    if 'ckpt' in f:
+        ckpts = [int(_) for _ in f['ckpt']]
+        ckpts_data = (c_int * len(ckpts))(*ckpts)
+        ch.ckpts_offset = offset
+        ch.ckpts_len = sizeof(ckpts_data)
+        offset += sizeof(ckpts_data)
+
+    if 'obj' in f:
+        objs = [[int(x) for x in y.split(',')] for y in f['obj']]
+        objs_data = (ckpt_obj * len(objs))()
+        for i in range(len(objs)):
+            s,h,d,l = objs[i]
+            objs_data[i] = ckpt_obj(seq=s, hdr_sectors=h, data_sectors=d, live_sectors=l)
+        ch.objs_offset = offset
+        ch.objs_len = sizeof(objs_data)
+        offset += sizeof(objs_data)
+
+    if 'delete' in f:
+        dels = [[int(x) for x in y.split(',')] for y in f['delete']]
+        dels_data = (deferred_delete * len(dels))()
+        for i in range(len(dels)):
+            s,t = dels[i]
+            dels_data[i] = deferred_delete(seq=s, time=t)
+        ch.dels_offset = offset
+        ch.dels_len = sizeof(dels_data)
+        offset += sizeof(dels_data)
+
+    if 'map' in f:
+        maps = [[int(x) for x in y.split(',')] for y in f['delete']]
+        map_data = (ckpt_mapentry * len(maps))()
+        for i in range(len(maps)):
+            a,l,o,f = maps[i]
+            map_data[i] = ckpt_mapentry(lba=a, len=l, obj=o, offset=f)
+        ch.map_offset = offset
+        ch.map_len = sizeof(map_data)
+        offset += sizeof(map_data)
+    
+    n_sectors = (offset + 511) // 512
+    h.hdr_sectors = n_sectors
+    pad = b'\0' * (n_sectors * 512 - offset)
+    
+    buf = bytearray() + h + ch + ckpts_data + objs_data + deletes_data + map_data + pad
+    h.crc = zlib.crc32(buf)
+    buf = bytearray() + h + ch + ckpts_data + objs_data + deletes_data + map_data + pad
+    
+    write_obj(name, buf)
+
+
+def encode_super(f, name):
+    print('writing super')
+    h = hdr(magic = LSVD_MAGIC, version=1, type=LSVD_SUPER,
+                     seq=0, hdr_sectors=8, data_sectors=0)
+    h.vol_uuid[:] = uuid.UUID(f['uuid'][0]).bytes
+
+    sh = super_hdr()
+    sh.vol_size = int(f['vol_size'][0])
+    ckpts = b''
+    if 'ckpt' in f:
+        ckpt_list = f['ckpt']
+        c = (c_int * len(ckpt_list))()
+        for i in range(len(ckpt_list)):
+            c[i] = int(ckpt_list[i])
+        ckpts = bytearray() + c
+    clone = b''
+    if 'clone' in f:
+        name,uu,seq = f['clone'][0].split()
+        cl = clone_info(last_seq = int(seq))
+        cl.vol_uuid[:] = uuid.UUID(uu).bytes
+        cl.name_len = int(len(name))
+        clone = bytearray() + cl + bytes(name,'utf-8')
+
+    offset = sizeof(h) + sizeof(sh)
+
+    sh.ckpts_offset = offset
+    sh.ckpts_len = len(ckpts)
+    offset += len(ckpts)
+
+    sh.clones_offset = offset
+    sh.clone_len = len(clone)
+    offset += len(clone)
+
+    buf = bytearray() + h + sh + ckpts + clone
+    buf += b'\0' * (4096 - len(buf))
+    crc = zlib.crc32(buf)
+    h.crc = crc
+    buf = bytearray() + h + sh + ckpts + clone
+    buf += b'\0' * (4096 - len(buf))
+
+    write_obj(name, buf)
+
+if args.encode:
+    fields = dict()
+    if args.src == '-':
+        fp = sys.stdin
+    else:
+        fp = open(args.src, 'r')
+    for line in fp:
+        tmp = line.split()
+        if tmp[0] in fields:
+            fields[tmp[0]].extend(tmp[1:])
+        else:
+            fields[tmp[0]] = tmp[1:]
+    if fields['type'][0] == 'SUPER':
+        encode_super(fields, args.dst)
+    elif fields['type'][0] == 'CKPT':
+        encode_ckpt(fields, args.dst)
+    else:
+        print('type:', fields['type'])
+
+elif args.decode:
+    obj = read_obj(args.src)
+    if args.dst:
+        fp = open(args.dst, 'w')
+    else:
+        fp = sys.stdout
+    h = hdr.from_buffer(bytearray(obj[:sizeof(hdr)]))
+    if h.type == LSVD_SUPER:
+        decode_super(obj, fp)
+    elif h.type == LSVD_CKPT:
+        decode_ckpt(obj, fp)

--- a/src/liblsvd/tools/lsvd.py
+++ b/src/liblsvd/tools/lsvd.py
@@ -1,0 +1,235 @@
+from ctypes import *
+import os
+from lsvd_types import *
+
+dir = os.getcwd()
+dir = '/home/pjd/lsvd-rbd'
+lsvd_lib = CDLL("liblsvd.so")
+assert lsvd_lib
+
+
+# translation layer only, no read or write cache
+#
+class translate:
+    def __init__(self, name, n, flush):
+        if type(name) != bytes:
+            name = bytes(name, 'utf-8')
+        self.name = name
+        p = c_void_p()
+        sz = lsvd_lib.xlate_open(name, n, c_bool(flush), byref(p))
+        self.lsvd = p
+        self.nbytes = sz
+
+    def close(self):
+        lsvd_lib.xlate_close(self.lsvd)
+
+    def write(self, offset, data):
+        if type(data) != bytes:
+            data = bytes(data, 'utf-8')
+        nbytes = len(data)
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        return lsvd_lib.xlate_write(self.lsvd, data, c_ulong(offset), c_uint(nbytes))
+
+    def read(self, offset, nbytes):
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        buf = (c_char * nbytes)()
+        val = lsvd_lib.xlate_read(self.lsvd, buf, c_ulong(offset), c_uint(nbytes))
+        return buf[0:nbytes]
+
+    def flush(self):
+        lsvd_lib.xlate_flush(self.lsvd)
+
+    def mapsize(self):
+        return lsvd_lib.xlate_size(self.lsvd)
+
+    def getmap(self, base, limit):
+        n_tuples = self.mapsize()
+        tuples = (tuple * n_tuples)()
+        n = lsvd_lib.xlate_getmap(self.lsvd, c_int(base), c_int(limit),
+                                      c_int(n_tuples), byref(tuples))
+        return [_ for _ in map(lambda x: [x.base, x.limit, x.obj, x.offset], tuples[0:n])]
+
+    def frontier(self):
+        return lsvd_lib.xlate_frontier(self.lsvd)
+
+    def reset(self):
+        lsvd_lib.xlate_reset(self.lsvd)
+
+    def batch_seq(self):
+        return lsvd_lib.xlate_seq(self.lsvd)
+
+    def checkpoint(self):
+        return lsvd_lib.xlate_checkpoint(self.lsvd)
+
+    def fakemap_update(self, base, limit, obj, offset):
+        lsvd_lib.fakemap_update(self.lsvd, c_int(base), c_int(limit),
+                                    c_int(obj), c_int(offset))
+
+    def fakemap_reset(self):
+        lsvd_lib.fakemap_reset(self.lsvd)
+
+        
+def img_write(img, offset, data):
+    if type(data) != bytes:
+        data = bytes(data, 'utf-8')
+    nbytes = len(data)
+    assert (nbytes % 512) == 0 and (offset % 512) == 0
+    val = lsvd_lib.dbg_lsvd_write(img, data, c_ulong(offset), c_uint(nbytes))
+    return val
+
+def img_read(img, offset, nbytes):
+    assert (nbytes % 512) == 0 and (offset % 512) == 0
+    buf = (c_char * nbytes)()
+    val = lsvd_lib.dbg_lsvd_read(img, buf, c_ulong(offset), c_uint(nbytes))
+    return buf[0:nbytes]
+
+def img_flush(img):
+    lsvd_lib.dbg_lsvd_flush(img)
+
+LSVD_SUPER = 1
+LSVD_DATA = 2
+LSVD_CKPT = 3
+LSVD_MAGIC = 0x4456534c
+
+
+###############
+
+class write_cache:
+    def __init__(self, file):
+        self._fd = os.open(file, os.O_RDWR | os.O_DIRECT)
+        self.fd = os.open(file, os.O_RDONLY)
+        data = os.pread(self.fd, 4096, 0)
+        self.super = j_super.from_buffer(bytearray(data[0:sizeof(j_super)]))
+
+    def init(self, xlate, blkno):
+        p = c_void_p()
+        lsvd_lib.wcache_open(xlate.lsvd, c_int(blkno), c_int(self._fd), byref(p))
+        self.wcache = p
+        
+    def shutdown(self):
+        os.close(self._fd)
+        os.close(self.fd)
+        lsvd_lib.wcache_close(self.wcache)
+
+    def read(self, offset, nbytes):
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        buf = (c_char * nbytes)()
+        lsvd_lib.wcache_read(self.wcache, buf, c_ulong(offset), c_uint(nbytes))
+        return buf[0:nbytes]
+        
+    def write(self, offset, data):
+        if type(data) != bytes:
+            data = bytes(data, 'utf-8')
+        nbytes = len(data)
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        val = lsvd_lib.wcache_write(self.wcache, data, c_ulong(offset), c_uint(nbytes))
+
+    def getmap(self, base, limit):
+        n_tuples = 128
+        tuples = (tuple * n_tuples)()
+        n = lsvd_lib.wcache_getmap(self.wcache, c_int(base), c_int(limit), c_int(n_tuples), byref(tuples))
+        return list(map(lambda x: [x.base, x.limit, x.plba], tuples[0:n]))
+
+    def getsuper(self):
+        s = j_write_super()
+        lsvd_lib.wcache_get_super(self.wcache, byref(s))
+        return s
+
+    def oldest(self, blk):
+        exts = (j_extent * 32)()
+        n = c_int()
+        newer = lsvd_lib.wcache_oldest(self.wcache, c_int(blk), byref(exts), 32, byref(n))
+        e = [(_.lba, _.len) for _ in exts[0:n.value]]
+        return [newer, e]
+
+    def checkpoint(self):
+        lsvd_lib.wcache_write_ckpt(self.wcache)
+
+def wcache_img_write(img, offset, data):
+    if type(data) != bytes:
+        data = bytes(data, 'utf-8')
+    nbytes = len(data)
+    assert (nbytes % 512) == 0 and (offset % 512) == 0
+    val = lsvd_lib.wcache_img_write(img, data, c_ulong(offset), c_uint(nbytes))
+
+
+class read_cache:
+    def __init__(self, xlate, blkno, _fd):
+        p = c_void_p()
+        lsvd_lib.rcache_init(xlate.lsvd, c_uint(blkno), c_int(_fd), byref(p))
+        self.rcache = p
+        self.rsuper = j_read_super()
+        lsvd_lib.rcache_getsuper(self.rcache, byref(self.rsuper))
+
+    def close(self):
+        lsvd_lib.rcache_shutdown(self.rcache)
+
+    def read(self, offset, nbytes):
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        buf = (c_char * nbytes)()
+        lsvd_lib.rcache_read(self.rcache, buf, c_ulong(offset), c_ulong(nbytes))
+        return buf[0:nbytes]
+
+    def read2(self, offset, nbytes):
+        assert (nbytes % 512) == 0 and (offset % 512) == 0
+        buf = (c_char * nbytes)()
+        lsvd_lib.rcache_read2(self.rcache, buf, c_ulong(offset), c_ulong(nbytes))
+        return buf[0:nbytes]
+    
+    def add(self, obj, blk, data):
+        if type(data) != bytes:
+            data = bytes(data, 'utf-8')
+        nbytes = len(data)
+        assert nbytes == 65536
+        lsvd_lib.rcache_add(self.rcache, c_int(obj), c_int(blk), data, c_int(nbytes))
+        
+    def getmap(self):
+        n = self.rsuper.units
+        k = (obj_offset * n)()
+        v = (c_int * n)()
+        m = lsvd_lib.rcache_getmap(self.rcache, byref(k), byref(v), n)
+        keys = [[_.obj, _.offset] for _ in k[0:m]]
+        vals = v[:]
+        return list(zip(keys, vals))
+
+    def flatmap(self):
+        n = self.rsuper.units
+        vals = (obj_offset * n)()
+        n = lsvd_lib.rcache_get_flat(self.rcache, byref(vals), c_int(n))
+        return [[_.obj,_.offset] for _ in vals[0:n]]
+
+    def evict(self, n):
+        lsvd_lib.rcache_evict(self.rcache, c_int(n))
+
+def logbuf():
+    buf = (c_char * 4096)()
+    nbytes = lsvd_lib.get_logbuf(buf, c_int(4096))
+    return (buf[0:nbytes]).decode('utf-8')
+
+# RBD functions
+
+def rbd_open(name):
+    img = c_void_p()
+    rv = lsvd_lib.rbd_open(None, c_char_p(bytes(name, 'utf-8')), byref(img), None)
+    assert rv >= 0
+    return img
+
+def rbd_close(img):
+    lsvd_lib.rbd_close(img)
+
+def rbd_read(img, off, nbytes):
+    buf = (c_char * nbytes)()
+    lsvd_lib.rbd_read(img, c_ulong(off), c_ulong(nbytes), buf)
+    return buf[0:nbytes]
+
+def rbd_write(img, off, data):
+    if type(data) != bytes:
+        data = bytes(data, 'utf-8')
+    nbytes = len(data)
+    lsvd_lib.rbd_write(img, c_ulong(off), c_ulong(nbytes), data)
+    
+def rbd_flush(img):
+    lsvd_lib.rbd_flush(img)
+
+
+

--- a/src/liblsvd/tools/lsvd_types.py
+++ b/src/liblsvd/tools/lsvd_types.py
@@ -1,0 +1,203 @@
+from ctypes import *
+
+class tuple(Structure):
+    _fields_ = [("base",   c_int),
+                ("limit",  c_int),
+                ("obj",    c_int),
+                ("offset", c_int),
+                ("plba",   c_int)]
+
+LSVD_SUPER = 1
+LSVD_DATA = 2
+LSVD_CKPT = 3
+LSVD_MAGIC = 0x4456534c
+
+# these match version 453d93 of objects.cc
+
+class hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",               c_uint),
+                ("version",             c_uint),
+                ("vol_uuid",            c_ubyte*16),
+                ("type",                c_uint),
+                ("seq",                 c_uint),
+                ("hdr_sectors",         c_uint),
+                ("data_sectors",        c_uint),
+                ("crc",                 c_uint)]
+sizeof_hdr = sizeof(hdr) # 44
+
+class super_hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("vol_size",            c_ulong),
+                ("ckpts_offset",        c_uint),
+                ("ckpts_len",           c_uint),
+                ("clones_offset",       c_uint),
+                ("clones_len",          c_uint),
+                ("snaps_offset",        c_uint),
+                ("snaps_len",           c_uint)]
+sizeof_super_hdr = sizeof(super_hdr) # 56
+
+# ckpts is array of uint32
+
+class clone_info(Structure):
+    _pack_ = 1
+    _fields_ = [("vol_uuid",            c_ubyte*16),
+                ("last_seq",            c_uint),
+                ("name_len",            c_ubyte)]   # 21 bytes
+        # followed by 'name_len' bytes of name
+sizeof_clone_info = sizeof(clone_info) # 21
+
+class snap(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("name_len",            c_ubyte)]
+sizeof_snap = sizeof(snap) # 5
+
+class data_hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("cache_seq",           c_ulong),
+                ("objs_cleaned_offset", c_uint),
+                ("objs_cleaned_len",    c_uint),
+                ("map_offset",          c_uint),
+                ("map_len",             c_uint)]
+sizeof_data_hdr = sizeof(data_hdr) # 24
+
+class obj_cleaned(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("was_deleted",         c_uint)]
+sizeof_obj_cleaned = sizeof(obj_cleaned) # 8
+
+class data_map(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("lba",                 c_ulong, 36),
+                ("len",                 c_ulong, 28)]
+sizeof_data_map = sizeof(data_map) # 8
+
+class ckpt_hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("cache_seq",           c_ulong),
+                ("ckpts_offset",        c_uint),
+                ("ckpts_len",           c_uint),
+                ("objs_offset",         c_uint),
+                ("objs_len",            c_uint),
+                ("deletes_offset",      c_uint),
+                ("deletes_len",         c_uint),
+                ("map_offset",          c_uint),
+                ("map_len",             c_uint)]
+sizeof_ckpt_hdr = sizeof(ckpt_hdr) # 40
+
+class ckpt_obj(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("hdr_sectors",         c_uint),
+                ("data_sectors",        c_uint),
+                ("live_sectors",        c_uint)]
+sizeof_ckpt_obj = sizeof(ckpt_obj) # 16
+
+class deferred_delete(Structure):
+    _pack_ = 1
+    _fields_ = [("seq",                 c_uint),
+                ("time",                c_uint)]
+sizeof_deferred_delete = sizeof(deferred_delete)
+
+class ckpt_mapentry(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("lba",                 c_ulong, 36),
+                ("len",                 c_ulong, 28),
+                ("obj",                 c_uint),
+                ("offset",              c_uint)]
+sizeof_ckpt_mapentry = sizeof(ckpt_mapentry) # 16
+
+class obj_offset(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("obj", c_ulong, 36),
+                ("offset", c_ulong, 28)]
+sizeof_obj_offset = sizeof(obj_offset)
+
+class j_extent(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("lba", c_ulong, 40),
+                ("len", c_ulong, 24)]
+sizeof_j_extent = sizeof(j_extent)
+
+class j_map_extent(LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("lba",  c_ulong, 40),
+                ("len",  c_ulong, 24),
+                ("plba", c_ulong)]
+sizeof_j_map_extent = sizeof(j_map_extent)
+
+class j_length(Structure):
+    _pack_ = 1
+    _fields_ = [("page", c_uint),
+                ("len", c_uint)]
+sizeof_j_length = sizeof(j_length)
+
+LSVD_J_DATA    = 10
+LSVD_J_CKPT    = 11
+LSVD_J_PAD     = 12
+LSVD_J_SUPER   = 13
+LSVD_J_W_SUPER = 14
+LSVD_J_R_SUPER = 15
+
+class j_hdr(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",         c_uint),
+                ("type",          c_uint),
+                ("version",       c_uint),
+                ("len",           c_uint),
+                ("seq",           c_ulong),
+                ("crc32",         c_uint),
+                ("extent_offset", c_uint),
+                ("extent_len",    c_uint),
+                ("prev",          c_uint)]
+sizeof_j_hdr = sizeof(j_hdr)
+
+class j_write_super(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",       c_uint),
+                ("type",        c_uint),
+                ("version",     c_uint),
+                ("clean",       c_uint),
+                ("seq",         c_ulong),
+                ("meta_base",   c_int),
+                ("meta_limit",  c_int),
+                ("base",        c_int),
+                ("limit",       c_int),
+                ("next",        c_int),
+                ("map_start",   c_int),
+                ("map_blocks",  c_int),
+                ("map_entries", c_int),
+                ("len_start",   c_int),
+                ("len_blocks",  c_int),
+                ("len_entries", c_int)]
+sizeof_j_write_super = sizeof(j_write_super)
+
+class j_read_super(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",        c_uint),
+                ("type",         c_uint),
+                ("version",      c_uint),
+                ("unit_size",    c_int),
+                ("base",         c_int),
+                ("units",        c_int),
+                ("map_start",    c_int),
+                ("map_blocks",   c_int)]
+sizeof_j_read_super = sizeof(j_read_super)
+
+class j_super(Structure):
+    _pack_ = 1
+    _fields_ = [("magic",        c_uint),
+                ("type",         c_uint),
+                ("version",      c_uint),
+                ("write_super",  c_uint),
+                ("read_super",   c_uint),
+                ("vol_uuid",     c_ubyte*16)]
+sizeof_j_super = sizeof(j_super)
+
+class iovec(Structure):
+    _fields_ = [('iov_base', c_void_p),
+                ('iov_len', c_size_t)]
+
+iovec_ptr = POINTER(iovec)

--- a/src/liblsvd/tools/mkcache.py
+++ b/src/liblsvd/tools/mkcache.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python3
+
+import lsvd_types as lsvd
+import sys
+import os
+import argparse
+import uuid
+import blkdev
+
+# TODO:
+# 1. variable size
+# 3. option to not write cache pages
+
+def div_round_up(n, m):
+    return (n + m - 1) // m
+
+# rm -f <cachedir>/*.cache
+def cleanup(name):
+    cache_dir = os.path.dirname(name)
+    if not os.access(cache_dir, os.R_OK | os.X_OK):
+        os.mkdir(cache_dir)
+    for f in os.listdir(cache_dir):
+        if f.endswith('.cache'):
+            os.unlink(cache_dir + '/' + f)
+    
+# https://stackoverflow.com/questions/42865724/parse-human-readable-filesizes-into-bytes
+units = {"K": 2**10, "M": 2**20, "G": 2**30}
+def parse_size(size):
+    if size[-1:] in units:
+        return int(float(size[:-1])*units[size[-1]])
+    else:
+        return int(size)
+
+# backend batch size is 8MB, write cache should be >= 2 batches
+# 
+def mkcache(name, uuid=b'\0'*16, write_zeros=True, wblks=4096, rblks=4096):
+    fd = os.open(name, os.O_RDWR | os.O_CREAT, 0o777)
+
+    sup = lsvd.j_super(magic=lsvd.LSVD_MAGIC, type=lsvd.LSVD_J_SUPER,
+                       write_super=1, read_super=2, backend_type=lsvd.LSVD_BE_FILE)
+    sup.vol_uuid[:] = uuid
+    data = bytearray() + sup
+    data += b'\0' * (4096-len(data))
+    os.write(fd, data) # page 0
+
+    # assuming 4KB min write size, write cache has max metadata of 16 bytes
+    # extent + 8 bytes length per 4KB, but we need an integer
+    # number of pages for each section, and enough room for 2.
+    #
+    _map = div_round_up(wblks, 256)
+    _len = div_round_up(wblks, 512)
+    mblks = 2 * (_map + _len)
+    wblks -= mblks
+    
+    # write cache has 125 single-page entries. default: map_blocks = map_entries = 0
+    wsup = lsvd.j_write_super(magic=lsvd.LSVD_MAGIC, type=lsvd.LSVD_J_W_SUPER,
+                                seq=1, meta_base = 3, meta_limit = 3+mblks,
+                                base=3+mblks, limit=3+mblks+wblks,
+                                next=3+mblks, oldest=3+mblks, clean=1)
+    data = bytearray() + wsup
+    data += b'\0' * (4096-len(data))
+    os.write(fd, data) # page 1
+
+    rbase = wblks+mblks+3
+    units = rblks // 16
+    map_blks = div_round_up(units*lsvd.sizeof_obj_offset, 4096)
+    
+    # 1 page for map
+    rsup = lsvd.j_read_super(magic=lsvd.LSVD_MAGIC, type=lsvd.LSVD_J_R_SUPER,
+                                unit_size=128, units=units,
+                                map_start=rbase, map_blocks=map_blks,
+                                base=rbase+map_blks)
+
+    data = bytearray() + rsup
+    data += b'\0' * (4096-len(data))
+    os.write(fd, data) # page 2
+
+    # zeros are invalid entries for cache map
+    # 130 + 16*(64KB/4KB) = 386
+
+    data = bytearray(b'\0'*4096)
+    if (write_zeros):
+        for i in range(3 + mblks + wblks + map_blks + rblks):
+            os.write(fd, data)
+    else:
+        for i in range(rbase,rbase+map_blks):
+            os.pwrite(fd, data, i*4096)
+    
+    os.close(fd)
+    
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='initialize LSVD cache')
+    parser.add_argument('--uuid', help='volume UUID',
+                            default='00000000-0000-0000-0000-000000000000')
+    parser.add_argument('--size', help='volue size',
+                            default=0)
+    parser.add_argument('device', help='cache partition')
+    args = parser.parse_args()
+
+    uuid = uuid.UUID(args.uuid).bytes
+
+    if not os.access(args.device, os.F_OK) and args.size:
+        size = parse_size(args.size)
+        buf = bytes(4096)
+        fp = open(args.device, 'wb')
+        for i in range(0, size, 4096):
+            fp.write(buf)
+        fp.close()
+    
+    if os.access(args.device, os.F_OK):
+        s = os.stat(args.device)
+        if blkdev.S_ISBLK(s.st_mode):
+            bytes = blkdev.dev_get_size(os.open(args.device, os.O_RDONLY))
+        else:
+            bytes = s.st_size
+        pages = bytes // 4096
+        print('%d pages' % pages)
+        r_units = int(0.75*pages) // 16
+        r_pages = r_units * 16
+        r_oh = div_round_up(r_units*lsvd.sizeof_obj_offset, 4096)
+        w_pages = pages - r_pages - r_oh - 3     # mkcache subtracts write metadata
+    
+        mkcache(args.device, uuid, write_zeros=False, wblks=w_pages, rblks=r_pages)
+    else:
+        mkcache(args.device, uuid)
+

--- a/src/liblsvd/tools/mkdisk.py
+++ b/src/liblsvd/tools/mkdisk.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+import ctypes
+from lsvd_types import *
+import os
+import re
+import argparse
+import uuid
+try:
+    import rados
+except:
+    pass
+
+# based on https://stackoverflow.com/a/42865957/2002471
+units = {"B": 1, "KB": 2**10, "MB": 2**20, "GB": 2**30, "TB": 2**40}
+
+def parse_size(size):
+    size = re.sub(r'(\d+)([KMGT]?)', r'\1 \2B', size.upper())
+    number, unit = [string.strip() for string in size.split()]
+    return int(float(number)*units[unit])
+
+def mkdisk(name, sectors, uuid=b'\0'*16, use_rados=False):
+    _hdr = hdr(magic=LSVD_MAGIC, version=1, type=LSVD_SUPER,
+                  hdr_sectors=8, data_sectors=0)
+    _hdr.vol_uuid[:] = uuid
+    data = bytearray() + _hdr
+    
+    super = super_hdr(vol_size=sectors, next_obj=1)
+    data += super
+
+    data += b'\0' * (4096-len(data))
+
+    if use_rados:
+        cluster = rados.Rados(conffile='')
+        cluster.connect();
+        pool,prefix = name.split("/")
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        print(type(data))
+        ioctx.write(prefix, bytes(data))
+        ioctx.close()
+        cluster.shutdown()
+    else:
+        fp = open(name, 'wb')
+        fp.write(data) # page 1
+        fp.close()
+
+def cleanup_files(name):
+    d = os.path.dirname(name)
+    b = os.path.basename(name)
+    if not os.access(d, os.F_OK):
+        os.mkdir(d)
+    for f in os.listdir(d):
+        if f.startswith(b):
+            os.unlink(d + '/' + f)
+
+# go to a bit of trouble to handle object names containing '/'
+def cleanup_rados(name):
+    tmp = name.split('/')
+    pool = tmp[0]
+    prefix = '/'.join(tmp[1:])
+    
+    cluster = rados.Rados(conffile='')
+    cluster.connect()
+    if not cluster.pool_exists(pool):
+        raise RuntimeError('Pool not found ' + pool)
+    ioctx = cluster.open_ioctx(pool)
+    for obj in ioctx.list_objects():
+        if obj.key.startswith(prefix):
+            ioctx.remove_object(obj.key)
+    ioctx.close()
+    cluster.shutdown()
+    
+if __name__ == '__main__':
+    _rnd_uuid = str(uuid.uuid4())
+    parser = argparse.ArgumentParser(description='create LSVD disk')
+    parser.add_argument('--size', help='volume size (k/m/g)', default='10m')
+    parser.add_argument('--uuid', help='volume UUID', default=_rnd_uuid)
+    parser.add_argument('--rados', help='use RADOS backend', action='store_true');
+    parser.add_argument('prefix', help='superblock name')
+    args = parser.parse_args()
+
+    size = parse_size(args.size)
+    _uuid = uuid.UUID(args.uuid).bytes
+
+    if not args.rados:
+        cleanup_files(args.prefix)
+    mkdisk(args.prefix, size//512, _uuid, args.rados)
+

--- a/src/liblsvd/tools/parse.py
+++ b/src/liblsvd/tools/parse.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python3
+
+import os
+import lsvd_types as lsvd
+import sys
+import uuid
+from ctypes import *
+import argparse
+
+parser = argparse.ArgumentParser(description='Read backend object')
+parser.add_argument('--rados', help='fetch from RADOS', action='store_true')
+parser.add_argument('--nowrap', help='one entry per line', action='store_true')
+parser.add_argument('object', help='object path')
+args = parser.parse_args()
+
+if args.rados:
+    import rados
+    pool,oid = args.object.split('/')
+    cluster = rados.Rados(conffile='')
+    cluster.connect()
+    if not cluster.pool_exists(pool):
+        raise RuntimeError('Pool not found: ' + pool)
+    ioctx = cluster.open_ioctx(pool)
+    obj = ioctx.read(oid, 4096, 0)
+    h = lsvd.hdr.from_buffer(bytearray(obj[0:sizeof(lsvd.hdr)]))
+    obj = ioctx.read(oid, 512*h.hdr_sectors, 0)
+    ioctx.close()
+else:
+    f = open(args.object, 'rb')
+    obj = f.read(None)
+    f.close()
+
+def read_obj(name):
+    if args.rados:
+        pool,oid = name.split('/')
+        if not cluster.pool_exists(pool):
+            raise RuntimeError('Pool not found: ' + pool)
+        ioctx = cluster.open_ioctx(pool)
+        obj = ioctx.read(oid)
+        ioctx.close()
+    else:
+        f = open(name, 'rb')
+        obj = f.read(None)
+        f.close()
+    return obj
+
+o2 = l1 = lsvd.sizeof_hdr
+
+def fmt_ckpt(ckpts):
+    return map(lambda x: "%d (0x%x)" % (x,x), ckpts)
+
+def fmt_obj_cleaned(objs):
+    l = []
+    for o in objs:
+        l.append("[%d %d]" % (o.seq, o.was_deleted))
+    return l
+
+def fmt_obj(objs):
+    l = []
+    for o in objs:
+        l.append("[obj=%d hdr=%d data=%d live=%d]" % (o.seq, o.hdr_sectors, o.data_sectors, o.live_sectors))
+    return l
+
+def fmt_data_map(maps):
+    l = []
+    for m in maps:
+        l.append("[%d %d]" % (m.lba, m.len))
+    return l
+
+def fmt_ckpt_map(maps):
+    l = []
+    for m in maps:
+        l.append("[%d+%d -> %d+%d]" % (m.lba, m.len, m.obj, m.offset))
+    return l
+
+def read_ckpts(buf, base, bytes):
+    if bytes <= 0:
+        return [ ]
+    n = bytes//4
+    ckpts = (c_int * n).from_buffer(buf[base:base+bytes])
+    return [_ for _ in ckpts]
+
+import zlib
+print('crc:          %08x' % zlib.crc32(obj))
+
+def print_clone(c, name, indent):
+    uu = uuid.UUID(bytes=bytes(c.vol_uuid))
+    print(indent + 'clone base:    ', str(name,'utf-8'))
+    print(indent + '  last seq:    ', c.last_seq)
+    print(indent + '      uuid:    ', str(uu))
+
+    _name = str(name,'utf-8')
+    obj = read_obj(_name)
+    o2 = lsvd.sizeof_hdr
+    o3 = o2+lsvd.sizeof_super_hdr
+    sh = lsvd.super_hdr.from_buffer(bytearray(obj[o2:o3]))
+
+    if sh.clones_len > 0:
+        o1 = sh.clones_offset
+        o2 = o1+lsvd.sizeof_clone
+        c = lsvd.clone_info.from_buffer(bytearray(obj[o1:o2]))
+        name = obj[o2:o2+c.name_len]
+        print_clone(c, name, '  ')
+
+    
+h = lsvd.hdr.from_buffer(bytearray(obj[0:l1]))
+if h.type == lsvd.LSVD_SUPER:
+    o3 = o2+lsvd.sizeof_super_hdr
+    sh = lsvd.super_hdr.from_buffer(bytearray(obj[o2:o3]))
+    uu = uuid.UUID(bytes=bytes(h.vol_uuid))
+    print('name:     ', args.object)
+    print('magic:    ', 'OK' if h.magic == lsvd.LSVD_MAGIC else '**BAD**')
+    print('UUID:     ', str(uu))
+    print('version:  ', h.version)
+    print('type:     ', 'SUPER')
+    print('seq:      ', h.seq)
+    print('n_hdr:    ', h.hdr_sectors)
+    print('n_data:   ', h.data_sectors)
+    print('crc:      ', '%08x' % h.crc)
+
+    print('vol_size:      ', sh.vol_size)
+    print('ckpts_offset:  ', sh.ckpts_offset)
+    print('ckpts_len:     ', sh.ckpts_len)
+    if sh.ckpts_len > 0:
+        ckpts = read_ckpts(bytearray(obj), sh.ckpts_offset, sh.ckpts_len)
+        print('ckpts:         ', ','.join(map(lambda x: '%08x' % x, ckpts)))
+    if sh.clones_len > 0:
+        o1 = sh.clones_offset
+        o2 = o1+sizeof(lsvd.clone_info)
+        c = lsvd.clone_info.from_buffer(bytearray(obj[o1:o2]))
+        name = obj[o2:o2+c.name_len]
+        print_clone(c, name, '')
+
+    print('snaps:         ', '[tbd]')
+    
+elif h.type == lsvd.LSVD_DATA:
+    o3 = o2+lsvd.sizeof_data_hdr
+    dh = lsvd.data_hdr.from_buffer(bytearray(obj[o2:o3]))
+        
+    o5 = dh.objs_cleaned_offset; l5 = dh.objs_cleaned_len
+    objs = (lsvd.obj_cleaned * (l5//lsvd.sizeof_obj_cleaned)).from_buffer(bytearray(obj[o5:o5+l5]))
+
+    o6 = dh.map_offset; l6 = dh.map_len
+    maps = (lsvd.data_map * (l6//lsvd.sizeof_data_map)).from_buffer(bytearray(obj[o6:o6+l6]))
+
+    print('name:     ', args.object)
+    print('magic:    ', 'OK' if h.magic == lsvd.LSVD_MAGIC else '**BAD**')
+    print('version:  ', h.version)
+    print('type:     ', 'DATA')
+    print('seq:      ', h.seq)
+    print('n_hdr:    ', h.hdr_sectors)
+    print('n_data:   ', h.data_sectors)
+    print('crc:      ', '%08x' % h.crc)
+    print('wseq:     ', dh.cache_seq)
+    print('cleaned:  ', dh.objs_cleaned_offset, ':', ', '.join(fmt_obj_cleaned(objs)))
+    if args.nowrap:
+            print('map:')
+            print(' ' + '\n '.join(fmt_data_map(maps)))
+    else:
+        print('map:      ', '%d+%d' % (dh.map_offset,dh.map_len), ':', ', '.join(fmt_data_map(maps)))
+    
+elif h.type == lsvd.LSVD_CKPT:
+    o3 = o2+lsvd.sizeof_ckpt_hdr
+    ch = lsvd.ckpt_hdr.from_buffer(bytearray(obj[o2:o3]))
+
+    o4 = ch.ckpts_offset; l4 = ch.ckpts_len
+    ckpts = (c_uint * (l4//4)).from_buffer(bytearray(obj[o4:o4+l4]))
+    
+    o5 = ch.objs_offset; l5 = ch.objs_len
+
+    if o5+l5 > len(obj):
+        objs_txt = 'OBJECT TOO SHORT (%d bytes)' % len(obj)
+    else:
+        objs = (lsvd.ckpt_obj * (l5//lsvd.sizeof_ckpt_obj)).from_buffer(bytearray(obj[o5:o5+l5]))
+        if args.nowrap:
+            objs_txt = '\n ' + '\n '.join(fmt_obj(objs))
+        else:
+            objs_txt = ', '.join(fmt_obj(objs))
+
+#    o6 = ch.deletes_offset; l6 = ch.deletes_len
+#    dels = (lsvd.deferred_delete * (l5//lsvd.sizeof_deferred_delete)).from_buffer(bytearray(obj[o6:o6+l6]))
+
+    o7 = ch.map_offset; l7 = ch.map_len
+    if o7+l7 > len(obj):
+        map_txt = 'OBJECT TOO SHORT (%d bytes)' % len(obj)
+    else:
+        maps = (lsvd.ckpt_mapentry * (l7//lsvd.sizeof_ckpt_mapentry)).from_buffer(bytearray(obj[o7:o7+l7]))
+        if args.nowrap:
+            map_txt = '\n ' + '\n '.join(fmt_ckpt_map(maps))
+        else:
+            map_txt = ', '.join(fmt_ckpt_map(maps))
+
+    print('name:     ', args.object)
+    print('magic:    ', 'OK' if h.magic == lsvd.LSVD_MAGIC else '**BAD**')
+    print('version:  ', h.version)
+    print('type:     ', 'CKPT')
+    print('seq:      ', h.seq)
+    print('n_hdr:    ', h.hdr_sectors)
+    print('n_data:   ', h.data_sectors)
+    print('crc:      ', '%08x' % h.crc)
+    
+    print('cache_seq:', ch.cache_seq)
+    print('ckpts:    ', ch.ckpts_offset, ':', ', '.join(fmt_ckpt(ckpts)))
+    print('objs:     ', ch.objs_offset, ':', objs_txt)
+    print('map:      ', ch.map_offset, ':', map_txt)
+    
+else:
+    print("invalid type:", h.type)

--- a/src/liblsvd/tools/test3.py
+++ b/src/liblsvd/tools/test3.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import lsvd_types as lsvd
+import ctypes
+import mkdisk
+import mkcache
+
+def c_super(fd):
+    b = bytearray(os.pread(fd, 4096, 0))   # always first block
+    return lsvd.j_super.from_buffer(b[0:lsvd.sizeof_j_super])
+
+def c_w_super(fd, blk):
+    b = bytearray(os.pread(fd, 4096, 4096*blk))
+    return lsvd.j_write_super.from_buffer(b[0:lsvd.sizeof_j_write_super])
+
+def c_r_super(fd, blk):
+    b = bytearray(os.pread(fd, 4096, 4096*blk))
+    return lsvd.j_read_super.from_buffer(b[0:lsvd.sizeof_j_read_super])
+
+def c_hdr(fd, blk):
+    b = bytearray(os.pread(fd, 4096, 4096*blk))
+    o2 = lsvd.sizeof_j_hdr
+    h = lsvd.j_hdr.from_buffer(b[0:o2])
+    e = []
+    if h.magic == lsvd.LSVD_MAGIC:
+        n_exts = h.extent_len // lsvd.sizeof_j_extent
+        e = (lsvd.j_extent*n_exts).from_buffer(b[o2:o2+h.extent_len])
+    return [h, e]
+

--- a/src/liblsvd/translate.cc
+++ b/src/liblsvd/translate.cc
@@ -1,0 +1,1363 @@
+/*
+ * file:        translate.cc
+ * description: core translation layer - implementation
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <unistd.h>
+#include <sys/uio.h>
+#include <string.h>
+
+#include <uuid/uuid.h>
+#include <zlib.h>
+
+#include <vector>
+#include <mutex>
+#include <condition_variable>
+#include <shared_mutex>
+#include <atomic>
+
+#include <stack>
+#include <map>
+
+#include <algorithm>
+
+#include <thread>
+
+#include "extent.h"
+#include "lsvd_types.h"
+#include "request.h"
+#include "objects.h"
+#include "objname.h"
+#include "config.h"
+#include "translate.h"
+
+#include "backend.h"
+#include "smartiov.h"
+#include "misc_cache.h"
+
+
+void do_log(const char*, ...);
+void fp_log(const char*, ...);
+extern void log_time(uint64_t loc, uint64_t val); // debug
+
+/* ----------- Object translation layer -------------- */
+
+class batch {
+public:
+    std::vector<data_map> entries;
+    char  *_buf = NULL;		// allocation start
+    char  *buf = NULL;		// data goes here
+    size_t len = 0;		// current data size
+    size_t max;			// done when len hits here
+    int    seq = 0;		// sequence number for backend
+    uint64_t cache_seq = 0;
+
+    batch(size_t bytes){
+	int room = 16*1024*sizeof(data_map) + 512;
+	_buf = (char*)malloc(bytes + room);
+	buf = _buf + room;
+	max = bytes;
+    }
+    ~batch(){
+	free(_buf);
+    }
+    void append(uint64_t lba, smartiov *iov) {
+	auto bytes = iov->bytes();
+	entries.push_back((data_map){lba, bytes/512});
+	char *ptr = buf + len;
+	iov->copy_out(ptr);
+	len += bytes;
+    }
+};
+
+class translate_impl : public translate {
+    /* lock ordering: lock m before *map_lock
+     */
+    std::mutex         m;	// for things in this instance
+    extmap::objmap    *map;	// shared object map
+    std::shared_mutex *map_lock; // locks the object map
+    lsvd_config       *cfg;
+
+    std::atomic<int>   seq;
+    uint64_t           ckpt_cache_seq = 0; // from last data object
+    
+    friend class translate_req;
+    batch *b = NULL;
+    
+    /* info on live data objects - all sizes in sectors 
+     * checkpoints are tracked in @checkpoints, and in the superblock
+     */
+    struct obj_info {
+	int hdr;		// sectors
+	int data;		// sectors
+	int live;		// sectors
+    };
+    std::map<int,obj_info> object_info;
+
+    std::vector<uint32_t> checkpoints;
+    
+    /* tracking completions for flush()
+     */
+    int       next_compln = 1;
+    int       last_sent = 0;	// most recent data object
+    std::atomic<int> outstanding_writes = 0; // wait_for_room
+    
+    std::set<int> pending_writes;
+    std::condition_variable cv;
+    bool stopped = false;	// stop GC from writing
+
+    /* various constant state
+     */
+    struct clone {
+	char prefix[128];
+	int  last_seq;
+	int  first_seq = 0;
+    };
+    std::vector<clone> clone_list;
+    char               super_name[128];
+
+    /* superblock has two sections: [obj_hdr] [super_hdr]
+     */
+    char      *super_buf = NULL;
+    obj_hdr   *super_h = NULL;
+    super_hdr *super_sh = NULL;
+    size_t     super_len;
+
+
+    thread_pool<batch*> *workers;
+    thread_pool<int>    *misc_threads; // so we can stop ckpt, gc first
+
+    /* for triggering GC
+     */
+    sector_t total_sectors = 0;
+    sector_t total_live_sectors = 0;
+    int gc_cycles = 0;
+    int gc_sectors_read = 0;
+    int gc_sectors_written = 0;
+    int gc_deleted = 0;
+
+    /* for shutdown
+     */
+    bool gc_running = false;
+    std::condition_variable gc_cv;
+    void stop_gc(void);
+    
+    object_reader *parser;
+    
+    /* maybe use insertion sorted vector?
+     *  https://stackoverflow.com/questions/15843525/how-do-you-insert-the-value-in-a-sorted-vector
+     */
+
+    void write_checkpoint(int seq);
+    batch *check_batch_room(size_t len);
+    void process_batch(batch *b);
+    void worker_thread(thread_pool<batch*> *p);
+    
+    sector_t make_gc_hdr(char *buf, uint32_t seq, sector_t sectors,
+			 data_map *extents, int n_extents);
+
+    void do_gc(bool *running);
+    void gc_thread(thread_pool<int> *p);
+    void flush_thread(thread_pool<int> *p);
+
+    backend *objstore;
+
+    /* all objects seq<next_compln have been completed
+     */
+    void seq_record(int _seq) {
+	std::unique_lock lk(m);
+	if (_seq > last_sent) {
+	    last_sent = _seq;
+	    do_log("last_sent2 : %d\n", last_sent);
+	}
+	pending_writes.insert(_seq);
+    }
+
+    void seq_complete(int _seq) {
+	std::unique_lock lk(m);
+	pending_writes.erase(_seq);
+	auto it = pending_writes.begin();
+	if (it == pending_writes.end())
+	    next_compln = last_sent+1;
+	else
+	    next_compln = *it;
+	do_log("next_compln = %d\n", next_compln);
+	cv.notify_all();
+    }
+
+public:
+    translate_impl(backend *_io, lsvd_config *cfg_,
+		   extmap::objmap *map, std::shared_mutex *m);
+    ~translate_impl();
+
+    ssize_t init(const char *name, bool timedflush);
+    void shutdown(void);
+
+    int flush(void);            /* write out current batch */
+    int checkpoint(void);       /* flush, then write checkpoint */
+
+    ssize_t writev(uint64_t cache_seq, size_t offset, iovec *iov, int iovcnt);
+    void wait_for_room(void);
+    ssize_t readv(size_t offset, iovec *iov, int iovcnt);
+    bool check_object_ready(int obj);
+    void wait_object_ready(int obj);
+    void start_gc(void);
+    
+    const char *prefix(int seq);
+    
+};
+
+const char *translate_impl::prefix(int seq) {
+    if (clone_list.size() == 0 || seq > clone_list.front().last_seq)
+	return super_name;
+    for (auto const & c : clone_list)
+	if (seq >= c.first_seq)
+	    return c.prefix;
+    assert(false);
+}
+
+translate_impl::translate_impl(backend *_io, lsvd_config *cfg_,
+			       extmap::objmap *map_, std::shared_mutex *m_) {
+    misc_threads = new thread_pool<int>(&m);
+    workers = new thread_pool<batch*>(&m);
+    objstore = _io;
+    parser = new object_reader(objstore);
+    map = map_;
+    map_lock = m_;
+    cfg = cfg_;
+}
+
+translate *make_translate(backend *_io, lsvd_config *cfg,
+			  extmap::objmap *map, std::shared_mutex *m) {
+    return (translate*) new translate_impl(_io, cfg, map, m);
+}
+
+translate_impl::~translate_impl() {
+    stopped = true;
+    cv.notify_all();
+    if (b) 
+	delete b;
+    delete parser;
+    if (super_buf)
+	free(super_buf);
+}
+
+ssize_t translate_impl::init(const char *prefix_, bool timedflush) {
+    std::vector<uint32_t>    ckpts;
+    std::vector<clone_info*> clones;
+    std::vector<snap_info*>  snaps;
+
+    /* note prefix = superblock name
+     */
+    strcpy(super_name, prefix_);
+
+    auto [_buf, bytes] = parser->read_super(super_name, ckpts, clones,
+					    snaps, uuid);
+    if (bytes < 0)
+	return bytes;
+    
+    int n_ckpts = ckpts.size();
+    do_log("read super crc %0x8 ckpts %d\n", (uint32_t)crc32(0, (const unsigned char*)_buf, 4096));
+
+    for (auto c : ckpts) 
+	do_log("got ckpt from super (total %d): %d\n", n_ckpts, c);
+    
+    super_buf = _buf;
+    super_h = (obj_hdr*)super_buf;
+    super_len = super_h->hdr_sectors * 512;
+    super_sh = (super_hdr*)(super_h+1);
+
+    memcpy(&uuid, super_h->vol_uuid, sizeof(uuid));
+
+    b = new batch(cfg->batch_size);
+    seq = 1;			// empty volume case
+    
+    /* is this a clone?
+     */
+    if (super_sh->clones_len > 0) {
+	char buf[4096];
+	auto ci = (clone_info*)(_buf + super_sh->clones_offset);
+	auto obj_name = (char*)(ci+1);
+	while (true) {
+	    if (objstore->read_object(obj_name, buf, sizeof(buf), 0) < 0)
+		return -1;
+	    auto _h = (obj_hdr*)buf;
+	    auto _sh = (super_hdr*)(_h+1);
+	    if (_h->magic != LSVD_MAGIC || _h->type != LSVD_SUPER) {
+		printf("clone: bad magic\n");
+		return -1;
+	    }
+	    if (memcmp(_h->vol_uuid, ci->vol_uuid, sizeof(uuid_t)) != 0) {
+		printf("clone: bad UUID\n");
+		return -1;
+	    }
+	    clone c;
+	    strcpy(c.prefix, obj_name);
+	    c.last_seq = ci->last_seq;
+	    if (clone_list.size() > 0)
+		clone_list.back().first_seq = ci->last_seq + 1;
+	    clone_list.push_back(c);
+
+	    if (_sh->clones_len == 0)
+		break;
+	    ci = (clone_info*)(buf + _sh->clones_offset);
+	    obj_name = (char*)(ci + 1);
+	}
+    }
+    
+    /* read in the last checkpoint, then roll forward from there;
+     */
+    int last_ckpt = -1;
+    if (ckpts.size() > 0) {
+	std::vector<ckpt_obj> objects;
+	std::vector<deferred_delete> deletes;
+	std::vector<ckpt_mapentry> entries;
+
+	/* hmm, we should never have checkpoints listed in the
+	 * super that aren't persisted on the backend, should we?
+	 */
+	while (n_ckpts > 0) {
+	    int c = ckpts[n_ckpts-1];
+	    objname name(prefix(c), c);
+	    do_log("reading ckpt %s\n", name.c_str());
+	    if (parser->read_checkpoint(name.c_str(), max_cache_seq,
+					ckpts, objects,
+					deletes, entries) >= 0) {
+		last_ckpt = c;
+		break;
+	    }
+	    do_log("chkpt skip %d\n", c);
+	    n_ckpts--;
+	}
+	if (last_ckpt == -1)
+	    return -1;
+
+	for (int i = 0; i < n_ckpts; i++) {
+	    do_log("chkpt from super: %d\n", ckpts[i]);
+	    checkpoints.push_back(ckpts[i]); // so we can delete them later
+	}
+
+	for (auto o : objects) {
+	    object_info[o.seq] = (obj_info){.hdr = (int)o.hdr_sectors,
+					    .data = (int)o.data_sectors,
+					    .live = (int)o.live_sectors};
+	    total_sectors += o.data_sectors;
+	    total_live_sectors += o.live_sectors;
+	}
+	for (auto m : entries) {
+	    map->update(m.lba, m.lba + m.len,
+			    (extmap::obj_offset){.obj = m.obj,
+				    .offset = m.offset});
+	}
+	seq = next_compln = last_ckpt + 1;
+    }
+
+    /* roll forward
+     */
+    for (; ; seq++) {
+	std::vector<obj_cleaned> cleaned;
+	std::vector<data_map>    entries;
+	obj_hdr h; obj_data_hdr dh;
+
+	objname name(prefix(seq), seq);
+	if (parser->read_data_hdr(name.c_str(), h, dh, cleaned, entries) < 0)
+	    break;
+	if (h.type == LSVD_CKPT) {
+	    do_log("ckpt from roll-forward: %d\n", seq.load());
+	    checkpoints.push_back(seq);
+	    continue;
+	}
+
+	do_log("roll %d\n", seq.load());
+	assert(h.type == LSVD_DATA);
+	object_info[seq] = (obj_info){.hdr = (int)h.hdr_sectors,
+				      .data = (int)h.data_sectors,
+				      .live = (int)h.data_sectors};
+	total_sectors += h.data_sectors;
+	total_live_sectors += h.data_sectors;
+	if (dh.cache_seq)	// skip GC writes
+	    max_cache_seq = dh.cache_seq;
+	
+	int offset = 0, hdr_len = h.hdr_sectors;
+	std::vector<extmap::lba2obj> deleted;
+	for (auto m : entries) {
+	    extmap::obj_offset oo = {seq, offset + hdr_len};
+	    map->update(m.lba, m.lba + m.len, oo, &deleted);
+	    offset += m.len;
+	}
+	for (auto d : deleted) {
+	    auto [base, limit, ptr] = d.vals();
+	    object_info[ptr.obj].live -= (limit - base);
+	    assert(object_info[ptr.obj].live >= 0);
+	    total_live_sectors -= (limit - base);
+	}
+    }
+    next_compln = seq;
+    last_sent = next_compln - 1;
+    do_log("set next_compln %d\n", next_compln);
+
+    /* delete any potential "dangling" objects.
+     */
+    for (int i = 1; i < 32; i++) {
+	objname name(prefix(i+seq), i + seq);
+	objstore->delete_object(name.c_str());
+    }
+
+    workers->pool.push(std::thread(&translate_impl::worker_thread,
+				   this, workers));
+    if (timedflush)
+	misc_threads->pool.push(std::thread(&translate_impl::flush_thread,
+					    this, misc_threads));
+    return bytes;
+}
+
+void translate_impl::start_gc(void) {
+    misc_threads->pool.push(std::thread(&translate_impl::gc_thread,
+				       this, misc_threads));
+}
+    
+void translate_impl::shutdown(void) {
+}
+
+/* ----------- parsing and serializing various objects -------------*/
+
+/* read object header
+ *  fast: just read first 4KB
+ *  !fast: read first 4KB, resize and read again if >4KB
+ */
+
+
+/* create header for a GC object
+ */
+sector_t translate_impl::make_gc_hdr(char *buf, uint32_t _seq, sector_t sectors,
+				     data_map *extents, int n_extents) {
+    auto h = (obj_hdr*)buf;
+    auto dh = (obj_data_hdr*)(h+1);
+    uint32_t o1 = sizeof(*h) + sizeof(*dh),
+	l1 = n_extents * sizeof(data_map),
+	hdr_bytes = o1 + l1;
+    sector_t hdr_sectors = div_round_up(hdr_bytes, 512);
+
+    *h = (obj_hdr){.magic = LSVD_MAGIC, .version = 1, .vol_uuid = {0},
+		   .type = LSVD_DATA, .seq = _seq,
+		   .hdr_sectors = (uint32_t)hdr_sectors,
+		   .data_sectors = (uint32_t)sectors, .crc = 0};
+    memcpy(h->vol_uuid, &uuid, sizeof(uuid_t));
+
+    *dh = (obj_data_hdr){.cache_seq = 0,
+			 .objs_cleaned_offset = 0, .objs_cleaned_len = 0,
+			 .data_map_offset = o1, .data_map_len = l1};
+
+    data_map *dm = (data_map*)(dh+1);
+    for (int i = 0; i < n_extents; i++)
+	*dm++ = extents[i];
+
+    assert(hdr_bytes == ((char*)dm - buf));
+    memset(buf + hdr_bytes, 0, 512*hdr_sectors - hdr_bytes); // valgrind
+    h->crc = (uint32_t)crc32(0, (const unsigned char*)buf, 512*hdr_sectors);
+    
+    return hdr_sectors;
+}
+
+/* ----------- data transfer logic -------------*/
+
+// call with len=0 to force a new batch
+batch *translate_impl::check_batch_room(size_t len) {
+    batch *full = NULL;
+    if ((b->len + len > b->max) || (len == 0 && b->len > 0)) {
+	b->seq = last_sent = seq++;
+	do_log("last_sent = %d\n", last_sent);
+	full = b;
+	b = new batch(cfg->batch_size);
+    }
+    return full;
+}
+
+/* NOTE: offset is in bytes
+ */
+ssize_t translate_impl::writev(uint64_t cache_seq, size_t offset,
+			       iovec *iov, int iovcnt) {
+    smartiov siov(iov, iovcnt);
+    size_t len = siov.bytes();
+
+    std::unique_lock lk(m);
+    auto old_batch = check_batch_room(len);
+    if (b->cache_seq == 0) {	// lowest sequence number
+	b->cache_seq = cache_seq;
+	if (ckpt_cache_seq < cache_seq)
+	    ckpt_cache_seq = cache_seq;
+    }
+
+    b->append(offset / 512, &siov);
+    if (old_batch != NULL)
+	workers->put_locked(old_batch);
+
+    return len;
+}
+
+void translate_impl::wait_for_room(void) {
+    std::unique_lock lk(m);
+    while (outstanding_writes > cfg->xlate_window)
+	cv.wait(lk);
+}
+
+/* GC (like normal write) updates the map before it writes an object,
+ * but we can't assume the data is in cache, so we might get writes
+ * for objects that haven't committed yet.
+ * since this almost never blocks, do an unlocked check before the
+ * locked one.
+ */
+bool translate_impl::check_object_ready(int obj) {
+    return obj < (int)next_compln;
+}
+void translate_impl::wait_object_ready(int obj) {
+    std::unique_lock lk(m);
+    while (obj >= next_compln)
+	cv.wait(lk);
+}
+
+class translate_req : public request {
+    uint32_t seq;
+    translate_impl *tx;
+    std::mutex      m;
+    bool            waiting;
+    bool            done = false;
+    std::condition_variable cv;
+    
+    friend class translate_impl;
+    
+    /* various things that we might need to free
+     */
+    std::vector<char*> to_free;
+    batch *b = NULL;
+    
+public:
+    translate_req(uint32_t seq_, translate_impl *tx_, bool waiting_) {
+	seq = seq_;
+	tx = tx_;
+	waiting = waiting_;
+    }
+    ~translate_req(){}
+
+    void wait(void) {
+	std::unique_lock lk(m);
+	while (!done)
+	    cv.wait(lk);
+	delete this;		// always call wait
+    }
+
+    void notify(request *child) {
+	if (child)
+	    child->release();
+	tx->seq_complete(seq);
+	for (auto ptr : to_free)
+	    free(ptr);
+	if (b) 
+	    delete b;
+
+	std::unique_lock lk(tx->m);
+	if (--tx->outstanding_writes < tx->cfg->xlate_window)
+	    tx->cv.notify_all();
+
+	if (!waiting) 
+	    delete this;
+	else {
+	    done = true;
+	    cv.notify_one();
+	}
+    }
+
+    void run(request *parent) {} // unused
+    void release(void) {}	// unused
+};
+
+void translate_impl::worker_thread(thread_pool<batch*> *p) {
+    pthread_setname_np(pthread_self(), "batch_writer");
+    while (p->running) {
+	std::unique_lock lk(m);
+	batch *b;
+	if (!p->get_locked(lk, b)) 
+           return;
+
+	int _seq = checkpoints.size() ? checkpoints.back() : 0;
+	lk.unlock();
+
+	process_batch(b);
+
+	if (p->running && b->seq - _seq > cfg->ckpt_interval && !gc_running)
+	    write_checkpoint(seq++);
+    }
+}
+
+void translate_impl::process_batch(batch *b) {
+
+    /* TODO: coalesce writes: 
+     *   bufmap m
+     *   for e in entries
+     *      m.insert(lba, len, ptr)
+     *   for e in m:
+     *      (lba, iovec) -> output
+     */
+
+    /* make the following updates:
+     * - object_info - hdrlen, total/live data sectors
+     * - map - LBA to obj/offset map
+     * - object_info, totals - adjust for new garbage
+     */
+    size_t hdr_bytes = obj_hdr_len(b->entries.size());
+    int hdr_sectors = div_round_up(hdr_bytes, 512);
+    char *hdr_ptr = b->buf - hdr_sectors*512;
+
+    // deadlock risk - locks m, can't call with map_lock held
+    seq_record(b->seq);
+
+    std::unique_lock obj_w_lock(*map_lock);
+    obj_info oi = {.hdr = hdr_sectors, .data = (int)b->len/512,
+		   .live = (int)b->len/512};
+    object_info[b->seq] = oi;
+
+    /* note that we update the map before the object is written,
+     * and count on the write cache preventing any reads until
+     * it's persisted. TODO: verify this
+     */
+    sector_t sector_offset = hdr_sectors;
+    std::vector<extmap::lba2obj> deleted;
+
+    for (auto e : b->entries) {
+	extmap::obj_offset oo = {b->seq, sector_offset};
+	map->update(e.lba, e.lba+e.len, oo, &deleted);
+	sector_offset += e.len;
+    }
+
+    for (auto d : deleted) {
+	auto [base, limit, ptr] = d.vals();
+	if (object_info.find(ptr.obj) == object_info.end())
+	    continue;		// skip clone base
+	object_info[ptr.obj].live -= (limit - base);
+	assert(object_info[ptr.obj].live >= 0);
+	total_live_sectors -= (limit - base);
+    }
+
+    /* live sectors, after subtracting dups */
+    auto live = object_info[b->seq].live; 
+    total_live_sectors += live;
+
+    obj_w_lock.unlock();
+
+    std::unique_lock lk(m);
+    total_sectors += b->len / 512;
+    if (next_compln == -1)
+	next_compln = b->seq;
+    lk.unlock();
+    
+    make_data_hdr(hdr_ptr, b->len, b->cache_seq, &b->entries, b->seq, &uuid);
+    size_t total_len = hdr_sectors*512 + b->len;
+
+    /* on completion, t_req calls seq_complete
+     */
+    auto t_req = new translate_req(b->seq, this, false);
+    t_req->b = b;
+
+    objname name(prefix(b->seq), b->seq);
+    auto req = objstore->make_write_req(name.c_str(), hdr_ptr, total_len);
+    outstanding_writes++;
+    req->run(t_req);
+}
+
+/* flushes any data buffered in current batch, and blocks until all 
+ * outstanding writes are complete.
+ * returns sequence number of last written object.
+ */
+int translate_impl::flush() {
+    auto old_batch = check_batch_room(0);
+    if (old_batch == NULL)
+	return last_sent;
+
+    std::unique_lock lk(m);
+    auto _seq = old_batch->seq;
+
+    workers->put_locked(old_batch);
+
+    while (next_compln <= _seq)
+	cv.wait(lk);
+
+    return _seq;
+}
+
+/* wake up every @wait_time, if data is pending in current batch
+ * for @timeout then write it to backend
+ */
+void translate_impl::flush_thread(thread_pool<int> *p) {
+    pthread_setname_np(pthread_self(), "flush_thread");
+    auto wait_time = std::chrono::milliseconds(500);
+    auto timeout = std::chrono::milliseconds(cfg->flush_msec);
+    auto t0 = std::chrono::system_clock::now();
+    auto seq0 = seq.load();
+
+    while (p->running) {
+	std::unique_lock lk(*p->m);
+	if (p->cv.wait_for(lk, wait_time, [p] {return !p->running;}))
+	    return;
+	lk.unlock();
+
+	if (p->running && seq0 == seq.load() && b->len > 0) {
+	    if (std::chrono::system_clock::now() - t0 > timeout) 
+		flush();
+	}
+	else {
+	    seq0 = seq.load();
+	    t0 = std::chrono::system_clock::now();
+	}
+    }
+}
+
+/* -------------- Checkpointing -------------- */
+
+/* synchronously write a checkpoint
+ */
+void translate_impl::write_checkpoint(int ckpt_seq) {
+    std::vector<ckpt_mapentry> entries;
+    std::vector<ckpt_obj> objects;
+
+    seq_record(ckpt_seq);
+
+    /* - map lock protects both object_info and map
+     * - damned if I know why I need lk(m) to keep test10 from failing,
+     *   but I do.
+     */
+    std::unique_lock lk(m);
+    std::unique_lock obj_w_lock(*map_lock);
+
+    for (auto it = map->begin(); it != map->end(); it++) {
+	auto [base, limit, ptr] = it->vals();
+	entries.push_back((ckpt_mapentry){.lba = base,
+		    .len = limit-base, .obj = (int32_t)ptr.obj,
+		    .offset = (int32_t)ptr.offset});
+    }
+
+    size_t map_bytes = entries.size() * sizeof(ckpt_mapentry);
+
+    for (auto it = object_info.begin(); it != object_info.end(); it++) {
+	auto obj_num = it->first;
+	auto [hdr, data, live] = it->second;
+	objects.push_back((ckpt_obj){.seq = (uint32_t)obj_num,
+		    .hdr_sectors = (uint32_t)hdr,
+		    .data_sectors = (uint32_t)data,
+		    .live_sectors = (uint32_t)live});
+    }
+    obj_w_lock.unlock();
+
+    /* wait until all prior objects have been acked by backend, 
+     */
+    while (next_compln < ckpt_seq && !stopped)
+	cv.wait(lk);
+    if (stopped)
+	return;
+    lk.unlock();
+
+    /* assemble the object
+     */
+    size_t objs_bytes = objects.size() * sizeof(ckpt_obj);
+    size_t hdr_bytes = sizeof(obj_hdr) + sizeof(obj_ckpt_hdr);
+    int sectors = div_round_up(hdr_bytes + sizeof(ckpt_seq) + map_bytes +
+			       objs_bytes, 512);
+
+    auto buf = (char*)calloc(sectors*512, 1);
+    auto h = (obj_hdr*)buf;
+    *h = (obj_hdr){.magic = LSVD_MAGIC, .version = 1, .vol_uuid = {0},
+		   .type = LSVD_CKPT, .seq = (uint32_t)ckpt_seq,
+		   .hdr_sectors = (uint32_t)sectors, .data_sectors = 0};
+    memcpy(h->vol_uuid, uuid, sizeof(uuid_t));
+    auto ch = (obj_ckpt_hdr*)(h+1);
+
+    uint32_t o1 = sizeof(obj_hdr)+sizeof(obj_ckpt_hdr), o2 = o1 + objs_bytes;
+    *ch = (obj_ckpt_hdr){.cache_seq = ckpt_cache_seq,
+			 .ckpts_offset = 0, .ckpts_len = 0,
+			 .objs_offset = o1, .objs_len = o2-o1,
+			 .deletes_offset = 0, .deletes_len = 0,
+			 .map_offset = o2, .map_len = (uint32_t)map_bytes};
+
+    auto objs = (char*)(ch+1);
+    memcpy(objs, (char*)objects.data(), objs_bytes);
+    auto maps = objs + objs_bytes;
+    memcpy(maps, (char*)entries.data(), map_bytes);
+    
+    /* and write it
+     */
+    objname name(prefix(ckpt_seq), ckpt_seq);
+    objstore->write_object(name.c_str(), buf, sectors*512);
+    seq_complete(ckpt_seq);	// no locks held
+    free(buf);
+
+    /* Now re-write the superblock with the new list of checkpoints
+     */
+    lk.lock();
+    checkpoints.push_back(ckpt_seq);
+    size_t offset = sizeof(*super_h) + sizeof(*super_sh);
+
+    /* trim checkpoints. This function is the only place we modify
+     * checkpoints[]
+     */
+    std::vector<int> ckpts_to_delete;
+    while (checkpoints.size() > 3) {
+	ckpts_to_delete.push_back(checkpoints.front());
+	checkpoints.erase(checkpoints.begin());
+    }
+    lk.unlock();
+    
+    /* this is the only place we modify *super_sh
+     */
+    super_sh->ckpts_offset = offset;
+    super_sh->ckpts_len = checkpoints.size() * sizeof(ckpt_seq);
+    auto pc = (uint32_t*)(super_buf + offset);
+    for (size_t i = 0; i < checkpoints.size(); i++)
+	*pc++ = checkpoints[i];
+	
+    if (stopped)
+	return;
+    
+    objstore->write_object(super_name, super_buf, 4096);
+
+    for (auto c : ckpts_to_delete) {
+	objname name(prefix(c), c);
+	objstore->delete_object(name.c_str());
+    }
+}
+
+/* called on shutdown
+ */
+int translate_impl::checkpoint(void) {
+    auto old_batch = check_batch_room(0);
+    if (old_batch != NULL) {
+	std::unique_lock lk(m);
+	auto _seq = old_batch->seq;
+	workers->put_locked(old_batch);
+
+	while (next_compln <= _seq)
+	    cv.wait(lk);
+    }
+
+    int _seq = seq++;
+    write_checkpoint(_seq);
+    return _seq;
+}
+
+
+/* -------------- Garbage collection ---------------- */
+
+struct _extent {
+    int64_t base;
+    int64_t limit;
+    extmap::obj_offset ptr;
+};
+
+/* [describe GC algorithm here]
+ */
+void translate_impl::do_gc(bool *running) {
+    gc_cycles++;
+    int max_obj = seq.load();
+
+    std::shared_lock obj_r_lock(*map_lock);
+    std::vector<int> dead_objects;
+    for (auto const &p : object_info)  {
+	auto [hdrlen, datalen, live] = p.second;
+	if (live == 0) {
+	    total_sectors -= datalen;
+	    dead_objects.push_back(p.first);
+	}
+    }
+    obj_r_lock.unlock();
+
+    std::queue<request*> deletes;
+    for (auto const &o : dead_objects) {
+	objname name(prefix(o), o);
+	auto r = objstore->delete_object_req(name.c_str());
+	r->run(NULL);
+	deletes.push(r);
+	while (deletes.size() > 8) {
+	    deletes.front()->wait();
+	    deletes.pop();
+	}
+    }
+    while (deletes.size() > 0) {
+	deletes.front()->wait();
+	deletes.pop();
+    }
+    
+    std::unique_lock obj_w_lock(*map_lock);
+    for (auto const &o : dead_objects) 
+	object_info.erase(o);
+    obj_w_lock.unlock();
+    
+    /* create list of object info in increasing order of 
+     * utilization, i.e. (live data) / (total size)
+     */
+    obj_r_lock.lock();
+    int calculated_total = 0;
+    std::set<std::tuple<double,int,int>> utilization;
+    for (auto p : object_info)  {
+	auto [hdrlen, datalen, live] = p.second;
+	double rho = 1.0 * live / datalen;
+	sector_t sectors = hdrlen + datalen;
+	calculated_total += datalen;
+	utilization.insert(std::make_tuple(rho, p.first, sectors));
+	assert(sectors <= 20*1024*1024/512);
+    }
+    
+    /* gather list of objects needing cleaning, return if none
+     */
+    const double threshold = cfg->gc_threshold / 100.0;
+    std::vector<std::pair<int,int>> objs_to_clean;
+    for (auto [u, o, n] : utilization) {
+	if (u > threshold)
+	    continue;
+	if (objs_to_clean.size() > 32)
+	    break;
+	objs_to_clean.push_back(std::make_pair(o, n));
+    }
+    if (objs_to_clean.size() == 0) 
+	return;
+
+    /* find all live extents in objects listed in objs_to_clean:
+     * - make bitmap from objs_to_clean
+     * - find all entries in map pointing to those objects
+     */
+    std::vector<bool> bitmap(max_obj+1);
+    for (auto it = objs_to_clean.begin(); it != objs_to_clean.end(); it++)
+	bitmap[it->first] = true;
+
+    extmap::objmap live_extents;
+    for (auto it = map->begin(); it != map->end(); it++) {
+	auto [base, limit, ptr] = it->vals();
+	if (ptr.obj <= max_obj && bitmap[ptr.obj])
+	    live_extents.update(base, limit, ptr);
+    }
+    obj_r_lock.unlock();
+
+    /* everything before this point was in-memory only, with the 
+     * translation instance mutex held, doing no I/O.
+     */
+
+    /* this is really gross. We really should check to see if data is
+     * in the read cache, and put retrieved data there...
+     */
+    if (live_extents.size() > 0) {
+	/* temporary file, delete on close. 
+	 */
+	char temp[cfg->cache_dir.size() + 20];
+	sprintf(temp, "%s/gc.XXXXXX", cfg->cache_dir.c_str());
+	int fd = mkstemp(temp);
+
+	/* read all objects in completely. Someday we can check to see whether
+	 * (a) data is already in cache, or (b) sparse reading would be quicker
+	 */
+	extmap::cachemap file_map;
+	sector_t offset = 0;
+	char *buf = (char*)malloc(20*1024*1024);
+
+	for (auto [i,sectors] : objs_to_clean) {
+	    objname name(prefix(i), i);
+	    objstore->read_object(name.c_str(), buf, sectors*512UL, 0);
+	    gc_sectors_read += sectors;
+	    extmap::obj_offset _base = {i, 0}, _limit = {i, sectors};
+	    file_map.update(_base, _limit, offset);
+	    if (write(fd, buf, sectors*512) < 0)
+		throw("no space");
+	    offset += sectors;
+	}
+	free(buf);
+
+	auto file_offset = offset;
+
+	std::vector<_extent> all_extents;
+	for (auto it = live_extents.begin(); it != live_extents.end(); it++) {
+	    auto [base, limit, ptr] = it->vals();
+	    all_extents.push_back((_extent){base, limit, ptr});
+	}
+	
+	/* outstanding writes
+	 */
+	std::queue<translate_req*> requests;
+	
+	while (all_extents.size() > 0) {
+	    sector_t sectors = 0, max = 16 * 1024; // 8MB
+	    
+	    auto it = all_extents.begin();
+	    while (it != all_extents.end() && sectors < max) {
+		auto [base, limit, ptr] = *it++;
+		sectors += (limit - base);
+		(void)ptr;	// suppress warning
+	    }
+	    std::vector<_extent> extents(std::make_move_iterator(all_extents.begin()),
+					 std::make_move_iterator(it));
+	    all_extents.erase(all_extents.begin(), it);
+	    
+	    /* figure out what we need to read from the file, create
+	     * the header etc., then drop the lock and actually read it.
+	     */
+	    size_t prepend = 2048*sizeof(data_map) + 512;
+	    char *_buf = (char*)malloc(sectors * 512 + prepend);
+	    char *buf = _buf + prepend;
+
+	    /* file offset, buffer ptr, length */
+	    std::vector<std::tuple<sector_t,char*,size_t>> to_read; 
+	    
+	    off_t byte_offset = 0;
+	    sector_t data_sectors = 0;
+	    std::vector<data_map> obj_extents;
+
+	    /* the extents may have been fragmented in the meantime...
+	     */
+	    sector_t _debug_sector = 0;
+	    std::unique_lock lk(m); // not sure exactly why test10 needs this...
+	    obj_r_lock.lock();
+	    for (auto const & [base, limit, ptr] : extents) {
+		for (auto it2 = map->lookup(base);
+		     it2->base() < limit && it2 != map->end(); it2++) {
+		     /* [_base,_limit] is a piece of the extent
+		      * obj_base is where that piece starts in the object
+		      */
+		    auto [_base, _limit, obj_base] = it2->vals(base, limit);
+
+		    /* skip if it's not still in the object, otherwise
+		     * _obj_limit is where it ends.
+		     */
+		    if (obj_base.obj != ptr.obj)
+			continue;
+		    sector_t _sectors = _limit - _base;
+		    auto obj_limit =
+			extmap::obj_offset{obj_base.obj,
+					   obj_base.offset+_sectors};
+
+		    /* file_sector is where that piece starts in 
+		     * the GC file...
+		     */
+		    auto it3 = file_map.lookup(obj_base);
+		    auto [file_base,file_limit,file_sector] =
+			it3->vals(obj_base, obj_limit);
+		    (void)file_limit; // suppress warning
+		    (void)file_base;  // suppress warning
+		    assert(file_sector != _debug_sector);
+		    _debug_sector = file_sector;
+		    size_t bytes = _sectors*512;
+		    to_read.push_back(std::make_tuple(file_sector,
+						      buf+byte_offset, bytes));
+
+		    obj_extents.push_back((data_map){(uint64_t)_base, (uint64_t)_sectors});
+
+		    data_sectors += _sectors;
+		    byte_offset += bytes;
+		}
+	    }
+	    int32_t _seq = seq++;
+	    obj_r_lock.unlock();
+	    lk.unlock();
+
+	    seq_record(_seq);
+	    gc_sectors_written += data_sectors; // only written in this thread
+	    int hdr_size = div_round_up(sizeof(obj_hdr) + sizeof(obj_data_hdr) +
+					obj_extents.size()*sizeof(data_map), 512);
+	    char *hdr = buf - hdr_size*512;
+	    int hdr_sectors = make_gc_hdr(hdr, _seq, data_sectors,
+					  obj_extents.data(), obj_extents.size());
+	    assert(hdr_size == hdr_sectors);
+	    sector_t offset = hdr_sectors;
+
+	    int gc_sectors = byte_offset / 512;
+	    obj_info oi = {.hdr = hdr_sectors, .data = gc_sectors,
+			   .live = gc_sectors};
+
+	    obj_w_lock.lock();
+	    object_info[_seq] = oi;
+	    std::vector<extmap::lba2obj> deleted;
+	    for (auto const &e : obj_extents) {
+		extmap::obj_offset oo = {_seq, offset};
+		map->update(e.lba, e.lba+e.len, oo, &deleted);
+		offset += e.len;
+	    }
+
+	    for (auto &d : deleted) {
+		auto [base, limit, ptr] = d.vals();
+		if (object_info.find(ptr.obj) == object_info.end())
+		    continue;	// skip clone base
+		object_info[ptr.obj].live -= (limit - base);
+		assert(object_info[ptr.obj].live >= 0);
+		total_live_sectors -= (limit - base);
+	    }
+	    obj_w_lock.unlock();
+
+	    /* Now we actually read from the file
+	     */
+	    for (auto const & tpl : to_read) {
+		auto [file_sector, ptr, bytes] = tpl;
+		assert(file_sector < file_offset);  // total file size
+		auto err = pread(fd, ptr, bytes, file_sector*512);
+		assert(err == (ssize_t)bytes);
+	    }
+	    
+	    auto t_req = new translate_req(_seq, this, true);
+	    t_req->to_free.push_back(_buf);
+
+	    if (stopped)
+		return;
+	    
+	    objname name(prefix(_seq), _seq);
+	    auto req = objstore->make_write_req(name.c_str(), hdr,
+						(hdr_sectors+data_sectors)*512);
+	    outstanding_writes++;
+	    req->run(t_req);
+	    requests.push(t_req);
+	    
+	    while (requests.size() > 8) {
+		auto t = requests.front();
+		t->wait();
+		requests.pop();
+	    }
+	}
+	while (requests.size() > 0) {
+	    auto t = requests.front();
+	    t->wait();
+	    requests.pop();
+	}
+	close(fd);
+	unlink(temp);
+    }
+
+    obj_w_lock.lock();
+    for (auto it = objs_to_clean.begin(); it != objs_to_clean.end(); it++) {
+	total_sectors -= object_info[it->first].data;
+	object_info.erase(object_info.find(it->first));
+    }
+    obj_w_lock.unlock();
+    
+    /* write checkpoint *before* deleting any objects
+     */
+    if (stopped)
+	return;
+    if (objs_to_clean.size()) {
+	int ckpt_seq = seq++;
+	write_checkpoint(ckpt_seq);
+    
+	for (auto it = objs_to_clean.begin(); it != objs_to_clean.end(); it++) {
+	    objname name(prefix(it->first), it->first);
+	    objstore->delete_object(name.c_str());
+	    gc_deleted++;		// single-threaded, no lock needed
+	}
+    }
+}
+
+void translate_impl::stop_gc(void) {
+    delete misc_threads;
+    std::unique_lock lk(m);
+    while (gc_running)
+	gc_cv.wait(lk);
+}
+
+void translate_impl::gc_thread(thread_pool<int> *p) {
+    auto interval = std::chrono::milliseconds(100);
+    //sector_t trigger = 128 * 1024 * 2; // 128 MB
+    const char *name = "gc_thread";
+    pthread_setname_np(pthread_self(), name);
+	
+    while (p->running) {
+	std::unique_lock lk(m);
+	p->cv.wait_for(lk, interval);
+	if (!p->running)
+	    return;
+
+	/* check to see if we should run a GC cycle
+	 */
+	//if (total_sectors - total_live_sectors < trigger)
+	//    continue;
+	//if ((total_live_sectors / (double)total_sectors) > (cfg->gc_threshold / 100.0))
+	//continue;
+
+	gc_running = true;
+	lk.unlock();
+
+	do_gc(&p->running);
+
+	lk.lock();
+	gc_running = false;
+	gc_cv.notify_all();
+    }
+}
+    
+/* ---------------- Debug ---------------- */
+
+/* synchronous read from offset (in bytes)
+ */
+ssize_t translate_impl::readv(size_t offset, iovec *iov, int iovcnt) {
+    smartiov iovs(iov, iovcnt);
+    size_t len = iovs.bytes();
+    int64_t base = offset / 512;
+    int64_t sectors = len / 512, limit = base + sectors;
+
+    /* various things break when map size is zero
+     */
+    if (map->size() == 0) {
+	iovs.zero();
+	return len;
+    }
+
+    /* object number, offset (bytes), length (bytes) */
+    std::vector<std::tuple<int, size_t, size_t>> regions;
+	
+    auto prev = base;
+    {
+	std::unique_lock lk(m);
+	std::shared_lock slk(*map_lock);
+
+	for (auto it = map->lookup(base);
+	     it != map->end() && it->base() < limit; it++) {
+	    auto [_base, _limit, oo] = it->vals(base, limit);
+	    if (_base > prev) {	// unmapped
+		size_t _len = (_base - prev)*512;
+		regions.push_back(std::tuple(-1, 0, _len));
+	    }
+	    size_t _len = (_limit - _base) * 512, _offset = oo.offset * 512;
+	    regions.push_back(std::tuple((int)oo.obj, _offset, _len));
+	    prev = _limit;
+	}
+    }
+
+    if (regions.size() == 0) {
+	iovs.zero();
+	return 0;
+    }
+    
+    size_t iov_offset = 0;
+    for (auto [obj, _offset, _len] : regions) {
+	auto slice = iovs.slice(iov_offset, iov_offset + _len);
+	if (obj == -1)
+	    slice.zero();
+	else {
+	    objname name(prefix(obj), obj);
+	    auto [iov,iovcnt] = slice.c_iov();
+	    objstore->read_object(name.c_str(), iov, iovcnt, _offset);
+	}
+	iov_offset += _len;
+    }
+
+    if (iov_offset < iovs.bytes()) {
+	auto slice = iovs.slice(iov_offset, len - iov_offset);
+	slice.zero();
+    }
+    
+    return 0;
+}
+
+int translate_create_image(backend *objstore, const char *name,
+			   uint64_t size) {
+    char buf[4096];
+    memset(buf, 0, 4096);
+
+    auto _hdr = (obj_hdr*) buf;
+    *_hdr = (obj_hdr){LSVD_MAGIC,
+		      1,	  // version
+		      {0},	  // UUID
+		      LSVD_SUPER, // type
+		      0,	  // seq
+		      8,	  // hdr_sectors
+		      0};	  // data_sectors
+    uuid_generate_random(_hdr->vol_uuid);
+
+    auto _super = (super_hdr*)(_hdr + 1);
+    uint64_t sectors = size / 512;
+    *_super = (super_hdr){sectors, // vol_size
+			  0, 0,	   // checkpoint offset, len
+			  0, 0,	   // clone offset, len
+			  0, 0};   // snap offset, len
+    
+    auto rv = objstore->write_object(name, buf, 4096);
+    return rv;
+}
+
+int translate_get_uuid(backend *objstore, const char *name, uuid_t &uu) {
+    char buf[4096];
+    int rv = objstore->read_object(name, buf, sizeof(buf), 0);
+    if (rv < 0)
+	return rv;
+    auto hdr = (obj_hdr*)buf;
+    memcpy(uu, hdr->vol_uuid, sizeof(uuid_t));
+    return 0;
+}
+
+int translate_remove_image(backend *objstore, const char *name) {
+
+    /* read the superblock to get the list of checkpoints
+     */
+    char buf[4096];
+    int rv = objstore->read_object(name, buf, sizeof(buf), 0);
+    if (rv < 0)
+	return rv;
+    auto hdr = (obj_hdr*) buf;
+    auto sh = (super_hdr*)(hdr+1);
+
+    if (hdr->magic != LSVD_MAGIC || hdr->type != LSVD_SUPER)
+	return -1;
+
+    int seq = 1;
+    std::vector<uint32_t> ckpts;
+    decode_offset_len<uint32_t>(buf, sh->ckpts_offset, sh->ckpts_len, ckpts);
+
+    /* read the most recent checkpoint and get its object map
+     */
+    if (ckpts.size() > 0) {
+	object_reader r(objstore);
+	seq = ckpts.back();
+	objname obj(name, seq);
+	auto ckpt_buf = r.read_object_hdr(obj.c_str(), false);
+	auto c_hdr = (obj_hdr*)ckpt_buf;
+	auto c_data = (obj_ckpt_hdr*)(c_hdr+1);
+	if (c_hdr->magic != LSVD_MAGIC || c_hdr->type != LSVD_CKPT)
+	    return -1;
+	std::vector<ckpt_obj> objects;
+	decode_offset_len<ckpt_obj>(ckpt_buf, c_data->objs_offset,
+				    c_data->objs_len, objects);
+
+	/* delete all the objects in the objmap
+	 */
+	std::queue<request*> deletes;
+	for (auto const & o : objects) {
+	    objname obj(name, o.seq);
+	    auto r = objstore->delete_object_req(obj.c_str());
+	    r->run(NULL);
+	    deletes.push(r);
+	    while (deletes.size() > 8) {
+		deletes.front()->wait();
+		deletes.pop();
+	    }
+	}
+	while (deletes.size() > 0) {
+	    deletes.front()->wait();
+	    deletes.pop();
+	}
+	
+	/* delete all the checkpoints
+	 */
+	for (auto const & c : ckpts) {
+	    objname obj(name, c);
+	    objstore->delete_object(obj.c_str());
+	}
+    }
+    /* delete any objects after the last checkpoint, up to the first run of
+     * 32 missing sequence numbers
+     */
+    for (int n = 0; n < 16; seq++, n++) {
+	objname obj(name, seq);
+	if (objstore->delete_object(obj.c_str()) >= 0)
+	    n = 0;
+    }
+
+    /* and delete the superblock
+     */
+    objstore->delete_object(name);
+    return 0;
+}
+

--- a/src/liblsvd/translate.cc
+++ b/src/liblsvd/translate.cc
@@ -548,6 +548,7 @@ public:
 	std::unique_lock lk(m);
 	while (!done)
 	    cv.wait(lk);
+	lk.unlock();
 	delete this;		// always call wait
     }
 

--- a/src/liblsvd/translate.cc
+++ b/src/liblsvd/translate.cc
@@ -568,6 +568,7 @@ public:
 	if (!waiting) 
 	    delete this;
 	else {
+	    std::unique_lock lk(m);
 	    done = true;
 	    cv.notify_one();
 	}

--- a/src/liblsvd/translate.h
+++ b/src/liblsvd/translate.h
@@ -1,0 +1,53 @@
+/*
+ * file:        translate.h
+ * description: core translation layer - interface
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef TRANSLATE_H
+#define TRANSLATE_H
+
+struct iovec;
+class backend;
+class lsvd_config;
+
+class translate {
+public:
+    uuid_t    uuid;
+    uint64_t  max_cache_seq;
+    
+    translate() {}
+    virtual ~translate() {}
+
+    virtual ssize_t init(const char *name, bool timedflush) = 0;
+    virtual void shutdown(void) = 0;
+
+    virtual int flush(void) = 0;      /* write out current batch */
+    virtual int checkpoint(void) = 0; /* flush, then write checkpoint */
+
+    virtual ssize_t writev(uint64_t cache_seq, size_t offset,
+                           iovec *iov, int iovcnt) = 0;
+    virtual void wait_for_room(void) = 0;
+    virtual ssize_t readv(size_t offset, iovec *iov, int iovcnt) = 0;
+    virtual bool check_object_ready(int obj) = 0; /* GC stalls */
+    virtual void wait_object_ready(int obj) = 0;
+    
+    virtual const char *prefix(int seq) = 0; /* for read cache */
+
+    virtual void stop_gc(void) = 0; /* do this before shutdown */
+    virtual void start_gc(void) = 0;
+};
+
+extern translate *make_translate(backend *_io, lsvd_config *cfg,
+                                 extmap::objmap *map, std::shared_mutex *m);
+
+extern int translate_create_image(backend *objstore, const char *name,
+                                  uint64_t size);
+extern int translate_remove_image(backend *objstore, const char *name);
+extern int translate_get_uuid(backend *objstore, const char *name, uuid_t &uu);
+
+#endif

--- a/src/liblsvd/write_cache.cc
+++ b/src/liblsvd/write_cache.cc
@@ -1,0 +1,908 @@
+/*
+ * file:        write_cache.cc
+ * description: write_cache implementation
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#include <uuid/uuid.h>
+
+#include <atomic>
+
+#include <vector>
+#include <map>
+#include <stack>
+
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <thread>
+#include <cassert>
+#include <algorithm>
+
+#include "lsvd_types.h"
+
+#include "journal.h"
+#include "smartiov.h"
+#include "extent.h"
+#include "misc_cache.h"
+#include "backend.h"
+#include "translate.h"
+#include "io.h"
+#include "request.h"
+#include "nvme.h"
+
+#include "write_cache.h"
+#include "config.h"
+
+extern void do_log(const char *, ...);
+extern void log_time(uint64_t loc, uint64_t val); // debug
+
+/* ------------- Write cache structure ------------- */
+
+class wcache_write_req;
+class write_cache_impl : public write_cache {
+    size_t         dev_max;
+    uint32_t       super_blkno;
+    lsvd_config   *cfg;
+    
+    std::atomic<uint64_t> sequence = 1; // write sequence #
+
+    /* bookkeeping for write throttle
+     */
+    std::mutex m2; 		// for total_write_pages
+    int total_write_pages = 0;
+    int max_write_pages = 0;
+    int outstanding_writes = 0;
+    size_t write_batch = 0;
+    std::condition_variable write_cv;
+
+    page_t cleared_limit;
+    void evict(page_t base, page_t len);
+    void send_writes(std::unique_lock<std::mutex> &m);
+
+    /* initialization stuff
+     */
+    void read_map_entries();
+    int roll_log_forward();
+    char *_hdrbuf;		// for reading at startup
+
+    /* 
+     * track contents of the write cache. 
+     *    before:         after:     
+     * +---+--+-----+ +--+----+---+ +-----+
+     * |   |  |     | |  |    |   | |empty|
+     * +---+--+-----+ +--+----+---+ +-----+
+     *               ^
+     *    allocation point (super->next)
+     * corner cases are when one or more lists are empty, e.g. if
+     * next==base, before=[]
+     */
+    std::vector<j_length> before; // writes before super->next
+    std::vector<j_length> after;  // writes after super->next
+    
+    friend void print_pages(write_cache_impl*, const char*);
+    
+    /* track outstanding requests and point before which
+     * all writes are durable in SSD. Pad
+     */
+    struct write_record {
+	uint64_t          seq;
+	wcache_write_req *req = NULL;
+	page_t            next = 0; // next acked page
+	mutable bool      done = false;
+	bool operator<(const write_record &other) const {
+	    return seq < other.seq;
+	}
+    };
+    std::set<write_record> outstanding;
+    page_t next_acked_page = 0;
+    void notify_complete(uint64_t seq);
+    void record_outstanding(uint64_t seq, page_t next, wcache_write_req *req);
+
+    thread_pool<int>          *misc_threads;
+
+    void flush_thread(thread_pool<int> *p);
+    void write_checkpoint(void);
+    
+    /* allocate journal entry, create a header
+     */
+    uint32_t allocate(page_t n, page_t &pad, page_t &n_pad, page_t &prev);
+    std::vector<write_cache_work*> work;
+    sector_t work_sectors;	// queued in work[]
+    j_write_super *super;
+    page_t         previous_hdr = 0;
+
+    /* these are used by wcache_write_req
+     */
+    friend class wcache_write_req;
+    std::mutex                m;
+    extmap::cachemap2 map;
+    translate        *be;
+    j_hdr *mk_header(char *buf, uint32_t type, page_t blks, page_t prev);
+    nvme 		      *nvme_w = NULL;
+    
+public:
+
+    /* throttle writes with window of max_write_pages
+     */
+    void get_room(sector_t sectors); 
+    void release_room(sector_t sectors);
+    void flush(void);
+
+    write_cache_impl(uint32_t blkno, int _fd, translate *_be,
+		     lsvd_config *cfg);
+    ~write_cache_impl();
+
+    write_cache_work *writev(request *req, sector_t lba, smartiov *iov);
+    virtual std::tuple<size_t,size_t,request*> 
+        async_read(size_t offset, char *buf, size_t bytes);
+    virtual std::tuple<size_t,size_t,request*> 
+        async_readv(size_t offset, smartiov *iov);
+
+    void do_write_checkpoint(void);
+};
+
+
+/* ------------- batched write request ------------- */
+
+class wcache_write_req : public request {
+    std::atomic<int> reqs = 0;
+
+    sector_t      plba;
+    uint64_t      seq;
+    
+    std::vector<write_cache_work*> work;
+    request      *r_data = NULL;
+    char         *hdr = NULL;
+    smartiov      *data_iovs;
+
+    request      *r_pad = NULL;
+    char         *pad_hdr = NULL;
+    smartiov      pad_iov;
+
+    write_cache_impl *wcache = NULL;
+    
+public:
+    wcache_write_req(std::vector<write_cache_work*> *w, page_t n_pages,
+		     page_t page, page_t n_pad, page_t pad, page_t prev,
+		     write_cache *wcache);
+    ~wcache_write_req();
+    void run(request *parent);
+    void notify(request *child);
+    void notify_in_order(void);
+    
+    void wait() {}
+    void release() {}		// TODO: free properly
+};
+
+static char *z_page;
+void pad_out(smartiov &iov, int pages) {
+    if (z_page == NULL) {
+	z_page = (char*)aligned_alloc(512, 4096);
+	memset(z_page, 0, 4096); // make valgrind happy
+    }
+    for (int i = 0; i < pages; i++)
+	iov.push_back((iovec){z_page, 4096});
+}
+
+/* n_pages: number of 4KB data pages (not counting header)
+ * page:    page number to begin writing 
+ * n_pad:   number of pages to skip (not counting header)
+ * pad:     page number for pad entry (0 if none)
+ */
+wcache_write_req::wcache_write_req(std::vector<write_cache_work*> *work_,
+				   page_t n_pages, page_t page,
+				   page_t n_pad, page_t pad,
+				   page_t prev, write_cache* wcache_) :
+    work(work_->begin(), work_->end()) {
+    
+    wcache = (write_cache_impl*)wcache_;
+
+    /* if we pad, then the data record has prev=pad, and the pad 
+     * has prev=prev
+     */
+    if (pad != 0) {
+	pad_hdr = (char*)aligned_alloc(512, 4096);
+	wcache->mk_header(pad_hdr, LSVD_J_PAD, n_pad+1, prev);
+	prev = pad;
+	
+	/* if we pad before journal wraparound, zero out the remaining
+	 * pages to make crash recovery easier.
+	 */
+	pad_iov.push_back((iovec){pad_hdr, 4096});
+	pad_out(pad_iov, n_pad);
+	reqs++;
+	r_pad = wcache->nvme_w->make_write_request(&pad_iov, pad*4096L);
+    }
+  
+    std::vector<j_extent> extents;
+    for (auto w : work) {
+	extents.push_back((j_extent){(uint64_t)w->lba, w->iov->bytes() / 512});
+    }
+
+    /* TODO: don't assign seq# in mk_header
+     */
+    hdr = (char*)aligned_alloc(512, 4096);
+    j_hdr *j = wcache->mk_header(hdr, LSVD_J_DATA, 1+n_pages, prev);
+    seq = j->seq;
+    
+    /* track completion 
+     */
+    wcache->record_outstanding(seq, page+n_pages+1, this);
+
+    j->extent_offset = sizeof(*j);
+    size_t e_bytes = extents.size() * sizeof(j_extent);
+    j->extent_len = e_bytes;
+    memcpy((void*)(hdr + sizeof(*j)), (void*)extents.data(), e_bytes);
+
+    plba = (page+1) * 8;
+    int i = 0;
+    data_iovs = new smartiov();
+    data_iovs->push_back((iovec){hdr, 4096});
+    for (auto w : work) {
+	auto [iov, iovcnt] = w->iov->c_iov();
+	data_iovs->ingest(iov, iovcnt);
+	i += w->iov->bytes() / 512;
+    }
+    reqs++;
+    r_data = wcache->nvme_w->make_write_request(data_iovs, page*4096L);
+}
+
+wcache_write_req::~wcache_write_req() {
+    free(hdr);
+    if (pad_hdr) 
+        free(pad_hdr);
+    delete data_iovs;
+}
+
+/* called in order from notify_complete
+ * write cache lock must be held
+ */
+void wcache_write_req::notify_in_order(void) {
+    auto _plba = plba;
+
+    /* update the write cache forward and reverse maps
+     */
+    std::unique_lock lk(wcache->m);
+    std::vector<extmap::lba2lba> garbage; 
+    for (auto w : work) {
+	sector_t sectors = w->iov->bytes() / 512;
+	wcache->map.update(w->lba, w->lba + sectors, _plba, &garbage);
+	_plba += sectors;
+    }
+    lk.unlock();
+    
+    /* send data to backend, invoke callbacks, then clean up
+     */
+    for (auto w : work) {
+	auto [iov, iovcnt] = w->iov->c_iov();
+	wcache->be->writev(seq, w->lba*512, iov, iovcnt);
+    }
+
+    for (auto w : work) {
+	w->req->notify((request*)w);
+	delete w;
+    }
+    
+    /* if there are enough pending writes, send them
+     */
+    lk.lock();
+    wcache->outstanding_writes--;
+    if (wcache->work.size() >= wcache->write_batch ||
+	wcache->work_sectors >= wcache->cfg->wcache_chunk / 512)
+	wcache->send_writes(lk); // unlocks
+    else
+	lk.unlock();
+
+    /* we don't implement release or wait - just delete ourselves.
+     */
+    delete this;
+}
+
+void wcache_write_req::notify(request *child) {
+    child->release();
+    if(--reqs > 0)
+	return;
+    wcache->notify_complete(seq);
+}
+
+void wcache_write_req::run(request *parent /* unused */) {
+    if(r_pad) 
+	r_pad->run(this);
+    r_data->run(this);
+}
+
+/* --------------- Write Cache ------------- */
+
+/* stall write requests using window of max_write_blocks, which should
+ * be <= 0.5 * write cache size.
+ */
+void write_cache_impl::get_room(sector_t sectors) {
+    int pages = sectors / 8;
+    std::unique_lock lk(m2);
+    while (total_write_pages + pages > max_write_pages)
+	write_cv.wait(lk);
+    total_write_pages += pages;
+}
+
+void write_cache_impl::release_room(sector_t sectors) {
+    int pages = sectors / 8;
+    std::unique_lock lk(m2);
+    total_write_pages -= pages;
+    if (total_write_pages < max_write_pages)
+	write_cv.notify_all();
+}
+
+/* this is kind of messed up. total_write_pages only counts calls to
+ * get/release_room from lsvd.cc, outstanding.size() should be zero whenever
+ * total_write_pages is zero. Could just flush at higher level.
+ */
+void write_cache_impl::flush(void) {
+    std::unique_lock lk2(m2);	// total_write_pages
+    std::unique_lock lk(m);	// outstanding
+    while (total_write_pages > 0 || outstanding.size() > 0)
+	write_cv.wait(lk);
+}
+
+/* dump map entries for locations being reallocated.
+ * instead of maintaining a reverse map and going to a lot of effort,
+ * we occasionally go through the entire map and remove all entries that
+ * point to a particular 1/8th section of the write cache.
+ */
+void write_cache_impl::evict(page_t p_base, page_t p_limit) {
+    if (cleared_limit == super->limit) {
+	if (p_base >= (super->base + super->limit) / 2)
+	    return;
+	cleared_limit = p_base = super->base;
+    }
+    else if (p_limit <= cleared_limit)
+	return;
+
+    int octant = (super->limit + 7 - super->base) / 8;
+    cleared_limit = std::min(super->limit, cleared_limit + octant);
+    if (super->limit - cleared_limit < octant/2)
+	cleared_limit = super->limit;
+    std::vector<j_map_extent> exts;
+    sector_t s_base = p_base * 8;
+    sector_t s_cleared_limit = cleared_limit * 8;
+
+    for (auto it = map.begin(); it != map.end(); ) {
+	auto [base, limit, plba] = it->vals();
+	auto len = limit - base;
+	if (plba + len <= s_base || plba >= s_cleared_limit)
+	    it++;
+	else 
+	    it = map._erase(it);
+    }
+}
+
+#if 0
+void write_cache_impl::evict(page_t p_base, page_t p_limit) {
+    sector_t s_base = p_base*8, s_limit = p_limit*8;
+    for (auto it = rmap.lookup(s_base);
+	 it != rmap.end() && it->base() < s_limit; it++) {
+	auto [_base, _limit, ptr] = it->vals(s_base, s_limit);
+	map.trim(ptr, ptr+(_limit-_base));
+    }
+    rmap.trim(s_base, s_limit);
+}
+#endif
+    
+/* must be called with lock held. 
+ * n:        total length to allocate (including header)
+ * <return>: page number for header
+ * pad:      page number for pad header (or 0)
+ * n_pad:    total pages for pad
+ * prev_:    previously
+ *
+ * TODO: totally confusing that n_pad includes the header page here,
+ * while it excluses the header page in wcache_write_req constructor
+ */
+uint32_t write_cache_impl::allocate(page_t n, page_t &pad, page_t &n_pad,
+				    page_t &prev) {
+    //assert(!m.try_lock());
+    assert(n > 0);
+    assert(super->next >= super->base && super->next < super->limit);
+
+    prev = previous_hdr;
+    pad = n_pad = 0;
+    page_t start = super->next, end = start;
+
+again:
+    while ((end - start) < n && after.size() > 0) {
+	end = after.front().page;
+	if (end < start + n) {
+	    auto it = after.begin();
+	    evict(it->page, it->page + it->len);
+	    end = it->page + it->len;
+	    after.erase(it);
+	}
+    }
+
+    if (after.size() == 0)
+	end = super->limit;
+
+    if (end - start < n) {
+	assert(after.size() == 0); // looping twice not allowed
+	assert(pad == 0);	   // ditto
+	pad = start;
+	n_pad = end - start;
+	after.insert(after.end(), before.begin(), before.end());
+	before.clear();
+	start = end = super->base;
+	goto again;
+    }
+
+    before.push_back({start, n});
+    super->next = start + n;
+    if (super->next == super->limit) {
+	super->next = super->base;
+	after.insert(after.end(), before.begin(), before.end());
+	before.clear();
+    }
+
+    previous_hdr = start;
+    return start;
+}
+
+void write_cache_impl::notify_complete(uint64_t seq) {
+    std::unique_lock lk(m);
+    write_record r = {seq, NULL, 0, false};
+    auto it = outstanding.find(r);
+    assert(it != outstanding.end() && it->seq == seq);
+    it->done = true;
+
+    std::vector<wcache_write_req*> reqs;
+    for (it = outstanding.begin(); it != outstanding.end() && it->done;) {
+	next_acked_page = it->next;
+	reqs.push_back(it->req);
+	it = outstanding.erase(it);
+    }
+    lk.unlock();
+    
+    for (auto r : reqs)
+	r->notify_in_order();
+    write_cv.notify_all();
+}
+
+void write_cache_impl::record_outstanding(uint64_t seq, page_t next,
+					  wcache_write_req *req) {
+    //assert(!m.try_lock());	// must be locked
+    write_record r = {seq, req, next, false};
+    outstanding.insert(r);
+}
+
+/* call with lock held
+ */
+j_hdr *write_cache_impl::mk_header(char *buf, uint32_t type, page_t blks,
+				   page_t prev) {
+    //assert(!m.try_lock());
+    memset(buf, 0, 4096);
+    j_hdr *h = (j_hdr*)buf;
+    // OH NO - am I using wcache->sequence or wcache->super->seq???
+    *h = (j_hdr){.magic = LSVD_MAGIC, .type = type, .version = 1,
+		 .len = blks, .seq = sequence++, .crc32 = 0,
+		 .extent_offset = 0, .extent_len = 0, .prev = prev};
+    return h;
+}
+
+void write_cache_impl::flush_thread(thread_pool<int> *p) {
+    pthread_setname_np(pthread_self(), "wcache_flush");
+    auto period = std::chrono::milliseconds(50);
+    while (p->running) {
+	std::unique_lock lk(m);
+	p->cv.wait_for(lk, period);
+	if (!p->running)
+	    return;
+	if (outstanding_writes == 0 && work.size() > 0)
+	    send_writes(lk);	// unlocks
+    }
+}
+
+/* note that this is only called on shutdown, so we don't
+ * worry about locking, and we set the 'clean' flag in the superblock
+ */
+void write_cache_impl::write_checkpoint(void) {
+
+    /* get all the lengths
+     */
+    std::vector<j_length> lengths;
+    lengths.insert(lengths.end(), before.begin(), before.end());
+    lengths.insert(lengths.end(), after.begin(), after.end());
+
+    /* and the map
+     */
+    size_t map_bytes = map.size() * sizeof(j_map_extent);
+    size_t len_bytes = lengths.size() * sizeof(j_length);
+    page_t map_pages = div_round_up(map_bytes, 4096),
+	len_pages = div_round_up(len_bytes, 4096),
+	ckpt_pages = map_pages + len_pages;
+
+    char *e_buf = (char*)aligned_alloc(512, 4096L*map_pages);
+    auto jme = (j_map_extent*)e_buf;
+    int n_extents = 0;
+    if (map.size() > 0)
+	for (auto it = map.begin(); it != map.end(); it++)
+	    jme[n_extents++] = (j_map_extent){(uint64_t)it->s.base,
+					      (uint64_t)it->s.len, (uint32_t)it->s.ptr};
+
+    // valgrind: clean up the end
+    int pad1 = 4096L*map_pages - map_bytes;
+    assert(map_bytes == n_extents * sizeof(j_map_extent));
+    assert(pad1 + map_bytes == 4096UL*map_pages);
+    if (pad1 > 0)
+	memset(e_buf + map_bytes, 0, pad1);
+
+    char *l_buf = (char*)aligned_alloc(512, 4096L * len_pages);
+    auto jl = (j_length*)l_buf;
+    int n_lens = 0;
+    for (auto l : lengths)
+	jl[n_lens++] = l;
+
+    // valgrind:
+    int pad2 = 4096L * len_pages - len_bytes;
+    assert(len_bytes + pad2 == len_pages*4096UL);
+    if (pad2 > 0)
+	memset(l_buf + len_bytes, 0, pad2);
+
+    /* shouldn't really need the copy, since it's only called on
+     * shutdown, except that some unit tests call this and expect things
+     * to work afterwards
+     */
+    page_t blockno = super->meta_base;
+    j_write_super *super_copy = (j_write_super*)aligned_alloc(512, 4096);
+
+    memcpy(super_copy, super, 4096);
+    super_copy->seq = sequence;
+    super_copy->next = next_acked_page;
+
+    super_copy->map_start = super->map_start = blockno;
+    super_copy->map_blocks = super->map_blocks = map_pages;
+    super_copy->map_entries = super->map_entries = n_extents;
+
+    super_copy->len_start = super->len_start = blockno+map_pages;
+    super_copy->len_blocks = super->len_blocks = len_pages;
+    super_copy->len_entries = super->len_entries = n_lens;
+
+    super_copy->clean = true;
+
+    if (!(4096UL*blockno + 4096UL*ckpt_pages <= dev_max))
+	throw("some-sort-of-error");
+    iovec iov[] = {{e_buf, map_pages*4096UL},
+		   {l_buf, len_pages*4096UL}};
+
+    if (nvme_w->writev(iov, 2, 4096L*blockno) < 0)
+	throw_fs_error("wckpt_e");
+    if (nvme_w->write((char*)super_copy, 4096, 4096L*super_blkno) < 0)
+	throw_fs_error("wckpt_s");
+
+    free(super_copy);
+    free(e_buf);
+    free(l_buf);
+}
+
+void write_cache_impl::read_map_entries() {
+    /* 
+     * first read the checkpoint map and update map
+     */
+    size_t map_bytes = super->map_entries * sizeof(j_map_extent),
+	map_bytes_4k = round_up(map_bytes, 4096);
+    char *map_buf = (char*)aligned_alloc(512, map_bytes_4k);
+    std::vector<j_map_extent> extents;
+
+    if (nvme_w->read(map_buf, map_bytes_4k, 4096L * super->map_start) < 0)
+	throw_fs_error("wcache_map");
+    decode_offset_len<j_map_extent>(map_buf, 0, map_bytes, extents);
+
+    for (auto e : extents)
+	map.update(e.lba, e.lba+e.len, e.plba);
+
+    free(map_buf);
+
+    /* read the lengths
+     */
+    size_t len_bytes = super->len_entries * sizeof(j_length),
+	len_bytes_4k = round_up(len_bytes, 4096);
+    char *len_buf = (char*)aligned_alloc(512, len_bytes_4k);
+    std::vector<j_length> lengths;
+
+    if (nvme_w->read(len_buf, len_bytes_4k, 4096L * super->len_start) < 0)
+	throw_fs_error("wcache_len");
+    decode_offset_len<j_length>(len_buf, 0, len_bytes, lengths);
+    free(len_buf);
+    std::sort(lengths.begin(), lengths.end());
+    
+    int max_page = 0;
+    for (auto l : lengths) {
+	page_t limit = l.page + l.len;
+	if (limit <= super->next)
+	    before.push_back(l);
+	else
+	    after.push_back(l);
+	if (max_page < limit)
+	    max_page = limit;
+    }
+
+    // (super->next == base) ==> (before == [])
+    assert(super->next != super->base || before.size() == 0);
+    // (before != []) ==> before <= super->next
+    assert(before.size() == 0 ||
+	     before.back().page + before.back().len <= super->next);
+    
+    next_acked_page = cleared_limit = super->next;
+}
+
+/* needs to set the following variables:
+ *  super->next
+ *  next_acked_page
+ *  sequence
+ */
+int write_cache_impl::roll_log_forward() {
+    page_t start = super->base, prev = 0;
+    auto h = (j_hdr*)_hdrbuf;
+    
+    if (nvme_w->read(_hdrbuf, 4096, 4096L * start) < 0)
+	throw_fs_error("cache log roll-forward");
+
+    /* nothing in cache
+     */
+    if (h->magic != LSVD_MAGIC || h->type != LSVD_J_DATA) {
+	sequence = 1;
+	super->next = next_acked_page = super->base;
+	// before = after = {}
+	return 0;
+    }
+    sequence = h->seq;
+
+    /* find the oldest journal entry
+     */
+    while (true) {
+	prev = h->prev;
+	if (prev == 0)		// hasn't wrapped
+	    break;
+	if (nvme_w->read(_hdrbuf, 4096, 4096L * prev) < 0)
+	    throw_fs_error("cache log roll-forward");
+	if (h->magic != LSVD_MAGIC || h->seq != sequence-1 ||
+	    (h->type != LSVD_J_DATA && h->type != LSVD_J_PAD))
+	    break;
+	sequence = h->seq;
+	start = prev;
+    }
+
+    /* Read all the records in, update lengths and map, and write
+     * to backend if they're newer than the last write the translation
+     * layer guarantees is persisted.
+     */
+    while (true) {
+	/* handle wrap-around
+	 */
+	if (start == super->limit) {
+	    after.insert(after.end(), before.begin(), before.end());
+	    before.clear();
+	    start = super->base;
+	    continue;
+	}
+
+	/* is this another journal record?
+	 */
+	if (nvme_w->read(_hdrbuf, 4096, 4096L * start) < 0)
+	    throw_fs_error("cache log roll-forward");
+	if (h->magic != LSVD_MAGIC || h->seq != sequence ||
+	    (h->type != LSVD_J_DATA && h->type != LSVD_J_PAD))
+	    break;
+
+	if (h->type == LSVD_J_PAD) {
+	    start = super->limit;
+	    sequence++;
+	    continue;
+	}
+	
+	before.push_back({start, h->len});
+
+	/* read LBA info from header, read data, then 
+	 * - put mappings into cache map
+	 * - write data to backend
+	 */
+	std::vector<j_extent> entries;
+	decode_offset_len<j_extent>(_hdrbuf, h->extent_offset,
+				    h->extent_len, entries);
+
+	size_t data_len = 4096L * (h->len - 1);
+	char *data = (char*)aligned_alloc(512, data_len);
+	if (nvme_w->read(data, data_len, 4096L * (start+1)) < 0)
+	    throw_fs_error("wcache");
+
+	sector_t plba = (start+1) * 8;
+	size_t offset = 0;
+
+	/* all write batches with sequence < max_cache_seq are
+	 * guaranteed to be persisted in the backend already
+	 */
+	for (auto e : entries) {
+	    map.update(e.lba, e.lba+e.len, plba);
+
+	    size_t bytes = e.len * 512;
+	    iovec iov = {data+offset, bytes};
+	    if (sequence >= be->max_cache_seq) {
+		do_log("write %ld %d+%d\n", sequence.load(), (int)e.lba, e.len);
+		be->writev(sequence, e.lba*512, &iov, 1);
+	    }
+	    else
+		do_log("skip %ld %d (max %d) %ld+%d\n", start,
+		       sequence.load(), be->max_cache_seq, e.lba, e.len);
+	    offset += bytes;
+	    plba += e.len;
+	}
+
+	free(data);
+
+	start += h->len;
+	sequence++;
+    }
+
+    super->next = next_acked_page = cleared_limit = start;
+    
+    be->flush();
+    usleep(10000);
+    
+    return 0;
+}
+
+write_cache_impl::write_cache_impl( uint32_t blkno, int fd, translate *_be,
+				    lsvd_config *cfg_) {
+
+    super_blkno = blkno;
+    dev_max = getsize64(fd);
+    be = _be;
+    cfg = cfg_;
+
+    _hdrbuf = (char*)aligned_alloc(512, 4096);
+    
+    const char *name = "write_cache_cb";
+    nvme_w = make_nvme(fd, name);
+
+    char *buf = (char*)aligned_alloc(512, 4096);
+    if (nvme_w->read(buf, 4096, 4096L*super_blkno) < 4096)
+	throw_fs_error("wcache");
+    super = (j_write_super*)buf;
+
+    /* if it's clean we can read in the map and lengths, otherwise
+     * do crash recovery. Then set the dirty flag
+     */
+    if (super->clean) {
+	sequence = super->seq;
+	read_map_entries();	// length, too
+    }
+    else if (roll_log_forward() < 0)
+	throw("write log roll-forward failed");
+
+    super->clean = false;
+    if (nvme_w->write(buf, 4096, 4096L*super_blkno) < 4096)
+	throw_fs_error("wcache");
+    
+    int n_pages = super->limit - super->base;
+    max_write_pages = n_pages / 2 + n_pages / 4;
+    write_batch = cfg->wcache_batch;
+    
+    misc_threads = new thread_pool<int>(&m);
+    misc_threads->pool.push(std::thread(&write_cache_impl::flush_thread,
+					this, misc_threads));
+}
+
+write_cache *make_write_cache(uint32_t blkno, int fd,
+			      translate *be, lsvd_config *cfg) {
+    return new write_cache_impl(blkno, fd, be, cfg);
+}
+
+write_cache_impl::~write_cache_impl() {
+    delete misc_threads;
+    free(super);
+    free(_hdrbuf);
+    delete nvme_w;
+}
+
+void write_cache_impl::send_writes(std::unique_lock<std::mutex> &lk) {
+    sector_t sectors = 0;
+    for (auto w : work) {
+        sectors += w->iov->bytes() / 512;
+        assert(w->iov->aligned(512));
+    }
+
+    page_t pages = div_round_up(sectors, 8);
+    page_t pad, n_pad, prev = 0;
+    page_t page = allocate(pages+1, pad, n_pad, prev);
+
+    auto req = new wcache_write_req(&work, pages, page,
+				    n_pad-1, pad, prev, this);
+    work.clear();
+    work_sectors = 0;
+    outstanding_writes++;
+
+    lk.unlock();
+    req->run(NULL);
+}
+
+write_cache_work *write_cache_impl::writev(request *req, sector_t lba, smartiov *iov) {
+    std::unique_lock lk(m);
+    auto w = new write_cache_work(req, lba, iov);
+    work.push_back(w);
+    work_sectors += iov->bytes() / 512L;
+
+    // if we're not under write pressure, send writes immediately; else
+    // batch them
+    if (outstanding_writes == 0 || work.size() >= write_batch ||
+	work_sectors >= cfg->wcache_chunk / 512)
+	send_writes(lk);
+    return w;
+}
+
+/* arguments:
+ *  lba to start at
+ *  iov corresponding to lba (iov.bytes() = length to read)
+ * returns (number of bytes skipped), (number of bytes read_started)
+ */
+std::tuple<size_t,size_t,request*>
+write_cache_impl::async_read(size_t offset, char *buf, size_t bytes) {
+    sector_t base = offset/512, limit = base + bytes/512;
+    size_t skip_len = 0, read_len = 0;
+    request *rreq = NULL;
+    
+    std::unique_lock<std::mutex> lk(m);
+    off_t nvme_offset = 0;
+
+    auto it = map.lookup(base);
+    if (it == map.end() || it->base() >= limit)
+	skip_len = bytes;
+    else {
+	auto [_base, _limit, plba] = it->vals(base, limit);
+	if (_base > base) {
+	    skip_len = 512 * (_base - base);
+	    buf += skip_len;
+	}
+	read_len = 512 * (_limit - _base);
+	nvme_offset = 512L * plba;
+    }
+    lk.unlock();
+
+    if (read_len) 
+	rreq = nvme_w->make_read_request(buf, read_len, nvme_offset);
+
+    return std::make_tuple(skip_len, read_len, rreq);
+}
+
+std::tuple<size_t,size_t,request*>
+write_cache_impl::async_readv(size_t offset, smartiov *iov) {
+    auto bytes = iov->bytes();
+    sector_t base = offset/512, limit = base + bytes/512;
+    size_t skip_len = 0, read_len = 0;
+    request *rreq = NULL;
+    
+    std::unique_lock<std::mutex> lk(m);
+    off_t nvme_offset = 0;
+
+    auto it = map.lookup(base);
+    if (it == map.end() || it->base() >= limit)
+	skip_len = bytes;
+    else {
+	auto [_base, _limit, plba] = it->vals(base, limit);
+	if (_base > base) 
+	    skip_len = 512 * (_base - base);
+	read_len = 512 * (_limit - _base);
+	nvme_offset = 512L * plba;
+    }
+
+    if (read_len) {
+	smartiov _iovs = iov->slice(skip_len, skip_len+read_len);
+	rreq = nvme_w->make_read_request(&_iovs, nvme_offset);
+    }
+
+    return std::make_tuple(skip_len, read_len, rreq);
+}
+
+void write_cache_impl::do_write_checkpoint(void) {
+    write_checkpoint();
+}

--- a/src/liblsvd/write_cache.h
+++ b/src/liblsvd/write_cache.h
@@ -1,0 +1,47 @@
+/*
+ * file:        write_cache.h
+ * description: full structure for write cache
+ * 
+ * author:      Peter Desnoyers, Northeastern University
+ * Copyright 2021, 2022 Peter Desnoyers
+ * license:     GNU LGPL v2.1 or newer
+ *              LGPL-2.1-or-later
+ */
+
+#ifndef WRITE_CACHE_H
+#define WRITE_CACHE_H
+
+struct write_cache_work {
+public:
+    request  *req;
+    sector_t  lba;
+    smartiov *iov;
+    write_cache_work(request *r, sector_t a, smartiov *v) : req(r), lba(a), iov(v) {}
+};
+
+/* all addresses are in units of 4KB blocks
+ */
+class write_cache {
+public:
+    virtual void get_room(sector_t sectors) = 0; 
+    virtual void release_room(sector_t sectors) = 0;
+    virtual void flush(void) = 0;
+
+    virtual ~write_cache() {}
+
+    virtual write_cache_work* writev(request *req, sector_t lba, smartiov *iov) = 0;
+    virtual std::tuple<size_t,size_t,request*>
+        async_read(size_t offset, char* buf, size_t len) = 0;
+    virtual std::tuple<size_t,size_t,request*>
+        async_readv(size_t offset, smartiov *iovs) = 0;
+
+    virtual void do_write_checkpoint(void) = 0;
+};
+
+extern write_cache *make_write_cache(uint32_t blkno, int fd,
+                                     translate *be, lsvd_config *cfg);
+
+
+#endif
+
+


### PR DESCRIPTION
Log Structured Virtual Disk (LSVD) technology preview see "Beating the I/O Bottleneck - a Case for Log-Structured Virtual Disks" Hajkazemi et al, EuroSys 2022 https://dl.acm.org/doi/10.1145/3492321.3524271

This adds a new library, liblsvd.so, which "pirates" the librbd interface and can be used via LD_PRELOAD; it's been tested with QEMU and fio.

See README.md for more details. Note that this needs re-writing to conform to Ceph coding guidelines, as well as a lot of discussion to figure out how it can live alongside RBD, use Ceph async completion and buffer lists so it can use the internal RADOS interface, etc.

Signed-off-by: Peter Desnoyers p.desnoyers@northeastern.edu

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

Includes unit tests, but they aren't integrated into Ceph make check or teuthology
