### PR TITLE
quincy: mgr/dashboard: fix rbd mirroring daemon health status

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -94,7 +94,7 @@ def get_daemons():
 
 def get_daemon_health(daemon):
     health = {
-        'health': MirrorHealth.MIRROR_HEALTH_UNKNOWN
+        'health': MirrorHealth.MIRROR_HEALTH_DISABLED
     }
     for _, pool_data in daemon['status'].items():
         if (health['health'] != MirrorHealth.MIRROR_HEALTH_ERROR
@@ -109,7 +109,7 @@ def get_daemon_health(daemon):
             health = {
                 'health': MirrorHealth.MIRROR_HEALTH_WARNING
             }
-        elif health['health'] == MirrorHealth.MIRROR_HEALTH_INFO:
+        elif health['health'] == MirrorHealth.MIRROR_HEALTH_DISABLED:
             health = {
                 'health': MirrorHealth.MIRROR_HEALTH_OK
             }

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -31,7 +31,11 @@ mock_get_metadata = {
 
 _status = {
     1: {
-        'callouts': {},
+        'callouts': {
+            'image': {
+                'level': 'warning',
+            }
+        },
         'image_local_count': 5,
         'image_remote_count': 6,
         'image_error_count': 7,
@@ -288,6 +292,7 @@ class RbdMirroringSummaryControllerTest(ControllerTestCase):
         self.assertStatus(200)
 
         summary = self.json_body()['rbd_mirroring']
+        # 2 warnings: 1 for the daemon, 1 for the pool
         self.assertEqual(summary, {'errors': 0, 'warnings': 2})
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58729

---

backport of https://github.com/ceph/ceph/pull/50051
parent tracker: https://tracker.ceph.com/issues/58679

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh