### PR TITLE
ceph-volume/tests: add allowlist_externals to tox.ini

### DIFF
--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -8,6 +8,8 @@ deps=
   pytest-xdist
   mock
   pyfakefs
+allowlist_externals=
+  ./tox_install_command.sh
 install_command=./tox_install_command.sh {opts} {packages}
 commands=py.test --numprocesses=auto -vv {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 


### PR DESCRIPTION
typical failure seen in the CI:

```
py3-flake8: install_deps> ./tox_install_command.sh flake8
py3-flake8: failed with ./tox_install_command.sh (resolves to ./tox_install_command.sh) is not allowed, use allowlist_externals to allow it
```

Fixes: https://tracker.ceph.com/issues/58377

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
