### PR TITLE
osd: mClock recovery/backfill cost fixes

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -102,11 +102,11 @@ shows the resource control parameters set by the profile:
 +------------------------+-------------+--------+-------+
 |  Service Type          | Reservation | Weight | Limit |
 +========================+=============+========+=======+
-| client                 | 50%         | 2      | MAX   |
+| client                 | 60%         | 5      | MAX   |
 +------------------------+-------------+--------+-------+
-| background recovery    | 25%         | 1      | 100%  |
+| background recovery    | 20%         | 1      | 50%   |
 +------------------------+-------------+--------+-------+
-| background best-effort | 25%         | 2      | MAX   |
+| background best-effort | 20%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
 
 high_recovery_ops
@@ -122,9 +122,9 @@ parameters set by the profile:
 +========================+=============+========+=======+
 | client                 | 30%         | 1      | 80%   |
 +------------------------+-------------+--------+-------+
-| background recovery    | 60%         | 2      | 200%  |
+| background recovery    | 60%         | 2      | MAX   |
 +------------------------+-------------+--------+-------+
-| background best-effort | 1 (MIN)     | 2      | MAX   |
+| background best-effort | MIN         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
 
 balanced
@@ -141,9 +141,9 @@ within the OSD.
 +========================+=============+========+=======+
 | client                 | 40%         | 1      | 100%  |
 +------------------------+-------------+--------+-------+
-| background recovery    | 40%         | 1      | 150%  |
+| background recovery    | 40%         | 1      | 70%   |
 +------------------------+-------------+--------+-------+
-| background best-effort | 20%         | 2      | MAX   |
+| background best-effort | 20%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
 
 .. note:: Across the built-in profiles, internal background best-effort clients
@@ -184,27 +184,27 @@ config parameters cannot be modified when using any of the built-in profiles:
 
 Recovery/Backfill Options
 -------------------------
-The following recovery and backfill related Ceph options are set to new defaults
-for mClock:
+The following recovery and backfill related Ceph options are overridden to
+mClock defaults:
 
 - :confval:`osd_max_backfills`
 - :confval:`osd_recovery_max_active`
 - :confval:`osd_recovery_max_active_hdd`
 - :confval:`osd_recovery_max_active_ssd`
 
-The following table shows the new mClock defaults. This is done to maximize the
+The following table shows the mClock defaults. This is done to maximize the
 impact of the built-in profile:
 
 +----------------------------------------+------------------+----------------+
 |  Config Option                         | Original Default | mClock Default |
 +========================================+==================+================+
-| :confval:`osd_max_backfills`           | 1                | 10             |
+| :confval:`osd_max_backfills`           | 1                | 3              |
 +----------------------------------------+------------------+----------------+
 | :confval:`osd_recovery_max_active`     | 0                | 0              |
 +----------------------------------------+------------------+----------------+
-| :confval:`osd_recovery_max_active_hdd` | 3                | 10             |
+| :confval:`osd_recovery_max_active_hdd` | 3                | 3              |
 +----------------------------------------+------------------+----------------+
-| :confval:`osd_recovery_max_active_ssd` | 10               | 20             |
+| :confval:`osd_recovery_max_active_ssd` | 10               | 10             |
 +----------------------------------------+------------------+----------------+
 
 The above mClock defaults, can be modified if necessary by enabling
@@ -293,15 +293,17 @@ command can be used:
 
 After switching to the *custom* profile, the desired mClock configuration
 option may be modified. For example, to change the client reservation IOPS
-allocation for a specific OSD (say osd.0), the following command can be used:
+ratio for a specific OSD (say osd.0) to 0.5 (or 50%), the following command
+can be used:
 
   .. prompt:: bash #
 
-    ceph config set osd.0 osd_mclock_scheduler_client_res 3000
+    ceph config set osd.0 osd_mclock_scheduler_client_res 0.5
 
-.. important:: Care must be taken to change the reservations of other services like
-   recovery and background best effort accordingly to ensure that the sum of the
-   reservations do not exceed the maximum IOPS capacity of the OSD.
+.. important:: Care must be taken to change the reservations of other services
+   like recovery and background best effort accordingly to ensure that the sum
+   of the reservations do not exceed the maximum proportion (1.0) of the IOPS
+   capacity of the OSD.
 
 .. tip::  The reservation and limit parameter allocations are per-shard based on
    the type of backing device (HDD/SSD) under the OSD. See
@@ -669,12 +671,8 @@ mClock Config Options
 .. confval:: osd_mclock_profile
 .. confval:: osd_mclock_max_capacity_iops_hdd
 .. confval:: osd_mclock_max_capacity_iops_ssd
-.. confval:: osd_mclock_cost_per_io_usec
-.. confval:: osd_mclock_cost_per_io_usec_hdd
-.. confval:: osd_mclock_cost_per_io_usec_ssd
-.. confval:: osd_mclock_cost_per_byte_usec
-.. confval:: osd_mclock_cost_per_byte_usec_hdd
-.. confval:: osd_mclock_cost_per_byte_usec_ssd
+.. confval:: osd_mclock_max_sequential_bandwidth_hdd
+.. confval:: osd_mclock_max_sequential_bandwidth_ssd
 .. confval:: osd_mclock_force_run_benchmark_on_init
 .. confval:: osd_mclock_skip_benchmark
 .. confval:: osd_mclock_override_recovery_settings

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -17,6 +17,9 @@ the QoS related parameters:
 * total capacity (IOPS) of each OSD (determined automatically -
   See `OSD Capacity Determination (Automated)`_)
 
+* the max sequential bandwidth capacity (MiB/s) of each OSD -
+  See *osd_mclock_max_sequential_bandwidth_[hdd|ssd]* option
+
 * an mclock profile type to enable
 
 Using the settings in the specified profile, an OSD determines and applies the
@@ -35,15 +38,15 @@ Each service can be considered as a type of client from mclock's perspective.
 Depending on the type of requests handled, mclock clients are classified into
 the buckets as shown in the table below,
 
-+------------------------+----------------------------------------------------+
-|  Client Type           | Request Types                                      |
-+========================+====================================================+
-| Client                 | I/O requests issued by external clients of Ceph    |
-+------------------------+----------------------------------------------------+
-| Background recovery    | Internal recovery/backfill requests                |
-+------------------------+----------------------------------------------------+
-| Background best-effort | Internal scrub, snap trim and PG deletion requests |
-+------------------------+----------------------------------------------------+
++------------------------+--------------------------------------------------------------+
+|  Client Type           | Request Types                                                |
++========================+==============================================================+
+| Client                 | I/O requests issued by external clients of Ceph              |
++------------------------+--------------------------------------------------------------+
+| Background recovery    | Internal recovery requests                                   |
++------------------------+--------------------------------------------------------------+
+| Background best-effort | Internal backfill, scrub, snap trim and PG deletion requests |
++------------------------+--------------------------------------------------------------+
 
 The mclock profiles allocate parameters like reservation, weight and limit
 (see :ref:`dmclock-qos`) differently for each client type. The next sections
@@ -81,32 +84,54 @@ Built-in Profiles
 -----------------
 Users can choose between the following built-in profile types:
 
-.. note:: The values mentioned in the tables below represent the percentage
+.. note:: The values mentioned in the tables below represent the proportion
           of the total IOPS capacity of the OSD allocated for the service type.
 
-By default, the *high_client_ops* profile is enabled to ensure that a larger
-chunk of the bandwidth allocation goes to client ops. Background recovery ops
-are given lower allocation (and therefore take a longer time to complete). But
-there might be instances that necessitate giving higher allocations to either
-client ops or recovery ops. In order to deal with such a situation, the
-alternate built-in profiles may be enabled by following the steps mentioned
-in next sections.
+* balanced (default)
+* high_client_ops
+* high_recovery_ops
 
-high_client_ops (*default*)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This profile optimizes client performance over background activities by
-allocating more reservation and limit to client operations as compared to
-background operations in the OSD. This profile is enabled by default. The table
-shows the resource control parameters set by the profile:
+balanced (*default*)
+^^^^^^^^^^^^^^^^^^^^
+The *balanced* profile is the default mClock profile. This profile allocates
+equal reservation/priority to client operations and background recovery
+operations. Background best-effort ops are given lower reservation and therefore
+take a longer time to complete when are are competing operations. This profile
+helps meet the normal/steady-state requirements of the cluster. This is the
+case when external client performance requirement is not critical and there are
+other background operations that still need attention within the OSD.
+
+But there might be instances that necessitate giving higher allocations to either
+client ops or recovery ops. In order to deal with such a situation, the alternate
+built-in profiles may be enabled by following the steps mentioned in next sections.
 
 +------------------------+-------------+--------+-------+
 |  Service Type          | Reservation | Weight | Limit |
 +========================+=============+========+=======+
-| client                 | 60%         | 5      | MAX   |
+| client                 | 50%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
-| background recovery    | 20%         | 1      | 50%   |
+| background recovery    | 50%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
-| background best-effort | 20%         | 1      | MAX   |
+| background best-effort | MIN         | 1      | 90%   |
++------------------------+-------------+--------+-------+
+
+high_client_ops
+^^^^^^^^^^^^^^^
+This profile optimizes client performance over background activities by
+allocating more reservation and limit to client operations as compared to
+background operations in the OSD. This profile, for example, may be enabled
+to provide the needed performance for I/O intensive applications for a
+sustained period of time at the cost of slower recoveries. The table shows
+the resource control parameters set by the profile:
+
++------------------------+-------------+--------+-------+
+|  Service Type          | Reservation | Weight | Limit |
++========================+=============+========+=======+
+| client                 | 60%         | 2      | MAX   |
++------------------------+-------------+--------+-------+
+| background recovery    | 40%         | 1      | MAX   |
++------------------------+-------------+--------+-------+
+| background best-effort | MIN         | 1      | 70%   |
 +------------------------+-------------+--------+-------+
 
 high_recovery_ops
@@ -120,34 +145,16 @@ parameters set by the profile:
 +------------------------+-------------+--------+-------+
 |  Service Type          | Reservation | Weight | Limit |
 +========================+=============+========+=======+
-| client                 | 30%         | 1      | 80%   |
+| client                 | 30%         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
-| background recovery    | 60%         | 2      | MAX   |
+| background recovery    | 70%         | 2      | MAX   |
 +------------------------+-------------+--------+-------+
 | background best-effort | MIN         | 1      | MAX   |
 +------------------------+-------------+--------+-------+
 
-balanced
-^^^^^^^^
-This profile allocates equal reservation to client I/O operations and background
-recovery operations. This means that equal I/O resources are allocated to both
-external and background recovery operations. This profile, for example, may be
-enabled by an administrator when external client performance requirement is not
-critical and there are other background operations that still need attention
-within the OSD.
-
-+------------------------+-------------+--------+-------+
-|  Service Type          | Reservation | Weight | Limit |
-+========================+=============+========+=======+
-| client                 | 40%         | 1      | 100%  |
-+------------------------+-------------+--------+-------+
-| background recovery    | 40%         | 1      | 70%   |
-+------------------------+-------------+--------+-------+
-| background best-effort | 20%         | 1      | MAX   |
-+------------------------+-------------+--------+-------+
-
 .. note:: Across the built-in profiles, internal background best-effort clients
-          of mclock include "scrub", "snap trim", and "pg deletion" operations.
+          of mclock include "backfill", "scrub", "snap trim", and "pg deletion"
+          operations.
 
 
 Custom Profile
@@ -184,6 +191,10 @@ config parameters cannot be modified when using any of the built-in profiles:
 
 Recovery/Backfill Options
 -------------------------
+.. warning:: The recommendation is to not change these options as the built-in
+   profiles are optimized based on them. Changing these defaults can result in
+   unexpected performance outcomes.
+
 The following recovery and backfill related Ceph options are overridden to
 mClock defaults:
 
@@ -192,13 +203,14 @@ mClock defaults:
 - :confval:`osd_recovery_max_active_hdd`
 - :confval:`osd_recovery_max_active_ssd`
 
-The following table shows the mClock defaults. This is done to maximize the
-impact of the built-in profile:
+The following table shows the mClock defaults which is the same as the current
+defaults. This is done to maximize the performance of the foreground (client)
+operations:
 
 +----------------------------------------+------------------+----------------+
 |  Config Option                         | Original Default | mClock Default |
 +========================================+==================+================+
-| :confval:`osd_max_backfills`           | 1                | 3              |
+| :confval:`osd_max_backfills`           | 1                | 1              |
 +----------------------------------------+------------------+----------------+
 | :confval:`osd_recovery_max_active`     | 0                | 0              |
 +----------------------------------------+------------------+----------------+
@@ -207,7 +219,7 @@ impact of the built-in profile:
 | :confval:`osd_recovery_max_active_ssd` | 10               | 10             |
 +----------------------------------------+------------------+----------------+
 
-The above mClock defaults, can be modified if necessary by enabling
+The above mClock defaults, can be modified only if necessary by enabling
 :confval:`osd_mclock_override_recovery_settings` (default: false). The
 steps for this is discussed in the
 `Steps to Modify mClock Max Backfills/Recovery Limits`_ section.
@@ -242,8 +254,8 @@ all its clients.
 Steps to Enable mClock Profile
 ==============================
 
-As already mentioned, the default mclock profile is set to *high_client_ops*.
-The other values for the built-in profiles include *balanced* and
+As already mentioned, the default mclock profile is set to *balanced*.
+The other values for the built-in profiles include *high_client_ops* and
 *high_recovery_ops*.
 
 If there is a requirement to change the default profile, then the option

--- a/qa/config/rados.yaml
+++ b/qa/config/rados.yaml
@@ -8,5 +8,6 @@ overrides:
         osd debug verify cached snaps: true
         bluestore zero block detection: true
         osd mclock override recovery settings: true
+        osd mclock profile: high_recovery_ops
       mon:
         mon scrub interval: 300

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -654,6 +654,7 @@ function run_osd() {
     ceph_args+=" --osd-max-object-name-len=460"
     ceph_args+=" --osd-max-object-namespace-len=64"
     ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features=*"
+    ceph_args+=" --osd-mclock-profile=high_recovery_ops"
     ceph_args+=" "
     ceph_args+="$@"
     mkdir -p $osd_data
@@ -864,6 +865,7 @@ function activate_osd() {
     ceph_args+=" --osd-max-object-name-len=460"
     ceph_args+=" --osd-max-object-namespace-len=64"
     ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features=*"
+    ceph_args+=" --osd-mclock-profile=high_recovery_ops"
     ceph_args+=" "
     ceph_args+="$@"
     mkdir -p $osd_data

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -26,7 +26,6 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
     CEPH_ARGS+="--osd_mclock_override_recovery_settings=true "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}

--- a/qa/standalone/osd-backfill/osd-backfill-space.sh
+++ b/qa/standalone/osd-backfill/osd-backfill-space.sh
@@ -28,7 +28,6 @@ function run() {
     CEPH_ARGS+="--osd_min_pg_log_entries=5 --osd_max_pg_log_entries=10 "
     CEPH_ARGS+="--fake_statfs_for_testing=3686400 "
     CEPH_ARGS+="--osd_max_backfills=10 "
-    CEPH_ARGS+="--osd_mclock_profile=high_recovery_ops "
     CEPH_ARGS+="--osd_mclock_override_recovery_settings=true "
     export objects=600
     export poolprefix=test

--- a/qa/standalone/osd-backfill/osd-backfill-stats.sh
+++ b/qa/standalone/osd-backfill/osd-backfill-stats.sh
@@ -27,8 +27,6 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     CEPH_ARGS+="--osd_min_pg_log_entries=5 --osd_max_pg_log_entries=10 "
-    # Use "high_recovery_ops" profile if mclock_scheduler is enabled.
-    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
     export margin=10
     export objects=200
     export poolname=test

--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -28,8 +28,6 @@ function run() {
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     # so we will not force auth_log_shard to be acting_primary
     CEPH_ARGS+="--osd_force_auth_primary_missing_objects=1000000 "
-    # Use "high_recovery_ops" profile if mclock_scheduler is enabled.
-    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
     export margin=10
     export objects=200
     export poolname=test

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -29,7 +29,6 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
 
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}

--- a/qa/standalone/osd/repeer-on-acting-back.sh
+++ b/qa/standalone/osd/repeer-on-acting-back.sh
@@ -34,7 +34,6 @@ function run() {
     CEPH_ARGS+="--osd_force_auth_primary_missing_objects=1000000 "
     # use small pg_log settings, so we always do backfill instead of recovery
     CEPH_ARGS+="--osd_min_pg_log_entries=$loglen --osd_max_pg_log_entries=$loglen --osd_pg_log_trim_min=$trim "
-    CEPH_ARGS+="--osd_mclock_profile=high_recovery_ops "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1172,7 +1172,7 @@ options:
     parameters [*reservation, weight, limit*] and some Ceph
     configuration parameters are set transparently. Note that the
     above does not apply for the *custom* profile.
-  default: high_client_ops
+  default: balanced
   see_also:
   - osd_op_queue
   enum_values:

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1100,7 +1100,7 @@ options:
     QoS calculations. Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: The maximum sequential bandwidth in bytes/second to consider for the
     OSD (for solid state media)
-  default: 750_M
+  default: 1200_M
   flags:
   - runtime
 - name: osd_mclock_max_capacity_iops_hdd

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -951,12 +951,17 @@ options:
   - debug_random
   with_legacy: true
 - name: osd_mclock_scheduler_client_res
-  type: uint
+  type: float
   level: advanced
-  desc: IO proportion reserved for each client (default)
+  desc: IO proportion reserved for each client (default). The default value
+    of 0 specifies the lowest possible reservation. Any value greater than
+    0 and up to 1.0 specifies the minimum IO proportion to reserve for each
+    client in terms of a fraction of the OSD's maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO proportion reserved for each client (default).
-  default: 1
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_client_wgt
@@ -969,21 +974,34 @@ options:
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_client_lim
-  type: uint
+  type: float
   level: advanced
-  desc: IO limit for each client (default) over reservation
+  desc: IO limit for each client (default) over reservation. The default
+    value of 0 specifies no limit enforcement, which means each client can
+    use the maximum possible IOPS capacity of the OSD. Any value greater
+    than 0 and up to 1.0 specifies the upper IO limit over reservation
+    that each client receives in terms of a fraction of the OSD's
+    maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO limit for each client (default) over reservation.
-  default: 999999
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_recovery_res
-  type: uint
+  type: float
   level: advanced
-  desc: IO proportion reserved for background recovery (default)
+  desc: IO proportion reserved for background recovery (default). The
+    default value of 0 specifies the lowest possible reservation. Any value
+    greater than 0 and up to 1.0 specifies the minimum IO proportion to
+    reserve for background recovery operations in terms of a fraction of
+    the OSD's maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO proportion reserved for background recovery (default).
-  default: 1
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_recovery_wgt
@@ -996,21 +1014,34 @@ options:
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_recovery_lim
-  type: uint
+  type: float
   level: advanced
-  desc: IO limit for background recovery over reservation
+  desc: IO limit for background recovery over reservation. The default
+    value of 0 specifies no limit enforcement, which means background
+    recovery operation can use the maximum possible IOPS capacity of the
+    OSD. Any value greater than 0 and up to 1.0 specifies the upper IO
+    limit over reservation that background recovery operation receives in
+    terms of a fraction of the OSD's maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO limit for background recovery over reservation.
-  default: 999999
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_best_effort_res
-  type: uint
+  type: float
   level: advanced
-  desc: IO proportion reserved for background best_effort (default)
+  desc: IO proportion reserved for background best_effort (default). The
+    default value of 0 specifies the lowest possible reservation. Any value
+    greater than 0 and up to 1.0 specifies the minimum IO proportion to
+    reserve for background best_effort operations in terms of a fraction
+    of the OSD's maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO proportion reserved for background best_effort (default).
-  default: 1
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_best_effort_wgt
@@ -1023,12 +1054,19 @@ options:
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_background_best_effort_lim
-  type: uint
+  type: float
   level: advanced
-  desc: IO limit for background best_effort over reservation
+  desc: IO limit for background best_effort over reservation. The default
+    value of 0 specifies no limit enforcement, which means background
+    best_effort operation can use the maximum possible IOPS capacity of the
+    OSD. Any value greater than 0 and up to 1.0 specifies the upper IO
+    limit over reservation that background best_effort operation receives
+    in terms of a fraction of the OSD's maximum IOPS capacity.
   long_desc: Only considered for osd_op_queue = mclock_scheduler
   fmt_desc: IO limit for background best_effort over reservation.
-  default: 999999
+  default: 0
+  min: 0
+  max: 1.0
   see_also:
   - osd_op_queue
 - name: osd_mclock_scheduler_anticipation_timeout
@@ -1037,106 +1075,57 @@ options:
   desc: mclock anticipation timeout in seconds
   long_desc: the amount of time that mclock waits until the unused resource is forfeited
   default: 0
-- name: osd_mclock_cost_per_io_usec
-  type: float
-  level: dev
-  desc: Cost per IO in microseconds to consider per OSD (overrides _ssd and _hdd if
-    non-zero)
-  long_desc: This option specifies the cost factor to consider in usec per OSD. This
-    is considered by the mclock scheduler to set an additional cost factor in QoS
-    calculations. Only considered for osd_op_queue = mclock_scheduler
-  fmt_desc: Cost per IO in microseconds to consider per OSD (overrides _ssd
-    and _hdd if non-zero)
-  default: 0
+- name: osd_mclock_max_sequential_bandwidth_hdd
+  type: size
+  level: basic
+  desc: The maximum sequential bandwidth in bytes/second of the OSD (for
+    rotational media)
+  long_desc: This option specifies the maximum sequential bandwidth to consider
+    for an OSD whose underlying device type is rotational media. This is
+    considered by the mclock scheduler to derive the cost factor to be used in
+    QoS calculations. Only considered for osd_op_queue = mclock_scheduler
+  fmt_desc: The maximum sequential bandwidth in bytes/second to consider for the
+    OSD (for rotational media)
+  default: 150_M
   flags:
   - runtime
-- name: osd_mclock_cost_per_io_usec_hdd
-  type: float
-  level: dev
-  desc: Cost per IO in microseconds to consider per OSD (for rotational media)
-  long_desc: This option specifies the cost factor to consider in usec per OSD for
-    rotational device type. This is considered by the mclock_scheduler to set an additional
-    cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler
-  fmt_desc: Cost per IO in microseconds to consider per OSD (for rotational
-    media)
-  default: 11400
-  flags:
-  - runtime
-- name: osd_mclock_cost_per_io_usec_ssd
-  type: float
-  level: dev
-  desc: Cost per IO in microseconds to consider per OSD (for solid state media)
-  long_desc: This option specifies the cost factor to consider in usec per OSD for
-    solid state device type. This is considered by the mclock_scheduler to set an
-    additional cost factor in QoS calculations. Only considered for osd_op_queue =
-    mclock_scheduler
-  fmt_desc: Cost per IO in microseconds to consider per OSD (for solid state
-    media)
-  default: 50
-  flags:
-  - runtime
-- name: osd_mclock_cost_per_byte_usec
-  type: float
-  level: dev
-  desc: Cost per byte in microseconds to consider per OSD (overrides _ssd and _hdd
-    if non-zero)
-  long_desc: This option specifies the cost per byte to consider in microseconds per
-    OSD. This is considered by the mclock scheduler to set an additional cost factor
-    in QoS calculations. Only considered for osd_op_queue = mclock_scheduler
-  fmt_desc: Cost per byte in microseconds to consider per OSD (overrides _ssd
-    and _hdd if non-zero)
-  default: 0
-  flags:
-  - runtime
-- name: osd_mclock_cost_per_byte_usec_hdd
-  type: float
-  level: dev
-  desc: Cost per byte in microseconds to consider per OSD (for rotational media)
-  long_desc: This option specifies the cost per byte to consider in microseconds per
-    OSD for rotational device type. This is considered by the mclock_scheduler to
-    set an additional cost factor in QoS calculations. Only considered for osd_op_queue
-    = mclock_scheduler
-  fmt_desc: Cost per byte in microseconds to consider per OSD (for rotational
-    media)
-  default: 2.6
-  flags:
-  - runtime
-- name: osd_mclock_cost_per_byte_usec_ssd
-  type: float
-  level: dev
-  desc: Cost per byte in microseconds to consider per OSD (for solid state media)
-  long_desc: This option specifies the cost per byte to consider in microseconds per
-    OSD for solid state device type. This is considered by the mclock_scheduler to
-    set an additional cost factor in QoS calculations. Only considered for osd_op_queue
-    = mclock_scheduler
-  fmt_desc: Cost per byte in microseconds to consider per OSD (for solid state
-    media)
-  default: 0.011
+- name: osd_mclock_max_sequential_bandwidth_ssd
+  type: size
+  level: basic
+  desc: The maximum sequential bandwidth in bytes/second of the OSD (for
+    solid state media)
+  long_desc: This option specifies the maximum sequential bandwidth to consider
+    for an OSD whose underlying device type is solid state media. This is
+    considered by the mclock scheduler to derive the cost factor to be used in
+    QoS calculations. Only considered for osd_op_queue = mclock_scheduler
+  fmt_desc: The maximum sequential bandwidth in bytes/second to consider for the
+    OSD (for solid state media)
+  default: 750_M
   flags:
   - runtime
 - name: osd_mclock_max_capacity_iops_hdd
   type: float
   level: basic
-  desc: Max IOPs capacity (at 4KiB block size) to consider per OSD (for rotational
-    media)
-  long_desc: This option specifies the max OSD capacity in iops per OSD. Helps in
-    QoS calculations when enabling a dmclock profile. Only considered for osd_op_queue
-    = mclock_scheduler
-  fmt_desc: Max IOPS capacity (at 4KiB block size) to consider per OSD (for
-    rotational media)
+  desc: Max random write IOPS capacity (at 4KiB block size) to consider per OSD
+    (for rotational media)
+  long_desc: This option specifies the max OSD random write IOPS capacity per
+    OSD. Contributes in QoS calculations when enabling a dmclock profile. Only
+    considered for osd_op_queue = mclock_scheduler
+  fmt_desc: Max random write IOPS capacity (at 4 KiB block size) to consider per
+    OSD (for rotational media)
   default: 315
   flags:
   - runtime
 - name: osd_mclock_max_capacity_iops_ssd
   type: float
   level: basic
-  desc: Max IOPs capacity (at 4KiB block size) to consider per OSD (for solid state
-    media)
-  long_desc: This option specifies the max OSD capacity in iops per OSD. Helps in
-    QoS calculations when enabling a dmclock profile. Only considered for osd_op_queue
-    = mclock_scheduler
-  fmt_desc: Max IOPS capacity (at 4KiB block size) to consider per OSD (for
-    solid state media)
+  desc: Max random write IOPS capacity (at 4 KiB block size) to consider per OSD
+    (for solid state media)
+  long_desc: This option specifies the max OSD random write IOPS capacity per
+    OSD. Contributes in QoS calculations when enabling a dmclock profile. Only
+    considered for osd_op_queue = mclock_scheduler
+  fmt_desc: Max random write IOPS capacity (at 4 KiB block size) to consider per
+    OSD (for solid state media)
   default: 21500
   flags:
   - runtime

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9991,7 +9991,7 @@ bool OSD::maybe_override_options_for_qos(const std::set<std::string> *changed)
       {"osd_recovery_max_active", 0},
       {"osd_recovery_max_active_hdd", 3},
       {"osd_recovery_max_active_ssd", 10},
-      {"osd_max_backfills", 3},
+      {"osd_max_backfills", 1},
     };
 
     // Check if we were called because of a configuration change

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1697,7 +1697,8 @@ void OSDService::enqueue_front(OpSchedulerItem&& qi)
 void OSDService::queue_recovery_context(
   PG *pg,
   GenContext<ThreadPool::TPHandle&> *c,
-  uint64_t cost)
+  uint64_t cost,
+  int priority)
 {
   epoch_t e = get_osdmap_epoch();
 
@@ -1717,7 +1718,7 @@ void OSDService::queue_recovery_context(
   enqueue_back(
     OpSchedulerItem(
       unique_ptr<OpSchedulerItem::OpQueueable>(
-	new PGRecoveryContext(pg->get_pgid(), c, e)),
+	new PGRecoveryContext(pg->get_pgid(), c, e, priority)),
       cost_for_queue,
       cct->_conf->osd_recovery_priority,
       ceph_clock_now(),
@@ -2063,7 +2064,8 @@ void OSDService::_queue_for_recovery(
 	new PGRecovery(
 	  p.pg->get_pgid(),
 	  p.epoch_queued,
-          reserved_pushes)),
+          reserved_pushes,
+	  p.priority)),
       cost_for_queue,
       cct->_conf->osd_recovery_priority,
       ceph_clock_now(),
@@ -9390,7 +9392,7 @@ unsigned OSDService::get_target_pg_log_entries() const
 }
 
 void OSD::do_recovery(
-  PG *pg, epoch_t queued, uint64_t reserved_pushes,
+  PG *pg, epoch_t queued, uint64_t reserved_pushes, int priority,
   ThreadPool::TPHandle &handle)
 {
   uint64_t started = 0;
@@ -9407,13 +9409,14 @@ void OSD::do_recovery(
     std::lock_guard l(service.sleep_lock);
     if (recovery_sleep > 0 && service.recovery_needs_sleep) {
       PGRef pgref(pg);
-      auto recovery_requeue_callback = new LambdaContext([this, pgref, queued, reserved_pushes](int r) {
+      auto recovery_requeue_callback = new LambdaContext(
+	[this, pgref, queued, reserved_pushes, priority](int r) {
         dout(20) << "do_recovery wake up at "
                  << ceph_clock_now()
 	         << ", re-queuing recovery" << dendl;
 	std::lock_guard l(service.sleep_lock);
         service.recovery_needs_sleep = false;
-        service.queue_recovery_after_sleep(pgref.get(), queued, reserved_pushes);
+        service.queue_recovery_after_sleep(pgref.get(), queued, reserved_pushes, priority);
       });
 
       // This is true for the first recovery op and when the previous recovery op

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10052,17 +10052,28 @@ bool OSD::maybe_override_options_for_qos(const std::set<std::string> *changed)
         }
       }
     } else { // if (changed != nullptr) (osd boot-up)
-      // Override the default recovery max active and max backfills to
-      // higher values based on the type of backing device (hdd/ssd).
-      // This section is executed only during osd boot-up.
+      /**
+       * This section is executed only during osd boot-up.
+       * Override the default recovery max active (hdd & ssd) and max backfills
+       * config options to either the mClock defaults or retain their respective
+       * overridden values before the osd was restarted.
+       */
       for (auto opt : recovery_qos_defaults) {
+        /**
+         * Note: set_val_default doesn't overwrite an option if it was earlier
+         * set at a config level greater than CONF_DEFAULT. It doesn't return
+         * a status. With get_val(), the config subsystem is guaranteed to
+         * either return the overridden value (if any) or the default value.
+         */
         cct->_conf.set_val_default(opt.first, std::to_string(opt.second));
+        auto opt_val = cct->_conf.get_val<uint64_t>(opt.first);
+        dout(1) << __func__ << " "
+                << opt.first << " set to " << opt_val
+                << dendl;
         if (opt.first == "osd_max_backfills") {
-          service.local_reserver.set_max(opt.second);
-          service.remote_reserver.set_max(opt.second);
+          service.local_reserver.set_max(opt_val);
+          service.remote_reserver.set_max(opt_val);
         }
-        dout(1) << __func__ << " Set default value for " << opt.first
-                << " to " << opt.second << dendl;
       }
     }
     return true;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9565,8 +9565,7 @@ void OSD::enqueue_op(spg_t pg, OpRequestRef&& op, epoch_t epoch)
 
   op->mark_queued_for_pg();
   logger->tinc(l_osd_op_before_queue_op_lat, latency);
-  if (type == MSG_OSD_PG_PUSH ||
-      type == MSG_OSD_PG_PUSH_REPLY) {
+  if (PGRecoveryMsg::is_recovery_msg(op)) {
     op_shardedwq.queue(
       OpSchedulerItem(
         unique_ptr<OpSchedulerItem::OpQueueable>(new PGRecoveryMsg(pg, std::move(op))),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9987,9 +9987,9 @@ bool OSD::maybe_override_options_for_qos(const std::set<std::string> *changed)
       !unsupported_objstore_for_qos()) {
     static const std::map<std::string, uint64_t> recovery_qos_defaults {
       {"osd_recovery_max_active", 0},
-      {"osd_recovery_max_active_hdd", 10},
-      {"osd_recovery_max_active_ssd", 20},
-      {"osd_max_backfills", 10},
+      {"osd_recovery_max_active_hdd", 3},
+      {"osd_recovery_max_active_ssd", 10},
+      {"osd_max_backfills", 3},
     };
 
     // Check if we were called because of a configuration change

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -11098,9 +11098,6 @@ void OSD::ShardedOpWQ::_enqueue(OpSchedulerItem&& item) {
 
   OSDShard* sdata = osd->shards[shard_index];
   assert (NULL != sdata);
-  if (sdata->get_scheduler_type() == "mClockScheduler") {
-    item.maybe_set_is_qos_item();
-  }
 
   dout(20) << __func__ << " " << item << dendl;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1567,6 +1567,7 @@ protected:
   friend class ceph::osd::scheduler::PGOpItem;
   friend class ceph::osd::scheduler::PGPeeringItem;
   friend class ceph::osd::scheduler::PGRecovery;
+  friend class ceph::osd::scheduler::PGRecoveryContext;
   friend class ceph::osd::scheduler::PGRecoveryMsg;
   friend class ceph::osd::scheduler::PGDelete;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -509,7 +509,8 @@ public:
   AsyncReserver<spg_t, Finisher> snap_reserver;
   void queue_recovery_context(PG *pg,
                               GenContext<ThreadPool::TPHandle&> *c,
-                              uint64_t cost);
+                              uint64_t cost,
+			      int priority);
   void queue_for_snap_trim(PG *pg);
   void queue_for_scrub(PG* pg, Scrub::scrub_prio_t with_priority);
 
@@ -589,6 +590,7 @@ private:
     const epoch_t epoch_queued;
     PGRef pg;
     const uint64_t cost_per_object;
+    const int priority;
   };
   std::list<pg_awaiting_throttle_t> awaiting_throttle;
 
@@ -651,25 +653,31 @@ public:
   unsigned get_target_pg_log_entries() const;
 
   // delayed pg activation
-  void queue_for_recovery(PG *pg, uint64_t cost_per_object) {
+  void queue_for_recovery(
+    PG *pg, uint64_t cost_per_object,
+    int priority) {
     std::lock_guard l(recovery_lock);
 
     if (pg->is_forced_recovery_or_backfill()) {
       awaiting_throttle.emplace_front(
         pg_awaiting_throttle_t{
-          pg->get_osdmap()->get_epoch(), pg, cost_per_object});
+          pg->get_osdmap()->get_epoch(), pg, cost_per_object, priority});
     } else {
       awaiting_throttle.emplace_back(
         pg_awaiting_throttle_t{
-          pg->get_osdmap()->get_epoch(), pg, cost_per_object});
+          pg->get_osdmap()->get_epoch(), pg, cost_per_object, priority});
     }
     _maybe_queue_recovery();
   }
-  void queue_recovery_after_sleep(PG *pg, epoch_t queued, uint64_t reserved_pushes) {
+  void queue_recovery_after_sleep(
+    PG *pg, epoch_t queued, uint64_t reserved_pushes,
+    int priority) {
     std::lock_guard l(recovery_lock);
     // Send cost as 1 in pg_awaiting_throttle_t below. The cost is ignored
     // as this path is only applicable for WeightedPriorityQueue scheduler.
-    _queue_for_recovery(pg_awaiting_throttle_t{queued, pg, 1}, reserved_pushes);
+    _queue_for_recovery(
+      pg_awaiting_throttle_t{queued, pg, 1, priority},
+      reserved_pushes);
   }
 
   void queue_check_readable(spg_t spgid,
@@ -1875,6 +1883,7 @@ protected:
 
   // -- pg recovery --
   void do_recovery(PG *pg, epoch_t epoch_queued, uint64_t pushes_reserved,
+		   int priority,
 		   ThreadPool::TPHandle &handle);
 
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -507,7 +507,9 @@ public:
   void send_pg_created();
 
   AsyncReserver<spg_t, Finisher> snap_reserver;
-  void queue_recovery_context(PG *pg, GenContext<ThreadPool::TPHandle&> *c);
+  void queue_recovery_context(PG *pg,
+                              GenContext<ThreadPool::TPHandle&> *c,
+                              uint64_t cost);
   void queue_for_snap_trim(PG *pg);
   void queue_for_scrub(PG* pg, Scrub::scrub_prio_t with_priority);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -584,7 +584,13 @@ public:
 private:
   // -- pg recovery and associated throttling --
   ceph::mutex recovery_lock = ceph::make_mutex("OSDService::recovery_lock");
-  std::list<std::pair<epoch_t, PGRef> > awaiting_throttle;
+
+  struct pg_awaiting_throttle_t {
+    const epoch_t epoch_queued;
+    PGRef pg;
+    const uint64_t cost_per_object;
+  };
+  std::list<pg_awaiting_throttle_t> awaiting_throttle;
 
   /// queue a scrub-related message for a PG
   template <class MSG_TYPE>
@@ -607,8 +613,7 @@ private:
 #endif
   bool _recover_now(uint64_t *available_pushes);
   void _maybe_queue_recovery();
-  void _queue_for_recovery(
-    std::pair<epoch_t, PGRef> p, uint64_t reserved_pushes);
+  void _queue_for_recovery(pg_awaiting_throttle_t p, uint64_t reserved_pushes);
 public:
   void start_recovery_op(PG *pg, const hobject_t& soid);
   void finish_recovery_op(PG *pg, const hobject_t& soid, bool dequeue);
@@ -639,26 +644,32 @@ public:
     std::lock_guard l(recovery_lock);
     awaiting_throttle.remove_if(
       [pg](decltype(awaiting_throttle)::const_reference awaiting ) {
-	return awaiting.second.get() == pg;
+        return awaiting.pg.get() == pg;
       });
   }
 
   unsigned get_target_pg_log_entries() const;
 
   // delayed pg activation
-  void queue_for_recovery(PG *pg) {
+  void queue_for_recovery(PG *pg, uint64_t cost_per_object) {
     std::lock_guard l(recovery_lock);
 
     if (pg->is_forced_recovery_or_backfill()) {
-      awaiting_throttle.push_front(std::make_pair(pg->get_osdmap()->get_epoch(), pg));
+      awaiting_throttle.emplace_front(
+        pg_awaiting_throttle_t{
+          pg->get_osdmap()->get_epoch(), pg, cost_per_object});
     } else {
-      awaiting_throttle.push_back(std::make_pair(pg->get_osdmap()->get_epoch(), pg));
+      awaiting_throttle.emplace_back(
+        pg_awaiting_throttle_t{
+          pg->get_osdmap()->get_epoch(), pg, cost_per_object});
     }
     _maybe_queue_recovery();
   }
   void queue_recovery_after_sleep(PG *pg, epoch_t queued, uint64_t reserved_pushes) {
     std::lock_guard l(recovery_lock);
-    _queue_for_recovery(std::make_pair(queued, pg), reserved_pushes);
+    // Send cost as 1 in pg_awaiting_throttle_t below. The cost is ignored
+    // as this path is only applicable for WeightedPriorityQueue scheduler.
+    _queue_for_recovery(pg_awaiting_throttle_t{queued, pg, 1}, reserved_pushes);
   }
 
   void queue_check_readable(spg_t spgid,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -419,7 +419,17 @@ void PG::queue_recovery()
   } else {
     dout(10) << "queue_recovery -- queuing" << dendl;
     recovery_queued = true;
-    osd->queue_for_recovery(this);
+    // Let cost per object be the average object size
+    auto num_bytes = static_cast<uint64_t>(
+      std::max<int64_t>(
+	0, // ensure bytes is non-negative
+	info.stats.stats.sum.num_bytes));
+    auto num_objects = static_cast<uint64_t>(
+      std::max<int64_t>(
+	1, // ensure objects is non-negative and non-zero
+	info.stats.stats.sum.num_objects));
+    uint64_t cost_per_object = std::max<uint64_t>(num_bytes / num_objects, 1);
+    osd->queue_for_recovery(this, cost_per_object);
   }
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -429,7 +429,9 @@ void PG::queue_recovery()
 	1, // ensure objects is non-negative and non-zero
 	info.stats.stats.sum.num_objects));
     uint64_t cost_per_object = std::max<uint64_t>(num_bytes / num_objects, 1);
-    osd->queue_for_recovery(this, cost_per_object);
+    osd->queue_for_recovery(
+      this, cost_per_object, recovery_state.get_recovery_op_priority()
+    );
   }
 }
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -260,7 +260,8 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        const pg_stat_t &stat) = 0;
 
      virtual void schedule_recovery_work(
-       GenContext<ThreadPool::TPHandle&> *c) = 0;
+       GenContext<ThreadPool::TPHandle&> *c,
+       uint64_t cost) = 0;
 
      virtual pg_shard_t whoami_shard() const = 0;
      int whoami() const {

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -992,13 +992,7 @@ int PeeringState::clamp_recovery_priority(int priority, int pool_recovery_priori
   priority += pool_recovery_priority;
 
   // Clamp to valid range
-  if (priority > max) {
-    return max;
-  } else if (priority < OSD_RECOVERY_PRIORITY_MIN) {
-    return OSD_RECOVERY_PRIORITY_MIN;
-  } else {
-    return priority;
-  }
+  return std::clamp<int>(priority, OSD_RECOVERY_PRIORITY_MIN, max);
 }
 
 unsigned PeeringState::get_recovery_priority()

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1569,11 +1569,43 @@ public:
   unsigned get_delete_priority();
 
 public:
+  /**
+   * recovery_msg_priority_t
+   *
+   * Defines priority values for use with recovery messages.  The values are
+   * chosen to be reasonable for wpq during an upgrade scenarios, but are
+   * actually translated into a class in PGRecoveryMsg::get_scheduler_class()
+   */
+  enum recovery_msg_priority_t : int {
+    FORCED = 20,
+    UNDERSIZED = 15,
+    DEGRADED = 10,
+    BEST_EFFORT = 5
+  };
+
   /// get message priority for recovery messages
   int get_recovery_op_priority() const {
-    int64_t pri = 0;
-    pool.info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);
-    return  pri > 0 ? pri : cct->_conf->osd_recovery_op_priority;
+    if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+      /* For mclock, we use special priority values which will be
+       * translated into op classes within PGRecoveryMsg::get_scheduler_class
+       */
+      if (is_forced_recovery_or_backfill()) {
+	return recovery_msg_priority_t::FORCED;
+      } else if (is_undersized()) {
+	return recovery_msg_priority_t::UNDERSIZED;
+      } else if (is_degraded()) {
+	return recovery_msg_priority_t::DEGRADED;
+      } else {
+	return recovery_msg_priority_t::BEST_EFFORT;
+      }
+    } else {
+      /* For WeightedPriorityQueue, we use pool or osd config settings to
+       * statically set the priority for recovery messages.  This special
+       * handling should probably be removed after Reef */
+      int64_t pri = 0;
+      pool.info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);
+      return  pri > 0 ? pri : cct->_conf->osd_recovery_op_priority;
+    }
   }
 
 private:

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1568,6 +1568,15 @@ public:
   /// get priority for pg deletion
   unsigned get_delete_priority();
 
+public:
+  /// get message priority for recovery messages
+  int get_recovery_op_priority() const {
+    int64_t pri = 0;
+    pool.info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);
+    return  pri > 0 ? pri : cct->_conf->osd_recovery_op_priority;
+  }
+
+private:
   bool check_prior_readable_down_osds(const OSDMapRef& map);
 
   bool adjust_need_up_thru(const OSDMapRef osdmap);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -526,7 +526,9 @@ void PrimaryLogPG::schedule_recovery_work(
   GenContext<ThreadPool::TPHandle&> *c,
   uint64_t cost)
 {
-  osd->queue_recovery_context(this, c, cost);
+  osd->queue_recovery_context(
+    this, c, cost,
+    recovery_state.get_recovery_op_priority());
 }
 
 void PrimaryLogPG::replica_clear_repop_obc(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -523,9 +523,10 @@ void PrimaryLogPG::on_global_recover(
 }
 
 void PrimaryLogPG::schedule_recovery_work(
-  GenContext<ThreadPool::TPHandle&> *c)
+  GenContext<ThreadPool::TPHandle&> *c,
+  uint64_t cost)
 {
-  osd->queue_recovery_context(this, c);
+  osd->queue_recovery_context(this, c, cost);
 }
 
 void PrimaryLogPG::replica_clear_repop_obc(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -630,6 +630,7 @@ void PrimaryLogPG::wait_for_unreadable_object(
   maybe_kick_recovery(soid);
   waiting_for_unreadable_object[soid].push_back(op);
   op->mark_delayed("waiting for missing object");
+  osd->logger->inc(l_osd_op_delayed_unreadable);
 }
 
 bool PrimaryLogPG::is_degraded_or_backfilling_object(const hobject_t& soid)
@@ -689,6 +690,7 @@ void PrimaryLogPG::wait_for_degraded_object(const hobject_t& soid, OpRequestRef 
   maybe_kick_recovery(soid);
   waiting_for_degraded_object[soid].push_back(op);
   op->mark_delayed("waiting for degraded object");
+  osd->logger->inc(l_osd_op_delayed_degraded);
 }
 
 void PrimaryLogPG::block_write_on_full_cache(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13883,6 +13883,12 @@ uint64_t PrimaryLogPG::recover_backfill(
 	  MOSDPGScan::OP_SCAN_GET_DIGEST, pg_whoami, e, get_last_peering_reset(),
 	  spg_t(info.pgid.pgid, bt.shard),
 	  pbi.end, hobject_t());
+
+	if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+	  /* This guard preserves legacy WeightedPriorityQueue behavior for
+	   * now, but should be removed after Reef */
+	  m->set_priority(recovery_state.get_recovery_op_priority());
+	}
 	osd->send_message_osd_cluster(bt.osd, m, get_osdmap_epoch());
 	ceph_assert(waiting_on_backfill.find(bt) == waiting_on_backfill.end());
 	waiting_on_backfill.insert(bt);
@@ -14050,6 +14056,11 @@ uint64_t PrimaryLogPG::recover_backfill(
       m = reqs[peer] = new MOSDPGBackfillRemove(
 	spg_t(info.pgid.pgid, peer.shard),
 	get_osdmap_epoch());
+      if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+	/* This guard preserves legacy WeightedPriorityQueue behavior for
+	   * now, but should be removed after Reef */
+	m->set_priority(recovery_state.get_recovery_op_priority());
+      }
     }
     m->ls.push_back(make_pair(oid, v));
 
@@ -14134,6 +14145,13 @@ uint64_t PrimaryLogPG::recover_backfill(
       }
       m->last_backfill = pinfo.last_backfill;
       m->stats = pinfo.stats;
+
+      if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+	/* This guard preserves legacy WeightedPriorityQueue behavior for
+	 * now, but should be removed after Reef */
+	m->set_priority(recovery_state.get_recovery_op_priority());
+      }
+
       osd->send_message_osd_cluster(bt.osd, m, get_osdmap_epoch());
       dout(10) << " peer " << bt
 	       << " num_objects now " << pinfo.stats.stats.sum.num_objects

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4527,7 +4527,7 @@ void PrimaryLogPG::do_backfill(OpRequestRef op)
 	get_osdmap_epoch(),
 	m->query_epoch,
 	spg_t(info.pgid.pgid, get_primary().shard));
-      reply->set_priority(get_recovery_op_priority());
+      reply->set_priority(recovery_state.get_recovery_op_priority());
       osd->send_message_osd_cluster(reply, m->get_connection());
       queue_peering_event(
 	PGPeeringEventRef(
@@ -13493,7 +13493,7 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 	++skipped;
       } else {
 	int r = recover_missing(
-	  soid, need, get_recovery_op_priority(), h);
+	  soid, need, recovery_state.get_recovery_op_priority(), h);
 	switch (r) {
 	case PULL_YES:
 	  ++started;
@@ -13516,7 +13516,7 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
       recovery_state.set_last_requested(v);
   }
 
-  pgbackend->run_recovery_op(h, get_recovery_op_priority());
+  pgbackend->run_recovery_op(h, recovery_state.get_recovery_op_priority());
   return started;
 }
 
@@ -13586,7 +13586,7 @@ int PrimaryLogPG::prep_object_replica_pushes(
       } else {
 	int r = recover_missing(
 	    head, recovery_state.get_pg_log().get_missing().get_items().find(head)->second.need,
-	    get_recovery_op_priority(), h);
+	    recovery_state.get_recovery_op_priority(), h);
 	if (r != PULL_NONE)
 	  return 1;
 	return 0;
@@ -13736,7 +13736,7 @@ uint64_t PrimaryLogPG::recover_replicas(uint64_t max, ThreadPool::TPHandle &hand
     }
   }
 
-  pgbackend->run_recovery_op(h, get_recovery_op_priority());
+  pgbackend->run_recovery_op(h, recovery_state.get_recovery_op_priority());
   return started;
 }
 
@@ -14061,7 +14061,7 @@ uint64_t PrimaryLogPG::recover_backfill(
 				  get_osdmap_epoch());
   }
 
-  pgbackend->run_recovery_op(h, get_recovery_op_priority());
+  pgbackend->run_recovery_op(h, recovery_state.get_recovery_op_priority());
 
   hobject_t backfill_pos =
     std::min(backfill_info.begin, earliest_peer_backfill());

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -543,7 +543,8 @@ public:
   }
 
   void schedule_recovery_work(
-    GenContext<ThreadPool::TPHandle&> *c) override;
+    GenContext<ThreadPool::TPHandle&> *c,
+    uint64_t cost) override;
 
   pg_shard_t whoami_shard() const override {
     return pg_whoami;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1532,12 +1532,6 @@ private:
   /// generate a new temp object name (for recovery)
   hobject_t get_temp_recovery_object(const hobject_t& target,
 				     eversion_t version) override;
-  int get_recovery_op_priority() const {
-    int64_t pri = 0;
-    pool.info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);
-    return  pri > 0 ? pri : cct->_conf->osd_recovery_op_priority;
-  }
-
 public:
   coll_t get_coll() {
     return coll;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -68,12 +68,14 @@ class PG_SendMessageOnConn: public Context {
 class PG_RecoveryQueueAsync : public Context {
   PGBackend::Listener *pg;
   unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
+  uint64_t cost;
   public:
   PG_RecoveryQueueAsync(
     PGBackend::Listener *pg,
-    GenContext<ThreadPool::TPHandle&> *c) : pg(pg), c(c) {}
+    GenContext<ThreadPool::TPHandle&> *c,
+    uint64_t cost) : pg(pg), c(c), cost(cost) {}
   void finish(int) override {
-    pg->schedule_recovery_work(c.release());
+    pg->schedule_recovery_work(c.release(), cost);
   }
 };
 }
@@ -817,8 +819,11 @@ struct C_ReplicatedBackend_OnPullComplete : GenContext<ThreadPool::TPHandle&> {
   ReplicatedBackend *bc;
   list<ReplicatedBackend::pull_complete_info> to_continue;
   int priority;
-  C_ReplicatedBackend_OnPullComplete(ReplicatedBackend *bc, int priority)
-    : bc(bc), priority(priority) {}
+  C_ReplicatedBackend_OnPullComplete(
+    ReplicatedBackend *bc,
+    int priority,
+    list<ReplicatedBackend::pull_complete_info> &&to_continue)
+    : bc(bc), to_continue(std::move(to_continue)), priority(priority) {}
 
   void finish(ThreadPool::TPHandle &handle) override {
     ReplicatedBackend::RPGHandle *h = bc->_open_recovery_op();
@@ -840,6 +845,15 @@ struct C_ReplicatedBackend_OnPullComplete : GenContext<ThreadPool::TPHandle&> {
       handle.reset_tp_timeout();
     }
     bc->run_recovery_op(h, priority);
+  }
+
+  /// Estimate total data reads required to perform pushes
+  uint64_t estimate_push_costs() const {
+    uint64_t cost = 0;
+    for (const auto &i: to_continue) {
+      cost += i.stat.num_bytes_recovered;
+    }
+    return cost;
   }
 };
 
@@ -870,12 +884,13 @@ void ReplicatedBackend::_do_pull_response(OpRequestRef op)
     C_ReplicatedBackend_OnPullComplete *c =
       new C_ReplicatedBackend_OnPullComplete(
 	this,
-	m->get_priority());
-    c->to_continue.swap(to_continue);
+	m->get_priority(),
+	std::move(to_continue));
     t.register_on_complete(
       new PG_RecoveryQueueAsync(
 	get_parent(),
-	get_parent()->bless_unlocked_gencontext(c)));
+	get_parent()->bless_unlocked_gencontext(c),
+        std::max<uint64_t>(1, c->estimate_push_costs())));
   }
   replies.erase(replies.end() - 1);
 

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -187,6 +187,15 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "l_osd_recovery_scan_queue_latency",
     "MOSDPGScan queue latency");
 
+  osd_plb.add_time_avg(
+    l_osd_recovery_queue_lat,
+    "l_osd_recovery_queue_latency",
+    "PGRecovery queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_context_queue_lat,
+    "l_osd_recovery_context_queue_latency",
+    "PGRecoveryContext queue latency");
+
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
   osd_plb.add_u64(
     l_osd_cached_crc, "cached_crc", "Total number getting crc from crc_cache");

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -57,6 +57,13 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "Latency of client operations (excluding queue time and wait for finished)");
 
   osd_plb.add_u64_counter(
+    l_osd_op_delayed_unreadable, "op_delayed_unreadable",
+    "Count of ops delayed due to target object being unreadable");
+  osd_plb.add_u64_counter(
+    l_osd_op_delayed_degraded, "op_delayed_degraded",
+    "Count of ops delayed due to target object being degraded");
+
+  osd_plb.add_u64_counter(
     l_osd_op_r, "op_r", "Client read operations");
   osd_plb.add_u64_counter(
     l_osd_op_r_outb, "op_r_out_bytes", "Client data read", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -162,6 +162,31 @@ PerfCounters *build_osd_logger(CephContext *cct) {
    "recovery bytes",
    "rbt", PerfCountersBuilder::PRIO_INTERESTING);
 
+  osd_plb.add_time_avg(
+    l_osd_recovery_push_queue_lat,
+    "l_osd_recovery_push_queue_latency",
+    "MOSDPGPush queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_push_reply_queue_lat,
+    "l_osd_recovery_push_reply_queue_latency",
+    "MOSDPGPushReply queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_pull_queue_lat,
+    "l_osd_recovery_pull_queue_latency",
+    "MOSDPGPull queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_backfill_queue_lat,
+    "l_osd_recovery_backfill_queue_latency",
+    "MOSDPGBackfill queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_backfill_remove_queue_lat,
+    "l_osd_recovery_backfill_remove_queue_latency",
+    "MOSDPGBackfillDelete queue latency");
+  osd_plb.add_time_avg(
+    l_osd_recovery_scan_queue_lat,
+    "l_osd_recovery_scan_queue_latency",
+    "MOSDPGScan queue latency");
+
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
   osd_plb.add_u64(
     l_osd_cached_crc, "cached_crc", "Total number getting crc from crc_cache");

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -58,6 +58,13 @@ enum {
   l_osd_rop,
   l_osd_rbytes,
 
+  l_osd_recovery_push_queue_lat,
+  l_osd_recovery_push_reply_queue_lat,
+  l_osd_recovery_pull_queue_lat,
+  l_osd_recovery_backfill_queue_lat,
+  l_osd_recovery_backfill_remove_queue_lat,
+  l_osd_recovery_scan_queue_lat,
+
   l_osd_loadavg,
   l_osd_cached_crc,
   l_osd_cached_crc_adjusted,

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -65,6 +65,9 @@ enum {
   l_osd_recovery_backfill_remove_queue_lat,
   l_osd_recovery_scan_queue_lat,
 
+  l_osd_recovery_queue_lat,
+  l_osd_recovery_context_queue_lat,
+
   l_osd_loadavg,
   l_osd_cached_crc,
   l_osd_cached_crc_adjusted,

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -36,6 +36,9 @@ enum {
   l_osd_op_rw_process_lat,
   l_osd_op_rw_prepare_lat,
 
+  l_osd_op_delayed_unreadable,
+  l_osd_op_delayed_degraded,
+
   l_osd_op_before_queue_op_lat,
   l_osd_op_before_dequeue_op_lat,
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -15,6 +15,7 @@
  *
  */
 
+#include <algorithm>
 #include <list>
 #include <map>
 #include <ostream>
@@ -6807,8 +6808,20 @@ ostream& operator<<(ostream& out, const PullOp &op)
 
 uint64_t PullOp::cost(CephContext *cct) const
 {
-  return cct->_conf->osd_push_per_object_cost +
-    cct->_conf->osd_recovery_max_chunk;
+  if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+    return std::clamp<uint64_t>(
+      recovery_progress.estimate_remaining_data_to_recover(recovery_info),
+      1,
+      cct->_conf->osd_recovery_max_chunk);
+  } else {
+    /* We retain this legacy behavior for WeightedPriorityQueue. It seems to
+     * require very large costs for several messages in order to do any
+     * meaningful amount of throttling.  This branch should be removed after
+     * Reef.
+     */
+    return cct->_conf->osd_push_per_object_cost +
+      cct->_conf->osd_recovery_max_chunk;
+  }
 }
 
 // -- PushOp --

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6716,9 +6716,34 @@ ostream& operator<<(ostream& out, const PushReplyOp &op)
 
 uint64_t PushReplyOp::cost(CephContext *cct) const
 {
-
-  return cct->_conf->osd_push_per_object_cost +
-    cct->_conf->osd_recovery_max_chunk;
+  if (cct->_conf->osd_op_queue == "mclock_scheduler") {
+    /* In general, we really never want to throttle PushReplyOp messages.
+     * As long as the object is smaller than osd_recovery_max_chunk (8M at
+     * time of writing this comment, so this is basically always true),
+     * processing the PushReplyOp does not cost any further IO and simply
+     * permits the object once more to be written to.
+     *
+     * In the unlikely event that the object is larger than
+     * osd_recovery_max_chunk (again, 8M at the moment, so never for common
+     * configurations of rbd and virtually never for cephfs and rgw),
+     * we *still* want to push out the next portion immediately so that we can
+     * release the object for IO.
+     *
+     * The throttling for this operation on the primary occurs at the point
+     * where we queue the PGRecoveryContext which calls into recover_missing
+     * and recover_backfill to initiate pushes.
+     * See OSD::queue_recovery_context.
+     */
+    return 1;
+  } else {
+    /* We retain this legacy behavior for WeightedPriorityQueue. It seems to
+     * require very large costs for several messages in order to do any
+     * meaningful amount of throttling.  This branch should be removed after
+     * Reef.
+     */
+    return cct->_conf->osd_push_per_object_cost +
+      cct->_conf->osd_recovery_max_chunk;
+  }
 }
 
 // -- PullOp --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -6028,6 +6028,11 @@ struct ObjectRecoveryProgress {
       omap_complete;
   }
 
+  uint64_t estimate_remaining_data_to_recover(const ObjectRecoveryInfo& info) const {
+    // Overestimates in case of clones, but avoids traversing copy_subset
+    return info.size - data_recovered_to;
+  }
+
   static void generate_test_instances(std::list<ObjectRecoveryProgress*>& o);
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -253,6 +253,21 @@ void PGRecoveryMsg::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
+  auto latency = time_queued - ceph_clock_now();
+  switch (op->get_req()->get_type()) {
+  case MSG_OSD_PG_PUSH:
+    osd->logger->tinc(l_osd_recovery_push_queue_lat, latency);
+  case MSG_OSD_PG_PUSH_REPLY:
+    osd->logger->tinc(l_osd_recovery_push_reply_queue_lat, latency);
+  case MSG_OSD_PG_PULL:
+    osd->logger->tinc(l_osd_recovery_pull_queue_lat, latency);
+  case MSG_OSD_PG_BACKFILL:
+    osd->logger->tinc(l_osd_recovery_backfill_queue_lat, latency);
+  case MSG_OSD_PG_BACKFILL_REMOVE:
+    osd->logger->tinc(l_osd_recovery_backfill_remove_queue_lat, latency);
+  case MSG_OSD_PG_SCAN:
+    osd->logger->tinc(l_osd_recovery_scan_queue_lat, latency);
+  }
   osd->dequeue_op(pg, op, handle);
   pg->unlock();
 }

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -224,7 +224,7 @@ void PGRecovery::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
-  osd->do_recovery(pg.get(), epoch_queued, reserved_pushes, handle);
+  osd->do_recovery(pg.get(), epoch_queued, reserved_pushes, priority, handle);
   pg->unlock();
 }
 

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -224,6 +224,9 @@ void PGRecovery::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
+  osd->logger->tinc(
+    l_osd_recovery_queue_lat,
+    time_queued - ceph_clock_now());
   osd->do_recovery(pg.get(), epoch_queued, reserved_pushes, priority, handle);
   pg->unlock();
 }
@@ -234,6 +237,9 @@ void PGRecoveryContext::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
+  osd->logger->tinc(
+    l_osd_recovery_context_queue_lat,
+    time_queued - ceph_clock_now());
   c.release()->complete(handle);
   pg->unlock();
 }

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -577,6 +577,9 @@ public:
     case MSG_OSD_PG_PUSH:
     case MSG_OSD_PG_PUSH_REPLY:
     case MSG_OSD_PG_PULL:
+    case MSG_OSD_PG_BACKFILL:
+    case MSG_OSD_PG_BACKFILL_REMOVE:
+    case MSG_OSD_PG_SCAN:
       return true;
     default:
       return false;

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -500,6 +500,7 @@ class PGScrubChunkIsFree : public PGScrubItem {
 };
 
 class PGRecovery : public PGOpQueueable {
+  utime_t time_queued;
   epoch_t epoch_queued;
   uint64_t reserved_pushes;
   int priority;
@@ -510,6 +511,7 @@ public:
     uint64_t reserved_pushes,
     int priority)
     : PGOpQueueable(pg),
+      time_queued(ceph_clock_now()),
       epoch_queued(epoch_queued),
       reserved_pushes(reserved_pushes),
       priority(priority) {}
@@ -530,6 +532,7 @@ public:
 };
 
 class PGRecoveryContext : public PGOpQueueable {
+  utime_t time_queued;
   std::unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
   epoch_t epoch;
   int priority;
@@ -538,6 +541,7 @@ public:
 		    GenContext<ThreadPool::TPHandle&> *c, epoch_t epoch,
 		    int priority)
     : PGOpQueueable(pgid),
+      time_queued(ceph_clock_now()),
       c(c), epoch(epoch), priority(priority) {}
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecoveryContext(pgid=" << get_pgid()

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -565,6 +565,7 @@ public:
     switch (op->get_req()->get_type()) {
     case MSG_OSD_PG_PUSH:
     case MSG_OSD_PG_PUSH_REPLY:
+    case MSG_OSD_PG_PULL:
       return true;
     default:
       return false;

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -106,7 +106,7 @@ private:
   utime_t start_time;
   uint64_t owner;  ///< global id (e.g., client.XXX)
   epoch_t map_epoch;    ///< an epoch we expect the PG to exist in
-  int qos_cost;  ///< scaled cost calculated by the mclock scheduler
+  uint32_t qos_cost;  ///< scaled cost calculated by the mclock scheduler
   bool qos_item;  ///< set to true if item is scheduled by mclock scheduler
 
 public:
@@ -183,11 +183,11 @@ public:
     return qos_item;
   }
 
-  void set_qos_cost(int scaled_cost) {
+  void set_qos_cost(uint32_t scaled_cost) {
     qos_cost = scaled_cost;
   }
 
-  int get_qos_cost() const {
+  uint32_t get_qos_cost() const {
     return qos_cost;
   }
 

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -213,15 +213,6 @@ public:
 class PGOpItem : public PGOpQueueable {
   OpRequestRef op;
 
-  const MOSDOp *maybe_get_mosd_op() const {
-    auto req = op->get_req();
-    if (req->get_type() == CEPH_MSG_OSD_OP) {
-      return op->get_req<MOSDOp>();
-    } else {
-      return nullptr;
-    }
-  }
-
 public:
   PGOpItem(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(std::move(op)) {}
 

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -572,10 +572,12 @@ public:
 };
 
 class PGRecoveryMsg : public PGOpQueueable {
+  utime_t time_queued;
   OpRequestRef op;
 
 public:
-  PGRecoveryMsg(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(std::move(op)) {}
+  PGRecoveryMsg(spg_t pg, OpRequestRef op)
+    : PGOpQueueable(pg), time_queued(ceph_clock_now()), op(std::move(op)) {}
 
   static bool is_recovery_msg(OpRequestRef &op) {
     switch (op->get_req()->get_type()) {

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -561,6 +561,16 @@ class PGRecoveryMsg : public PGOpQueueable {
 public:
   PGRecoveryMsg(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(std::move(op)) {}
 
+  static bool is_recovery_msg(OpRequestRef &op) {
+    switch (op->get_req()->get_type()) {
+    case MSG_OSD_PG_PUSH:
+    case MSG_OSD_PG_PUSH_REPLY:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecoveryMsg(op=" << *(op->get_req()) << ")";
   }

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -236,48 +236,48 @@ void mClockScheduler::set_config_defaults_from_profile()
    * high_client_ops
    *
    * Client Allocation:
-   *   reservation: 60% | weight: 5 | limit: 0 (max) |
+   *   reservation: 60% | weight: 2 | limit: 0 (max) |
    * Background Recovery Allocation:
-   *   reservation: 20% | weight: 1 | limit: 50% |
+   *   reservation: 40% | weight: 1 | limit: 0 (max) |
    * Background Best Effort Allocation:
-   *   reservation: 20% | weight: 1 | limit: 0 (max) |
+   *   reservation: 0 (min) | weight: 1 | limit: 70% |
    */
   static constexpr profile_t high_client_ops_profile{
-    { .6, 5, 0 },
-    { .2, 1, .5},
-    { .2, 1, 0 }
+    { .6, 2,  0 },
+    { .4, 1,  0 },
+    {  0, 1, .7 }
   };
 
   /**
    * high_recovery_ops
    *
    * Client Allocation:
-   *   reservation: 30% | weight: 1 | limit: 80% |
+   *   reservation: 30% | weight: 1 | limit: 0 (max) |
    * Background Recovery Allocation:
-   *   reservation: 60% | weight: 2 | limit: 0 (max) |
+   *   reservation: 70% | weight: 2 | limit: 0 (max) |
    * Background Best Effort Allocation:
    *   reservation: 0 (min) | weight: 1 | limit: 0 (max) |
    */
   static constexpr profile_t high_recovery_ops_profile{
-    { .3, 1, .8 },
-    { .6, 2, 0 },
-    { 0, 1, 0 }
+    { .3, 1, 0 },
+    { .7, 2, 0 },
+    {  0, 1, 0 }
   };
 
   /**
    * balanced
    *
    * Client Allocation:
-   *   reservation: 40% | weight: 1 | limit: 100% |
+   *   reservation: 50% | weight: 1 | limit: 0 (max) |
    * Background Recovery Allocation:
-   *   reservation: 40% | weight: 1 | limit: 70% |
+   *   reservation: 50% | weight: 1 | limit: 0 (max) |
    * Background Best Effort Allocation:
-   *   reservation: 20% | weight: 1 | limit: 0 (max) |
+   *   reservation: 0 (min) | weight: 1 | limit: 90% |
    */
   static constexpr profile_t balanced_profile{
-    { .4, 1, 1.0 },
-    { .4, 1, .7 },
-    { .2, 1, 0 }
+    { .5, 1, 0 },
+    { .5, 1, 0 },
+    {  0, 1, .9 }
   };
 
   const profile_t *profile = nullptr;

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -81,33 +81,6 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   bool is_rotational;
   MonClient *monc;
 
-  std::string mclock_profile = "high_client_ops";
-  struct ClientAllocs {
-    double res;
-    double wgt;
-    double lim;
-
-    ClientAllocs(double _res, double _wgt, double _lim) {
-      update(_res, _wgt, _lim);
-    }
-
-    inline void update(double _res, double _wgt, double _lim) {
-      res = _res;
-      wgt = _wgt;
-      lim = _lim;
-    }
-  };
-  std::array<
-    ClientAllocs,
-    static_cast<size_t>(op_scheduler_class::client) + 1
-  > client_allocs = {
-    // Placeholder, get replaced with configured values
-    ClientAllocs(0, 1, 0), // background_recovery
-    ClientAllocs(0, 1, 0), // background_best_effort
-    ClientAllocs(0, 1, 0), // immediate (not used)
-    ClientAllocs(0, 1, 0)  // client
-  };
-
   /**
    * osd_bandwidth_cost_per_io
    *
@@ -238,31 +211,13 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
    */
   void set_osd_capacity_params_from_config();
 
+  // Set the mclock related config params based on the profile
+  void set_config_defaults_from_profile();
+
 public:
   mClockScheduler(CephContext *cct, int whoami, uint32_t num_shards,
     int shard_id, bool is_rotational, MonClient *monc);
   ~mClockScheduler() override;
-
-  // Set the mclock profile type to enable
-  void set_mclock_profile();
-
-  // Get the active mclock profile
-  std::string get_mclock_profile();
-
-  // Set "balanced" profile allocations
-  void set_balanced_profile_allocations();
-
-  // Set "high_recovery_ops" profile allocations
-  void set_high_recovery_ops_profile_allocations();
-
-  // Set "high_client_ops" profile allocations
-  void set_high_client_ops_profile_allocations();
-
-  // Set the mclock related config params based on the profile
-  void enable_mclock_profile_settings();
-
-  // Set mclock config parameter based on allocations
-  void set_profile_config();
 
   /// Calculate scaled cost per item
   uint32_t calc_scaled_cost(int cost);

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -33,8 +33,10 @@
 
 namespace ceph::osd::scheduler {
 
-constexpr uint64_t default_min = 1;
-constexpr uint64_t default_max = 999999;
+constexpr double default_min = 1.0;
+constexpr double default_max = std::numeric_limits<double>::is_iec559 ?
+  std::numeric_limits<double>::infinity() :
+  std::numeric_limits<double>::max();
 
 using client_id_t = uint64_t;
 using profile_id_t = uint64_t;
@@ -78,20 +80,18 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const int shard_id;
   bool is_rotational;
   MonClient *monc;
-  double max_osd_capacity;
-  double osd_mclock_cost_per_io;
-  double osd_mclock_cost_per_byte;
+
   std::string mclock_profile = "high_client_ops";
   struct ClientAllocs {
-    uint64_t res;
-    uint64_t wgt;
-    uint64_t lim;
+    double res;
+    double wgt;
+    double lim;
 
-    ClientAllocs(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+    ClientAllocs(double _res, double _wgt, double _lim) {
       update(_res, _wgt, _lim);
     }
 
-    inline void update(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+    inline void update(double _res, double _wgt, double _lim) {
       res = _res;
       wgt = _wgt;
       lim = _lim;
@@ -102,11 +102,55 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     static_cast<size_t>(op_scheduler_class::client) + 1
   > client_allocs = {
     // Placeholder, get replaced with configured values
-    ClientAllocs(1, 1, 1), // background_recovery
-    ClientAllocs(1, 1, 1), // background_best_effort
-    ClientAllocs(1, 1, 1), // immediate (not used)
-    ClientAllocs(1, 1, 1)  // client
+    ClientAllocs(0, 1, 0), // background_recovery
+    ClientAllocs(0, 1, 0), // background_best_effort
+    ClientAllocs(0, 1, 0), // immediate (not used)
+    ClientAllocs(0, 1, 0)  // client
   };
+
+  /**
+   * osd_bandwidth_cost_per_io
+   *
+   * mClock expects all queued items to have a uniform expression of
+   * "cost".  However, IO devices generally have quite different capacity
+   * for sequential IO vs small random IO.  This implementation handles this
+   * by expressing all costs as a number of sequential bytes written adding
+   * additional cost for each random IO equal to osd_bandwidth_cost_per_io.
+   *
+   * Thus, an IO operation requiring a total of <size> bytes to be written
+   * accross <iops> different locations will have a cost of
+   * <size> + (osd_bandwidth_cost_per_io * <iops>) bytes.
+   *
+   * Set in set_osd_capacity_params_from_config in the constructor and upon
+   * config change.
+   *
+   * Has units bytes/io.
+   */
+  double osd_bandwidth_cost_per_io;
+
+  /**
+   * osd_bandwidth_capacity_per_shard
+   *
+   * mClock expects reservation and limit paramters to be expressed in units
+   * of cost/second -- which means bytes/second for this implementation.
+   *
+   * Rather than expecting users to compute appropriate limit and reservation
+   * values for each class of OSDs in their cluster, we instead express
+   * reservation and limit paramaters as ratios of the OSD's maxmimum capacity.
+   * osd_bandwidth_capacity_per_shard is that capacity divided by the number
+   * of shards.
+   *
+   * Set in set_osd_capacity_params_from_config in the constructor and upon
+   * config change.
+   *
+   * This value gets passed to ClientRegistry::update_from_config in order
+   * to resolve the full reservaiton and limit parameters for mclock from
+   * the configured ratios.
+   *
+   * Has units bytes/second.
+   */
+  double osd_bandwidth_capacity_per_shard;
+
   class ClientRegistry {
     std::array<
       crimson::dmclock::ClientInfo,
@@ -123,7 +167,16 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     const crimson::dmclock::ClientInfo *get_external_client(
       const client_profile_id_t &client) const;
   public:
-    void update_from_config(const ConfigProxy &conf);
+    /**
+     * update_from_config
+     *
+     * Sets the mclock paramaters (reservation, weight, and limit)
+     * for each class of IO (background_recovery, background_best_effort,
+     * and client).
+     */
+    void update_from_config(
+      const ConfigProxy &conf,
+      double capacity_per_shard);
     const crimson::dmclock::ClientInfo *get_info(
       const scheduler_id_t &id) const;
   } client_registry;
@@ -171,19 +224,24 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     }
   }
 
+  /**
+   * set_osd_capacity_params_from_config
+   *
+   * mClockScheduler uses two parameters, osd_bandwidth_cost_per_io
+   * and osd_bandwidth_capacity_per_shard, internally.  These two
+   * parameters are derived from config parameters
+   * osd_mclock_max_capacity_iops_(hdd|ssd) and
+   * osd_mclock_max_sequential_bandwidth_(hdd|ssd) as well as num_shards.
+   * Invoking set_osd_capacity_params_from_config() resets those derived
+   * params based on the current config and should be invoked any time they
+   * are modified as well as in the constructor.  See handle_conf_change().
+   */
+  void set_osd_capacity_params_from_config();
+
 public:
   mClockScheduler(CephContext *cct, int whoami, uint32_t num_shards,
     int shard_id, bool is_rotational, MonClient *monc);
   ~mClockScheduler() override;
-
-  // Set the max osd capacity in iops
-  void set_max_osd_capacity();
-
-  // Set the cost per io for the osd
-  void set_osd_mclock_cost_per_io();
-
-  // Set the cost per byte for the osd
-  void set_osd_mclock_cost_per_byte();
 
   // Set the mclock profile type to enable
   void set_mclock_profile();
@@ -206,8 +264,8 @@ public:
   // Set mclock config parameter based on allocations
   void set_profile_config();
 
-  // Calculate scale cost per item
-  int calc_scaled_cost(int cost);
+  /// Calculate scaled cost per item
+  uint32_t calc_scaled_cost(int cost);
 
   // Helper method to display mclock queues
   std::string display_queues() const;

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -78,7 +78,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const int whoami;
   const uint32_t num_shards;
   const int shard_id;
-  bool is_rotational;
+  const bool is_rotational;
   MonClient *monc;
 
   /**

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -60,10 +60,6 @@ public:
     MockDmclockItem()
       : MockDmclockItem(op_scheduler_class::background_best_effort) {}
 
-    op_type_t get_op_type() const final {
-      return op_type_t::client_op; // not used
-    }
-
     ostream &print(ostream &rhs) const final { return rhs; }
 
     std::optional<OpRequestRef> maybe_get_op() const final {


### PR DESCRIPTION
This PR addresses the issue of slow backfill/recoveries due to non-ideal
cost settings for recovery/backfill operations. 

The following summarizes the changes:

1. Set cost for PGRecovery item based on average size of objects in PG.
2. Set cost for PGRecoveryContext item (Replicated and EC backend) based on the aggregate cost of impending pushes.
3. PushReplyOp cost set to min cost and PullOp cost is set based on the remaining bytes to be pushed.
4. Modify IO cost model to incorporate device characteristics like random write IOPS and sequential bandwidth capacity.
5. Represent QoS cost in terms bytes instead of secs.
6. Consider degraded object recoveries with greater urgency than backfill recovery. 
7. Categorize backfill operations as best-effort client.
8. Change QoS parameter allocation in terms of proportions and optimize mClock profiles.
9. Set 'balanced' profile as the default mClock profile.
10. Restore backfill/recovery limits to original defaults.
11. Update mClock configuration document to reflect all the changes.

Fixes: https://tracker.ceph.com/issues/58529
Fixes: https://tracker.ceph.com/issues/58606
Fixes: https://tracker.ceph.com/issues/58607
Fixes: https://tracker.ceph.com/issues/59080
Signed-off-by: Samuel Just <sjust@redhat.com>
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
