### PR TITLE
crimson: Support Partial Object Recovery

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(crimson-osd
   pg_shard_manager.cc
   object_context.cc
   object_context_loader.cc
+  object_metadata_helper.cc
   ops_executer.cc
   osd_operation.cc
   osd_operations/client_request.cc

--- a/src/crimson/osd/object_metadata_helper.cc
+++ b/src/crimson/osd/object_metadata_helper.cc
@@ -1,0 +1,222 @@
+#include "crimson/osd/object_metadata_helper.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+/*
+ *   The clone object content may already overlap with the
+ *   next older and the next newest clone obejct.
+ *   Use the existing (next) clones object overlaps instead
+ *   of pushing the whole clone object to the replica.
+ */
+
+subsets_t calc_clone_subsets(
+  SnapSet& snapset, const hobject_t& soid,
+  const pg_missing_t& missing,
+  const hobject_t &last_backfill)
+{
+  subsets_t subsets;
+  logger().debug("{}: {} clone_overlap {} ",
+                 __func__, soid, snapset.clone_overlap);
+
+  uint64_t size = snapset.clone_size[soid.snap];
+  if (size) {
+    subsets.data_subset.insert(0, size);
+  }
+
+  // TODO: make sure CEPH_FEATURE_OSD_CACHEPOOL is not supported in Crimson
+  // Skips clone subsets if caching was enabled (allow_incomplete_clones).
+
+#ifndef UNIT_TESTS_BUILT
+  if (!crimson::common::local_conf()->osd_recover_clone_overlap) {
+    logger().debug("{} {} -- osd_recover_clone_overlap is disabled",
+                   __func__, soid); ;
+    return subsets;
+  }
+#endif
+
+  if (snapset.clones.empty()) {
+    logger().debug("{} {} -- no clones", __func__, soid);
+    return subsets;
+  }
+
+  auto soid_snap_iter = find(snapset.clones.begin(),
+                             snapset.clones.end(),
+                             soid.snap);
+  assert(soid_snap_iter != snapset.clones.end());
+  auto soid_snap_index = soid_snap_iter - snapset.clones.begin();
+
+  // any overlap with next older clone?
+  interval_set<uint64_t> cloning;
+  interval_set<uint64_t> prev;
+  if (size) {
+    prev.insert(0, size);
+  }
+  for (int i = soid_snap_index - 1; i >= 0; i--) {
+    hobject_t clone = soid;
+    clone.snap = snapset.clones[i];
+    // clone_overlap of i holds the overlap between i to i+1
+    prev.intersection_of(snapset.clone_overlap[snapset.clones[i]]);
+    if (!missing.is_missing(clone) && clone < last_backfill) {
+      logger().debug("{} {} has prev {} overlap {}",
+                     __func__, soid, clone, prev);
+      subsets.clone_subsets[clone] = prev;
+      cloning.union_of(prev);
+      break;
+    }
+    logger().debug("{} {} does not have prev {} overlap {}",
+                   __func__, soid, clone, prev);
+  }
+
+  // overlap with next newest?
+  interval_set<uint64_t> next;
+  if (size) {
+    next.insert(0, size);
+  }
+  for (unsigned i = soid_snap_index+1;
+       i < snapset.clones.size(); i++) {
+    hobject_t clone = soid;
+    clone.snap = snapset.clones[i];
+    // clone_overlap of i-1 holds the overlap between i-1 to i
+    next.intersection_of(snapset.clone_overlap[snapset.clones[i - 1]]);
+    if (!missing.is_missing(clone) && clone < last_backfill) {
+      logger().debug("{} {} has next {} overlap {}",
+                     __func__, soid, clone, next);
+      subsets.clone_subsets[clone] = next;
+      cloning.union_of(next);
+      break;
+    }
+    logger().debug("{} {} does not have next {} overlap {}",
+                   __func__, soid, clone, next);
+  }
+
+#ifndef UNIT_TESTS_BUILT
+  if (cloning.num_intervals() >
+      crimson::common::local_conf().get_val<uint64_t>
+      ("osd_recover_clone_overlap_limit")) {
+    logger().debug("skipping clone, too many holes");
+    subsets.clone_subsets.clear();
+    cloning.clear();
+  }
+#endif
+
+  // what's left for us to push?
+  subsets.data_subset.subtract(cloning);
+  logger().debug("{} {} data_subsets {}"
+                 "clone_subsets {}",
+                 __func__, soid, subsets.data_subset, subsets.clone_subsets);
+  return subsets;
+}
+
+/*
+ * Instead of pushing the whole object to the replica,
+ * make use of:
+ * 1) ObjectCleanRegion - push modified content only.
+ *    - See: dev/osd_internals/partial_object_recovery
+ * 2) The modified content may already overlap with the
+ *    next older clone obejct. Use the existing clone
+ *    object overlap as well.
+ */
+
+subsets_t calc_head_subsets(
+  uint64_t obj_size,
+  SnapSet& snapset,
+  const hobject_t& head,
+  const pg_missing_t& missing,
+  const hobject_t &last_backfill)
+{
+  logger().debug("{}: {} clone_overlap {} ",
+                 __func__, head, snapset.clone_overlap);
+
+  subsets_t subsets;
+
+// 1) Calculate modified content only
+  if (obj_size) {
+    subsets.data_subset.insert(0, obj_size);
+  }
+  assert(missing.get_items().contains(head));
+  const pg_missing_item missing_item = missing.get_items().at(head);
+  // let data_subset store only the modified content of the object.
+  subsets.data_subset.intersection_of(missing_item.clean_regions.get_dirty_regions());
+  logger().debug("{} {} data_subset {}",
+                 __func__, head, subsets.data_subset);
+
+  // TODO: make sure CEPH_FEATURE_OSD_CACHEPOOL is not supported in Crimson
+  // Skips clone subsets if caching was enabled (allow_incomplete_clones).
+
+#ifndef UNIT_TESTS_BUILT
+  if (!crimson::common::local_conf()->osd_recover_clone_overlap) {
+    logger().debug("{} {} -- osd_recover_clone_overlap is disabled",
+                   __func__, head);
+    return subsets;
+  }
+#endif
+
+  if (snapset.clones.empty()) {
+    logger().debug("{} {} -- no clones", __func__, head);
+    return subsets;
+  }
+
+  // 2) Find any overlap with next older clone
+  interval_set<uint64_t> cloning;
+  interval_set<uint64_t> prev;
+  hobject_t clone = head;
+  if (obj_size) {
+    prev.insert(0, obj_size);
+  }
+  for (int i = snapset.clones.size()-1; i >= 0; i--) {
+    clone.snap = snapset.clones[i];
+    // let prev store only the overlap with clone i
+    prev.intersection_of(snapset.clone_overlap[snapset.clones[i]]);
+    if (!missing.is_missing(clone) && clone < last_backfill) {
+      logger().debug("{} {} has prev {} overlap {}",
+                     __func__, head, clone, prev);
+      cloning = prev;
+      break;
+    }
+    logger().debug("{} {} does not have prev {} overlap {}",
+                   __func__, head, clone, prev);
+  }
+
+  // let cloning store only the overlap with data_subset
+  cloning.intersection_of(subsets.data_subset);
+  if (cloning.empty()) {
+    logger().debug("skipping clone, nothing needs to clone");
+    return subsets;
+  }
+
+#ifndef UNIT_TESTS_BUILT
+  if (cloning.num_intervals() >
+      crimson::common::local_conf().get_val<uint64_t>
+      ("osd_recover_clone_overlap_limit")) {
+    logger().debug("skipping clone, too many holes");
+    subsets.clone_subsets.clear();
+    cloning.clear();
+  }
+#endif
+
+  // what's left for us to push?
+  subsets.clone_subsets[clone] = cloning;
+  subsets.data_subset.subtract(cloning);
+  logger().debug("{} {} data_subsets {}"
+                 "clone_subsets {}",
+                 __func__, head, subsets.data_subset, subsets.clone_subsets);
+
+  return subsets;
+}
+
+void set_subsets(
+  const subsets_t& subsets,
+  ObjectRecoveryInfo& recovery_info)
+{
+  recovery_info.copy_subset = subsets.data_subset;
+  recovery_info.clone_subset = subsets.clone_subsets;
+}
+
+
+}

--- a/src/crimson/osd/object_metadata_helper.h
+++ b/src/crimson/osd/object_metadata_helper.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "osd/osd_types_fmt.h"
+
+namespace crimson::osd {
+  struct subsets_t {
+    interval_set<uint64_t> data_subset;
+    std::map<hobject_t, interval_set<uint64_t>> clone_subsets;
+  };
+
+  subsets_t calc_clone_subsets(
+    SnapSet& snapset, const hobject_t& soid,
+    const pg_missing_t& missing,
+    const hobject_t &last_backfill);
+  subsets_t calc_head_subsets(
+    uint64_t obj_size,
+    SnapSet& snapset,
+    const hobject_t& head,
+    const pg_missing_t& missing,
+    const hobject_t &last_backfill);
+  void set_subsets(
+    const subsets_t& subsets,
+    ObjectRecoveryInfo& recovery_info);
+}

--- a/src/crimson/osd/osd_operations/osdop_params.h
+++ b/src/crimson/osd/osd_operations/osdop_params.h
@@ -17,6 +17,7 @@ struct osd_op_params_t {
   version_t user_at_version = 0;
   bool user_modify = false;
   ObjectCleanRegions clean_regions;
-
+  interval_set<uint64_t> modified_ranges;
+  //TODO: Move delta_stats to osd_op_params_t
   osd_op_params_t() = default;
 };

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -506,7 +506,9 @@ PGBackend::write_iertr::future<> PGBackend::_writefull(
       coll->get_cid(), ghobject_t{os.oi.soid}, 0, bl.length(),
       bl, flags);
     update_size_and_usage(
-      delta_stats, os.oi, 0,
+      delta_stats,
+      osd_op_params.modified_ranges,
+      os.oi, 0,
       bl.length(), true);
     osd_op_params.clean_regions.mark_data_region_dirty(
       0,
@@ -543,7 +545,9 @@ PGBackend::write_iertr::future<> PGBackend::_truncate(
       coll->get_cid(),
       ghobject_t{os.oi.soid}, offset);
     if (os.oi.size > offset) {
-      // TODO: modified_ranges.union_of(trim);
+      interval_set<uint64_t> trim;
+      trim.insert(offset, os.oi.size - offset);
+      osd_op_params.modified_ranges.union_of(trim);
       osd_op_params.clean_regions.mark_data_region_dirty(
         offset,
 	os.oi.size - offset);
@@ -581,9 +585,19 @@ bool PGBackend::maybe_create_new_object(
 }
 
 void PGBackend::update_size_and_usage(object_stat_sum_t& delta_stats,
+  interval_set<uint64_t>& modified,
   object_info_t& oi, uint64_t offset,
   uint64_t length, bool write_full)
 {
+  interval_set<uint64_t> ch;
+  if (write_full) {
+    if (oi.size) {
+      ch.insert(0, oi.size);
+    } else if (length) {
+      ch.insert(offset, length);
+    }
+    modified.union_of(ch);
+  }
   if (write_full ||
       (offset + length > oi.size && length)) {
     uint64_t new_size = offset + length;
@@ -681,12 +695,14 @@ PGBackend::write_iertr::future<> PGBackend::write(
                    ghobject_t{os.oi.soid}, op.extent.truncate_size);
       if (op.extent.truncate_size != os.oi.size) {
         os.oi.size = length;
-        if (op.extent.truncate_size > os.oi.size) {
-          osd_op_params.clean_regions.mark_data_region_dirty(os.oi.size,
-              op.extent.truncate_size - os.oi.size);
-        } else {
-          osd_op_params.clean_regions.mark_data_region_dirty(op.extent.truncate_size,
-              os.oi.size - op.extent.truncate_size);
+        if (op.extent.truncate_size < os.oi.size) {
+          interval_set<uint64_t> trim;
+          trim.insert(op.extent.truncate_size,
+            os.oi.size - op.extent.truncate_size);
+          osd_op_params.modified_ranges.union_of(trim);
+          osd_op_params.clean_regions.mark_data_region_dirty(
+            op.extent.truncate_size, os.oi.size - op.extent.truncate_size);
+          os.oi.clear_data_digest();
         }
       }
       truncate_update_size_and_usage(delta_stats, os.oi, op.extent.truncate_size);
@@ -705,10 +721,12 @@ PGBackend::write_iertr::future<> PGBackend::write(
   } else {
     txn.write(coll->get_cid(), ghobject_t{os.oi.soid},
 	      offset, length, std::move(buf), op.flags);
-    update_size_and_usage(delta_stats, os.oi, offset, length);
+    update_size_and_usage(delta_stats, osd_op_params.modified_ranges,
+                          os.oi, offset, length);
   }
   osd_op_params.clean_regions.mark_data_region_dirty(op.extent.offset,
 						     op.extent.length);
+  logger().debug("{} clean_regions modified", __func__);
 
   return seastar::now();
 }
@@ -738,7 +756,8 @@ PGBackend::interruptible_future<> PGBackend::write_same(
   txn.write(coll->get_cid(), ghobject_t{os.oi.soid},
             op.writesame.offset, len,
             std::move(repeated_indata), op.flags);
-  update_size_and_usage(delta_stats, os.oi, op.writesame.offset, len);
+  update_size_and_usage(delta_stats, osd_op_params.modified_ranges,
+                        os.oi, op.writesame.offset, len);
   osd_op_params.clean_regions.mark_data_region_dirty(op.writesame.offset, len);
   return seastar::now();
 }
@@ -788,7 +807,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
   target_coid.snap = snapid;
   return obc_loader.with_clone_obc_only<RWState::RWWRITE>(
     head, target_coid,
-    [this, &os, &txn, &delta_stats, &osd_op_params]
+    [this, &os, &txn, &delta_stats, &osd_op_params, &snapid]
     (auto, auto resolved_obc) {
     if (resolved_obc->obs.oi.soid.is_head()) {
       // no-op: The resolved oid returned the head object
@@ -824,9 +843,24 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
     osd_op_params.clean_regions.mark_data_region_dirty(0,
       std::max(os.oi.size, resolved_obc->obs.oi.size));
     osd_op_params.clean_regions.mark_omap_dirty();
-    // TODO: 3) Calculate clone_overlaps by following overlaps
-    //          forward from rollback snapshot
-    //          https://tracker.ceph.com/issues/58263
+
+    // 3) Calculate clone_overlaps by following overlaps
+    const auto& clone_overlap =
+      resolved_obc->ssc->snapset.clone_overlap;
+    auto iter = clone_overlap.lower_bound(snapid);
+    ceph_assert(iter != clone_overlap.end());
+    interval_set<uint64_t> overlaps = iter->second;
+    for (const auto&i: clone_overlap) {
+      overlaps.intersection_of(i.second);
+    }
+
+    if (os.oi.size > 0) {
+      interval_set<uint64_t> modified;
+      modified.insert(0, os.oi.size);
+      overlaps.intersection_of(modified);
+      modified.subtract(overlaps);
+      osd_op_params.modified_ranges.union_of(modified);
+    }
     return rollback_iertr::now();
   }).safe_then_interruptible([] {
     logger().debug("PGBackend::rollback succefully");
@@ -835,12 +869,13 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
     // if there's no snapshot, we delete the object;
     // otherwise, do nothing.
     crimson::ct_error::enoent::handle(
-    [this, &os, &snapid, &txn, &delta_stats, &snapc, &ss] {
+    [this, &os, &snapid, &txn, &delta_stats, &snapc, &ss, &osd_op_params] {
       logger().debug("PGBackend::rollback: deleting head on {}"
                      " with snap_id of {}"
                      " because got ENOENT|whiteout on obc lookup",
                      os.oi.soid, snapid);
-      return remove(os, txn, delta_stats, should_whiteout(ss, snapc));
+      return remove(os, txn, osd_op_params, delta_stats,
+                    should_whiteout(ss, snapc), os.oi.size);
     }),
     rollback_ertr::pass_further{},
     crimson::ct_error::assert_all{"unexpected error in rollback"}
@@ -863,8 +898,9 @@ PGBackend::append_ierrorator::future<> PGBackend::append(
     txn.write(coll->get_cid(), ghobject_t{os.oi.soid},
               os.oi.size /* offset */, op.extent.length,
               std::move(osd_op.indata), op.flags);
-    update_size_and_usage(delta_stats, os.oi, os.oi.size,
-      op.extent.length);
+    update_size_and_usage(delta_stats,
+                          osd_op_params.modified_ranges,
+                          os.oi, os.oi.size, op.extent.length);
     osd_op_params.clean_regions.mark_data_region_dirty(os.oi.size,
                                                        op.extent.length);
   }
@@ -921,7 +957,9 @@ PGBackend::write_iertr::future<> PGBackend::zero(
            ghobject_t{os.oi.soid},
            op.extent.offset,
            op.extent.length);
-  // TODO: modified_ranges.union_of(zeroed);
+  interval_set<uint64_t> ch;
+  ch.insert(op.extent.offset, op.extent.length);
+  osd_op_params.modified_ranges.union_of(ch);
   osd_op_params.clean_regions.mark_data_region_dirty(op.extent.offset,
 						     op.extent.length);
   delta_stats.num_wr++;
@@ -975,7 +1013,10 @@ PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn)
 
 PGBackend::remove_iertr::future<>
 PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn,
-  object_stat_sum_t& delta_stats, bool whiteout)
+  osd_op_params_t& osd_op_params,
+  object_stat_sum_t& delta_stats,
+  bool whiteout,
+  int num_bytes)
 {
   if (!os.exists) {
     return crimson::ct_error::enoent::make();
@@ -991,17 +1032,28 @@ PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn,
   }
   txn.remove(coll->get_cid(),
 	     ghobject_t{os.oi.soid, ghobject_t::NO_GEN, shard});
-  delta_stats.num_bytes -= os.oi.size;
 
   if (os.oi.is_omap()) {
     os.oi.clear_flag(object_info_t::FLAG_OMAP);
     delta_stats.num_objects_omap--;
   }
 
+  if (os.oi.size > 0) {
+    interval_set<uint64_t> ch;
+    ch.insert(0, os.oi.size);
+    osd_op_params.modified_ranges.union_of(ch);
+    osd_op_params.clean_regions.mark_data_region_dirty(0, os.oi.size);
+  }
+
+  osd_op_params.clean_regions.mark_omap_dirty();
+  delta_stats.num_wr++;
+  // num_bytes of the removed clone or head object
+  delta_stats.num_bytes -= num_bytes;
   os.oi.size = 0;
   os.oi.new_object();
 
-  // todo: clone_overlap
+  // todo: update watchers
+
   if (whiteout) {
     logger().debug("{} setting whiteout on {} ",__func__, os.oi.soid);
     os.oi.set_flag(object_info_t::FLAG_WHITEOUT);
@@ -1010,12 +1062,17 @@ PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn,
                ghobject_t{os.oi.soid, ghobject_t::NO_GEN, shard});
     return seastar::now();
   }
-  // todo: update watchers
+
+  // delete the head
+  delta_stats.num_objects--;
+  if (os.oi.soid.is_snap()) {
+    delta_stats.num_object_clones--;
+  }
   if (os.oi.is_whiteout()) {
+    logger().debug("{} deleting whiteout on {}", __func__, os.oi.soid);
     os.oi.clear_flag(object_info_t::FLAG_WHITEOUT);
     delta_stats.num_whiteouts--;
   }
-  delta_stats.num_objects--;
   os.exists = false;
   return seastar::now();
 }

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -149,8 +149,10 @@ public:
   remove_iertr::future<> remove(
     ObjectState& os,
     ceph::os::Transaction& txn,
+    osd_op_params_t& osd_op_params,
     object_stat_sum_t& delta_stats,
-    bool whiteout);
+    bool whiteout,
+    int num_bytes);
   interruptible_future<> remove(
     ObjectState& os,
     ceph::os::Transaction& txn);
@@ -432,6 +434,7 @@ private:
     ceph::os::Transaction& txn,
     object_stat_sum_t& delta_stats);
   void update_size_and_usage(object_stat_sum_t& delta_stats,
+    interval_set<uint64_t>& modified,
     object_info_t& oi, uint64_t offset,
     uint64_t length, bool write_full = false);
   void truncate_update_size_and_usage(

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -61,7 +61,7 @@ ReplicatedRecoveryBackend::maybe_push_shards(
     return interruptor::parallel_for_each(
       shards,
       [this, need, soid, head_obc](auto shard) {
-      return prep_push(head_obc, soid, need, shard
+      return prep_push_to_replica(soid, need, shard
       ).then_interruptible([this, soid, shard](auto push) {
         auto msg = crimson::make_message<MOSDPGPush>();
         msg->from = pg.get_pg_whoami();
@@ -310,8 +310,7 @@ ReplicatedRecoveryBackend::recover_delete(
 }
 
 RecoveryBackend::interruptible_future<PushOp>
-ReplicatedRecoveryBackend::prep_push(
-  const crimson::osd::ObjectContextRef &head_obc,
+ReplicatedRecoveryBackend::prep_push_to_replica(
   const hobject_t& soid,
   eversion_t need,
   pg_shard_t pg_shard)
@@ -342,8 +341,6 @@ ReplicatedRecoveryBackend::prep_push(
   push_info.recovery_info.copy_subset = data_subset;
   push_info.recovery_info.soid = soid;
   push_info.recovery_info.oi = obc->obs.oi;
-  assert(head_obc->ssc);
-  push_info.recovery_info.ss = head_obc->ssc->snapset;
   push_info.recovery_info.version = obc->obs.oi.version;
   push_info.recovery_info.object_exist =
     missing_iter->second.clean_regions.object_is_exist();

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -53,6 +53,11 @@ protected:
     const hobject_t& soid,
     eversion_t need,
     pg_shard_t pg_shard);
+  interruptible_future<PushOp> prep_push(
+    const hobject_t& soid,
+    eversion_t need,
+    pg_shard_t pg_shard,
+    const crimson::osd::subsets_t& subsets);
   void prepare_pull(
     const crimson::osd::ObjectContextRef &head_obc,
     PullOp& pull_op,

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -82,6 +82,9 @@ protected:
     PushOp& push_op,
     PullOp* response,
     ceph::os::Transaction* t);
+  void recalc_subsets(
+    ObjectRecoveryInfo& recovery_info,
+    crimson::osd::SnapSetContextRef ssc);
   std::pair<interval_set<uint64_t>, ceph::bufferlist> trim_pushed_data(
     const interval_set<uint64_t> &copy_subset,
     const interval_set<uint64_t> &intervals_received,

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -49,8 +49,7 @@ protected:
     Ref<MOSDPGRecoveryDelete> m);
   interruptible_future<> handle_recovery_delete_reply(
     Ref<MOSDPGRecoveryDeleteReply> m);
-  interruptible_future<PushOp> prep_push(
-    const crimson::osd::ObjectContextRef &head_obc,
+  interruptible_future<PushOp> prep_push_to_replica(
     const hobject_t& soid,
     eversion_t need,
     pg_shard_t pg_shard);

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -6,6 +6,7 @@
 #include "crimson/common/interruptible_future.h"
 #include "crimson/osd/pg_interval_interrupt_condition.h"
 #include "crimson/osd/recovery_backend.h"
+#include "crimson/osd/object_metadata_helper.h"
 
 #include "messages/MOSDPGPull.h"
 #include "messages/MOSDPGPush.h"

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -57,7 +57,8 @@ protected:
     const hobject_t& soid,
     eversion_t need,
     pg_shard_t pg_shard,
-    const crimson::osd::subsets_t& subsets);
+    const crimson::osd::subsets_t& subsets,
+    const SnapSet push_info_ss);
   void prepare_pull(
     const crimson::osd::ObjectContextRef &head_obc,
     PullOp& pull_op,

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -60,6 +60,10 @@ protected:
     pull_info_t& pull_info,
     const hobject_t& soid,
     eversion_t need);
+  ObjectRecoveryInfo set_recovery_info(
+    const hobject_t& soid,
+    const crimson::osd::SnapSetContextRef ssc,
+    const hobject_t& last_backfill);
   std::vector<pg_shard_t> get_shards_to_push(
     const hobject_t& soid) const;
   interruptible_future<PushOp> build_push_op(

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -71,6 +71,13 @@ add_ceph_unittest(unittest-seastar-lru
   --memory 256M --smp 1)
 target_link_libraries(unittest-seastar-lru crimson GTest::Main)
 
+add_executable(unittest-seastar-calc-subsets
+    ${PROJECT_SOURCE_DIR}/src/crimson/osd/object_metadata_helper.cc
+  test_calc_subsets.cc)
+add_ceph_unittest(unittest-seastar-calc-subsets
+  --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-calc-subsets crimson GTest::Main)
+
 add_executable(unittest-fixed-kv-node-layout
   test_fixed_kv_node_layout.cc)
 add_ceph_unittest(unittest-fixed-kv-node-layout)

--- a/src/test/crimson/test_calc_subsets.cc
+++ b/src/test/crimson/test_calc_subsets.cc
@@ -1,0 +1,255 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "crimson/osd/object_metadata_helper.h"
+
+
+TEST(head_subsets, dirty_region)
+{
+  uint64_t obj_size = 10;
+  SnapSet empty_ss;
+  hobject_t head{object_t{"foo"}, "foo", CEPH_NOSNAP, 42, 0, "nspace"};
+  pg_missing_t missing;
+  pg_missing_item item;
+  uint64_t offset_1, len_1;
+  offset_1 = 3;
+  len_1 = 2;
+  item.clean_regions.mark_data_region_dirty(offset_1, len_1);
+  missing.add(head, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+  interval_set<uint64_t> expect_data_region;
+  expect_data_region.insert(offset_1, len_1);
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_head_subsets(obj_size,
+                                    empty_ss,
+                                    head,
+                                    missing,
+                                    last_backfill);
+
+  EXPECT_TRUE(result.clone_subsets.empty());
+  EXPECT_TRUE(result.data_subset == expect_data_region);
+}
+
+TEST(head_subsets, head_all_clean)
+{
+  uint64_t obj_size = 10;
+  SnapSet empty_ss;
+  hobject_t head{object_t{"foo"}, "foo", CEPH_NOSNAP, 42, 0, "nspace"};
+  pg_missing_t missing;
+  pg_missing_item item;
+  missing.add(head, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_head_subsets(obj_size,
+                                    empty_ss,
+                                    head,
+                                    missing,
+                                    last_backfill);
+
+  EXPECT_TRUE(result.clone_subsets.empty());
+  EXPECT_TRUE(result.data_subset.empty());
+}
+
+TEST(head_subsets, all_dirty)
+{
+  uint64_t obj_size = 10;
+  SnapSet empty_ss;
+  hobject_t head{object_t{"foo"}, "foo", CEPH_NOSNAP, 42, 0, "nspace"};
+  pg_missing_t missing;
+  pg_missing_item item;
+  item.clean_regions.mark_fully_dirty();
+  missing.add(head, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_head_subsets(obj_size,
+                                    empty_ss,
+                                    head,
+                                    missing,
+                                    last_backfill);
+
+  EXPECT_TRUE(result.clone_subsets.empty());
+  EXPECT_TRUE(result.data_subset.size() == obj_size);
+}
+
+TEST(head_subsets, clone_overlap)
+{
+  uint64_t obj_size = 10;
+  SnapSet ss;
+  hobject_t head{object_t{"foo"}, "foo", CEPH_NOSNAP, 42, 0, "nspace"};
+  pg_missing_t missing;
+  pg_missing_item item;
+  item.clean_regions.mark_fully_dirty();
+  missing.add(head, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+
+  // Clone object:
+  hobject_t clone = head;
+  clone.snap = 0;
+  std::map<snapid_t, interval_set<uint64_t>> clone_overlap;  // overlap w/ next
+  interval_set<uint64_t> overlap;
+  uint64_t offset_2, len_2;
+  offset_2 = 2;
+  len_2 = 2;
+  overlap.insert(offset_2, len_2);
+  clone_overlap[clone.snap] = overlap;
+
+  // Snapset:
+  // ss.seq = 0;
+  // ss.snaps = snaps; (legacy)
+  ss.clones.push_back(clone.snap);
+  ss.clone_overlap = clone_overlap;
+  // ss.clone_size = clone_size;
+  // ss.clone_snaps = clone_snaps;
+
+  // Expected intervals:
+  interval_set<uint64_t> expect_clone_subset;
+  expect_clone_subset.insert(offset_2, len_2);
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_head_subsets(obj_size,
+                                    ss,
+                                    head,
+                                    missing,
+                                    last_backfill);
+  EXPECT_TRUE(result.clone_subsets[clone] == expect_clone_subset);
+}
+
+TEST(head_subsets, dirty_region_and_clone_overlap)
+{
+  uint64_t obj_size = 100;
+  SnapSet ss;
+  hobject_t head{object_t{"foo"}, "foo", CEPH_NOSNAP, 42, 0, "nspace"};
+  pg_missing_t missing;
+  pg_missing_item item;
+  uint64_t offset_1, len_1;
+  offset_1 = 3;
+  len_1 = 2;
+  item.clean_regions.mark_data_region_dirty(offset_1, len_1);
+  missing.add(head, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+  interval_set<uint64_t> expect_data_region;
+  expect_data_region.insert(offset_1, len_1);
+
+  // Clone object:
+  hobject_t clone = head;
+  clone.snap = 0;
+  std::map<snapid_t, interval_set<uint64_t>> clone_overlap;  // overlap w/ next
+  interval_set<uint64_t> overlap;
+  uint64_t offset_2, len_2;
+  offset_2 = 2;
+  len_2 = 2;
+  overlap.insert(offset_2, len_2);
+  clone_overlap[clone.snap] = overlap;
+
+  // Snapset:
+  // ss.seq = 0;
+  // ss.snaps = snaps; (legacy)
+  ss.clones.push_back(clone.snap);
+  ss.clone_overlap = clone_overlap;
+  // ss.clone_size = clone_size;
+  // ss.clone_snaps = clone_snaps;
+
+  // Expected intervals:
+  interval_set<uint64_t> expect_clone_subset;
+  expect_clone_subset.insert(offset_2, len_2);
+  expect_clone_subset.intersection_of(expect_data_region);
+  expect_data_region.subtract(expect_clone_subset);
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_head_subsets(obj_size,
+                                    ss,
+                                    head,
+                                    missing,
+                                    last_backfill);
+  EXPECT_TRUE(result.clone_subsets[clone] == expect_clone_subset);
+  EXPECT_TRUE(result.data_subset == expect_data_region);
+}
+
+TEST(clone_subsets, overlap)
+{
+  uint64_t clone_size = 10;
+  SnapSet ss;
+  hobject_t clone{object_t{"foo"}, "foo", 1, 42, 0, "nspace"};
+  ss.clone_size[1] = clone_size;
+  ss.clones.push_back(snapid_t(0));
+  ss.clones.push_back(snapid_t(1));
+  ss.clones.push_back(snapid_t(2));
+  pg_missing_t missing;
+  pg_missing_item item;
+  missing.add(clone, std::move(item));
+  hobject_t last_backfill{object_t{"foo1"}, "foo1", CEPH_NOSNAP, 42, 0, "nspace"};
+
+  interval_set<uint64_t> expect_clone_subset1, expect_clone_subset2;
+
+  // Next older clone:
+  hobject_t older_clone = clone;
+  older_clone.snap = 0;
+  {
+    std::map<snapid_t, interval_set<uint64_t>> clone_overlap;  // overlap w/ next
+    interval_set<uint64_t> overlap;
+    uint64_t offset_2, len_2;
+    offset_2 = 4;
+    len_2 = 2;
+    overlap.insert(offset_2, len_2);
+    ss.clone_overlap[older_clone.snap] = overlap;
+
+    // Snapset:
+    // ss.seq = 0;
+    // ss.snaps = snaps; (legacy)
+    // ss.clones.push_back(snapid_t());
+    // ss.clone_overlap = clone_overlap;
+    // ss.clone_size = clone_size;
+    // ss.clone_snaps = clone_snaps;
+
+    // Expected intervals:
+    expect_clone_subset1.insert(offset_2, len_2);
+  }
+
+  // Next newest clone:
+  hobject_t newest_clone = clone;
+  newest_clone.snap = 2;
+  {
+    std::map<snapid_t, interval_set<uint64_t>> clone_overlap;  // overlap w/ next
+    interval_set<uint64_t> overlap;
+    uint64_t offset_2, len_2;
+    offset_2 = 2;
+    len_2 = 2;
+    overlap.insert(offset_2, len_2);
+    ss.clone_overlap[newest_clone.snap - 1] = overlap;
+
+    // Snapset:
+    // ss.seq = 0;
+    // ss.snaps = snaps; (legacy)
+    // ss.clones.push_back(snapid_t());
+    // ss.clone_overlap = clone_overlap;
+    // ss.clone_size = clone_size;
+    // ss.clone_snaps = clone_snaps;
+
+    // Expected intervals:
+    expect_clone_subset2.insert(offset_2, len_2);
+  }
+
+// ****
+
+  crimson::osd::subsets_t result =
+    crimson::osd::calc_clone_subsets(ss,
+                                     clone,
+                                     missing,
+                                     last_backfill);
+  EXPECT_TRUE(result.clone_subsets[older_clone] == expect_clone_subset1);
+  EXPECT_TRUE(result.clone_subsets[newest_clone] == expect_clone_subset2);
+}


### PR DESCRIPTION
## TODO:
  - [x] Track `modified_ranges` interval_set when executing osd ops
  - [x] `OpsExecuter::make_writeable`: Update `clone_overlap` if the most recent clone has been evicted
  - [x] `handle_pull_response()` to `recalc_subsets()`
  - [x] Unblock #49568, #48756
  - [x] `PGBackend::rollback` Calculate clone_overlaps by following overlaps forward from rollback snapshot
  - [x] Add `calc_*_subsets` unit tests and behavior explanation.
## `do_recovery()` Comparisons:
Classic:
<img src="https://raw.githubusercontent.com/Matan-B/Diagrams/master/classic-subsets.png" width="800" height="600">

Crimson:
<img src="https://raw.githubusercontent.com/Matan-B/Diagrams/master/crimson_subsets.png" width="800" height="600">


* Blocked by: #49568 (Commits from 49568 will be dropped after merge)
* Fixes: https://tracker.ceph.com/issues/58263

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
