### PR TITLE
pacific: Wip nitzan fixing few rados/test.sh

### DIFF
--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -20,6 +20,10 @@ overrides:
         debug monc: 20
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
+        osd client watch timeout: 120
 tasks:
 - workunit:
     timeout: 6h

--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
+#include <fmt/format.h>
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 #include "include/scope_guard.h"
@@ -13,7 +14,8 @@ rados_t RadosTestNS::s_cluster = NULL;
 
 void RadosTestNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -65,7 +67,8 @@ rados_t RadosTestECNS::s_cluster = NULL;
 
 void RadosTestECNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 
@@ -97,7 +100,8 @@ rados_t RadosTest::s_cluster = NULL;
 
 void RadosTest::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -157,7 +161,8 @@ rados_t RadosTestEC::s_cluster = NULL;
 
 void RadosTestEC::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name()); 
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <utility>
 #include <boost/scoped_ptr.hpp>
+#include <fmt/format.h>
 
 #include "include/err.h"
 #include "include/rados/librados.h"
@@ -40,7 +41,8 @@ public:
   std::string init()
   {
     int ret;
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_pool(m_pool_name, &m_cluster);
     if (!err.empty()) {
       ostringstream oss;
@@ -1006,7 +1008,8 @@ public:
   std::string init()
   {
     int ret;
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_ec_pool(m_pool_name, &m_cluster);
     if (!err.empty()) {
       ostringstream oss;

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <boost/scoped_ptr.hpp>
+#include <fmt/format.h>
 
 #include "gtest/gtest.h"
 
@@ -24,7 +25,8 @@ class AioTestDataPP
 {
 public:
   AioTestDataPP()
-    : m_init(false)
+    : m_init(false),    
+      m_oid("foo")
   {
   }
 
@@ -44,8 +46,8 @@ public:
   std::string init(const std::map<std::string, std::string> &config)
   {
     int ret;
-
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_pool_pp(m_pool_name, m_cluster, config);
     if (!err.empty()) {
       ostringstream oss;
@@ -59,6 +61,7 @@ public:
       oss << "rados_ioctx_create failed: error " << ret;
       return oss.str();
     }
+    m_oid = fmt::format("oid_{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
     m_init = true;
     return "";
   }
@@ -67,6 +70,7 @@ public:
   IoCtx m_ioctx;
   std::string m_pool_name;
   bool m_init;
+  std::string m_oid;
 };
 
 TEST(LibRadosAio, TooBigPP) {
@@ -75,15 +79,16 @@ TEST(LibRadosAio, TooBigPP) {
 
   bufferlist bl;
   auto aio_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_write("foo", aio_completion.get(), bl, UINT_MAX, 0));
-  ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_append("foo", aio_completion.get(), bl, UINT_MAX));
+  ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_write(test_data.m_oid, aio_completion.get(), bl, UINT_MAX, 0));
+  ASSERT_EQ(-E2BIG, test_data.m_ioctx.aio_append(test_data.m_oid, aio_completion.get(), bl, UINT_MAX));
   // ioctx.aio_write_full no way to overflow bl.length()
 }
 
 TEST(LibRadosAio, PoolQuotaPP) {
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
-  string p = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  string p = get_temp_pool_name(pool_prefix);
   ASSERT_EQ(0, test_data.m_cluster.pool_create(p.c_str()));
   IoCtx ioctx;
   ASSERT_EQ(0, test_data.m_cluster.ioctx_create(p.c_str(), ioctx));
@@ -103,7 +108,7 @@ TEST(LibRadosAio, PoolQuotaPP) {
     ObjectWriteOperation op;
     op.write_full(bl);
     auto completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-    ASSERT_EQ(0, ioctx.aio_operate("foo" + stringify(n),
+    ASSERT_EQ(0, ioctx.aio_operate(test_data.m_oid + stringify(n),
                                    completion.get(), &op,
                                    librados::OPERATION_FULL_TRY));
     completion->wait_for_complete();
@@ -142,7 +147,7 @@ TEST(LibRadosAio, SimpleWritePP) {
   ASSERT_EQ("", test_data.init());
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -156,7 +161,7 @@ TEST(LibRadosAio, SimpleWritePP) {
   ASSERT_EQ("", test_data.init());
   test_data.m_ioctx.set_namespace("nspace");
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -175,7 +180,7 @@ TEST(LibRadosAio, WaitForSafePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   TestAlarm alarm;
   ASSERT_EQ(0, my_completion->wait_for_complete());
@@ -191,7 +196,7 @@ TEST(LibRadosAio, RoundTripPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -201,7 +206,7 @@ TEST(LibRadosAio, RoundTripPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -221,7 +226,7 @@ TEST(LibRadosAio, RoundTripPP2) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -231,7 +236,7 @@ TEST(LibRadosAio, RoundTripPP2) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -246,7 +251,8 @@ TEST(LibRadosAio, RoundTripPP2) {
 TEST(LibRadosAio, RoundTripPP3)
 {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -306,7 +312,7 @@ TEST(LibRadosAio, RoundTripSparseReadPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -317,7 +323,7 @@ TEST(LibRadosAio, RoundTripSparseReadPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_sparse_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_sparse_read(test_data.m_oid, my_completion2.get(),
                                                  &extents, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -340,7 +346,7 @@ TEST(LibRadosAioPP, ReadIntoBufferlist) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -354,7 +360,7 @@ TEST(LibRadosAioPP, ReadIntoBufferlist) {
   bl2.append(buffer::create_static(sizeof(buf2), buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -373,11 +379,11 @@ TEST(LibRadosAioPP, XattrsRoundTripPP) {
   bl1.append(buf, sizeof(buf));
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, test_data.m_ioctx.append("foo", bl1, sizeof(buf)));
+  ASSERT_EQ(0, test_data.m_ioctx.append(test_data.m_oid, bl1, sizeof(buf)));
   bufferlist bl2;
   // async getxattr
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr("foo", my_completion.get(), attr1, bl2));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr(test_data.m_oid, my_completion.get(), attr1, bl2));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion->wait_for_complete());
@@ -390,7 +396,7 @@ TEST(LibRadosAioPP, XattrsRoundTripPP) {
   AioTestDataPP test_data2;
   ASSERT_EQ("", test_data2.init());
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_setxattr("foo", my_completion2.get(), attr1, bl3));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_setxattr(test_data.m_oid, my_completion2.get(), attr1, bl3));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion2->wait_for_complete());
@@ -401,7 +407,7 @@ TEST(LibRadosAioPP, XattrsRoundTripPP) {
   AioTestDataPP test_data3;
   ASSERT_EQ("", test_data3.init());
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr("foo", my_completion3.get(), attr1, bl4));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr(test_data.m_oid, my_completion3.get(), attr1, bl4));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion3->wait_for_complete());
@@ -420,12 +426,12 @@ TEST(LibRadosAioPP, RmXattrPP) {
   bl1.append(buf, sizeof(buf));
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, test_data.m_ioctx.append("foo", bl1, sizeof(buf)));
+  ASSERT_EQ(0, test_data.m_ioctx.append(test_data.m_oid, bl1, sizeof(buf)));
   // async setxattr
   bufferlist bl2;
   bl2.append(attr1_buf, sizeof(attr1_buf));
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_setxattr("foo", my_completion.get(), attr1, bl2));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_setxattr(test_data.m_oid, my_completion.get(), attr1, bl2));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion->wait_for_complete());
@@ -435,7 +441,7 @@ TEST(LibRadosAioPP, RmXattrPP) {
   AioTestDataPP test_data2;
   ASSERT_EQ("", test_data2.init());
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_rmxattr("foo", my_completion2.get(), attr1));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_rmxattr(test_data.m_oid, my_completion2.get(), attr1));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion2->wait_for_complete());
@@ -446,7 +452,7 @@ TEST(LibRadosAioPP, RmXattrPP) {
   ASSERT_EQ("", test_data3.init());
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   bufferlist bl3;
-  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr("foo", my_completion3.get(), attr1, bl3));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattr(test_data.m_oid, my_completion3.get(), attr1, bl3));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion3->wait_for_complete());
@@ -501,17 +507,17 @@ TEST(LibRadosIoPP, XattrListPP) {
   memset(buf, 0xaa, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.append("foo", bl1, sizeof(buf)));
+  ASSERT_EQ(0, test_data.m_ioctx.append(test_data.m_oid, bl1, sizeof(buf)));
   bufferlist bl2;
   bl2.append(attr1_buf, sizeof(attr1_buf));
-  ASSERT_EQ(0, test_data.m_ioctx.setxattr("foo", attr1, bl2));
+  ASSERT_EQ(0, test_data.m_ioctx.setxattr(test_data.m_oid, attr1, bl2));
   bufferlist bl3;
   bl3.append(attr2_buf, sizeof(attr2_buf));
-  ASSERT_EQ(0, test_data.m_ioctx.setxattr("foo", attr2, bl3));
+  ASSERT_EQ(0, test_data.m_ioctx.setxattr(test_data.m_oid, attr2, bl3));
   // call async version of getxattrs
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   std::map<std::string, bufferlist> attrset;
-  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattrs("foo", my_completion.get(), attrset));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_getxattrs(test_data.m_oid, my_completion.get(), attrset));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion->wait_for_complete());
@@ -540,7 +546,7 @@ TEST(LibRadosAio, IsCompletePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -550,7 +556,7 @@ TEST(LibRadosAio, IsCompletePP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -577,7 +583,7 @@ TEST(LibRadosAio, IsSafePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -594,7 +600,7 @@ TEST(LibRadosAio, IsSafePP) {
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   bufferlist bl2;
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -629,14 +635,14 @@ TEST(LibRadosAio, FlushPP) {
   memset(buf, 0xee, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   ASSERT_EQ(0, test_data.m_ioctx.aio_flush());
   ASSERT_EQ(0, my_completion->get_return_value());
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -657,7 +663,7 @@ TEST(LibRadosAio, FlushAsyncPP) {
   memset(buf, 0xee, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   ASSERT_EQ(0, test_data.m_ioctx.aio_flush_async(flush_completion.get()));
   {
@@ -670,7 +676,7 @@ TEST(LibRadosAio, FlushAsyncPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -690,7 +696,7 @@ TEST(LibRadosAio, RoundTripWriteFullPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -703,7 +709,7 @@ TEST(LibRadosAio, RoundTripWriteFullPP) {
   bl2.append(buf2, sizeof(buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write_full("foo", my_completion2.get(), bl2));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write_full(test_data.m_oid, my_completion2.get(), bl2));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion2->wait_for_complete());
@@ -712,7 +718,7 @@ TEST(LibRadosAio, RoundTripWriteFullPP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
 					  &bl3, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -727,7 +733,8 @@ TEST(LibRadosAio, RoundTripWriteFullPP) {
 TEST(LibRadosAio, RoundTripWriteFullPP2)
 {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -774,7 +781,7 @@ TEST(LibRadosAio, RoundTripWriteSamePP) {
   memset(full, 0xcc, sizeof(full));
   bufferlist bl1;
   bl1.append(full, sizeof(full));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(full), 0));
   {
     TestAlarm alarm;
@@ -789,7 +796,7 @@ TEST(LibRadosAio, RoundTripWriteSamePP) {
   bl2.append(buf, sizeof(buf));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_writesame("foo", my_completion2.get(), bl2,
+  ASSERT_EQ(0, test_data.m_ioctx.aio_writesame(test_data.m_oid, my_completion2.get(), bl2,
 					       ws_write_len, 0));
   {
     TestAlarm alarm;
@@ -799,7 +806,7 @@ TEST(LibRadosAio, RoundTripWriteSamePP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
 					  &bl3, sizeof(full), 0));
   {
     TestAlarm alarm;
@@ -816,7 +823,8 @@ TEST(LibRadosAio, RoundTripWriteSamePP) {
 TEST(LibRadosAio, RoundTripWriteSamePP2)
 {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -870,7 +878,7 @@ TEST(LibRadosAio, SimpleStatPPNS) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -881,7 +889,7 @@ TEST(LibRadosAio, SimpleStatPPNS) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -900,7 +908,7 @@ TEST(LibRadosAio, SimpleStatPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -911,7 +919,7 @@ TEST(LibRadosAio, SimpleStatPP) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -930,7 +938,7 @@ TEST(LibRadosAio, StatRemovePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -941,7 +949,7 @@ TEST(LibRadosAio, StatRemovePP) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -953,7 +961,7 @@ TEST(LibRadosAio, StatRemovePP) {
   time_t pmtime2;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_remove("foo", my_completion3.get()));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_remove(test_data.m_oid, my_completion3.get()));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion3->wait_for_complete());
@@ -962,7 +970,7 @@ TEST(LibRadosAio, StatRemovePP) {
 
   auto my_completion4 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion4);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion4.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion4.get(),
 			  		&psize2, &pmtime2));
   {
     TestAlarm alarm;
@@ -980,7 +988,7 @@ TEST(LibRadosAio, ExecuteClassPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -990,7 +998,7 @@ TEST(LibRadosAio, ExecuteClassPP) {
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
   bufferlist in, out;
-  ASSERT_EQ(0, test_data.m_ioctx.aio_exec("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_exec(test_data.m_oid, my_completion2.get(),
 					  "hello", "say_hello", in, &out));
   {
     TestAlarm alarm;
@@ -1006,7 +1014,8 @@ using std::set;
 
 TEST(LibRadosAio, OmapPP) {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -1214,7 +1223,7 @@ TEST(LibRadosAio, MultiWritePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1228,7 +1237,7 @@ TEST(LibRadosAio, MultiWritePP) {
   bl2.append(buf2, sizeof(buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion2.get(),
 					   bl2, sizeof(buf2), sizeof(buf)));
   {
     TestAlarm alarm;
@@ -1239,7 +1248,7 @@ TEST(LibRadosAio, MultiWritePP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
 					  &bl3, (sizeof(buf) + sizeof(buf2) * 3), 0));
   {
     TestAlarm alarm;
@@ -1254,23 +1263,24 @@ TEST(LibRadosAio, MultiWritePP) {
 TEST(LibRadosAio, AioUnlockPP) {
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, test_data.m_ioctx.lock_exclusive("foo", "TestLock", "Cookie", "", NULL, 0));
+  ASSERT_EQ(0, test_data.m_ioctx.lock_exclusive(test_data.m_oid, "TestLock", "Cookie", "", NULL, 0));
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_unlock("foo", "TestLock", "Cookie", my_completion.get()));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_unlock(test_data.m_oid, "TestLock", "Cookie", my_completion.get()));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion->wait_for_complete());
   }
   ASSERT_EQ(0, my_completion->get_return_value());
   bufferlist bl2;
-  ASSERT_EQ(0, test_data.m_ioctx.lock_exclusive("foo", "TestLock", "Cookie", "", NULL, 0));
+  ASSERT_EQ(0, test_data.m_ioctx.lock_exclusive(test_data.m_oid, "TestLock", "Cookie", "", NULL, 0));
 }
 
 class AioTestDataECPP
 {
 public:
   AioTestDataECPP()
-    : m_init(false)
+    : m_init(false),
+      m_oid("foo")
   {}
 
   ~AioTestDataECPP()
@@ -1284,7 +1294,8 @@ public:
   std::string init()
   {
     int ret;
-    m_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    m_pool_name = get_temp_pool_name(pool_prefix);
     std::string err = create_one_ec_pool_pp(m_pool_name, m_cluster);
     if (!err.empty()) {
       ostringstream oss;
@@ -1298,6 +1309,7 @@ public:
       oss << "rados_ioctx_create failed: error " << ret;
       return oss.str();
     }
+    m_oid = fmt::format("oid_{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
     m_init = true;
     return "";
   }
@@ -1306,6 +1318,7 @@ public:
   IoCtx m_ioctx;
   std::string m_pool_name;
   bool m_init;
+  std::string m_oid;
 };
 
 // EC test cases
@@ -1319,7 +1332,7 @@ TEST(LibRadosAioEC, SimpleWritePP) {
   ASSERT_EQ("", test_data.init());
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1333,7 +1346,7 @@ TEST(LibRadosAioEC, SimpleWritePP) {
   ASSERT_EQ("", test_data.init());
   test_data.m_ioctx.set_namespace("nspace");
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1352,7 +1365,7 @@ TEST(LibRadosAioEC, WaitForSafePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                            bl1, sizeof(buf), 0));
   TestAlarm alarm;
   ASSERT_EQ(0, my_completion->wait_for_complete());
@@ -1368,7 +1381,7 @@ TEST(LibRadosAioEC, RoundTripPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1378,7 +1391,7 @@ TEST(LibRadosAioEC, RoundTripPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1398,7 +1411,7 @@ TEST(LibRadosAioEC, RoundTripPP2) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1408,7 +1421,7 @@ TEST(LibRadosAioEC, RoundTripPP2) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
                                           &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1423,7 +1436,8 @@ TEST(LibRadosAioEC, RoundTripPP2) {
 TEST(LibRadosAioEC, RoundTripPP3)
 {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -1470,7 +1484,7 @@ TEST(LibRadosAio, RoundTripAppendPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_append("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_append(test_data.m_oid, my_completion.get(),
 					    bl1, sizeof(buf)));
   {
     TestAlarm alarm;
@@ -1483,7 +1497,7 @@ TEST(LibRadosAio, RoundTripAppendPP) {
   bl2.append(buf2, sizeof(buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_append("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_append(test_data.m_oid, my_completion2.get(),
 					    bl2, sizeof(buf2)));
   {
     TestAlarm alarm;
@@ -1493,7 +1507,7 @@ TEST(LibRadosAio, RoundTripAppendPP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
                                           &bl3, 2 * sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1512,16 +1526,16 @@ TEST(LibRadosAioPP, RemoveTestPP) {
   bl1.append(buf, sizeof(buf));
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, test_data.m_ioctx.append("foo", bl1, sizeof(buf)));
+  ASSERT_EQ(0, test_data.m_ioctx.append(test_data.m_oid, bl1, sizeof(buf)));
   auto my_completion = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_remove("foo", my_completion.get()));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_remove(test_data.m_oid, my_completion.get()));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion->wait_for_complete());
   }
   ASSERT_EQ(0, my_completion->get_return_value());
   bufferlist bl2;
-  ASSERT_EQ(-ENOENT, test_data.m_ioctx.read("foo", bl2, sizeof(buf), 0));
+  ASSERT_EQ(-ENOENT, test_data.m_ioctx.read(test_data.m_oid, bl2, sizeof(buf), 0));
 }
 
 TEST(LibRadosAioEC, RoundTripSparseReadPP) {
@@ -1533,7 +1547,7 @@ TEST(LibRadosAioEC, RoundTripSparseReadPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1545,7 +1559,7 @@ TEST(LibRadosAioEC, RoundTripSparseReadPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_sparse_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_sparse_read(test_data.m_oid, my_completion2.get(),
                                                  &extents, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1571,7 +1585,7 @@ TEST(LibRadosAioEC, RoundTripAppendPP) {
   memset(buf, 0xcc, bsize);
   bufferlist bl1;
   bl1.append(buf, bsize);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_append("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_append(test_data.m_oid, my_completion.get(),
 					    bl1, bsize));
   {
     TestAlarm alarm;
@@ -1586,7 +1600,7 @@ TEST(LibRadosAioEC, RoundTripAppendPP) {
   bl2.append(buf2, hbsize);
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_append("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_append(test_data.m_oid, my_completion2.get(),
 					    bl2, hbsize));
   {
     TestAlarm alarm;
@@ -1596,7 +1610,7 @@ TEST(LibRadosAioEC, RoundTripAppendPP) {
 
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_append("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_append(test_data.m_oid, my_completion3.get(),
 					    bl2, hbsize));
   {
     TestAlarm alarm;
@@ -1607,7 +1621,7 @@ TEST(LibRadosAioEC, RoundTripAppendPP) {
   bufferlist bl3;
   auto my_completion4 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion4);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion4.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion4.get(),
                                           &bl3, bsize * 3, 0));
   {
     TestAlarm alarm;
@@ -1631,7 +1645,7 @@ TEST(LibRadosAioEC, IsCompletePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1641,7 +1655,7 @@ TEST(LibRadosAioEC, IsCompletePP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1667,7 +1681,7 @@ TEST(LibRadosAioEC, IsSafePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1684,7 +1698,7 @@ TEST(LibRadosAioEC, IsSafePP) {
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   bufferlist bl2;
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1719,14 +1733,14 @@ TEST(LibRadosAioEC, FlushPP) {
   memset(buf, 0xee, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   ASSERT_EQ(0, test_data.m_ioctx.aio_flush());
   ASSERT_EQ(0, my_completion->get_return_value());
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1747,7 +1761,7 @@ TEST(LibRadosAioEC, FlushAsyncPP) {
   memset(buf, 0xee, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   ASSERT_EQ(0, test_data.m_ioctx.aio_flush_async(flush_completion.get()));
   {
@@ -1760,7 +1774,7 @@ TEST(LibRadosAioEC, FlushAsyncPP) {
   bufferlist bl2;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion2.get(),
 					  &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1780,7 +1794,7 @@ TEST(LibRadosAioEC, RoundTripWriteFullPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1793,7 +1807,7 @@ TEST(LibRadosAioEC, RoundTripWriteFullPP) {
   bl2.append(buf2, sizeof(buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write_full("foo", my_completion2.get(), bl2));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write_full(test_data.m_oid, my_completion2.get(), bl2));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion2->wait_for_complete());
@@ -1802,7 +1816,7 @@ TEST(LibRadosAioEC, RoundTripWriteFullPP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
 					  &bl3, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1817,7 +1831,8 @@ TEST(LibRadosAioEC, RoundTripWriteFullPP) {
 TEST(LibRadosAioEC, RoundTripWriteFullPP2)
 {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -1864,7 +1879,7 @@ TEST(LibRadosAioEC, SimpleStatPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1875,7 +1890,7 @@ TEST(LibRadosAioEC, SimpleStatPP) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -1894,7 +1909,7 @@ TEST(LibRadosAioEC, SimpleStatPPNS) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1905,7 +1920,7 @@ TEST(LibRadosAioEC, SimpleStatPPNS) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -1924,7 +1939,7 @@ TEST(LibRadosAioEC, StatRemovePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1935,7 +1950,7 @@ TEST(LibRadosAioEC, StatRemovePP) {
   time_t pmtime;
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion2.get(),
 			  		&psize, &pmtime));
   {
     TestAlarm alarm;
@@ -1947,7 +1962,7 @@ TEST(LibRadosAioEC, StatRemovePP) {
   time_t pmtime2;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_remove("foo", my_completion3.get()));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_remove(test_data.m_oid, my_completion3.get()));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion3->wait_for_complete());
@@ -1956,7 +1971,7 @@ TEST(LibRadosAioEC, StatRemovePP) {
 
   auto my_completion4 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion4);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_stat("foo", my_completion4.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_stat(test_data.m_oid, my_completion4.get(),
 			  		&psize2, &pmtime2));
   {
     TestAlarm alarm;
@@ -1974,7 +1989,7 @@ TEST(LibRadosAioEC, ExecuteClassPP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -1984,7 +1999,7 @@ TEST(LibRadosAioEC, ExecuteClassPP) {
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
   bufferlist in, out;
-  ASSERT_EQ(0, test_data.m_ioctx.aio_exec("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_exec(test_data.m_oid, my_completion2.get(),
 					  "hello", "say_hello", in, &out));
   {
     TestAlarm alarm;
@@ -1996,7 +2011,8 @@ TEST(LibRadosAioEC, ExecuteClassPP) {
 
 TEST(LibRadosAioEC, OmapPP) {
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
@@ -2036,7 +2052,7 @@ TEST(LibRadosAioEC, MultiWritePP) {
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
   bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -2050,7 +2066,7 @@ TEST(LibRadosAioEC, MultiWritePP) {
   bl2.append(buf2, sizeof(buf2));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion2.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion2.get(),
 					   bl2, sizeof(buf2), sizeof(buf)));
   {
     TestAlarm alarm;
@@ -2061,7 +2077,7 @@ TEST(LibRadosAioEC, MultiWritePP) {
   bufferlist bl3;
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion3);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_read("foo", my_completion3.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_read(test_data.m_oid, my_completion3.get(),
 					  &bl3, (sizeof(buf) + sizeof(buf2) * 3), 0));
   {
     TestAlarm alarm;
@@ -2084,8 +2100,8 @@ TEST(LibRadosAio, RacingRemovePP) {
   bl.append(buf, sizeof(buf));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
   ASSERT_TRUE(my_completion2);
-  ASSERT_EQ(0, test_data.m_ioctx.aio_remove("foo", my_completion2.get()));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_remove(test_data.m_oid, my_completion2.get()));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
                                          bl, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -2094,7 +2110,7 @@ TEST(LibRadosAio, RacingRemovePP) {
   }
   ASSERT_EQ(-ENOENT, my_completion2->get_return_value());
   ASSERT_EQ(0, my_completion->get_return_value());
-  ASSERT_EQ(0, test_data.m_ioctx.stat("foo", nullptr, nullptr));
+  ASSERT_EQ(0, test_data.m_ioctx.stat(test_data.m_oid, nullptr, nullptr));
 }
 
 TEST(LibRadosAio, RoundTripCmpExtPP) {
@@ -2106,7 +2122,7 @@ TEST(LibRadosAio, RoundTripCmpExtPP) {
   memset(full, 0xcc, sizeof(full));
   bufferlist bl1;
   bl1.append(full, sizeof(full));
-  ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo", my_completion.get(),
+  ASSERT_EQ(0, test_data.m_ioctx.aio_write(test_data.m_oid, my_completion.get(),
 					   bl1, sizeof(full), 0));
   {
     TestAlarm alarm;
@@ -2118,7 +2134,7 @@ TEST(LibRadosAio, RoundTripCmpExtPP) {
   bufferlist cbl;
   cbl.append(full, sizeof(full));
   auto my_completion2 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext("foo", my_completion2.get(), 0, cbl));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext(test_data.m_oid, my_completion2.get(), 0, cbl));
 
   {
     TestAlarm alarm;
@@ -2131,7 +2147,7 @@ TEST(LibRadosAio, RoundTripCmpExtPP) {
   cbl.clear();
   cbl.append(full, sizeof(full));
   auto my_completion3 = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
-  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext("foo", my_completion3.get(), 0, cbl));
+  ASSERT_EQ(0, test_data.m_ioctx.aio_cmpext(test_data.m_oid, my_completion3.get(), 0, cbl));
   {
     TestAlarm alarm;
     ASSERT_EQ(0, my_completion3->wait_for_complete());
@@ -2146,7 +2162,8 @@ TEST(LibRadosAio, RoundTripCmpExtPP2)
   char miscmp_buf[128];
   bufferlist cbl;
   Rados cluster;
-  std::string pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);

--- a/src/test/librados/test_shared.h
+++ b/src/test/librados/test_shared.h
@@ -21,7 +21,7 @@ class TestAlarm
 public:
   #ifndef _WIN32
   TestAlarm() {
-    alarm(1200);
+    alarm(2400);
   }
   ~TestAlarm() {
     alarm(0);

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -4,6 +4,7 @@
 #include "testcase_cxx.h"
 
 #include <errno.h>
+#include <fmt/format.h>
 #include "test_cxx.h"
 #include "test_shared.h"
 #include "include/scope_guard.h"
@@ -29,7 +30,8 @@ Rados RadosTestPPNS::s_cluster;
 
 void RadosTestPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -72,7 +74,8 @@ Rados RadosTestParamPPNS::s_cluster;
 
 void RadosTestParamPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -101,7 +104,8 @@ void RadosTestParamPPNS::TearDownTestCase()
 void RadosTestParamPPNS::SetUp()
 {
   if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
-    cache_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+    cache_pool_name = get_temp_pool_name(pool_prefix);
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -154,7 +158,8 @@ Rados RadosTestECPPNS::s_cluster;
 
 void RadosTestECPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 
@@ -187,7 +192,8 @@ void RadosTestPP::SetUpTestCase()
 {
   init_rand();
 
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -268,7 +274,8 @@ Rados RadosTestParamPP::s_cluster;
 
 void RadosTestParamPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -297,7 +304,8 @@ void RadosTestParamPP::TearDownTestCase()
 void RadosTestParamPP::SetUp()
 {
   if (strcmp(GetParam(), "cache") == 0 && cache_pool_name.empty()) {
-    cache_pool_name = get_temp_pool_name();
+    auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+    cache_pool_name = get_temp_pool_name(pool_prefix);
     bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
@@ -359,7 +367,8 @@ Rados RadosTestECPP::s_cluster;
 
 void RadosTestECPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
+  pool_name = get_temp_pool_name(pool_prefix);
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -240,7 +240,10 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete) {
   }
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
-  ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
+  int rados_watch_check_err = rados_watch_check(ioctx, handle);
+  // We may hit ENOENT due to socket failure injection and a forced reconnect
+  EXPECT_TRUE(rados_watch_check_err == -ENOTCONN || rados_watch_check_err == -ENOENT)
+    << "Where rados_watch_check_err = " << rados_watch_check_err;
   ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -97,8 +97,10 @@ start()
     #else
     std::string err_msg;
     ret = preforker.prefork(err_msg);
-    if (ret < 0)
-      preforker.exit(ret);
+    if (ret < 0) {
+      printf("prefork failed: %s\n", err_msg.c_str());
+      return ret;
+    }
 
     if (preforker.is_child()) {
       m_started = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58611

---

backport of https://github.com/ceph/ceph/pull/49109
parent tracker: https://tracker.ceph.com/issues/45615

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh