### PR TITLE
quincy: ceph-volume: do not raise RuntimeError in util.lsblk

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -242,7 +242,8 @@ def lsblk(device, columns=None, abspath=False):
                        columns=columns,
                        abspath=abspath)
     if not result:
-        raise RuntimeError(f"{device} not found is lsblk report")
+        logger.debug(f"{device} not found is lsblk report")
+        return {}
 
     return result[0]
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58735

---

backport of https://github.com/ceph/ceph/pull/50017
parent tracker: https://tracker.ceph.com/issues/58655

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh