### PR TITLE
crimson/osd: make the ObjectContextRegistry per-PG

### DIFF
--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -1,4 +1,5 @@
 #include "crimson/osd/object_context_loader.h"
+#include "osd/osd_types_fmt.h"
 
 SET_SUBSYS(osd);
 
@@ -66,7 +67,7 @@ using crimson::common::local_conf;
         crimson::ct_error::enoent::make()
       };
     }
-    auto [clone, existed] = shard_services.get_cached_obc(*coid);
+    auto [clone, existed] = obc_registry.get_cached_obc(*coid);
     return clone->template with_lock<State, IOInterruptCondition>(
       [existed=existed, clone=std::move(clone),
        func=std::move(func), head=std::move(head), this]()
@@ -87,7 +88,7 @@ using crimson::common::local_conf;
   {
     if (oid.is_head()) {
       auto [obc, existed] =
-        shard_services.get_cached_obc(std::move(oid));
+        obc_registry.get_cached_obc(std::move(oid));
       return with_head_obc<State>(std::move(obc),
                                   existed,
                                   std::move(func));

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -3,7 +3,6 @@
 #include <seastar/core/future.hh>
 #include "crimson/common/errorator.h"
 #include "crimson/osd/object_context.h"
-#include "crimson/osd/shard_services.h"
 #include "crimson/osd/pg_backend.h"
 
 namespace crimson::osd {
@@ -14,10 +13,10 @@ public:
     ObjectContext::obc_accessing_option_t>;
 
   ObjectContextLoader(
-    ShardServices& _shard_services,
+    ObjectContextRegistry& _obc_services,
     PGBackend& _backend,
     DoutPrefixProvider& dpp)
-    : shard_services{_shard_services},
+    : obc_registry{_obc_services},
       backend{_backend},
       dpp{dpp}
     {}
@@ -67,7 +66,7 @@ public:
   void notify_on_change(bool is_primary);
 
 private:
-  ShardServices &shard_services;
+  ObjectContextRegistry& obc_registry;
   PGBackend& backend;
   DoutPrefixProvider& dpp;
   obc_accessing_list_t obc_set_accessing;

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -956,8 +956,7 @@ std::pair<object_info_t, ObjectContextRef> OpsExecuter::prepare_clone(
   if (pg->is_primary()) {
     // lookup_or_create
     auto [c_obc, existed] =
-      pg->get_shard_services().get_cached_obc(
-        std::move(coid));
+      pg->obc_registry.get_cached_obc(std::move(coid));
     assert(!existed);
     c_obc->obs.oi = static_snap_oi;
     c_obc->obs.exists = true;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -134,8 +134,10 @@ PG::PG(
       osdmap,
       this,
       this),
+    obc_registry{
+      local_conf()},
     obc_loader{
-      shard_services,
+      obc_registry,
       *backend.get(),
       *this},
     wait_for_active_blocker(this)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -618,6 +618,7 @@ private:
   eversion_t projected_last_update;
 
 public:
+  ObjectContextRegistry obc_registry;
   ObjectContextLoader obc_loader;
 
   // PeeringListener

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -183,7 +183,7 @@ RecoveryBackend::scan_for_backfill(
 	-> interruptible_future<> {
 	crimson::osd::ObjectContextRef obc;
 	if (pg.is_primary()) {
-	  obc = shard_services.maybe_get_cached_obc(object);
+	  obc = pg.obc_registry.maybe_get_cached_obc(object);
 	}
 	if (obc) {
 	  if (obc->obs.exists) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -43,7 +43,6 @@ PerShardState::PerShardState(
     store(store),
     perf(perf), recoverystate_perf(recoverystate_perf),
     throttler(crimson::common::local_conf()),
-    obc_registry(crimson::common::local_conf()),
     next_tid(
       static_cast<ceph_tid_t>(seastar::this_shard_id()) <<
       (std::numeric_limits<ceph_tid_t>::digits - 8)),

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -92,8 +92,6 @@ class PerShardState {
     up_epoch = epoch;
   }
 
-  crimson::osd::ObjectContextRegistry obc_registry;
-
   // prevent creating new osd operations when system is shutting down,
   // this is necessary because there are chances that a new operation
   // is created, after the interruption of all ongoing operations, and
@@ -456,11 +454,6 @@ public:
   FORWARD_TO_LOCAL(get_hb_stamps)
 
   FORWARD(pg_created, pg_created, local_state.pg_map)
-
-  FORWARD(
-    maybe_get_cached_obc, maybe_get_cached_obc, local_state.obc_registry)
-  FORWARD(
-    get_cached_obc, get_cached_obc, local_state.obc_registry)
 
   FORWARD_TO_OSD_SINGLETON_TARGET(
     local_update_priority,


### PR DESCRIPTION
This patch moves the OBC registry from ShardServices (which is basicaly a gateway to a bunch of PGs) into PG itself. Dividing OBCs by PG (they truly belong to) minimizes the space to search when e.g. checking whether a client is blocked or not. Therefore, this commit is enabler of more performant PR #47637.

The changeset draws the assumption that OBC registry and all its users live on the same CPU core. It looks valid to me.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
