### PR TITLE
quincy: Wip nitzan fixing few rados/test.sh

### DIFF
--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -23,6 +23,7 @@ overrides:
       osd:
         osd class load list: "*"
         osd class default list: "*"
+        osd client watch timeout: 120
 tasks:
 - workunit:
     timeout: 6h

--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
+#include <fmt/format.h>
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 #include "include/scope_guard.h"
@@ -13,7 +14,8 @@ rados_t RadosTestNS::s_cluster = NULL;
 
 void RadosTestNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -65,7 +67,8 @@ rados_t RadosTestECNS::s_cluster = NULL;
 
 void RadosTestECNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 
@@ -97,7 +100,8 @@ rados_t RadosTest::s_cluster = NULL;
 
 void RadosTest::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -157,7 +161,8 @@ rados_t RadosTestEC::s_cluster = NULL;
 
 void RadosTestEC::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name()); 
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <utility>
 #include <boost/scoped_ptr.hpp>
+#include <fmt/format.h>
 
 #include "include/err.h"
 #include "include/rados/librados.h"
@@ -40,7 +41,8 @@ public:
   std::string init()
   {
     int ret;
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_pool(m_pool_name, &m_cluster);
     if (!err.empty()) {
       ostringstream oss;
@@ -1006,7 +1008,8 @@ public:
   std::string init()
   {
     int ret;
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_ec_pool(m_pool_name, &m_cluster);
     if (!err.empty()) {
       ostringstream oss;

--- a/src/test/librados/test_shared.h
+++ b/src/test/librados/test_shared.h
@@ -21,7 +21,7 @@ class TestAlarm
 public:
   #ifndef _WIN32
   TestAlarm() {
-    alarm(1200);
+    alarm(2400);
   }
   ~TestAlarm() {
     alarm(0);

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -4,6 +4,7 @@
 #include "testcase_cxx.h"
 
 #include <errno.h>
+#include <fmt/format.h>
 #include "test_cxx.h"
 #include "test_shared.h"
 #include "include/scope_guard.h"
@@ -29,7 +30,8 @@ Rados RadosTestPPNS::s_cluster;
 
 void RadosTestPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -72,7 +74,8 @@ Rados RadosTestParamPPNS::s_cluster;
 
 void RadosTestParamPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -101,7 +104,8 @@ void RadosTestParamPPNS::TearDownTestCase()
 void RadosTestParamPPNS::SetUp()
 {
   if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
-    cache_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+    cache_pool_name = get_temp_pool_name(pool_prefix);
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -154,7 +158,8 @@ Rados RadosTestECPPNS::s_cluster;
 
 void RadosTestECPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 
@@ -187,7 +192,8 @@ void RadosTestPP::SetUpTestCase()
 {
   init_rand();
 
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -268,7 +274,8 @@ Rados RadosTestParamPP::s_cluster;
 
 void RadosTestParamPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -297,7 +304,8 @@ void RadosTestParamPP::TearDownTestCase()
 void RadosTestParamPP::SetUp()
 {
   if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
-    cache_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+    cache_pool_name = get_temp_pool_name(pool_prefix);
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -359,7 +367,8 @@ Rados RadosTestECPP::s_cluster;
 
 void RadosTestECPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -196,7 +196,10 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete) {
   }
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
-  ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
+  int rados_watch_check_err = rados_watch_check(ioctx, handle);
+  // We may hit ENOENT due to socket failure injection and a forced reconnect
+  EXPECT_TRUE(rados_watch_check_err == -ENOTCONN || rados_watch_check_err == -ENOENT)
+    << "Where rados_watch_check_err = " << rados_watch_check_err;
   ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -97,8 +97,10 @@ start()
     #else
     std::string err_msg;
     ret = preforker.prefork(err_msg);
-    if (ret < 0)
-      preforker.exit(ret);
+    if (ret < 0) {
+      printf("prefork failed: %s\n", err_msg.c_str());
+      return ret;
+    }
 
     if (preforker.is_child()) {
       m_started = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58612

---

backport of https://github.com/ceph/ceph/pull/49109
parent tracker: https://tracker.ceph.com/issues/45615

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh