### PR TITLE
drive_group: fix limit filter in drive_selection.selector

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -128,6 +128,17 @@ class DriveSelection(object):
                 )
                 continue
 
+            if not disk.available and disk.ceph_device and disk.lvs:
+                other_osdspec_affinity = ''
+                for lv in disk.lvs:
+                    if lv['osdspec_affinity'] != self.spec.service_id:
+                        other_osdspec_affinity = lv['osdspec_affinity']
+                        break
+                if other_osdspec_affinity:
+                    logger.debug("{} is already used in spec {}, "
+                                 "skipping it.".format(disk.path, other_osdspec_affinity))
+                    continue
+
             if not self._has_mandatory_idents(disk):
                 logger.debug(
                     "Ignoring disk {}. Missing mandatory idents".format(

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -62,7 +62,7 @@ class Device(object):
                  sys_api=None,  # type: Optional[Dict[str, Any]]
                  available=None,  # type: Optional[bool]
                  rejected_reasons=None,  # type: Optional[List[str]]
-                 lvs=None,  # type: Optional[List[str]]
+                 lvs=None,  # type: Optional[List[Dict[str, str]]]
                  device_id=None,  # type: Optional[str]
                  lsm_data=None,  # type: Optional[Dict[str, Dict[str, str]]]
                  created=None,  # type: Optional[datetime.datetime]
@@ -124,7 +124,7 @@ class Device(object):
         return 'hdd' if self.sys_api["rotational"] == "1" else 'ssd'
 
     def __repr__(self) -> str:
-        device_desc: Dict[str, Union[str, List[str]]] = {
+        device_desc: Dict[str, Union[str, List[str], List[Dict[str, str]]]] = {
             'path': self.path if self.path is not None else 'unknown',
             'lvs': self.lvs if self.lvs else 'None',
             'available': str(self.available),


### PR DESCRIPTION
When multiple osd service specs with 'limit' filter are applied, the current logic makes the second service speec
try to pick devices that are already used by the first service spec.

Fixes: https://tracker.ceph.com/issues/58626

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
