### PR TITLE
mgr/dashboard: added recovery throghput graph

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/new-dashboard/dashboard-area-chart/dashboard-area-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/new-dashboard/dashboard-area-chart/dashboard-area-chart.component.ts
@@ -233,13 +233,17 @@ export class DashboardAreaChartComponent implements OnInit, OnChanges, AfterView
       };
       this.chart.chart.update();
     } else if (this.chart && this.data) {
+      let maxValue = 0,
+        maxValueDataUnits = '';
       let maxValueData = Math.max(...this.data.map((values: any) => values[1]));
       if (this.data2) {
         var maxValueData2 = Math.max(...this.data2.map((values: any) => values[1]));
+        [maxValue, maxValueDataUnits] = this.convertUnits(
+          Math.max(maxValueData, maxValueData2)
+        ).split(' ');
+      } else {
+        [maxValue, maxValueDataUnits] = this.convertUnits(Math.max(maxValueData)).split(' ');
       }
-      let [maxValue, maxValueDataUnits] = this.convertUnits(
-        Math.max(maxValueData, maxValueData2)
-      ).split(' ');
 
       this.chart.chart.options.scales.yAxes[0].ticks.suggestedMax = maxValue * 1.2;
       this.chart.chart.options.scales.yAxes[0].ticks.suggestedMin = 0;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/new-dashboard/dashboard/dashboard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/new-dashboard/dashboard/dashboard.component.html
@@ -205,6 +205,11 @@
                                  [data]="queriesResults.READCLIENTTHROUGHPUT"
                                  [data2]="queriesResults.WRITECLIENTTHROUGHPUT">
         </cd-dashboard-area-chart>
+        <cd-dashboard-area-chart chartTitle="Recovery Throughput"
+                                 dataUnits="bytesPerSecond"
+                                 label="Recovery Throughput"
+                                 [data]="queriesResults.RECOVERYBYTES">
+        </cd-dashboard-area-chart>
       </div>
     </cd-card>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -5,5 +5,6 @@ export enum Promqls {
   READLATENCY = 'avg(ceph_osd_apply_latency_ms)',
   WRITELATENCY = 'avg(ceph_osd_commit_latency_ms)',
   READCLIENTTHROUGHPUT = 'sum(irate(ceph_pool_rd_bytes[1m]))',
-  WRITECLIENTTHROUGHPUT = 'sum(irate(ceph_pool_wr_bytes[1m]))'
+  WRITECLIENTTHROUGHPUT = 'sum(irate(ceph_pool_wr_bytes[1m]))',
+  RECOVERYBYTES = 'ceph_osd_recovery_bytes'
 }


### PR DESCRIPTION
Added the Recovery Throughput graph below the existing ones on the cluster utilization card.
The data is retrieved from prometheu's `ceph_osd_recovery_bytes` metric.

![image](https://user-images.githubusercontent.com/106810838/214357311-196df3e6-6fe1-4389-bb06-9db84e3a5dc0.png)

This PR also fixes a bug I found while testing the graphs, there was an issue if the graph had only one data set and no max value that would cause the data not plotting on the graph. Now is fixed. 


Signed-off-by: Pedro Gonzalez Gomez <pegonzal@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
