### PR TITLE
pacific: mgr/dashboard: fix "can't read .ssh/known_hosts: No such file or directory 

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -25,7 +25,7 @@ fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
 cephadm_shell="cephadm shell --fsid ${fsid} -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring"
 
 {% for number in range(1, nodes) %}
-  ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@{{ prefix }}-node-0{{ number }}
+  ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@192.168.100.10{{ number }}
   {% if expanded_cluster is defined %}
     ${cephadm_shell} ceph orch host add {{ prefix }}-node-0{{ number }}
   {% endif %}

--- a/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
+++ b/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
@@ -8,7 +8,7 @@ parameters:
  prefix: ceph
  numcpus: 1
  memory: 2048
- image: fedora34
+ image: fedora36
  notify: false
  admin_password: password
  disks:

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -41,7 +41,7 @@ on_error() {
 trap 'on_error $? $LINENO' ERR
 trap 'cleanup $? $LINENO' EXIT
 
-sed -i '/ceph-node-/d' $HOME/.ssh/known_hosts
+sed -i '/ceph-node-/d' $HOME/.ssh/known_hosts || true
 
 : ${CEPH_DEV_FOLDER:=${PWD}}
 EXTRA_PARAMS=''
@@ -71,8 +71,8 @@ fi
 npm run build ${FRONTEND_BUILD_OPTS} &
 
 cd ${CEPH_DEV_FOLDER}
-: ${VM_IMAGE:='fedora34'}
-: ${VM_IMAGE_URL:='https://fedora.mirror.liteserver.nl/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2'}
+: ${VM_IMAGE:='fedora36'}
+: ${VM_IMAGE_URL:='https://fedora.mirror.liteserver.nl/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2'}
 kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}
 kcli delete plan -y ceph || true
 kcli create plan -f src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57433

---

backport of https://github.com/ceph/ceph/pull/47634
parent tracker: https://tracker.ceph.com/issues/57365

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh