### PR TITLE
osd/scrub: guarantee only a primary calls publish_stats_to_osd()

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -810,10 +810,8 @@ Scrub::BlockedRangeWarning PgScrubber::acquire_blocked_alarm()
   dout(20) << fmt::format(": timeout:{}",
 			  std::chrono::duration_cast<seconds>(grace_period))
 	   << dendl;
-  return std::make_unique<blocked_range_t>(m_osds,
-					   grace_period,
-					   *this,
-					   m_pg_id);
+  return std::make_unique<blocked_range_t>(
+      m_pg, m_osds, grace_period, *this, m_epoch_start, m_pg_id);
 }
 
 /**
@@ -1802,23 +1800,23 @@ bool PgScrubber::is_queued_or_active() const
 void PgScrubber::set_scrub_blocked(utime_t since)
 {
   ceph_assert(!m_scrub_job->blocked);
-  // we are called from a time-triggered lambda,
-  // thus - not under PG-lock
-  PGRef pg = m_osds->osd->lookup_lock_pg(m_pg_id);
-  ceph_assert(pg); // 'this' here should not exist if the PG was removed
+
+  // note: the PG is locked by the caller
   m_osds->get_scrub_services().mark_pg_scrub_blocked(m_pg_id);
   m_scrub_job->blocked_since = since;
   m_scrub_job->blocked = true;
+  // Marking the scrub as blocked in scrub_sched_status,
+  // which is part of pg_stat_t.
+  // caller has verified that the PG was not reset
   m_pg->publish_stats_to_osd();
-  pg->unlock();
 }
 
 void PgScrubber::clear_scrub_blocked()
 {
+  ceph_assert(m_pg->is_locked());
   ceph_assert(m_scrub_job->blocked);
   m_osds->get_scrub_services().clear_pg_scrub_blocked(m_pg_id);
   m_scrub_job->blocked = false;
-  m_pg->publish_stats_to_osd();
 }
 
 /*
@@ -2914,43 +2912,85 @@ ostream& operator<<(ostream& out, const MapsCollectionStatus& sf)
 
 // ///////////////////// blocked_range_t ///////////////////////////////
 
-blocked_range_t::blocked_range_t(OSDService* osds,
-				 ceph::timespan waittime,
-				 ScrubMachineListener& scrubber,
-				 spg_t pg_id)
-    : m_osds{osds}
+blocked_range_t::blocked_range_t(
+    PGRef pg,
+    OSDService* osds,
+    ceph::timespan waittime,
+    ScrubMachineListener& scrubber,
+    epoch_t epoch,
+    spg_t pg_id)
+    : m_pg{pg}
+    , m_osds{osds}
     , m_scrubber{scrubber}
+    , m_epoch{epoch}
     , m_pgid{pg_id}
 {
   auto now_is = std::chrono::system_clock::now();
-  m_callbk = new LambdaContext([this, now_is]([[maybe_unused]] int r) {
-    std::time_t now_c = std::chrono::system_clock::to_time_t(now_is);
-    char buf[50];
-    strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", std::localtime(&now_c));
-    lgeneric_subdout(g_ceph_context, osd, 10)
-      << "PgScrubber: " << m_pgid
-      << " blocked on an object for too long (since " << buf << ")" << dendl;
-    m_osds->clog->warn() << "osd." << m_osds->whoami
-			 << " PgScrubber: " << m_pgid
-			 << " blocked on an object for too long (since " << buf
-			 << ")";
+  m_callbk = new LambdaContext([=, this]([[maybe_unused]] int r) {
+    if (m_was_deleted) {
+      return;
+    }
+    pg->lock();
+    if (!pg->pg_has_reset_since(epoch)) {
+      std::time_t now_c = std::chrono::system_clock::to_time_t(now_is);
+      char buf[50];
+      strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", std::localtime(&now_c));
+      lgeneric_subdout(g_ceph_context, osd, 10)
+	  << "PgScrubber: " << m_pgid
+	  << " blocked on an object for too long (since " << buf << ")"
+	  << dendl;
+      m_osds->clog->warn() << "osd." << m_osds->whoami
+			   << " PgScrubber: " << m_pgid
+			   << " blocked on an object for too long (since "
+			   << buf << ")";
 
-    m_warning_issued = true;
-    m_scrubber.set_scrub_blocked(utime_t{now_c,0});
+      m_warning_issued = true;
+      m_scrubber.set_scrub_blocked(utime_t{now_c, 0});
+    }
+    pg->unlock();
     return;
   });
 
   std::lock_guard l(m_osds->sleep_lock);
-  m_osds->sleep_timer.add_event_after(waittime, m_callbk);
+  m_callbk = m_osds->sleep_timer.add_event_after(waittime, m_callbk);
 }
 
+/**
+ * \attn must hold the PG lock
+ * \attn must *not* be holding the sleep_lock
+ */
+void blocked_range_t::cancel_future_alarm()
+{
+  if (!m_callbk) {
+    return;
+  }
+  if (m_warning_issued) {
+    // too late. The dtor will clear the OSD-wide flag
+    return;
+  }
+  std::lock_guard l(m_osds->sleep_lock);
+  if (m_callbk) {
+    m_osds->sleep_timer.cancel_event(m_callbk);
+    m_callbk = nullptr;
+  }
+  // we could call m_pg.reset() here (the PGRef is not needed anymore),
+  // but - as we know that the RangeBlocked state is exiting - there is
+  // no need.
+}
+
+/*
+ * we are only discarded when the RangeBlocked state is exited. Which means
+ * that we are under the PG lock.
+ */
 blocked_range_t::~blocked_range_t()
 {
+  if (!m_callbk) {
+    return;
+  }
+  m_was_deleted = true;	 // instead of accessing the sleep_timer
   if (m_warning_issued) {
     m_scrubber.clear_scrub_blocked();
   }
-  std::lock_guard l(m_osds->sleep_lock);
-  m_osds->sleep_timer.cancel_event(m_callbk);
 }
 
 }  // namespace Scrub

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -537,6 +537,16 @@ void PgScrubber::on_primary_change(
     << dendl;
 }
 
+/*
+ * A note re the call to publish_stats_to_osd() below:
+ * - we are called from either request_rescrubbing() or scrub_requested().
+ * - in both cases - the schedule was modified, and needs to be published;
+ * - we are a Primary.
+ * - in the 1st case - the call is made as part of scrub_finish(), which
+ *   guarantees that the PG is locked and the interval is still the same.
+ * - in the 2nd case - we know the PG state and we know we are only called
+ *   for a Primary.
+*/
 void PgScrubber::update_scrub_job(const requested_scrub_t& request_flags)
 {
   dout(10) << fmt::format("{}: flags:<{}>", __func__, request_flags) << dendl;
@@ -1005,9 +1015,7 @@ void PgScrubber::on_init()
   ceph_assert(!is_scrub_active());
   m_pg->reset_objects_scrubbed();
   preemption_data.reset();
-  m_pg->publish_stats_to_osd();
   m_interval_start = m_pg->get_history().same_interval_since;
-
   dout(10) << __func__ << " start same_interval:" << m_interval_start << dendl;
 
   m_be = std::make_unique<ScrubBackend>(
@@ -1030,6 +1038,7 @@ void PgScrubber::on_init()
   m_start = m_pg->info.pgid.pgid.get_hobj_start();
   m_active = true;
   ++m_sessions_counter;
+  // publish the session counter and the fact the we are scrubbing.
   m_pg->publish_stats_to_osd();
 }
 
@@ -1367,6 +1376,8 @@ void PgScrubber::maps_compare_n_cleanup()
 
   m_start = m_end;
   run_callbacks();
+
+  // requeue the writes from the chunk that just finished
   requeue_waiting();
   m_osds->queue_scrub_maps_compared(m_pg, Scrub::scrub_prio_t::low_priority);
 }
@@ -1495,7 +1506,8 @@ void PgScrubber::set_op_parameters(const requested_scrub_t& request)
     update_op_mode_text();
   }
 
-  // the publishing here is required for tests synchronization
+  // The publishing here is required for tests synchronization.
+  // The PG state flags were modified.
   m_pg->publish_stats_to_osd();
   m_flags.deep_scrub_on_error = request.deep_scrub_on_error;
 }
@@ -2277,19 +2289,17 @@ void PgScrubber::cleanup_on_finish()
 
   state_clear(PG_STATE_SCRUBBING);
   state_clear(PG_STATE_DEEP_SCRUB);
-  m_pg->publish_stats_to_osd();
 
   clear_scrub_reservations();
-  m_pg->publish_stats_to_osd();
-
   requeue_waiting();
 
   reset_internal_state();
-  m_pg->publish_stats_to_osd();
   m_flags = scrub_flags_t{};
 
   // type-specific state clear
   _scrub_clear_state();
+  // PG state flags changed:
+  m_pg->publish_stats_to_osd();
 }
 
 // uses process_event(), so must be invoked externally
@@ -2315,8 +2325,6 @@ void PgScrubber::clear_pgscrub_state()
   state_clear(PG_STATE_REPAIR);
 
   clear_scrub_reservations();
-  m_pg->publish_stats_to_osd();
-
   requeue_waiting();
 
   reset_internal_state();
@@ -2324,7 +2332,6 @@ void PgScrubber::clear_pgscrub_state()
 
   // type-specific state clear
   _scrub_clear_state();
-  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::replica_handling_done()

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -213,6 +213,17 @@ RangeBlocked::RangeBlocked(my_context ctx)
   m_timeout = scrbr->acquire_blocked_alarm();
 }
 
+sc::result RangeBlocked::react(const Unblocked&)
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  dout(10) << "RangeBlocked::react(const Unblocked&)" << dendl;
+
+  if (m_timeout) {
+    m_timeout->cancel_future_alarm();
+  }
+  return transit<PendingTimer>();
+}
+
 // ----------------------- PendingTimer -----------------------------------
 
 /**

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -244,7 +244,9 @@ struct ActiveScrubbing
 
 struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
   explicit RangeBlocked(my_context ctx);
-  using reactions = mpl::list<sc::transition<Unblocked, PendingTimer>>;
+  using reactions = mpl::list<sc::custom_reaction<Unblocked>>;
+
+  sc::result react(const Unblocked&);
 
   Scrub::BlockedRangeWarning m_timeout;
 };


### PR DESCRIPTION

and fix "scrub blocked on object" alarm to prevent both
deadlocks, and calling publish_stats() where not allowed.
Note also the discussion in https://github.com/ceph/ceph/pull/49959.

Fixes: https://tracker.ceph.com/issues/58496
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
