### PR TITLE
BlueStore: Improve fragmentation score metric

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -190,8 +190,13 @@ void Allocator::release(const PExtentVector& release_vec)
 double Allocator::get_fragmentation_score()
 {
   // this value represents how much worth is 2X bytes in one chunk then in X + X bytes
-  static const double double_size_worth = 1.1 ;
-  std::vector<double> scales{1};
+  static const double double_size_worth_small = 1.2;
+  // chunks larger then 128MB are large enough that should be counted without penalty
+  static const double double_size_worth_huge = 1;
+  static const size_t small_chunk_p2 = 20; // 1MB
+  static const size_t huge_chunk_p2 = 27; // 128MB
+  // for chunks 1MB - 128MB penalty coeffs are linearly weighted 1.2 (at small) ... 1 (at huge)
+  static std::vector<double> scales{1};
   double score_sum = 0;
   size_t sum = 0;
 
@@ -199,9 +204,17 @@ double Allocator::get_fragmentation_score()
     size_t sc = sizeof(v) * 8 - std::countl_zero(v) - 1; //assign to grade depending on log2(len)
     while (scales.size() <= sc + 1) {
       //unlikely expand scales vector
-      scales.push_back(scales[scales.size() - 1] * double_size_worth);
+      auto ss = scales.size();
+      double scale = double_size_worth_small;
+      if (ss >= huge_chunk_p2) {
+	scale = double_size_worth_huge;
+      } else if (ss > small_chunk_p2) {
+	// linear decrease 1.2 ... 1
+	scale = (double_size_worth_huge * (ss - small_chunk_p2) + double_size_worth_small * (huge_chunk_p2 - ss)) /
+	  (huge_chunk_p2 - small_chunk_p2);
+      }
+      scales.push_back(scales[scales.size() - 1] * scale);
     }
-
     size_t sc_shifted = size_t(1) << sc;
     double x = double(v - sc_shifted) / sc_shifted; //x is <0,1) in its scale grade
     // linear extrapolation in its scale grade

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -217,8 +217,7 @@ double Allocator::get_fragmentation_score()
   };
   foreach(iterated_allocation);
 
-
   double ideal = get_score(sum);
-  double terrible = sum * get_score(1);
+  double terrible = (sum / block_size) * get_score(block_size);
   return (ideal - score_sum) / (ideal - terrible);
 }

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -301,7 +301,6 @@ TEST_P(AllocTest, test_alloc_fragmentation)
     alloc->release(release_set);
   }
   EXPECT_EQ(1.0, alloc->get_fragmentation());
-  EXPECT_EQ(66u, uint64_t(alloc->get_fragmentation_score() * 100));
 
   for (size_t i = 1; i < allocated.size() / 2; i += 2)
   {
@@ -316,7 +315,6 @@ TEST_P(AllocTest, test_alloc_fragmentation)
     // fragmentation approx = 257 intervals / 768 max intervals
     EXPECT_EQ(33u, uint64_t(alloc->get_fragmentation() * 100));
   }
-  EXPECT_EQ(27u, uint64_t(alloc->get_fragmentation_score() * 100));
 
   for (size_t i = allocated.size() / 2 + 1; i < allocated.size(); i += 2)
   {
@@ -329,11 +327,84 @@ TEST_P(AllocTest, test_alloc_fragmentation)
   // Hence leaving just two 
   // digits after decimal point due to this.
   EXPECT_EQ(0u, uint64_t(alloc->get_fragmentation() * 100));
-  if (bitmap_alloc) {
-    EXPECT_EQ(0u, uint64_t(alloc->get_fragmentation_score() * 100));
-  } else {
-    EXPECT_EQ(11u, uint64_t(alloc->get_fragmentation_score() * 100));
+}
+
+TEST_P(AllocTest, test_fragmentation_score_0)
+{
+  uint64_t capacity = 16LL * 1024 * 1024 * 1024; //16 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  EXPECT_EQ(0, alloc->get_fragmentation_score());
+
+  // alloc every 100M, should get very small score
+  for (uint64_t pos = 0; pos < capacity; pos +=  100 * 1024 * 1024) {
+    alloc->init_rm_free(pos, alloc_unit);
   }
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.0001); // frag < 0.01%
+  for (uint64_t pos = 0; pos < capacity; pos +=  100 * 1024 * 1024) {
+    // put back
+    alloc->init_add_free(pos, alloc_unit);
+  }
+
+  // 10% space is trashed, rest is free, small score
+  for (uint64_t pos = 0; pos < capacity / 10; pos +=  3 * alloc_unit) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.01, alloc->get_fragmentation_score()); // 1% < frag < 10%
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.1);
+}
+
+TEST_P(AllocTest, test_fragmentation_score_some)
+{
+  uint64_t capacity = 1024 * 1024 * 1024; //1 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // half (in 16 chunks) is completely free,
+  // other half completely fragmented, expect less than 50% fragmentation score
+  for (uint64_t chunk = 0; chunk < capacity; chunk += capacity / 16) {
+    for (uint64_t pos = 0; pos < capacity / 32; pos += alloc_unit * 3) {
+      alloc->init_rm_free(chunk + pos, alloc_unit);
+    }
+  }
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.5); // f < 50%
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // half (in 16 chunks) is completely full,
+  // other half completely fragmented, expect really high fragmentation score
+  for (uint64_t chunk = 0; chunk < capacity; chunk += capacity / 16) {
+    alloc->init_rm_free(chunk + capacity / 32, capacity / 32);
+    for (uint64_t pos = 0; pos < capacity / 32; pos += alloc_unit * 3) {
+      alloc->init_rm_free(chunk + pos, alloc_unit);
+    }
+  }
+  EXPECT_LT(0.9, alloc->get_fragmentation_score()); // 50% < f
+}
+
+TEST_P(AllocTest, test_fragmentation_score_1)
+{
+  uint64_t capacity = 1024 * 1024 * 1024; //1 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // alloc every second AU, max fragmentation
+  for (uint64_t pos = 0; pos < capacity; pos += alloc_unit * 2) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.99, alloc->get_fragmentation_score()); // 99% < f
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // 1 allocated, 4 empty; expect very high score
+  for (uint64_t pos = 0; pos < capacity; pos += alloc_unit * 5) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.90, alloc->get_fragmentation_score()); // 90% < f
 }
 
 TEST_P(AllocTest, test_dump_fragmentation_score)


### PR DESCRIPTION
This is combination of fix and improvement to fragmentation score.
1) The fix
This eradicates error in calculation of maximum reference fragmentation score.
Max fragmentation is denominator of % calculation.
Basically, we used to assume that 1 byte wide chunks are possible.
Now, we assume that min_alloc_size is the minimal chunk possible.
https://docs.google.com/spreadsheets/d/16pfs-xoV6rhR3nHXmja-5iQ3pZW6AlSz_aZqi7_ZOFI/edit#gid=0

2) The improvement
The improvement downplays splitting large free chunks into multiple large free chunks.
It is intended to make fragmentation not increase much for as long as dominating chunks are >16MB.
It is when small chunks become frequent that we want fragmentation to increase.

Partially (and maybe completely) fixes:
https://tracker.ceph.com/issues/58022

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
