### PR TITLE
mon/MonClient: reconnect session if needed on ticks

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -815,9 +815,9 @@ void MgrMonitor::tick()
       && last_beacon.at(pending_map.active_gid) < cutoff
       && mon.osdmon()->is_writeable()) {
     const std::string old_active_name = pending_map.active_name;
+    dout(4) << "Dropping active " << pending_map.active_gid << dendl;
     drop_active();
     propose = true;
-    dout(4) << "Dropping active" << pending_map.active_gid << dendl;
     if (promote_standby()) {
       dout(4) << "Promoted standby " << pending_map.active_gid << dendl;
       mon.clog->info() << "Manager daemon " << old_active_name

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -960,6 +960,11 @@ void MonClient::tick()
       schedule_tick();
     });
 
+  if (!_opened()) {
+    ldout(cct, 10) << __func__ << " not opened." << dendl;
+    _reopen_session();
+  }
+
   _check_auth_tickets();
   _check_tell_commands();
   

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -968,10 +968,7 @@ void MonClient::tick()
   _check_auth_tickets();
   _check_tell_commands();
   
-  if (_hunting()) {
-    ldout(cct, 1) << "continuing hunt" << dendl;
-    return _reopen_session();
-  } else if (active_con) {
+  if (active_con) {
     // just renew as needed
     auto cur_con = active_con->get_con();
     if (!cur_con->has_feature(CEPH_FEATURE_MON_STATEFUL_SUB)) {


### PR DESCRIPTION
If MonClient fail to connect or return with EAGAIN during authentication We will end up with no active_con and not hunting, that will cause the MonClient to skip connection every tick and not sent any messages like beacon from MGR.
the fix will check for _open and reconnect if not connected.

Fixes: https://tracker.ceph.com/issues/58379
Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
