### PR TITLE
cephadm: more test coverage for various utils functions

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2460,7 +2460,7 @@ def find_executable(executable: str, path: Optional[str] = None) -> Optional[str
     """
     _, ext = os.path.splitext(executable)
     if (sys.platform == 'win32') and (ext != '.exe'):
-        executable = executable + '.exe'
+        executable = executable + '.exe'  # pragma: no cover
 
     if os.path.isfile(executable):
         return executable

--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -328,3 +328,11 @@ class TestFindExecutable:
     def test_no_such_exe(self):
         exe = _cephadm.find_executable("foo_bar-baz.noway")
         assert exe is None
+
+
+def test_find_program():
+    exe = _cephadm.find_program("true")
+    assert exe.endswith("true")
+
+    with pytest.raises(ValueError):
+        _cephadm.find_program("foo_bar-baz.noway")

--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -288,3 +288,43 @@ def test_recursive_chown(tmp_path):
     assert _chown.mock_calls[0].args == (str(d1), 500, 500)
     assert _chown.mock_calls[1].args == (str(d2), 500, 500)
     assert _chown.mock_calls[2].args == (str(f1), 500, 500)
+
+
+class TestFindExecutable:
+    def test_standard_exe(self):
+        # pretty much every system will have `true` on the path. It's a safe choice
+        # for the first assertion
+        exe = _cephadm.find_executable("true")
+        assert exe.endswith("true")
+
+    def test_custom_path(self, tmp_path):
+        foo_sh = tmp_path / "foo.sh"
+        with open(foo_sh, "w") as fh:
+            fh.write("#!/bin/sh\n")
+            fh.write("echo foo\n")
+        foo_sh.chmod(0o755)
+
+        exe = _cephadm.find_executable(foo_sh)
+        assert str(exe) == str(foo_sh)
+
+    def test_no_path(self, monkeypatch):
+        monkeypatch.delenv("PATH")
+        exe = _cephadm.find_executable("true")
+        assert exe.endswith("true")
+
+    def test_no_path_no_confstr(self, monkeypatch):
+        def _fail(_):
+            raise ValueError("fail")
+
+        monkeypatch.delenv("PATH")
+        monkeypatch.setattr("os.confstr", _fail)
+        exe = _cephadm.find_executable("true")
+        assert exe.endswith("true")
+
+    def test_unset_path(self):
+        exe = _cephadm.find_executable("true", path="")
+        assert exe is None
+
+    def test_no_such_exe(self):
+        exe = _cephadm.find_executable("foo_bar-baz.noway")
+        assert exe is None


### PR DESCRIPTION
More test coverage for assorted utility functions found in cephadm.

I did touch cephadm this time, just to add a "no cover" pragma comment on a line that only can execute on windows. That way we can have "full" coverage of the function. :-)


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] All tests, all the time

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
