### PR TITLE
quincy: mgr/dashboard: rgw server side encryption config values set to wrong daemon

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -189,27 +189,28 @@ class CephService(object):
         kms_backend: str = ''
         sse_s3_backend: str = ''
         vault_stats = []
+        full_daemon_name = 'rgw.' + daemon_name
 
         kms_backend = CephService.send_command('mon', 'config get',
-                                               who=name_to_config_section(daemon_name),
+                                               who=name_to_config_section(full_daemon_name),
                                                key='rgw_crypt_s3_kms_backend')
         sse_s3_backend = CephService.send_command('mon', 'config get',
-                                                  who=name_to_config_section(daemon_name),
+                                                  who=name_to_config_section(full_daemon_name),
                                                   key='rgw_crypt_sse_s3_backend')
 
         if kms_backend.strip() == 'vault':
             kms_vault_auth: str = CephService.send_command('mon', 'config get',
-                                                           who=name_to_config_section(daemon_name),
+                                                           who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                            key='rgw_crypt_vault_auth')
             kms_vault_engine: str = CephService.send_command('mon', 'config get',
-                                                             who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                             who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                              key='rgw_crypt_vault_secret_engine')
             kms_vault_address: str = CephService.send_command('mon', 'config get',
-                                                              who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                              who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                               key='rgw_crypt_vault_addr')
             kms_vault_token: str = CephService.send_command('mon', 'config get',
-                                                            who=name_to_config_section(daemon_name),
-                                                            key='rgw_crypt_vault_token_file')
+                                                            who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                            key='rgw_crypt_vault_token_file')  # noqa E501 #pylint: disable=line-too-long
             if (
                 kms_vault_auth.strip() != ""
                 and kms_vault_engine.strip() != ""
@@ -220,18 +221,18 @@ class CephService(object):
 
         if sse_s3_backend.strip() == 'vault':
             s3_vault_auth: str = CephService.send_command('mon', 'config get',
-                                                          who=name_to_config_section(daemon_name),
+                                                          who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                           key='rgw_crypt_sse_s3_vault_auth')
             s3_vault_engine: str = CephService.send_command('mon',
                                                             'config get',
-                                                            who=name_to_config_section(daemon_name),
+                                                            who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                             key='rgw_crypt_sse_s3_vault_secret_engine')  # noqa E501 #pylint: disable=line-too-long
             s3_vault_address: str = CephService.send_command('mon', 'config get',
-                                                             who=name_to_config_section(daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                             who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
                                                              key='rgw_crypt_sse_s3_vault_addr')
             s3_vault_token: str = CephService.send_command('mon', 'config get',
-                                                           who=name_to_config_section(daemon_name),
-                                                           key='rgw_crypt_sse_s3_vault_token_file')
+                                                           who=name_to_config_section(full_daemon_name),  # noqa E501 #pylint: disable=line-too-long
+                                                           key='rgw_crypt_sse_s3_vault_token_file')  # noqa E501 #pylint: disable=line-too-long
             if (
                 s3_vault_auth.strip() != ""
                 and s3_vault_engine.strip() != ""
@@ -248,7 +249,7 @@ class CephService(object):
     def set_encryption_config(cls, encryption_type, kms_provider, auth_method,
                               secret_engine, secret_path, namespace, address,
                               token, daemon_name, ssl_cert, client_cert, client_key):
-
+        full_daemon_name = 'rgw.' + daemon_name
         if encryption_type == 'aws:kms':
 
             KMS_CONFIG = [
@@ -268,7 +269,7 @@ class CephService(object):
                 if value == 'null':
                     continue
                 CephService.send_command('mon', 'config set',
-                                         who=name_to_config_section(daemon_name),
+                                         who=name_to_config_section(full_daemon_name),
                                          name=key, value=value)
 
         if encryption_type == 'AES256':
@@ -290,7 +291,7 @@ class CephService(object):
                 if value == 'null':
                     continue
                 CephService.send_command('mon', 'config set',
-                                         who=name_to_config_section(daemon_name),
+                                         who=name_to_config_section(full_daemon_name),
                                          name=key, value=value)
 
         return {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58424

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh