### PR TITLE
qa/rgw: run ragweed tests with tox

### DIFF
--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -2,6 +2,7 @@ tasks:
 - install:
 - ceph:
 - rgw: [client.0]
+- tox: [client.0]
 - ragweed:
     client.0:
       default-branch: ceph-master

--- a/qa/suites/rgw/verify/0-install.yaml
+++ b/qa/suites/rgw/verify/0-install.yaml
@@ -8,6 +8,7 @@ tasks:
 - openssl_keys:
 - rgw:
     client.0:
+- tox: [client.0]
 
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,5 +1,4 @@
 tasks:
-- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0


### PR DESCRIPTION
similar to https://github.com/ceph/ceph/pull/49826 for s3-tests. depends on https://github.com/ceph/ragweed/pull/25 and https://github.com/ceph/ragweed/pull/26

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
