### PR TITLE
pacific: os/memstore: Fix memory leak

### DIFF
--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -1796,5 +1796,5 @@ int MemStore::PageSetObject::truncate(uint64_t size)
 MemStore::ObjectRef MemStore::Collection::create_object() const {
   if (use_page_set)
     return ceph::make_ref<PageSetObject>(cct->_conf->memstore_page_size);
-  return new BufferlistObject();
+  return make_ref<BufferlistObject>();
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58703

---

backport of https://github.com/ceph/ceph/pull/46507
parent tracker: https://tracker.ceph.com/issues/58701

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh