### PR TITLE
mgr/prometheus: use vendored "packaging" instead

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -662,6 +662,7 @@ Requires:       python%{python3_pkgversion}-pecan
 Requires:       python%{python3_pkgversion}-pyOpenSSL
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-dateutil
+Requires:       python%{python3_pkgversion}-setuptools
 %if 0%{?fedora} || 0%{?rhel} >= 8
 Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-pyyaml

--- a/debian/ceph-mgr-modules-core.requires
+++ b/debian/ceph-mgr-modules-core.requires
@@ -3,4 +3,5 @@ CherryPy
 pecan
 werkzeug
 requests
+pkg-resources
 python-dateutil

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,6 +1,6 @@
 import cherrypy
 from collections import defaultdict
-from packaging.version import Version
+from pkg_resources import packaging  # type: ignore
 import json
 import math
 import os
@@ -32,6 +32,7 @@ DEFAULT_PORT = 9283
 # ipv6 isn't yet configured / supported and CherryPy throws an uncaught
 # exception.
 if cherrypy is not None:
+    Version = packaging.version.Version
     v = Version(cherrypy.__version__)
     # the issue was fixed in 3.2.3. it's present in 3.2.2 (current version on
     # centos:7) and back to at least 3.0.0.

--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -12,5 +12,6 @@ pytest-cov==2.7.1
 pyyaml
 requests-mock
 scipy
+setuptools
 werkzeug
 natsort


### PR DESCRIPTION
instead of using the top-level "packaging" module, use the one vendored by setuptools.

packaging python module provides versioning defined by PEP-440. but python3-packaging is provided by CentOS8 powertools repo, which is not enabled by default. and in CentOS9, this package is provided by AppStream instead of BaseOS.

as prometheus mgr module is included by ceph-mgr-module-core, it would be desirable if our user can install ceph-mgr-module-core without enabling powertools or AppStream repo on a CentOS or its derivative distros.

fortunately, setuptools vendors packaging module. and both CentOS8 and CentOS9 provide python3-setuptools in their BaseOS repos.

in this change, instead of using "packging" module, we use the venderored one, which is in turn embedded in pkg_resources. this python module is provided by python3-setuptools on CentOS distros, and python3-pkg-resources on Debian and its derivatives.

the packaging recipes are updated accordingly to reflect the new runtime dependency.

Fixes: https://tracker.ceph.com/issues/58385

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
