### PR TITLE
pacific: doc: document the relevance of mds_namespace mount option

### DIFF
--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -53,7 +53,8 @@ If you have more than one FS on your Ceph cluster, use the option
 
     ceph-fuse --id foo --client_fs mycephfs2 /mnt/mycephfs2
 
-You may also add a ``client_fs`` setting to your ``ceph.conf``
+You may also add a ``client_fs`` setting to your ``ceph.conf``. Alternatively, the option
+``--client_mds_namespace`` is supported for backward compatibility.
 
 Unmounting CephFS
 =================

--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -96,6 +96,28 @@ non-default FS as follows::
 
     mount -t ceph :/ /mnt/mycephfs2 -o name=fs,fs=mycephfs2
 
+Backward Compatibility
+======================
+The old syntax is supported for backward compatibility.
+
+To mount CephFS with the kernel driver::
+
+    mkdir /mnt/mycephfs
+    mount -t ceph :/ /mnt/mycephfs -o name=admin
+
+The key-value argument right after option ``-o`` is CephX credential;
+``name`` is the username of the CephX user we are using to mount CephFS.
+
+To mount a non-default FS ``cephfs2``, in case the cluster has multiple FSs::
+
+    mount -t ceph :/ /mnt/mycephfs -o name=admin,fs=cephfs2
+
+    or
+
+    mount -t ceph :/ /mnt/mycephfs -o name=admin,mds_namespace=cephfs2
+
+.. note:: The option ``mds_namespace`` is deprecated. Use ``fs=`` instead when using the old syntax for mounting.
+
 Unmounting CephFS
 =================
 To unmount the Ceph file system, use the ``umount`` command as usual::

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -110,6 +110,12 @@ Basic
       them. If an inode contains any stale file locks, read/write on the inode
       is not allowed until applications release all stale file locks.
 
+:command: `fs=<fs-name>`
+    Specify the non-default file system to be mounted, when using the old syntax.
+
+:command: `mds_namespace=<fs-name>`
+    A synonym of "fs=" (Deprecated).
+
 Advanced
 --------
 :command:`cap_release_safety`
@@ -235,6 +241,10 @@ history::
 
     mount.ceph :/ /mnt/mycephfs -o name=fs_username,secretfile=/etc/ceph/fs_username.secret
 
+
+To mount using the old syntax::
+
+    mount -t ceph 192.168.0.1:/ /mnt/mycephfs
 
 Availability
 ============


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/57673
(cherry picked from commit 86f8fa19e5ab1defea925e44b07bed11b2b4c7d4)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>