### PR TITLE
rgw: Fix segfault due to concurrent socket use at timeout

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -338,6 +338,8 @@ struct Connection : boost::intrusive::list_base_hook<>,
   void close(boost::system::error_code& ec) {
     socket.close(ec);
   }
+
+  tcp_socket& get_socket() { return socket; }
 };
 
 class ConnectionList {

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -20,7 +20,8 @@ struct timeout_handler {
   void operator()(boost::system::error_code ec) {
     if (!ec) { // wait was not canceled
       boost::system::error_code ec_ignored;
-      stream->close(ec_ignored);
+      stream->get_socket().cancel();
+      stream->get_socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec_ignored);
     }
   }
 };


### PR DESCRIPTION
This commit fixes a potential segfault risk when rgw timeout handler works on the socket in one thread while it is concurrently used by another. The details of the fix are:

1. Instead of calling socket close(), which resets descriptor_data in boost::asio socket and risks segfault due to concurrent use of the socket, the timeout handler now calls cancel() to abort all pending ops followed by shutdown() to disable the underlying transport. The eventual closure of the socket will be done in the socket destructor.

3. Expose the actual boost::asio socket via get_socket() from Connection so that the timeout handler can call cancel() and shutdown() on it, although the socket data member is already accessible. It allows future expansion that wants to hide the socket even though it renders the existing close() less useful.

Fixes: https://tracker.ceph.com/issues/58670
Signed-off-by: Yixin Jin <yjin77@yahoo.ca>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
