### PR TITLE
qa: Added script for collecting Windows Event Logs

### DIFF
--- a/qa/workunits/windows/collect-event-logs.ps1
+++ b/qa/workunits/windows/collect-event-logs.ps1
@@ -1,0 +1,36 @@
+function DumpEventLog($path){
+    foreach ($i in (Get-WinEvent -ListLog * |  ? {$_.RecordCount -gt 0 })) {
+        $logName = "eventlog_" + $i.LogName + ".evtx"
+        $logName = $logName.replace(" ","-").replace("/", "-").replace("\", "-")
+        Write-Host "exporting "$i.LogName" as "$logName
+        $logFile = Join-Path $path $logName
+        & $Env:WinDir\System32\wevtutil.exe epl $i.LogName $logFile
+    }
+}
+
+function ExportEventLog($path){
+    foreach ($i in (Get-ChildItem $path -Filter eventlog_*.evtx)) {
+        $logName = $i.BaseName + ".txt"
+        $logName = $logName.replace(" ","-").replace("/", "-").replace("\", "-")
+        Write-Host "converting "$i.BaseName" evtx to txt"
+        $logFile = Join-Path $path $logName
+        & $Env:WinDir\System32\wevtutil.exe qe $i.FullName /lf > $logFile
+    }
+}
+
+function ClearEventLog(){
+    foreach ($i in (Get-WinEvent -ListLog * |  ? {$_.RecordCount -gt 0 })) {
+        & $Env:WinDir\System32\wevtutil.exe cl $i.LogName
+    }
+}
+
+
+$logDir = $Env:WinDir + "\EventLogs"
+
+mkdir -force $logDir
+
+DumpEventLog $logDir
+ExportEventLog $logDir
+ClearEventLog
+
+rm $logDir\eventlog_*.evtx


### PR DESCRIPTION
In order to collect more information for the Windows ceph-build artifacts, the collect-event-logs.ps1 script will be run in order to extract the event logs from the Windows client machine.

It will dump all the event logs as evtx and then convert them to txt in order to be accessible on all platforms.

The dumped event log files can be found at %WINDIR%\EventLogs.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
