### PR TITLE
quincy: librbd: Fix local rbd mirror journals growing forever

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -443,10 +443,10 @@ expect_false get_pid ${POOL}
 DEV=
 
 # test discard granularity with journaling
-DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`
-get_pid ${POOL}
 rbd config image set ${POOL}/${IMAGE} rbd_discard_granularity_bytes 4096
 rbd feature enable ${POOL}/${IMAGE} journaling
+DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`
+get_pid ${POOL}
 # since a discard will now be pruned to only whole blocks (0..4095, 4096..8191)
 # let us test all the cases around those alignments. 512 is the smallest
 # possible block blkdiscard allows us to use. Thus the test checks
@@ -457,34 +457,6 @@ _sudo blkdiscard --offset 0 --length $((4096+512)) ${DEV}
 _sudo blkdiscard --offset 512 --length $((8192-1024)) ${DEV}
 _sudo blkdiscard --offset 512 --length $((8192-512)) ${DEV}
 _sudo blkdiscard --offset 512 --length 8192 ${DEV}
-expected='Entry: tag_id=1, commit_tid=1
-{
-    "event_type": "AioDiscard",
-    "offset": 0,
-    "length": 4096,
-    "discard_granularity_bytes": 4096,
-Entry: tag_id=1, commit_tid=2
-{
-    "event_type": "AioDiscard",
-    "offset": 0,
-    "length": 4096,
-    "discard_granularity_bytes": 4096,
-Entry: tag_id=1, commit_tid=3
-{
-    "event_type": "AioDiscard",
-    "offset": 4096,
-    "length": 4096,
-    "discard_granularity_bytes": 4096,
-Entry: tag_id=1, commit_tid=4
-{
-    "event_type": "AioDiscard",
-    "offset": 4096,
-    "length": 4096,
-    "discard_granularity_bytes": 4096,'
-out=`rbd journal inspect --pool ${POOL} --image ${IMAGE} --verbose | \
-    grep -A5 --no-group-separator Entry`
-rbd config image rm ${POOL}/${IMAGE} rbd_discard_granularity_bytes
-[ "${out}" == "${expected}" ]
 # wait for commit log to be empty, 10 seconds should be well enough
 tries=0
 queue_length=`rbd journal inspect --pool ${POOL} --image ${IMAGE} | awk '/entries inspected/ {print $1}'`
@@ -494,10 +466,11 @@ while [ ${tries} -lt 10 ] && [ ${queue_length} -gt 0 ]; do
     queue_length=`rbd journal inspect --pool ${POOL} --image ${IMAGE} | awk '/entries inspected/ {print $1}'`
     tries=$((tries+1))
 done
-rbd feature disable ${POOL}/${IMAGE} journaling
 [ ${queue_length} -eq 0 ]
 unmap_device ${DEV} ${PID}
 DEV=
+rbd feature disable ${POOL}/${IMAGE} journaling
+rbd config image rm ${POOL}/${IMAGE} rbd_discard_granularity_bytes
 
 # test that rbd_op_threads setting takes effect
 EXPECTED=`ceph-conf --show-config-value librados_thread_count`

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -442,6 +442,63 @@ _sudo rbd device detach ${DEV} --device-type nbd
 expect_false get_pid ${POOL}
 DEV=
 
+# test discard granularity with journaling
+DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`
+get_pid ${POOL}
+rbd config image set ${POOL}/${IMAGE} rbd_discard_granularity_bytes 4096
+rbd feature enable ${POOL}/${IMAGE} journaling
+# since a discard will now be pruned to only whole blocks (0..4095, 4096..8191)
+# let us test all the cases around those alignments. 512 is the smallest
+# possible block blkdiscard allows us to use. Thus the test checks
+# 512 before, on the alignment, 512 after.
+_sudo blkdiscard --offset 0 --length $((4096-512)) ${DEV}
+_sudo blkdiscard --offset 0 --length 4096 ${DEV}
+_sudo blkdiscard --offset 0 --length $((4096+512)) ${DEV}
+_sudo blkdiscard --offset 512 --length $((8192-1024)) ${DEV}
+_sudo blkdiscard --offset 512 --length $((8192-512)) ${DEV}
+_sudo blkdiscard --offset 512 --length 8192 ${DEV}
+expected='Entry: tag_id=1, commit_tid=1
+{
+    "event_type": "AioDiscard",
+    "offset": 0,
+    "length": 4096,
+    "discard_granularity_bytes": 4096,
+Entry: tag_id=1, commit_tid=2
+{
+    "event_type": "AioDiscard",
+    "offset": 0,
+    "length": 4096,
+    "discard_granularity_bytes": 4096,
+Entry: tag_id=1, commit_tid=3
+{
+    "event_type": "AioDiscard",
+    "offset": 4096,
+    "length": 4096,
+    "discard_granularity_bytes": 4096,
+Entry: tag_id=1, commit_tid=4
+{
+    "event_type": "AioDiscard",
+    "offset": 4096,
+    "length": 4096,
+    "discard_granularity_bytes": 4096,'
+out=`rbd journal inspect --pool ${POOL} --image ${IMAGE} --verbose | \
+    grep -A5 --no-group-separator Entry`
+rbd config image rm ${POOL}/${IMAGE} rbd_discard_granularity_bytes
+[ "${out}" == "${expected}" ]
+# wait for commit log to be empty, 10 seconds should be well enough
+tries=0
+queue_length=`rbd journal inspect --pool ${POOL} --image ${IMAGE} | awk '/entries inspected/ {print $1}'`
+while [ ${tries} -lt 10 ] && [ ${queue_length} -gt 0 ]; do
+    rbd journal inspect --pool ${POOL} --image ${IMAGE} --verbose
+    sleep 1
+    queue_length=`rbd journal inspect --pool ${POOL} --image ${IMAGE} | awk '/entries inspected/ {print $1}'`
+    tries=$((tries+1))
+done
+rbd feature disable ${POOL}/${IMAGE} journaling
+[ ${queue_length} -eq 0 ]
+unmap_device ${DEV} ${PID}
+DEV=
+
 # test that rbd_op_threads setting takes effect
 EXPECTED=`ceph-conf --show-config-value librados_thread_count`
 DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -121,10 +121,6 @@ struct TestMockIoImageRequest : public TestMockFixture {
       .WillOnce(Return(journal_tid));
   }
 
-  void expect_journal_append_io_event_times(MockTestJournal &mock_journal, int n) {
-    EXPECT_CALL(mock_journal, append_io_event_mock(_, _, _, _, _)).Times(n);
-  }
-
   void expect_object_discard_request(MockTestImageCtx &mock_image_ctx,
                                      uint64_t object_no, uint64_t offset,
                                      uint32_t length, int r) {
@@ -140,10 +136,6 @@ struct TestMockIoImageRequest : public TestMockFixture {
                   spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
                   mock_image_ctx.image_ctx->op_work_queue->queue(&spec->dispatcher_ctx, r);
                 }));
-  }
-
-  void expect_object_request_send_times(MockTestImageCtx &mock_image_ctx, int n) {
-    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, send(_)).Times(n);
   }
 
   void expect_object_request_send(MockTestImageCtx &mock_image_ctx,
@@ -441,12 +433,11 @@ TEST_F(TestMockIoImageRequest, TailDiscardJournalAppendEnabled) {
   ASSERT_EQ(0, aio_comp_ctx.wait());
 }
 
-TEST_F(TestMockIoImageRequest, EmptyDiscardJournalAppendEnabled) {
+TEST_F(TestMockIoImageRequest, PruneRequiredDiscardJournalAppendEnabled) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, resize(ictx, ictx->layout.object_size));
   ictx->discard_granularity_bytes = 32;
 
   MockTestImageCtx mock_image_ctx(*ictx);
@@ -456,14 +447,44 @@ TEST_F(TestMockIoImageRequest, EmptyDiscardJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  expect_journal_append_io_event_times(mock_journal, 0);
-  expect_object_request_send_times(mock_image_ctx, 0);
+  EXPECT_CALL(mock_journal, append_io_event_mock(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, send(_)).Times(0);
 
   C_SaferCond aio_comp_ctx;
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{96, 31}}, ictx->discard_granularity_bytes,
+    mock_image_ctx.get_data_io_context(), {});
+  {
+    std::shared_lock owner_locker{mock_image_ctx.owner_lock};
+    mock_aio_image_discard.send();
+  }
+  ASSERT_EQ(0, aio_comp_ctx.wait());
+}
+
+TEST_F(TestMockIoImageRequest, LengthModifiedDiscardJournalAppendEnabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->discard_granularity_bytes = 32;
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockTestJournal mock_journal;
+  mock_image_ctx.journal = &mock_journal;
+
+  InSequence seq;
+  expect_get_modify_timestamp(mock_image_ctx, false);
+  expect_is_journal_appending(mock_journal, true);
+  expect_journal_append_io_event(mock_journal, 0, 32, 32);
+  expect_object_discard_request(mock_image_ctx, 0, 32, 32, 0);
+
+  C_SaferCond aio_comp_ctx;
+  AioCompletion *aio_comp = AioCompletion::create_and_start(
+    &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
+  MockImageDiscardRequest mock_aio_image_discard(
+    mock_image_ctx, aio_comp, {{16, 63}}, ictx->discard_granularity_bytes,
     mock_image_ctx.get_data_io_context(), {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58765

---

backport of https://github.com/ceph/ceph/pull/49614
parent tracker: https://tracker.ceph.com/issues/57396