### PR TITLE
rgw: rgw_token.cc error: reference to 'formatter' is ambiguous

### DIFF
--- a/src/rgw/rgw_token.cc
+++ b/src/rgw/rgw_token.cc
@@ -40,7 +40,7 @@ namespace {
   string access_key{""};
   string secret_key{""};
 
-  Formatter* formatter{nullptr};
+  Formatter* token_formatter{nullptr};
 
   bool verbose {false};
   bool do_encode {false};
@@ -122,13 +122,13 @@ int main(int argc, char **argv)
     return -EINVAL;
   }
 
-  formatter = new JSONFormatter(true /* pretty */);
+  token_formatter = new JSONFormatter(true /* pretty */);
 
   RGWToken token(type, access_key, secret_key);
   if (do_encode) {
-    token.encode_json(formatter);
+    token.encode_json(token_formatter);
     std::ostringstream os;
-    formatter->flush(os);
+    token_formatter->flush(os);
     string token_str = os.str();
     if (verbose) {
       std::cout << "expanded token: " << token_str << std::endl;

--- a/src/test/test_rgw_token.cc
+++ b/src/test/test_rgw_token.cc
@@ -45,25 +45,25 @@ namespace {
   std::string non_base64{"stuff here"};
   std::string non_base64_sploded{"90KLscc0Dz4U49HX-7Tx"};
 
-  Formatter* formatter{nullptr};
+  Formatter* token_formatter{nullptr};
   bool verbose {false};
 }
 
 using namespace std;
 
 TEST(TOKEN, INIT) {
-  formatter = new JSONFormatter(true /* pretty */);
-  ASSERT_NE(formatter, nullptr);
+  token_formatter = new JSONFormatter(true /* pretty */);
+  ASSERT_NE(token_formatter, nullptr);
 }
 
 TEST(TOKEN, ENCODE) {
   // encode the two supported types
   RGWToken token_ad(RGWToken::TOKEN_AD, access_key, secret_key);
-  ASSERT_EQ(token_ad.encode_json_base64(formatter), enc_ad);
+  ASSERT_EQ(token_ad.encode_json_base64(token_formatter), enc_ad);
   tokens.push_back(token_ad); // provies copiable
 
   RGWToken token_ldap(RGWToken::TOKEN_LDAP, access_key, secret_key);
-  ASSERT_EQ(token_ldap.encode_json_base64(formatter), enc_ldap);
+  ASSERT_EQ(token_ldap.encode_json_base64(token_formatter), enc_ldap);
   tokens.push_back(token_ldap);
 }
 
@@ -101,7 +101,7 @@ TEST(TOKEN, BADINPUT3) {
 }
 
 TEST(TOKEN, SHUTDOWN) {
-  delete formatter;
+  delete token_formatter;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
compiling main branch on Fedora 38 and 39/rawhide with gcc-c++-13.0.1 fails with the error:

/builddir/build/BUILD/ceph-18.0.0-2148-g9754cafc/src/rgw/rgw_token.cc: In function 'int main(int, char**)':
/builddir/build/BUILD/ceph-18.0.0-2148-g9754cafc/src/rgw/rgw_token.cc:125:3: error: reference to 'formatter' is ambiguous
  125 | formatter = new JSONFormatter(true /* pretty */);
      |   ^~~~~~~~~

Similar error for src/test/test_rgw_token.cc

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
