### PR TITLE
ceph-volume/util: Improve performance for Ceph OSDs that use encryption

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -195,6 +195,26 @@ def device_family(device):
 
     return devices
 
+def is_rotational(device):
+    """
+    Returns true if a device is rotational or not.
+    """
+    labels = ['ROTA']
+    command = ['lsblk', '-P', '-p', '-o', ','.join(labels), device]
+    out, err, rc = process.call(command)
+    device = []
+    for line in out:
+        device.append(_lsblk_parser(line))
+
+    for i in device:
+        if type(i) is dict and "ROTA" in i.keys():
+            if i['ROTA'] == '1':
+                rotational = True
+            else:
+                rotational = False
+
+    return rotational
+
 
 def udevadm_property(device, properties=[]):
     """
@@ -911,6 +931,10 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         metadata['sectorsize'] = get_file_contents(sysdir +
                                                    "/queue/logical_block_size",
                                                    fallback_sectorsize)
+        fallback_rotational = '1'
+        metadata['rotational'] = get_file_contents(sysdir +
+                                                   "/queue/rotational",
+                                                   fallback_rotational)
         metadata['size'] = float(size) * 512
         metadata['human_readable_size'] = human_readable_size(metadata['size'])
         metadata['path'] = diskname


### PR DESCRIPTION
The commits in this PR are the following:

Changes in ceph-volume/util/encryption.py and disk.py to influence parameters used when opening encrypted devices.

- minor formatting fix
~~- automatically derive the optimal sector size to use for cryptsetup LuksFormat~~
- automatically disable dm-crypt "workqueues" for flash media when opening encrypted devices to improve I/O performance

Author has proof of performance improvements on request (not sure if / how to supply in this PR). These changes have been discussed on [ceph-user ML](https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/D5URLVPVGX52O6WYV474T6IVTHGHCASB/) and pitched at ceph-performance weekly. @markhpc asked to write a PR, so here we are ;-).


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
