### PR TITLE
quincy: RGW - Fix NoSuchTagSet error

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -127,7 +127,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_SERVICE_UNAVAILABLE, {503, "ServiceUnavailable"}},
     { ERR_RATE_LIMITED, {503, "SlowDown"}},
     { ERR_ZERO_IN_URL, {400, "InvalidRequest" }},
-    { ERR_NO_SUCH_TAG_SET, {404, "NoSuchTagSetError"}},
+    { ERR_NO_SUCH_TAG_SET, {404, "NoSuchTagSet"}},
     { ERR_NO_SUCH_BUCKET_ENCRYPTION_CONFIGURATION, {404, "ServerSideEncryptionConfigurationNotFoundError"}},
 });
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55614

---

backport of https://github.com/ceph/ceph/pull/46167
parent tracker: https://tracker.ceph.com/issues/55460

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh