### PR TITLE
github: add rgw team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,7 @@ README*                                         @ceph/doc-writers
 /doc/man/8/monmaptool.rst                       @ceph/core
 /doc/man/8/rados.rst                            @ceph/core
 /doc/rados                                      @ceph/core
+/examples/librados                              @ceph/core
 /qa/standalone                                  @ceph/core
 /qa/suites/rados                                @ceph/core
 /qa/workunits/erasure-code                      @ceph/core
@@ -88,6 +89,8 @@ README*                                         @ceph/doc-writers
 /doc/man/8/rbd*                                 @ceph/rbd
 /doc/rbd                                        @ceph/rbd
 /doc/start/quick-rbd.rst                        @ceph/rbd
+/examples/librbd                                @ceph/rbd
+/examples/rbd-replay                            @ceph/rbd
 /qa/rbd                                         @ceph/rbd
 /qa/run_xfstests*                               @ceph/rbd
 /qa/suites/krbd                                 @ceph/rbd
@@ -134,6 +137,7 @@ README*                                         @ceph/doc-writers
 # rgw
 /doc/dev/radosgw                                @ceph/rgw @ceph/doc-writers
 /doc/radosgw                                    @ceph/rgw @ceph/doc-writers
+/examples                                       @ceph/rgw
 /qa/rgw                                         @ceph/rgw
 /qa/suites/rgw                                  @ceph/rgw
 /qa/tasks/barbican.py                           @ceph/rgw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,7 @@ README*                                         @ceph/doc-writers
 /qa/workunits/rbd                               @ceph/rbd
 /src/ceph-rbdnamer                              @ceph/rbd
 /src/cls/journal                                @ceph/rbd
-/src/cls/lock                                   @ceph/rbd
+/src/cls/lock                                   @ceph/rbd @ceph/rgw
 /src/cls/rbd                                    @ceph/rbd
 /src/common/options/rbd*                        @ceph/rbd
 /src/etc-rbdmap                                 @ceph/rbd
@@ -119,7 +119,7 @@ README*                                         @ceph/doc-writers
 /src/test/cli/rbd                               @ceph/rbd
 /src/test/cli-integration/rbd                   @ceph/rbd
 /src/test/cls_journal                           @ceph/rbd
-/src/test/cls_lock                              @ceph/rbd
+/src/test/cls_lock                              @ceph/rbd @ceph/rgw
 /src/test/cls_rbd                               @ceph/rbd
 /src/test/journal                               @ceph/rbd
 /src/test/librbd                                @ceph/rbd
@@ -130,3 +130,44 @@ README*                                         @ceph/doc-writers
 /src/tools/rbd*                                 @ceph/rbd
 /systemd/rbdmap.service.in                      @ceph/rbd
 /udev/50-rbd.rules                              @ceph/rbd
+
+# rgw
+/doc/dev/radosgw                                @ceph/rgw @ceph/doc-writers
+/doc/radosgw                                    @ceph/rgw @ceph/doc-writers
+/qa/rgw                                         @ceph/rgw
+/qa/suites/rgw                                  @ceph/rgw
+/qa/tasks/barbican.py                           @ceph/rgw
+/qa/tasks/kafka.py                              @ceph/rgw
+/qa/tasks/keycloak.py                           @ceph/rgw
+/qa/tasks/keystone.py                           @ceph/rgw
+/qa/tasks/pykmip.py                             @ceph/rgw
+/qa/tasks/rabbitmq.py                           @ceph/rgw
+/qa/tasks/rgw*                                  @ceph/rgw
+/qa/tasks/s3*                                   @ceph/rgw
+/qa/tasks/tempest.py                            @ceph/rgw
+/qa/tasks/vault.py                              @ceph/rgw
+/qa/workunits/rgw                               @ceph/rgw
+/src/cls/2pc_queue                              @ceph/rgw
+/src/cls/cmpomap                                @ceph/rgw
+/src/cls/fifo                                   @ceph/rgw
+/src/cls/log                                    @ceph/rgw
+/src/cls/otp                                    @ceph/rgw
+/src/cls/queue                                  @ceph/rgw
+/src/cls/refcount                               @ceph/rgw
+/src/cls/rgw                                    @ceph/rgw
+/src/cls/rgw_gc                                 @ceph/rgw
+/src/cls/user                                   @ceph/rgw
+/src/cls/version                                @ceph/rgw
+/src/rgw                                        @ceph/rgw
+/src/s3select                                   @ceph/rgw
+/src/spawn                                      @ceph/rgw
+/src/test/cls_2pc_queue                         @ceph/rgw
+/src/test/cls_cmpomap                           @ceph/rgw
+/src/test/cls_otp                               @ceph/rgw
+/src/test/cls_queue                             @ceph/rgw
+/src/test/cls_refcount                          @ceph/rgw
+/src/test/cls_rgw                               @ceph/rgw
+/src/test/cls_rgw_gc                            @ceph/rgw
+/src/test/cls_version                           @ceph/rgw
+/src/test/rgw                                   @ceph/rgw
+/src/test/test_rgw*                             @ceph/rgw


### PR DESCRIPTION
update CODEOWNERS for new team https://github.com/orgs/ceph/teams/rgw

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
