### PR TITLE
pacific: mgr: don't dump global config holding gil

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -253,10 +253,16 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     }
     f.close_section();
   } else if (what.substr(0, 6) == "config") {
+    // We make a copy of the global config to avoid printing
+    // to py formater (which may drop-take GIL) while holding
+    // the global config lock, which might deadlock with other
+    // thread that is holding the GIL and acquiring the global
+    // config lock.
+    ConfigProxy config{g_conf()};
     if (what == "config_options") {
-      g_conf().config_options(&f);
+      config.config_options(&f);
     } else if (what == "config") {
-      g_conf().show_config(&f);
+      config.show_config(&f);
     }
   } else if (what == "mon_map") {
     without_gil_t no_gil;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58805

---

backport of https://github.com/ceph/ceph/pull/49487
parent tracker: https://tracker.ceph.com/issues/58269

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh