### PR TITLE
qa/workunits: give telemetry opt-in check more time

### DIFF
--- a/qa/workunits/test_telemetry_pacific_x.sh
+++ b/qa/workunits/test_telemetry_pacific_x.sh
@@ -35,11 +35,15 @@ ceph telemetry preview-all
 ceph telemetry on --license sharing-1-0
 ceph telemetry enable channel perf
 
-# Check the warning (should be gone after 2 seconds):
-sleep 2
+# Check the warning:
+timeout=60
 STATUS=$(ceph -s)
-if [[ $STATUS == *"Telemetry requires re-opt-in"* ]]
-then
+until [[ $STATUS != *"Telemetry requires re-opt-in"* ]] || [ $timeout -le 0 ]; do
+    STATUS=$(ceph -s)
+    sleep 1
+    timeout=$(( timeout - 1 ))
+done
+if [ $timeout -le 0 ]; then
     echo "STATUS should not contain re-opt-in warning at this point"
     exit 1
 fi


### PR DESCRIPTION
Previously, we only allotted 2 seconds for the telemetry opt-in status to disappear. However, it sometimes takes longer than this for the ceph status to update.

Here, we give the status up to 60 seconds to update.

Fixes: https://tracker.ceph.com/issues/58545
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
