### PR TITLE
crimson: fix incorrect interval check in PG::submit_transaction

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -52,6 +52,14 @@ public:
   virtual ~DoutPrefixProvider() {}
 };
 
+inline std::ostream &operator<<(
+  std::ostream &lhs, const DoutPrefixProvider &dpp) {
+  return dpp.gen_prefix(lhs);
+}
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<DoutPrefixProvider> : fmt::ostream_formatter {};
+#endif
+
 // a prefix provider with empty prefix
 class NoDoutPrefix : public DoutPrefixProvider {
   CephContext *const cct;

--- a/src/crimson/common/log.h
+++ b/src/crimson/common/log.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <seastar/util/log.hh>
+
 #include "common/subsys_types.h"
 
 namespace crimson {
@@ -22,3 +24,65 @@ static inline seastar::log_level to_log_level(int level) {
   }
 }
 }
+
+/* Logging convenience macros
+ *
+ * The intention here is to standardize prefixing log lines with the function name
+ * and a context prefix (like the operator<< for the PG).  Place
+ *
+ * SET_SUBSYS(osd);
+ *
+ * at the top of the file to declare the log lines within the file as being (in this case)
+ * in the osd subsys.  At the beginning of each method/function, add
+ *
+ * LOG_PREFIX(Class::method_name)
+ *
+ * to set the FNAME symbol to Class::method_name.  In order to use the log macros
+ * within lambdas, capture FNAME by value.
+ *
+ * Log lines can then be declared using the appropriate macro below.
+ */
+
+#define SET_SUBSYS(subname_) static constexpr auto SOURCE_SUBSYS = ceph_subsys_##subname_
+#define LOCAL_LOGGER crimson::get_logger(SOURCE_SUBSYS)
+#define LOGGER(subname_) crimson::get_logger(ceph_subsys_##subname_)
+#define LOG_PREFIX(x) constexpr auto FNAME = #x
+
+#define LOG(level_, MSG, ...) \
+  LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
+#define SUBLOG(subname_, level_, MSG, ...) \
+  LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
+
+#define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
+#define SUBTRACE(subname_, ...) SUBLOG(subname_, seastar::log_level::trace, __VA_ARGS__)
+
+#define DEBUG(...) LOG(seastar::log_level::debug, __VA_ARGS__)
+#define SUBDEBUG(subname_, ...) SUBLOG(subname_, seastar::log_level::debug, __VA_ARGS__)
+
+#define INFO(...) LOG(seastar::log_level::info, __VA_ARGS__)
+#define SUBINFO(subname_, ...) SUBLOG(subname_, seastar::log_level::info, __VA_ARGS__)
+
+#define WARN(...) LOG(seastar::log_level::warn, __VA_ARGS__)
+#define SUBWARN(subname_, ...) SUBLOG(subname_, seastar::log_level::warn, __VA_ARGS__)
+
+#define ERROR(...) LOG(seastar::log_level::error, __VA_ARGS__)
+#define SUBERROR(subname_, ...) SUBLOG(subname_, seastar::log_level::error, __VA_ARGS__)
+
+// *DPP macros are intended to take DoutPrefixProvider implementations, but anything with
+// an operator<< will work as a prefix
+
+#define SUBLOGDPP(subname_, level_, MSG, dpp, ...) \
+  LOGGER(subname_).log(level_, "{} {}: " MSG, dpp, FNAME , ##__VA_ARGS__)
+#define SUBTRACEDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::trace, __VA_ARGS__)
+#define SUBDEBUGDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::debug, __VA_ARGS__)
+#define SUBINFODPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::info, __VA_ARGS__)
+#define SUBWARNDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::warn, __VA_ARGS__)
+#define SUBERRORDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::error, __VA_ARGS__)
+
+#define LOGDPP(level_, MSG, dpp, ...) \
+  LOCAL_LOGGER.log(level_, "{} {}: " MSG, dpp, FNAME , ##__VA_ARGS__)
+#define TRACEDPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)
+#define DEBUGDPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)
+#define INFODPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)
+#define WARNDPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)
+#define ERRORDPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -7,41 +7,22 @@
 
 #include "crimson/common/log.h"
 
-#define SET_SUBSYS(subname_) static constexpr auto SOURCE_SUBSYS = ceph_subsys_##subname_
-#define LOCAL_LOGGER crimson::get_logger(SOURCE_SUBSYS)
-#define LOGGER(subname_) crimson::get_logger(ceph_subsys_##subname_)
-#define LOG_PREFIX(x) constexpr auto FNAME = #x
-
-#define LOG(level_, MSG, ...) \
-  LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define LOGT(level_, MSG, t, ...) \
   LOCAL_LOGGER.log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
-#define SUBLOG(subname_, level_, MSG, ...) \
-  LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOGT(subname_, level_, MSG, t, ...) \
   LOGGER(subname_).log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
 
-#define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
 #define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)
-#define SUBTRACE(subname_, ...) SUBLOG(subname_, seastar::log_level::trace, __VA_ARGS__)
 #define SUBTRACET(subname_, ...) SUBLOGT(subname_, seastar::log_level::trace, __VA_ARGS__)
 
-#define DEBUG(...) LOG(seastar::log_level::debug, __VA_ARGS__)
 #define DEBUGT(...) LOGT(seastar::log_level::debug, __VA_ARGS__)
-#define SUBDEBUG(subname_, ...) SUBLOG(subname_, seastar::log_level::debug, __VA_ARGS__)
 #define SUBDEBUGT(subname_, ...) SUBLOGT(subname_, seastar::log_level::debug, __VA_ARGS__)
 
-#define INFO(...) LOG(seastar::log_level::info, __VA_ARGS__)
 #define INFOT(...) LOGT(seastar::log_level::info, __VA_ARGS__)
-#define SUBINFO(subname_, ...) SUBLOG(subname_, seastar::log_level::info, __VA_ARGS__)
 #define SUBINFOT(subname_, ...) SUBLOGT(subname_, seastar::log_level::info, __VA_ARGS__)
 
-#define WARN(...) LOG(seastar::log_level::warn, __VA_ARGS__)
 #define WARNT(...) LOGT(seastar::log_level::warn, __VA_ARGS__)
-#define SUBWARN(subname_, ...) SUBLOG(subname_, seastar::log_level::warn, __VA_ARGS__)
 #define SUBWARNT(subname_, ...) SUBLOGT(subname_, seastar::log_level::warn, __VA_ARGS__)
 
-#define ERROR(...) LOG(seastar::log_level::error, __VA_ARGS__)
 #define ERRORT(...) LOGT(seastar::log_level::error, __VA_ARGS__)
-#define SUBERROR(subname_, ...) SUBLOG(subname_, seastar::log_level::error, __VA_ARGS__)
 #define SUBERRORT(subname_, ...) SUBLOGT(subname_, seastar::log_level::error, __VA_ARGS__)

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -6,8 +6,9 @@ ECBackend::ECBackend(shard_id_t shard,
                      ECBackend::CollectionRef coll,
                      crimson::osd::ShardServices& shard_services,
                      const ec_profile_t&,
-                     uint64_t)
-  : PGBackend{shard, coll, shard_services}
+                     uint64_t,
+		     DoutPrefixProvider &dpp)
+  : PGBackend{shard, coll, shard_services, dpp}
 {
   // todo
 }

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -21,7 +21,7 @@ public:
   seastar::future<> stop() final {
     return seastar::now();
   }
-  void on_actingset_changed(peering_info_t pi) final {}
+  void on_actingset_changed(bool same_primary) final {}
 private:
   ll_read_ierrorator::future<ceph::bufferlist>
   _read(const hobject_t& hoid, uint64_t off, uint64_t len, uint32_t flags) override;

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -16,7 +16,8 @@ public:
 	    CollectionRef coll,
 	    crimson::osd::ShardServices& shard_services,
 	    const ec_profile_t& ec_profile,
-	    uint64_t stripe_width);
+	    uint64_t stripe_width,
+	    DoutPrefixProvider &dpp);
   seastar::future<> stop() final {
     return seastar::now();
   }

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -101,7 +101,7 @@ using crimson::common::local_conf;
   ObjectContextLoader::load_obc_iertr::future<ObjectContextRef>
   ObjectContextLoader::load_obc(ObjectContextRef obc)
   {
-    return backend->load_metadata(obc->get_oid())
+    return backend.load_metadata(obc->get_oid())
     .safe_then_interruptible(
       [obc=std::move(obc)](auto md)
       -> load_obc_ertr::future<ObjectContextRef> {
@@ -152,7 +152,7 @@ using crimson::common::local_conf;
   ObjectContextLoader::reload_obc(ObjectContext& obc) const
   {
     assert(obc.is_head());
-    return backend->load_metadata(obc.get_oid())
+    return backend.load_metadata(obc.get_oid())
     .safe_then_interruptible<false>(
       [&obc](auto md)-> load_obc_ertr::future<> {
       logger().debug(

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -1,10 +1,6 @@
 #include "crimson/osd/object_context_loader.h"
 
-namespace {
-  seastar::logger& logger() {
-    return crimson::get_logger(ceph_subsys_osd);
-  }
-}
+SET_SUBSYS(osd);
 
 namespace crimson::osd {
 
@@ -16,7 +12,8 @@ using crimson::common::local_conf;
                                      bool existed,
                                      with_obc_func_t&& func)
   {
-    logger().debug("{} {}", __func__, obc->get_oid());
+    LOG_PREFIX(ObjectContextLoader::with_head_obc);
+    DEBUGDPP("object {}", dpp, obc->get_oid());
     assert(obc->is_head());
     obc->append_to(obc_set_accessing);
     return obc->with_lock<State, IOInterruptCondition>(
@@ -26,8 +23,8 @@ using crimson::common::local_conf;
         [func = std::move(func)](auto obc) {
         return std::move(func)(std::move(obc));
       });
-    }).finally([this, obc=std::move(obc)] {
-      logger().debug("with_head_obc: released {}", obc->get_oid());
+    }).finally([FNAME, this, obc=std::move(obc)] {
+      DEBUGDPP("released object {}", dpp, obc->get_oid());
       obc->remove_from(obc_set_accessing);
     });
   }
@@ -37,13 +34,14 @@ using crimson::common::local_conf;
   ObjectContextLoader::with_clone_obc(hobject_t oid,
                                       with_obc_func_t&& func)
   {
+    LOG_PREFIX(ObjectContextLoader::with_clone_obc);
     assert(!oid.is_head());
-    return with_obc<RWState::RWREAD>(oid.get_head(),
-      [oid, func=std::move(func), this](auto head) mutable
+    return with_obc<RWState::RWREAD>(
+      oid.get_head(),
+      [FNAME, oid, func=std::move(func), this](auto head) mutable
       -> load_obc_iertr::future<> {
       if (!head->obs.exists) {
-        logger().error("with_clone_obc: {} head doesn't exist",
-                       head->obs.oi.soid);
+	ERRORDPP("head doesn't exist for object {}", dpp, head->obs.oi.soid);
         return load_obc_iertr::future<>{
           crimson::ct_error::enoent::make()
         };
@@ -60,10 +58,10 @@ using crimson::common::local_conf;
                                            hobject_t oid,
                                            with_obc_func_t&& func)
   {
+    LOG_PREFIX(ObjectContextLoader::with_clone_obc_only);
     auto coid = resolve_oid(head->get_ro_ss(), oid);
     if (!coid) {
-      logger().error("with_clone_obc_only: {} clone not found",
-                     oid);
+      ERRORDPP("clone {} not found", dpp, oid);
       return load_obc_iertr::future<>{
         crimson::ct_error::enoent::make()
       };
@@ -101,17 +99,16 @@ using crimson::common::local_conf;
   ObjectContextLoader::load_obc_iertr::future<ObjectContextRef>
   ObjectContextLoader::load_obc(ObjectContextRef obc)
   {
+    LOG_PREFIX(ObjectContextLoader::load_obc);
     return backend.load_metadata(obc->get_oid())
     .safe_then_interruptible(
-      [obc=std::move(obc)](auto md)
+      [FNAME, this, obc=std::move(obc)](auto md)
       -> load_obc_ertr::future<ObjectContextRef> {
       const hobject_t& oid = md->os.oi.soid;
-      logger().debug(
-        "load_obc: loaded obs {} for {}", md->os.oi, oid);
+      DEBUGDPP("loaded obs {} for {}", dpp, md->os.oi, oid);
       if (oid.is_head()) {
         if (!md->ssc) {
-          logger().error(
-            "load_obc: oid {} missing snapsetcontext", oid);
+	  ERRORDPP("oid {} missing snapsetcontext", dpp, oid);
           return crimson::ct_error::object_corrupted::make();
         }
         obc->set_head_state(std::move(md->os),
@@ -119,9 +116,7 @@ using crimson::common::local_conf;
       } else {
         obc->set_clone_state(std::move(md->os));
       }
-      logger().debug(
-        "load_obc: returning obc {} for {}",
-        obc->obs.oi, obc->obs.oi.soid);
+      DEBUGDPP("returning obc {} for {}", dpp, obc->obs.oi, obc->obs.oi.soid);
       return load_obc_ertr::make_ready_future<ObjectContextRef>(obc);
     });
   }
@@ -131,14 +126,13 @@ using crimson::common::local_conf;
   ObjectContextLoader::get_or_load_obc(ObjectContextRef obc,
                                        bool existed)
   {
+    LOG_PREFIX(ObjectContextLoader::get_or_load_obc);
     auto loaded =
       load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
     if (existed) {
-      logger().debug("{}: found {} in cache",
-                     __func__, obc->get_oid());
+      DEBUGDPP("cache hit on {}", dpp, obc->get_oid());
     } else {
-      logger().debug("{}: cache miss on {}",
-                     __func__, obc->get_oid());
+      DEBUGDPP("cache miss on {}", dpp, obc->get_oid());
       loaded =
         obc->template with_promoted_lock<State, IOInterruptCondition>(
         [obc, this] {
@@ -151,20 +145,14 @@ using crimson::common::local_conf;
   ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::reload_obc(ObjectContext& obc) const
   {
+    LOG_PREFIX(ObjectContextLoader::reload_obc);
     assert(obc.is_head());
     return backend.load_metadata(obc.get_oid())
     .safe_then_interruptible<false>(
-      [&obc](auto md)-> load_obc_ertr::future<> {
-      logger().debug(
-        "{}: reloaded obs {} for {}",
-        __func__,
-        md->os.oi,
-        obc.get_oid());
+      [FNAME, this, &obc](auto md)-> load_obc_ertr::future<> {
+      DEBUGDPP("reloaded obs {} for {}", dpp, md->os.oi, obc.get_oid());
       if (!md->ssc) {
-        logger().error(
-          "{}: oid {} missing snapsetcontext",
-          __func__,
-          obc.get_oid());
+	ERRORDPP("oid {} missing snapsetcontext", dpp, obc.get_oid());
         return crimson::ct_error::object_corrupted::make();
       }
       obc.set_head_state(std::move(md->os), std::move(md->ssc));

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -162,7 +162,10 @@ using crimson::common::local_conf;
 
   void ObjectContextLoader::notify_on_change(bool is_primary)
   {
+    LOG_PREFIX(ObjectContextLoader::notify_on_change);
+    DEBUGDPP("is_primary: {}", dpp, is_primary);
     for (auto& obc : obc_set_accessing) {
+      DEBUGDPP("interrupting obc: {}", dpp, obc.get_oid());
       obc.interrupt(::crimson::common::actingset_changed(is_primary));
     }
   }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -15,7 +15,7 @@ public:
 
   ObjectContextLoader(
     ShardServices& _shard_services,
-    PGBackend* _backend)
+    PGBackend& _backend)
     : shard_services{_shard_services},
       backend{_backend}
     {}
@@ -66,7 +66,7 @@ public:
 
 private:
   ShardServices &shard_services;
-  PGBackend* backend;
+  PGBackend& backend;
   obc_accessing_list_t obc_set_accessing;
 };
 }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -15,9 +15,11 @@ public:
 
   ObjectContextLoader(
     ShardServices& _shard_services,
-    PGBackend& _backend)
+    PGBackend& _backend,
+    DoutPrefixProvider& dpp)
     : shard_services{_shard_services},
-      backend{_backend}
+      backend{_backend},
+      dpp{dpp}
     {}
 
   using load_obc_ertr = crimson::errorator<
@@ -67,6 +69,7 @@ public:
 private:
   ShardServices &shard_services;
   PGBackend& backend;
+  DoutPrefixProvider& dpp;
   obc_accessing_list_t obc_set_accessing;
 };
 }

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -226,7 +226,7 @@ ClientRequest::process_op(instance_handle_t &ihref, Ref<PG> &pg)
         return ihref.enter_stage<interruptor>(pp(*pg).get_obc, *this
 	).then_interruptible(
           [this, pg, &ihref]() mutable -> PG::load_obc_iertr::future<> {
-          logger().debug("{}: got obc lock", *this);
+          logger().debug("{}: in get_obc stage", *this);
           op_info.set_from_op(&*m, *pg->get_osdmap());
           return pg->with_locked_obc(
             m->get_hobj(), op_info,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -594,10 +594,7 @@ PG::submit_transaction(
   }
 
   epoch_t map_epoch = get_osdmap_epoch();
-
-  if (__builtin_expect(osd_op_p.at_version.epoch != map_epoch, false)) {
-    throw crimson::common::actingset_changed(is_primary());
-  }
+  ceph_assert(!has_reset_since(osd_op_p.at_version.epoch));
 
   peering_state.pre_submit_op(obc->obs.oi.soid, log_entries, osd_op_p.at_version);
   peering_state.append_log_with_trim_to_updated(std::move(log_entries), osd_op_p.at_version,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -136,7 +136,8 @@ PG::PG(
       this),
     obc_loader{
       shard_services,
-      *backend.get()},
+      *backend.get(),
+      *this},
     wait_for_active_blocker(this)
 {
   peering_state.set_backend_predicates(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -327,7 +327,6 @@ void PG::on_activate_complete()
       PeeringState::AllReplicasRecovered{});
   }
   publish_stats_to_osd();
-  backend->on_activate_complete();
 }
 
 void PG::prepare_write(pg_info_t &info,
@@ -1203,7 +1202,7 @@ void PG::on_change(ceph::os::Transaction &t) {
   logger().debug("{} {}:", *this, __func__);
   obc_loader.notify_on_change(is_primary());
   recovery_backend->on_peering_interval_change(t);
-  backend->on_actingset_changed({ is_primary() });
+  backend->on_actingset_changed(is_primary());
   wait_for_active_blocker.unblock();
   if (is_primary()) {
     logger().debug("{} {}: requeueing", *this, __func__);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -115,7 +115,8 @@ PG::PG(
 	pool,
 	coll_ref,
 	shard_services,
-	profile)),
+	profile,
+	*this)),
     recovery_backend(
       std::make_unique<ReplicatedRecoveryBackend>(
 	*this, shard_services, coll_ref, backend.get())),

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -136,7 +136,7 @@ PG::PG(
       this),
     obc_loader{
       shard_services,
-      backend.get()},
+      *backend.get()},
     wait_for_active_blocker(this)
 {
   peering_state.set_backend_predicates(

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -383,19 +383,13 @@ public:
 
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
   virtual seastar::future<> stop() = 0;
-  struct peering_info_t {
-    bool is_primary;
-  };
-  virtual void on_actingset_changed(peering_info_t pi) = 0;
-  virtual void on_activate_complete();
+  virtual void on_actingset_changed(bool same_primary) = 0;
 protected:
   const shard_id_t shard;
   CollectionRef coll;
   crimson::osd::ShardServices &shard_services;
   DoutPrefixProvider &dpp; ///< provides log prefix context
   crimson::os::FuturizedStore* store;
-  bool stopping = false;
-  std::optional<peering_info_t> peering;
   virtual seastar::future<> request_committed(
     const osd_reqid_t& reqid,
     const eversion_t& at_version) = 0;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -64,14 +64,16 @@ public:
     std::tuple<interruptible_future<>,
 	       interruptible_future<crimson::osd::acked_peers_t>>;
   PGBackend(shard_id_t shard, CollectionRef coll,
-            crimson::osd::ShardServices &shard_services);
+            crimson::osd::ShardServices &shard_services,
+            DoutPrefixProvider &dpp);
   virtual ~PGBackend() = default;
   static std::unique_ptr<PGBackend> create(pg_t pgid,
 					   const pg_shard_t pg_shard,
 					   const pg_pool_t& pool,
 					   crimson::os::CollectionRef coll,
 					   crimson::osd::ShardServices& shard_services,
-					   const ec_profile_t& ec_profile);
+					   const ec_profile_t& ec_profile,
+					   DoutPrefixProvider &dpp);
   using attrs_t =
     std::map<std::string, ceph::bufferptr, std::less<>>;
   using read_errorator = ll_read_errorator::extend<
@@ -390,6 +392,7 @@ protected:
   const shard_id_t shard;
   CollectionRef coll;
   crimson::osd::ShardServices &shard_services;
+  DoutPrefixProvider &dpp; ///< provides log prefix context
   crimson::os::FuturizedStore* store;
   bool stopping = false;
   std::optional<peering_info_t> peering;

--- a/src/crimson/osd/pg_interval_interrupt_condition.cc
+++ b/src/crimson/osd/pg_interval_interrupt_condition.cc
@@ -6,6 +6,8 @@
 
 #include "crimson/common/log.h"
 
+SET_SUBSYS(osd);
+
 namespace crimson::osd {
 
 IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg)
@@ -17,17 +19,20 @@ IOInterruptCondition::~IOInterruptCondition() {
 }
 
 bool IOInterruptCondition::new_interval_created() {
-  bool ret = e < pg->get_interval_start_epoch();
-  if (ret)
-    ::crimson::get_logger(ceph_subsys_osd).debug(
-      "{} new interval, should interrupt, e{}", *pg, e);
+  LOG_PREFIX(IOInterruptCondition::new_interval_created);
+  const epoch_t interval_start = pg->get_interval_start_epoch();
+  bool ret = e < interval_start;
+  if (ret) {
+    DEBUGDPP("stored interval e{} < interval_start e{}", *pg, e, interval_start);
+  }
   return ret;
 }
 
 bool IOInterruptCondition::is_stopping() {
-  if (pg->stopping)
-    ::crimson::get_logger(ceph_subsys_osd).debug(
-      "{} shutting down, should interrupt", *pg);
+  LOG_PREFIX(IOInterruptCondition::is_stopping);
+  if (pg->stopping) {
+    DEBUGDPP("pg stopping", *pg);
+  }
   return pg->stopping;
 }
 

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -11,17 +11,14 @@
 #include "crimson/osd/shard_services.h"
 #include "osd/PeeringState.h"
 
-namespace {
-  seastar::logger& logger() {
-    return crimson::get_logger(ceph_subsys_osd);
-  }
-}
+SET_SUBSYS(osd);
 
 ReplicatedBackend::ReplicatedBackend(pg_t pgid,
                                      pg_shard_t whoami,
                                      ReplicatedBackend::CollectionRef coll,
-                                     crimson::osd::ShardServices& shard_services)
-  : PGBackend{whoami.shard, coll, shard_services},
+                                     crimson::osd::ShardServices& shard_services,
+				     DoutPrefixProvider &dpp)
+  : PGBackend{whoami.shard, coll, shard_services, dpp},
     pgid{pgid},
     whoami{whoami}
 {}
@@ -46,6 +43,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
                                        epoch_t min_epoch, epoch_t map_epoch,
 				       std::vector<pg_log_entry_t>&& log_entries)
 {
+  LOG_PREFIX(ReplicatedBackend::_submit_transaction);
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
   }
@@ -59,7 +57,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
   bufferlist encoded_txn;
   encode(txn, encoded_txn);
 
-  logger().debug("ReplicatedBackend::_submit_transaction: do_transaction...");
+  DEBUGDPP("object {}", dpp, hoid);
   auto all_completed = interruptor::make_interruptible(
       shard_services.get_store().do_transaction(coll, std::move(txn)))
   .then_interruptible([this, peers=pending_txn->second.weak_from_this()] {
@@ -122,9 +120,10 @@ void ReplicatedBackend::on_actingset_changed(peering_info_t pi)
 
 void ReplicatedBackend::got_rep_op_reply(const MOSDRepOpReply& reply)
 {
+  LOG_PREFIX(ReplicatedBackend::got_rep_op_reply);
   auto found = pending_trans.find(reply.get_tid());
   if (found == pending_trans.end()) {
-    logger().warn("{}: no matched pending rep op: {}", __func__, reply);
+    WARNDPP("cannot find rep op for message {}", dpp, reply);
     return;
   }
   auto& peers = found->second;
@@ -142,7 +141,8 @@ void ReplicatedBackend::got_rep_op_reply(const MOSDRepOpReply& reply)
 
 seastar::future<> ReplicatedBackend::stop()
 {
-  logger().info("ReplicatedBackend::stop {}", coll->get_cid());
+  LOG_PREFIX(ReplicatedBackend::stop);
+  INFODPP("cid {}", coll->get_cid());
   stopping = true;
   for (auto& [tid, pending_on] : pending_trans) {
     pending_on.all_committed.set_exception(

--- a/src/crimson/osd/replicated_backend.h
+++ b/src/crimson/osd/replicated_backend.h
@@ -21,7 +21,8 @@ class ReplicatedBackend : public PGBackend
 public:
   ReplicatedBackend(pg_t pgid, pg_shard_t whoami,
 		    CollectionRef coll,
-		    crimson::osd::ShardServices& shard_services);
+		    crimson::osd::ShardServices& shard_services,
+		    DoutPrefixProvider &dpp);
   void got_rep_op_reply(const MOSDRepOpReply& reply) final;
   seastar::future<> stop() final;
   void on_actingset_changed(peering_info_t pi) final;

--- a/src/crimson/osd/replicated_backend.h
+++ b/src/crimson/osd/replicated_backend.h
@@ -25,7 +25,7 @@ public:
 		    DoutPrefixProvider &dpp);
   void got_rep_op_reply(const MOSDRepOpReply& reply) final;
   seastar::future<> stop() final;
-  void on_actingset_changed(peering_info_t pi) final;
+  void on_actingset_changed(bool same_primary) final;
 private:
   ll_read_ierrorator::future<ceph::bufferlist>
     _read(const hobject_t& hoid, uint64_t off,


### PR DESCRIPTION
Removes incorrect interval check in PG::submit_transaction as well as a few other checks which duplicate IOInterruptCondition.  This PR also adds logging improvements that were helpful in tracking down the bug.

Fixes: https://tracker.ceph.com/issues/58486

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
