### PR TITLE
ceph-volume: do not raise RuntimeError in util.lsblk

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -242,7 +242,8 @@ def lsblk(device, columns=None, abspath=False):
                        columns=columns,
                        abspath=abspath)
     if not result:
-        raise RuntimeError(f"{device} not found is lsblk report")
+        logger.debug(f"{device} not found is lsblk report")
+        return {}
 
     return result[0]
 


### PR DESCRIPTION
Otherwise it makes `simple scan` calls fail.

```
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/disk.py", line 246, in lsblk
    raise RuntimeError(f"{device} not found is lsblk report")
RuntimeError: /var/lib/ceph/osd/ceph-0/ not found is lsblk report
```

Fixes: https://tracker.ceph.com/issues/58655

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
