### PR TITLE
rgw/rados: remove sal handles from RGWRados::Object ops

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -736,8 +736,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
   rgw::sal::Attrs attrs;
 
-  rgw::sal::RadosBucket bucket(store, src_bucket);
-  rgw::sal::RadosObject src_obj(store, key, &bucket);
+  rgw_obj src_obj(src_bucket, key);
+
   rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
   rgw::sal::RadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
     
@@ -748,9 +748,9 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
                        user_id.value_or(rgw_user()),
                        NULL, /* req_info */
                        source_zone,
-                       &dest_obj,
-                       &src_obj,
-                       &dest_bucket, /* dest */
+                       dest_obj.get_obj(),
+                       src_obj,
+                       dest_bucket_info, /* dest */
                        nullptr, /* source */
                        dest_placement_rule,
                        nullptr, /* real_time* src_mtime, */
@@ -839,15 +839,15 @@ int RGWAsyncStatRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   char buf[16];
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
 
-  rgw::sal::RadosBucket bucket(store, src_bucket);
-  rgw::sal::RadosObject src_obj(store, key, &bucket);
+
+  rgw_obj src_obj(src_bucket, key);
 
   int r = store->getRados()->stat_remote_obj(dpp,
                        obj_ctx,
                        rgw_user(user_id),
                        nullptr, /* req_info */
                        source_zone,
-                       &src_obj,
+                       src_obj,
                        nullptr, /* source */
                        pmtime, /* real_time* src_mtime, */
                        psize, /* uint64_t * */

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -6400,14 +6400,14 @@ string RGWBucketPipeSyncStatusManager::inc_status_oid(const rgw_zone_id& source_
 
 string RGWBucketPipeSyncStatusManager::obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
                                                       const rgw_zone_id& source_zone,
-                                                      const rgw::sal::Object* obj)
+                                                      const rgw_obj& obj)
 {
-  string prefix = object_status_oid_prefix + "." + source_zone.id + ":" + obj->get_bucket()->get_key().get_key();
+  string prefix = object_status_oid_prefix + "." + source_zone.id + ":" + obj.bucket.get_key();
   if (sync_pipe.source_bucket_info.bucket !=
       sync_pipe.dest_bucket_info.bucket) {
     prefix += string("/") + sync_pipe.dest_bucket_info.bucket.get_key();
   }
-  return prefix + ":" + obj->get_name() + ":" + obj->get_instance();
+  return prefix + ":" + obj.key.name + ":" + obj.key.instance;
 }
 
 int rgw_read_remote_bilog_info(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -823,8 +823,8 @@ public:
 				    uint64_t gen);
   // specific source obj sync status, can be used by sync modules
   static std::string obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
-				    const rgw_zone_id& source_zone, const rgw::sal::Object* obj); /* specific source obj sync status,
-										       can be used by sync modules */
+				    const rgw_zone_id& source_zone,
+				    const rgw_obj& obj);
 
   // implements DoutPrefixProvider
   CephContext *get_cct() const override;

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -237,35 +237,24 @@ static void init_headers(map<string, bufferlist>& attrs,
 static int cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
                          std::map<std::string, std::string>& headers) {
   RGWRESTConn::get_obj_params req_params;
-  RGWBucketInfo b;
   std::string target_obj_name;
   int ret = 0;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
         tier_ctx.target_storage_class);
   std::string etag;
   RGWRESTStreamRWRequest *in_req;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
                     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , reterr = " << ret << dendl;
-    return ret;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
   /* init input connection */
   req_params.get_op = !head;
   req_params.prepend_metadata = true;
@@ -273,7 +262,7 @@ static int cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
   req_params.sync_manifest = true;
   req_params.skip_decrypt = true;
 
-  ret = tier_ctx.conn.get_obj(tier_ctx.dpp, dest_obj.get(), req_params, true /* send */, &in_req);
+  ret = tier_ctx.conn.get_obj(tier_ctx.dpp, dest_obj, req_params, true /* send */, &in_req);
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: " << __func__ << "(): conn.get_obj() returned ret=" << ret << dendl;
     return ret;
@@ -360,7 +349,7 @@ class RGWLCCloudStreamPut
   const DoutPrefixProvider *dpp;
   rgw_lc_obj_properties obj_properties;
   RGWRESTConn& conn;
-  rgw::sal::Object *dest_obj;
+  const rgw_obj& dest_obj;
   std::string etag;
   RGWRESTStreamS3PutObj *out_req{nullptr};
 
@@ -377,7 +366,7 @@ class RGWLCCloudStreamPut
   RGWLCCloudStreamPut(const DoutPrefixProvider *_dpp,
       const rgw_lc_obj_properties&  _obj_properties,
       RGWRESTConn& _conn,
-      rgw::sal::Object *_dest_obj) :
+      const rgw_obj& _dest_obj) :
     dpp(_dpp), obj_properties(_obj_properties), conn(_conn), dest_obj(_dest_obj) {
     }
   int init();
@@ -756,33 +745,22 @@ static int cloud_tier_transfer_object(const DoutPrefixProvider* dpp,
 
 static int cloud_tier_plain_transfer(RGWLCCloudTierCtx& tier_ctx) {
   int ret;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
 
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
                         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
                         tier_ctx.target_storage_class);
-  RGWBucketInfo b;
   std::string target_obj_name;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
+
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , ret = " << ret << dendl;
-    return ret;
-  }
-
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
   tier_ctx.obj->set_atomic();
 
@@ -797,7 +775,7 @@ static int cloud_tier_plain_transfer(RGWLCCloudTierCtx& tier_ctx) {
 
   std::shared_ptr<RGWLCCloudStreamPut> writef;
   writef.reset(new RGWLCCloudStreamPut(tier_ctx.dpp, obj_properties, tier_ctx.conn,
-               dest_obj.get()));
+               dest_obj));
 
   /* actual Read & Write */
   ret = cloud_tier_transfer_object(tier_ctx.dpp, readf.get(), writef.get());
@@ -810,34 +788,23 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
                                 const rgw_lc_multipart_part_info& part_info,
                                 std::string *petag) {
   int ret;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
 
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
                         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
                         tier_ctx.target_storage_class);
-  RGWBucketInfo b;
   std::string target_obj_name;
   off_t end;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
+
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , ret = " << ret << dendl;
-    return ret;
-  }
-
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
   tier_ctx.obj->set_atomic();
 
@@ -850,7 +817,7 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
 
   std::shared_ptr<RGWLCCloudStreamPut> writef;
   writef.reset(new RGWLCCloudStreamPut(tier_ctx.dpp, obj_properties, tier_ctx.conn,
-               dest_obj.get()));
+               dest_obj));
 
   /* Prepare Read from source */
   end = part_info.ofs + part_info.size - 1;

--- a/src/rgw/driver/rados/rgw_obj_manifest.h
+++ b/src/rgw/driver/rados/rgw_obj_manifest.h
@@ -58,7 +58,7 @@ public:
   }
 
   rgw_raw_obj get_raw_obj(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params) const;
-  rgw_raw_obj get_raw_obj(rgw::sal::RadosStore* store) const;
+  rgw_raw_obj get_raw_obj(RGWRados* store) const;
 
   rgw_obj_select& operator=(const rgw_obj& rhs) {
     obj = rhs;
@@ -607,7 +607,7 @@ public:
     int create_next(uint64_t ofs);
 
     rgw_raw_obj get_cur_obj(RGWZoneGroup& zonegroup, RGWZoneParams& zone_params) { return cur_obj.get_raw_obj(zonegroup, zone_params); }
-    rgw_raw_obj get_cur_obj(rgw::sal::RadosStore* store) const { return cur_obj.get_raw_obj(store); }
+    rgw_raw_obj get_cur_obj(RGWRados* store) const { return cur_obj.get_raw_obj(store); }
 
     /* total max size of current stripe (including head obj) */
     uint64_t cur_stripe_max_size() const {

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -79,8 +79,7 @@ static int process_completed(const AioResultList& completed, RawObjSet *written)
 }
 
 void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
-  const rgw_obj obj = head_obj->get_obj();
-  const RGWObjStateManifest *sm = obj_ctx.get_state(obj);
+  const RGWObjStateManifest *sm = obj_ctx.get_state(head_obj);
   const bool compressed = sm->state.compressed;
   uint32_t alloc_hint_flags = 0;
   if (compressed) {
@@ -92,7 +91,7 @@ void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
 
 int RadosWriter::set_stripe_obj(const rgw_raw_obj& raw_obj)
 {
-  stripe_obj = store->svc()->rados->obj(raw_obj);
+  stripe_obj = store->svc.rados->obj(raw_obj);
   return stripe_obj.open(dpp);
 }
 
@@ -143,10 +142,9 @@ RadosWriter::~RadosWriter()
 
   bool need_to_remove_head = false;
   std::optional<rgw_raw_obj> raw_head;
-  if (!rgw::sal::Object::empty(head_obj.get())) {
+  if (!head_obj.empty()) {
     raw_head.emplace();
-    rgw::sal::RadosObject* obj = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get());
-    obj->get_raw_obj(&*raw_head);
+    store->obj_to_raw(bucket_info.placement_rule, head_obj, &*raw_head);
   }
 
   /**
@@ -177,7 +175,7 @@ RadosWriter::~RadosWriter()
   if (need_to_remove_head) {
     std::string version_id;
     ldpp_dout(dpp, 5) << "NOTE: we are going to process the head obj (" << *raw_head << ")" << dendl;
-    int r = head_obj->delete_object(dpp, null_yield);
+    int r = store->delete_obj(dpp, obj_ctx, bucket_info, head_obj, 0, 0);
     if (r < 0 && r != -ENOENT) {
       ldpp_dout(dpp, 0) << "WARNING: failed to remove obj (" << *raw_head << "), leaked" << dendl;
     }
@@ -197,7 +195,7 @@ int ManifestObjectProcessor::next(uint64_t offset, uint64_t *pstripe_size)
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
 
   uint64_t chunk_size = 0;
-  r = store->get_raw_chunk_size(dpp, stripe_obj, &chunk_size);
+  r = store->get_max_chunk_size(stripe_obj.pool, &chunk_size, dpp);
   if (r < 0) {
     return r;
   }
@@ -227,29 +225,39 @@ int AtomicObjectProcessor::prepare(optional_yield y)
   uint64_t head_max_size;
   uint64_t chunk_size = 0;
   uint64_t alignment;
+  rgw_pool head_pool;
 
-  int r = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_chunk_size(
-				       dpp, head_obj->get_bucket()->get_placement_rule(),
-				       &max_head_chunk_size, &alignment);
+  if (!store->get_obj_data_pool(bucket_info.placement_rule, head_obj, &head_pool)) {
+    return -EIO;
+  }
+
+  int r = store->get_max_chunk_size(head_pool, &max_head_chunk_size, dpp, &alignment);
   if (r < 0) {
     return r;
   }
 
   bool same_pool = true;
-  if (head_obj->get_bucket()->get_placement_rule() != tail_placement_rule) {
-    if (!head_obj->placement_rules_match(head_obj->get_bucket()->get_placement_rule(), tail_placement_rule)) {
+  if (bucket_info.placement_rule != tail_placement_rule) {
+    rgw_pool tail_pool;
+    if (!store->get_obj_data_pool(tail_placement_rule, head_obj, &tail_pool)) {
+      return -EIO;
+    }
+
+    if (tail_pool != head_pool) {
       same_pool = false;
-      r = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_chunk_size(dpp, tail_placement_rule, &chunk_size);
+
+      r = store->get_max_chunk_size(tail_pool, &chunk_size, dpp);
       if (r < 0) {
         return r;
       }
+
       head_max_size = 0;
     }
   }
 
   if (same_pool) {
     RGWZonePlacementInfo placement_info;
-    if (!store->svc()->zone->get_zone_params().get_placement(head_obj->get_bucket()->get_placement_rule().name, &placement_info) || placement_info.inline_data) {
+    if (!store->svc.zone->get_zone_params().get_placement(bucket_info.placement_rule.name, &placement_info) || placement_info.inline_data) {
       head_max_size = max_head_chunk_size;
     } else {
       head_max_size = 0;
@@ -260,17 +268,14 @@ int AtomicObjectProcessor::prepare(optional_yield y)
   uint64_t stripe_size;
   const uint64_t default_stripe_size = store->ctx()->_conf->rgw_obj_stripe_size;
 
-  dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_aligned_size(
-					default_stripe_size, alignment, &stripe_size);
+  store->get_max_aligned_size(default_stripe_size, alignment, &stripe_size);
 
   manifest.set_trivial_rule(head_max_size, stripe_size);
 
-  rgw_obj obj = head_obj->get_obj();
-
   r = manifest_gen.create_begin(store->ctx(), &manifest,
-                                head_obj->get_bucket()->get_placement_rule(),
+                                bucket_info.placement_rule,
                                 &tail_placement_rule,
-                                obj.bucket, obj);
+                                head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
   }
@@ -311,15 +316,14 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  head_obj->set_atomic();
+  obj_ctx.set_atomic(head_obj);
 
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
 
   /* some object types shouldn't be versioned, e.g., multipart parts */
-  op_target.set_versioning_disabled(!head_obj->get_bucket()->versioning_enabled());
+  op_target.set_versioning_disabled(!bucket_info.versioning_enabled());
+
+  RGWRados::Object::Write obj_op(&op_target);
   obj_op.meta.data = &first_chunk;
   obj_op.meta.manifest = &manifest;
   obj_op.meta.ptag = &unique_tag; /* use req_id as operation tag */
@@ -365,8 +369,8 @@ int MultipartObjectProcessor::process_first_chunk(bufferlist&& data,
     // randomize the oid prefix and reprepare the head/manifest
     std::string oid_rand = gen_rand_alphanumeric(store->ctx(), 32);
 
-    mp.init(target_obj->get_name(), upload_id, oid_rand);
-    manifest.set_prefix(target_obj->get_name() + "." + oid_rand);
+    mp.init(target_obj.key.name, upload_id, oid_rand);
+    manifest.set_prefix(target_obj.key.name + "." + oid_rand);
 
     r = prepare_head();
     if (r < 0) {
@@ -389,29 +393,26 @@ int MultipartObjectProcessor::prepare_head()
   uint64_t stripe_size;
   uint64_t alignment;
 
-  int r = dynamic_cast<rgw::sal::RadosObject*>(target_obj.get())->get_max_chunk_size(dpp,
-					  tail_placement_rule, &chunk_size, &alignment);
+  int r = store->get_max_chunk_size(tail_placement_rule, target_obj, &chunk_size, dpp, &alignment);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: unexpected: get_max_chunk_size(): placement_rule=" << tail_placement_rule.to_str() << " obj=" << target_obj << " returned r=" << r << dendl;
     return r;
   }
-  dynamic_cast<rgw::sal::RadosObject*>(target_obj.get())->get_max_aligned_size(
-					default_stripe_size, alignment, &stripe_size);
+  store->get_max_aligned_size(default_stripe_size, alignment, &stripe_size);
 
   manifest.set_multipart_part_rule(stripe_size, part_num);
 
   r = manifest_gen.create_begin(store->ctx(), &manifest,
-				head_obj->get_bucket()->get_placement_rule(),
+				bucket_info.placement_rule,
 				&tail_placement_rule,
-				target_obj->get_bucket()->get_key(),
-				target_obj->get_obj());
+				target_obj.bucket, target_obj);
   if (r < 0) {
     return r;
   }
 
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
-  dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->raw_obj_to_obj(stripe_obj);
-  head_obj->set_hash_source(target_obj->get_name());
+  RGWSI_Tier_RADOS::raw_obj_to_obj(head_obj.bucket, stripe_obj, &head_obj);
+  head_obj.index_hash_source = target_obj.key.name;
 
   r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {
@@ -427,7 +428,7 @@ int MultipartObjectProcessor::prepare_head()
 
 int MultipartObjectProcessor::prepare(optional_yield y)
 {
-  manifest.set_prefix(target_obj->get_name() + "." + upload_id);
+  manifest.set_prefix(target_obj.key.name + "." + upload_id);
 
   return prepare_head();
 }
@@ -454,13 +455,11 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
-
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
   op_target.set_versioning_disabled(true);
   op_target.set_meta_placement_rule(&tail_placement_rule);
+
+  RGWRados::Object::Write obj_op(&op_target);
   obj_op.meta.set_mtime = set_mtime;
   obj_op.meta.mtime = mtime;
   obj_op.meta.owner = owner;
@@ -497,16 +496,15 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  std::unique_ptr<rgw::sal::Object> meta_obj =
-    head_obj->get_bucket()->get_object(rgw_obj_key(mp.get_meta(), std::string(), RGW_OBJ_NS_MULTIPART));
-  meta_obj->set_in_extra_data(true);
+  rgw_obj meta_obj;
+  meta_obj.init_ns(bucket_info.bucket, mp.get_meta(), RGW_OBJ_NS_MULTIPART);
+  meta_obj.set_in_extra_data(true);
 
   rgw_raw_obj meta_raw_obj;
-  store->getRados()->obj_to_raw(meta_obj->get_bucket()->get_placement_rule(), 
-                                meta_obj->get_obj(),
-                                &meta_raw_obj);
+  store->obj_to_raw(bucket_info.placement_rule, meta_obj, &meta_raw_obj); 
+
   rgw_rados_ref meta_obj_ref;
-  r = store->getRados()->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
+  r = store->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed to get obj ref of meta obj with ret=" << r << dendl;
     return r;
@@ -521,7 +519,14 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     // New CLS call to update part info is not yet supported. Fall back to the old handling.
     bufferlist bl;
     encode(info, bl);
-    r = meta_obj->omap_set_val_by_key(dpp, p, bl, true, null_yield);
+
+    map<string, bufferlist> m;
+    m[p] = bl;
+
+    op = librados::ObjectWriteOperation{};
+    op.assert_exists(); // detect races with abort
+    op.omap_set(m);
+    r = rgw_rados_operate(dpp, meta_obj_ref.pool.ioctx(), meta_obj_ref.obj.oid, &op, y);
   }
   if (r < 0) {
     return r == -ENOENT ? -ERR_NO_SUCH_UPLOAD : r;
@@ -550,7 +555,8 @@ int AppendObjectProcessor::process_first_chunk(bufferlist &&data, rgw::sal::Data
 int AppendObjectProcessor::prepare(optional_yield y)
 {
   RGWObjState *astate;
-  int r = head_obj->get_obj_state(dpp, &astate, y);
+  int r = store->get_obj_state(dpp, &obj_ctx, bucket_info, head_obj,
+                               &astate, &cur_manifest, y);
   if (r < 0) {
     return r;
   }
@@ -565,7 +571,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
       //set the prefix
       char buf[33];
       gen_rand_alphanumeric(store->ctx(), buf, sizeof(buf) - 1);
-      string oid_prefix = head_obj->get_name();
+      string oid_prefix = head_obj.key.name;
       oid_prefix.append(".");
       oid_prefix.append(buf);
       oid_prefix.append("_");
@@ -604,22 +610,19 @@ int AppendObjectProcessor::prepare(optional_yield y)
     } else {
       tail_placement_rule.storage_class = RGW_STORAGE_CLASS_STANDARD;
     }
-    cur_manifest = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_manifest();
     manifest.set_prefix(cur_manifest->get_prefix());
     astate->keep_tail = true;
   }
   manifest.set_multipart_part_rule(store->ctx()->_conf->rgw_obj_stripe_size, cur_part_num);
 
-  rgw_obj obj = head_obj->get_obj();
-
-  r = manifest_gen.create_begin(store->ctx(), &manifest, head_obj->get_bucket()->get_placement_rule(), &tail_placement_rule, obj.bucket, obj);
+  r = manifest_gen.create_begin(store->ctx(), &manifest, bucket_info.placement_rule, &tail_placement_rule, head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
   }
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
 
   uint64_t chunk_size = 0;
-  r = store->get_raw_chunk_size(dpp, stripe_obj, &chunk_size);
+  r = store->get_max_chunk_size(stripe_obj.pool, &chunk_size, dpp);
   if (r < 0) {
     return r;
   }
@@ -654,15 +657,13 @@ int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, c
   if (r < 0) {
     return r;
   }
-  head_obj->set_atomic();
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
+  obj_ctx.set_atomic(head_obj);
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
   //For Append obj, disable versioning
   op_target.set_versioning_disabled(true);
+  RGWRados::Object::Write obj_op(&op_target);
   if (cur_manifest) {
-    cur_manifest->append(dpp, manifest, store->svc()->zone->get_zonegroup(), store->svc()->zone->get_zone_params());
+    cur_manifest->append(dpp, manifest, store->svc.zone->get_zonegroup(), store->svc.zone->get_zone_params());
     obj_op.meta.manifest = cur_manifest;
   } else {
     obj_op.meta.manifest = &manifest;

--- a/src/rgw/driver/rados/rgw_putobj_processor.h
+++ b/src/rgw/driver/rados/rgw_putobj_processor.h
@@ -66,26 +66,23 @@ using RawObjSet = std::set<rgw_raw_obj>;
 // a data sink that writes to rados objects and deletes them on cancelation
 class RadosWriter : public rgw::sal::DataProcessor {
   Aio *const aio;
-  rgw::sal::RadosStore *const store;
+  RGWRados *const store;
+  const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  const rgw_obj head_obj;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
   const DoutPrefixProvider *dpp;
   optional_yield y;
 
  public:
-  RadosWriter(Aio *aio, rgw::sal::RadosStore *store,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
+  RadosWriter(Aio *aio, RGWRados *store,
+              const RGWBucketInfo& bucket_info,
+              RGWObjectCtx& obj_ctx, const rgw_obj& _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
-    : aio(aio), store(store),
-      obj_ctx(obj_ctx), head_obj(std::move(_head_obj)), dpp(dpp), y(y)
+    : aio(aio), store(store), bucket_info(bucket_info),
+      obj_ctx(obj_ctx), head_obj(_head_obj), dpp(dpp), y(y)
   {}
-  RadosWriter(RadosWriter&& r)
-    : aio(r.aio), store(r.store),
-      obj_ctx(r.obj_ctx), head_obj(std::move(r.head_obj)), dpp(r.dpp), y(r.y)
-  {}
-
   ~RadosWriter();
 
   // add alloc hint to osd
@@ -113,11 +110,12 @@ class RadosWriter : public rgw::sal::DataProcessor {
 class ManifestObjectProcessor : public HeadObjectProcessor,
                                 public StripeGenerator {
  protected:
-  rgw::sal::RadosStore* const store;
+  RGWRados* const store;
+  RGWBucketInfo& bucket_info;
   rgw_placement_rule tail_placement_rule;
   rgw_user owner;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  rgw_obj head_obj;
 
   RadosWriter writer;
   RGWObjManifest manifest;
@@ -130,16 +128,17 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   int next(uint64_t offset, uint64_t *stripe_size) override;
 
  public:
-  ManifestObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  ManifestObjectProcessor(Aio *aio, RGWRados* store,
+                          RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& _obj_ctx,
-                          std::unique_ptr<rgw::sal::Object> _head_obj,
+                          const rgw_obj& _head_obj,
                           const DoutPrefixProvider* dpp, optional_yield y)
     : HeadObjectProcessor(0),
-      store(store),
+      store(store), bucket_info(bucket_info),
       owner(owner),
-      obj_ctx(_obj_ctx), head_obj(std::move(_head_obj)),
-      writer(aio, store, obj_ctx, head_obj->clone(), dpp, y),
+      obj_ctx(_obj_ctx), head_obj(_head_obj),
+      writer(aio, store, bucket_info, obj_ctx, head_obj, dpp, y),
       chunk(&writer, 0), stripe(&chunk, this, 0), dpp(dpp) {
         if (ptail_placement_rule) {
           tail_placement_rule = *ptail_placement_rule;
@@ -169,16 +168,16 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 
   int process_first_chunk(bufferlist&& data, rgw::sal::DataProcessor **processor) override;
  public:
-  AtomicObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  AtomicObjectProcessor(Aio *aio, RGWRados* store,
+                        RGWBucketInfo& bucket_info,
                         const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
-                        RGWObjectCtx& obj_ctx,
-			std::unique_ptr<rgw::sal::Object> _head_obj,
+                        RGWObjectCtx& obj_ctx, const rgw_obj& _head_obj,
                         std::optional<uint64_t> olh_epoch,
                         const std::string& unique_tag,
                         const DoutPrefixProvider *dpp, optional_yield y)
-    : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                              owner, obj_ctx, std::move(_head_obj), dpp, y),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, _head_obj, dpp, y),
       olh_epoch(olh_epoch), unique_tag(unique_tag)
   {}
 
@@ -201,7 +200,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 // part's head is written with an exclusive create to detect racing uploads of
 // the same part/upload id, which are restarted with a random oid prefix
 class MultipartObjectProcessor : public ManifestObjectProcessor {
-  std::unique_ptr<rgw::sal::Object> target_obj; // target multipart object
+  const rgw_obj target_obj; // target multipart object
   const std::string upload_id;
   const int part_num;
   const std::string part_num_str;
@@ -213,18 +212,19 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   // prepare the head stripe and manifest
   int prepare_head();
  public:
-  MultipartObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  MultipartObjectProcessor(Aio *aio, RGWRados* store,
+                           RGWBucketInfo& bucket_info,
                            const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
-                           std::unique_ptr<rgw::sal::Object> _head_obj,
+                           const rgw_obj& _head_obj,
                            const std::string& upload_id, uint64_t part_num,
                            const std::string& part_num_str,
                            const DoutPrefixProvider *dpp, optional_yield y)
-    : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                              owner, obj_ctx, std::move(_head_obj), dpp, y),
-      target_obj(head_obj->clone()), upload_id(upload_id),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, _head_obj, dpp, y),
+      target_obj(head_obj), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
-      mp(head_obj->get_name(), upload_id)
+      mp(head_obj.key.name, upload_id)
   {}
 
   // prepare a multipart manifest
@@ -255,15 +255,16 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int process_first_chunk(bufferlist&& data, rgw::sal::DataProcessor **processor) override;
 
   public:
-    AppendObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+    AppendObjectProcessor(Aio *aio, RGWRados* store,
+                          RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+                          const rgw_obj& _head_obj,
                           const std::string& unique_tag, uint64_t position,
                           uint64_t *cur_accounted_size,
                           const DoutPrefixProvider *dpp, optional_yield y)
-            : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                                      owner, obj_ctx, std::move(_head_obj), dpp, y),
+            : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                                      owner, obj_ctx, _head_obj, dpp, y),
               position(position), cur_size(0), cur_accounted_size(cur_accounted_size),
               unique_tag(unique_tag), cur_manifest(nullptr)
     {}

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -116,11 +116,11 @@ static string default_storage_extra_pool_suffix = "rgw.buckets.non-ec";
 static RGWObjCategory main_category = RGWObjCategory::Main;
 #define RGW_USAGE_OBJ_PREFIX "usage."
 
-rgw_raw_obj rgw_obj_select::get_raw_obj(rgw::sal::RadosStore* driver) const
+rgw_raw_obj rgw_obj_select::get_raw_obj(RGWRados* store) const
 {
   if (!is_raw) {
     rgw_raw_obj r;
-    driver->get_raw_obj(placement_rule, obj, &r);
+    store->obj_to_raw(placement_rule, obj, &r);
     return r;
   }
   return raw_obj;
@@ -191,7 +191,7 @@ void RGWObjectCtx::set_compressed(const rgw_obj& obj) {
   objs_state[obj].state.compressed = true;
 }
 
-void RGWObjectCtx::set_atomic(rgw_obj& obj) {
+void RGWObjectCtx::set_atomic(const rgw_obj& obj) {
   std::unique_lock wl{lock};
   assert (!obj.empty());
   objs_state[obj].state.is_atomic = true;
@@ -2607,16 +2607,15 @@ int RGWRados::fix_tail_obj_locator(const DoutPrefixProvider *dpp,
                                    RGWBucketInfo& bucket_info, rgw_obj_key& key,
                                    bool fix, bool *need_fix, optional_yield y)
 {
-  std::unique_ptr<rgw::sal::Bucket> bucket;
-  driver->get_bucket(nullptr, bucket_info, &bucket);
-  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
+  const rgw_bucket& bucket = bucket_info.bucket;
+  rgw_obj obj(bucket, key);
 
   if (need_fix) {
     *need_fix = false;
   }
 
   rgw_rados_ref ref;
-  int r = get_obj_head_ref(dpp, bucket_info, obj->get_obj(), &ref);
+  int r = get_obj_head_ref(dpp, bucket_info, obj, &ref);
   if (r < 0) {
     return r;
   }
@@ -2624,14 +2623,14 @@ int RGWRados::fix_tail_obj_locator(const DoutPrefixProvider *dpp,
   RGWObjState *astate = nullptr;
   RGWObjManifest* manifest = nullptr;
   RGWObjectCtx rctx(this->driver);
-  r = get_obj_state(dpp, &rctx, bucket_info, obj.get(), &astate, &manifest, false, y);
+  r = get_obj_state(dpp, &rctx, bucket_info, obj, &astate, &manifest, false, y);
   if (r < 0)
     return r;
 
   if (manifest) {
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest->obj_begin(dpp); miter != manifest->obj_end(dpp); ++miter) {
-      rgw_raw_obj raw_loc = miter.get_location().get_raw_obj(driver);
+      rgw_raw_obj raw_loc = miter.get_location().get_raw_obj(this);
       rgw_obj loc;
       string oid;
       string locator;
@@ -2656,7 +2655,7 @@ int RGWRados::fix_tail_obj_locator(const DoutPrefixProvider *dpp,
       }
 
       string bad_loc;
-      prepend_bucket_marker(bucket->get_key(), loc.key.name, bad_loc);
+      prepend_bucket_marker(bucket, loc.key.name, bad_loc);
 
       /* create a new ioctx with the bad locator */
       librados::IoCtx src_ioctx;
@@ -2797,28 +2796,28 @@ int RGWRados::on_last_entry_in_listing(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-bool RGWRados::swift_versioning_enabled(rgw::sal::Bucket* bucket) const
+bool RGWRados::swift_versioning_enabled(const RGWBucketInfo& bucket_info) const
 {
-  return bucket->get_info().has_swift_versioning() &&
-    bucket->get_info().swift_ver_location.size();
+  return bucket_info.has_swift_versioning() &&
+    bucket_info.swift_ver_location.size();
 }
 
 int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
                                     const rgw_user& user,
-                                    rgw::sal::Bucket* bucket,
-                                    rgw::sal::Object* obj,
+                                    RGWBucketInfo& bucket_info,
+                                    const rgw_obj& obj,
                                     const DoutPrefixProvider *dpp,
                                     optional_yield y)
 {
-  if (! swift_versioning_enabled(bucket)) {
+  if (! swift_versioning_enabled(bucket_info)) {
     return 0;
   }
 
-  obj->set_atomic();
+  obj_ctx.set_atomic(obj);
 
   RGWObjState * state = nullptr;
   RGWObjManifest *manifest = nullptr;
-  int r = get_obj_state(dpp, &obj_ctx, bucket->get_info(), obj, &state, &manifest, false, y);
+  int r = get_obj_state(dpp, &obj_ctx, bucket_info, obj, &state, &manifest, false, y);
   if (r < 0) {
     return r;
   }
@@ -2827,7 +2826,7 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
     return 0;
   }
 
-  const string& src_name = obj->get_oid();
+  const string& src_name = obj.get_oid();
   char buf[src_name.size() + 32];
   struct timespec ts = ceph::real_clock::to_timespec(state->mtime);
   snprintf(buf, sizeof(buf), "%03x%s/%lld.%06ld", (int)src_name.size(),
@@ -2835,7 +2834,7 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
 
   RGWBucketInfo dest_bucket_info;
 
-  r = get_bucket_info(&svc, bucket->get_tenant(), bucket->get_info().swift_ver_location, dest_bucket_info, NULL, null_yield, NULL);
+  r = get_bucket_info(&svc, bucket_info.bucket.tenant, bucket_info.swift_ver_location, dest_bucket_info, NULL, null_yield, NULL);
   if (r < 0) {
     ldpp_dout(dpp, 10) << "failed to read dest bucket info: r=" << r << dendl;
     if (r == -ENOENT) {
@@ -2844,18 +2843,17 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
     return r;
   }
 
-  if (dest_bucket_info.owner != bucket->get_info().owner) {
+  if (dest_bucket_info.owner != bucket_info.owner) {
     return -ERR_PRECONDITION_FAILED;
   }
 
-  rgw::sal::RadosBucket dest_bucket(driver, dest_bucket_info);
-  rgw::sal::RadosObject dest_obj(driver, rgw_obj_key(buf), &dest_bucket);
+  rgw_obj dest_obj(dest_bucket_info.bucket, buf);
 
   if (dest_bucket_info.versioning_enabled()){
-    dest_obj.gen_rand_obj_instance_name();
+    gen_rand_obj_instance_name(&dest_obj);
   }
 
-  dest_obj.set_atomic();
+  obj_ctx.set_atomic(dest_obj);
 
   rgw_zone_id no_zone;
 
@@ -2863,11 +2861,11 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
                user,
                NULL, /* req_info *info */
                no_zone,
-               &dest_obj,
+               dest_obj,
                obj,
-               &dest_bucket,
-               bucket,
-               bucket->get_placement_rule(),
+               dest_bucket_info,
+               bucket_info,
+               bucket_info.placement_rule,
                NULL, /* time_t *src_mtime */
                NULL, /* time_t *mtime */
                NULL, /* const time_t *mod_ptr */
@@ -2899,20 +2897,20 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
 
 int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
                                        const rgw_user& user,
-                                       rgw::sal::Bucket* bucket,
-                                       rgw::sal::Object* obj,
-                                       bool& restored,                  /* out */
+                                       RGWBucketInfo& bucket_info,
+                                       rgw_obj& obj,
+                                       bool& restored,
                                        const DoutPrefixProvider *dpp)
 {
-  if (! swift_versioning_enabled(bucket)) {
+  if (! swift_versioning_enabled(bucket_info)) {
     return 0;
   }
 
   /* Bucket info of the bucket that stores previous versions of our object. */
   RGWBucketInfo archive_binfo;
 
-  int ret = get_bucket_info(&svc, bucket->get_tenant(),
-                            bucket->get_info().swift_ver_location,
+  int ret = get_bucket_info(&svc, bucket_info.bucket.tenant,
+                            bucket_info.swift_ver_location,
 			    archive_binfo, nullptr, null_yield, nullptr);
   if (ret < 0) {
     return ret;
@@ -2923,7 +2921,7 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
    * into consideration. For we can live with that.
    *
    * TODO: delegate this check to un upper layer and compare with ACLs. */
-  if (bucket->get_info().owner != archive_binfo.owner) {
+  if (bucket_info.owner != archive_binfo.owner) {
     return -EPERM;
   }
 
@@ -2944,25 +2942,24 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
      * irrelevant and may be safely skipped. */
     std::map<std::string, ceph::bufferlist> no_attrs;
 
-    rgw::sal::RadosBucket archive_bucket(driver, archive_binfo);
-    rgw::sal::RadosObject archive_obj(driver, entry.key, &archive_bucket);
+    rgw_obj archive_obj(archive_binfo.bucket, entry.key);
 
-    if (bucket->versioning_enabled()){
-      obj->gen_rand_obj_instance_name();
+    if (bucket_info.versioning_enabled()){
+      gen_rand_obj_instance_name(&obj);
     }
 
-    archive_obj.set_atomic();
-    obj->set_atomic();
+    obj_ctx.set_atomic(archive_obj);
+    obj_ctx.set_atomic(obj);
 
     int ret = copy_obj(obj_ctx,
                        user,
                        nullptr,       /* req_info *info */
                        no_zone,
                        obj,           /* dest obj */
-                       &archive_obj,   /* src obj */
-                       bucket,   /* dest bucket info */
-                       &archive_bucket, /* src bucket info */
-                       bucket->get_placement_rule(),  /* placement_rule */
+                       archive_obj,   /* src obj */
+                       bucket_info,   /* dest bucket info */
+                       archive_binfo, /* src bucket info */
+                       bucket_info.placement_rule,  /* placement_rule */
                        nullptr,       /* time_t *src_mtime */
                        nullptr,       /* time_t *mtime */
                        nullptr,       /* const time_t *mod_ptr */
@@ -2994,13 +2991,13 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
     }
 
     /* Need to remove the archived copy. */
-    ret = delete_obj(dpp, archive_binfo, &archive_obj,
+    ret = delete_obj(dpp, obj_ctx, archive_binfo, archive_obj,
                      archive_binfo.versioning_status());
 
     return ret;
   };
 
-  const std::string& obj_name = obj->get_oid();
+  const std::string& obj_name = obj.get_oid();
   const auto prefix = boost::str(boost::format("%03x%s") % obj_name.size()
                                                          % obj_name);
 
@@ -3035,7 +3032,7 @@ int RGWRados::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
   if (r < 0)
     return r;
 
-  rgw_obj obj = target->get_obj();
+  rgw_obj& obj = target->get_obj();
 
   if (obj.get_oid().empty()) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): cannot write object with empty name" << dendl;
@@ -3226,7 +3223,7 @@ int RGWRados::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
   state = NULL;
 
   if (versioned_op && meta.olh_epoch) {
-    r = store->set_olh(dpp, target->get_ctx(), target->get_bucket_info(), target->get_target(), false, NULL, *meta.olh_epoch, real_time(), false, y, meta.zones_trace);
+    r = store->set_olh(dpp, target->get_ctx(), target->get_bucket_info(), obj, false, NULL, *meta.olh_epoch, real_time(), false, y, meta.zones_trace);
     if (r < 0) {
       return r;
     }
@@ -3558,13 +3555,13 @@ static void set_copy_attrs(map<string, bufferlist>& src_attrs,
   }
 }
 
-int RGWRados::rewrite_obj(rgw::sal::Object* obj, const DoutPrefixProvider *dpp, optional_yield y)
+int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, const rgw_obj& obj, const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWObjectCtx rctx(this->driver);
   rgw::sal::Attrs attrset;
   uint64_t obj_size;
   ceph::real_time mtime;
-  RGWRados::Object op_target(this, obj->get_bucket(), rctx, obj);
+  RGWRados::Object op_target(this, dest_bucket_info, rctx, obj);
   RGWRados::Object::Read read_op(&op_target);
 
   read_op.params.attrs = &attrset;
@@ -3579,10 +3576,9 @@ int RGWRados::rewrite_obj(rgw::sal::Object* obj, const DoutPrefixProvider *dpp, 
   attrset.erase(RGW_ATTR_TAIL_TAG);
   attrset.erase(RGW_ATTR_STORAGE_CLASS);
 
-  return this->copy_obj_data(rctx, obj->get_bucket(),
-			     obj->get_bucket()->get_info().placement_rule,
-			     read_op, obj_size - 1, obj, NULL, mtime,
-			     attrset, 0, real_time(), NULL, dpp, y);
+  return copy_obj_data(rctx, dest_bucket_info, dest_bucket_info.placement_rule,
+                       read_op, obj_size - 1, obj, NULL, mtime,
+                       attrset, 0, real_time(), NULL, dpp, y);
 }
 
 struct obj_time_weight {
@@ -3684,7 +3680,7 @@ int RGWRados::stat_remote_obj(const DoutPrefixProvider *dpp,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::Object* src_obj,
+               const rgw_obj& src_obj,
                const RGWBucketInfo *src_bucket_info,
                real_time *src_mtime,
                uint64_t *psize,
@@ -3822,10 +3818,10 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::Object* dest_obj,
-               rgw::sal::Object* src_obj,
-               rgw::sal::Bucket* dest_bucket,
-               rgw::sal::Bucket* src_bucket,
+               const rgw_obj& dest_obj,
+               const rgw_obj& src_obj,
+               RGWBucketInfo& dest_bucket_info,
+               RGWBucketInfo *src_bucket_info,
                std::optional<rgw_placement_rule> dest_placement_rule,
                real_time *src_mtime,
                real_time *mtime,
@@ -3861,18 +3857,18 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   rgw::BlockingAioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   using namespace rgw::putobj;
-  AtomicObjectProcessor processor(&aio, this->driver, nullptr, user_id,
-                                  obj_ctx, dest_obj->clone(), olh_epoch,
+  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, nullptr,
+                                  user_id, obj_ctx, dest_obj, olh_epoch,
 				  tag, dpp, null_yield);
   RGWRESTConn *conn;
   auto& zone_conn_map = svc.zone->get_zone_conn_map();
   auto& zonegroup_conn_map = svc.zone->get_zonegroup_conn_map();
   if (source_zone.empty()) {
-    if (!src_bucket || src_bucket->get_info().zonegroup.empty()) {
+    if (!src_bucket_info || src_bucket_info->zonegroup.empty()) {
       /* source is in the master zonegroup */
       conn = svc.zone->get_master_conn();
     } else {
-      map<string, RGWRESTConn *>::iterator iter = zonegroup_conn_map.find(src_bucket->get_info().zonegroup);
+      map<string, RGWRESTConn *>::iterator iter = zonegroup_conn_map.find(src_bucket_info->zonegroup);
       if (iter == zonegroup_conn_map.end()) {
         ldpp_dout(dpp, 0) << "could not find zonegroup connection to zonegroup: " << source_zone << dendl;
         return -ENOENT;
@@ -3903,8 +3899,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                       const rgw_placement_rule *ptail_rule;
 
                       int ret = filter->filter(cct,
-                                               src_obj->get_key(),
-                                               dest_bucket->get_info(),
+                                               src_obj.key,
+                                               dest_bucket_info,
                                                dest_placement_rule,
                                                obj_attrs,
 					       &override_owner,
@@ -3945,7 +3941,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   if (copy_if_newer) {
     /* need to get mtime for destination */
-    ret = get_obj_state(dpp, &obj_ctx, dest_bucket->get_info(), dest_obj, &dest_state, &manifest, false, null_yield);
+    ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, dest_obj, &dest_state, &manifest, false, null_yield);
     if (ret < 0)
       goto set_err_state;
 
@@ -4117,8 +4113,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
     if (copy_if_newer && canceled) {
       ldpp_dout(dpp, 20) << "raced with another write of obj: " << dest_obj << dendl;
-      obj_ctx.invalidate(dest_obj->get_obj()); /* object was overwritten */
-      ret = get_obj_state(dpp, &obj_ctx, dest_bucket->get_info(), dest_obj, &dest_state, &manifest, false, null_yield);
+      obj_ctx.invalidate(dest_obj); /* object was overwritten */
+      ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, dest_obj, &dest_state, &manifest, false, null_yield);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": get_err_state() returned ret=" << ret << dendl;
         goto set_err_state;
@@ -4152,7 +4148,7 @@ set_err_state:
     // for OP_LINK_OLH to call set_olh() with a real olh_epoch
     if (olh_epoch && *olh_epoch > 0) {
       constexpr bool log_data_change = true;
-      ret = set_olh(dpp, obj_ctx, dest_bucket->get_info(), dest_obj, false, nullptr,
+      ret = set_olh(dpp, obj_ctx, dest_bucket_info, dest_obj, false, nullptr,
                     *olh_epoch, real_time(), false, null_yield, zones_trace, log_data_change);
     } else {
       // we already have the latest copy
@@ -4168,7 +4164,7 @@ int RGWRados::copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
                                       map<string, bufferlist>& src_attrs,
                                       RGWRados::Object::Read& read_op,
                                       const rgw_user& user_id,
-                                      rgw::sal::Object* dest_obj,
+                                      const rgw_obj& dest_obj,
                                       real_time *mtime)
 {
   string etag;
@@ -4222,10 +4218,10 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::Object* dest_obj,
-               rgw::sal::Object* src_obj,
-               rgw::sal::Bucket* dest_bucket,
-               rgw::sal::Bucket* src_bucket,
+               const rgw_obj& dest_obj,
+               const rgw_obj& src_obj,
+               RGWBucketInfo& dest_bucket_info,
+               RGWBucketInfo& src_bucket_info,
                const rgw_placement_rule& dest_placement,
                real_time *src_mtime,
                real_time *mtime,
@@ -4250,30 +4246,30 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 {
   int ret;
   uint64_t obj_size;
-  rgw_obj shadow_obj = dest_obj->get_obj();
+  rgw_obj shadow_obj = dest_obj;
   string shadow_oid;
 
   bool remote_src;
   bool remote_dest;
 
-  append_rand_alpha(cct, dest_obj->get_oid(), shadow_oid, 32);
-  shadow_obj.init_ns(dest_obj->get_bucket()->get_key(), shadow_oid, shadow_ns);
+  append_rand_alpha(cct, dest_obj.get_oid(), shadow_oid, 32);
+  shadow_obj.init_ns(dest_obj.bucket, shadow_oid, shadow_ns);
 
   auto& zonegroup = svc.zone->get_zonegroup();
 
-  remote_dest = !zonegroup.equals(dest_bucket->get_info().zonegroup);
-  remote_src = !zonegroup.equals(src_bucket->get_info().zonegroup);
+  remote_dest = !zonegroup.equals(dest_bucket_info.zonegroup);
+  remote_src = !zonegroup.equals(src_bucket_info.zonegroup);
 
   if (remote_src && remote_dest) {
     ldpp_dout(dpp, 0) << "ERROR: can't copy object when both src and dest buckets are remote" << dendl;
     return -EINVAL;
   }
 
-  ldpp_dout(dpp, 5) << "Copy object " << src_obj->get_bucket() << ":" << src_obj->get_oid() << " => " << dest_obj->get_bucket() << ":" << dest_obj->get_oid() << dendl;
+  ldpp_dout(dpp, 5) << "Copy object " << src_obj.bucket << ":" << src_obj.get_oid() << " => " << dest_obj.bucket << ":" << dest_obj.get_oid() << dendl;
 
   if (remote_src || !source_zone.empty()) {
     return fetch_remote_obj(obj_ctx, user_id, info, source_zone,
-               dest_obj, src_obj, dest_bucket, src_bucket,
+               dest_obj, src_obj, dest_bucket_info, &src_bucket_info,
                dest_placement, src_mtime, mtime, mod_ptr,
                unmod_ptr, high_precision_time,
                if_match, if_nomatch, attrs_mod, copy_if_newer, attrs, category,
@@ -4282,7 +4278,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   map<string, bufferlist> src_attrs;
-  RGWRados::Object src_op_target(this, src_bucket, obj_ctx, src_obj);
+  RGWRados::Object src_op_target(this, src_bucket_info, obj_ctx, src_obj);
   RGWRados::Object::Read read_op(&src_op_target);
 
   read_op.conds.mod_ptr = mod_ptr;
@@ -4332,7 +4328,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   RGWObjState *astate = NULL;
   RGWObjManifest *amanifest = nullptr;
 
-  ret = get_obj_state(dpp, &obj_ctx, src_bucket->get_info(), src_obj, &astate, &amanifest, y);
+  ret = get_obj_state(dpp, &obj_ctx, src_bucket_info, src_obj, &astate, &amanifest, y);
   if (ret < 0) {
     return ret;
   }
@@ -4345,9 +4341,9 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
   uint64_t max_chunk_size;
 
-  ret = get_max_chunk_size(dest_bucket->get_placement_rule(), dest_obj->get_obj(), &max_chunk_size, dpp);
+  ret = get_max_chunk_size(dest_bucket_info.placement_rule, dest_obj, &max_chunk_size, dpp);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to get max_chunk_size() for bucket " << dest_obj->get_bucket() << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: failed to get max_chunk_size() for bucket " << dest_obj.bucket << dendl;
     return ret;
   }
 
@@ -4362,15 +4358,15 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   if (!src_rule || src_rule->empty()) {
-    src_rule = &src_bucket->get_placement_rule();
+    src_rule = &src_bucket_info.placement_rule;
   }
 
-  if (!get_obj_data_pool(*src_rule, src_obj->get_obj(), &src_pool)) {
+  if (!get_obj_data_pool(*src_rule, src_obj, &src_pool)) {
     ldpp_dout(dpp, 0) << "ERROR: failed to locate data pool for " << src_obj << dendl;
     return -EIO;
   }
 
-  if (!get_obj_data_pool(dest_placement, dest_obj->get_obj(), &dest_pool)) {
+  if (!get_obj_data_pool(dest_placement, dest_obj, &dest_pool)) {
     ldpp_dout(dpp, 0) << "ERROR: failed to locate data pool for " << dest_obj << dendl;
     return -EIO;
   }
@@ -4408,7 +4404,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
     attrs.erase(RGW_ATTR_TAIL_TAG);
-    return copy_obj_data(obj_ctx, dest_bucket, dest_placement, read_op, obj_size - 1, dest_obj,
+    return copy_obj_data(obj_ctx, dest_bucket_info, dest_placement, read_op, obj_size - 1, dest_obj,
                          mtime, real_time(), attrs, olh_epoch, delete_at, petag, dpp, y);
   }
 
@@ -4421,11 +4417,11 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   bufferlist first_chunk;
 
-  const bool copy_itself = (dest_obj->get_obj() == src_obj->get_obj());
+  const bool copy_itself = (dest_obj == src_obj);
   RGWObjManifest *pmanifest; 
   ldpp_dout(dpp, 20) << "dest_obj=" << dest_obj << " src_obj=" << src_obj << " copy_itself=" << (int)copy_itself << dendl;
 
-  RGWRados::Object dest_op_target(this, dest_bucket, obj_ctx, dest_obj);
+  RGWRados::Object dest_op_target(this, dest_bucket_info, obj_ctx, dest_obj);
   RGWRados::Object::Write write_op(&dest_op_target);
 
   string tag;
@@ -4446,7 +4442,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     manifest = *amanifest;
     const rgw_bucket_placement& tail_placement = manifest.get_tail_placement();
     if (tail_placement.bucket.name.empty()) {
-      manifest.set_tail_placement(tail_placement.placement_rule, src_obj->get_bucket()->get_key());
+      manifest.set_tail_placement(tail_placement.placement_rule, src_obj.bucket);
     }
     string ref_tag;
     for (; miter != amanifest->obj_end(dpp); ++miter) {
@@ -4454,7 +4450,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
       ref_tag = tag + '\0';
       cls_refcount_get(op, ref_tag, true);
 
-      auto obj = svc.rados->obj(miter.get_location().get_raw_obj(driver));
+      auto obj = svc.rados->obj(miter.get_location().get_raw_obj(this));
       ret = obj.open(dpp);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "failed to open rados context for " << obj << dendl;
@@ -4493,15 +4489,15 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
       goto done_ret;
     }
 
-    pmanifest->set_head(dest_bucket->get_placement_rule(), dest_obj->get_obj(), first_chunk.length());
+    pmanifest->set_head(dest_bucket_info.placement_rule, dest_obj, first_chunk.length());
   } else {
-    pmanifest->set_head(dest_bucket->get_placement_rule(), dest_obj->get_obj(), 0);
+    pmanifest->set_head(dest_bucket_info.placement_rule, dest_obj, 0);
   }
 
   write_op.meta.data = &first_chunk;
   write_op.meta.manifest = pmanifest;
   write_op.meta.ptag = &tag;
-  write_op.meta.owner = dest_bucket->get_info().owner;
+  write_op.meta.owner = dest_bucket_info.owner;
   write_op.meta.mtime = mtime;
   write_op.meta.flags = PUT_OBJ_CREATE;
   write_op.meta.category = category;
@@ -4552,10 +4548,10 @@ done_ret:
 
 
 int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
-               rgw::sal::Bucket* bucket,
+               RGWBucketInfo& dest_bucket_info,
                const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
-               rgw::sal::Object* dest_obj,
+               const rgw_obj& dest_obj,
 	       real_time *mtime,
 	       real_time set_mtime,
                rgw::sal::Attrs& attrs,
@@ -4572,9 +4568,9 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   using namespace rgw::putobj;
   // do not change the null_yield in the initialization of this AtomicObjectProcessor
   // it causes crashes in the ragweed tests
-  AtomicObjectProcessor processor(&aio, this->driver, &dest_placement,
-                                  bucket->get_info().owner, obj_ctx,
-                                  dest_obj->clone(), olh_epoch, tag,
+  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, &dest_placement,
+                                  dest_bucket_info.owner, obj_ctx,
+                                  dest_obj, olh_epoch, tag,
 				  dpp, null_yield);
   int ret = processor.prepare(y);
   if (ret < 0)
@@ -4633,8 +4629,8 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
 }
 
 int RGWRados::transition_obj(RGWObjectCtx& obj_ctx,
-			     rgw::sal::Bucket* bucket,
-                             rgw::sal::Object& obj,
+                             RGWBucketInfo& bucket_info,
+                             const rgw_obj& obj,
                              const rgw_placement_rule& placement_rule,
                              const real_time& mtime,
                              uint64_t olh_epoch,
@@ -4645,8 +4641,8 @@ int RGWRados::transition_obj(RGWObjectCtx& obj_ctx,
   real_time read_mtime;
   uint64_t obj_size;
 
-  obj.set_atomic();
-  RGWRados::Object op_target(this, bucket, obj_ctx, &obj);
+  obj_ctx.set_atomic(obj);
+  RGWRados::Object op_target(this, bucket_info, obj_ctx, obj);
   RGWRados::Object::Read read_op(&op_target);
 
   read_op.params.attrs = &attrs;
@@ -4667,11 +4663,11 @@ int RGWRados::transition_obj(RGWObjectCtx& obj_ctx,
   attrs.erase(RGW_ATTR_TAIL_TAG);
 
   ret = copy_obj_data(obj_ctx,
-                      bucket,
+                      bucket_info,
                       placement_rule,
                       read_op,
                       obj_size - 1,
-                      &obj,
+                      obj,
                       nullptr /* pmtime */,
                       mtime,
                       attrs,
@@ -4883,7 +4879,7 @@ int RGWRados::Object::complete_atomic_modification(const DoutPrefixProvider *dpp
     return 0;
 
   cls_rgw_obj_chain chain;
-  store->update_gc_chain(dpp, obj->get_obj(), *manifest, &chain);
+  store->update_gc_chain(dpp, obj, *manifest, &chain);
 
   if (chain.empty()) {
     return 0;
@@ -4910,7 +4906,7 @@ void RGWRados::update_gc_chain(const DoutPrefixProvider *dpp, rgw_obj head_obj, 
   rgw_raw_obj raw_head;
   obj_to_raw(manifest.get_head_placement_rule(), head_obj, &raw_head);
   for (iter = manifest.obj_begin(dpp); iter != manifest.obj_end(dpp); ++iter) {
-    const rgw_raw_obj& mobj = iter.get_location().get_raw_obj(driver);
+    const rgw_raw_obj& mobj = iter.get_location().get_raw_obj(this);
     if (mobj == raw_head)
       continue;
     cls_rgw_obj_key key(mobj.oid);
@@ -5045,10 +5041,10 @@ int RGWRados::bucket_set_reshard(const DoutPrefixProvider *dpp, const RGWBucketI
   return r;
 }
 
-int RGWRados::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, optional_yield y)
+int RGWRados::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
 {
   std::string oid, key;
-  get_obj_bucket_and_oid_loc(obj->get_obj(), oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
   if (!rctx)
     return 0;
 
@@ -5119,7 +5115,8 @@ struct tombstone_entry {
 int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvider *dpp)
 {
   RGWRados *store = target->get_store();
-  const string& instance = target->get_instance();
+  const rgw_obj& src_obj = target->get_obj();
+  const string& instance = src_obj.key.instance;
   rgw_obj obj = target->get_obj();
 
   if (instance == "null") {
@@ -5130,18 +5127,18 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
 
   if (params.versioning_status & BUCKET_VERSIONED || explicit_marker_version) {
     if (instance.empty() || explicit_marker_version) {
-      std::unique_ptr<rgw::sal::Object> marker = target->get_target()->clone();
-      marker->clear_instance();
+      rgw_obj marker = obj;
+      marker.key.instance.clear();
 
       if (!params.marker_version_id.empty()) {
         if (params.marker_version_id != "null") {
-          marker->set_instance(params.marker_version_id);
+          marker.key.set_instance(params.marker_version_id);
         }
       } else if ((params.versioning_status & BUCKET_VERSIONS_SUSPENDED) == 0) {
-	marker->gen_rand_obj_instance_name();
+	store->gen_rand_obj_instance_name(&marker);
       }
 
-      result.version_id = marker->get_instance();
+      result.version_id = marker.key.instance;
       if (result.version_id.empty())
         result.version_id = "null";
       result.delete_marker = true;
@@ -5157,7 +5154,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
         meta.mtime = params.mtime;
       }
 
-      int r = store->set_olh(dpp, target->get_ctx(), target->get_bucket_info(), marker.get(), true, &meta, params.olh_epoch, params.unmod_since, params.high_precision_time, y, params.zones_trace);
+      int r = store->set_olh(dpp, target->get_ctx(), target->get_bucket_info(), marker, true, &meta, params.olh_epoch, params.unmod_since, params.high_precision_time, y, params.zones_trace);
       if (r < 0) {
         return r;
       }
@@ -5169,7 +5166,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
         return r;
       }
       result.delete_marker = dirent.is_delete_marker();
-      r = store->unlink_obj_instance(dpp, target->get_bucket_info(), target->get_target(), params.olh_epoch, y, params.zones_trace);
+      r = store->unlink_obj_instance(dpp, target->get_ctx(), target->get_bucket_info(), obj, params.olh_epoch, y, params.zones_trace);
       if (r < 0) {
         return r;
       }
@@ -5309,8 +5306,8 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
   return 0;
 }
 
-int RGWRados::delete_obj(rgw::sal::Driver* store,
-			 const DoutPrefixProvider *dpp,
+int RGWRados::delete_obj(const DoutPrefixProvider *dpp,
+                         RGWObjectCtx& obj_ctx,
                          const RGWBucketInfo& bucket_info,
                          const rgw_obj& obj,
                          int versioning_status, // versioning flags defined in enum RGWBucketFlags
@@ -5318,31 +5315,16 @@ int RGWRados::delete_obj(rgw::sal::Driver* store,
                          const real_time& expiration_time,
                          rgw_zone_set *zones_trace)
 {
-  std::unique_ptr<rgw::sal::Bucket> bucket;
-  store->get_bucket(nullptr, bucket_info, &bucket);
-  std::unique_ptr<rgw::sal::Object> object = bucket->get_object(obj.key);
+  RGWRados::Object del_target(this, bucket_info, obj_ctx, obj);
+  RGWRados::Object::Delete del_op(&del_target);
 
-  return delete_obj(dpp, bucket_info, object.get(), versioning_status,
-		    bilog_flags, expiration_time, zones_trace);
-}
+  del_op.params.bucket_owner = bucket_info.owner;
+  del_op.params.versioning_status = versioning_status;
+  del_op.params.bilog_flags = bilog_flags;
+  del_op.params.expiration_time = expiration_time;
+  del_op.params.zones_trace = zones_trace;
 
-int RGWRados::delete_obj(const DoutPrefixProvider *dpp,
-                         const RGWBucketInfo& bucket_info,
-                         rgw::sal::Object* obj,
-                         int versioning_status, // versioning flags defined in enum RGWBucketFlags
-                         uint16_t bilog_flags,
-                         const real_time& expiration_time,
-                         rgw_zone_set *zones_trace)
-{
-  std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = obj->get_delete_op();
-
-  del_op->params.bucket_owner = bucket_info.owner;
-  del_op->params.versioning_status = versioning_status;
-  del_op->params.bilog_flags = bilog_flags;
-  del_op->params.expiration_time = expiration_time;
-  del_op->params.zones_trace = zones_trace;
-
-  return del_op->delete_obj(dpp, null_yield);
+  return del_op.delete_obj(null_yield, dpp);
 }
 
 int RGWRados::delete_raw_obj(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj)
@@ -5382,7 +5364,7 @@ int RGWRados::delete_obj_index(const rgw_obj& obj, ceph::real_time mtime,
   return index_op.complete_del(dpp, -1 /* pool */, 0, mtime, nullptr, y);
 }
 
-static void generate_fake_tag(const DoutPrefixProvider *dpp, rgw::sal::Driver* store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
+static void generate_fake_tag(const DoutPrefixProvider *dpp, RGWRados* store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
 {
   string tag;
 
@@ -5390,8 +5372,7 @@ static void generate_fake_tag(const DoutPrefixProvider *dpp, rgw::sal::Driver* s
   if (mi != manifest.obj_end(dpp)) {
     if (manifest.has_tail()) // first object usually points at the head, let's skip to a more unique part
       ++mi;
-    rgw::sal::RadosStore* rstore = dynamic_cast<rgw::sal::RadosStore*>(store);
-    tag = mi.get_location().get_raw_obj(rstore).oid;
+    tag = mi.get_location().get_raw_obj(store).oid;
     tag.append("_");
   }
 
@@ -5431,7 +5412,7 @@ static bool has_olh_tag(map<string, bufferlist>& attrs)
 
 int RGWRados::get_olh_target_state(const DoutPrefixProvider *dpp, RGWObjectCtx&
 				   obj_ctx, RGWBucketInfo& bucket_info,
-				   rgw::sal::Object* obj, RGWObjState *olh_state,
+				   const rgw_obj& obj, RGWObjState *olh_state,
 				   RGWObjState **target_state,
 				   RGWObjManifest **target_manifest, optional_yield y)
 {
@@ -5443,11 +5424,7 @@ int RGWRados::get_olh_target_state(const DoutPrefixProvider *dpp, RGWObjectCtx&
     return r;
   }
 
-  std::unique_ptr<rgw::sal::Bucket> bucket;
-  driver->get_bucket(nullptr, bucket_info, &bucket);
-  std::unique_ptr<rgw::sal::Object> target_obj = bucket->get_object(target.key);
-
-  r = get_obj_state(dpp, &obj_ctx, bucket_info, target_obj.get(), target_state,
+  r = get_obj_state(dpp, &obj_ctx, bucket_info, target, target_state,
 		    target_manifest, false, y);
   if (r < 0) {
     return r;
@@ -5457,18 +5434,18 @@ int RGWRados::get_olh_target_state(const DoutPrefixProvider *dpp, RGWObjectCtx&
 }
 
 int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx,
-				 RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+				 RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  RGWObjState **state, RGWObjManifest** manifest,
 				 bool follow_olh, optional_yield y, bool assume_noent)
 {
-  if (obj->empty()) {
+  if (obj.empty()) {
     return -EINVAL;
   }
 
-  bool need_follow_olh = follow_olh && obj->get_obj().key.instance.empty();
+  bool need_follow_olh = follow_olh && obj.key.instance.empty();
   *manifest = nullptr;
 
-  RGWObjStateManifest *sm = rctx->get_state(obj->get_obj());
+  RGWObjStateManifest *sm = rctx->get_state(obj);
   RGWObjState *s = &(sm->state);
   ldpp_dout(dpp, 20) << "get_obj_state: rctx=" << (void *)rctx << " obj=" << obj << " state=" << (void *)s << " s->prefetch_data=" << s->prefetch_data << dendl;
   *state = s;
@@ -5482,10 +5459,10 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
     return 0;
   }
 
-  s->obj = obj->get_obj();
+  s->obj = obj;
 
   rgw_raw_obj raw_obj;
-  obj_to_raw(bucket_info.placement_rule, obj->get_obj(), &raw_obj);
+  obj_to_raw(bucket_info.placement_rule, obj, &raw_obj);
 
   int r = -ENOENT;
 
@@ -5497,7 +5474,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
     s->exists = false;
     s->has_attrs = true;
     tombstone_entry entry;
-    if (obj_tombstone_cache && obj_tombstone_cache->find(obj->get_obj(), entry)) {
+    if (obj_tombstone_cache && obj_tombstone_cache->find(obj, entry)) {
       s->mtime = entry.mtime;
       s->zone_short_id = entry.zone_short_id;
       s->pg_ver = entry.pg_ver;
@@ -5560,7 +5537,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
     try {
       sm->manifest.emplace();
       decode(*sm->manifest, miter);
-      sm->manifest->set_head(bucket_info.placement_rule, obj->get_obj(), s->size); /* patch manifest to reflect the head we just read, some manifests might be
+      sm->manifest->set_head(bucket_info.placement_rule, obj, s->size); /* patch manifest to reflect the head we just read, some manifests might be
                                              broken due to old bugs */
       s->size = sm->manifest->get_obj_size();
       if (!compressed)
@@ -5575,7 +5552,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
 	sm->manifest->has_explicit_objs()) {
       RGWObjManifest::obj_iterator mi;
       for (mi = sm->manifest->obj_begin(dpp); mi != sm->manifest->obj_end(dpp); ++mi) {
-        ldpp_dout(dpp, 20) << "manifest: ofs=" << mi.get_ofs() << " loc=" << mi.get_location().get_raw_obj(driver) << dendl;
+        ldpp_dout(dpp, 20) << "manifest: ofs=" << mi.get_ofs() << " loc=" << mi.get_location().get_raw_obj(this) << dendl;
       }
     }
 
@@ -5584,7 +5561,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
        * Uh oh, something's wrong, object with manifest should have tag. Let's
        * create one out of the manifest, would be unique
        */
-      generate_fake_tag(dpp, driver, s->attrset, *sm->manifest, manifest_bl, s->obj_tag);
+      generate_fake_tag(dpp, this, s->attrset, *sm->manifest, manifest_bl, s->obj_tag);
       s->fake_tag = true;
     }
   }
@@ -5633,7 +5610,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
 
     if (need_follow_olh) {
       return get_olh_target_state(dpp, *rctx, bucket_info, obj, s, state, manifest, y);
-    } else if (obj->get_obj().key.have_null_instance() && !sm->manifest) {
+    } else if (obj.key.have_null_instance() && !sm->manifest) {
       // read null version, and the head object only have olh info
       s->exists = false;
       return -ENOENT;
@@ -5643,7 +5620,7 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
   return 0;
 }
 
-int RGWRados::get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, RGWObjState **state, RGWObjManifest** manifest,
+int RGWRados::get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, RGWObjManifest** manifest,
                             bool follow_olh, optional_yield y, bool assume_noent)
 {
   int ret;
@@ -5683,17 +5660,18 @@ int RGWRados::Object::Read::get_attr(const DoutPrefixProvider *dpp, const char *
 
 int RGWRados::Object::Stat::stat_async(const DoutPrefixProvider *dpp)
 {
-  rgw::sal::Object* target = source->get_target(); 
-  rgw_obj obj = target->get_obj();
+  RGWObjectCtx& ctx = source->get_ctx();
+  rgw_obj& obj = source->get_obj();
   RGWRados *store = source->get_store();
 
+  RGWObjStateManifest *sm = ctx.get_state(obj);
   result.obj = obj;
-  if (target->has_attrs()) {
+  if (sm->state.has_attrs) {
     state.ret = 0;
-    result.size = target->get_obj_size();
-    result.mtime = ceph::real_clock::to_timespec(target->get_mtime());
-    result.attrs = target->get_attrs();
-    //result.manifest = sm->manifest;
+    result.size = sm->state.size;
+    result.mtime = ceph::real_clock::to_timespec(sm->state.mtime);
+    result.attrs = sm->state.attrset;
+    result.manifest = sm->manifest;
     return 0;
   }
 
@@ -5758,12 +5736,15 @@ int RGWRados::Object::Stat::finish(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int RGWRados::append_atomic_test(const DoutPrefixProvider *dpp,
-                                 RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+int RGWRados::append_atomic_test(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx,
+                                 RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  ObjectOperation& op, RGWObjState **pstate,
 				 RGWObjManifest** pmanifest, optional_yield y)
 {
-  int r = obj->get_obj_state(dpp, pstate, y, false);
+  if (!rctx)
+    return 0;
+
+  int r = get_obj_state(dpp, rctx, bucket_info, obj, pstate, pmanifest, false, y);
   if (r < 0)
     return r;
 
@@ -5789,18 +5770,12 @@ int RGWRados::append_atomic_test(const DoutPrefixProvider *dpp,
 
 int RGWRados::Object::get_state(const DoutPrefixProvider *dpp, RGWObjState **pstate, RGWObjManifest **pmanifest, bool follow_olh, optional_yield y, bool assume_noent)
 {
-  int r = obj->get_obj_state(dpp, pstate, y, follow_olh);
-  if (r < 0) {
-    return r;
-  }
-  *pmanifest = static_cast<rgw::sal::RadosObject*>(obj)->get_manifest();
-
-  return r;
+  return store->get_obj_state(dpp, &ctx, bucket_info, obj, pstate, pmanifest, follow_olh, y, assume_noent);
 }
 
 void RGWRados::Object::invalidate_state()
 {
-  obj->invalidate();
+  ctx.invalidate(obj);
 }
 
 int RGWRados::Object::prepare_atomic_modification(const DoutPrefixProvider *dpp,
@@ -5905,25 +5880,25 @@ int RGWRados::Object::prepare_atomic_modification(const DoutPrefixProvider *dpp,
  * bl: the contents of the attr
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::set_attr(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, const char *name, bufferlist& bl)
+int RGWRados::set_attr(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char *name, bufferlist& bl)
 {
   map<string, bufferlist> attrs;
   attrs[name] = bl;
   return set_attrs(dpp, rctx, bucket_info, obj, attrs, NULL, null_yield);
 }
 
-int RGWRados::set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo& bucket_info, rgw::sal::Object* src_obj,
+int RGWRados::set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, const rgw_obj& src_obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist>* rmattrs,
                         optional_yield y)
 {
-  std::unique_ptr<rgw::sal::Object> obj = src_obj->clone();
-  if (obj->get_instance() == "null") {
-    obj->clear_instance();
+  rgw_obj obj = src_obj;
+  if (obj.key.instance == "null") {
+    obj.key.instance.clear();
   }
 
   rgw_rados_ref ref;
-  int r = get_obj_head_ref(dpp, bucket_info, obj->get_obj(), &ref);
+  int r = get_obj_head_ref(dpp, bucket_info, obj, &ref);
   if (r < 0) {
     return r;
   }
@@ -5932,12 +5907,12 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo&
   RGWObjState *state = NULL;
   RGWObjManifest *manifest = nullptr;
 
-  r = append_atomic_test(dpp, bucket_info, obj.get(), op, &state, &manifest, y);
+  r = append_atomic_test(dpp, rctx, bucket_info, obj, op, &state, &manifest, y);
   if (r < 0)
     return r;
 
   // ensure null version object exist
-  if (src_obj->get_instance() == "null" && !manifest) {
+  if (src_obj.key.instance == "null" && !manifest) {
     return -ENOENT;
   }
 
@@ -5949,7 +5924,7 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo&
     }
   }
 
-  const rgw_bucket& bucket = obj->get_bucket()->get_key();
+  const rgw_bucket& bucket = obj.bucket;
 
   for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
     const string& name = iter->first;
@@ -5966,7 +5941,7 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo&
         decode(ts, bl);
 
         rgw_obj_index_key obj_key;
-        obj->get_key().get_index_key(&obj_key);
+        obj.key.get_index_key(&obj_key);
 
         obj_expirer->hint_add(dpp, ts, bucket.tenant, bucket.name, bucket.bucket_id, obj_key);
       } catch (buffer::error& err) {
@@ -5980,7 +5955,7 @@ int RGWRados::set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo&
 
   bufferlist bl;
   RGWRados::Bucket bop(this, bucket_info);
-  RGWRados::Bucket::UpdateIndex index_op(&bop, obj->get_obj());
+  RGWRados::Bucket::UpdateIndex index_op(&bop, obj);
 
   if (state) {
     string tag;
@@ -6399,7 +6374,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end,
     RGWObjManifest::obj_iterator iter = manifest->obj_find(dpp, ofs);
 
     uint64_t stripe_ofs = iter.get_stripe_ofs();
-    read_obj = iter.get_location().get_raw_obj(store->driver);
+    read_obj = iter.get_location().get_raw_obj(store);
     len = std::min(len, iter.get_stripe_size() - (ofs - stripe_ofs));
     read_ofs = iter.location_ofs() + (ofs - stripe_ofs);
     reading_from_head = (read_obj == state.head_obj);
@@ -6421,8 +6396,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end,
 
   if (reading_from_head) {
     /* only when reading from the head object do we need to do the atomic test */
-    std::unique_ptr<rgw::sal::Object> obj = source->bucket->get_object(state.obj.key);
-    r = store->append_atomic_test(dpp, source->get_bucket_info(), obj.get(), op, &astate, &manifest, y);
+    r = store->append_atomic_test(dpp, &source->get_ctx(), source->get_bucket_info(), state.obj, op, &astate, &manifest, y);
     if (r < 0)
       return r;
 
@@ -6587,8 +6561,7 @@ int RGWRados::Object::Read::iterate(const DoutPrefixProvider *dpp, int64_t ofs, 
   auto aio = rgw::make_throttle(window_size, y);
   get_obj_data data(store, cb, &*aio, ofs, y);
 
-  int r = store->iterate_obj(dpp, source->get_ctx(), source->get_bucket_info(),
-			     source->get_target(),
+  int r = store->iterate_obj(dpp, source->get_ctx(), source->get_bucket_info(), state.obj,
                              ofs, end, chunk_size, _get_obj_iterate_cb, &data, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "iterate_obj() failed with " << r << dendl;
@@ -6600,7 +6573,7 @@ int RGWRados::Object::Read::iterate(const DoutPrefixProvider *dpp, int64_t ofs, 
 }
 
 int RGWRados::iterate_obj(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
-                          RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+                          RGWBucketInfo& bucket_info, const rgw_obj& obj,
                           off_t ofs, off_t end, uint64_t max_chunk_size,
                           iterate_obj_cb cb, void *arg, optional_yield y)
 {
@@ -6612,7 +6585,7 @@ int RGWRados::iterate_obj(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
   RGWObjState *astate = NULL;
   RGWObjManifest *manifest = nullptr;
 
-  obj_to_raw(bucket_info.placement_rule, obj->get_obj(), &head_obj);
+  obj_to_raw(bucket_info.placement_rule, obj, &head_obj);
 
   int r = get_obj_state(dpp, &obj_ctx, bucket_info, obj, &astate, &manifest, false, y);
   if (r < 0) {
@@ -6635,7 +6608,7 @@ int RGWRados::iterate_obj(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
       off_t next_stripe_ofs = stripe_ofs + iter.get_stripe_size();
 
       while (ofs < next_stripe_ofs && ofs <= end) {
-        read_obj = iter.get_location().get_raw_obj(driver);
+        read_obj = iter.get_location().get_raw_obj(this);
         uint64_t read_len = std::min(len, iter.get_stripe_size() - (ofs - stripe_ofs));
         read_ofs = iter.location_ofs() + (ofs - stripe_ofs);
 
@@ -7278,9 +7251,10 @@ static int decode_olh_info(const DoutPrefixProvider *dpp, CephContext* cct, cons
 }
 
 int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
+			    RGWObjectCtx& obj_ctx,
 			    RGWObjState& state,
 			    RGWBucketInfo& bucket_info,
-			    const rgw::sal::Object* obj,
+			    const rgw_obj& obj,
 			    bufferlist& olh_tag,
 			    std::map<uint64_t, std::vector<rgw_bucket_olh_log_entry> >& log,
 			    uint64_t *plast_ver,
@@ -7375,15 +7349,15 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   }
 
   rgw_rados_ref ref;
-  int r = get_obj_head_ref(dpp, bucket_info, obj->get_obj(), &ref);
+  int r = get_obj_head_ref(dpp, bucket_info, obj, &ref);
   if (r < 0) {
     return r;
   }
 
-  rgw::sal::Bucket* bucket = obj->get_bucket();
+  const rgw_bucket& bucket = obj.bucket;
 
   if (need_to_link) {
-    rgw_obj target(bucket->get_key(), key);
+    rgw_obj target(bucket, key);
     RGWOLHInfo info;
     info.target = target;
     info.removed = delete_marker;
@@ -7396,8 +7370,8 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
   for (list<cls_rgw_obj_key>::iterator liter = remove_instances.begin();
        liter != remove_instances.end(); ++liter) {
     cls_rgw_obj_key& key = *liter;
-    std::unique_ptr<rgw::sal::Object> obj_instance = bucket->get_object(key);
-    int ret = delete_obj(dpp, bucket_info, obj_instance.get(), 0, RGW_BILOG_FLAG_VERSIONED_OP, ceph::real_time(), zones_trace);
+    rgw_obj obj_instance(bucket, key);
+    int ret = delete_obj(dpp, obj_ctx, bucket_info, obj_instance, 0, RGW_BILOG_FLAG_VERSIONED_OP, ceph::real_time(), zones_trace);
     if (ret < 0 && ret != -ENOENT) {
       ldpp_dout(dpp, 0) << "ERROR: delete_obj() returned " << ret << " obj_instance=" << obj_instance << dendl;
       return ret;
@@ -7411,7 +7385,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  r = bucket_index_trim_olh_log(dpp, bucket_info, state, obj->get_obj(), last_ver);
+  r = bucket_index_trim_olh_log(dpp, bucket_info, state, obj, last_ver);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: could not trim olh log, r=" << r << dendl;
     return r;
@@ -7432,7 +7406,7 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
       /* 
        * only clear if was successful, otherwise we might clobber pending operations on this object
        */
-      r = bucket_index_clear_olh(dpp, bucket_info, state, obj->get_obj());
+      r = bucket_index_clear_olh(dpp, bucket_info, state, obj);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "ERROR: could not clear bucket index olh entries r=" << r << dendl;
         return r;
@@ -7446,18 +7420,18 @@ int RGWRados::apply_olh_log(const DoutPrefixProvider *dpp,
 /*
  * read olh log and apply it
  */
-int RGWRados::update_olh(const DoutPrefixProvider *dpp, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw::sal::Object* obj, rgw_zone_set *zones_trace)
+int RGWRados::update_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
 {
   map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
   uint64_t ver_marker = 0;
 
   do {
-    int ret = bucket_index_read_olh_log(dpp, bucket_info, *state, obj->get_obj(), ver_marker, &log, &is_truncated);
+    int ret = bucket_index_read_olh_log(dpp, bucket_info, *state, obj, ver_marker, &log, &is_truncated);
     if (ret < 0) {
       return ret;
     }
-    ret = apply_olh_log(dpp, *state, bucket_info, obj, state->olh_tag, log, &ver_marker, zones_trace);
+    ret = apply_olh_log(dpp, obj_ctx, *state, bucket_info, obj, state->olh_tag, log, &ver_marker, zones_trace);
     if (ret < 0) {
       return ret;
     }
@@ -7468,15 +7442,15 @@ int RGWRados::update_olh(const DoutPrefixProvider *dpp, RGWObjState *state, RGWB
 
 int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
 		      RGWBucketInfo& bucket_info,
-		      rgw::sal::Object* target_obj, bool delete_marker,
+		      const rgw_obj& target_obj, bool delete_marker,
 		      rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
                       optional_yield y, rgw_zone_set *zones_trace, bool log_data_change)
 {
   string op_tag;
 
-  std::unique_ptr<rgw::sal::Object> olh_obj = target_obj->clone();
-  olh_obj->clear_instance();
+  rgw_obj olh_obj = target_obj;
+  olh_obj.key.instance.clear();
 
   RGWObjState *state = NULL;
   RGWObjManifest *manifest = nullptr;
@@ -7487,15 +7461,15 @@ int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
 #define MAX_ECANCELED_RETRY 100
   for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
     if (ret == -ECANCELED) {
-      olh_obj->invalidate();
+      obj_ctx.invalidate(olh_obj);
     }
 
-    ret = get_obj_state(dpp, &obj_ctx, bucket_info, olh_obj.get(), &state, &manifest, false, y); /* don't follow olh */
+    ret = get_obj_state(dpp, &obj_ctx, bucket_info, olh_obj, &state, &manifest, false, y); /* don't follow olh */
     if (ret < 0) {
       return ret;
     }
 
-    ret = olh_init_modification(dpp, bucket_info, *state, olh_obj->get_obj(), &op_tag);
+    ret = olh_init_modification(dpp, bucket_info, *state, olh_obj, &op_tag);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)delete_marker << " returned " << ret << dendl;
       if (ret == -ECANCELED) {
@@ -7503,7 +7477,7 @@ int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
       }
       return ret;
     }
-    ret = bucket_index_link_olh(dpp, bucket_info, *state, target_obj->get_obj(),
+    ret = bucket_index_link_olh(dpp, bucket_info, *state, target_obj,
 				delete_marker, op_tag, meta, olh_epoch, unmod_since,
 				high_precision_time, y, zones_trace, log_data_change);
     if (ret < 0) {
@@ -7511,7 +7485,7 @@ int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
       if (ret == -ECANCELED) {
         // the bucket index rejected the link_olh() due to olh tag mismatch;
         // attempt to reconstruct olh head attributes based on the bucket index
-        int r2 = repair_olh(dpp, state, bucket_info, olh_obj->get_obj());
+        int r2 = repair_olh(dpp, state, bucket_info, olh_obj);
         if (r2 < 0 && r2 != -ECANCELED) {
           return r2;
         }
@@ -7527,7 +7501,7 @@ int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
     return -EIO;
   }
 
-  ret = update_olh(dpp, state, bucket_info, olh_obj.get());
+  ret = update_olh(dpp, obj_ctx, state, bucket_info, olh_obj);
   if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
     ret = 0;
   }
@@ -7539,29 +7513,30 @@ int RGWRados::set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx,
   return 0;
 }
 
-int RGWRados::unlink_obj_instance(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, rgw::sal::Object* target_obj,
+int RGWRados::unlink_obj_instance(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj,
                                   uint64_t olh_epoch, optional_yield y, rgw_zone_set *zones_trace)
 {
   string op_tag;
 
-  std::unique_ptr<rgw::sal::Object> olh_obj = target_obj->clone();
-  olh_obj->clear_instance();
+  rgw_obj olh_obj = target_obj;
+  olh_obj.key.instance.clear();
 
   RGWObjState *state = NULL;
+  RGWObjManifest *manifest = NULL;
 
   int ret = 0;
   int i;
 
   for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
     if (ret == -ECANCELED) {
-      olh_obj->invalidate();
+      obj_ctx.invalidate(olh_obj);
     }
 
-    ret = olh_obj->get_obj_state(dpp, &state, y, false); /* don't follow olh */
+    ret = get_obj_state(dpp, &obj_ctx, bucket_info, olh_obj, &state, &manifest, false, y); /* don't follow olh */
     if (ret < 0)
       return ret;
 
-    ret = olh_init_modification(dpp, bucket_info, *state, olh_obj->get_obj(), &op_tag);
+    ret = olh_init_modification(dpp, bucket_info, *state, olh_obj, &op_tag);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "olh_init_modification() target_obj=" << target_obj << " returned " << ret << dendl;
       if (ret == -ECANCELED) {
@@ -7572,7 +7547,7 @@ int RGWRados::unlink_obj_instance(const DoutPrefixProvider *dpp, RGWBucketInfo& 
 
     string olh_tag(state->olh_tag.c_str(), state->olh_tag.length());
 
-    ret = bucket_index_unlink_instance(dpp, bucket_info, target_obj->get_obj(), op_tag, olh_tag, olh_epoch, zones_trace);
+    ret = bucket_index_unlink_instance(dpp, bucket_info, target_obj, op_tag, olh_tag, olh_epoch, zones_trace);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "bucket_index_unlink_instance() target_obj=" << target_obj << " returned " << ret << dendl;
       if (ret == -ECANCELED) {
@@ -7588,7 +7563,7 @@ int RGWRados::unlink_obj_instance(const DoutPrefixProvider *dpp, RGWBucketInfo& 
     return -EIO;
   }
 
-  ret = update_olh(dpp, state, bucket_info, olh_obj.get(), zones_trace);
+  ret = update_olh(dpp, obj_ctx, state, bucket_info, olh_obj, zones_trace);
   if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
     return 0;
   }
@@ -7701,7 +7676,7 @@ int RGWRados::remove_olh_pending_entries(const DoutPrefixProvider *dpp, RGWBucke
   return 0;
 }
 
-int RGWRados::follow_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, rgw::sal::Object* olh_obj, rgw_obj *target)
+int RGWRados::follow_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
 {
   map<string, bufferlist> pending_entries;
   rgw_filter_attrset(state->attrset, RGW_ATTR_OLH_PENDING_PREFIX, &pending_entries);
@@ -7710,16 +7685,16 @@ int RGWRados::follow_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_in
   check_pending_olh_entries(dpp, pending_entries, &rm_pending_entries);
 
   if (!rm_pending_entries.empty()) {
-    int ret = remove_olh_pending_entries(dpp, bucket_info, *state, olh_obj->get_obj(), rm_pending_entries);
+    int ret = remove_olh_pending_entries(dpp, bucket_info, *state, olh_obj, rm_pending_entries);
     if (ret < 0) {
       ldpp_dout(dpp, 20) << "ERROR: rm_pending_entries returned ret=" << ret << dendl;
       return ret;
     }
   }
   if (!pending_entries.empty()) {
-    ldpp_dout(dpp, 20) << __func__ << "(): found pending entries, need to update_olh() on bucket=" << olh_obj->get_bucket() << dendl;
+    ldpp_dout(dpp, 20) << __func__ << "(): found pending entries, need to update_olh() on bucket=" << olh_obj.bucket << dendl;
 
-    int ret = update_olh(dpp, state, bucket_info, olh_obj);
+    int ret = update_olh(dpp, obj_ctx, state, bucket_info, olh_obj);
     if (ret < 0) {
       if (ret == -ECANCELED) {
         // In this context, ECANCELED means that the OLH tag changed in either the bucket index entry or the OLH object.
@@ -9291,21 +9266,20 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   ldout_bitx(bitx, dpp, 10) << "ENTERING " << __func__ << ": bucket=" <<
     bucket_info.bucket << " dir_entry=" << list_state.key << dendl_bitx;
 
-  std::unique_ptr<rgw::sal::Bucket> bucket;
-  driver->get_bucket(nullptr, bucket_info, &bucket);
   uint8_t suggest_flag = (svc.zone->get_zone().log_data ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
 
   std::string loc;
 
-  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(list_state.key);
+  rgw_obj obj(bucket_info.bucket, list_state.key);
+
   MultipartMetaFilter multipart_meta_filter;
   string temp_key;
   if (multipart_meta_filter.filter(list_state.key.name, temp_key)) {
-    obj->set_in_extra_data(true);
+    obj.in_extra_data = true;
   }
 
   string oid;
-  get_obj_bucket_and_oid_loc(obj->get_obj(), oid, loc);
+  get_obj_bucket_and_oid_loc(obj, oid, loc);
 
   if (loc != list_state.locator) {
     ldpp_dout(dpp, 0) << "WARNING: generated locator (" << loc << ") is different from listed locator (" << list_state.locator << ")" << dendl;
@@ -9316,7 +9290,7 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   RGWObjState *astate = NULL;
   RGWObjManifest *manifest = nullptr;
   RGWObjectCtx rctx(this->driver);
-  int r = get_obj_state(dpp, &rctx, bucket_info, obj.get(), &astate, &manifest, false, y);
+  int r = get_obj_state(dpp, &rctx, bucket_info, obj, &astate, &manifest, false, y);
   if (r < 0)
     return r;
 
@@ -9377,7 +9351,7 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   if (manifest) {
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest->obj_begin(dpp); miter != manifest->obj_end(dpp); ++miter) {
-      const rgw_raw_obj& raw_loc = miter.get_location().get_raw_obj(driver);
+      const rgw_raw_obj& raw_loc = miter.get_location().get_raw_obj(this);
       rgw_obj loc;
       RGWSI_Tier_RADOS::raw_obj_to_obj(manifest->get_obj().bucket, raw_loc, &loc);
 
@@ -9411,7 +9385,7 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   list_state.meta.storage_class = storage_class;
 
   librados::IoCtx head_obj_ctx; // initialize to data pool so we can get pool id
-  r = get_obj_head_ioctx(dpp, bucket_info, obj->get_obj(), &head_obj_ctx);
+  r = get_obj_head_ioctx(dpp, bucket_info, obj, &head_obj_ctx);
   if (r < 0) {
     ldpp_dout(dpp, 0) << __func__ <<
       " WARNING: unable to find head object data pool for \"" <<

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -203,7 +203,7 @@ public:
   RGWObjStateManifest *get_state(const rgw_obj& obj);
 
   void set_compressed(const rgw_obj& obj);
-  void set_atomic(rgw_obj& obj);
+  void set_atomic(const rgw_obj& obj);
   void set_prefetch_data(const rgw_obj& obj);
   void invalidate(const rgw_obj& obj);
 };
@@ -400,12 +400,12 @@ class RGWRados
   uint64_t max_bucket_id;
 
   int get_olh_target_state(const DoutPrefixProvider *dpp, RGWObjectCtx& rctx,
-			   RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+			   RGWBucketInfo& bucket_info, const rgw_obj& obj,
 			   RGWObjState *olh_state, RGWObjState **target_state,
 			   RGWObjManifest **target_manifest, optional_yield y);
-  int get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, RGWObjState **state, RGWObjManifest** manifest,
+  int get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, RGWObjManifest** manifest,
                          bool follow_olh, optional_yield y, bool assume_noent = false);
-  int append_atomic_test(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+  int append_atomic_test(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                          librados::ObjectOperation& op, RGWObjState **state,
 			 RGWObjManifest** pmanifest, optional_yield y);
 
@@ -660,9 +660,9 @@ public:
 
   class Object {
     RGWRados *store;
-    rgw::sal::Bucket* bucket;
+    RGWBucketInfo bucket_info;
     RGWObjectCtx& ctx;
-    rgw::sal::Object* obj;
+    rgw_obj obj;
 
     BucketShard bs;
 
@@ -684,24 +684,24 @@ public:
     int complete_atomic_modification(const DoutPrefixProvider *dpp);
 
   public:
-    Object(RGWRados *_store, rgw::sal::Bucket* _bucket, RGWObjectCtx& _ctx, rgw::sal::Object* _obj) : store(_store), bucket(_bucket),
+    Object(RGWRados *_store, const RGWBucketInfo& _bucket_info, RGWObjectCtx& _ctx, const rgw_obj& _obj) : store(_store), bucket_info(_bucket_info),
                                                                                                ctx(_ctx), obj(_obj), bs(store),
                                                                                                state(NULL), manifest(nullptr), versioning_disabled(false),
                                                                                                bs_initialized(false),
                                                                                                pmeta_placement_rule(nullptr) {}
 
     RGWRados *get_store() { return store; }
-    rgw_obj get_obj() { return obj->get_obj(); }
+    rgw_obj& get_obj() { return obj; }
     RGWObjectCtx& get_ctx() { return ctx; }
-    RGWBucketInfo& get_bucket_info() { return bucket->get_info(); }
-    const std::string& get_instance() { return obj->get_instance(); }
-    rgw::sal::Object* get_target() { return obj; }
+    RGWBucketInfo& get_bucket_info() { return bucket_info; }
+    //const std::string& get_instance() { return obj->get_instance(); }
+    //rgw::sal::Object* get_target() { return obj; }
     int get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest, optional_yield y);
 
     int get_bucket_shard(BucketShard **pbs, const DoutPrefixProvider *dpp) {
       if (!bs_initialized) {
         int r =
-	  bs.init(bucket->get_key(), obj->get_obj(), nullptr /* no RGWBucketInfo */, dpp);
+	  bs.init(bucket_info.bucket, obj, nullptr /* no RGWBucketInfo */, dpp);
         if (r < 0) {
           return r;
         }
@@ -716,7 +716,7 @@ public:
     }
 
     bool versioning_enabled() {
-      return (!versioning_disabled && bucket->versioning_enabled());
+      return (!versioning_disabled && bucket_info.versioning_enabled());
     }
 
     void set_meta_placement_rule(const rgw_placement_rule *p) {
@@ -724,7 +724,7 @@ public:
     }
 
     const rgw_placement_rule& get_meta_placement_rule() {
-        return pmeta_placement_rule ? *pmeta_placement_rule : bucket->get_placement_rule();
+        return pmeta_placement_rule ? *pmeta_placement_rule : bucket_info.placement_rule;
     }
 
     struct Read {
@@ -1048,26 +1048,26 @@ public:
                                const std::string& obj_delim,
                                std::function<int(const rgw_bucket_dir_entry&)> handler);
 
-  bool swift_versioning_enabled(rgw::sal::Bucket* bucket) const;
+  bool swift_versioning_enabled(const RGWBucketInfo& bucket_info) const;
 
   int swift_versioning_copy(RGWObjectCtx& obj_ctx,              /* in/out */
                             const rgw_user& user,               /* in */
-                            rgw::sal::Bucket* bucket,        /* in */
-                            rgw::sal::Object* obj,           /* in */
-                            const DoutPrefixProvider *dpp,      /* in/out */
+                            RGWBucketInfo& bucket_info,         /* in */
+                            const rgw_obj& obj,                 /* in */
+                            const DoutPrefixProvider *dpp,      /* in */
                             optional_yield y);                  /* in */
   int swift_versioning_restore(RGWObjectCtx& obj_ctx,           /* in/out */
                                const rgw_user& user,            /* in */
-                               rgw::sal::Bucket* bucket,     /* in */
-                               rgw::sal::Object* obj,        /* in */
-                               bool& restored,                 /* out */
-                               const DoutPrefixProvider *dpp);     /* in/out */
+                               RGWBucketInfo& bucket_info,      /* in */
+                               rgw_obj& obj,                    /* in/out */
+                               bool& restored,                  /* out */
+                               const DoutPrefixProvider *dpp);  /* in */
   int copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
                               RGWObjState *astate,
                               std::map<std::string, bufferlist>& src_attrs,
                               RGWRados::Object::Read& read_op,
                               const rgw_user& user_id,
-                              rgw::sal::Object* dest_obj,
+                              const rgw_obj& dest_obj,
                               ceph::real_time *mtime);
 
   enum AttrsMod {
@@ -1078,14 +1078,14 @@ public:
 
   D3nDataCache* d3n_data_cache{nullptr};
 
-  int rewrite_obj(rgw::sal::Object* obj, const DoutPrefixProvider *dpp, optional_yield y);
+  int rewrite_obj(RGWBucketInfo& dest_bucket_info, const rgw_obj& obj, const DoutPrefixProvider *dpp, optional_yield y);
 
   int stat_remote_obj(const DoutPrefixProvider *dpp,
                RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::Object* src_obj,
+               const rgw_obj& src_obj,
                const RGWBucketInfo *src_bucket_info,
                real_time *src_mtime,
                uint64_t *psize,
@@ -1104,10 +1104,10 @@ public:
                        const rgw_user& user_id,
                        req_info *info,
                        const rgw_zone_id& source_zone,
-                       rgw::sal::Object* dest_obj,
-                       rgw::sal::Object* src_obj,
-		       rgw::sal::Bucket* dest_bucket,
-		       rgw::sal::Bucket* src_bucket,
+                       const rgw_obj& dest_obj,
+                       const rgw_obj& src_obj,
+                       RGWBucketInfo& dest_bucket_info,
+                       RGWBucketInfo *src_bucket_info,
 		       std::optional<rgw_placement_rule> dest_placement,
                        ceph::real_time *src_mtime,
                        ceph::real_time *mtime,
@@ -1148,10 +1148,10 @@ public:
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::Object* dest_obj,
-               rgw::sal::Object* src_obj,
-               rgw::sal::Bucket* dest_bucket,
-               rgw::sal::Bucket* src_bucket,
+               const rgw_obj& dest_obj,
+               const rgw_obj& src_obj,
+               RGWBucketInfo& dest_bucket_info,
+               RGWBucketInfo& src_bucket_info,
                const rgw_placement_rule& dest_placement,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
@@ -1175,10 +1175,10 @@ public:
                optional_yield y);
 
   int copy_obj_data(RGWObjectCtx& obj_ctx,
-               rgw::sal::Bucket* bucket,
+               RGWBucketInfo& dest_bucket_info,
                const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
-               rgw::sal::Object* dest_obj,
+               const rgw_obj& dest_obj,
 	       ceph::real_time *mtime,
 	       ceph::real_time set_mtime,
                std::map<std::string, bufferlist>& attrs,
@@ -1189,8 +1189,8 @@ public:
                optional_yield y);
 
   int transition_obj(RGWObjectCtx& obj_ctx,
-                     rgw::sal::Bucket* bucket,
-                     rgw::sal::Object& obj,
+                     RGWBucketInfo& bucket_info,
+                     const rgw_obj& obj,
                      const rgw_placement_rule& placement_rule,
                      const real_time& mtime,
                      uint64_t olh_epoch,
@@ -1218,17 +1218,10 @@ public:
   int bucket_suspended(const DoutPrefixProvider *dpp, rgw_bucket& bucket, bool *suspended);
 
   /** Delete an object.*/
-  int delete_obj(rgw::sal::Driver* driver,
-		 const DoutPrefixProvider *dpp,
-		 const RGWBucketInfo& bucket_owner,
-		 const rgw_obj& src_obj,
-		 int versioning_status,  // versioning flags defined in enum RGWBucketFlags
-		 uint16_t bilog_flags = 0,
-		 const ceph::real_time& expiration_time = ceph::real_time(),
-		 rgw_zone_set *zones_trace = nullptr);
   int delete_obj(const DoutPrefixProvider *dpp,
-		 const RGWBucketInfo& bucket_owner,
-		 rgw::sal::Object* src_obj,
+		 RGWObjectCtx& obj_ctx,
+		 const RGWBucketInfo& bucket_info,
+		 const rgw_obj& obj,
 		 int versioning_status,  // versioning flags defined in enum RGWBucketFlags
 		 uint16_t bilog_flags = 0,
 		 const ceph::real_time& expiration_time = ceph::real_time(),
@@ -1248,16 +1241,16 @@ public:
    * bl: the contents of the attr
    * Returns: 0 on success, -ERR# otherwise.
    */
-  int set_attr(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, const char *name, bufferlist& bl);
+  int set_attr(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char *name, bufferlist& bl);
 
-  int set_attrs(const DoutPrefixProvider *dpp, void *ctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
+  int set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                         std::map<std::string, bufferlist>& attrs,
                         std::map<std::string, bufferlist>* rmattrs,
                         optional_yield y);
 
-  int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, RGWObjState **state, RGWObjManifest** manifest,
+  int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, RGWObjManifest** manifest,
                     bool follow_olh, optional_yield y, bool assume_noent = false);
-  int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, RGWObjState **state, RGWObjManifest** manifest, optional_yield y) {
+  int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, RGWObjManifest** manifest, optional_yield y) {
     return get_obj_state(dpp, rctx, bucket_info, obj, state, manifest, true, y);
   }
 
@@ -1265,7 +1258,7 @@ public:
                                  off_t, bool, RGWObjState*, void*);
 
   int iterate_obj(const DoutPrefixProvider *dpp, RGWObjectCtx& ctx, RGWBucketInfo& bucket_info,
-                  rgw::sal::Object* obj, off_t ofs, off_t end,
+                  const rgw_obj& obj, off_t ofs, off_t end,
                   uint64_t max_chunk_size, iterate_obj_cb cb, void *arg,
                   optional_yield y);
 
@@ -1322,21 +1315,21 @@ public:
                                 std::map<uint64_t, std::vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
   int bucket_index_trim_olh_log(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
   int bucket_index_clear_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
-  int apply_olh_log(const DoutPrefixProvider *dpp, RGWObjState& obj_state, RGWBucketInfo& bucket_info, const rgw::sal::Object* obj,
+  int apply_olh_log(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWObjState& obj_state, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                     bufferlist& obj_tag, std::map<uint64_t, std::vector<rgw_bucket_olh_log_entry> >& log,
                     uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);
-  int update_olh(const DoutPrefixProvider *dpp, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw::sal::Object* obj, rgw_zone_set *zones_trace = nullptr);
-  int set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, rgw::sal::Object* target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+  int update_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
+  int set_olh(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
               uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time,
               optional_yield y, rgw_zone_set *zones_trace = nullptr, bool log_data_change = false);
   int repair_olh(const DoutPrefixProvider *dpp, RGWObjState* state, const RGWBucketInfo& bucket_info,
                  const rgw_obj& obj);
-  int unlink_obj_instance(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, rgw::sal::Object* target_obj,
+  int unlink_obj_instance(const DoutPrefixProvider *dpp, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj,
                           uint64_t olh_epoch, optional_yield y, rgw_zone_set *zones_trace = nullptr);
 
   void check_pending_olh_entries(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist>& pending_entries, std::map<std::string, bufferlist> *rm_pending_entries);
   int remove_olh_pending_entries(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, std::map<std::string, bufferlist>& pending_attrs);
-  int follow_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjectCtx& ctx, RGWObjState *state, rgw::sal::Object* olh_obj, rgw_obj *target);
+  int follow_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, RGWObjectCtx& ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target);
   int get_olh(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWOLHInfo *olh);
 
   void gen_rand_obj_instance_name(rgw_obj_key *target_key);
@@ -1346,7 +1339,7 @@ public:
   int append_async(const DoutPrefixProvider *dpp, rgw_raw_obj& obj, size_t size, bufferlist& bl);
 
 public:
-  void set_atomic(void *ctx, rgw_obj& obj) {
+  void set_atomic(void *ctx, const rgw_obj& obj) {
     RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
     rctx->set_atomic(obj);
   }
@@ -1485,7 +1478,7 @@ public:
   int list_gc_objs(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue);
   int process_gc(bool expired_only);
   bool process_expire_objects(const DoutPrefixProvider *dpp);
-  int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, rgw::sal::Object* obj, optional_yield y);
+  int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc(const std::unique_ptr<rgw::sal::Bucket>& optional_bucket);
   int list_lc_progress(std::string& marker, uint32_t max_entries,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1653,7 +1653,7 @@ int RadosObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjState **psta
 
 int RadosObject::read_attrs(const DoutPrefixProvider* dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj* target_obj)
 {
-  read_op.params.attrs = &attrs;
+  read_op.params.attrs = &state.attrset;
   read_op.params.target_obj = target_obj;
   read_op.params.obj_size = &state.size;
   read_op.params.lastmod = &state.mtime;
@@ -1692,8 +1692,8 @@ int RadosObject::modify_obj_attrs(const char* attr_name, bufferlist& attr_val, o
   /* Temporarily set target */
   state.obj = target;
   set_atomic();
-  attrs[attr_name] = attr_val;
-  r = set_obj_attrs(dpp, &attrs, nullptr, y);
+  state.attrset[attr_name] = attr_val;
+  r = set_obj_attrs(dpp, &state.attrset, nullptr, y);
   /* Restore target */
   state.obj = save;
 
@@ -1711,23 +1711,20 @@ int RadosObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* att
 }
 
 bool RadosObject::is_expired() {
-  auto iter = attrs.find(RGW_ATTR_DELETE_AT);
-  if (iter != attrs.end()) {
-    utime_t delete_at;
-    try {
-      auto bufit = iter->second.cbegin();
-      decode(delete_at, bufit);
-    } catch (buffer::error& err) {
-      ldout(store->ctx(), 0) << "ERROR: " << __func__ << ": failed to decode " RGW_ATTR_DELETE_AT " attr" << dendl;
-      return false;
-    }
-
-    if (delete_at <= ceph_clock_now() && !delete_at.is_zero()) {
-      return true;
-    }
+  auto iter = state.attrset.find(RGW_ATTR_DELETE_AT);
+  if (iter == state.attrset.end()) {
+    return false;
+  }
+  utime_t delete_at;
+  try {
+    auto bufit = iter->second.cbegin();
+    decode(delete_at, bufit);
+  } catch (buffer::error& err) {
+    ldout(store->ctx(), 0) << "ERROR: " << __func__ << ": failed to decode " RGW_ATTR_DELETE_AT " attr" << dendl;
+    return false;
   }
 
-  return false;
+  return delete_at <= ceph_clock_now() && !delete_at.is_zero();
 }
 
 void RadosObject::gen_rand_obj_instance_name()

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -136,11 +136,6 @@ static int drain_aio(std::list<librados::AioCompletion*>& handles)
   return ret;
 }
 
-int RadosCompletions::drain()
-{
-  return drain_aio(handles);
-}
-
 int RadosUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& marker,
 			       const std::string& end_marker, uint64_t max, bool need_stats,
 			       BucketList &buckets, optional_yield y)
@@ -1273,11 +1268,6 @@ std::unique_ptr<Lifecycle> RadosStore::get_lifecycle(void)
   return std::make_unique<RadosLifecycle>(this);
 }
 
-std::unique_ptr<Completions> RadosStore::get_completions(void)
-{
-  return std::make_unique<RadosCompletions>();
-}
-
 std::unique_ptr<Notification> RadosStore::get_notification(
   rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name)
 {
@@ -1292,13 +1282,6 @@ std::unique_ptr<Notification> RadosStore::get_notification(const DoutPrefixProvi
 int RadosStore::delete_raw_obj(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj)
 {
   return rados->delete_raw_obj(dpp, obj);
-}
-
-int RadosStore::delete_raw_obj_aio(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, Completions* aio)
-{
-  RadosCompletions* raio = static_cast<RadosCompletions*>(aio);
-
-  return rados->delete_raw_obj_aio(dpp, obj, raio->handles);
 }
 
 void RadosStore::get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj)
@@ -2172,16 +2155,6 @@ int RadosObject::delete_object(const DoutPrefixProvider* dpp,
   del_op.params.versioning_status = prevent_versioning ? 0 : bucket->get_info().versioning_status();
 
   return del_op.delete_obj(y, dpp);
-}
-
-int RadosObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-				   Completions* aio, bool keep_index_consistent,
-				   optional_yield y)
-{
-  RadosCompletions* raio = static_cast<RadosCompletions*>(aio);
-
-  return store->getRados()->delete_obj_aio(dpp, get_obj(), bucket->get_info(), astate,
-					   raio->handles, keep_index_consistent, y);
 }
 
 int RadosObject::copy_object(User* user,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -466,11 +466,6 @@ class RadosObject : public StoreObject {
     virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
     /* OMAP */
-    virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-			      std::map<std::string, bufferlist> *m,
-			      bool* pmore, optional_yield y) override;
-    virtual int omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
-			     optional_yield y) override;
     virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
 			      const std::set<std::string>& keys,
 			      Attrs* vals) override;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -29,14 +29,6 @@ namespace rgw { namespace sal {
 
 class RadosMultipartUpload;
 
-class RadosCompletions : public Completions {
-  public:
-    std::list<librados::AioCompletion*> handles;
-    RadosCompletions() {}
-    ~RadosCompletions() = default;
-    virtual int drain() override;
-};
-
 class RadosPlacementTier: public StorePlacementTier {
   RadosStore* store;
   RGWZoneGroupPlacementTier tier;
@@ -162,7 +154,6 @@ class RadosStore : public StoreDriver {
     virtual int list_all_zones(const DoutPrefixProvider* dpp, std::list<std::string>& zone_ids) override;
     virtual int cluster_stat(RGWClusterStat& stats) override;
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-    virtual std::unique_ptr<Completions> get_completions(void) override;
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name=nullptr) override;
     virtual std::unique_ptr<Notification> get_notification(
     const DoutPrefixProvider* dpp, rgw::sal::Object* obj, rgw::sal::Object* src_obj, 
@@ -246,7 +237,6 @@ class RadosStore : public StoreDriver {
     int get_obj_head_ioctx(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
 			   librados::IoCtx* ioctx);
     int delete_raw_obj(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj);
-    int delete_raw_obj_aio(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, Completions* aio);
     void get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj);
     int get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size);
 
@@ -393,8 +383,6 @@ class RadosObject : public StoreObject {
     }
     virtual int delete_object(const DoutPrefixProvider* dpp,
 			      optional_yield y, bool prevent_versioning) override;
-    virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
-			       bool keep_index_consistent, optional_yield y) override;
     virtual int copy_object(User* user,
                req_info* info, const rgw_zone_id& source_zone,
                rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -220,7 +220,7 @@ class RadosStore : public StoreDriver {
 				   std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -228,7 +228,7 @@ class RadosStore : public StoreDriver {
 				  uint64_t *cur_accounted_size) override;
     virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
@@ -675,7 +675,7 @@ public:
   virtual int get_info(const DoutPrefixProvider *dpp, optional_yield y, rgw_placement_rule** rule, rgw::sal::Attrs* attrs = nullptr) override;
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -766,13 +766,15 @@ class RadosAtomicWriter : public StoreWriter {
 protected:
   rgw::sal::RadosStore* store;
   std::unique_ptr<Aio> aio;
-  RGWObjectCtx* obj_ctx;
+  RGWObjectCtx& obj_ctx;
   rgw::putobj::AtomicObjectProcessor processor;
 
 public:
   RadosAtomicWriter(const DoutPrefixProvider *dpp,
 		    optional_yield y,
-		    std::unique_ptr<rgw::sal::Object> _head_obj,
+		    RGWBucketInfo& bucket_info,
+		    RGWObjectCtx& obj_ctx,
+		    const rgw_obj& obj,
 		    RadosStore* _store, std::unique_ptr<Aio> _aio,
 		    const rgw_user& owner,
 		    const rgw_placement_rule *ptail_placement_rule,
@@ -781,11 +783,10 @@ public:
 			StoreWriter(dpp, y),
 			store(_store),
 			aio(std::move(_aio)),
-			obj_ctx(&dynamic_cast<RadosObject*>(_head_obj.get())->get_ctx()),
-			processor(&*aio, store,
-				  ptail_placement_rule, owner, 
-				  *obj_ctx,
-				  std::move(_head_obj), olh_epoch, unique_tag,
+			obj_ctx(obj_ctx),
+			processor(&*aio, store->getRados(), bucket_info,
+				  ptail_placement_rule, owner, obj_ctx,
+				  obj, olh_epoch, unique_tag,
 				  dpp, y)
   {}
   ~RadosAtomicWriter() = default;
@@ -811,13 +812,15 @@ class RadosAppendWriter : public StoreWriter {
 protected:
   rgw::sal::RadosStore* store;
   std::unique_ptr<Aio> aio;
-  RGWObjectCtx* obj_ctx;
+  RGWObjectCtx& obj_ctx;
   rgw::putobj::AppendObjectProcessor processor;
 
 public:
   RadosAppendWriter(const DoutPrefixProvider *dpp,
 		    optional_yield y,
-		    std::unique_ptr<rgw::sal::Object> _head_obj,
+		    RGWBucketInfo& bucket_info,
+		    RGWObjectCtx& obj_ctx,
+		    const rgw_obj& obj,
 		    RadosStore* _store, std::unique_ptr<Aio> _aio,
 		    const rgw_user& owner,
 		    const rgw_placement_rule *ptail_placement_rule,
@@ -827,11 +830,10 @@ public:
 			StoreWriter(dpp, y),
 			store(_store),
 			aio(std::move(_aio)),
-			obj_ctx(&dynamic_cast<RadosObject*>(_head_obj.get())->get_ctx()),
-			processor(&*aio, store,
-				  ptail_placement_rule, owner,
-				  *obj_ctx,
-				  std::move(_head_obj), unique_tag, position,
+			obj_ctx(obj_ctx),
+			processor(&*aio, store->getRados(), bucket_info,
+				  ptail_placement_rule, owner, obj_ctx,
+				  obj, unique_tag, position,
 				  cur_accounted_size, dpp, y)
   {}
   ~RadosAppendWriter() = default;
@@ -857,13 +859,15 @@ class RadosMultipartWriter : public StoreWriter {
 protected:
   rgw::sal::RadosStore* store;
   std::unique_ptr<Aio> aio;
-  RGWObjectCtx* obj_ctx;
+  RGWObjectCtx& obj_ctx;
   rgw::putobj::MultipartObjectProcessor processor;
 
 public:
   RadosMultipartWriter(const DoutPrefixProvider *dpp,
-		       optional_yield y, MultipartUpload* upload,
-		       std::unique_ptr<rgw::sal::Object> _head_obj,
+		       optional_yield y, const std::string& upload_id,
+		       RGWBucketInfo& bucket_info,
+		       RGWObjectCtx& obj_ctx,
+		       const rgw_obj& obj,
 		       RadosStore* _store, std::unique_ptr<Aio> _aio,
 		       const rgw_user& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
@@ -871,11 +875,10 @@ public:
 			StoreWriter(dpp, y),
 			store(_store),
 			aio(std::move(_aio)),
-			obj_ctx(&dynamic_cast<RadosObject*>(_head_obj.get())->get_ctx()),
-			processor(&*aio, store,
-				  ptail_placement_rule, owner,
-				  *obj_ctx,
-				  std::move(_head_obj), upload->get_upload_id(),
+			obj_ctx(obj_ctx),
+			processor(&*aio, store->getRados(), bucket_info,
+				  ptail_placement_rule, owner, obj_ctx,
+				  obj, upload_id,
 				  part_num, part_num_str, dpp, y)
   {}
   ~RadosMultipartWriter() = default;

--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -37,12 +37,9 @@ static string get_key_oid(const rgw_obj_key& key)
   return oid;
 }
 
-static string obj_to_aws_path(rgw::sal::Object* obj)
+static string obj_to_aws_path(const rgw_obj& obj)
 {
-  string path = obj->get_bucket()->get_name() + "/" + get_key_oid(obj->get_key());
-
-
-  return path;
+  return obj.bucket.name + "/" + get_key_oid(obj.key);
 }
 
 /*
@@ -730,7 +727,7 @@ class RGWRESTStreamGetCRF : public RGWStreamReadHTTPResourceCRF
 {
   RGWDataSyncCtx *sc;
   RGWRESTConn *conn;
-  rgw::sal::Object* src_obj;
+  const rgw_obj& src_obj;
   RGWRESTConn::get_obj_params req_params;
 
   rgw_sync_aws_src_obj_properties src_properties;
@@ -740,9 +737,9 @@ public:
                                RGWCoroutine *_caller,
                                RGWDataSyncCtx *_sc,
                                RGWRESTConn *_conn,
-                               rgw::sal::Object* _src_obj,
+                               const rgw_obj& _src_obj,
                                const rgw_sync_aws_src_obj_properties& _src_properties) : RGWStreamReadHTTPResourceCRF(_cct, _env, _caller,
-                                                                                                                      _sc->env->http_manager, _src_obj->get_key()),
+                                                                                                                      _sc->env->http_manager, _src_obj.key),
                                                                                  sc(_sc), conn(_conn), src_obj(_src_obj),
                                                                                  src_properties(_src_properties) {
   }
@@ -809,7 +806,7 @@ class RGWAWSStreamPutCRF : public RGWStreamWriteHTTPResourceCRF
   RGWDataSyncCtx *sc;
   rgw_sync_aws_src_obj_properties src_properties;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
   string etag;
 public:
   RGWAWSStreamPutCRF(CephContext *_cct,
@@ -818,7 +815,7 @@ public:
                                RGWDataSyncCtx *_sc,
                                const rgw_sync_aws_src_obj_properties&  _src_properties,
                                std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                               rgw::sal::Object* _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
+                               const rgw_obj& _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
                                                      sc(_sc), src_properties(_src_properties), target(_target), dest_obj(_dest_obj) {
   }
 
@@ -1007,8 +1004,8 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1018,10 +1015,10 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudPlainCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 std::shared_ptr<AWSSyncConfig_Profile> _target,
-                                rgw::sal::Object* _dest_obj) : RGWCoroutine(_sc->cct),
+                                const rgw_obj& _dest_obj) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    source_conn(_source_conn),
                                                    target(_target),
@@ -1056,8 +1053,8 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1073,9 +1070,9 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudMultipartPartCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const string& _upload_id,
                                 const rgw_sync_aws_multipart_part_info& _part_info,
@@ -1125,14 +1122,14 @@ public:
 class RGWAWSAbortMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   string upload_id;
 
 public:
   RGWAWSAbortMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         const string& _upload_id) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    dest_conn(_dest_conn),
@@ -1164,7 +1161,7 @@ public:
 class RGWAWSInitMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   uint64_t obj_size;
   map<string, string> attrs;
@@ -1188,7 +1185,7 @@ class RGWAWSInitMultipartCR : public RGWCoroutine {
 public:
   RGWAWSInitMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         uint64_t _obj_size,
                         const map<string, string>& _attrs,
                         string *_upload_id) : RGWCoroutine(_sc->cct),
@@ -1254,7 +1251,7 @@ public:
 class RGWAWSCompleteMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   bufferlist out_bl;
 
@@ -1292,7 +1289,7 @@ class RGWAWSCompleteMultipartCR : public RGWCoroutine {
 public:
   RGWAWSCompleteMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         string _upload_id,
                         const map<int, rgw_sync_aws_multipart_part_info>& _parts) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
@@ -1364,7 +1361,7 @@ public:
 class RGWAWSStreamAbortMultipartUploadCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
   const rgw_raw_obj status_obj;
 
   string upload_id;
@@ -1373,7 +1370,7 @@ public:
 
   RGWAWSStreamAbortMultipartUploadCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_dest_conn,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 const rgw_raw_obj& _status_obj,
                                 const string& _upload_id) : RGWCoroutine(_sc->cct), sc(_sc),
                                                             dest_conn(_dest_conn),
@@ -1406,8 +1403,8 @@ class RGWAWSStreamObjToCloudMultipartCR : public RGWCoroutine {
   AWSSyncConfig& conf;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   uint64_t obj_size;
   string src_etag;
@@ -1429,9 +1426,9 @@ public:
 				    rgw_bucket_sync_pipe& _sync_pipe,
                                 AWSSyncConfig& _conf,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 uint64_t _obj_size,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const rgw_rest_obj& _rest_obj) : RGWCoroutine(_sc->cct),
@@ -1576,8 +1573,6 @@ class RGWAWSHandleRemoteObjCBCR: public RGWStatRemoteObjCBCR {
   std::shared_ptr<AWSSyncConfig_Profile> target;
   bufferlist res;
   unordered_map <string, bool> bucket_created;
-  string target_bucket_name;
-  string target_obj_name;
   rgw_rest_obj rest_obj;
   int ret{0};
 
@@ -1594,12 +1589,8 @@ class RGWAWSHandleRemoteObjCBCR: public RGWStatRemoteObjCBCR {
     }
   } result;
 
-  rgw_bucket target_bucket;
-  std::unique_ptr<rgw::sal::RadosBucket> bucket;
-  std::unique_ptr<rgw::sal::RadosObject> src_obj;
-  std::unique_ptr<rgw::sal::RadosBucket> dest_bucket;
-  std::unique_ptr<rgw::sal::RadosObject> dest_obj;
-
+  rgw_obj src_obj;
+  rgw_obj dest_obj;
 
 public:
   RGWAWSHandleRemoteObjCBCR(RGWDataSyncCtx *_sc,
@@ -1639,15 +1630,15 @@ public:
       }
 
       instance.get_profile(sync_pipe.info.source_bs.bucket, &target);
-      instance.conf.get_target(target, sync_pipe.dest_bucket_info, key, &target_bucket_name, &target_obj_name);
+      instance.conf.get_target(target, sync_pipe.dest_bucket_info, key, &dest_obj.bucket.name, &dest_obj.key.name);
 
-      if (bucket_created.find(target_bucket_name) == bucket_created.end()){
+      if (bucket_created.find(dest_obj.bucket.name) == bucket_created.end()){
         yield {
-          ldpp_dout(dpp, 0) << "AWS: creating bucket " << target_bucket_name << dendl;
+          ldpp_dout(dpp, 0) << "AWS: creating bucket " << dest_obj.bucket.name << dendl;
           bufferlist bl;
           call(new RGWPutRawRESTResourceCR <bufferlist> (sc->cct, target->conn.get(),
                                                   sync_env->http_manager,
-                                                  target_bucket_name, nullptr, bl, &out_bl));
+                                                  dest_obj.bucket.name, nullptr, bl, &out_bl));
         }
         if (retcode < 0 ) {
           RGWXMLDecoder::XMLParser parser;
@@ -1675,19 +1666,14 @@ public:
           }
         }
 
-        bucket_created[target_bucket_name] = true;
+        bucket_created[dest_obj.bucket.name] = true;
       }
 
       yield {
-        bucket.reset(new rgw::sal::RadosBucket(sync_env->driver, src_bucket));
-        src_obj.reset(new rgw::sal::RadosObject(sync_env->driver, key, bucket.get()));
+        src_obj.bucket = src_bucket;
+        src_obj.key = key;
 
         /* init output */
-        target_bucket.name = target_bucket_name; /* this is only possible because we only use bucket name for
-                                                    uri resolution */
-        dest_bucket.reset(new rgw::sal::RadosBucket(sync_env->driver, target_bucket));
-        dest_obj.reset(new rgw::sal::RadosObject(sync_env->driver, rgw_obj_key(target_obj_name), dest_bucket.get()));
-
         rgw_sync_aws_src_obj_properties src_properties;
         src_properties.mtime = mtime;
         src_properties.etag = etag;
@@ -1696,10 +1682,10 @@ public:
         src_properties.versioned_epoch = versioned_epoch;
 
         if (size < instance.conf.s3.multipart_sync_threshold) {
-          call(new RGWAWSStreamObjToCloudPlainCR(sc, source_conn, src_obj.get(),
+          call(new RGWAWSStreamObjToCloudPlainCR(sc, source_conn, src_obj,
                                                  src_properties,
                                                  target,
-                                                 dest_obj.get()));
+                                                 dest_obj));
         } else {
           rgw_rest_obj rest_obj;
           rest_obj.init(key);
@@ -1707,8 +1693,8 @@ public:
             ldpp_dout(dpp, 0) << "ERROR: failed to decode rest obj out of headers=" << headers << ", attrs=" << attrs << dendl;
             return set_cr_error(-EINVAL);
           }
-          call(new RGWAWSStreamObjToCloudMultipartCR(sc, sync_pipe, instance.conf, source_conn, src_obj.get(),
-                                                     target, dest_obj.get(), size, src_properties, rest_obj));
+          call(new RGWAWSStreamObjToCloudMultipartCR(sc, sync_pipe, instance.conf, source_conn, src_obj,
+                                                     target, dest_obj, size, src_properties, rest_obj));
         }
       }
       if (retcode < 0) {

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -323,7 +323,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
   string req_id = driver->zone_unique_id(driver->get_new_req_id());
 
   std::unique_ptr<rgw::sal::Writer> processor;
-  processor = driver->get_atomic_writer(dpp, y, std::move(obj),
+  processor = driver->get_atomic_writer(dpp, y, obj.get(),
 				       owner.get_id(),
 				       nullptr, olh_epoch, req_id);
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7764,7 +7764,8 @@ next:
       }
     }
     if (need_rewrite) {
-      ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->rewrite_obj(obj.get(), dpp(), null_yield);
+      RGWRados* store = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
+      ret = store->rewrite_obj(bucket->get_info(), obj->get_obj(), dpp(), null_yield);
       if (ret < 0) {
         cerr << "ERROR: object rewrite returned: " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -7894,7 +7895,8 @@ next:
           if (!need_rewrite) {
             formatter->dump_string("status", "Skipped");
           } else {
-            r = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->rewrite_obj(obj.get(), dpp(), null_yield);
+            RGWRados* store = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
+            r = store->rewrite_obj(bucket->get_info(), obj->get_obj(), dpp(), null_yield);
             if (r == 0) {
               formatter->dump_string("status", "Success");
             } else {

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1864,7 +1864,7 @@ namespace rgw {
         version_id = state->object->get_instance();
       }
     }
-    processor = get_driver()->get_atomic_writer(this, state->yield, state->object->clone(),
+    processor = get_driver()->get_atomic_writer(this, state->yield, state->object.get(),
 					 state->bucket_owner.get_id(),
 					 &state->dest_placement, 0, state->req_id);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4020,7 +4020,7 @@ void RGWPutObj::execute(optional_yield y)
     s->dest_placement = *pdest_placement;
     pdest_placement = &s->dest_placement;
     ldpp_dout(this, 20) << "dest_placement for part=" << *pdest_placement << dendl;
-    processor = upload->get_writer(this, s->yield, s->object->clone(),
+    processor = upload->get_writer(this, s->yield, s->object.get(),
 				   s->user->get_id(), pdest_placement,
 				   multipart_part_num, multipart_part_str);
   } else if(append) {
@@ -4028,7 +4028,7 @@ void RGWPutObj::execute(optional_yield y)
       op_ret = -ERR_INVALID_BUCKET_STATE;
       return;
     }
-    processor = driver->get_append_writer(this, s->yield, s->object->clone(),
+    processor = driver->get_append_writer(this, s->yield, s->object.get(),
 					 s->bucket_owner.get_id(),
 					 pdest_placement, s->req_id, position,
 					 &cur_accounted_size);
@@ -4041,7 +4041,7 @@ void RGWPutObj::execute(optional_yield y)
         version_id = s->object->get_instance();
       }
     }
-    processor = driver->get_atomic_writer(this, s->yield, s->object->clone(),
+    processor = driver->get_atomic_writer(this, s->yield, s->object.get(),
 					 s->bucket_owner.get_id(),
 					 pdest_placement, olh_epoch, s->req_id);
   }
@@ -4438,7 +4438,7 @@ void RGWPostObj::execute(optional_yield y)
     }
 
     std::unique_ptr<rgw::sal::Writer> processor;
-    processor = driver->get_atomic_writer(this, s->yield, std::move(obj),
+    processor = driver->get_atomic_writer(this, s->yield, obj.get(),
 					 s->bucket_owner.get_id(),
 					 &s->dest_placement, 0, s->req_id);
     op_ret = processor->prepare(s->yield);
@@ -7556,7 +7556,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   dest_placement.inherit_from(bucket->get_placement_rule());
 
   std::unique_ptr<rgw::sal::Writer> processor;
-  processor = driver->get_atomic_writer(this, s->yield, std::move(obj),
+  processor = driver->get_atomic_writer(this, s->yield, obj.get(),
 				       bowner.get_id(),
 				       &s->dest_placement, 0, s->req_id);
   op_ret = processor->prepare(s->yield);

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -452,7 +452,7 @@ int RGWOrphanSearch::handle_stat_result(const DoutPrefixProvider *dpp, map<int, 
 
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(dpp); miter != manifest.obj_end(dpp); ++miter) {
-      const rgw_raw_obj& loc = miter.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+      const rgw_raw_obj& loc = miter.get_location().get_raw_obj(store->getRados());
       string s = loc.oid;
       obj_oids.insert(obj_fingerprint(s));
     }
@@ -579,9 +579,9 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const DoutPrefixProvider *dpp,
         continue;
       }
 
-      std::unique_ptr<rgw::sal::Object> obj = cur_bucket->get_object(entry.key);
+      rgw_obj obj(cur_bucket->get_key(), entry.key);
 
-      RGWRados::Object op_target(store->getRados(), cur_bucket.get(), obj_ctx, obj.get());
+      RGWRados::Object op_target(store->getRados(), cur_bucket->get_info(), obj_ctx, obj);
 
       stat_ops.push_back(RGWRados::Object::Stat(&op_target));
       RGWRados::Object::Stat& op = stat_ops.back();
@@ -1042,7 +1042,7 @@ int RGWRadosList::handle_stat_result(const DoutPrefixProvider *dpp,
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(dpp); miter != manifest.obj_end(dpp); ++miter) {
       const rgw_raw_obj& loc =
-	miter.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+	miter.get_location().get_raw_obj(store->getRados());
       string s = loc.oid;
       obj_oids.insert(s);
     }
@@ -1248,9 +1248,9 @@ int RGWRadosList::process_bucket(
 	[&](const rgw_obj_key& key) -> int {
 	  int ret;
 
-	  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
-	  RGWRados::Object op_target(store->getRados(), bucket.get(),
-				     obj_ctx, obj.get());
+	  rgw_obj obj(bucket_info.bucket, key);
+	  RGWRados::Object op_target(store->getRados(), bucket_info,
+				     obj_ctx, obj);
 
 	  stat_ops.push_back(RGWRados::Object::Stat(&op_target));
 	  RGWRados::Object::Stat& op = stat_ops.back();
@@ -1536,7 +1536,7 @@ int RGWRadosList::do_incomplete_multipart(const DoutPrefixProvider *dpp,
 		 obj_it != manifest.obj_end(dpp);
 		 ++obj_it) {
 	      const rgw_raw_obj& loc =
-		obj_it.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+		obj_it.get_location().get_raw_obj(store->getRados());
 	      std::cout << loc.oid << std::endl;
 	    } // for (auto obj_it
 	  } // for (auto& p

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -695,22 +695,22 @@ int RGWRESTGenerateHTTPHeaders::sign(const DoutPrefixProvider *dpp, RGWAccessKey
   return 0;
 }
 
-void RGWRESTStreamS3PutObj::send_init(rgw::sal::Object* obj)
+void RGWRESTStreamS3PutObj::send_init(const rgw_obj& obj)
 {
   string resource_str;
   string resource;
   string new_url = url;
   string new_host = host;
 
-   const auto& bucket_name = obj->get_bucket()->get_name();
+   const auto& bucket_name = obj.bucket.name;
 
   if (host_style == VirtualStyle) {
-    resource_str = obj->get_oid();
+    resource_str = obj.get_oid();
 
     new_url = bucket_name + "."  + new_url;
     new_host = bucket_name + "." + new_host;
   } else {
-    resource_str = bucket_name + "/" + obj->get_oid();
+    resource_str = bucket_name + "/" + obj.get_oid();
   }
 
   //do not encode slash in object key name
@@ -752,7 +752,7 @@ void RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessK
   out_cb = new RGWRESTStreamOutCB(this);
 }
 
-void RGWRESTStreamS3PutObj::put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::Object* obj, map<string, bufferlist>& attrs)
+void RGWRESTStreamS3PutObj::put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, const rgw_obj& obj, map<string, bufferlist>& attrs)
 {
   send_init(obj);
   send_ready(dpp, key, attrs);

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -245,13 +245,13 @@ public:
                 out_cb(NULL), new_info(cct, &new_env), headers_gen(_cct, &new_env, &new_info) {}
   ~RGWRESTStreamS3PutObj() override;
 
-  void send_init(rgw::sal::Object* obj);
+  void send_init(const rgw_obj& obj);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, std::map<std::string, bufferlist>& rgw_attrs);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, const std::map<std::string, std::string>& http_attrs,
                   RGWAccessControlPolicy& policy);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key);
 
-  void put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::Object* obj, std::map<std::string, bufferlist>& attrs);
+  void put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, const rgw_obj& obj, std::map<std::string, bufferlist>& attrs);
 
   RGWGetDataCB *get_out_cb() { return out_cb; }
 };

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -132,8 +132,8 @@ public:
 
 
   /* async requests */
-  int put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
-  int put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, rgw::sal::Object* obj,
+  int put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
+  int put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, const rgw_obj& obj,
                          std::map<std::string, bufferlist>& attrs, RGWRESTStreamS3PutObj **req);
   int complete_request(RGWRESTStreamS3PutObj *req, std::string& etag,
                        ceph::real_time *mtime, optional_yield y);
@@ -163,9 +163,9 @@ public:
     uint64_t range_end{0};
   };
 
-  int get_obj(const DoutPrefixProvider *dpp, const rgw::sal::Object* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
 
-  int get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw::sal::Object* obj,
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw_obj& obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -422,7 +422,7 @@ class Driver {
     /** Get a Writer that appends to an object */
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -431,7 +431,7 @@ class Driver {
     /** Get a Writer that atomically writes an entire object */
     virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
@@ -1205,7 +1205,7 @@ public:
   /** Get a Writer to write to a part of this upload */
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -244,14 +244,6 @@ class ObjectProcessor : public DataProcessor {
                        optional_yield y) = 0;
 };
 
-/** Base class for AIO completions */
-class Completions {
-  public:
-    Completions() {}
-    virtual ~Completions() = default;
-    virtual int drain() = 0;
-};
-
 /** A list of key-value attributes */
   using Attrs = std::map<std::string, ceph::buffer::list>;
 
@@ -323,8 +315,6 @@ class Driver {
     virtual int cluster_stat(RGWClusterStat& stats) = 0;
     /** Get a @a Lifecycle object. Used to manage/run lifecycle transitions */
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) = 0;
-    /** Get a @a Completions object.  Used for Async I/O tracking */
-    virtual std::unique_ptr<Completions> get_completions(void) = 0;
 
      /** Get a @a Notification object.  Used to communicate with non-RGW daemons, such as
       * management/tracking software */
@@ -937,9 +927,6 @@ class Object {
     virtual int delete_object(const DoutPrefixProvider* dpp,
 			      optional_yield y,
 			      bool prevent_versioning = false) = 0;
-    /** Asynchronous delete call */
-    virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
-			       bool keep_index_consistent, optional_yield y) = 0;
     /** Copy an this object to another object. */
     virtual int copy_object(User* user,
                req_info* info, const rgw_zone_id& source_zone,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1071,13 +1071,7 @@ class Object {
     /** Get a new DeleteOp for this object */
     virtual std::unique_ptr<DeleteOp> get_delete_op() = 0;
 
-    /** Get @a count OMAP values via listing, starting at @a marker for this object */
-    virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-			      std::map<std::string, bufferlist>* m,
-			      bool* pmore, optional_yield y) = 0;
-    /** Get all OMAP key/value pairs for this object */
-    virtual int omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist>* m,
-			     optional_yield y) = 0;
+    // TODO: remove omap APIs. rgw_torrent.cc shouldn't use omap
     /** Get the OMAP values matching the given set of keys */
     virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
 			      const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1502,7 +1502,7 @@ int DaosObject::mark_as_latest(const DoutPrefixProvider* dpp,
 
 DaosAtomicWriter::DaosAtomicWriter(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, DaosStore* _store,
+    rgw::sal::Object* obj, DaosStore* _store,
     const rgw_user& _owner, const rgw_placement_rule* _ptail_placement_rule,
     uint64_t _olh_epoch, const std::string& _unique_tag)
     : StoreWriter(dpp, y),
@@ -1511,7 +1511,7 @@ DaosAtomicWriter::DaosAtomicWriter(
       ptail_placement_rule(_ptail_placement_rule),
       olh_epoch(_olh_epoch),
       unique_tag(_unique_tag),
-      obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+      obj(_store, obj->get_key(), obj->get_bucket()) {}
 
 int DaosAtomicWriter::prepare(optional_yield y) {
   ldpp_dout(dpp, 20) << "DEBUG: prepare" << dendl;
@@ -2019,13 +2019,13 @@ int DaosMultipartUpload::get_info(const DoutPrefixProvider* dpp,
 
 std::unique_ptr<Writer> DaosMultipartUpload::get_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule, uint64_t part_num,
     const std::string& part_num_str) {
   ldpp_dout(dpp, 20) << "DaosMultipartUpload::get_writer(): enter part="
                      << part_num << " head_obj=" << _head_obj << dendl;
   return std::make_unique<DaosMultipartWriter>(
-      dpp, y, this, std::move(_head_obj), store, owner, ptail_placement_rule,
+      dpp, y, this, obj, store, owner, ptail_placement_rule,
       part_num, part_num_str);
 }
 
@@ -2163,7 +2163,7 @@ std::unique_ptr<MultipartUpload> DaosBucket::get_multipart_upload(
 
 std::unique_ptr<Writer> DaosStore::get_append_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule,
     const std::string& unique_tag, uint64_t position,
     uint64_t* cur_accounted_size) {
@@ -2173,11 +2173,11 @@ std::unique_ptr<Writer> DaosStore::get_append_writer(
 
 std::unique_ptr<Writer> DaosStore::get_atomic_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule, uint64_t olh_epoch,
     const std::string& unique_tag) {
   ldpp_dout(dpp, 20) << "get_atomic_writer" << dendl;
-  return std::make_unique<DaosAtomicWriter>(dpp, y, std::move(_head_obj), this,
+  return std::make_unique<DaosAtomicWriter>(dpp, y, obj, this,
                                             owner, ptail_placement_rule,
                                             olh_epoch, unique_tag);
 }

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1016,19 +1016,6 @@ void DaosObject::gen_rand_obj_instance_name() {
   state.obj.key.set_instance(buf);
 }
 
-int DaosObject::omap_get_vals(const DoutPrefixProvider* dpp,
-                              const std::string& marker, uint64_t count,
-                              std::map<std::string, bufferlist>* m, bool* pmore,
-                              optional_yield y) {
-  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
-}
-
-int DaosObject::omap_get_all(const DoutPrefixProvider* dpp,
-                             std::map<std::string, bufferlist>* m,
-                             optional_yield y) {
-  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
-}
-
 int DaosObject::omap_get_vals_by_keys(const DoutPrefixProvider* dpp,
                                       const std::string& oid,
                                       const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1229,13 +1229,6 @@ int DaosObject::delete_object(const DoutPrefixProvider* dpp, optional_yield y,
   return del_op.delete_obj(dpp, y);
 }
 
-int DaosObject::delete_obj_aio(const DoutPrefixProvider* dpp,
-                               RGWObjState* astate, Completions* aio,
-                               bool keep_index_consistent, optional_yield y) {
-  /* XXX: Make it async */
-  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
-}
-
 int DaosObject::copy_object(
     User* user, req_info* info, const rgw_zone_id& source_zone,
     rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
@@ -2337,11 +2330,6 @@ int DaosStore::cluster_stat(RGWClusterStat& stats) {
 }
 
 std::unique_ptr<Lifecycle> DaosStore::get_lifecycle(void) {
-  DAOS_NOT_IMPLEMENTED_LOG(nullptr);
-  return 0;
-}
-
-std::unique_ptr<Completions> DaosStore::get_completions(void) {
   DAOS_NOT_IMPLEMENTED_LOG(nullptr);
   return 0;
 }

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -741,7 +741,7 @@ class DaosAtomicWriter : public StoreWriter {
 
  public:
   DaosAtomicWriter(const DoutPrefixProvider* dpp, optional_yield y,
-                   std::unique_ptr<rgw::sal::Object> _head_obj,
+                   rgw::sal::Object* obj,
                    DaosStore* _store, const rgw_user& _owner,
                    const rgw_placement_rule* _ptail_placement_rule,
                    uint64_t _olh_epoch, const std::string& _unique_tag);
@@ -780,7 +780,7 @@ class DaosMultipartWriter : public StoreWriter {
  public:
   DaosMultipartWriter(const DoutPrefixProvider* dpp, optional_yield y,
                       MultipartUpload* _upload,
-                      std::unique_ptr<rgw::sal::Object> _head_obj,
+                      rgw::sal::Object* obj,
                       DaosStore* _store, const rgw_user& owner,
                       const rgw_placement_rule* ptail_placement_rule,
                       uint64_t _part_num, const std::string& part_num_str)
@@ -874,7 +874,7 @@ class DaosMultipartUpload : public StoreMultipartUpload {
                        rgw::sal::Attrs* attrs = nullptr) override;
   virtual std::unique_ptr<Writer> get_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule, uint64_t part_num,
       const std::string& part_num_str) override;
   const std::string& get_bucket_name() { return bucket->get_name(); }
@@ -1027,13 +1027,13 @@ class DaosStore : public StoreDriver {
       std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule,
       const std::string& unique_tag, uint64_t position,
       uint64_t* cur_accounted_size) override;
   virtual std::unique_ptr<Writer> get_atomic_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule, uint64_t olh_epoch,
       const std::string& unique_tag) override;
   virtual const std::string& get_compression_type(

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -604,9 +604,6 @@ class DaosObject : public StoreObject {
 
   virtual int delete_object(const DoutPrefixProvider* dpp, optional_yield y,
                             bool prevent_versioning = false) override;
-  virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-                             Completions* aio, bool keep_index_consistent,
-                             optional_yield y) override;
   virtual int copy_object(
       User* user, req_info* info, const rgw_zone_id& source_zone,
       rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
@@ -925,7 +922,6 @@ class DaosStore : public StoreDriver {
   virtual std::string zone_unique_trans_id(const uint64_t unique_num) override;
   virtual int cluster_stat(RGWClusterStat& stats) override;
   virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-  virtual std::unique_ptr<Completions> get_completions(void) override;
   virtual std::unique_ptr<Notification> get_notification(
       rgw::sal::Object* obj, rgw::sal::Object* src_obj, struct req_state* s,
       rgw::notify::EventType event_type, optional_yield y,

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -672,13 +672,6 @@ class DaosObject : public StoreObject {
   virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
   /* OMAP */
-  virtual int omap_get_vals(const DoutPrefixProvider* dpp,
-                            const std::string& marker, uint64_t count,
-                            std::map<std::string, bufferlist>* m, bool* pmore,
-                            optional_yield y) override;
-  virtual int omap_get_all(const DoutPrefixProvider* dpp,
-                           std::map<std::string, bufferlist>* m,
-                           optional_yield y) override;
   virtual int omap_get_vals_by_keys(const DoutPrefixProvider* dpp,
                                     const std::string& oid,
                                     const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -630,7 +630,7 @@ namespace rgw::sal {
 
   int DBObject::read_attrs(const DoutPrefixProvider* dpp, DB::Object::Read &read_op, optional_yield y, rgw_obj* target_obj)
   {
-    read_op.params.attrs = &attrs;
+    read_op.params.attrs = &state.attrset;
     read_op.params.target_obj = target_obj;
     read_op.params.obj_size = &state.size;
     read_op.params.lastmod = &state.mtime;
@@ -662,8 +662,8 @@ namespace rgw::sal {
       return r;
     }
     set_atomic();
-    attrs[attr_name] = attr_val;
-    return set_obj_attrs(dpp, &attrs, nullptr, y);
+    state.attrset[attr_name] = attr_val;
+    return set_obj_attrs(dpp, &state.attrset, nullptr, y);
   }
 
   int DBObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name, optional_yield y)

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1227,21 +1227,20 @@ namespace rgw::sal {
   std::unique_ptr<Writer> DBMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
   {
-    return std::make_unique<DBMultipartWriter>(dpp, y, this,
-				 std::move(_head_obj), store, owner,
+    return std::make_unique<DBMultipartWriter>(dpp, y, this, obj, store, owner,
 				 ptail_placement_rule, part_num, part_num_str);
   }
 
   DBMultipartWriter::DBMultipartWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
                 MultipartUpload* upload,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* obj,
 		        DBStore* _driver,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -1250,7 +1249,7 @@ namespace rgw::sal {
 			store(_driver),
                 owner(_owner),
                 ptail_placement_rule(_ptail_placement_rule),
-                head_obj(std::move(_head_obj)),
+                head_obj(obj),
                 upload_id(upload->get_upload_id()),
                 part_num(_part_num),
                 oid(head_obj->get_name() + "." + upload_id +
@@ -1390,7 +1389,7 @@ namespace rgw::sal {
 
   DBAtomicWriter::DBAtomicWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* _obj,
 		        DBStore* _driver,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -1402,7 +1401,7 @@ namespace rgw::sal {
                 ptail_placement_rule(_ptail_placement_rule),
                 olh_epoch(_olh_epoch),
                 unique_tag(_unique_tag),
-                obj(_driver, _head_obj->get_key(), _head_obj->get_bucket()),
+                obj(_driver, _obj->get_key(), _obj->get_bucket()),
                 op_target(_driver->getDB(), obj.get_bucket()->get_info(), obj.get_obj()),
                 parent_op(&op_target) {}
 
@@ -1579,7 +1578,7 @@ namespace rgw::sal {
 
   std::unique_ptr<Writer> DBStore::get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -1590,13 +1589,12 @@ namespace rgw::sal {
 
   std::unique_ptr<Writer> DBStore::get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag) {
-    return std::make_unique<DBAtomicWriter>(dpp, y,
-                    std::move(_head_obj), this, owner,
+    return std::make_unique<DBAtomicWriter>(dpp, y, obj, this, owner,
                     ptail_placement_rule, olh_epoch, unique_tag);
   }
 

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -686,23 +686,6 @@ namespace rgw::sal {
   }
 
 
-  int DBObject::omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-      std::map<std::string, bufferlist> *m,
-      bool* pmore, optional_yield y)
-  {
-    DB::Object op_target(store->getDB(),
-        get_bucket()->get_info(), get_obj());
-    return op_target.obj_omap_get_vals(dpp, marker, count, m, pmore);
-  }
-
-  int DBObject::omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
-      optional_yield y)
-  {
-    DB::Object op_target(store->getDB(),
-        get_bucket()->get_info(), get_obj());
-    return op_target.obj_omap_get_all(dpp, m);
-  }
-
   int DBObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
       const std::set<std::string>& keys,
       Attrs* vals)

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -838,14 +838,6 @@ namespace rgw::sal {
     return del_op.delete_obj(dpp);
   }
 
-  int DBObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-      Completions* aio, bool keep_index_consistent,
-      optional_yield y)
-  {
-    /* XXX: Make it async */
-    return 0;
-  }
-
   int DBObject::copy_object(User* user,
       req_info* info,
       const rgw_zone_id& source_zone,
@@ -1756,11 +1748,6 @@ namespace rgw::sal {
   std::unique_ptr<Lifecycle> DBStore::get_lifecycle(void)
   {
     return std::make_unique<DBLifecycle>(this);
-  }
-
-  std::unique_ptr<Completions> DBStore::get_completions(void)
-  {
-    return 0;
   }
 
   int DBLifecycle::get_entry(const std::string& oid, const std::string& marker,

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -515,7 +515,7 @@ protected:
     virtual int get_info(const DoutPrefixProvider *dpp, optional_yield y, rgw_placement_rule** rule, rgw::sal::Attrs* attrs = nullptr) override;
     virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -680,7 +680,7 @@ protected:
     public:
     DBAtomicWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* obj,
 		        DBStore* _store,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -711,7 +711,7 @@ protected:
     const rgw_user& owner;
 	const rgw_placement_rule *ptail_placement_rule;
 	uint64_t olh_epoch;
-    std::unique_ptr<rgw::sal::Object> head_obj;
+    rgw::sal::Object* head_obj;
     std::string upload_id;
     int part_num;
     std::string oid; /* object->name() + "." + "upload_id" + "." + part_num */
@@ -729,7 +729,7 @@ protected:
 public:
     DBMultipartWriter(const DoutPrefixProvider *dpp,
 		       optional_yield y, MultipartUpload* upload,
-		       std::unique_ptr<rgw::sal::Object> _head_obj,
+		       rgw::sal::Object* obj,
 		       DBStore* _store,
 		       const rgw_user& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
@@ -880,7 +880,7 @@ public:
           std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
       virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -888,7 +888,7 @@ public:
 				  uint64_t *cur_accounted_size) override;
       virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -636,11 +636,6 @@ protected:
       virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
       /* OMAP */
-      virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-          std::map<std::string, bufferlist> *m,
-          bool* pmore, optional_yield y) override;
-      virtual int omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
-          optional_yield y) override;
       virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
           const std::set<std::string>& keys,
           Attrs* vals) override;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -584,8 +584,6 @@ protected:
       virtual int delete_object(const DoutPrefixProvider* dpp,
           optional_yield y,
           bool prevent_versioning = false) override;
-      virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
-          bool keep_index_consistent, optional_yield y) override;
       virtual int copy_object(User* user,
           req_info* info, const rgw_zone_id& source_zone,
           rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
@@ -805,7 +803,6 @@ public:
       virtual int list_all_zones(const DoutPrefixProvider* dpp, std::list<std::string>& zone_ids) override;
       virtual int cluster_stat(RGWClusterStat& stats) override;
       virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-      virtual std::unique_ptr<Completions> get_completions(void) override;
 
   virtual std::unique_ptr<Notification> get_notification(
     rgw::sal::Object* obj, rgw::sal::Object* src_obj, req_state* s,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -488,38 +488,34 @@ int FilterDriver::get_oidc_providers(const DoutPrefixProvider *dpp,
 
 std::unique_ptr<Writer> FilterDriver::get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
 				  uint64_t position,
 				  uint64_t *cur_accounted_size)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
-  std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, std::move(no),
+  std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, nextObject(obj),
 							   owner, ptail_placement_rule,
 							   unique_tag, position,
 							   cur_accounted_size);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 std::unique_ptr<Writer> FilterDriver::get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
-  std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, std::move(no),
+  std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, nextObject(obj),
 							   owner, ptail_placement_rule,
 							   olh_epoch, unique_tag);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 const std::string& FilterDriver::get_compression_type(const rgw_placement_rule& rule)
@@ -1170,19 +1166,17 @@ int FilterMultipartUpload::get_info(const DoutPrefixProvider *dpp,
 std::unique_ptr<Writer> FilterMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
   std::unique_ptr<Writer> writer;
-  writer = next->get_writer(dpp, y, std::move(no), owner,
+  writer = next->get_writer(dpp, y, nextObject(obj), owner,
 			    ptail_placement_rule, part_num, part_num_str);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 int FilterMPSerializer::try_lock(const DoutPrefixProvider *dpp, utime_t dur,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -1020,20 +1020,6 @@ std::unique_ptr<Object::DeleteOp> FilterObject::get_delete_op()
   return std::make_unique<FilterDeleteOp>(std::move(d));
 }
 
-int FilterObject::omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker,
-				uint64_t count, std::map<std::string, bufferlist> *m,
-				bool* pmore, optional_yield y)
-{
-  return next->omap_get_vals(dpp, marker, count, m, pmore, y);
-}
-
-int FilterObject::omap_get_all(const DoutPrefixProvider *dpp,
-			       std::map<std::string, bufferlist> *m,
-			       optional_yield y)
-{
-  return next->omap_get_all(dpp, m, y);
-}
-
 int FilterObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp,
 					const std::string& oid,
 					const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -267,12 +267,6 @@ std::unique_ptr<Lifecycle> FilterDriver::get_lifecycle(void)
   return std::make_unique<FilterLifecycle>(std::move(lc));
 }
 
-std::unique_ptr<Completions> FilterDriver::get_completions(void)
-{
-  std::unique_ptr<Completions> c = next->get_completions();
-  return std::make_unique<FilterCompletions>(std::move(c));
-}
-
 std::unique_ptr<Notification> FilterDriver::get_notification(rgw::sal::Object* obj,
 				rgw::sal::Object* src_obj, req_state* s,
 				rgw::notify::EventType event_type, optional_yield y,
@@ -855,13 +849,6 @@ int FilterObject::delete_object(const DoutPrefixProvider* dpp,
 				bool prevent_versioning)
 {
   return next->delete_object(dpp, y, prevent_versioning);
-}
-
-int FilterObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-				 Completions* aio, bool keep_index_consistent,
-				 optional_yield y)
-{
-  return next->delete_obj_aio(dpp, astate, aio, keep_index_consistent, y);
 }
 
 int FilterObject::copy_object(User* user,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -284,7 +284,7 @@ public:
 				 providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule
 				  *ptail_placement_rule,
@@ -293,7 +293,7 @@ public:
 				  uint64_t *cur_accounted_size) override;
   virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
@@ -743,7 +743,7 @@ public:
 
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -855,10 +855,10 @@ public:
 class FilterWriter : public Writer {
 protected:
   std::unique_ptr<Writer> next;
-  std::unique_ptr<Object> head_obj;
+  Object* obj;
 public:
-  FilterWriter(std::unique_ptr<Writer> _next, std::unique_ptr<Object> _head_obj) :
-    next(std::move(_next)), head_obj(std::move(_head_obj)) {}
+  FilterWriter(std::unique_ptr<Writer> _next, Object* _obj) :
+    next(std::move(_next)), obj(_obj) {}
   virtual ~FilterWriter() = default;
 
   virtual int prepare(optional_yield y) { return next->prepare(y); }

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -658,12 +658,6 @@ public:
   virtual std::unique_ptr<ReadOp> get_read_op() override;
   virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
-  virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker,
-			    uint64_t count, std::map<std::string, bufferlist>* m,
-			    bool* pmore, optional_yield y) override;
-  virtual int omap_get_all(const DoutPrefixProvider *dpp,
-			   std::map<std::string, bufferlist>* m,
-			   optional_yield y) override;
   virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp,
 				    const std::string& oid,
 				    const std::set<std::string>& keys,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -21,16 +21,6 @@
 
 namespace rgw { namespace sal {
 
-class FilterCompletions : public Completions {
-protected:
-  std::unique_ptr<Completions> next;
-
-public:
-  FilterCompletions(std::unique_ptr<Completions> _next) : next(std::move(_next)) {}
-  virtual ~FilterCompletions() = default;
-  virtual int drain() override { return next->drain(); }
-};
-
 class FilterPlacementTier : public PlacementTier {
 protected:
   std::unique_ptr<PlacementTier> next;
@@ -198,7 +188,6 @@ public:
   }
   virtual int cluster_stat(RGWClusterStat& stats) override;
   virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-  virtual std::unique_ptr<Completions> get_completions(void) override;
 
   virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj,
 				 rgw::sal::Object* src_obj, struct req_state* s,
@@ -561,9 +550,6 @@ public:
   virtual int delete_object(const DoutPrefixProvider* dpp,
 			    optional_yield y,
 			    bool prevent_versioning = false) override;
-  virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-			     Completions* aio,
-			     bool keep_index_consistent, optional_yield y) override;
   virtual int copy_object(User* user,
                req_info* info, const rgw_zone_id& source_zone,
 	       rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1606,7 +1606,7 @@ int MotrObject::swift_versioning_copy(const DoutPrefixProvider* dpp,
 
 MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
           optional_yield y,
-          std::unique_ptr<rgw::sal::Object> _head_obj,
+          rgw::sal::Object* obj,
           MotrStore* _store,
           const rgw_user& _owner,
           const rgw_placement_rule *_ptail_placement_rule,
@@ -1618,8 +1618,8 @@ MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
               ptail_placement_rule(_ptail_placement_rule),
               olh_epoch(_olh_epoch),
               unique_tag(_unique_tag),
-              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()),
-              old_obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+              obj(_store, obj->get_key(), obj->get_bucket()),
+              old_obj(_store, obj->get_key(), obj->get_bucket()) {}
 
 static const unsigned MAX_BUFVEC_NR = 256;
 
@@ -2984,14 +2984,14 @@ int MotrMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield 
 std::unique_ptr<Writer> MotrMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
   return std::make_unique<MotrMultipartWriter>(dpp, y, this,
-				 std::move(_head_obj), store, owner,
+				 obj, store, owner,
 				 ptail_placement_rule, part_num, part_num_str);
 }
 
@@ -3128,7 +3128,7 @@ std::unique_ptr<MultipartUpload> MotrBucket::get_multipart_upload(const std::str
 
 std::unique_ptr<Writer> MotrStore::get_append_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         const std::string& unique_tag,
@@ -3139,13 +3139,13 @@ std::unique_ptr<Writer> MotrStore::get_append_writer(const DoutPrefixProvider *d
 
 std::unique_ptr<Writer> MotrStore::get_atomic_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         uint64_t olh_epoch,
         const std::string& unique_tag) {
   return std::make_unique<MotrAtomicWriter>(dpp, y,
-                  std::move(_head_obj), this, owner,
+                  obj, this, owner,
                   ptail_placement_rule, olh_epoch, unique_tag);
 }
 

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1540,14 +1540,6 @@ int MotrObject::delete_object(const DoutPrefixProvider* dpp, optional_yield y, b
   return del_op.delete_obj(dpp, y);
 }
 
-int MotrObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
-    Completions* aio, bool keep_index_consistent,
-    optional_yield y)
-{
-  /* XXX: Make it async */
-  return 0;
-}
-
 int MotrObject::copy_object(User* user,
     req_info* info,
     const rgw_zone_id& source_zone,
@@ -3358,11 +3350,6 @@ int MotrStore::cluster_stat(RGWClusterStat& stats)
 }
 
 std::unique_ptr<Lifecycle> MotrStore::get_lifecycle(void)
-{
-  return 0;
-}
-
-std::unique_ptr<Completions> MotrStore::get_completions(void)
 {
   return 0;
 }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1296,19 +1296,6 @@ void MotrObject::gen_rand_obj_instance_name()
   state.obj.key.set_instance(buf);
 }
 
-int MotrObject::omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-    std::map<std::string, bufferlist> *m,
-    bool* pmore, optional_yield y)
-{
-  return 0;
-}
-
-int MotrObject::omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
-    optional_yield y)
-{
-  return 0;
-}
-
 int MotrObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
     const std::set<std::string>& keys,
     Attrs* vals)

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -792,7 +792,7 @@ class MotrAtomicWriter : public StoreWriter {
   public:
   MotrAtomicWriter(const DoutPrefixProvider *dpp,
           optional_yield y,
-          std::unique_ptr<rgw::sal::Object> _head_obj,
+          rgw::sal::Object* obj,
           MotrStore* _store,
           const rgw_user& _owner,
           const rgw_placement_rule *_ptail_placement_rule,
@@ -827,7 +827,7 @@ protected:
   rgw::sal::MotrStore* store;
 
   // Head object.
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  rgw::sal::Object* head_obj;
 
   // Part parameters.
   const uint64_t part_num;
@@ -838,12 +838,12 @@ protected:
 public:
   MotrMultipartWriter(const DoutPrefixProvider *dpp,
 		       optional_yield y, MultipartUpload* upload,
-		       std::unique_ptr<rgw::sal::Object> _head_obj,
+		       rgw::sal::Object* obj,
 		       MotrStore* _store,
 		       const rgw_user& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
 		       uint64_t _part_num, const std::string& part_num_str) :
-				  StoreWriter(dpp, y), store(_store), head_obj(std::move(_head_obj)),
+				  StoreWriter(dpp, y), store(_store), head_obj(obj),
 				  part_num(_part_num), part_num_str(part_num_str)
   {
   }
@@ -951,7 +951,7 @@ public:
   virtual int get_info(const DoutPrefixProvider *dpp, optional_yield y, rgw_placement_rule** rule, rgw::sal::Attrs* attrs = nullptr) override;
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -1072,7 +1072,7 @@ class MotrStore : public StoreDriver {
         std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         const std::string& unique_tag,
@@ -1080,7 +1080,7 @@ class MotrStore : public StoreDriver {
         uint64_t *cur_accounted_size) override;
     virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         uint64_t olh_epoch,

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -674,8 +674,6 @@ class MotrObject : public StoreObject {
     virtual int delete_object(const DoutPrefixProvider* dpp,
         optional_yield y,
         bool prevent_versioning = false) override;
-    virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
-        bool keep_index_consistent, optional_yield y) override;
     virtual int copy_object(User* user,
         req_info* info, const rgw_zone_id& source_zone,
         rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
@@ -1007,7 +1005,6 @@ class MotrStore : public StoreDriver {
     virtual int list_all_zones(const DoutPrefixProvider* dpp, std::list<std::string>& zone_ids) override;
     virtual int cluster_stat(RGWClusterStat& stats) override;
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
-    virtual std::unique_ptr<Completions> get_completions(void) override;
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, rgw::sal::Object* src_obj,
         req_state* s, rgw::notify::EventType event_type, optional_yield y, const std::string* object_name=nullptr) override;
     virtual std::unique_ptr<Notification> get_notification(const DoutPrefixProvider* dpp, rgw::sal::Object* obj,

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -724,11 +724,6 @@ class MotrObject : public StoreObject {
     virtual std::unique_ptr<DeleteOp> get_delete_op() override;
 
     /* OMAP */
-    virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
-        std::map<std::string, bufferlist> *m,
-        bool* pmore, optional_yield y) override;
-    virtual int omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
-        optional_yield y) override;
     virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
         const std::set<std::string>& keys,
         Attrs* vals) override;

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -155,36 +155,17 @@ class StoreBucket : public Bucket {
 class StoreObject : public Object {
   protected:
     RGWObjState state;
-    Bucket* bucket;
-    Attrs attrs;
+    Bucket* bucket = nullptr;
     bool delete_marker{false};
 
   public:
-
-    struct StoreReadOp : ReadOp {
-      virtual ~StoreReadOp() = default;
-    };
-
-    struct StoreDeleteOp : DeleteOp {
-      virtual ~StoreDeleteOp() = default;
-    };
-
-    StoreObject()
-      : state(),
-      bucket(nullptr),
-      attrs()
-      {}
+    StoreObject() = default;
     StoreObject(const rgw_obj_key& _k)
-      : state(),
-      bucket(),
-      attrs()
-      { state.obj.key = _k; }
+    { state.obj.key = _k; }
     StoreObject(const rgw_obj_key& _k, Bucket* _b)
-      : state(),
-      bucket(_b),
-      attrs()
-      { state.obj.init(_b->get_key(), _k); }
-    StoreObject(StoreObject& _o) = default;
+      : bucket(_b)
+    { state.obj.init(_b->get_key(), _k); }
+    StoreObject(const StoreObject& _o) = default;
 
     virtual ~StoreObject() = default;
 


### PR DESCRIPTION
a cleanup of the `RGWRados` layer that restores many functions to their pre-pacific form, where buckets are passed as `RGWBucketInfo&` and objects are passed as `const rgw_obj&`. this avoids a lots of cases where we had to allocate sal objects just to specify an object name. this also removed some sal APIs that had only been used internally by rgw_sal_sados

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
