### PR TITLE
pacific: cephadm: don't overwrite cluster logrotate file

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3427,6 +3427,10 @@ def install_base_units(ctx, fsid):
         call_throws(ctx, ['systemctl', 'enable', 'ceph-%s.target' % fsid])
         call_throws(ctx, ['systemctl', 'start', 'ceph-%s.target' % fsid])
 
+    # don't overwrite file in order to allow users to manipulate it
+    if os.path.exists(ctx.logrotate_dir + f'/ceph-{fsid}'):
+        return
+
     # logrotate for the cluster
     with open(ctx.logrotate_dir + '/ceph-%s' % fsid, 'w') as f:
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58559

---

backport of https://github.com/ceph/ceph/pull/49815
parent tracker: https://tracker.ceph.com/issues/58527

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh