### PR TITLE
ceph-volume: do not reject removable devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -798,8 +798,6 @@ def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys
             continue
         type_ = 'disk'
         holders = os.listdir(os.path.join(_sys_block_path, dev, 'holders'))
-        if get_file_contents(os.path.join(_sys_block_path, dev, 'removable')) == "1":
-            continue
         if holder_inner_loop():
             continue
         dm_dir_path = os.path.join(_sys_block_path, dev, 'dm')


### PR DESCRIPTION
https://github.com/ceph/ceph/commit/c7f017b21ade3762ba5b7b9688bed72c6b60dc0e introduced a behavior change given that ceph-volume used to accept removable devices.

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
