### PR TITLE
crimson/osd/osd_operations: Remove replicated_request_pg_pipeline

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -87,7 +87,7 @@ ConnectionPipeline &ClientRequest::cp()
 
 ClientRequest::PGPipeline &ClientRequest::pp(PG &pg)
 {
-  return pg.client_request_pg_pipeline;
+  return pg.request_pg_pipeline;
 }
 
 bool ClientRequest::same_session_and_pg(const ClientRequest& other_op) const

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -53,6 +53,9 @@ public:
     friend class ClientRequest;
     friend class LttngBackend;
     friend class HistoricBackend;
+    friend class ReqRequest;
+    friend class LogMissingRequest;
+    friend class LogMissingRequestReply;
   };
 
   /**

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -44,7 +44,7 @@ void InternalClientRequest::dump_detail(Formatter *f) const
 
 CommonPGPipeline& InternalClientRequest::pp()
 {
-  return pg->client_request_pg_pipeline;
+  return pg->request_pg_pipeline;
 }
 
 seastar::future<> InternalClientRequest::start()

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -49,9 +49,9 @@ ConnectionPipeline &LogMissingRequest::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-RepRequest::PGPipeline &LogMissingRequest::pp(PG &pg)
+ClientRequest::PGPipeline &LogMissingRequest::pp(PG &pg)
 {
-  return pg.replicated_request_pg_pipeline;
+  return pg.client_request_pg_pipeline;
 }
 
 seastar::future<> LogMissingRequest::with_pg(

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -51,7 +51,7 @@ ConnectionPipeline &LogMissingRequest::get_connection_pipeline()
 
 ClientRequest::PGPipeline &LogMissingRequest::pp(PG &pg)
 {
-  return pg.client_request_pg_pipeline;
+  return pg.request_pg_pipeline;
 }
 
 seastar::future<> LogMissingRequest::with_pg(

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -6,7 +6,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
-#include "crimson/osd/osd_operations/replicated_request.h"
+#include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/pg_map.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDPGUpdateLogMissing.h"
@@ -24,15 +24,6 @@ class PG;
 
 class LogMissingRequest final : public PhasedOperationT<LogMissingRequest> {
 public:
-  class PGPipeline {
-    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
-      static constexpr auto type_name = "LogMissingRequest::PGPipeline::await_map";
-    } await_map;
-    struct Process : OrderedExclusivePhaseT<Process> {
-      static constexpr auto type_name = "LogMissingRequest::PGPipeline::process";
-    } process;
-    friend LogMissingRequest;
-  };
   static constexpr OperationTypeCode type = OperationTypeCode::logmissing_request;
   LogMissingRequest(crimson::net::ConnectionRef&&, Ref<MOSDPGUpdateLogMissing>&&);
 
@@ -59,7 +50,7 @@ public:
   > tracking_events;
 
 private:
-  RepRequest::PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &pp(PG &pg);
 
   crimson::net::ConnectionFRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.cc
@@ -49,9 +49,9 @@ ConnectionPipeline &LogMissingRequestReply::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-RepRequest::PGPipeline &LogMissingRequestReply::pp(PG &pg)
+ClientRequest::PGPipeline &LogMissingRequestReply::pp(PG &pg)
 {
-  return pg.replicated_request_pg_pipeline;
+  return pg.client_request_pg_pipeline;
 }
 
 seastar::future<> LogMissingRequestReply::with_pg(

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.cc
@@ -51,7 +51,7 @@ ConnectionPipeline &LogMissingRequestReply::get_connection_pipeline()
 
 ClientRequest::PGPipeline &LogMissingRequestReply::pp(PG &pg)
 {
-  return pg.client_request_pg_pipeline;
+  return pg.request_pg_pipeline;
 }
 
 seastar::future<> LogMissingRequestReply::with_pg(

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.h
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.h
@@ -6,7 +6,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
-#include "crimson/osd/osd_operations/replicated_request.h"
+#include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/pg_map.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
@@ -24,15 +24,6 @@ class PG;
 
 class LogMissingRequestReply final : public PhasedOperationT<LogMissingRequestReply> {
 public:
-  class PGPipeline {
-    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
-      static constexpr auto type_name = "LogMissingRequestReply::PGPipeline::await_map";
-    } await_map;
-    struct Process : OrderedExclusivePhaseT<Process> {
-      static constexpr auto type_name = "LogMissingRequestReply::PGPipeline::process";
-    } process;
-    friend LogMissingRequestReply;
-  };
   static constexpr OperationTypeCode type = OperationTypeCode::logmissing_request_reply;
   LogMissingRequestReply(crimson::net::ConnectionRef&&, Ref<MOSDPGUpdateLogMissingReply>&&);
 
@@ -59,7 +50,7 @@ public:
   > tracking_events;
 
 private:
-  RepRequest::PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &pp(PG &pg);
 
   crimson::net::ConnectionFRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -49,9 +49,9 @@ ConnectionPipeline &RepRequest::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-RepRequest::PGPipeline &RepRequest::pp(PG &pg)
+ClientRequest::PGPipeline &RepRequest::pp(PG &pg)
 {
-  return pg.replicated_request_pg_pipeline;
+  return pg.client_request_pg_pipeline;
 }
 
 seastar::future<> RepRequest::with_pg(

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -51,7 +51,7 @@ ConnectionPipeline &RepRequest::get_connection_pipeline()
 
 ClientRequest::PGPipeline &RepRequest::pp(PG &pg)
 {
-  return pg.client_request_pg_pipeline;
+  return pg.request_pg_pipeline;
 }
 
 seastar::future<> RepRequest::with_pg(

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -7,6 +7,7 @@
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/pg_map.h"
+#include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDRepOp.h"
 
@@ -23,15 +24,6 @@ class PG;
 
 class RepRequest final : public PhasedOperationT<RepRequest> {
 public:
-  class PGPipeline {
-    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
-      static constexpr auto type_name = "RepRequest::PGPipeline::await_map";
-    } await_map;
-    struct Process : OrderedExclusivePhaseT<Process> {
-      static constexpr auto type_name = "RepRequest::PGPipeline::process";
-    } process;
-    friend RepRequest;
-  };
   static constexpr OperationTypeCode type = OperationTypeCode::replicated_request;
   RepRequest(crimson::net::ConnectionRef&&, Ref<MOSDRepOp>&&);
 
@@ -58,7 +50,7 @@ public:
   > tracking_events;
 
 private:
-  PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &pp(PG &pg);
 
   crimson::net::ConnectionFRef conn;
   PipelineHandle handle;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -71,7 +71,6 @@ class PG : public boost::intrusive_ref_counter<
 
   ClientRequest::PGPipeline client_request_pg_pipeline;
   PGPeeringPipeline peering_request_pg_pipeline;
-  RepRequest::PGPipeline replicated_request_pg_pipeline;
 
   ClientRequest::Orderer client_request_orderer;
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -69,7 +69,7 @@ class PG : public boost::intrusive_ref_counter<
   using ec_profile_t = std::map<std::string,std::string>;
   using cached_map_t = OSDMapService::cached_map_t;
 
-  ClientRequest::PGPipeline client_request_pg_pipeline;
+  ClientRequest::PGPipeline request_pg_pipeline;
   PGPeeringPipeline peering_request_pg_pipeline;
 
   ClientRequest::Orderer client_request_orderer;

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -161,7 +161,7 @@ ReplicatedBackend::request_committed(const osd_reqid_t& reqid,
   //
   // The following line of code should be "assert(pending_txn.at_version == at_version)",
   // as there can be only one transaction at any time in pending_trans due to
-  // PG::client_request_pg_pipeline. But there's a high possibility that we will
+  // PG::request_pg_pipeline. But there's a high possibility that we will
   // improve the parallelism here in the future, which means there may be multiple
   // client requests in flight, so we loosed the restriction to as follows. Correct
   // me if I'm wrong:-)


### PR DESCRIPTION
Remove `replicated_request_pg_pipeline` and use `client_request_pg_pipeline` instead to ensure order
across a PG. We should preserve order between `ClientRequest`/`ReqRequest`/`LogMissingRequest`.

```
At any moment, a ClientRequest being served should be in one and only one of the phases described
above (await_map, wait_for_active, etc). Similarly, an object denoting particular phase can host not
more than a single ClientRequest the same time. 
..
All these phases form a pipeline which assures the order is preserved.
```

Originated from: #49116

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
