### PR TITLE
pacific: doc/cephadm: refine "Removing Hosts"

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -79,7 +79,7 @@ To add each new host to the cluster, perform two steps:
 Removing Hosts
 ==============
 
-A host can safely be removed from a the cluster after all daemons are removed
+A host can safely be removed from the cluster after all daemons are removed
 from it.
 
 To drain all daemons from a host, run a command of the following form:
@@ -88,23 +88,26 @@ To drain all daemons from a host, run a command of the following form:
 
    ceph orch host drain *<host>*
 
-The '_no_schedule' label will be applied to the host. See :ref:`cephadm-special-host-labels`
+The ``_no_schedule`` label will be applied to the host. See
+:ref:`cephadm-special-host-labels`.
 
-All osds on the host will be scheduled to be removed. You can check osd removal progress with the following:
+All osds on the host will be scheduled to be removed. You can check the progress of the osd removal operation with the following command:
 
 .. prompt:: bash #
 
    ceph orch osd rm status
 
-see :ref:`cephadm-osd-removal` for more details about osd removal
+See :ref:`cephadm-osd-removal` for more details about osd removal.
 
-You can check if there are no deamons left on the host with the following:
+Use the following command to determine whether any daemons are still on the
+host:
 
 .. prompt:: bash #
 
    ceph orch ps <host> 
 
-Once all daemons are removed you can remove the host with the following:
+After all daemons have been removed from the host, remove the host from the
+cluster by running the following command: 
 
 .. prompt:: bash #
 
@@ -113,14 +116,16 @@ Once all daemons are removed you can remove the host with the following:
 Offline host removal
 --------------------
 
-If a host is offline and can not be recovered it can still be removed from the cluster with the following:
+Even if a host is offline and can not be recovered, it can be removed from the
+cluster by running a command of the following form:
 
 .. prompt:: bash #
 
    ceph orch host rm <host> --offline --force
 
-This can potentially cause data loss as osds will be forcefully purged from the cluster by calling ``osd purge-actual`` for each osd.
-Service specs that still contain this host should be manually updated.
+.. warning:: This can potentially cause data loss. This command forcefully
+   purges OSDs from the cluster by calling ``osd purge-actual`` for each OSD.
+   Any service specs that still contain this host should be manually updated.
 
 .. _orchestrator-host-labels:
 


### PR DESCRIPTION
An intended edit to remove a redundant indefinite article became a longer (but still brief) full editorial pass.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit 2e1fd6308726ecfdfe39c51c6e8fc99e922a3f84)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
