### PR TITLE
osd: fix pg delete local reservations invalid

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -48,6 +48,18 @@ options:
   level: dev
   default: true
   with_legacy: true
+- name: osd_max_pg_deletes
+  type: uint
+  level: advanced
+  desc: Maximum number of concurrent pg deletes per OSD
+  long_desc: There can be osd_max_pg_deletes pg delete reservations per OSD.
+    So a value of 1 lets this OSD participate as 1 PG in deleting.
+  fmt_desc: Maximum number of concurrent pg deletes per OSD
+    Note that this is applied separately for read and write operations.
+  default: 1
+  flags:
+  - runtime
+  with_legacy: true
 - name: osd_max_backfills
   type: uint
   level: advanced

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -344,7 +344,7 @@ public:
     // Not needed yet
   }
 
-  void on_removal(ceph::os::Transaction &t) final {
+  void on_removal(ceph::os::Transaction &t, bool is_deleting=false) final {
     // TODO
   }
   std::pair<ghobject_t, bool>

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -490,6 +490,7 @@ public:
   Finisher reserver_finisher;
   AsyncReserver<spg_t, Finisher> local_reserver;
   AsyncReserver<spg_t, Finisher> remote_reserver;
+  AsyncReserver<spg_t, Finisher> pg_delete_reserver;
 
   // -- pg merge --
   ceph::mutex merge_lock = ceph::make_mutex("OSD::merge_lock");

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1761,6 +1761,24 @@ OstreamTemp PG::get_clog_error() {
   return osd->clog->error();
 }
 
+void PG::request_pg_delete_background_io_reservation(
+  unsigned priority,
+  PGPeeringEventURef on_grant,
+  PGPeeringEventURef on_preempt) {
+  osd->pg_delete_reserver.request_reservation(
+    pg_id,
+    on_grant ? new QueuePeeringEvt(
+      this, std::move(on_grant)) : nullptr,
+    priority,
+    on_preempt ? new QueuePeeringEvt(
+      this, std::move(on_preempt)) : nullptr);
+}
+
+void PG::cancel_pg_delete_background_io_reservation() {
+  osd->pg_delete_reserver.cancel_reservation(
+    pg_id);
+}
+
 void PG::schedule_event_after(
   PGPeeringEventRef event,
   float delay) {
@@ -2747,7 +2765,7 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
 
       // cancel reserver here, since the PG is about to get deleted and the
       // exit() methods don't run when that happens.
-      osd->local_reserver.cancel_reservation(info.pgid);
+      osd->pg_delete_reserver.cancel_reservation(info.pgid);
 
       running = false;
     }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -704,7 +704,7 @@ public:
   void with_heartbeat_peers(std::function<void(int)>&& f);
 
   void shutdown();
-  virtual void on_shutdown() = 0;
+  virtual void on_shutdown(bool is_deleting=false) = 0;
 
   bool get_must_scrub() const;
   Scrub::schedule_result_t sched_scrub();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -598,6 +598,12 @@ public:
   OstreamTemp get_clog_info() override;
   OstreamTemp get_clog_debug() override;
 
+  void request_pg_delete_background_io_reservation(
+    unsigned priority,
+    PGPeeringEventURef on_grant,
+    PGPeeringEventURef on_preempt) override;
+  void cancel_pg_delete_background_io_reservation() override;
+
   void schedule_event_after(
     PGPeeringEventRef event,
     float delay) override;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6670,7 +6670,7 @@ PeeringState::Deleting::Deleting(my_context ctx)
   ps->pg_log.reset_backfill();
   ps->dirty_info = true;
 
-  pl->on_removal(t);
+  pl->on_removal(t, true);
 }
 
 boost::statechart::result PeeringState::Deleting::react(

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6607,7 +6607,7 @@ void PeeringState::ToDelete::exit()
   // do_delete_work().
   pl->get_perf_logger().dec(l_osd_pg_removing);
 
-  pl->cancel_local_background_io_reservation();
+  pl->cancel_pg_delete_background_io_reservation();
 }
 
 /*----WaitDeleteReserved----*/
@@ -6620,8 +6620,8 @@ PeeringState::WaitDeleteReserved::WaitDeleteReserved(my_context ctx)
   DECLARE_LOCALS;
   context< ToDelete >().priority = ps->get_delete_priority();
 
-  pl->cancel_local_background_io_reservation();
-  pl->request_local_background_io_reservation(
+  pl->cancel_pg_delete_background_io_reservation();
+  pl->request_pg_delete_background_io_reservation(
     context<ToDelete>().priority,
     std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
@@ -6689,7 +6689,7 @@ void PeeringState::Deleting::exit()
   context< PeeringMachine >().log_exit(state_name, enter_time);
   DECLARE_LOCALS;
   ps->deleting = false;
-  pl->cancel_local_background_io_reservation();
+  pl->cancel_pg_delete_background_io_reservation();
 }
 
 /*--------GetInfo---------*/

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -406,7 +406,7 @@ public:
 
     // ====================== PG deletion =======================
     /// Notification of removal complete, t must be populated to complete removal
-    virtual void on_removal(ObjectStore::Transaction &t) = 0;
+    virtual void on_removal(ObjectStore::Transaction &t, bool is_deleting=false) = 0;
     /// Perform incremental removal work
     virtual std::pair<ghobject_t, bool> do_delete_work(
       ObjectStore::Transaction &t, ghobject_t _next) = 0;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -328,6 +328,20 @@ public:
     /// Notification that all outstanding flushes for interval have completed
     virtual void on_flushed() = 0;
 
+    //============= Delete ====================
+    /**
+     * request_pg_delete_background_io_reservation
+     *
+     * Request reservation at priority with on_grant queued on grant
+     * and on_preempt on preempt
+     */
+    virtual void request_pg_delete_background_io_reservation(
+      unsigned priority,
+      PGPeeringEventURef on_grant,
+      PGPeeringEventURef on_preempt) = 0;
+    /// Cancel pending pg delete background reservation request
+    virtual void cancel_pg_delete_background_io_reservation() = 0;
+
     //============= Recovery ====================
     /// Arrange for even to be queued after delay
     virtual void schedule_event_after(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12927,12 +12927,14 @@ void PrimaryLogPG::on_shutdown(bool is_deleting)
   clear_async_reads();
 
   osd->remote_reserver.cancel_reservation(info.pgid);
+  osd->local_reserver.cancel_reservation(info.pgid);
 
-  // PG Deleting need to request local_reserver
+  // PG Deleting need to request pg_delete_reserver
   // and limit the stray PG concurrent deleting,
-  // it will be cancel by Deleting::exit(), not here
+  // it will be cancel by Deleting::exit(),
+  // not here
   if (!is_deleting)
-    osd->local_reserver.cancel_reservation(info.pgid);
+    osd->pg_delete_reserver.cancel_reservation(info.pgid);
 
   clear_primary_state();
   cancel_recovery();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12865,11 +12865,12 @@ void PrimaryLogPG::on_flushed()
   }
 }
 
-void PrimaryLogPG::on_removal(ObjectStore::Transaction &t)
+void PrimaryLogPG::on_removal(ObjectStore::Transaction &t,
+                              bool is_deleting)
 {
   dout(10) << __func__ << dendl;
 
-  on_shutdown();
+  on_shutdown(is_deleting);
 
   t.register_on_commit(new C_DeleteMore(this, get_osdmap_epoch()));
 }
@@ -12891,7 +12892,7 @@ void PrimaryLogPG::clear_cache()
   object_contexts.clear();
 }
 
-void PrimaryLogPG::on_shutdown()
+void PrimaryLogPG::on_shutdown(bool is_deleting)
 {
   dout(10) << __func__ << dendl;
 
@@ -12926,7 +12927,12 @@ void PrimaryLogPG::on_shutdown()
   clear_async_reads();
 
   osd->remote_reserver.cancel_reservation(info.pgid);
-  osd->local_reserver.cancel_reservation(info.pgid);
+
+  // PG Deleting need to request local_reserver
+  // and limit the stray PG concurrent deleting,
+  // it will be cancel by Deleting::exit(), not here
+  if (!is_deleting)
+    osd->local_reserver.cancel_reservation(info.pgid);
 
   clear_primary_state();
   cancel_recovery();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1893,8 +1893,8 @@ public:
   void on_change(ObjectStore::Transaction &t) override;
   void on_activate_complete() override;
   void on_flushed() override;
-  void on_removal(ObjectStore::Transaction &t, bool is_deleting=false) override;
-  void on_shutdown(bool is_deleting=false) override;
+  void on_removal(ObjectStore::Transaction &t, bool is_deleting) override;
+  void on_shutdown(bool is_deleting) override;
   bool check_failsafe_full() override;
   bool maybe_preempt_replica_scrub(const hobject_t& oid) override;
   int rep_repair_primary_object(const hobject_t& soid, OpContext *ctx);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1893,8 +1893,8 @@ public:
   void on_change(ObjectStore::Transaction &t) override;
   void on_activate_complete() override;
   void on_flushed() override;
-  void on_removal(ObjectStore::Transaction &t) override;
-  void on_shutdown() override;
+  void on_removal(ObjectStore::Transaction &t, bool is_deleting=false) override;
+  void on_shutdown(bool is_deleting=false) override;
   bool check_failsafe_full() override;
   bool maybe_preempt_replica_scrub(const hobject_t& oid) override;
   int rep_repair_primary_object(const hobject_t& soid, OpContext *ctx);


### PR DESCRIPTION
https://tracker.ceph.com/issues/58357

```
When the cluster increases or decreases the host OSDs,
After PG is repair to active+clean, the service IO latency is higher than normal,
Set debug_osd=20, the osd log shows that a large number of stray PGs concurrent deleting,
But check osd_ max_ Backfills=1. one osd should have only one stray PG deleting, not multiple,
And ceph daemon osd {x} dump_recovery_reservations, there is no local_server "in progress or waiting",
which is obviously incorrect, indicating that local_reserver for stray PG Deleting
```


```
PeeringState::ToDelete::ToDelete
PeeringState::WaitDeleteReserved::WaitDeleteReserved 
   pl->cancel_local_background_io_reservation
      osd->local_reserver.cancel_reservation              //cancel local reservation
   pl->request_local_background_io_reservation
      osd->local_reserver.request_reservation           //request local reservation
boost::statechart::transition<DeleteReserved, Deleting>
PeeringState::Deleting::Deleting
   PrimaryLogPG::on_removal
   PrimaryLogPG::on_shutdown
      osd->local_reserver.cancel_reservation(info.pgid)   // deleting not started, but cancel local reservation now 

boost::statechart::result PeeringState::Deleting::react(const DeleteSome& evt)
    p = pl->do_delete_work          //after local reservation cancel, begin deleting
    return p.second ? discard_event() : terminate();
```


```
[osd: add pg_delete_reserver/osd_max_pg_deletes for pg delete](https://github.com/ceph/ceph/pull/49577/commits/b8da27a2bcc4257ec7e085a35bb10ae03acc33fa) 

1.pg delete priority higher than pg backfill
2.it will cause the degraded pg to wait for backfill
  for a long time, even if the space capacity is sufficient
3.in order to solve this problem,
  the reservations of backifll and delete are separated,
  add pg_delete_reserver, and control the maximum number of PGs
  that execute delete concurrently in a single osd
  through osd_max_pg_deletes
```