### PR TITLE
qa: add test_fscrypt_dummy_encryption test case support

### DIFF
--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -12,7 +12,7 @@ class TestFscrypt(XFSTestsDev):
     def setup_xfsprogs_devs(self):
         self.install_xfsprogs = True
 
-    def test_fscrypt(self):
+    def test_fscrypt_encrypt(self):
         from tasks.cephfs.fuse_mount import FuseMount
         from tasks.cephfs.kernel_mount import KernelMount
 

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -34,7 +34,7 @@ class TestFscrypt(XFSTestsDev):
         # accordingly.
         proc = self.mount_a.client_remote.run(args=['sudo', './check',
             '-g', 'encrypt'], cwd=self.xfstests_repo_path, stdout=StringIO(),
-            stderr=StringIO(), timeout=900, check_status=False,omit_sudo=False,
+            stderr=StringIO(), timeout=900, check_status=False, omit_sudo=False,
             label='running tests for encrypt from xfstests-dev')
 
         if proc.returncode != 0:
@@ -49,3 +49,29 @@ class TestFscrypt(XFSTestsDev):
         # skipped for now because of not supporting features in kernel or kceph.
         self.assertEqual(proc.returncode, 0)
         self.assertIn('Passed all 26 tests', stdout)
+
+    def test_fscrypt_dummy_encryption_with_quick_group(self):
+        self.require_kernel_mount()
+
+        self.write_local_config('test_dummy_encryption')
+
+        # XXX: check_status is set to False so that we can check for command's
+        # failure on our own (since this command doesn't set right error code
+        # and error message in some cases) and print custom log messages
+        # accordingly. This will take a long time and set the timeout to 3 hours.
+        proc = self.mount_a.client_remote.run(args=['sudo', './check',
+            '-g', 'quick', '-E', './ceph.exclude'], cwd=self.xfstests_repo_path,
+            stdout=StringIO(), stderr=StringIO(), timeout=10800, check_status=False,
+            omit_sudo=False, label='running tests for dummy_encryption from xfstests-dev')
+
+        if proc.returncode != 0:
+            log.info('Command failed.')
+        log.info(f'Command return value: {proc.returncode}')
+        stdout, stderr = proc.stdout.getvalue(), proc.stderr.getvalue()
+        log.info(f'Command stdout -\n{stdout}')
+        log.info(f'Command stderr -\n{stderr}')
+
+        # Currently, many test cases will be skipped due to unsupported features,
+        # but still will be marked as successful.
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn('Passed all ', stdout)

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -12,7 +12,7 @@ class TestFscrypt(XFSTestsDev):
     def setup_xfsprogs_devs(self):
         self.install_xfsprogs = True
 
-    def test_fscrypt_encrypt(self):
+    def require_kernel_mount(self):
         from tasks.cephfs.fuse_mount import FuseMount
         from tasks.cephfs.kernel_mount import KernelMount
 
@@ -20,11 +20,13 @@ class TestFscrypt(XFSTestsDev):
         # remounts CephFS before running tests using kernel, so ceph-fuse
         # mounts are never actually tested.
         if isinstance(self.mount_a, FuseMount):
-            log.info('client is fuse mounted')
             self.skipTest('Requires kernel client; xfstests-dev not '\
                           'compatible with ceph-fuse ATM.')
         elif isinstance(self.mount_a, KernelMount):
             log.info('client is kernel mounted')
+
+    def test_fscrypt_encrypt(self):
+        self.require_kernel_mount()
 
         # XXX: check_status is set to False so that we can check for command's
         # failure on our own (since this command doesn't set right error code

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -163,7 +163,9 @@ class XFSTestsDev(CephFSTestCase):
                                              '123456-fsgqa'], omit_sudo=False,
                                        check_status=False)
 
-    def write_local_config(self):
+    def write_local_config(self, options=None):
+        _options = '' if not options else ',' + options
+
         mon_sock = self.fs.mon_manager.get_msgrv1_mon_socks()[0]
         self.test_dev = mon_sock + ':/' + self.test_dirname
         self.scratch_dev = mon_sock + ':/' + self.scratch_dirname
@@ -174,9 +176,9 @@ class XFSTestsDev(CephFSTestCase):
             export TEST_DIR={}
             export SCRATCH_DEV={}
             export SCRATCH_MNT={}
-            export CEPHFS_MOUNT_OPTIONS="-o name=admin,secret={}"
+            export CEPHFS_MOUNT_OPTIONS="-o name=admin,secret={}{}"
             ''').format(self.test_dev, self.test_dirs_mount_path, self.scratch_dev,
-                        self.scratch_dirs_mount_path, self.get_admin_key())
+                        self.scratch_dirs_mount_path, self.get_admin_key(), _options)
 
         self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'local.config'),
                                               xfstests_config_contents, sudo=True)

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -1,5 +1,8 @@
 from io import StringIO
 from logging import getLogger
+from os.path import join
+from textwrap import dedent
+
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
@@ -29,6 +32,7 @@ class XFSTestsDev(CephFSTestCase):
         self.install_deps()
         self.create_reqd_users()
         self.write_local_config()
+        self.write_ceph_exclude()
 
         # NOTE: On teuthology machines it's necessary to run "make" as
         # superuser since the repo is cloned somewhere in /tmp.
@@ -82,7 +86,6 @@ class XFSTestsDev(CephFSTestCase):
             and "scratch" directories would be mounted. Look at xfstests-dev
             local.config's template inside this file to get some context.
         """
-        from os.path import join
 
         self.test_dirname = 'test'
         self.mount_a.run_shell(['mkdir', self.test_dirname])
@@ -161,9 +164,6 @@ class XFSTestsDev(CephFSTestCase):
                                        check_status=False)
 
     def write_local_config(self):
-        from os.path import join
-        from textwrap import dedent
-
         mon_sock = self.fs.mon_manager.get_msgrv1_mon_socks()[0]
         self.test_dev = mon_sock + ':/' + self.test_dirname
         self.scratch_dev = mon_sock + ':/' + self.scratch_dirname
@@ -180,6 +180,16 @@ class XFSTestsDev(CephFSTestCase):
 
         self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'local.config'),
                                               xfstests_config_contents, sudo=True)
+
+    def write_ceph_exclude(self):
+        # These tests will fail or take too much time and will
+        # make the test timedout, just skip them for now.
+        xfstests_exclude_contents = dedent('''\
+            {c}/001 {g}/003 {g}/020 {g}/075 {g}/317 {g}/538 {g}/531
+            ''').format(g="generic", c="ceph")
+
+        self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'ceph.exclude'),
+                                              xfstests_exclude_contents, sudo=True)
 
     def tearDown(self):
         self.mount_a.client_remote.run(args=['sudo', 'userdel', '--force',


### PR DESCRIPTION
After https://tracker.ceph.com/issues/58126 bug being fixed and all the content patches in the `testing` branch, it's time to add more test cases for fscrypt.

This will run around 130/707 xfstests-dev test cases, all the others will be skipped for now dues not support features.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
