### PR TITLE
mon: add support for --force in assimilate-conf

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -625,6 +625,9 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     pending_description = string("reset to ") + stringify(revert_to);
     goto update;
   } else if (prefix == "config assimilate-conf") {
+    bool force = false;
+    cmd_getval(cmdmap, "force", force);
+
     ConfFile cf;
     bufferlist bl = m->get_data();
     err = cf.parse_bufferlist(&bl, &ss);
@@ -665,7 +668,7 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
 	  const Section *s = config_map.find_section(section);
 	  if (s) {
 	    auto k = s->options.find(key);
-	    if (k != s->options.end()) {
+	    if (k != s->options.end() && !force) {
 	      if (value != k->second.raw_value) {
 		dout(20) << __func__ << " have " << key
 			 << " = " << k->second.raw_value

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1312,7 +1312,8 @@ COMMAND("config help "
 COMMAND("config ls",
 	"List available configuration options",
 	"config", "r")
-COMMAND("config assimilate-conf",
+COMMAND("config assimilate-conf "
+	"name=force,type=CephBool,req=false",
 	"Assimilate options from a conf, and return a new, minimal conf file",
 	"config", "rw")
 COMMAND("config log name=num,type=CephInt,req=false",


### PR DESCRIPTION
The rationale is to let overriding multiple configurables in one go (i.e. in single PAXOS transaction).
It's a useful when switching the Protocol v2's mode from `crc`-only to `secure`-only and vice versa.

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
