### PR TITLE
msg: fix poll event driver, handling POLLHUP and POLLERR

### DIFF
--- a/src/msg/async/EventPoll.cc
+++ b/src/msg/async/EventPoll.cc
@@ -178,6 +178,12 @@ int PollDriver::event_wait(std::vector<FiredFileEvent> &fired_events,
 	if (pfds[j].revents & POLLOUT) {
 	  mask |= EVENT_WRITABLE;
 	}
+	if (pfds[j].revents & POLLHUP) {
+	  mask |= EVENT_READABLE | EVENT_WRITABLE;
+	}
+	if (pfds[j].revents & POLLERR) {
+	  mask |= EVENT_READABLE | EVENT_WRITABLE;
+	}
 	if (mask) {
 	  fe.fd = pfds[j].fd;
 	  fe.mask = mask;


### PR DESCRIPTION
msg: fix poll event driver, handling POLLHUP and POLLERR

The poll event driver (mainly used on Windows) is currently ignoring POLLOUT and POLLERR events. Because of this, the caller doesn't get notified that the connection closed and can end up calling "event_wait" indefinitely, leading to 100% cpu usage.

This change ensures that POLLOUT and POLLERR events are properly propagated by the poll driver.

Related issue: https://github.com/cloudbase/wnbd/issues/98

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
