### PR TITLE
doc/dev: use underscores in config vars

### DIFF
--- a/doc/dev/ceph_krb_auth.rst
+++ b/doc/dev/ceph_krb_auth.rst
@@ -554,7 +554,7 @@ In order to configure connections (from Ceph nodes) to the KDC:
         ...
 
 
-6. A new *set parameter* was added in Ceph, ``gss ktab client file`` which
+6. A new *set parameter* was added in Ceph, ``gss_ktab_client_file`` which
    points to the keytab file related to the Ceph node *(or principal)* in
    question.
 
@@ -614,10 +614,10 @@ In order to configure connections (from Ceph nodes) to the KDC:
         /etc/ceph/ceph.conf
         [global]
             ...
-            auth cluster required = gss
-            auth service required = gss
-            auth client required = gss
-            gss ktab client file = /{$my_new_location}/{$my_new_ktab_client_file.keytab}
+            auth_cluster_required = gss
+            auth_service_required = gss
+            auth_client_required = gss
+            gss_ktab_client_file = /{$my_new_location}/{$my_new_ktab_client_file.keytab}
             ...
 
 


### PR DESCRIPTION
Use underscores instead of spaces in config vars in ceph_krb_auth.rst.

Signed-off-by: Ville Ojamo <14869000+bluikko@users.noreply.github.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
