### PR TITLE
qa/s3tests: run with tox instead of bootstrap+nose

### DIFF
--- a/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
+++ b/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
@@ -45,6 +45,7 @@ tasks:
         # cloud-user creds to be created on cloud-client
         #cloud_secret: "foobar"
         #cloud_access_key: "87654321"
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/crypt/4-tests/s3tests.yaml
+++ b/qa/suites/rgw/crypt/4-tests/s3tests.yaml
@@ -1,4 +1,5 @@
 tasks:
+- tox: [client.0]
 - s3tests:
     client.0:
       barbican:

--- a/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
@@ -2,6 +2,7 @@ tasks:
 - install:
 - ceph:
 - rgw: [client.0]
+- tox: [client.0]
 - exec:
     client.0:
       - sudo chmod 0777 /var/lib/ceph

--- a/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
@@ -12,5 +12,5 @@ tasks:
     client.0:
       dbstore_tests: True
       rgw_server: client.0
-      extra_attrs: ["!fails_on_rgw,!fails_on_dbstore"]
+      extra_attrs: ["not fails_on_rgw","not fails_on_dbstore"]
 

--- a/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
@@ -2,6 +2,7 @@ tasks:
 - install:
 - ceph:
 - rgw: [client.0]
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -2,6 +2,7 @@ tasks:
 - install:
 - ceph:
 - rgw: [client.0]
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,4 +1,5 @@
 tasks:
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,4 +1,5 @@
 tasks:
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/website/tasks/s3tests-website.yaml
+++ b/qa/suites/rgw/website/tasks/s3tests-website.yaml
@@ -10,6 +10,7 @@ tasks:
       dns-name: s3.
     client.1:
       dns-s3website-name: s3-website.
+- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
@@ -5,6 +5,7 @@ overrides:
 tasks:
 - ceph:
 - rgw: [client.0]
+- tox: [client.0]
 - s3tests:
     client.0:
       force-branch: ceph-master

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -2,6 +2,7 @@ tasks:
 - ceph:
     fs: xfs
 - rgw: [client.0]
+- tox: [client.0]
 - s3tests:
     client.0:
       force-branch: ceph-master


### PR DESCRIPTION
depends on https://github.com/ceph/s3-tests/pull/482

Fixes: https://tracker.ceph.com/issues/58512

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
