### PR TITLE
pacific: ceph-volume/tests: add allowlist_externals to tox.ini

### DIFF
--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -8,6 +8,8 @@ deps=
   pytest-xdist
   mock
   pyfakefs
+allowlist_externals=
+  ./tox_install_command.sh
 install_command=./tox_install_command.sh {opts} {packages}
 commands=py.test --numprocesses=auto -vv {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58397

---

backport of https://github.com/ceph/ceph/pull/49629
parent tracker: https://tracker.ceph.com/issues/58377

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh