### PR TITLE
cls/queue: use larger read chunks in queue_list_entries

### DIFF
--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -13,6 +13,9 @@ using ceph::bufferlist;
 using ceph::decode;
 using ceph::encode;
 
+const uint64_t page_size = 4096;
+const uint64_t large_chunk_size = 1ul << 22;
+
 int queue_write_head(cls_method_context_t hctx, cls_queue_head& head)
 {
   bufferlist bl;
@@ -42,7 +45,7 @@ int queue_write_head(cls_method_context_t hctx, cls_queue_head& head)
 
 int queue_read_head(cls_method_context_t hctx, cls_queue_head& head)
 {
-  uint64_t chunk_size = 1024, start_offset = 0;
+  uint64_t chunk_size = page_size, start_offset = 0;
 
   bufferlist bl_head;
   const auto  ret = cls_cxx_read(hctx, start_offset, chunk_size, &bl_head);
@@ -280,7 +283,6 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
   }
 
   op_ret.is_truncated = true;
-  uint64_t chunk_size = 1024;
   uint64_t contiguous_data_size = 0, size_to_read = 0;
   bool wrap_around = false;
 
@@ -309,11 +311,7 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
   
     bufferlist bl_chunk;
     //Read chunk size at a time, if it is less than contiguous data size, else read contiguous data size
-    if (contiguous_data_size > chunk_size) {
-      size_to_read = chunk_size;
-    } else {
-      size_to_read = contiguous_data_size;
-    }
+    size_to_read = std::min(contiguous_data_size, large_chunk_size);
     CLS_LOG(10, "INFO: queue_list_entries(): size_to_read is %lu", size_to_read);
     if (size_to_read == 0) {
       next_marker = head.tail;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58579

backport of https://github.com/ceph/ceph/pull/49313
parent tracker: https://tracker.ceph.com/issues/58190

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>
(cherry picked from commit 19a58750f8b1dfda3dd7d1fb2de8e17b6bf9b207)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
