### PR TITLE
cephadm: fix autopep8 arg parsing on newer tox versions

### DIFF
--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -10,24 +10,24 @@ skipsdist = true
 max-line-length = 100
 inline-quotes = '
 ignore =
-    E501,
+    E501, \
     W503,
 exclude =
-    .tox,
-    .vagrant,
-    __pycache__,
-    *.pyc,
-    templates,
+    .tox, \
+    .vagrant, \
+    __pycache__, \
+    *.pyc, \
+    templates, \
     .eggs
 statistics = True
 
 [autopep8]
 addopts =
-    --max-line-length {[flake8]max-line-length}
-    --ignore "{[flake8]ignore}"
-    --exclude "{[flake8]exclude}"
-    --in-place
-    --recursive
+    --max-line-length {[flake8]max-line-length} \
+    --ignore "{[flake8]ignore}" \
+    --exclude "{[flake8]exclude}" \
+    --in-place \
+    --recursive \
     --ignore-local-config
 
 [testenv]


### PR DESCRIPTION
This was failing for me on new tox versions with

fix: commands[1]> autopep8 --max-line-length 100
incorrect number of argumentsfix: exit 99 (0.06 seconds) /home/adking/ceph/src/cephadm> autopep8 --max-line-length 100 pid=309039 fix: FAIL ✖ in 0.08 seconds

As it was considering our list of args for autopep8 to each be one separate command. Fixed by just adding slashes to the ends of the lines (as has already been done in the tox.ini in src/pybind/mgr for some of the tests there)

Signed-off-by: Adam King <adking@redhat.com>


With this change am getting

fix: commands[1]> autopep8 --max-line-length 100 --ignore 'E501, W503,' --exclude '.tox, .vagrant, __pycache__, *.pyc, templates, .eggs' --in-place --recursive --ignore-local-config cephadm.py
fix: OK ✔ in 2.79 seconds


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
