### PR TITLE
quincy: rgw/beast: fix interaction between keepalive and 100-continue

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -123,6 +123,7 @@ size_t ClientIO::send_100_continue()
   const size_t sent = txbuf.sputn(HTTTP_100_CONTINUE,
                                   sizeof(HTTTP_100_CONTINUE) - 1);
   flush();
+  sent100continue = true;
   return sent;
 }
 

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -30,6 +30,7 @@ class ClientIO : public io::RestfulClient,
   RGWEnv env;
 
   rgw::io::StaticOutputBufferer<> txbuf;
+  bool sent100continue = false;
 
  public:
   ClientIO(parser_type& parser, bool is_ssl,
@@ -54,6 +55,8 @@ class ClientIO : public io::RestfulClient,
   RGWEnv& get_env() noexcept override {
     return env;
   }
+
+  bool sent_100_continue() const { return sent100continue; }
 };
 
 } // namespace asio


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58554

---

backport of https://github.com/ceph/ceph/pull/49642
parent tracker: https://tracker.ceph.com/issues/58286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh