### PR TITLE
pacific: mgr/prometheus: export zero valued pg state metrics

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1033,6 +1033,8 @@ class Module(MgrModule):
 
         for pool in pg_summary['by_pool']:
             num_by_state: DefaultDict[str, int] = defaultdict(int)
+            for state in PG_STATES:
+                num_by_state[state] = 0
 
             for state_name, count in pg_summary['by_pool'][pool].items():
                 for state in state_name.split('+'):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58502

---

backport of https://github.com/ceph/ceph/pull/49759
parent tracker: https://tracker.ceph.com/issues/58471

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh