### PR TITLE
CODEOWNERS: don't override doc-writers by core and rbd for some files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,18 +47,18 @@ README*                                         @ceph/doc-writers
 *.rst                                           @ceph/doc-writers
 
 # core
-/doc/man/8/ceph-authtool.rst                    @ceph/core
-/doc/man/8/ceph-conf.rst                        @ceph/core
-/doc/man/8/ceph-create-keys.rst                 @ceph/core
-/doc/man/8/ceph-kvstore-tool.rst                @ceph/core
-/doc/man/8/ceph-mon.rst                         @ceph/core
-/doc/man/8/ceph-objectstore-tool.rst            @ceph/core
-/doc/man/8/ceph-osd.rst                         @ceph/core
-/doc/man/8/ceph.rst                             @ceph/core
-/doc/man/8/crushtool.rst                        @ceph/core
-/doc/man/8/monmaptool.rst                       @ceph/core
-/doc/man/8/rados.rst                            @ceph/core
-/doc/rados                                      @ceph/core
+/doc/man/8/ceph-authtool.rst                    @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-conf.rst                        @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-create-keys.rst                 @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-kvstore-tool.rst                @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-mon.rst                         @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-objectstore-tool.rst            @ceph/core @ceph/doc-writers
+/doc/man/8/ceph-osd.rst                         @ceph/core @ceph/doc-writers
+/doc/man/8/ceph.rst                             @ceph/core @ceph/doc-writers
+/doc/man/8/crushtool.rst                        @ceph/core @ceph/doc-writers
+/doc/man/8/monmaptool.rst                       @ceph/core @ceph/doc-writers
+/doc/man/8/rados.rst                            @ceph/core @ceph/doc-writers
+/doc/rados                                      @ceph/core @ceph/doc-writers
 /examples/librados                              @ceph/core
 /qa/standalone                                  @ceph/core
 /qa/suites/rados                                @ceph/core
@@ -84,11 +84,11 @@ README*                                         @ceph/doc-writers
 /src/test/osd                                   @ceph/core
 
 # rbd
-/doc/dev/rbd*                                   @ceph/rbd
-/doc/man/8/ceph-rbdnamer.rst                    @ceph/rbd
-/doc/man/8/rbd*                                 @ceph/rbd
-/doc/rbd                                        @ceph/rbd
-/doc/start/quick-rbd.rst                        @ceph/rbd
+/doc/dev/rbd*                                   @ceph/rbd @ceph/doc-writers
+/doc/man/8/ceph-rbdnamer.rst                    @ceph/rbd @ceph/doc-writers
+/doc/man/8/rbd*                                 @ceph/rbd @ceph/doc-writers
+/doc/rbd                                        @ceph/rbd @ceph/doc-writers
+/doc/start/quick-rbd.rst                        @ceph/rbd @ceph/doc-writers
 /examples/librbd                                @ceph/rbd
 /examples/rbd-replay                            @ceph/rbd
 /qa/rbd                                         @ceph/rbd


### PR DESCRIPTION
This happens because core and rbd ownership is defined after doc-writers: a later match takes precedence.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>