### PR TITLE
pacific: rgw/beast: fix interaction between keepalive and 100-continue

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -121,6 +121,7 @@ size_t ClientIO::send_100_continue()
   const size_t sent = txbuf.sputn(HTTTP_100_CONTINUE,
                                   sizeof(HTTTP_100_CONTINUE) - 1);
   flush();
+  sent100continue = true;
   return sent;
 }
 

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -30,6 +30,7 @@ class ClientIO : public io::RestfulClient,
   RGWEnv env;
 
   rgw::io::StaticOutputBufferer<> txbuf;
+  bool sent100continue = false;
 
  public:
   ClientIO(parser_type& parser, bool is_ssl,
@@ -54,6 +55,8 @@ class ClientIO : public io::RestfulClient,
   RGWEnv& get_env() noexcept override {
     return env;
   }
+
+  bool sent_100_continue() const { return sent100continue; }
 };
 
 } // namespace asio

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -227,6 +227,8 @@ void handle_connection(boost::asio::io_context& context,
       return;
     }
 
+    bool expect_continue = (message[http::field::expect] == "100-continue");
+
     {
       auto lock = pause_mutex.async_lock_shared(yield[ec]);
       if (ec == boost::asio::error::operation_aborted) {
@@ -278,6 +280,10 @@ void handle_connection(boost::asio::io_context& context,
             << log_header{message, http::field::range} << " latency="
             << latency << dendl;
       }
+
+      if (real_client.sent_100_continue()) {
+        expect_continue = false;
+      }
     }
 
     if (!parser.keep_alive()) {
@@ -286,7 +292,7 @@ void handle_connection(boost::asio::io_context& context,
 
     // if we failed before reading the entire message, discard any remaining
     // bytes before reading the next
-    while (!parser.is_done()) {
+    while (!expect_continue && !parser.is_done()) {
       static std::array<char, 1024> discard_buffer;
 
       auto& body = parser.get().body();

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -331,6 +331,8 @@ struct Connection : boost::intrusive::list_base_hook<>,
   void close(boost::system::error_code& ec) {
     socket.close(ec);
   }
+
+  tcp_socket& get_socket() { return socket; }
 };
 
 class ConnectionList {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -69,6 +69,7 @@ class StreamIO : public rgw::asio::ClientIO {
   timeout_timer& timeout;
   yield_context yield;
   parse_buffer& buffer;
+  boost::system::error_code fatal_ec;
  public:
   StreamIO(CephContext *cct, Stream& stream, timeout_timer& timeout,
            rgw::asio::parser_type& parser, yield_context yield,
@@ -79,6 +80,8 @@ class StreamIO : public rgw::asio::ClientIO {
         cct(cct), stream(stream), timeout(timeout), yield(yield),
         buffer(buffer)
   {}
+
+  boost::system::error_code get_fatal_error_code() const { return fatal_ec; }
 
   size_t write_data(const char* buf, size_t len) override {
     boost::system::error_code ec;
@@ -91,6 +94,9 @@ class StreamIO : public rgw::asio::ClientIO {
       if (ec == boost::asio::error::broken_pipe) {
         boost::system::error_code ec_ignored;
         stream.lowest_layer().shutdown(tcp_socket::shutdown_both, ec_ignored);
+      }
+      if (!fatal_ec) {
+        fatal_ec = ec;
       }
       throw rgw::io::Exception(ec.value(), std::system_category());
     }
@@ -113,6 +119,9 @@ class StreamIO : public rgw::asio::ClientIO {
       }
       if (ec) {
         ldout(cct, 4) << "failed to read body: " << ec.message() << dendl;
+        if (!fatal_ec) {
+          fatal_ec = ec;
+        }
         throw rgw::io::Exception(ec.value(), std::system_category());
       }
     }
@@ -279,6 +288,13 @@ void handle_connection(boost::asio::io_context& context,
             << log_header{message, http::field::user_agent, "\""} << ' '
             << log_header{message, http::field::range} << " latency="
             << latency << dendl;
+      }
+
+      // process_request() can't distinguish between connection errors and
+      // http/s3 errors, so check StreamIO for fatal connection errors
+      ec = real_client.get_fatal_error_code();
+      if (ec) {
+        return;
       }
 
       if (real_client.sent_100_continue()) {

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -20,7 +20,8 @@ struct timeout_handler {
   void operator()(boost::system::error_code ec) {
     if (!ec) { // wait was not canceled
       boost::system::error_code ec_ignored;
-      stream->close(ec_ignored);
+      stream->get_socket().cancel();
+      stream->get_socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec_ignored);
     }
   }
 };


### PR DESCRIPTION
backport trackers:
https://tracker.ceph.com/issues/58553
https://tracker.ceph.com/issues/58769
https://tracker.ceph.com/issues/58771

---

backport of https://github.com/ceph/ceph/pull/49642
parent tracker: https://tracker.ceph.com/issues/58286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh