### PR TITLE
pacific: mgr/rbd_support: remove localized schedule option during module startup

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -342,15 +342,13 @@ class MirrorSnapshotScheduleHandler:
     def init_schedule_queue(self):
         self.queue = {}
         self.images = {}
+        self.schedules = Schedules(self)
         self.refresh_images()
         self.log.debug("MirrorSnapshotScheduleHandler: queue is initialized")
 
     def load_schedules(self):
         self.log.info("MirrorSnapshotScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load(namespace_validator, image_validator)
-        self.schedules = schedules
+        self.schedules.load(namespace_validator, image_validator)
 
     def refresh_images(self):
         elapsed = (datetime.now() - self.last_refresh_images).total_seconds()

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -338,16 +338,10 @@ class Schedules:
         self.level_specs = {}
         self.schedules = {}
 
-    def __len__(self):
-        return len(self.schedules)
-
-    def load(self, namespace_validator=None, image_validator=None):
-
-        schedule_cfg = self.handler.module.get_module_option(
-            self.handler.MODULE_OPTION_NAME, '')
-
         # Previous versions incorrectly stored the global config in
         # the localized module option. Check the config is here and fix it.
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if not schedule_cfg:
             schedule_cfg = self.handler.module.get_localized_module_option(
                 self.handler.MODULE_OPTION_NAME, '')
@@ -357,6 +351,15 @@ class Schedules:
         self.handler.module.set_localized_module_option(
             self.handler.MODULE_OPTION_NAME, None)
 
+    def __len__(self):
+        return len(self.schedules)
+
+    def load(self, namespace_validator=None, image_validator=None):
+        self.level_specs = {}
+        self.schedules = {}
+
+        schedule_cfg = self.handler.module.get_module_option(
+            self.handler.MODULE_OPTION_NAME, '')
         if schedule_cfg:
             try:
                 level_spec = LevelSpec.make_global()

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -63,15 +63,13 @@ class TrashPurgeScheduleHandler:
     def init_schedule_queue(self):
         self.queue = {}
         self.pools = {}
+        self.schedules = Schedules(self)
         self.refresh_pools()
         self.log.debug("TrashPurgeScheduleHandler: queue is initialized")
 
     def load_schedules(self):
         self.log.info("TrashPurgeScheduleHandler: load_schedules")
-
-        schedules = Schedules(self)
-        schedules.load()
-        self.schedules = schedules
+        self.schedules.load()
 
     def refresh_pools(self):
         elapsed = (datetime.now() - self.last_refresh_pools).total_seconds()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58361

---

backport of https://github.com/ceph/ceph/pull/49261
parent tracker: https://tracker.ceph.com/issues/57726

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh