### PR TITLE
doc/rgw: refine "Failover and Disaster Recovery"

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -592,41 +592,47 @@ this period to other zones.
 Failover and Disaster Recovery
 ==============================
 
-If the master zone should fail, failover to the secondary zone for
-disaster recovery.
+Setting Up Failover to the Secondary Zone
+-----------------------------------------
 
-1. Make the secondary zone the master and default zone. For example:
+If the master zone fails, you can fail over to the secondary zone for
+disaster recovery by following these steps:
+
+#. Make the secondary zone the master and default zone. For example:
 
    .. prompt:: bash #
 
       radosgw-admin zone modify --rgw-zone={zone-name} --master --default
 
-   By default, Ceph Object Gateway will run in an active-active
-   configuration. If the cluster was configured to run in an
+   By default, Ceph Object Gateway runs in an active-active
+   configuration. However, if the cluster is configured to run in an
    active-passive configuration, the secondary zone is a read-only zone.
-   Remove the ``--read-only`` status to allow the zone to receive write
-   operations. For example:
+   To allow the secondary zone to receive write
+   operations, remove its ``--read-only`` status. For example:
 
    .. prompt:: bash #
 
       radosgw-admin zone modify --rgw-zone={zone-name} --master --default \
                                    --read-only=false
 
-2. Update the period to make the changes take effect.
+#. Update the period to make the changes take effect.
 
    .. prompt:: bash #
 
       radosgw-admin period update --commit
 
-3. Finally, restart the Ceph Object Gateway.
+#. Finally, restart the Ceph Object Gateway.
 
    .. prompt:: bash #
 
       systemctl restart ceph-radosgw@rgw.`hostname -s`
 
-If the former master zone recovers, revert the operation.
+Reverting from Failover
+-----------------------
 
-1. From the recovered zone, pull the latest realm configuration
+If the former master zone recovers, you can revert the failover operation by following these steps:
+
+#. From within the recovered zone, pull the latest realm configuration
    from the current master zone:
 
    .. prompt:: bash #
@@ -634,38 +640,38 @@ If the former master zone recovers, revert the operation.
       radosgw-admin realm pull --url={url-to-master-zone-gateway} \
                                   --access-key={access-key} --secret={secret}
 
-2. Make the recovered zone the master and default zone.
+#. Make the recovered zone the master and default zone:
 
    .. prompt:: bash #
 
       radosgw-admin zone modify --rgw-zone={zone-name} --master --default
 
-3. Update the period to make the changes take effect.
+#. Update the period so that the changes take effect:
 
    .. prompt:: bash #
 
       radosgw-admin period update --commit
 
-4. Then, restart the Ceph Object Gateway in the recovered zone.
+#. Restart the Ceph Object Gateway in the recovered zone:
 
    .. prompt:: bash #
 
        systemctl restart ceph-radosgw@rgw.`hostname -s`
 
-5. If the secondary zone needs to be a read-only configuration, update
-   the secondary zone.
+#. If the secondary zone needs to be a read-only configuration, update
+   the secondary zone:
 
    .. prompt:: bash #
 
       radosgw-admin zone modify --rgw-zone={zone-name} --read-only
 
-6. Update the period to make the changes take effect.
+#. Update the period so that the changes take effect:
 
    .. prompt:: bash #
 
       radosgw-admin period update --commit
 
-7. Finally, restart the Ceph Object Gateway in the secondary zone.
+#. Restart the Ceph Object Gateway in the secondary zone:
 
    .. prompt:: bash #
 


### PR DESCRIPTION
English grammar and syntax pass for "Failover and Disaster Recovery" in doc/radosgw/multisite.rst.

https://tracker.ceph.com/issues/58632

Co-authored-by: Cole Mitchell <cole.mitchell@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
