### PR TITLE
rgw/beast: StreamIO remembers connection errors for graceful shutdown

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -72,6 +72,7 @@ class StreamIO : public rgw::asio::ClientIO {
   timeout_timer& timeout;
   yield_context yield;
   parse_buffer& buffer;
+  boost::system::error_code fatal_ec;
  public:
   StreamIO(CephContext *cct, Stream& stream, timeout_timer& timeout,
            rgw::asio::parser_type& parser, yield_context yield,
@@ -82,6 +83,8 @@ class StreamIO : public rgw::asio::ClientIO {
         cct(cct), stream(stream), timeout(timeout), yield(yield),
         buffer(buffer)
   {}
+
+  boost::system::error_code get_fatal_error_code() const { return fatal_ec; }
 
   size_t write_data(const char* buf, size_t len) override {
     boost::system::error_code ec;
@@ -94,6 +97,9 @@ class StreamIO : public rgw::asio::ClientIO {
       if (ec == boost::asio::error::broken_pipe) {
         boost::system::error_code ec_ignored;
         stream.lowest_layer().shutdown(tcp_socket::shutdown_both, ec_ignored);
+      }
+      if (!fatal_ec) {
+        fatal_ec = ec;
       }
       throw rgw::io::Exception(ec.value(), std::system_category());
     }
@@ -116,6 +122,9 @@ class StreamIO : public rgw::asio::ClientIO {
       }
       if (ec) {
         ldout(cct, 4) << "failed to read body: " << ec.message() << dendl;
+        if (!fatal_ec) {
+          fatal_ec = ec;
+        }
         throw rgw::io::Exception(ec.value(), std::system_category());
       }
     }
@@ -286,6 +295,13 @@ void handle_connection(boost::asio::io_context& context,
             << log_header{message, http::field::user_agent, "\""} << ' '
             << log_header{message, http::field::range} << " latency="
             << latency << dendl;
+      }
+
+      // process_request() can't distinguish between connection errors and
+      // http/s3 errors, so check StreamIO for fatal connection errors
+      ec = real_client.get_fatal_error_code();
+      if (ec) {
+        return;
       }
 
       if (real_client.sent_100_continue()) {


### PR DESCRIPTION
`handle_connection()` is blind to connection errors that occur inside of `StreamIO`, because the errors returned by `process_request()` can't distinguish between connection errors and higher-level http/s3 errors. as a result, `handle_connection()` doesn't know when to stop trying to process more requests. by feeding `StreamIO`'s connection errors back to `handle_connection()`, we can trigger the connection's graceful shutdown

Fixes: https://tracker.ceph.com/issues/58671

## prior work
@mdw-at-linuxbox wrote a similar commit [rgw/beast: must close after body read fails.](https://github.com/ceph/ceph/pull/35350/commits/bc3967a17b0b613084e51a11fe9cc162f16aa844) from unmerged https://github.com/ceph/ceph/pull/35350. this forces `handle_connection()` to return on read errors, but doesn't prevent the problematic call to `stream.async_shutdown()`

@ofriedma also did some related work in https://github.com/ceph/ceph/pull/36428

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
