### PR TITLE
pacific: rgw: fix the problem of duplicate idx when bi list

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2755,7 +2755,9 @@ static int list_instance_entries(cls_method_context_t hctx,
   if (ret < 0 && ret != -ENOENT) {
     return ret;
   }
-  bool found_first = (ret == 0);
+  // we need to include the exact match if a filter (name) is
+  // specified and the marker has not yet advanced (i.e., been set)
+  bool found_first = (ret == 0) && (start_after_key != marker);
   if (found_first) {
     --max;
   }
@@ -2845,7 +2847,9 @@ static int list_olh_entries(cls_method_context_t hctx,
   if (ret < 0 && ret != -ENOENT) {
     return ret;
   }
-  bool found_first = (ret == 0);
+    // we need to include the exact match if a filter (name) is
+   // specified and the marker has not yet advanced (i.e., been set)
+  bool found_first = (ret == 0) && (start_after_key != marker);
   if (found_first) {
     --max;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58542

---

backport of https://github.com/ceph/ceph/pull/49315
parent tracker: https://tracker.ceph.com/issues/58213

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh