### PR TITLE
mgr/cephadm: fix set-priv-key and set-pub-key

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -428,14 +428,23 @@ You can make use of an existing key by directly importing it with:
 
 .. prompt:: bash #
 
-   ceph config-key set mgr/cephadm/ssh_identity_key -i <key>
-   ceph config-key set mgr/cephadm/ssh_identity_pub -i <pub>
+   ceph cephadm set-priv-key -i <key>
+   ceph cephadm set-pub-key -i <pub>
 
-You will then need to restart the mgr daemon to reload the configuration with:
+.. warning::
 
-.. prompt:: bash #
+  Any imported key must have had it's public key added to  /<ssh-user>/.ssh/authorized_keys
+  in order for cephadm to make proper use of it (where ssh-user corresponds to the output
+  of ``ceph cephadm get-user``, see the next section for how to modify this user). You can
+  check that the key is correctly set up for cephadm to connect to the cluster hosts
+  by running ``cephadm shell --no-hosts --mount <key> -- ssh -i /mnt/<key> <host>``
+  where "host" is one of the hosts in the cluster. The set-priv-key and set-pub-key command will
+  attempt a connection to one of the hosts in the cluster and refuse to set the provided
+  key if the connection fails. Setting keys can be forced by using ``ceph config-key set
+  mgr/cephadm/ssh_identity_key -i <key>`` and ``ceph config-key set mgr/cephadm/ssh_identity_pub -i <pub>``
+  followed by ``ceph mgr fail`` to make cephadm use the new keys, but this is not recommended
+  and it is possible cephadm will no longer be able to connect to any hosts in the cluster after doing so.
 
-   ceph mgr fail
 
 .. _cephadm-ssh-user:
 

--- a/qa/suites/orch/cephadm/with-work/tasks/rotate-ssh-keys.yaml
+++ b/qa/suites/orch/cephadm/with-work/tasks/rotate-ssh-keys.yaml
@@ -1,0 +1,54 @@
+tasks:
+- exec:
+    mon.a:
+      - |
+        set -ex
+        # generate a new priv/pub key pair
+        ssh-keygen -q -t rsa -N '' -C '' -f new-key
+        # store key in unused config-key store location so other hosts can access it
+        /home/ubuntu/cephtest/cephadm shell --mount new-key -- ceph config-key set mgr/cephadm/testing_priv_key -i /mnt/new-key
+        /home/ubuntu/cephtest/cephadm shell --mount new-key.pub -- ceph config-key set mgr/cephadm/testing_pub_key -i /mnt/new-key.pub
+- exec:
+    all-hosts:
+      - |
+        set -ex
+        # set up the pub key on each host
+        /home/ubuntu/cephtest/cephadm shell -- ceph config-key get mgr/cephadm/testing_pub_key > new-key.pub
+        cat new-key.pub >> /root/.ssh/authorized_keys
+- exec:
+    mon.a:
+      - |
+        set -ex
+        NEW_SSH_PUB=$(cat new-key.pub)
+        NEW_SSH_PRIV=$(cat new-key)
+        # set the new keys to be used by cephadm for ssh
+        /home/ubuntu/cephtest/cephadm shell --mount new-key new-key.pub -- ceph cephadm set-priv-key -i /mnt/new-key
+        /home/ubuntu/cephtest/cephadm shell --mount new-key new-key.pub -- ceph cephadm set-pub-key -i /mnt/new-key.pub
+        # verify keys were properly set in config key store
+        CLUSTER_SSH_PRIV=$(/home/ubuntu/cephtest/cephadm shell -- ceph config-key get mgr/cephadm/ssh_identity_key)
+        CLUSTER_SSH_PUB=$(/home/ubuntu/cephtest/cephadm shell -- ceph config-key get mgr/cephadm/ssh_identity_pub)
+        if [ "$CLUSTER_SSH_PRIV" != "$NEW_SSH_PRIV" ]; then
+           printf "Cluster priv key\n\n$CLUSTER_SSH_PRIV\n\nis not equal to new ssh key\n\n$NEW_SSH_PRIV\n\n"
+           exit 1
+        else
+          echo "cluster private key successfully updated"
+        fi
+        if [ "$CLUSTER_SSH_PUB" != "$NEW_SSH_PUB" ]; then
+           printf "Cluster pub key\n\n$CLUSTER_SSH_PUB\n\nis not equal to new ssh key\n\n$NEW_SSH_PUB\n\n"
+           exit 1
+        else
+          echo "cluster pub key successfully updated"
+        fi
+        # verify all hosts are reachable with new ssh settings
+        HOSTNAMES=$(/home/ubuntu/cephtest/cephadm shell -- ceph orch host ls --format json | jq -r '.[] | .hostname')
+        for host in $HOSTNAMES; do
+          # cephadm puts most of the check-host output to stderr (even when no error)
+          # so redirecting stderr here. "Host looks OK" is printed at the end
+          # if no errors were found
+          /home/ubuntu/cephtest/cephadm shell -- ceph cephadm check-host ${host} 2> ${host}-ok.txt
+          HOST_OK=$(cat ${host}-ok.txt)
+          if ! grep -q "Host looks OK" <<< "$HOST_OK"; then
+            printf "Got bad host check after rotating ssh keys:\n\n$HOST_OK"
+            exit 1
+          fi
+        done

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -946,6 +946,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 # connection failed reset user
                 self.set_store(what, old)
                 self.ssh._reconfig_ssh()
+                # recheck the host with the old ssh settings
+                # to make sure it is marked back online (or kept
+                # offline if it's actually unreachable even with
+                # the old settings)
+                r = CephadmServe(self)._check_host(host)
                 raise OrchestratorError('ssh connection %s@%s failed' % (self.ssh_user, host))
         self.log.info(f'Set ssh {what}')
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -936,9 +936,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _validate_and_set_ssh_val(self, what: str, new: Optional[str], old: Optional[str]) -> None:
         self.set_store(what, new)
         self.ssh._reconfig_ssh()
-        if self.cache.get_hosts():
+        unreachable_hosts = [uh.hostname for uh in self.cache.get_unreachable_hosts()]
+        reachable_hosts = [h for h in self.cache.get_hosts() if h not in unreachable_hosts]
+        if reachable_hosts:
             # Can't check anything without hosts
-            host = self.cache.get_hosts()[0]
+            host = reachable_hosts[0]
             r = CephadmServe(self)._check_host(host)
             if r is not None:
                 # connection failed reset user

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -307,11 +307,7 @@ class SSHManager:
             self.mgr.tkey.write(ssh_key.encode('utf-8'))
             os.fchmod(self.mgr.tkey.fileno(), 0o600)
             self.mgr.tkey.flush()  # make visible to other processes
-            tpub = open(self.mgr.tkey.name + '.pub', 'w')
-            os.fchmod(tpub.fileno(), 0o600)
-            tpub.write(ssh_pub)
-            tpub.flush()  # make visible to other processes
-            temp_files += [self.mgr.tkey, tpub]
+            temp_files += [self.mgr.tkey]
             ssh_options += ['-i', self.mgr.tkey.name]
 
         self.mgr._temp_files = temp_files

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -299,13 +299,12 @@ class SSHManager:
 
         # identity
         ssh_key = self.mgr.get_store("ssh_identity_key")
-        ssh_pub = self.mgr.get_store("ssh_identity_pub")
-        self.mgr.ssh_pub = ssh_pub
+        self.mgr.ssh_pub = self.mgr.get_store("ssh_identity_pub")
         self.mgr.ssh_key = ssh_key
-        if ssh_key and ssh_pub:
+        if ssh_key:
             self.mgr.tkey = NamedTemporaryFile(prefix='cephadm-identity-')
-            self.mgr.tkey.write(ssh_key.encode('utf-8'))
             os.fchmod(self.mgr.tkey.fileno(), 0o600)
+            self.mgr.tkey.write(ssh_key.encode('utf-8'))
             self.mgr.tkey.flush()  # make visible to other processes
             temp_files += [self.mgr.tkey]
             ssh_options += ['-i', self.mgr.tkey.name]


### PR DESCRIPTION
These weren't working as asyncssh would fail the connection due to a mismatch in the private and public key which were un-resolvable since the commands both only let you set one key (see first tracker for more info)

Fixes: https://tracker.ceph.com/issues/58622
Fixes: https://tracker.ceph.com/issues/58449

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
