### PR TITLE
pacific: doc/man/ceph-rbdnamer: remove obsolete udev rule

### DIFF
--- a/doc/man/8/ceph-rbdnamer.rst
+++ b/doc/man/8/ceph-rbdnamer.rst
@@ -16,15 +16,10 @@ Synopsis
 Description
 ===========
 
-**ceph-rbdnamer** prints the pool and image name for the given RBD devices
-to stdout. It is used by `udev` (using a rule like the one below) to
-set up a device symlink.
-
-
-::
-
-        KERNEL=="rbd[0-9]*", PROGRAM="/usr/bin/ceph-rbdnamer %n", SYMLINK+="rbd/%c{1}/%c{2}"
-
+**ceph-rbdnamer** prints the pool, namespace, image and snapshot names
+for a given RBD device to stdout. It is used by `udev` device manager
+to set up RBD device symlinks. The appropriate `udev` rules are
+provided in a file named `50-rbd.rules`.
 
 Availability
 ============


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58413

---

backport of https://github.com/ceph/ceph/pull/49690
parent tracker: https://tracker.ceph.com/issues/58398