### PR TITLE
rgw: fix multipart upload object leaks due to re-upload

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -83,7 +83,7 @@ static bool bi_is_plain_entry(const std::string& s) {
   return (s.empty() || (unsigned char)s[0] != BI_PREFIX_CHAR);
 }
 
-int bi_entry_type(const string& s)
+static int bi_entry_type(const string& s)
 {
   if (bi_is_plain_entry(s)) {
     return BI_BUCKET_OBJS_INDEX;
@@ -3538,7 +3538,7 @@ static int usage_record_decode(bufferlist& record_bl, rgw_usage_log_entry& e)
   return 0;
 }
 
-int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+static int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   CLS_LOG(10, "entered %s", __func__);
 
@@ -4335,6 +4335,49 @@ static int rgw_cls_lc_get_head(cls_method_context_t hctx, bufferlist *in,  buffe
   return 0;
 }
 
+static int rgw_mp_upload_part_info_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  CLS_LOG(10, "entered %s", __func__);
+  cls_rgw_mp_upload_part_info_update_op op;
+  auto in_iter = in->cbegin();
+  try {
+    decode(op, in_iter);
+  } catch (ceph::buffer::error& err) {
+    CLS_LOG(1, "ERROR: rgw_cls_mp_upload_part_info_update(): failed to decode op\n");
+    return -EINVAL;
+  }
+
+  RGWUploadPartInfo stored_info;
+
+  int ret = read_omap_entry(hctx, op.part_key, &stored_info);
+  if (ret < 0 and ret != -ENOENT) {
+    return ret;
+  }
+
+  /* merge all the prior (stored) manifest prefixes to carry forward */
+  if (not stored_info.manifest.empty()) {
+    op.info.past_prefixes.insert(stored_info.manifest.get_prefix());
+  }
+  op.info.past_prefixes.merge(stored_info.past_prefixes);
+
+  if (op.info.past_prefixes.contains(op.info.manifest.get_prefix())) {
+    // Somehow the current chosen prefix collides with one of previous ones.
+    // Better fail this part upload so it can pick a different one in the next.
+    const object_info_t& oi = cls_get_object_info(hctx);
+    CLS_LOG(1, "ERROR: oid [%s]: Current prefix %s is also a past prefix for part %s", 
+            oi.soid.oid.name.c_str(),
+            op.info.manifest.get_prefix().c_str(),
+            op.part_key.c_str());
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  encode(op.info, bl);
+  ret = cls_cxx_map_set_val(hctx, op.part_key, &bl);
+  CLS_LOG(10, "part info update on key [%s]: %zu past prefixes, ret %d", op.part_key.c_str(), op.info.past_prefixes.size(), ret);
+  return ret;
+}
+
 static int rgw_reshard_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   CLS_LOG(10, "entered %s", __func__);
@@ -4608,6 +4651,7 @@ CLS_INIT(rgw)
   cls_method_handle_t h_rgw_lc_put_head;
   cls_method_handle_t h_rgw_lc_get_head;
   cls_method_handle_t h_rgw_lc_list_entries;
+  cls_method_handle_t h_rgw_mp_upload_part_info_update;
   cls_method_handle_t h_rgw_reshard_add;
   cls_method_handle_t h_rgw_reshard_list;
   cls_method_handle_t h_rgw_reshard_get;
@@ -4670,6 +4714,9 @@ CLS_INIT(rgw)
   cls_register_cxx_method(h_class, RGW_LC_PUT_HEAD, CLS_METHOD_RD| CLS_METHOD_WR, rgw_cls_lc_put_head, &h_rgw_lc_put_head);
   cls_register_cxx_method(h_class, RGW_LC_GET_HEAD, CLS_METHOD_RD, rgw_cls_lc_get_head, &h_rgw_lc_get_head);
   cls_register_cxx_method(h_class, RGW_LC_LIST_ENTRIES, CLS_METHOD_RD, rgw_cls_lc_list_entries, &h_rgw_lc_list_entries);
+
+  /* multipart */
+  cls_register_cxx_method(h_class, RGW_MP_UPLOAD_PART_INFO_UPDATE, CLS_METHOD_RD | CLS_METHOD_WR, rgw_mp_upload_part_info_update, &h_rgw_mp_upload_part_info_update);
 
   /* resharding */
   cls_register_cxx_method(h_class, RGW_RESHARD_ADD, CLS_METHOD_RD | CLS_METHOD_WR, rgw_reshard_add, &h_rgw_reshard_add);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -4350,12 +4350,12 @@ static int rgw_mp_upload_part_info_update(cls_method_context_t hctx, bufferlist 
   RGWUploadPartInfo stored_info;
 
   int ret = read_omap_entry(hctx, op.part_key, &stored_info);
-  if (ret < 0 and ret != -ENOENT) {
+  if (ret < 0 && ret != -ENOENT) {
     return ret;
   }
 
   /* merge all the prior (stored) manifest prefixes to carry forward */
-  if (not stored_info.manifest.empty()) {
+  if (!stored_info.manifest.empty()) {
     op.info.past_prefixes.insert(stored_info.manifest.get_prefix());
   }
   op.info.past_prefixes.merge(stored_info.past_prefixes);
@@ -4368,7 +4368,7 @@ static int rgw_mp_upload_part_info_update(cls_method_context_t hctx, bufferlist 
             oi.soid.oid.name.c_str(),
             op.info.manifest.get_prefix().c_str(),
             op.part_key.c_str());
-    return -EINVAL;
+    return -EEXIST;
   }
 
   bufferlist bl;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1068,6 +1068,26 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
   return r;
 }
 
+int cls_rgw_mp_upload_part_info_update(librados::IoCtx& io_ctx,
+                                       const std::string& oid,
+                                       const std::string& part_key,
+                                       const RGWUploadPartInfo& info)
+{
+  buffer::list in, out;
+  cls_rgw_mp_upload_part_info_update_op op;
+
+  // For now, there doesn't appear to be a need for an encoded
+  // result -- we might in future want to return a copy of the final
+  // RGWUploadPartInfo
+ 
+  op.part_key = part_key;
+  op.info = info;
+  encode(op, in);
+
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_MP_UPLOAD_PART_INFO_UPDATE, in, out);
+  return r;
+}
+
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)
 {
   bufferlist in;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1068,24 +1068,18 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
   return r;
 }
 
-int cls_rgw_mp_upload_part_info_update(librados::IoCtx& io_ctx,
-                                       const std::string& oid,
-                                       const std::string& part_key,
-                                       const RGWUploadPartInfo& info)
+void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op,
+                                        const std::string& part_key,
+                                        const RGWUploadPartInfo& info)
 {
-  buffer::list in, out;
-  cls_rgw_mp_upload_part_info_update_op op;
+  cls_rgw_mp_upload_part_info_update_op call;
+  call.part_key = part_key;
+  call.info     = info;
 
-  // For now, there doesn't appear to be a need for an encoded
-  // result -- we might in future want to return a copy of the final
-  // RGWUploadPartInfo
- 
-  op.part_key = part_key;
-  op.info = info;
-  encode(op, in);
+  buffer::list in;
+  encode(call, in);
 
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_MP_UPLOAD_PART_INFO_UPDATE, in, out);
-  return r;
+  op.exec(RGW_CLASS, RGW_MP_UPLOAD_PART_INFO_UPDATE, in);
 }
 
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -618,6 +618,9 @@ int cls_rgw_lc_list(librados::IoCtx& io_ctx, const std::string& oid,
                     std::vector<cls_rgw_lc_entry>& entries);
 #endif
 
+/* multipart */
+int cls_rgw_mp_upload_part_info_update(librados::IoCtx& io_ctx, const std::string& oid, const std::string& part_key, const RGWUploadPartInfo& info);
+
 /* resharding */
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);
 void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -619,7 +619,7 @@ int cls_rgw_lc_list(librados::IoCtx& io_ctx, const std::string& oid,
 #endif
 
 /* multipart */
-int cls_rgw_mp_upload_part_info_update(librados::IoCtx& io_ctx, const std::string& oid, const std::string& part_key, const RGWUploadPartInfo& info);
+void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op, const std::string& part_key, const RGWUploadPartInfo& info);
 
 /* resharding */
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);

--- a/src/cls/rgw/cls_rgw_const.h
+++ b/src/cls/rgw/cls_rgw_const.h
@@ -64,6 +64,9 @@ constexpr int RGWBIAdvanceAndRetryError = -EFBIG;
 #define RGW_LC_GET_HEAD "lc_get_head"
 #define RGW_LC_LIST_ENTRIES "lc_list_entries"
 
+/* multipart */
+#define RGW_MP_UPLOAD_PART_INFO_UPDATE "mp_upload_part_info_update"
+
 /* resharding */
 #define RGW_RESHARD_ADD "reshard_add"
 #define RGW_RESHARD_LIST "reshard_list"

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -430,6 +430,21 @@ void cls_rgw_bi_log_list_ret::generate_test_instances(list<cls_rgw_bi_log_list_r
   ls.back()->truncated = true;
 }
 
+void cls_rgw_mp_upload_part_info_update_op::generate_test_instances(std::list<cls_rgw_mp_upload_part_info_update_op*>& ls)
+{
+  ls.push_back(new cls_rgw_mp_upload_part_info_update_op);
+  ls.back()->part_key = "part1";
+  ls.push_back(new cls_rgw_mp_upload_part_info_update_op);
+  ls.back()->part_key = "part2";
+}
+
+void cls_rgw_mp_upload_part_info_update_op::dump(Formatter* f) const
+{
+  encode_json("part_key", part_key, f);
+  encode_json("part_num", info.num, f);
+  encode_json("part_prefix", info.manifest.get_prefix(), f);
+}
+
 void cls_rgw_reshard_add_op::generate_test_instances(list<cls_rgw_reshard_add_op*>& ls)
 {
   ls.push_back(new cls_rgw_reshard_add_op);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1287,6 +1287,31 @@ cls_rgw_lc_list_entries_ret(uint8_t compat_v = 3)
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_list_entries_ret)
 
+struct cls_rgw_mp_upload_part_info_update_op {
+  std::string part_key;
+  RGWUploadPartInfo info;
+
+  cls_rgw_mp_upload_part_info_update_op() {}
+
+  void encode(buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(part_key, bl);
+    encode(info, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(part_key, bl);
+    decode(info, bl);
+    DECODE_FINISH(bl);
+  }
+
+  static void generate_test_instances(std::list<cls_rgw_mp_upload_part_info_update_op*>& ls);
+  void dump(Formatter* f) const;
+};
+WRITE_CLASS_ENCODER(cls_rgw_mp_upload_part_info_update_op)
+
 struct cls_rgw_reshard_add_op {
  cls_rgw_reshard_entry entry;
 

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -497,13 +497,23 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  encode(info, bl);
-
   std::unique_ptr<rgw::sal::Object> meta_obj =
     head_obj->get_bucket()->get_object(rgw_obj_key(mp.get_meta(), std::string(), RGW_OBJ_NS_MULTIPART));
   meta_obj->set_in_extra_data(true);
 
-  r = meta_obj->omap_set_val_by_key(dpp, p, bl, true, null_yield);
+  rgw_raw_obj meta_raw_obj;
+  dynamic_cast<rgw::sal::RadosObject*>(meta_obj.get())->get_raw_obj(&meta_raw_obj);
+
+  rgw_rados_ref meta_obj_ref;
+  r = store->getRados()->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << "ERROR: failed to get obj ref of meta obj with ret=" << r << dendl;
+    return r;
+  }
+
+  r = cls_rgw_mp_upload_part_info_update(meta_obj_ref.pool.ioctx(), meta_obj_ref.obj.oid, p, info);
+  ldpp_dout(dpp, 20) << "Update meta: " << meta_obj_ref.obj.oid << " part " << p << " prefix " << info.manifest.get_prefix() << " return " << r << dendl;
+
   if (r < 0) {
     return r == -ENOENT ? -ERR_NO_SUCH_UPLOAD : r;
   }

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -502,8 +502,9 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
   meta_obj->set_in_extra_data(true);
 
   rgw_raw_obj meta_raw_obj;
-  dynamic_cast<rgw::sal::RadosObject*>(meta_obj.get())->get_raw_obj(&meta_raw_obj);
-
+  store->getRados()->obj_to_raw(meta_obj->get_bucket()->get_placement_rule(), 
+                                meta_obj->get_obj(),
+                                &meta_raw_obj);
   rgw_rados_ref meta_obj_ref;
   r = store->getRados()->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
   if (r < 0) {

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -630,6 +630,7 @@ public:
 
   /* For RadosStore code */
   RGWObjManifest& get_manifest() { return info.manifest; }
+  const std::set<std::string>& get_past_prefixes() const { return info.past_prefixes; }
 
   friend class RadosMultipartUpload;
 };
@@ -679,6 +680,11 @@ public:
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
 			  const std::string& part_num_str) override;
+protected:
+  int cleanup_part_history(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           RadosMultipartPart* part,
+                           std::list<rgw_obj_index_key>& remove_objs);
 };
 
 class MPRadosSerializer : public StoreMPSerializer {

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -249,10 +249,13 @@ struct RGWUploadPartInfo {
   RGWObjManifest manifest;
   RGWCompressionInfo cs_info;
 
+  // Previous part obj prefixes. Recorded here for later cleanup.
+  std::set<std::string> past_prefixes; 
+
   RGWUploadPartInfo() : num(0), size(0) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(4, 2, bl);
+    ENCODE_START(5, 2, bl);
     encode(num, bl);
     encode(size, bl);
     encode(etag, bl);
@@ -260,10 +263,11 @@ struct RGWUploadPartInfo {
     encode(manifest, bl);
     encode(cs_info, bl);
     encode(accounted_size, bl);
+    encode(past_prefixes, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(5, 2, 2, bl);
     decode(num, bl);
     decode(size, bl);
     decode(etag, bl);
@@ -275,6 +279,9 @@ struct RGWUploadPartInfo {
       decode(accounted_size, bl);
     } else {
       accounted_size = size;
+    }
+    if (struct_v >= 5) {
+      decode(past_prefixes, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -98,5 +98,6 @@ void RGWUploadPartInfo::dump(Formatter *f) const
   encode_json("etag", etag, f);
   utime_t ut(modified);
   encode_json("modified", ut, f);
+  encode_json("past_prefixes", past_prefixes, f);
 }
 


### PR DESCRIPTION
This commit fixes the object leaks when an mp part object is re-uploaded. Details of the fix are:

1. Upon re-upload, remember the prefix used in previous part upload in a new field "past_prefixes" in RGWUploadPartInfo.
2. Create a new CLS function for updating part info in the metadata object.
3. Utilize the new CLS function during mp upload.
4. At the upload conclusion (compete/abort), clean up the part objects that are not used for the final
assembly, thus preventing the object leak.

Fixes: https://tracker.ceph.com/issues/16767
Signed-off-by: Yixin Jin <yjin77@yahoo.ca>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
