### PR TITLE
pacific: doc/cephfs: add note about CephFS extended attributes and getfattr

### DIFF
--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -85,3 +85,11 @@ To remove a quota::
 
   setfattr -n ceph.quota.max_bytes -v 0 /some/dir
   setfattr -n ceph.quota.max_files -v 0 /some/dir
+
+
+.. note:: In cases where CephFS extended attributes are set on a CephFS
+   directory (for example, ``/some/dir``), running ``getfattr /some/dir -d -m
+   -`` will not print those CephFS extended attributes. This is because CephFS
+   kernel and FUSE clients hide this information from the ``listxattr(2)``
+   system call. You can access a specific CephFS extended attribute by running
+   ``getfattr /some/dir -n ceph.<some-xattr>`` instead.


### PR DESCRIPTION
Supersedes https://github.com/ceph/ceph/pull/50060

Add a note on the fact that CephFS extended attributes are not printed by "getfattr /some/cephfs/dir/ -d -m -" even when the CephFS directory has some extended attributes set on it.

https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/6ENI42ZMHTTP2OONBRD7FDP7LQBC4P2E/

Primary Author: Rishabh Dave <ridave@redhat.com>
Co-author: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 7f23dde6bec3ef75777438f5ae16347609ca0bf4)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
