### PR TITLE
quincy: mon: Fix condition to check for ceph version mismatch

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2988,7 +2988,7 @@ void Monitor::update_pending_metadata()
   const std::string current_version = mon_metadata[rank]["ceph_version_short"];
   const std::string pending_version = metadata["ceph_version_short"];
 
-  if (current_version.compare(0, version_size, pending_version) < 0) {
+  if (current_version.compare(0, version_size, pending_version) != 0) {
     mgr_client.update_daemon_metadata("mon", name, metadata);
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58639

---

backport of https://github.com/ceph/ceph/pull/48265
parent tracker: https://tracker.ceph.com/issues/57678

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh