### PR TITLE
ceph-volume: fix drive-group issue that expects the batch_args to be a string

### DIFF
--- a/src/ceph-volume/ceph_volume/drive_group/main.py
+++ b/src/ceph-volume/ceph_volume/drive_group/main.py
@@ -78,7 +78,7 @@ class Deploy(object):
             print(cmd)
         else:
             logger.info('Running ceph-volume command: {}'.format(cmd))
-            batch_args = cmd.split(' ')[2:]
+            batch_args = cmd[0].split(' ')[2:]
             b = Batch(batch_args)
             b.main()
 


### PR DESCRIPTION
The `drive-group` expects the `batch_args` to be a string, however in the current version it is passed as a list of one element, thus calling the first item of the list solves the issue.

Signed-off-by: Mohan Sharma <mohan7427@gmail.com>
