### PR TITLE
quincy: doc/rgw: refine "Zones" in multisite.rst

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1283,20 +1283,21 @@ Finally, update the period.
 Zones
 -----
 
-Ceph Object Gateway supports the notion of zones. A zone defines a
-logical group consisting of one or more Ceph Object Gateway instances.
+A zone defines a logical group that consists of one or more Ceph Object Gateway
+instances. Ceph Object Gateway supports zones.
 
-Configuring zones differs from typical configuration procedures, because
-not all of the settings end up in a Ceph configuration file. You can
-list zones, get a zone configuration and set a zone configuration.
+The procedure for configuring zones differs from typical configuration
+procedures, because not all of the settings end up in a Ceph configuration
+file. Zones can be listed. You can "get" a zone configuration and "set" a zone
+configuration.
 
 Create a Zone
 ~~~~~~~~~~~~~
 
-To create a zone, specify a zone name. If it is a master zone, specify
-the ``--master`` option. Only one zone in a zone group may be a master
-zone. To add the zone to a zonegroup, specify the ``--rgw-zonegroup``
-option with the zonegroup name.
+To create a zone, specify a zone name. If you are creating a master zone,
+specify the ``--master`` flag. Only one zone in a zone group may be a master
+zone. To add the zone to a zonegroup, specify the ``--rgw-zonegroup`` option
+with the zonegroup name.
 
 .. prompt:: bash #
    
@@ -1306,7 +1307,7 @@ option with the zonegroup name.
                     [--master] [--default] \
                     --access-key $SYSTEM_ACCESS_KEY --secret $SYSTEM_SECRET_KEY
 
-Then, update the period:
+After you have created the zone, update the period:
 
 .. prompt:: bash #
    
@@ -1315,7 +1316,7 @@ Then, update the period:
 Delete a Zone
 ~~~~~~~~~~~~~
 
-To delete zone, first remove it from the zonegroup.
+To delete a zone, first remove it from the zonegroup:
 
 .. prompt:: bash #
    
@@ -1328,7 +1329,7 @@ Then, update the period:
    
    radosgw-admin period update --commit
 
-Next, delete the zone. Execute the following:
+Next, delete the zone:
 
 .. prompt:: bash #
    
@@ -1347,13 +1348,13 @@ If the pools for the deleted zone will not be used anywhere else,
 consider deleting the pools. Replace ``<del-zone>`` in the example below
 with the deleted zone’s name.
 
-.. important:: Only delete the pools with prepended zone names. Deleting the root
-               pool, such as, ``.rgw.root`` will remove all of the system’s
-               configuration.
+.. important:: Only delete the pools with prepended zone names. Deleting the
+   root pool (for example, ``.rgw.root``) will remove all of the system’s
+   configuration.
 
-.. important:: Once the pools are deleted, all of the data within them are deleted
-               in an unrecoverable manner. Only delete the pools if the pool
-               contents are no longer needed.
+.. important:: When the pools are deleted, all of the data within them are
+   deleted in an unrecoverable manner. Delete the pools only if the pool's
+   contents are no longer needed.
 
 .. prompt:: bash #
    


### PR DESCRIPTION
Clean up the English under the section called "Zones". Part of a larger project aimed at giving the reader more understanding earlier in the documentation of how buckets and zones and zone groups and endpoints work.

https://tracker.ceph.com/issues/58632

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit f4f5183543303bf388bd364b4e5996b39df5f592)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
