### PR TITLE
rgw: store torrent file for GetObjectTorrent in object attrs instead of omap

### DIFF
--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -8,6 +8,7 @@ overrides:
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
+        rgw torrent flag: true
   rgw:
     compression type: random
     storage classes: LUKEWARM, FROZEN

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -13,6 +13,7 @@
  */
 
 #include <vector>
+#include <utility>
 
 #include "common/ceph_context.h"
 #include "common/ceph_mutex.h"
@@ -201,6 +202,21 @@ ssl::OpenSSLDigest::~OpenSSLDigest() {
     EVP_MD_free(mpType_FIPS);
 #endif  // OPENSSL_VERSION_NUMBER >= 0x30000000L
   }
+}
+
+ssl::OpenSSLDigest::OpenSSLDigest(OpenSSLDigest&& o) noexcept
+  : mpContext(std::exchange(o.mpContext, nullptr)),
+    mpType(std::exchange(o.mpType, nullptr)),
+    mpType_FIPS(std::exchange(o.mpType_FIPS, nullptr))
+{
+}
+
+ssl::OpenSSLDigest& ssl::OpenSSLDigest::operator=(OpenSSLDigest&& o) noexcept
+{
+  std::swap(mpContext, o.mpContext);
+  std::swap(mpType, o.mpType);
+  std::swap(mpType_FIPS, o.mpType_FIPS);
+  return *this;
 }
 
 void ssl::OpenSSLDigest::Restart() {

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -58,6 +58,8 @@ namespace TOPNSPC::crypto {
       public:
 	OpenSSLDigest (const EVP_MD *_type);
 	~OpenSSLDigest ();
+	OpenSSLDigest(OpenSSLDigest&& o) noexcept;
+	OpenSSLDigest& operator=(OpenSSLDigest&& o) noexcept;
 	void Restart();
 	void SetFlags(int flags);
 	void Update (const unsigned char *input, size_t length);

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3130,6 +3130,16 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_torrent_max_size
+  type: size
+  level: advanced
+  desc: Objects over this size will not store torrent info.
+  default: 5_G
+  services:
+  - rgw
+  see_also:
+  - rgw_torrent_flag
+  with_legacy: true
 - name: rgw_dynamic_resharding
   type: bool
   level: basic

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1835,6 +1835,42 @@ void RadosObject::get_raw_obj(rgw_raw_obj* raw_obj)
   store->getRados()->obj_to_raw((bucket->get_info()).placement_rule, get_obj(), raw_obj);
 }
 
+int RadosObject::get_torrent_info(const DoutPrefixProvider* dpp,
+                                  optional_yield y, bufferlist& bl)
+{
+  // try to read torrent info from attr
+  int ret = StoreObject::get_torrent_info(dpp, y, bl);
+  if (ret >= 0) {
+    return ret;
+  }
+
+  // try falling back to old torrent info stored in omap
+  rgw_raw_obj raw_obj;
+  get_raw_obj(&raw_obj);
+
+  rgw_rados_ref ref;
+  ret = store->getRados()->get_raw_obj_ref(dpp, raw_obj, &ref);
+  if (ret < 0) {
+    return ret;
+  }
+
+  const std::set<std::string> keys = {"rgw.torrent"};
+  std::map<std::string, bufferlist> result;
+
+  librados::ObjectReadOperation op;
+  op.omap_get_vals_by_keys(keys, &result, nullptr);
+
+  ret = rgw_rados_operate(dpp, ref.pool.ioctx(), ref.obj.oid, &op, nullptr, y);
+  if (ret < 0) {
+    return ret;
+  }
+  if (result.empty()) { // omap key not found
+    return -ENOENT;
+  }
+  bl = std::move(result.begin()->second);
+  return 0;
+}
+
 int RadosObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
 					  const std::set<std::string>& keys,
 					  Attrs* vals)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -460,6 +460,9 @@ class RadosObject : public StoreObject {
     virtual std::unique_ptr<ReadOp> get_read_op() override;
     virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
+    virtual int get_torrent_info(const DoutPrefixProvider* dpp,
+                                 optional_yield y, bufferlist& bl) override;
+
     /* OMAP */
     virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
 			      const std::set<std::string>& keys,

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8196,6 +8196,11 @@ next:
         handled = decode_dump<RGWCompressionInfo>("compression", bl, formatter.get());
       } else if (iter->first == RGW_ATTR_DELETE_AT) {
         handled = decode_dump<utime_t>("delete_at", bl, formatter.get());
+      } else if (iter->first == RGW_ATTR_TORRENT) {
+        // contains bencoded binary data which shouldn't be output directly
+        // TODO: decode torrent info for display as json?
+        formatter->dump_string("torrent", "<contains binary data>");
+        handled = true;
       }
 
       if (!handled)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -133,6 +133,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_OLH_PENDING_PREFIX RGW_ATTR_OLH_PREFIX "pending."
 
 #define RGW_ATTR_COMPRESSION    RGW_ATTR_PREFIX "compression"
+#define RGW_ATTR_TORRENT        RGW_ATTR_PREFIX "torrent"
 
 #define RGW_ATTR_APPEND_PART_NUM    RGW_ATTR_PREFIX "append_part_num"
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2208,18 +2208,16 @@ void RGWGetObj::execute(optional_yield y)
       op_ret = -EINVAL;
       goto done_err;
     }
-    torrent.init(s, driver);
-    rgw_obj obj = s->object->get_obj();
-    op_ret = torrent.get_torrent_file(s->object.get(), total_len, bl, obj);
-    if (op_ret < 0)
-    {
+    // read torrent info from attr
+    bufferlist torrentbl;
+    op_ret = rgw_read_torrent_file(this, s->object.get(), torrentbl, y);
+    if (op_ret < 0) {
       ldpp_dout(this, 0) << "ERROR: failed to get_torrent_file ret= " << op_ret
                        << dendl;
       goto done_err;
     }
-    op_ret = send_response_data(bl, 0, total_len);
-    if (op_ret < 0)
-    {
+    op_ret = send_response_data(torrentbl, 0, torrentbl.length());
+    if (op_ret < 0) {
       ldpp_dout(this, 0) << "ERROR: failed to send_response_data ret= " << op_ret << dendl;
       goto done_err;
     }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3893,6 +3893,24 @@ static CompressorRef get_compressor_plugin(const req_state *s,
   return Compressor::create(s->cct, alg);
 }
 
+auto RGWPutObj::get_torrent_filter(rgw::sal::DataProcessor* cb)
+    -> std::optional<RGWPutObj_Torrent>
+{
+  auto& conf = get_cct()->_conf;
+  if (!conf->rgw_torrent_flag) {
+    return std::nullopt; // torrent generation disabled
+  }
+  const auto max_len = conf->rgw_torrent_max_size;
+  const auto piece_len = conf->rgw_torrent_sha_unit;
+  if (!max_len || !piece_len) {
+    return std::nullopt; // invalid configuration
+  }
+  if (crypt_http_responses.count("x-amz-server-side-encryption-customer-algorithm")) {
+    return std::nullopt; // downloading the torrent would require customer keys
+  }
+  return RGWPutObj_Torrent{cb, max_len, piece_len};
+}
+
 int RGWPutObj::get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter, rgw::sal::DataProcessor* cb) {
   std::string script;
   const auto rc = rgw::lua::read_script(s, s->penv.lua.manager.get(), s->bucket_tenant, s->yield, rgw::lua::context::putData, script);
@@ -4099,7 +4117,8 @@ void RGWPutObj::execute(optional_yield y)
 
   const auto& compression_type = driver->get_compression_type(*pdest_placement);
   CompressorRef plugin;
-  boost::optional<RGWPutObj_Compress> compressor;
+  std::optional<RGWPutObj_Compress> compressor;
+  std::optional<RGWPutObj_Torrent> torrent;
 
   std::unique_ptr<rgw::sal::DataProcessor> encrypt;
   std::unique_ptr<rgw::sal::DataProcessor> run_lua;
@@ -4123,6 +4142,9 @@ void RGWPutObj::execute(optional_yield y)
         // always send incompressible hint when rgw is itself doing compression
         s->object->set_compressed();
       }
+    }
+    if (torrent = get_torrent_filter(filter); torrent) {
+      filter = &*torrent;
     }
     // run lua script before data is compressed and encrypted - last filter runs first
     op_ret = get_lua_filter(&run_lua, filter);
@@ -4160,9 +4182,6 @@ void RGWPutObj::execute(optional_yield y)
     if (need_calc_md5) {
       hash.Update((const unsigned char *)data.c_str(), data.length());
     }
-
-    /* update torrrent */
-    torrent.update(data);
 
     op_ret = filter->process(std::move(data), ofs);
     if (op_ret < 0) {
@@ -4216,6 +4235,14 @@ void RGWPutObj::execute(optional_yield y)
         << " with type=" << cs_info.compression_type
         << ", orig_size=" << cs_info.orig_size
         << ", blocks=" << cs_info.blocks.size() << dendl;
+  }
+  if (torrent) {
+    auto bl = torrent->bencode_torrent(s->object->get_name());
+    if (bl.length()) {
+      ldpp_dout(this, 20) << "storing " << bl.length()
+         << " bytes of torrent info in " << RGW_ATTR_TORRENT << dendl;
+      attrs[RGW_ATTR_TORRENT] = std::move(bl);
+    }
   }
 
   buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
@@ -4285,19 +4312,6 @@ void RGWPutObj::execute(optional_yield y)
                                (user_data.empty() ? nullptr : &user_data), nullptr, nullptr,
                                s->yield);
   tracepoint(rgw_op, processor_complete_exit, s->req_id.c_str());
-
-  /* produce torrent */
-  if (s->cct->_conf->rgw_torrent_flag && (ofs == torrent.get_data_len()))
-  {
-    torrent.init(s, driver);
-    torrent.set_create_date(mtime);
-    op_ret =  torrent.complete(y);
-    if (0 != op_ret)
-    {
-      ldpp_dout(this, 0) << "ERROR: torrent.handle_data() returned " << op_ret << dendl;
-      return;
-    }
-  }
 
   // send request to notification manager
   int ret = res->publish_commit(this, s->obj_size, mtime, etag, s->object->get_instance());

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -52,6 +52,7 @@
 #include "rgw_notify_event_type.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#include "rgw_torrent.h"
 #include "rgw_lua_data_filter.h"
 #include "rgw_lua.h"
 
@@ -964,7 +965,7 @@ int RGWGetObj::verify_permission(optional_yield y)
     if (has_s3_existing_tag || has_s3_resource_tag)
       rgw_iam_add_objtags(this, s, has_s3_existing_tag, has_s3_resource_tag);
 
-  if (torrent.get_flag()) {
+  if (get_torrent) {
     if (s->object->get_instance().empty()) {
       action = rgw::IAM::s3GetObjectTorrent;
     } else {
@@ -2199,8 +2200,7 @@ void RGWGetObj::execute(optional_yield y)
     goto done_err;
   }
   /* start gettorrent */
-  if (torrent.get_flag())
-  {
+  if (get_torrent) {
     attr_iter = attrs.find(RGW_ATTR_CRYPT_MODE);
     if (attr_iter != attrs.end() && attr_iter->second.to_str() == "SSE-C-AES256") {
       ldpp_dout(this, 0) << "ERROR: torrents are not supported for objects "

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1189,7 +1189,6 @@ WRITE_CLASS_ENCODER(RGWSLOInfo)
 
 class RGWPutObj : public RGWOp {
 protected:
-  seed torrent;
   off_t ofs;
   const char *supplied_md5_b64;
   const char *supplied_etag;
@@ -1285,6 +1284,9 @@ public:
                                  rgw::sal::DataProcessor *cb) {
     return 0;
   }
+  // if configured, construct a filter to generate torrent metadata
+  auto get_torrent_filter(rgw::sal::DataProcessor *cb)
+      -> std::optional<RGWPutObj_Torrent>;
 
   // get lua script to run as a "put object" filter
   int get_lua_filter(std::unique_ptr<rgw::sal::DataProcessor>* filter,

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -47,7 +47,6 @@
 #include "rgw_log.h"
 
 #include "rgw_lc.h"
-#include "rgw_torrent.h"
 #include "rgw_tag.h"
 #include "rgw_object_lock.h"
 #include "cls/rgw/cls_rgw_client.h"
@@ -60,12 +59,11 @@
 
 #include "include/ceph_assert.h"
 
-using ceph::crypto::SHA1;
-
 struct req_state;
 class RGWOp;
 class RGWRados;
 class RGWMultiCompleteUpload;
+class RGWPutObj_Torrent;
 
 
 namespace rgw {
@@ -331,7 +329,6 @@ public:
 
 class RGWGetObj : public RGWOp {
 protected:
-  seed torrent; // get torrent
   const char *range_str;
   const char *if_mod;
   const char *if_unmod;
@@ -349,6 +346,7 @@ protected:
   ceph::real_time *mod_ptr;
   ceph::real_time *unmod_ptr;
   rgw::sal::Attrs attrs;
+  bool get_torrent = false;
   bool get_data;
   bool partial_content;
   bool ignore_invalid_range;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1033,19 +1033,6 @@ int RGWPutObj_ObjStore::verify_params()
 
 int RGWPutObj_ObjStore::get_params(optional_yield y)
 {
-  /* start gettorrent */
-  if (s->cct->_conf->rgw_torrent_flag)
-  {
-    int ret = 0;
-    ret = torrent.get_params();
-    ldpp_dout(s, 5) << "NOTICE:  open produce torrent file " << dendl;
-    if (ret < 0)
-    {
-      return ret;
-    }
-    torrent.set_info_name(s->object->get_name());
-  }
-  /* end gettorrent */
   supplied_md5_b64 = s->info.env->get("HTTP_CONTENT_MD5");
 
   return 0;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -820,9 +820,6 @@ int RGWGetObj_ObjStore::get_params(optional_yield y)
     get_data &= (!rgwx_stat);
   }
 
-  if (s->info.args.exists(GET_TORRENT)) {
-    return torrent.get_params();
-  }
   return 0;
 }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -299,6 +299,8 @@ int RGWGetObj_ObjStore_S3::get_params(optional_yield y)
     skip_decrypt = s->info.args.exists(RGW_SYS_PARAM_PREFIX "skip-decrypt");
   }
 
+  get_torrent = s->info.args.exists("torrent");
+
   return RGWGetObj_ObjStore::get_params(y);
 }
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1078,7 +1078,10 @@ class Object {
     /** Get a new DeleteOp for this object */
     virtual std::unique_ptr<DeleteOp> get_delete_op() = 0;
 
-    // TODO: remove omap APIs. rgw_torrent.cc shouldn't use omap
+    /// Return stored torrent info or -ENOENT if there isn't any.
+    virtual int get_torrent_info(const DoutPrefixProvider* dpp,
+                                 optional_yield y, bufferlist& bl) = 0;
+
     /** Get the OMAP values matching the given set of keys */
     virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
 			      const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -1007,6 +1007,12 @@ std::unique_ptr<Object::DeleteOp> FilterObject::get_delete_op()
   return std::make_unique<FilterDeleteOp>(std::move(d));
 }
 
+int FilterObject::get_torrent_info(const DoutPrefixProvider* dpp,
+                                   optional_yield y, bufferlist& bl)
+{
+  return next->get_torrent_info(dpp, y, bl);
+}
+
 int FilterObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp,
 					const std::string& oid,
 					const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -670,6 +670,9 @@ public:
   virtual std::unique_ptr<ReadOp> get_read_op() override;
   virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
+  virtual int get_torrent_info(const DoutPrefixProvider* dpp,
+                               optional_yield y, bufferlist& bl) override;
+
   virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp,
 				    const std::string& oid,
 				    const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -241,6 +241,16 @@ class StoreObject : public Object {
       return -1;
     }
 
+    virtual int get_torrent_info(const DoutPrefixProvider* dpp,
+                                 optional_yield y, bufferlist& bl) override {
+      const auto& attrs = get_attrs();
+      if (auto i = attrs.find(RGW_ATTR_TORRENT); i != attrs.end()) {
+        bl = i->second;
+        return 0;
+      }
+      return -ENOENT;
+    }
+
     virtual void print(std::ostream& out) const override {
       if (bucket)
 	out << bucket << ":";

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -1,48 +1,63 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
-#include <errno.h>
-#include <stdlib.h>
-
-#include <ctime>
-
-#include "common/split.h"
 #include "rgw_torrent.h"
+#include <ctime>
+#include <fmt/format.h>
+#include "common/split.h"
 #include "rgw_sal.h"
-#include "rgw_sal_rados.h"
-#include "include/str_list.h"
-#include "include/rados/librados.hpp"
 
-#include "services/svc_sys_obj.h"
+#define ANNOUNCE           "announce"
+#define ANNOUNCE_LIST      "announce-list"
+#define COMMENT            "comment"
+#define CREATED_BY         "created by"
+#define CREATION_DATE      "creation date"
+#define ENCODING           "encoding"
+#define LENGTH             "length"
+#define NAME               "name"
+#define PIECE_LENGTH       "piece length"
+#define PIECES             "pieces"
+#define INFO_PIECES        "info"
 
-#define dout_subsys ceph_subsys_rgw
+//control characters
+void bencode_dict(bufferlist& bl) { bl.append('d'); }
+void bencode_list(bufferlist& bl) { bl.append('l'); }
+void bencode_end(bufferlist& bl) { bl.append('e'); }
 
-using namespace std;
-using namespace librados;
-using namespace boost;
-using ceph::crypto::SHA1;
-
-seed::seed()
+//key len
+void bencode_key(std::string_view key, bufferlist& bl)
 {
-  seed::info.piece_length = 0;
-  seed::info.len = 0;
-  sha_len = 0;
-  is_torrent = false; 
+  bl.append(fmt::format("{}:", key.size()));
+  bl.append(key);
 }
 
-seed::~seed()
+//single values
+void bencode(int value, bufferlist& bl)
 {
-  seed::info.sha1_bl.clear();
-  bl.clear();
-  s = NULL;
-  driver = NULL;
+  bl.append(fmt::format("i{}", value));
+  bencode_end(bl);
 }
 
-void seed::init(req_state *_req, rgw::sal::Driver* _driver)
+//single values
+void bencode(std::string_view str, bufferlist& bl)
 {
-  s = _req;
-  driver = _driver;
+  bencode_key(str, bl);
 }
+
+//dictionary elements
+void bencode(std::string_view key, int value, bufferlist& bl)
+{
+  bencode_key(key, bl);
+  bencode(value, bl);
+}
+
+//dictionary elements
+void bencode(std::string_view key, std::string_view value, bufferlist& bl)
+{
+  bencode_key(key, bl);
+  bencode(value, bl);
+}
+
 
 int rgw_read_torrent_file(const DoutPrefixProvider* dpp,
                           rgw::sal::Object* object,
@@ -59,35 +74,34 @@ int rgw_read_torrent_file(const DoutPrefixProvider* dpp,
   // add other fields from config
   auto& conf = dpp->get_cct()->_conf;
 
-  TorrentBencode benc;
-  benc.bencode_dict(bl);
+  bencode_dict(bl);
 
   auto trackers = ceph::split(conf->rgw_torrent_tracker, ",");
   if (auto i = trackers.begin(); i != trackers.end()) {
-    benc.bencode_key(ANNOUNCE, bl);
-    benc.bencode_key(*i, bl);
+    bencode_key(ANNOUNCE, bl);
+    bencode_key(*i, bl);
 
-    benc.bencode_key(ANNOUNCE_LIST, bl);
-    benc.bencode_list(bl);
+    bencode_key(ANNOUNCE_LIST, bl);
+    bencode_list(bl);
     for (; i != trackers.end(); ++i) {
-      benc.bencode_list(bl);
-      benc.bencode_key(*i, bl);
-      benc.bencode_end(bl);
+      bencode_list(bl);
+      bencode_key(*i, bl);
+      bencode_end(bl);
     }
-    benc.bencode_end(bl);
+    bencode_end(bl);
   }
 
   std::string_view comment = conf->rgw_torrent_comment;
   if (!comment.empty()) {
-    benc.bencode(COMMENT, comment, bl);
+    bencode(COMMENT, comment, bl);
   }
   std::string_view create_by = conf->rgw_torrent_createby;
   if (!create_by.empty()) {
-    benc.bencode(CREATED_BY, create_by, bl);
+    bencode(CREATED_BY, create_by, bl);
   }
   std::string_view encoding = conf->rgw_torrent_encoding;
   if (!encoding.empty()) {
-    benc.bencode(ENCODING, encoding, bl);
+    bencode(ENCODING, encoding, bl);
   }
 
   // append the info stored in the object
@@ -95,222 +109,6 @@ int rgw_read_torrent_file(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int seed::get_torrent_file(rgw::sal::Object* object,
-                           uint64_t &total_len,
-                           ceph::bufferlist &bl_data,
-                           rgw_obj &obj)
-{
-  /* add other field if config is set */
-  dencode.bencode_dict(bl);
-  set_announce();
-  if (!comment.empty())
-  {
-    dencode.bencode(COMMENT, comment, bl);
-  }
-  if (!create_by.empty())
-  {
-    dencode.bencode(CREATED_BY, create_by, bl);
-  }
-  if (!encoding.empty())
-  {
-    dencode.bencode(ENCODING, encoding, bl);
-  }
-
-  string oid, key;
-  get_obj_bucket_and_oid_loc(obj, oid, key);
-  ldpp_dout(s, 20) << "NOTICE: head obj oid= " << oid << dendl;
-
-  const set<string> obj_key{RGW_OBJ_TORRENT};
-  map<string, bufferlist> m;
-  const int r = object->omap_get_vals_by_keys(s, oid, obj_key, &m);
-  if (r < 0) {
-    ldpp_dout(s, 0) << "ERROR: omap_get_vals_by_keys failed: " << r << dendl;
-    return r;
-  }
-  if (m.size() != 1) {
-    ldpp_dout(s, 0) << "ERROR: omap key " RGW_OBJ_TORRENT " not found" << dendl;
-    return -EINVAL;
-  }
-  bl.append(std::move(m.begin()->second));
-  dencode.bencode_end(bl);
-
-  bl_data = bl;
-  total_len = bl.length();
-  return 0;
-}
-
-bool seed::get_flag()
-{
-  return is_torrent;
-}
-
-void seed::update(bufferlist &bl)
-{
-  if (!is_torrent)
-  {
-    return;
-  }
-  info.len += bl.length();
-  sha1(&h, bl, bl.length());
-}
-
-int seed::complete(optional_yield y)
-{
-  uint64_t remain = info.len%info.piece_length;
-  uint8_t  remain_len = ((remain > 0)? 1 : 0);
-  sha_len = (info.len/info.piece_length + remain_len)*CEPH_CRYPTO_SHA1_DIGESTSIZE;
-
-  int ret = 0;
-   /* produce torrent data */
-  do_encode();
-
-  /* save torrent data into OMAP */
-  ret = save_torrent_file(y);
-  if (0 != ret)
-  {
-    ldpp_dout(s, 0) << "ERROR: failed to save_torrent_file() ret= "<< ret << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-off_t seed::get_data_len()
-{
-  return info.len;
-}
-
-void seed::set_create_date(ceph::real_time& value)
-{
-  utime_t date = ceph::real_clock::to_timespec(value);
-  create_date = date.sec();
-}
-
-void seed::set_info_pieces(char *buff)
-{
-  info.sha1_bl.append(buff, CEPH_CRYPTO_SHA1_DIGESTSIZE);
-}
-
-void seed::set_info_name(const string& value)
-{
-  info.name = value;
-}
-
-void seed::sha1(SHA1 *h, bufferlist &bl, off_t bl_len)
-{
-  off_t num = bl_len/info.piece_length;
-  off_t remain = 0;
-  remain = bl_len%info.piece_length;
-
-  char *pstr = bl.c_str();
-  char sha[25];
-
-  /* get sha1 */
-  for (off_t i = 0; i < num; i++)
-  {
-    // FIPS zeroization audit 20191116: this memset is not intended to
-    // wipe out a secret after use.
-    memset(sha, 0x00, sizeof(sha));
-    h->Update((unsigned char *)pstr, info.piece_length);
-    h->Final((unsigned char *)sha);
-    set_info_pieces(sha);
-    pstr += info.piece_length;
-  }
-
-  /* process remain */
-  if (0 != remain)
-  {
-    // FIPS zeroization audit 20191116: this memset is not intended to
-    // wipe out a secret after use.
-    memset(sha, 0x00, sizeof(sha));
-    h->Update((unsigned char *)pstr, remain);
-    h->Final((unsigned char *)sha);
-    set_info_pieces(sha);
-  }
-  ::ceph::crypto::zeroize_for_security(sha, sizeof(sha));
-}
-
-int seed::get_params()
-{
-  is_torrent = true;
-  info.piece_length = g_conf()->rgw_torrent_sha_unit;
-  create_by = g_conf()->rgw_torrent_createby;
-  encoding = g_conf()->rgw_torrent_encoding;
-  origin = g_conf()->rgw_torrent_origin;
-  comment = g_conf()->rgw_torrent_comment;
-  announce = g_conf()->rgw_torrent_tracker;
-
-  /* tracker and tracker list is empty, set announce to origin */
-  if (announce.empty() && !origin.empty())
-  {
-    announce = origin;
-  }
-
-  return 0;
-}
-
-void seed::set_announce()
-{
-  list<string> announce_list;  // used to get announce list from conf
-  get_str_list(announce, ",", announce_list);
-
-  if (announce_list.empty())
-  {
-    ldpp_dout(s, 5) << "NOTICE: announce_list is empty " << dendl;    
-    return;
-  }
-
-  list<string>::iterator iter = announce_list.begin();
-  dencode.bencode_key(ANNOUNCE, bl);
-  dencode.bencode_key((*iter), bl);
-
-  dencode.bencode_key(ANNOUNCE_LIST, bl);
-  dencode.bencode_list(bl);
-  for (; iter != announce_list.end(); ++iter)
-  {
-    dencode.bencode_list(bl);
-    dencode.bencode_key((*iter), bl);
-    dencode.bencode_end(bl);
-  }
-  dencode.bencode_end(bl);
-}
-
-void seed::do_encode()
-{ 
-  /*Only encode create_date and sha1 info*/
-  /*Other field will be added if confi is set when run get torrent*/
-  dencode.bencode(CREATION_DATE, create_date, bl);
-
-  dencode.bencode_key(INFO_PIECES, bl);
-  dencode.bencode_dict(bl);  
-  dencode.bencode(LENGTH, info.len, bl);
-  dencode.bencode(NAME, info.name, bl);
-  dencode.bencode(PIECE_LENGTH, info.piece_length, bl);
-
-  char info_sha[100] = { 0 };
-  sprintf(info_sha, "%" PRIu64, sha_len);
-  string sha_len_str = info_sha;
-  dencode.bencode_key(PIECES, bl);
-  bl.append(sha_len_str.c_str(), sha_len_str.length());
-  bl.append(':');
-  bl.append(info.sha1_bl.c_str(), sha_len);
-  dencode.bencode_end(bl);
-}
-
-int seed::save_torrent_file(optional_yield y)
-{
-  int op_ret = 0;
-  string key = RGW_OBJ_TORRENT;
-
-  op_ret = s->object->omap_set_val_by_key(s, key, bl, false, y);
-  if (op_ret < 0)
-  {
-    ldpp_dout(s, 0) << "ERROR: failed to omap_set() op_ret = " << op_ret << dendl;
-    return op_ret;
-  }
-
-  return op_ret;
-}
 
 RGWPutObj_Torrent::RGWPutObj_Torrent(rgw::sal::DataProcessor* next,
                                      size_t max_len, size_t piece_len)
@@ -322,7 +120,7 @@ int RGWPutObj_Torrent::process(bufferlist&& data, uint64_t logical_offset)
 {
   if (!data.length()) { // done
     if (piece_offset) { // hash the remainder
-      char out[SHA1::digest_size];
+      char out[ceph::crypto::SHA1::digest_size];
       digest.Final(reinterpret_cast<unsigned char*>(out));
       piece_hashes.append(out, sizeof(out));
       piece_count++;
@@ -350,7 +148,7 @@ int RGWPutObj_Torrent::process(bufferlist&& data, uint64_t logical_offset)
 
     // record the hash digest at each piece boundary
     if (bytes == want) {
-      char out[SHA1::digest_size];
+      char out[ceph::crypto::SHA1::digest_size];
       digest.Final(reinterpret_cast<unsigned char*>(out));
       digest.Restart();
       piece_hashes.append(out, sizeof(out));
@@ -369,22 +167,21 @@ bufferlist RGWPutObj_Torrent::bencode_torrent(std::string_view filename) const
     return bl;
   }
 
-  /*Only encode create_date and sha1 info*/
-  /*Other field will be added if config is set when run get torrent*/
-  TorrentBencode benc;
-  benc.bencode(CREATION_DATE, std::time(nullptr), bl);
+  // Only encode create_date and sha1 info. Other fields will be added during
+  // GetObjectTorrent by rgw_read_torrent_file()
+  bencode(CREATION_DATE, std::time(nullptr), bl);
 
-  benc.bencode_key(INFO_PIECES, bl);
-  benc.bencode_dict(bl);
-  benc.bencode(LENGTH, len, bl);
-  benc.bencode(NAME, filename, bl);
-  benc.bencode(PIECE_LENGTH, piece_len, bl);
+  bencode_key(INFO_PIECES, bl);
+  bencode_dict(bl);
+  bencode(LENGTH, len, bl);
+  bencode(NAME, filename, bl);
+  bencode(PIECE_LENGTH, piece_len, bl);
 
-  benc.bencode_key(PIECES, bl);
+  bencode_key(PIECES, bl);
   bl.append(std::to_string(piece_count));
   bl.append(':');
   bl.append(piece_hashes);
-  benc.bencode_end(bl);
+  bencode_end(bl);
 
   return bl;
 }

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -3,141 +3,41 @@
 
 #pragma once
 
-#include <string>
-#include <list>
-#include <map>
-#include <set>
+#include "common/ceph_crypto.h"
+#include "common/dout.h"
+#include "common/async/yield_context.h"
 
-#include <fmt/format.h>
-
-#include "common/ceph_time.h"
-
-#include "rgw_common.h"
 #include "rgw_putobj.h"
+#include "rgw_sal_fwd.h"
 
-struct req_state;
+//control characters
+void bencode_dict(bufferlist& bl);
+void bencode_list(bufferlist& bl);
+void bencode_end(bufferlist& bl);
 
-#define RGW_OBJ_TORRENT    "rgw.torrent"
+//key len
+void bencode_key(std::string_view key, bufferlist& bl);
 
-#define ANNOUNCE           "announce"
-#define ANNOUNCE_LIST      "announce-list"
-#define COMMENT            "comment"
-#define CREATED_BY         "created by"
-#define CREATION_DATE      "creation date"
-#define ENCODING           "encoding"
-#define LENGTH             "length"
-#define NAME               "name"
-#define PIECE_LENGTH       "piece length"
-#define PIECES             "pieces"
-#define INFO_PIECES        "info"
-#define GET_TORRENT        "torrent"
+//single values
+void bencode(int value, bufferlist& bl);
 
-class TorrentBencode
-{
-public:
-  //control characters
-  void bencode_dict(bufferlist& bl) { bl.append('d'); }
-  void bencode_list(bufferlist& bl) { bl.append('l'); }
-  void bencode_end(bufferlist& bl) { bl.append('e'); }
+//single values
+void bencode(std::string_view str, bufferlist& bl);
 
-  //single values
-  void bencode(int value, bufferlist& bl)
-  {
-    bl.append('i');
-    char info[100] = { 0 };
-    sprintf(info, "%d", value);
-    bl.append(info, strlen(info));
-    bencode_end(bl);
-  }
+//dictionary elements
+void bencode(std::string_view key, int value, bufferlist& bl);
 
-  //single values
-  void bencode(std::string_view str, bufferlist& bl)
-  {
-    bencode_key(str, bl);
-  }
+//dictionary elements
+void bencode(std::string_view key, std::string_view value, bufferlist& bl);
 
-  //dictionary elements
-  void bencode(std::string_view key, int value, bufferlist& bl)
-  {
-    bencode_key(key, bl);
-    bencode(value, bl);
-  }
 
-  //dictionary elements
-  void bencode(std::string_view key, std::string_view value, bufferlist& bl)
-  {
-    bencode_key(key, bl);
-    bencode(value, bl);
-  }
-
-  //key len
-  void bencode_key(std::string_view key, bufferlist& bl)
-  {
-    bl.append(fmt::format("{}:", key.size()));
-    bl.append(key);
-  }
-};
-
-/* torrent file struct */
-class seed
-{
-private:
-  struct
-  {
-    int piece_length;    // each piece length
-    bufferlist sha1_bl;  // save sha1
-    std::string name;    // file name
-    off_t len;    // file total bytes
-  }info;
-
-  std::string  announce;    // tracker
-  std::string origin; // origin
-  time_t create_date{0};    // time of the file created
-  std::string comment;  // comment
-  std::string create_by;    // app name and version
-  std::string encoding;    // if encode use gbk rather than gtf-8 use this field
-  uint64_t sha_len;  // sha1 length
-  bool is_torrent;  // flag
-  bufferlist bl;  // bufflist ready to send
-
-  req_state *s{nullptr};
-  rgw::sal::Driver* driver{nullptr};
-  ceph::crypto::SHA1 h;
-
-  TorrentBencode dencode;
-public:
-  seed();
-  ~seed();
-
-  int get_params();
-  void init(req_state *p_req, rgw::sal::Driver* _driver);
-  int get_torrent_file(rgw::sal::Object* object,
-                       uint64_t &total_len,
-                       ceph::bufferlist &bl_data,
-                       rgw_obj &obj);
-
-  off_t get_data_len();
-  bool get_flag();
-
-  void set_create_date(ceph::real_time& value);
-  void set_info_name(const std::string& value);
-  void update(bufferlist &bl);
-  int complete(optional_yield y);
-
-private:
-  void do_encode ();
-  void set_announce();
-  void set_exist(bool exist);
-  void set_info_pieces(char *buff);
-  void sha1(ceph::crypto::SHA1 *h, bufferlist &bl, off_t bl_len);
-  int save_torrent_file(optional_yield y);
-};
-
+// read the bencoded torrent file from the given object
 int rgw_read_torrent_file(const DoutPrefixProvider* dpp,
                           rgw::sal::Object* object,
                           ceph::bufferlist &bl,
                           optional_yield y);
 
+// PutObj filter that builds a torrent file during upload
 class RGWPutObj_Torrent : public rgw::putobj::Pipe {
   size_t max_len = 0;
   size_t piece_len = 0;
@@ -153,6 +53,6 @@ class RGWPutObj_Torrent : public rgw::putobj::Pipe {
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
 
-  // after processing is complete, return the bencoded torrent info
+  // after processing is complete, return the bencoded torrent file
   bufferlist bencode_torrent(std::string_view filename) const;
 };

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -133,6 +133,11 @@ private:
   int save_torrent_file(optional_yield y);
 };
 
+int rgw_read_torrent_file(const DoutPrefixProvider* dpp,
+                          rgw::sal::Object* object,
+                          ceph::bufferlist &bl,
+                          optional_yield y);
+
 class RGWPutObj_Torrent : public rgw::putobj::Pipe {
   size_t max_len = 0;
   size_t piece_len = 0;

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -8,11 +8,11 @@
 #include <map>
 #include <set>
 
+#include <fmt/format.h>
+
 #include "common/ceph_time.h"
 
 #include "rgw_common.h"
-
-using ceph::crypto::SHA1;
 
 struct req_state;
 
@@ -34,9 +34,6 @@ struct req_state;
 class TorrentBencode
 {
 public:
-  TorrentBencode() {}
-  ~TorrentBencode() {}
-
   //control characters
   void bencode_dict(bufferlist& bl) { bl.append('d'); }
   void bencode_list(bufferlist& bl) { bl.append('l'); }
@@ -53,33 +50,30 @@ public:
   }
 
   //single values
-  void bencode(const std::string& str, bufferlist& bl)
+  void bencode(std::string_view str, bufferlist& bl)
   {
     bencode_key(str, bl);
   }
 
   //dictionary elements
-  void bencode(const std::string& key, int value, bufferlist& bl)
+  void bencode(std::string_view key, int value, bufferlist& bl)
   {
     bencode_key(key, bl);
     bencode(value, bl);
   }
 
   //dictionary elements
-  void bencode(const std::string& key, const std::string& value, bufferlist& bl)
+  void bencode(std::string_view key, std::string_view value, bufferlist& bl)
   {
     bencode_key(key, bl);
     bencode(value, bl);
   }
 
   //key len
-  void bencode_key(const std::string& key, bufferlist& bl)
+  void bencode_key(std::string_view key, bufferlist& bl)
   {
-    int len = key.length();
-    char info[100] = { 0 };
-    sprintf(info, "%d:", len);
-    bl.append(info, strlen(info));
-    bl.append(key.c_str(), len);
+    bl.append(fmt::format("{}:", key.size()));
+    bl.append(key);
   }
 };
 
@@ -107,7 +101,7 @@ private:
 
   req_state *s{nullptr};
   rgw::sal::Driver* driver{nullptr};
-  SHA1 h;
+  ceph::crypto::SHA1 h;
 
   TorrentBencode dencode;
 public:
@@ -134,6 +128,6 @@ private:
   void set_announce();
   void set_exist(bool exist);
   void set_info_pieces(char *buff);
-  void sha1(SHA1 *h, bufferlist &bl, off_t bl_len);
+  void sha1(ceph::crypto::SHA1 *h, bufferlist &bl, off_t bl_len);
   int save_torrent_file(optional_yield y);
 };

--- a/src/test/rgw/test_rgw_bencode.cc
+++ b/src/test/rgw/test_rgw_bencode.cc
@@ -8,12 +8,11 @@ using namespace std;
 
 TEST(Bencode, String)
 {
-  TorrentBencode decode;
   bufferlist bl;
 
-  decode.bencode("foo", bl);
-  decode.bencode("bar", bl);
-  decode.bencode("baz", bl);
+  bencode("foo", bl);
+  bencode("bar", bl);
+  bencode("baz", bl);
 
   string s(bl.c_str(), bl.length());
 
@@ -22,12 +21,11 @@ TEST(Bencode, String)
 
 TEST(Bencode, Integers)
 {
-  TorrentBencode decode;
   bufferlist bl;
 
-  decode.bencode(0, bl);
-  decode.bencode(-3, bl);
-  decode.bencode(7, bl);
+  bencode(0, bl);
+  bencode(-3, bl);
+  bencode(7, bl);
 
   string s(bl.c_str(), bl.length());
 
@@ -36,13 +34,12 @@ TEST(Bencode, Integers)
 
 TEST(Bencode, Dict)
 {
-  TorrentBencode decode;  
   bufferlist bl;
 
-  decode.bencode_dict(bl);
-  decode.bencode("foo", 5, bl);
-  decode.bencode("bar", "baz", bl);
-  decode.bencode_end(bl);
+  bencode_dict(bl);
+  bencode("foo", 5, bl);
+  bencode("bar", "baz", bl);
+  bencode_end(bl);
 
   string s(bl.c_str(), bl.length());
 
@@ -51,13 +48,12 @@ TEST(Bencode, Dict)
 
 TEST(Bencode, List)
 {
-  TorrentBencode decode;
   bufferlist bl;
 
-  decode.bencode_list(bl);
-  decode.bencode("foo", 5, bl);
-  decode.bencode("bar", "baz", bl);
-  decode.bencode_end(bl);
+  bencode_list(bl);
+  bencode("foo", 5, bl);
+  bencode("bar", "baz", bl);
+  bencode_end(bl);
 
   string s(bl.c_str(), bl.length());
 


### PR DESCRIPTION
when `rgw_torrent_flag` is enabled, new object uploads store the torrent in `RGW_ATTR_TORRENT` instead of the head object's omap. omap doesn't work for EC pools, and required a separate (non-atomic) write after the head object was written

Fixes: https://tracker.ceph.com/issues/23838

a new `get_torrent_info()` function was added to `rgw::sal::Object` for this, with a default implementation in `rgw::sal::StoreObject` that reads directly from attrs. for backward compatibility, `RadosObject` will fall back to omap if `StoreObject` doesn't find `RGW_ATTR_TORRENT`

this reimplements `class seed` as a `rgw::putobj::Pipe` for `RGWPutObj` and as a free function `rgw_read_torrent_file()` for `RGWGetObj`, then cleans up the header dependencies in general

a new `rgw_torrent_max_size` option was added, with the same 5G default that aws uses, to prevent `RGWPutObj_Torrent` from buffering too many sha hashes

the `RGWPutObj::get_torrent_filter()` function requires `RGWPutObj_Torrent` to be movable, but its `ceph::crypto::SHA1` member crashed after move. that's why the commit `crypto: enable move construct/assign for OpenSSLDigest` was necessary

for testing, the rgw/verify suite enables `rgw_torrent_flag` by default. a test case for `GetObjectTorrent` was added in https://github.com/ceph/s3-tests/pull/495

my real motivation for this project was to finally get the rados-specific omap APIs out of `sal::Object`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
