### PR TITLE
qa: export DIFF_LENGTH env parameter to print the full git diff

### DIFF
--- a/qa/tasks/cephfs/test_acls.py
+++ b/qa/tasks/cephfs/test_acls.py
@@ -27,8 +27,8 @@ class TestACLs(XFSTestsDev):
         # failure on our own (since this command doesn't set right error code
         # and error message in some cases) and print custom log messages
         # accordingly.
-        proc = self.mount_a.client_remote.run(args=['sudo', './check',
-            'generic/099'], cwd=self.xfstests_repo_path, stdout=StringIO(),
+        proc = self.mount_a.client_remote.run(args=['sudo', 'env', 'DIFF_LENGTH=0',
+            './check', 'generic/099'], cwd=self.xfstests_repo_path, stdout=StringIO(),
             stderr=StringIO(), timeout=30, check_status=False,omit_sudo=False,
             label='running tests for ACLs from xfstests-dev')
 

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -32,8 +32,8 @@ class TestFscrypt(XFSTestsDev):
         # failure on our own (since this command doesn't set right error code
         # and error message in some cases) and print custom log messages
         # accordingly.
-        proc = self.mount_a.client_remote.run(args=['sudo', './check',
-            '-g', 'encrypt'], cwd=self.xfstests_repo_path, stdout=StringIO(),
+        proc = self.mount_a.client_remote.run(args=['sudo', 'env', 'DIFF_LENGTH=0',
+            './check', '-g', 'encrypt'], cwd=self.xfstests_repo_path, stdout=StringIO(),
             stderr=StringIO(), timeout=900, check_status=False, omit_sudo=False,
             label='running tests for encrypt from xfstests-dev')
 
@@ -59,8 +59,8 @@ class TestFscrypt(XFSTestsDev):
         # failure on our own (since this command doesn't set right error code
         # and error message in some cases) and print custom log messages
         # accordingly. This will take a long time and set the timeout to 3 hours.
-        proc = self.mount_a.client_remote.run(args=['sudo', './check',
-            '-g', 'quick', '-E', './ceph.exclude'], cwd=self.xfstests_repo_path,
+        proc = self.mount_a.client_remote.run(args=['sudo', 'env', 'DIFF_LENGTH=0',
+            './check', '-g', 'quick', '-E', './ceph.exclude'], cwd=self.xfstests_repo_path,
             stdout=StringIO(), stderr=StringIO(), timeout=10800, check_status=False,
             omit_sudo=False, label='running tests for dummy_encryption from xfstests-dev')
 


### PR DESCRIPTION
From the xfstests-dev's README doc set DIFF_LENGTH to 0 will print
the full diff instead of the default 10.

This will be very helpful to debug the test failures, or we will
lose many valuable debug infomation.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
