### PR TITLE
doc/releases: Clarify Quincy CephFS MDS upgrade process

### DIFF
--- a/doc/releases/quincy.rst
+++ b/doc/releases/quincy.rst
@@ -866,10 +866,12 @@ Upgrading non-cephadm clusters
 
 #. Upgrade all CephFS MDS daemons. For each CephFS file system,
 
-   #. Disable standby_replay:
+   #. Disable standby_replay.  Before executing, note the current value
+      so that it may be re-enabled after the upgrade (if currently enabled):
          
       .. prompt:: bash #
 
+	 ceph fs get <fs_name> | grep allow_standby_replay
 	 ceph fs set <fs_name> allow_standby_replay false
 
    #. Reduce the number of ranks to 1.  (Make note of the original
@@ -877,7 +879,7 @@ Upgrading non-cephadm clusters
       
       .. prompt:: bash #
 
-	 ceph status
+	 ceph fs status
 	 ceph fs set <fs_name> max_mds 1
 
    #. Wait for the cluster to deactivate any non-zero ranks by
@@ -885,7 +887,7 @@ Upgrading non-cephadm clusters
       
       .. prompt:: bash #
 
-	 ceph status
+	 ceph fs status
 
    #. Take all standby MDS daemons offline on the appropriate hosts with:
 
@@ -897,7 +899,7 @@ Upgrading non-cephadm clusters
 
       .. prompt:: bash #
 
-	 ceph status
+	 ceph fs status
 
    #. Upgrade the last remaining MDS daemon by installing the new
       packages and restarting the daemon:
@@ -917,6 +919,13 @@ Upgrading non-cephadm clusters
       .. prompt:: bash #
 
 	 ceph fs set <fs_name> max_mds <original_max_mds>
+
+    #. Restore the original value of ``allow_standby_replay`` for the volume if
+       it was ``true``:
+
+      .. prompt:: bash #
+
+	 ceph fs set <fs_name> allow_standby_replay true
 
 #. Upgrade all radosgw daemons by upgrading packages and restarting
    daemons on all hosts:


### PR DESCRIPTION
doc/releases: Clarify Quincy CephFS MDS upgrade process including fixing example commands and potentially re-enabling `standby-replay`

Fixes: https://tracker.ceph.com/issues/58123
Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
