### PR TITLE
qa/rgw: update boto3 example path in notification_tests.py

### DIFF
--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -89,7 +89,7 @@ def pre_process(ctx, config):
 
         ctx.cluster.only(client).run(
             args=[
-                'cd', '/home/ubuntu/.aws/models/s3/2006-03-01/', run.Raw('&&'), 'cp', '{tdir}/ceph/examples/boto3/service-2.sdk-extras.json'.format(tdir=test_dir), 'service-2.sdk-extras.json'
+                'cd', '/home/ubuntu/.aws/models/s3/2006-03-01/', run.Raw('&&'), 'cp', '{tdir}/ceph/examples/rgw/boto3/service-2.sdk-extras.json'.format(tdir=test_dir), 'service-2.sdk-extras.json'
                 ],
             )
 


### PR DESCRIPTION
fallout from https://github.com/ceph/ceph/pull/50102:

```
2023-02-18T08:55:33.179 INFO:tasks.notification_tests:Using branch main from https://github.com/ceph/ceph.git for bucket notifications tests
2023-02-18T08:55:33.179 DEBUG:teuthology.orchestra.run.smithi133:> git clone -b main https://github.com/ceph/ceph.git /home/ubuntu/cephtest/ceph
2023-02-18T08:55:33.199 INFO:teuthology.orchestra.run.smithi133.stderr:Cloning into '/home/ubuntu/cephtest/ceph'...
2023-02-18T08:56:10.027 INFO:tasks.notification_tests:Pre-processing...
2023-02-18T08:56:10.028 DEBUG:teuthology.orchestra.run.smithi133:> mkdir -p /home/ubuntu/.aws/models/s3/2006-03-01/
2023-02-18T08:56:10.088 DEBUG:teuthology.orchestra.run.smithi133:> cd /home/ubuntu/.aws/models/s3/2006-03-01/ && cp /home/ubuntu/cephtest/ceph/examples/boto3/service-2.sdk-extras.json service-2.sdk-extras.json
2023-02-18T08:56:10.146 DEBUG:teuthology.orchestra.run:got remote process result: 1
2023-02-18T08:56:10.147 INFO:teuthology.orchestra.run.smithi133.stderr:cp: cannot stat '/home/ubuntu/cephtest/ceph/examples/boto3/service-2.sdk-extras.json': No such file or directory
```
from http://qa-proxy.ceph.com/teuthology/ivancich-2023-02-17_21:47:17-rgw-wip-eric-testing-1-distro-default-smithi/7179700/teuthology.log

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
