### PR TITLE
rgw/flight: don't access non-existant flight store during GetObj

### DIFF
--- a/src/rgw/rgw_flight_frontend.cc
+++ b/src/rgw/rgw_flight_frontend.cc
@@ -49,7 +49,11 @@ FlightFrontend::FlightFrontend(RGWProcessEnv& _env,
 
 FlightFrontend::~FlightFrontend() {
   delete env.flight_server;
+  env.flight_server = nullptr;
+
   delete env.flight_store;
+  env.flight_store = nullptr;
+
   INFO << "flight server shut down" << dendl;
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2237,10 +2237,14 @@ void RGWGetObj::execute(optional_yield y)
   }
 
 #ifdef WITH_ARROW_FLIGHT
-  if (ofs == 0) {
-    // insert a GetObj_Filter to monitor and create flight
-    flight_filter.emplace(s, filter);
-    filter = &*flight_filter;
+  if (s->penv.flight_store) {
+    if (ofs == 0) {
+      // insert a GetObj_Filter to monitor and create flight
+      flight_filter.emplace(s, filter);
+      filter = &*flight_filter;
+    }
+  } else {
+    ldpp_dout(this, 0) << "ERROR: flight_store not created in " << __func__ << dendl;
   }
 #endif
 

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -43,8 +43,8 @@ struct RGWProcessEnv {
 
 #ifdef WITH_ARROW_FLIGHT
   // managed by rgw:flight::FlightFrontend in rgw_flight_frontend.cc
-  rgw::flight::FlightServer* flight_server;
-  rgw::flight::FlightStore* flight_store;
+  rgw::flight::FlightServer* flight_server = nullptr;
+  rgw::flight::FlightStore* flight_store = nullptr;
 #endif
 };
 


### PR DESCRIPTION
The front end must be configured via ceph.conf to start up both the flight_server and the flight_store. RGWGetObj needs to check for the existence of a flight_store prior to trying to use it.

Recent commit that allowed for this: eac2905d9f64e174570ee25129112ed7ed53993c.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
