### PR TITLE
pacific: qa/tasks/cephadm.py: fix pulling cephadm from git.ceph.com

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -141,14 +141,15 @@ def download_cephadm(ctx, config, ref):
         else:
             ctx.cluster.run(
                 args=[
-                    'git', 'archive',
-                    '--remote=' + git_url,
-                    ref,
-                    'src/cephadm/cephadm',
-                    run.Raw('|'),
-                    'tar', '-xO', 'src/cephadm/cephadm',
+                    'git', 'clone', git_url, 'testrepo',
+                    run.Raw('&&'),
+                    'cd', 'testrepo',
+                    run.Raw('&&'),
+                    'git', 'show', f'{ref}:src/cephadm/cephadm',
                     run.Raw('>'),
                     ctx.cephadm,
+                    run.Raw('&&'),
+                    'ls', '-l', ctx.cephadm,
                 ],
             )
         # sanity-check the resulting file and set executable bit


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58444

---

backport of https://github.com/ceph/ceph/pull/49389
parent tracker: https://tracker.ceph.com/issues/58222

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh