### PR TITLE
Support numa with bond vlan

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -566,7 +566,13 @@ int get_iface_numa_node(
     fn = fmt::format("/sys/class/net/{}/bonding/slaves", ifa);
     fd = ::open(fn.c_str(), O_RDONLY);
     if (fd < 0) {
-      return -errno;
+      std::string_view delimiter = ".";
+      std::string_view bond = ifa.substr(0, ifa.find(delimiter));
+      fn = fmt::format("/sys/class/net/{}/lower_{}/bonding/slaves", ifa, bond);
+      fd = ::open(fn.c_str(), O_RDONLY);
+      if (fd < 0) {
+         return -errno;
+      }
     }
     ifatype = iface_t::BOND_PORT;
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58400
Signed-off-by: Xue Yantao xueyantao2114@163.com



In the function that int get_iface_numa_node(const std::string& iface, int *node), try two sysfs path:  /sys/class/net/{}/device/numa_node  and /sys/class/net/{}/bonding/slaves.

But, for the newer net adapater supports bond vlan,  there is another sysfs path, such as /sys/class/net/bond0.205/lower_bond0/bonding/slaves



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
