### PR TITLE
ceph-volume: fix the miscalculation of 'dedicated devices size' when more than one dedicated devices are present

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -120,9 +120,10 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
                 continue
             # any LV present is considered a taken slot
             occupied_slots = len(dev.lvs)
-            dev_size = dev.vg_size[0]
-            # this only looks at the first vg on device, unsure if there is a better
-            # way
+            total_size = 0
+            for t_size in vg_devices:
+                 total_size = total_size + dev.vg_size[0]
+            dev_size = total_size
             abs_size = disk.Size(b=int(dev_size / requested_slots))
             free_size = dev.vg_free[0]
             relative_size = int(abs_size) / dev_size

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -120,10 +120,7 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
                 continue
             # any LV present is considered a taken slot
             occupied_slots = len(dev.lvs)
-            total_size = 0
-            for t_size in vg_devices:
-                 total_size = total_size + dev.vg_size[0]
-            dev_size = total_size
+            dev_size = dev.vg_size[0] * len(vg_devices)
             abs_size = disk.Size(b=int(dev_size / requested_slots))
             free_size = dev.vg_free[0]
             relative_size = int(abs_size) / dev_size


### PR DESCRIPTION
`ceph-volume` miscalculates the `dedicated devices size` when more than one dedicated devices are present.

The current code only considers one dedicated device while calculating the size of all dedicated devices.
It works well when there is only one dedicated device but miscalculates the device size when we have more than one dedicated device.

Ceph deployment failed with the below error message when there is more than one dedicated device:

```
cmd: cephadm shell --config /etc/ceph/ceph.conf -e CEPH_VOLUME_SKIP_RESTORECON="yes" -m /var/lib/ceph/bootstrap-osd/ceph.keyring:/var/lib/ceph/bootstrap-osd/ceph.keyring /etc/ceph/main.py:/usr/lib/python3.6/site-packages/ceph_volume/drive_group/main.py /etc/ceph/osd_template.json -- ceph-volume drive-group /mnt/osd_template.json
delta: '0:00:09.047473'
end: '2022-12-23 10:59:01.136359'
msg: non-zero return code
rc: 1
start: '2022-12-23 10:58:52.088886'
stderr: |-
  Inferring fsid xxxxxx
  Using recent ceph image xxxx:5000/rhceph/rhceph-5-rhel8@sha256:31fbe18b6f81c53d21053a4a0897bc3875e8ee8ec424393e4d5c3c3afd388274
  --> passed data devices: 4 physical, 0 LVM
  --> relative data size: 1.0
  --> passed block_db devices: 2 physical, 0 LVM
  --> 93.00 GB was requested for block_db_size, but only 46.58 GB can be fulfilled
stderr_lines: <omitted>
stdout: |2-

  Device Path               Size         rotates available Model name
  /dev/sda                  186.31 GB    False   True      INTEL SSDSC2BA20
  /dev/sdb                  186.31 GB    False   True      INTEL SSDSC2BA20
  /dev/sdc                  3.64 TB      True    True      HUS726040ALS210
  /dev/sdd                  3.64 TB      True    True      HUS726040ALS210
  /dev/sde                  3.64 TB      True    True      HUS726040ALS210
  /dev/sdf                  3.64 TB      True    True      HUS726040ALS210
  /dev/sdg                  111.79 GB    False   True      SSDSC2BB120G7R
stdout_lines: <omitted>
```


Signed-off-by: Mohan Sharma <mohan7427@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
