### PR TITLE
quincy: mgr/orchestrator: fix upgrade status help message

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1499,7 +1499,7 @@ Usage:
 
     @_cli_write_command('orch upgrade status')
     def _upgrade_status(self) -> HandleCommandResult:
-        """Check service versions vs available and target containers"""
+        """Check the status of any potential ongoing upgrade operation"""
         completion = self.upgrade_status()
         status = raise_if_exception(completion)
         r = {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58451

---

backport of https://github.com/ceph/ceph/pull/48617
parent tracker: https://tracker.ceph.com/issues/57921

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh