### PR TITLE
osd/scrub: fix the handling of interval changes

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -161,10 +161,6 @@ public:
     // Not needed yet -- mainly for scrub scheduling
   }
 
-  /// Notify PG that Primary/Replica status has changed (to update scrub registration)
-  void on_primary_status_change(bool was_primary, bool now_primary) final {
-  }
-
   /// Need to reschedule next scrub. Assuming no change in role
   void reschedule_scrub() final {
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1695,7 +1695,10 @@ void PG::on_info_history_change()
 
 void PG::reschedule_scrub()
 {
-  dout(20) << __func__ << " for a " << (is_primary() ? "Primary" : "non-primary") <<dendl;
+  dout(20) << fmt::format(
+		  "{} for a {}", __func__,
+		  (is_primary() ? "Primary" : "non-primary"))
+	   << dendl;
 
   // we are assuming no change in primary status
   if (is_primary()) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -540,8 +540,6 @@ public:
 
   void on_info_history_change() override;
 
-  void on_primary_status_change(bool was_primary, bool now_primary) override;
-
   void reschedule_scrub() override;
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -711,8 +711,6 @@ void PeeringState::start_peering_interval(
     // did primary change?
     if (was_old_primary != is_primary()) {
       state_clear(PG_STATE_CLEAN);
-      // queue/dequeue the scrubber
-      pl->on_primary_status_change(was_old_primary, is_primary());
     }
 
     pl->on_role_change();

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -282,9 +282,6 @@ public:
     /// Notify that info/history changed (generally to update scrub registration)
     virtual void on_info_history_change() = 0;
 
-    /// Notify PG that Primary/Replica status has changed (to update scrub registration)
-    virtual void on_primary_status_change(bool was_primary, bool now_primary) = 0;
-
     /// Need to reschedule next scrub. Assuming no change in role
     virtual void reschedule_scrub() = 0;
 

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -276,6 +276,12 @@ class ScrubQueue {
     }
 
     /**
+     * access the 'state' directly, for when a distinction between 'registered'
+     * and 'unregistering' is needed (both have in_queues() == true)
+     */
+    bool is_state_registered() const { return state == qu_state_t::registered; }
+
+    /**
      * a text description of the "scheduling intentions" of this PG:
      * are we already scheduled for a scrub/deep scrub? when?
      */

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2634,8 +2634,6 @@ void ReplicaReservations::send_all_done()
 
 void ReplicaReservations::send_reject()
 {
-  // stop any pending timeout timer
-  m_no_reply.reset();
   m_scrub_job->resources_failure = true;
   m_osds->queue_for_scrub_denied(m_pg, scrub_prio_t::low_priority);
 }
@@ -2786,6 +2784,8 @@ void ReplicaReservations::handle_reserve_reject(OpRequestRef op,
     dout(10) << __func__ << ": osd." << from << " scrub reserve = fail"
 	     << dendl;
     m_had_rejections = true;  // preventing any additional notifications
+    // stop any pending timeout timer
+    m_no_reply.reset();
     send_reject();
   }
 }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -579,7 +579,7 @@ void PgScrubber::update_scrub_job(const requested_scrub_t& request_flags)
   if (is_primary() && m_scrub_job) {
     ceph_assert(m_pg->is_locked());
     auto suggested = m_osds->get_scrub_services().determine_scrub_time(
-      request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
+	request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
     m_osds->get_scrub_services().update_job(m_scrub_job, suggested);
   }
 
@@ -2407,7 +2407,9 @@ void PgScrubber::reset_internal_state()
 // note that only applicable to the Replica:
 void PgScrubber::advance_token()
 {
-  dout(10) << __func__ << " was: " << m_current_token << dendl;
+  dout(10) << fmt::format("{}: prev. token:{}", __func__, m_current_token)
+	   << dendl;
+
   m_current_token++;
 
   // when advance_token() is called, it is assumed that no scrubbing takes
@@ -2592,11 +2594,12 @@ ReplicaReservations::ReplicaReservations(
     , m_conf{conf}
 {
   epoch_t epoch = m_pg->get_osdmap_epoch();
-  m_timeout = conf.get_val<std::chrono::milliseconds>(
-    "osd_scrub_slow_reservation_response");
   m_log_msg_prefix = fmt::format(
-    "osd.{} ep: {} scrubber::ReplicaReservations pg[{}]: ", m_osds->whoami,
-    epoch, pg->pg_id);
+      "osd.{} ep: {} scrubber::ReplicaReservations pg[{}]: ", m_osds->whoami,
+      epoch, pg->pg_id);
+
+  m_timeout = conf.get_val<std::chrono::milliseconds>(
+      "osd_scrub_slow_reservation_response");
 
   if (m_pending <= 0) {
     // A special case of no replicas.

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -581,7 +581,6 @@ void PgScrubber::update_scrub_job(const requested_scrub_t& request_flags)
     auto suggested = m_osds->get_scrub_services().determine_scrub_time(
       request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
     m_osds->get_scrub_services().update_job(m_scrub_job, suggested);
-    m_pg->publish_stats_to_osd();
   }
 
   dout(15) << __func__ << ": done " << registration_state() << dendl;
@@ -2351,7 +2350,6 @@ void PgScrubber::clear_pgscrub_state()
   state_clear(PG_STATE_REPAIR);
 
   clear_scrub_reservations();
-  m_pg->publish_stats_to_osd();
 
   requeue_waiting();
 
@@ -2360,7 +2358,6 @@ void PgScrubber::clear_pgscrub_state()
 
   // type-specific state clear
   _scrub_clear_state();
-  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::replica_handling_done()

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -465,13 +465,6 @@ unsigned int PgScrubber::scrub_requeue_priority(
 // ///////////////////////////////////////////////////////////////////// //
 // scrub-op registration handling
 
-void PgScrubber::unregister_from_osd()
-{
-  if (m_scrub_job) {
-    dout(15) << __func__ << " prev. state: " << registration_state() << dendl;
-    m_osds->get_scrub_services().remove_from_osd_queue(m_scrub_job);
-  }
-}
 
 bool PgScrubber::is_scrub_registered() const
 {
@@ -488,8 +481,12 @@ std::string_view PgScrubber::registration_state() const
 
 void PgScrubber::rm_from_osd_scrubbing()
 {
-  // make sure the OSD won't try to scrub this one just now
-  unregister_from_osd();
+  if (m_scrub_job && m_scrub_job->is_state_registered()) {
+    dout(15) << fmt::format(
+		    "{}: prev. state: {}", __func__, registration_state())
+	     << dendl;
+    m_osds->get_scrub_services().remove_from_osd_queue(m_scrub_job);
+  }
 }
 
 void PgScrubber::on_primary_change(

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -407,9 +407,7 @@ class PgScrubber : public ScrubPgIF,
 
   void rm_from_osd_scrubbing() final;
 
-  void on_primary_change(
-    std::string_view caller,
-    const requested_scrub_t& request_flags) final;
+  void on_pg_activate(const requested_scrub_t& request_flags) final;
 
   void scrub_requested(scrub_level_t scrub_level,
 		       scrub_type_t scrub_type,
@@ -457,6 +455,8 @@ class PgScrubber : public ScrubPgIF,
 
   /// handle a message carrying a replica map
   void map_from_replica(OpRequestRef op) final;
+
+  void stop_active_scrubs() final;
 
   void scrub_clear_state() final;
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -409,9 +409,10 @@ class PgScrubber : public ScrubPgIF,
 
   void on_pg_activate(const requested_scrub_t& request_flags) final;
 
-  void scrub_requested(scrub_level_t scrub_level,
-		       scrub_type_t scrub_type,
-		       requested_scrub_t& req_flags) final;
+  void scrub_requested(
+      scrub_level_t scrub_level,
+      scrub_type_t scrub_type,
+      requested_scrub_t& req_flags) final;
 
   /**
    * Reserve local scrub resources (managed by the OSD)
@@ -494,6 +495,7 @@ class PgScrubber : public ScrubPgIF,
 		 std::string param,
 		 Formatter* f,
 		 std::stringstream& ss) override;
+
   int m_debug_blockrange{0};
 
   // --------------------------------------------------------------------------

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -893,8 +893,6 @@ class PgScrubber : public ScrubPgIF,
    */
   void request_rescrubbing(requested_scrub_t& req_flags);
 
-  void unregister_from_osd();
-
   /*
    * Select a range of objects to scrub.
    *

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -580,7 +580,8 @@ class PgScrubber : public ScrubPgIF,
 
   [[nodiscard]] bool was_epoch_changed() const final;
 
-  void set_queued_or_active() final;
+  void set_queued_or_active(Scrub::QueuedForRole role_queued) final;
+
   /// Clears `m_queued_or_active` and restarts snaptrimming
   void clear_queued_or_active() final;
 
@@ -831,7 +832,9 @@ class PgScrubber : public ScrubPgIF,
    * Compared with 'm_active', this flag is asserted earlier and remains ON for
    * longer.
    */
-  bool m_queued_or_active{false};
+  Scrub::QueuedForRole m_queued_or_active{Scrub::QueuedForRole::none};
+
+  Scrub::QueuedForRole queued_for_role() const;
 
   eversion_t m_subset_last_update{};
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -548,6 +548,19 @@ sc::result ReplicaWaitUpdates::react(const ReplicaPushesUpd&)
   return discard_event();
 }
 
+/*
+ * Note that we reset both the state machine and the scrubber.
+ */
+sc::result ReplicaWaitUpdates::react(const IntervalEnded&)
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  dout(10) << "ReplicaWaitUpdates::react(const IntervalEnded&)"
+	      ": clearing stale replica state"
+	   << dendl;
+  scrbr->replica_handling_done();
+  return transit<NotActive>();
+}
+
 /**
  * the event poster is handling the scrubber reset
  */
@@ -591,6 +604,19 @@ sc::result ActiveReplica::react(const SchedReplica&)
   }
 
   return discard_event();
+}
+
+/*
+ * Note that we reset both the state machine and the scrubber.
+ */
+sc::result ActiveReplica::react(const IntervalEnded&)
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  dout(10) << "ActiveReplica::react(const IntervalEnded&)"
+	      ": clearing stale replica state"
+	   << dendl;
+  scrbr->replica_handling_done();
+  return transit<NotActive>();
 }
 
 /**

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -97,6 +97,9 @@ MEV(GotReplicas)
 /// internal - BuildMap preempted. Required, as detected within the ctor
 MEV(IntBmPreempted)
 
+/// stops any replica scrubbing, and resets FSM & scrubber
+MEV(IntervalEnded)
+
 MEV(InternalError)
 
 MEV(IntLocalMapDone)
@@ -369,9 +372,14 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ScrubMachine>,
 			    NamedSimply {
   explicit ReplicaWaitUpdates(my_context ctx);
   using reactions = mpl::list<sc::custom_reaction<ReplicaPushesUpd>,
+			      sc::custom_reaction<IntervalEnded>,
 			      sc::custom_reaction<FullReset>>;
 
   sc::result react(const ReplicaPushesUpd&);
+
+  /// stop the active scrubbing and reset everything
+  sc::result react(const IntervalEnded&);
+
   sc::result react(const FullReset&);
 };
 
@@ -379,9 +387,14 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ScrubMachine>,
 struct ActiveReplica : sc::state<ActiveReplica, ScrubMachine>, NamedSimply {
   explicit ActiveReplica(my_context ctx);
   using reactions = mpl::list<sc::custom_reaction<SchedReplica>,
+			      sc::custom_reaction<IntervalEnded>,
 			      sc::custom_reaction<FullReset>>;
 
   sc::result react(const SchedReplica&);
+
+  /// stop the active scrubbing and reset everything
+  sc::result react(const IntervalEnded&);
+
   sc::result react(const FullReset&);
 };
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -186,9 +186,8 @@ struct ScrubMachineListener {
   virtual void clear_reserving_now() = 0;
 
   /**
-   * Manipulate the 'I am being scrubbed now' Scrubber's flag
+   * clear the 'I am being scrubbed now' Scrubber's flag
    */
-  virtual void set_queued_or_active() = 0;
   virtual void clear_queued_or_active() = 0;
 
   /**

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -293,6 +293,10 @@ struct ScrubPgIF {
 
   virtual void set_op_parameters(const requested_scrub_t&) = 0;
 
+  /// stop any active scrubbing (on interval end) and unregister from
+  /// the OSD scrub queue
+  virtual void stop_active_scrubs() = 0;
+
   virtual void scrub_clear_state() = 0;
 
   virtual void handle_query_state(ceph::Formatter* f) = 0;
@@ -393,13 +397,10 @@ struct ScrubPgIF {
   virtual bool reserve_local() = 0;
 
   /**
-   * Register/de-register with the OSD scrub queue
-   *
-   * Following our status as Primary or replica.
+   * if activated as a Primary - register the scrub job with the OSD
+   * scrub queue
    */
-  virtual void on_primary_change(
-    std::string_view caller,
-    const requested_scrub_t& request_flags) = 0;
+  virtual void on_pg_activate(const requested_scrub_t& request_flags) = 0;
 
   /**
    * Recalculate the required scrub time.

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -41,6 +41,17 @@ enum class scrub_prio_t : bool { low_priority = false, high_priority = true };
 /// see ScrubPGgIF::m_current_token
 using act_token_t = uint32_t;
 
+/**
+ * The possible values of m_queued_or_active, the flag used to prevent
+ * a second scrub being initiated on a PG before the first one has been
+ * fully initialized or fully terminated. See the description of
+ * 'm_queued_or_active' for details.
+ * It is also used to identify the role this PG is to play when queued for
+ * scrubbing (as the actual state-machine state transition, whether to a
+ * Primary or to a replica related state, might not have happened yet).
+ */
+enum class QueuedForRole { none, primary, replica };
+
 /// "environment" preconditions affecting which PGs are eligible for scrubbing
 struct ScrubPreconds {
   bool allow_requested_repair_only{false};
@@ -269,7 +280,7 @@ struct ScrubPgIF {
    *
    * clear_queued_or_active() will also restart any blocked snaptrimming.
    */
-  virtual void set_queued_or_active() = 0;
+  virtual void set_queued_or_active(Scrub::QueuedForRole role_queued) = 0;
   virtual void clear_queued_or_active() = 0;
 
   /// are we waiting for resource reservation grants form our replicas?


### PR DESCRIPTION
Separating and clarifying the handling of interval termination, new interval starting, and configuration changes:

A primary PG now registers with its OSD for scrubbing only when fully activated: on_pg_activate() called from PG::on_activate();

When the interval ends, the PG is removed from the OSD queue by stop_active_scrubs(), called from start_peering_interval().

Configuration changes are still handled by update_scrub_job().

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

