### PR TITLE
ceph.spec.in: remove the bcond_without cephfs_java option

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -46,7 +46,6 @@
 %endif
 %endif
 %bcond_without selinux
-%bcond_without cephfs_java
 %bcond_without amqp_endpoint
 %bcond_without kafka_endpoint
 %bcond_without lttng


### PR DESCRIPTION
This effectively disable cephfs_java for rpm builds for now. The only user appears to be cephfs jni bindings.

Fixes: https://tracker.ceph.com/issues/58382
Signed-off-by: Samuel Just <sjust@redhat.com>
