### PR TITLE
quincy: RGW - Make sure PostObj set bucket on s->object

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2847,7 +2847,7 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
     return -EINVAL;
   }
 
-  s->object = store->get_object(rgw_obj_key(object_str));
+  s->object = s->bucket->get_object(rgw_obj_key(object_str));
 
   rebuild_key(s->object.get());
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58388

---

backport of https://github.com/ceph/ceph/pull/48794
parent tracker: https://tracker.ceph.com/issues/57911

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh