### PR TITLE
Enable librbd tests on Windows

### DIFF
--- a/src/include/win32/winioctl_compat.h
+++ b/src/include/win32/winioctl_compat.h
@@ -1,0 +1,43 @@
+// Mingw provides a minimal version of this header and doesn't include all the
+// definitions that we need.
+
+#pragma once
+
+#ifdef __MINGW32__
+
+#include <winioctl.h>
+
+#define IOCTL_DISK_GET_DISK_ATTRIBUTES \
+	CTL_CODE(IOCTL_DISK_BASE, 0x003c, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_DISK_SET_DISK_ATTRIBUTES \
+	CTL_CODE(IOCTL_DISK_BASE, 0x003d, METHOD_BUFFERED, \
+		FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+#define DISK_ATTRIBUTE_OFFLINE   0x0000000000000001
+#define DISK_ATTRIBUTE_READ_ONLY 0x0000000000000002
+
+//
+// IOCTL_DISK_SET_DISK_ATTRIBUTES
+//
+// Input Buffer:
+//     Structure of type SET_DISK_ATTRIBUTES
+//
+// Output Buffer:
+//     None
+//
+typedef struct _SET_DISK_ATTRIBUTES {
+    // Specifies the size of the structure for versioning.
+    DWORD Version;
+    // Indicates whether to remember these settings across reboots or not.
+    BOOLEAN Persist;
+    // Reserved. Must set to zero.
+    BYTE  Reserved1[3];
+    // Specifies the new attributes.
+    DWORDLONG Attributes;
+    // Specifies the attributes that are being modified.
+    DWORDLONG AttributesMask;
+    // Reserved. Must set to zero.
+    DWORD Reserved2[4];
+} SET_DISK_ATTRIBUTES, *PSET_DISK_ATTRIBUTES;
+
+#endif // __MINGW32__

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -22,11 +22,9 @@ add_subdirectory(librados_test_stub)
 if(WITH_LIBRADOSSTRIPER)
   add_subdirectory(libradosstriper)
 endif()
-if(WITH_RBD AND NOT WIN32)
-  # librbd tests require libcls*, which in turn require libos and libosd, which
-  # haven't been ported to Windows yet.
+if(WITH_RBD)
   add_subdirectory(librbd)
-endif(WITH_RBD AND NOT WIN32)
+endif()
 if (WITH_CEPHFS)
   add_subdirectory(mds)
 endif()

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -152,6 +152,11 @@ if(LINUX AND HAVE_LIBCRYPTSETUP)
           crypto/luks/test_mock_LoadRequest.cc)
 endif()
 
+# On Windows, we'll skip librbd unit tests for the time being, running just the
+# functional tests. The reason is that the unit tests require libcls*, which in
+# turn requires libos and libosd, however those libraries haven't been ported to
+# Windows.
+if(NOT WIN32)
 add_executable(unittest_librbd
   ${unittest_librbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
@@ -187,6 +192,7 @@ if(WITH_RBD_RWL OR WITH_RBD_SSD_CACHE)
   target_link_libraries(unittest_librbd
     librbd_plugin_pwl_cache)
 endif()
+endif(NOT WIN32)
 
 add_executable(ceph_test_librbd
   test_main.cc


### PR DESCRIPTION
This change enables the librbd functional tests on Windows, updating the fsx test accordingly:

* aligned_free (compat.h wrapper) needs to be used after allocating memory using posix_memalign, "free" causes a crash on Windows
* long (4B) can't store x64 pointers on Windows, we'll use uintptr_t instead.
* use O_BINARY when opening files, otherwise certain characters get translated (e.g. LF to CRLF).
* add wnbd mode that exercises rbd-wnbd

We'll continue skipping the unit tests however, which require too much OSD code that hasn't been ported (e.g. cls, libosd, etc).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
