### PR TITLE
quincy: mgr/rbd_support: remove localized schedule option during module startup

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -369,15 +369,13 @@ class MirrorSnapshotScheduleHandler:
         self.queue: Dict[str, List[ImageSpec]] = {}
         # pool_id => {namespace => image_id}
         self.images: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self.schedules = Schedules(self)
         self.refresh_images()
         self.log.debug("MirrorSnapshotScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
         self.log.info("MirrorSnapshotScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load(namespace_validator, image_validator)
-        self.schedules = schedules
+        self.schedules.load(namespace_validator, image_validator)
 
     def refresh_images(self) -> float:
         elapsed = (datetime.now() - self.last_refresh_images).total_seconds()

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -378,18 +378,10 @@ class Schedules:
         self.level_specs: Dict[str, LevelSpec] = {}
         self.schedules: Dict[str, Schedule] = {}
 
-    def __len__(self) -> int:
-        return len(self.schedules)
-
-    def load(self,
-             namespace_validator: Optional[Callable] = None,
-             image_validator: Optional[Callable] = None) -> None:
-
-        schedule_cfg = self.handler.module.get_module_option(
-            self.handler.MODULE_OPTION_NAME, '')
-
         # Previous versions incorrectly stored the global config in
         # the localized module option. Check the config is here and fix it.
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if not schedule_cfg:
             schedule_cfg = self.handler.module.get_localized_module_option(
                 self.handler.MODULE_OPTION_NAME, '')
@@ -399,6 +391,17 @@ class Schedules:
         self.handler.module.set_localized_module_option(
             self.handler.MODULE_OPTION_NAME, None)
 
+    def __len__(self) -> int:
+        return len(self.schedules)
+
+    def load(self,
+             namespace_validator: Optional[Callable] = None,
+             image_validator: Optional[Callable] = None) -> None:
+        self.level_specs = {}
+        self.schedules = {}
+
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if schedule_cfg:
             try:
                 level_spec = LevelSpec.make_global()

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -64,15 +64,13 @@ class TrashPurgeScheduleHandler:
         self.queue: Dict[str, List[Tuple[str, str]]] = {}
         # pool_id => {namespace => pool_name}
         self.pools: Dict[str, Dict[str, str]] = {}
+        self.schedules = Schedules(self)
         self.refresh_pools()
         self.log.debug("TrashPurgeScheduleHandler: queue is initialized")
 
     def load_schedules(self) -> None:
         self.log.info("TrashPurgeScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load()
-        self.schedules = schedules
+        self.schedules.load()
 
     def refresh_pools(self) -> float:
         elapsed = (datetime.now() - self.last_refresh_pools).total_seconds()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58360

---

backport of https://github.com/ceph/ceph/pull/49261
parent tracker: https://tracker.ceph.com/issues/57726

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh