### PR TITLE
quincy: ceph-volume: legacy_encrypted() shouldn't call lsblk() when device is 'tmpfs'

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -238,9 +238,11 @@ def _udevadm_info(device):
 
 
 def lsblk(device, columns=None, abspath=False):
-    result = lsblk_all(device=device,
-                       columns=columns,
-                       abspath=abspath)
+    result = []
+    if not os.path.isdir(device):
+        result = lsblk_all(device=device,
+                           columns=columns,
+                           abspath=abspath)
     if not result:
         raise RuntimeError(f"{device} not found is lsblk report")
 

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -234,6 +234,7 @@ def legacy_encrypted(device):
 
     This function assumes that ``device`` will be a partition.
     """
+    disk_meta = {}
     if os.path.isdir(device):
         mounts = system.Mounts(paths=True).get_mounts()
         # yes, rebind the device variable here because a directory isn't going
@@ -265,7 +266,8 @@ def legacy_encrypted(device):
     # parent device name for the device so that we can query all of its
     # associated devices and *then* look for one that has the 'lockbox' label
     # on it. Thanks for being awesome ceph-disk
-    disk_meta = lsblk(device, abspath=True)
+    if not device == 'tmpfs':
+        disk_meta = lsblk(device, abspath=True)
     if not disk_meta:
         return metadata
     parent_device = disk_meta['PKNAME']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58785

---

backport of https://github.com/ceph/ceph/pull/50157
parent tracker: https://tracker.ceph.com/issues/58784

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh