### PR TITLE
quincy: rgw/notifications: sending metadata in COPY and CompleteMultipartUpload

### DIFF
--- a/src/rgw/rgw_notify.h
+++ b/src/rgw/rgw_notify.h
@@ -65,9 +65,10 @@ struct reservation_t {
   const std::string* const object_name;
   boost::optional<RGWObjTags&> tagset;
   meta_map_t x_meta_map; // metadata cached by value
-  std::string user_id;
-  std::string user_tenant;
-  std::string req_id;
+  bool metadata_fetched_from_attributes;
+  const std::string user_id;
+  const std::string user_tenant;
+  const std::string req_id;
   optional_yield yield;
 
   /* ctor for rgw_op callers */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58285

---

backport of https://github.com/ceph/ceph/pull/48875
parent tracker: https://tracker.ceph.com/issues/58014

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh