### PR TITLE
os/store_test: Retune tests to current code

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10246,6 +10246,9 @@ void BlueStore::inject_global_statfs(const store_statfs_t& new_statfs)
   v.encode(bl);
   t->set(PREFIX_STAT, BLUESTORE_GLOBAL_STATFS_KEY, bl);
   db->submit_transaction_sync(t);
+  // must set these; are needed at _close_db() statfs persisting
+  per_pool_stat_collection = false;
+  vstatfs = new_statfs;
 }
 
 void BlueStore::inject_misreference(coll_t cid1, ghobject_t oid1,

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -9343,9 +9343,10 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
 
   //////////// verify invalid statfs ///////////
   cerr << "fix invalid statfs" << std::endl;
-  SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_stats", "true");
+  SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_stats", "false");
+  // disable allocation recovery - it will fix statfs too
   SetVal(g_conf(),
-    "bluestore_debug_inject_allocation_from_file_failure", "1");
+    "bluestore_debug_inject_allocation_from_file_failure", "0");
   store_statfs_t statfs0;
   store_statfs_t statfs;
   bstore->mount();
@@ -9355,7 +9356,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
   statfs.data_stored += 0x10000;
   ASSERT_FALSE(statfs0 == statfs);
   // this enforces global stats usage
-  bstore->inject_statfs("bluestore_statfs", statfs);
+  bstore->inject_global_statfs(statfs);
   bstore->umount();
 
   ASSERT_GE(bstore->fsck(false), 1); // global stats mismatch might omitted when
@@ -9379,10 +9380,10 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
   statfs.data_stored += 0x20000;
   ASSERT_FALSE(statfs0 == statfs);
   // this enforces global stats usage
-  bstore->inject_statfs("bluestore_statfs", statfs);
+  bstore->inject_global_statfs(statfs);
   bstore->umount();
 
-  ASSERT_EQ(bstore->fsck(false), 2);
+  ASSERT_EQ(bstore->fsck(false), 1);
   ASSERT_EQ(bstore->repair(false), 0);
   ASSERT_EQ(bstore->fsck(false), 0);
   ASSERT_EQ(bstore->mount(), 0);


### PR DESCRIPTION
After introduction of lazy statfs updates and mechanism to store them at exit, some tests required tune-up.



Simple harmonization, it clears problems most likely introduced by https://github.com/ceph/ceph/pull/46036.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
