### PR TITLE
vstart: add user-policy caps to s3test users

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1629,14 +1629,14 @@ do_rgw_create_users()
         --access-key NOPQRSTUVWXYZABCDEFG \
         --secret nopqrstuvwxyzabcdefghijklmnabcdefghijklm \
         --display-name john.doe \
-        --email john.doe@example.com -c $conf_fn > /dev/null
+        --email john.doe@example.com --caps="user-policy=*" -c $conf_fn > /dev/null
     $CEPH_BIN/radosgw-admin user create \
 	--tenant testx \
         --uid 9876543210abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
         --access-key HIJKLMNOPQRSTUVWXYZA \
         --secret opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab \
         --display-name tenanteduser \
-        --email tenanteduser@example.com -c $conf_fn > /dev/null
+        --email tenanteduser@example.com --caps="user-policy=*" -c $conf_fn > /dev/null
 
     # Create Swift user
     debug echo "setting up user tester"


### PR DESCRIPTION
test_user_policy() requires user-policy caps on the tenanted user

Fixes: https://tracker.ceph.com/issues/58365

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
