### PR TITLE
DNM make-dist: fix hash for liburing tarball

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -195,7 +195,7 @@ boost_version=1.79.0
 download_boost $boost_version 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39 \
                https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://download.ceph.com/qa
-download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \
+download_liburing 0.7 2343e125d89600763ab277ef4699f1aa1d0d2076d60aba940de5737287bbc4b3 \
                   https://github.com/axboe/liburing/archive \
                   https://git.kernel.dk/cgit/liburing/snapshot
 pmdk_version=1.10

--- a/make-dist
+++ b/make-dist
@@ -196,8 +196,15 @@ download_boost $boost_version 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c1
                https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://download.ceph.com/qa
 download_liburing 0.7 2343e125d89600763ab277ef4699f1aa1d0d2076d60aba940de5737287bbc4b3 \
-                  https://github.com/axboe/liburing/archive \
-                  https://git.kernel.dk/cgit/liburing/snapshot
+                  https://github.com/axboe/liburing/archive
+
+# https://git.kernel.dk/cgit/liburing/snapshot/liburing-0.7.tar.gz is an alternate source
+# for liburing, but the top level directory name is different so it has a different
+# hash (05d0cf8493d573c76b11abfcf34aabc7153affebe17ff95f9ae88b0de062a59d) and will
+# fail the check.  It may be worth generalizing download_liburing and download_from
+# to handle this, but for now this file would need to be changed in order to change
+# the source location.
+
 pmdk_version=1.10
 download_pmdk $pmdk_version 08dafcf94db5ac13fac9139c92225d9aa5f3724ea74beee4e6ca19a01a2eb20c \
                https://github.com/pmem/pmdk/releases/download/$pmdk_version


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
