### PR TITLE
mgr/dashboard: rgw server side encryption daemon name fix

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -189,27 +189,28 @@ class CephService(object):
         kms_backend: str = ''
         sse_s3_backend: str = ''
         vault_stats = []
+        full_daemon_name = 'rgw.' + daemon_name
 
         kms_backend = CephService.send_command('mon', 'config get',
-                                               who=name_to_config_section(daemon_name),
+                                               who=name_to_config_section(full_daemon_name),
                                                key='rgw_crypt_s3_kms_backend')
         sse_s3_backend = CephService.send_command('mon', 'config get',
-                                                  who=name_to_config_section(daemon_name),
+                                                  who=name_to_config_section(full_daemon_name),
                                                   key='rgw_crypt_sse_s3_backend')
 
         if kms_backend.strip() == 'vault':
             kms_vault_auth: str = CephService.send_command('mon', 'config get',
-                                                           who=name_to_config_section(daemon_name),
+                                                           who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                            key='rgw_crypt_vault_auth')
             kms_vault_engine: str = CephService.send_command('mon', 'config get',
-                                                             who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                             who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                              key='rgw_crypt_vault_secret_engine')
             kms_vault_address: str = CephService.send_command('mon', 'config get',
-                                                              who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                              who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                               key='rgw_crypt_vault_addr')
             kms_vault_token: str = CephService.send_command('mon', 'config get',
-                                                            who=name_to_config_section(daemon_name),
-                                                            key='rgw_crypt_vault_token_file')
+                                                            who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                            key='rgw_crypt_vault_token_file')  # noqa E501 #pylint: disable=line-too-long
             if (
                 kms_vault_auth.strip() != ""
                 and kms_vault_engine.strip() != ""
@@ -220,18 +221,18 @@ class CephService(object):
 
         if sse_s3_backend.strip() == 'vault':
             s3_vault_auth: str = CephService.send_command('mon', 'config get',
-                                                          who=name_to_config_section(daemon_name),
+                                                          who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                           key='rgw_crypt_sse_s3_vault_auth')
             s3_vault_engine: str = CephService.send_command('mon',
                                                             'config get',
-                                                            who=name_to_config_section(daemon_name),
+                                                            who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                             key='rgw_crypt_sse_s3_vault_secret_engine')  # noqa E501 #pylint: disable=line-too-long
             s3_vault_address: str = CephService.send_command('mon', 'config get',
-                                                             who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                             who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                              key='rgw_crypt_sse_s3_vault_addr')
             s3_vault_token: str = CephService.send_command('mon', 'config get',
-                                                           who=name_to_config_section(daemon_name),
-                                                           key='rgw_crypt_sse_s3_vault_token_file')
+                                                           who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                           key='rgw_crypt_sse_s3_vault_token_file')  # noqa E501 #pylint: disable=line-too-long
             if (
                 s3_vault_auth.strip() != ""
                 and s3_vault_engine.strip() != ""
@@ -248,7 +249,7 @@ class CephService(object):
     def set_encryption_config(cls, encryption_type, kms_provider, auth_method,
                               secret_engine, secret_path, namespace, address,
                               token, daemon_name, ssl_cert, client_cert, client_key):
-
+        full_daemon_name = 'rgw.' + daemon_name
         if encryption_type == 'aws:kms':
 
             KMS_CONFIG = [
@@ -268,7 +269,7 @@ class CephService(object):
                 if value == 'null':
                     continue
                 CephService.send_command('mon', 'config set',
-                                         who=name_to_config_section(daemon_name),
+                                         who=name_to_config_section(full_daemon_name),
                                          name=key, value=value)
 
         if encryption_type == 'AES256':
@@ -290,7 +291,7 @@ class CephService(object):
                 if value == 'null':
                     continue
                 CephService.send_command('mon', 'config set',
-                                         who=name_to_config_section(daemon_name),
+                                         who=name_to_config_section(full_daemon_name),
                                          name=key, value=value)
 
         return {}


### PR DESCRIPTION
The config values for the server side encryption currently are wrongly set to the mon daemon by default. This PR intends to fix this issue

Fixes: https://tracker.ceph.com/issues/58419
Signed-off-by: Aashish Sharma <aasharma@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
