### PR TITLE
crush: fix compilation guard around specialization for libfmt => 9

### DIFF
--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -37,8 +37,9 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const CrushLocation& loc);
 }
-#endif
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<TOPNSPC::crush::CrushLocation> : fmt::ostream_formatter {};
+#endif
+
 #endif


### PR DESCRIPTION
```
[ 77%] Building CXX object src/crimson/CMakeFiles/crimson-common.dir/__/crush/CrushLocation.cc.o
In file included from /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-1862-g7689999c/rpm/el8/BUILD/ceph-18.0.0-1862-g7689999c/src/common/ceph_context.h:47,
                 from /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-1862-g7689999c/rpm/el8/BUILD/ceph-18.0.0-1862-g7689999c/src/crush/CrushLocation.cc:11:
/home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-1862-g7689999c/rpm/el8/BUILD/ceph-18.0.0-1862-g7689999c/src/crush/CrushLocation.h:43:25: error: redefinition of ‘struct fmt::v9::formatter<crimson::crush::CrushLocation>’
   43 | template <> struct fmt::formatter<TOPNSPC::crush::CrushLocation> : fmt::ostream_formatter {};
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

-------------------------
This caused the failure in https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos8,DIST=centos8,MACHINE_SIZE=gigantic/67410//consoleFull.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
