### PR TITLE
mds: record and dump last tid for trimming completed requests (or flu…

### DIFF
--- a/doc/cephfs/health-messages.rst
+++ b/doc/cephfs/health-messages.rst
@@ -130,7 +130,9 @@ other daemons, please see :ref:`health-checks`.
     from properly cleaning up resources used by client requests.  This message
     appears if a client appears to have more than ``max_completed_requests``
     (default 100000) requests that are complete on the MDS side but haven't
-    yet been accounted for in the client's *oldest tid* value.
+    yet been accounted for in the client's *oldest tid* value. The last tid
+    used by the MDS to trim completed client requests (or flush) is included
+    as part of `session ls` (or `client ls`) command as a debug aid.
 
 ``MDS_DAMAGE``
 --------------

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -601,6 +601,9 @@ void Session::dump(Formatter *f, bool cap_dump) const
   f->dump_object("session_cache_liveness", session_cache_liveness);
   f->dump_object("cap_acquisition", cap_acquisition);
 
+  f->dump_unsigned("last_trim_completed_requests_tid", last_trim_completed_requests_tid);
+  f->dump_unsigned("last_trim_completed_flushes_tid", last_trim_completed_flushes_tid);
+
   f->open_array_section("delegated_inos");
   for (const auto& [start, len] : delegated_inos) {
     f->open_object_section("ino_range");

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -313,6 +313,7 @@ public:
   bool trim_completed_requests(ceph_tid_t mintid) {
     // trim
     bool erased_any = false;
+    last_trim_completed_requests_tid = mintid;
     while (!info.completed_requests.empty() && 
 	   (mintid == 0 || info.completed_requests.begin()->first < mintid)) {
       info.completed_requests.erase(info.completed_requests.begin());
@@ -338,6 +339,7 @@ public:
   }
   bool trim_completed_flushes(ceph_tid_t mintid) {
     bool erased_any = false;
+    last_trim_completed_flushes_tid = mintid;
     while (!info.completed_flushes.empty() &&
 	(mintid == 0 || *info.completed_flushes.begin() < mintid)) {
       info.completed_flushes.erase(info.completed_flushes.begin());
@@ -492,6 +494,9 @@ private:
 
   unsigned num_trim_flushes_warnings = 0;
   unsigned num_trim_requests_warnings = 0;
+
+  ceph_tid_t last_trim_completed_requests_tid = 0;
+  ceph_tid_t last_trim_completed_flushes_tid = 0;
 };
 
 class SessionFilter


### PR DESCRIPTION
…shes)

CephFS clients include `oldest_tid` as part of the client request to the MDS. This field is the tid of the oldest incomplete mds request (excluding setfilelock request). The MDS uses this to trim completed requests (and flushes). In one case, the ceph cluster had an extremely high completed requests count, meaning, for some reason the client was not advancing its `oldest_tid` field, although, the MDS had successfully "safe replied" the request back to the client.

This change adds a debug aid for recording and dumping this field. It might be possible to fetch this from clients (if not, we should add that!), but it makes sense to have this information available from the MDS.

Partially-Fixes: http://tracker.ceph.com/issues/57985
Signed-off-by: Venky Shankar <vshankar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
