### PR TITLE
os/bluestore: do not reset prefetched buffer when doing multi-chunk r…

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1033,8 +1033,49 @@ TEST(BufferListIterator, get_current_ptr) {
     EXPECT_EQ('B', ptr[0]);
     EXPECT_EQ((unsigned)1, ptr.offset());
     EXPECT_EQ((unsigned)2, ptr.length());
-  }  
+  }
 }
+
+TEST(BufferListIterator, get_current_ptr_ext) {
+  bufferlist bl;
+  {
+    bufferlist::iterator i(&bl);
+    EXPECT_THROW(++i, buffer::end_of_buffer);
+  }
+  string s1("ABC");
+  string s2("abcd");
+
+  bufferlist bl0;
+  bl0.append(s1);
+
+  // make bl have two raw ptrs
+  bl = bl0;
+  bl.append(s2);
+  {
+    bufferlist::iterator i(&bl);
+    const buffer::ptr ptr = i.get_current_ptr();
+    EXPECT_TRUE(i.is_pointing_same_raw(ptr));
+    EXPECT_EQ('A', ptr[0]);
+    EXPECT_EQ((unsigned)0, ptr.offset());
+    EXPECT_EQ((unsigned)3, ptr.length());
+
+    i.seek(2);
+    const buffer::ptr ptr1 = i.get_current_ptr();
+    EXPECT_TRUE(i.is_pointing_same_raw(ptr));
+    EXPECT_EQ('C', ptr1[0]);
+    EXPECT_EQ((unsigned)2, ptr1.offset());
+    EXPECT_EQ((unsigned)1, ptr1.length());
+
+    i.seek(4);
+    const buffer::ptr ptr2 = i.get_current_ptr();
+    EXPECT_TRUE(!i.is_pointing_same_raw(ptr));
+    EXPECT_EQ('b', ptr2[0]);
+    EXPECT_EQ((unsigned)1, ptr2.offset());
+    EXPECT_EQ((unsigned)3, ptr2.length());
+  }
+}
+
+
 
 TEST(BufferListIterator, copy) {
   bufferlist bl;


### PR DESCRIPTION
…ead.

This might improve BlueFS prefetching utilization in some cases.

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
