### PR TITLE
rgw/beast: fix interaction between keepalive and 100-continue

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -123,6 +123,7 @@ size_t ClientIO::send_100_continue()
   const size_t sent = txbuf.sputn(HTTTP_100_CONTINUE,
                                   sizeof(HTTTP_100_CONTINUE) - 1);
   flush();
+  sent100continue = true;
   return sent;
 }
 

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -30,6 +30,7 @@ class ClientIO : public io::RestfulClient,
   RGWEnv env;
 
   rgw::io::StaticOutputBufferer<> txbuf;
+  bool sent100continue = false;
 
  public:
   ClientIO(parser_type& parser, bool is_ssl,
@@ -54,6 +55,8 @@ class ClientIO : public io::RestfulClient,
   RGWEnv& get_env() noexcept override {
     return env;
   }
+
+  bool sent_100_continue() const { return sent100continue; }
 };
 
 } // namespace asio

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -229,6 +229,8 @@ void handle_connection(boost::asio::io_context& context,
       return;
     }
 
+    bool expect_continue = (message[http::field::expect] == "100-continue");
+
     {
       auto lock = pause_mutex.async_lock_shared(yield[ec]);
       if (ec == boost::asio::error::operation_aborted) {
@@ -285,6 +287,10 @@ void handle_connection(boost::asio::io_context& context,
             << log_header{message, http::field::range} << " latency="
             << latency << dendl;
       }
+
+      if (real_client.sent_100_continue()) {
+        expect_continue = false;
+      }
     }
 
     if (!parser.keep_alive()) {
@@ -293,7 +299,7 @@ void handle_connection(boost::asio::io_context& context,
 
     // if we failed before reading the entire message, discard any remaining
     // bytes before reading the next
-    while (!parser.is_done()) {
+    while (!expect_continue && !parser.is_done()) {
       static std::array<char, 1024> discard_buffer;
 
       auto& body = parser.get().body();


### PR DESCRIPTION
if we reject a request with a "Expect: 100-continue" header before sending a "100 Continue" response, the keepalive logic should not try to read/discard request body before parsing the next request headers   

Fixes: https://tracker.ceph.com/issues/58286

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
