### PR TITLE
qa/openssl_keys: 'rm' ignores file not found

### DIFF
--- a/qa/tasks/openssl_keys.py
+++ b/qa/tasks/openssl_keys.py
@@ -134,7 +134,7 @@ class OpenSSLKeys(Task):
 
             csr = f'{self.cadir}/{cert.name}.csr'
             srl = f'{self.cadir}/{ca_cert.name}.srl'
-            remove_files = ['rm', csr, srl]
+            remove_files = ['rm', '-f', csr, srl]
 
             # these commands are run on the ca certificate's client because
             # they need access to its private key and cert


### PR DESCRIPTION
on distros with openssl 3, the .srl files don't appear to be created. don't fail if 'rm' can't find them

Fixes: https://tracker.ceph.com/issues/58513

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
