### PR TITLE
quincy: mgr/cephadm: fix handling of mgr upgrades with 3 or more mgrs

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1107,7 +1107,7 @@ class CephadmUpgrade:
                     # no point in trying to redeploy with new version if active mgr is not on the new version
                     need_upgrade_deployer = []
 
-            if not need_upgrade_self:
+            if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
                 # only after the mgr itself is upgraded can we expect daemons to have
                 # deployed_by == target_digests
                 need_upgrade += need_upgrade_deployer


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58248

---

backport of https://github.com/ceph/ceph/pull/48258
parent tracker: https://tracker.ceph.com/issues/57675

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh