### PR TITLE
debian/mgr: remove pytest from debian/ceph-mgr-dashboard.requires

### DIFF
--- a/debian/ceph-mgr-dashboard.requires
+++ b/debian/ceph-mgr-dashboard.requires
@@ -7,6 +7,5 @@ requests
 Routes
 pkg-resources
 prettytable
-pytest
 pyyaml
 ceph-common


### PR DESCRIPTION
pytest isn't listed in ceph.spec.in for rpm builds, so it probably isn't really a requirement for debian

what's the easiest way to confirm this?

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
