### PR TITLE
quincy: mgr/rook: Device inventory

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -495,7 +495,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                 "On": "On",
                 "Off": "Off",
                 True: "Yes",
-                False: "",
+                False: "No",
             }
 
             out = []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58577

---

backport of https://github.com/ceph/ceph/pull/48384
parent tracker: https://tracker.ceph.com/issues/58572

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh