### PR TITLE
pybind/mgr: Add packaging module

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -666,6 +666,7 @@ Requires:       python%{python3_pkgversion}-dateutil
 Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-pyyaml
 Requires:       python%{python3_pkgversion}-werkzeug
+Requires:       python%{python3_pkgversion}-packaging
 %endif
 %if 0%{?suse_version}
 Requires:       python%{python3_pkgversion}-CherryPy

--- a/debian/control
+++ b/debian/control
@@ -284,6 +284,7 @@ Package: ceph-mgr-modules-core
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
+         python3-packaging,
 Replaces: ceph-mgr (<< 15.1.0)
 Breaks: ceph-mgr (<< 15.1.0)
 Description: ceph manager modules which are always enabled

--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -14,3 +14,4 @@ requests-mock
 scipy
 werkzeug
 natsort
+packaging


### PR DESCRIPTION
Introduced: 9f0ee9798563efe4ce9759f5d8c0ca6aa47a6838

`ModuleNotFoundError: No module named 'packaging'`  was spotted in few teuthology log runs.
(https://pulpito.ceph.com/yuvalif-2022-12-23_07:38:27-rgw-wip-yuval-test-main-distro-default-smithi/7126208/)

Fixes: https://tracker.ceph.com/issues/58385


Signed-off-by: Matan Breizman <mbreizma@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
