### PR TITLE
scrub: use a generic interface for scheduling timer based events

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -75,7 +75,10 @@ function TEST_scrub_test() {
       local anotherosd="2"
     fi
 
-    objectstore_tool $dir $anotherosd obj1 set-bytes /etc/fstab
+    CORRUPT_DATA="corrupt-data.$$"
+    dd if=/dev/urandom of=$CORRUPT_DATA bs=512 count=1
+    objectstore_tool $dir $anotherosd obj1 set-bytes $CORRUPT_DATA
+    rm -f $CORRUPT_DATA
 
     local pgid="${poolid}.0"
     pg_deep_scrub "$pgid" || return 1

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -29,9 +29,13 @@ function run() {
     export -n CEPH_CLI_TEST_DUP_COMMAND
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
+        echo "-------------- Prepare Test $func -------------------"
         setup $dir || return 1
+        echo "-------------- Run Test $func -----------------------"
         $func $dir || return 1
+        echo "-------------- Teardown Test $func ------------------"
         teardown $dir || return 1
+        echo "-------------- Complete Test $func ------------------"
     done
 }
 

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -377,7 +377,7 @@ options:
   type: float
   level: advanced
   desc: Duration to inject a delay during scrubbing
-  fmt_desc: Time to sleep before scrubbing the next group of chunks. Increasing this value will slow
+  fmt_desc: Time to sleep before scrubbing the next group of chunks (seconds). Increasing this value will slow
     down the overall rate of scrubbing so that client operations will be less impacted.
   default: 0
   flags:
@@ -387,7 +387,7 @@ options:
 - name: osd_scrub_extended_sleep
   type: float
   level: advanced
-  desc: Duration to inject a delay during scrubbing out of scrubbing hours
+  desc: Duration to inject a delay during scrubbing out of scrubbing hours (seconds)
   default: 0
   see_also:
   - osd_scrub_begin_hour

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -558,9 +558,10 @@ ScrubQueue::scrub_schedule_t ScrubQueue::adjust_target_time(
   return sched_n_dead;
 }
 
-double ScrubQueue::scrub_sleep_time(bool must_scrub) const
+std::chrono::milliseconds ScrubQueue::scrub_sleep_time(bool must_scrub) const
 {
-  double regular_sleep_period = conf()->osd_scrub_sleep;
+  std::chrono::milliseconds regular_sleep_period{
+    uint64_t(std::max(0.0, conf()->osd_scrub_sleep) * 1000)};
 
   if (must_scrub || scrub_time_permit(time_now())) {
     return regular_sleep_period;
@@ -568,8 +569,10 @@ double ScrubQueue::scrub_sleep_time(bool must_scrub) const
 
   // relevant if scrubbing started during allowed time, but continued into
   // forbidden hours
-  double extended_sleep = conf()->osd_scrub_extended_sleep;
+  std::chrono::milliseconds extended_sleep{
+    uint64_t(std::max(0.0, conf()->osd_scrub_extended_sleep) * 1000)};
   dout(20) << "w/ extended sleep (" << extended_sleep << ")" << dendl;
+
   return std::max(extended_sleep, regular_sleep_period);
 }
 

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -389,15 +389,16 @@ class ScrubQueue {
   int get_blocked_pgs_count() const;
 
   /**
-   * Pacing the scrub operation by inserting delays (mostly between chunks)
+   * scrub_sleep_time
    *
-   * Special handling for regular scrubs that continued into "no scrub" times.
-   * Scrubbing will continue, but the delays will be controlled by a separate
-   * (read - with higher value) configuration element
-   * (osd_scrub_extended_sleep).
+   * Returns std::chrono::milliseconds indicating how long to wait between
+   * chunks.
+   *
+   * Implementation Note: Returned value will either osd_scrub_sleep or
+   * osd_scrub_extended_sleep depending on must_scrub_param and time
+   * of day (see configs osd_scrub_begin*)
    */
-  double scrub_sleep_time(bool must_scrub) const;  /// \todo (future) return
-						   /// milliseconds
+  std::chrono::milliseconds scrub_sleep_time(bool must_scrub) const;
 
   /**
    *  called every heartbeat to update the "daily" load average

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -683,6 +683,16 @@ void PgScrubber::cancel_callback(scrubber_callback_cancel_token_t token)
   m_osds->sleep_timer.cancel_event(token);
 }
 
+LogChannelRef &PgScrubber::get_clog() const
+{
+  return m_osds->clog;
+}
+
+int PgScrubber::get_whoami() const
+{
+  return m_osds->whoami;
+}
+
 /*
  * The selected range is set directly into 'm_start' and 'm_end'
  * setting:

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -860,8 +860,6 @@ bool PgScrubber::range_intersects_scrub(const hobject_t& start,
  */
 void PgScrubber::add_delayed_scheduling()
 {
-  m_end = m_start;  // not blocking any range now
-
   milliseconds sleep_time{0ms};
     sleep_time = m_osds->get_scrub_services().scrub_sleep_time(
       m_flags.required);

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -432,7 +432,6 @@ void PgScrubber::reset_epoch(epoch_t epoch_queued)
   m_fsm->assert_not_active();
 
   m_epoch_start = epoch_queued;
-  m_needs_sleep = true;
   ceph_assert(m_is_deep == state_test(PG_STATE_DEEP_SCRUB));
   update_op_mode_text();
 }
@@ -864,17 +863,13 @@ void PgScrubber::add_delayed_scheduling()
   m_end = m_start;  // not blocking any range now
 
   milliseconds sleep_time{0ms};
-  if (m_needs_sleep) {
     sleep_time = m_osds->get_scrub_services().scrub_sleep_time(
       m_flags.required);
-  }
-  dout(15) << __func__ << " sleep: " << sleep_time.count() << "ms. needed? "
-	   << m_needs_sleep << dendl;
+  dout(15) << __func__ << " sleep: " << sleep_time.count() << "ms." << dendl;
 
   if (sleep_time.count()) {
     // schedule a transition for some 'sleep_time' ms in the future
 
-    m_needs_sleep = false;
     m_sleep_started_at = ceph_clock_now();
 
     // the following log line is used by osd-scrub-test.sh
@@ -893,7 +888,6 @@ void PgScrubber::add_delayed_scheduling()
 	  << dendl;
 	return;
       }
-      scrbr->m_needs_sleep = true;
       lgeneric_dout(scrbr->get_pg_cct(), 7)
 	<< "scrub_requeue_callback: slept for "
 	<< ceph_clock_now() - scrbr->m_sleep_started_at << ", re-queuing scrub"
@@ -2414,7 +2408,6 @@ void PgScrubber::reset_internal_state()
   m_primary_scrubmap_pos.reset();
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos.reset();
-  m_needs_sleep = true;
   m_sleep_started_at = utime_t{};
 
   m_active = false;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1804,6 +1804,13 @@ void PgScrubber::unreserve_replicas()
   m_reservations.reset();
 }
 
+void PgScrubber::on_replica_reservation_timeout()
+{
+  if (m_reservations) {
+    m_reservations->handle_no_reply_timeout();
+  }
+}
+
 void PgScrubber::set_reserving_now()
 {
   m_osds->get_scrub_services().set_reserving_now();
@@ -2618,10 +2625,6 @@ ReplicaReservations::ReplicaReservations(
     send_all_done();
 
   } else {
-    // start a timer to handle the case of no replies
-    m_no_reply = make_unique<ReplicaReservations::no_reply_t>(
-      m_osds, m_conf, *this, m_log_msg_prefix);
-
     // send the reservation requests
     for (auto p : m_acting_set) {
       if (p == whoami)
@@ -2639,14 +2642,12 @@ ReplicaReservations::ReplicaReservations(
 void ReplicaReservations::send_all_done()
 {
   // stop any pending timeout timer
-  m_no_reply.reset();
   m_osds->queue_for_scrub_granted(m_pg, scrub_prio_t::low_priority);
 }
 
 void ReplicaReservations::send_reject()
 {
   // stop any pending timeout timer
-  m_no_reply.reset();
   m_scrub_job->resources_failure = true;
   m_osds->queue_for_scrub_denied(m_pg, scrub_prio_t::low_priority);
 }
@@ -2655,7 +2656,6 @@ void ReplicaReservations::discard_all()
 {
   dout(10) << __func__ << ": " << m_reserved_peers << dendl;
 
-  m_no_reply.reset();
   m_had_rejections = true;  // preventing late-coming responses from triggering
 			    // events
   m_reserved_peers.clear();
@@ -2684,9 +2684,6 @@ ReplicaReservations::~ReplicaReservations()
 {
   m_had_rejections = true;  // preventing late-coming responses from triggering
 			    // events
-
-  // stop any pending timeout timer
-  m_no_reply.reset();
 
   // send un-reserve messages to all reserved replicas. We do not wait for
   // answer (there wouldn't be one). Other incoming messages will be discarded
@@ -2807,6 +2804,7 @@ void ReplicaReservations::handle_no_reply_timeout()
 	       "{}: timeout! no reply from {}", __func__, m_waited_for_peers)
 	  << dendl;
 
+  // treat reply timeout as if a REJECT was received
   m_had_rejections = true;  // preventing any additional notifications
   send_reject();
 }
@@ -2816,39 +2814,6 @@ std::ostream& ReplicaReservations::gen_prefix(std::ostream& out) const
   return out << m_log_msg_prefix;
 }
 
-ReplicaReservations::no_reply_t::no_reply_t(
-  OSDService* osds,
-  const ConfigProxy& conf,
-  ReplicaReservations& parent,
-  std::string_view log_prfx)
-    : m_osds{osds}
-    , m_conf{conf}
-    , m_parent{parent}
-    , m_log_prfx{log_prfx}
-{
-  using namespace std::chrono;
-  auto now_is = clock::now();
-  auto timeout =
-    conf.get_val<std::chrono::milliseconds>("osd_scrub_reservation_timeout");
-
-  m_abort_callback = new LambdaContext([this, now_is]([[maybe_unused]] int r) {
-    // behave as if a REJECT was received
-    m_osds->clog->warn() << fmt::format(
-      "{} timeout on replica reservations (since {})", m_log_prfx, now_is);
-    m_parent.handle_no_reply_timeout();
-  });
-
-  std::lock_guard l(m_osds->sleep_lock);
-  m_osds->sleep_timer.add_event_after(timeout, m_abort_callback);
-}
-
-ReplicaReservations::no_reply_t::~no_reply_t()
-{
-  std::lock_guard l(m_osds->sleep_lock);
-  if (m_abort_callback) {
-    m_osds->sleep_timer.cancel_event(m_abort_callback);
-  }
-}
 
 // ///////////////////// LocalReservation //////////////////////////////////
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -865,9 +865,8 @@ void PgScrubber::add_delayed_scheduling()
 
   milliseconds sleep_time{0ms};
   if (m_needs_sleep) {
-    double scrub_sleep =
-      1000.0 * m_osds->get_scrub_services().scrub_sleep_time(m_flags.required);
-    sleep_time = milliseconds{int64_t(scrub_sleep)};
+    sleep_time = m_osds->get_scrub_services().scrub_sleep_time(
+      m_flags.required);
   }
   dout(15) << __func__ << " sleep: " << sleep_time.count() << "ms. needed? "
 	   << m_needs_sleep << dendl;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -851,60 +851,6 @@ bool PgScrubber::range_intersects_scrub(const hobject_t& start,
   return (start < m_max_end && end >= m_start);
 }
 
-/**
- *  if we are required to sleep:
- *	arrange a callback sometimes later.
- *	be sure to be able to identify a stale callback.
- *  Otherwise: perform a requeue (i.e. - rescheduling thru the OSD queue)
- *    anyway.
- */
-void PgScrubber::add_delayed_scheduling()
-{
-  milliseconds sleep_time{0ms};
-    sleep_time = m_osds->get_scrub_services().scrub_sleep_time(
-      m_flags.required);
-  dout(15) << __func__ << " sleep: " << sleep_time.count() << "ms." << dendl;
-
-  if (sleep_time.count()) {
-    // schedule a transition for some 'sleep_time' ms in the future
-
-    m_sleep_started_at = ceph_clock_now();
-
-    // the following log line is used by osd-scrub-test.sh
-    dout(20) << __func__ << " scrub state is PendingTimer, sleeping" << dendl;
-
-    // the 'delayer' for crimson is different. Will be factored out.
-
-    spg_t pgid = m_pg->get_pgid();
-    auto callbk = new LambdaContext([osds = m_osds, pgid, scrbr = this](
-				      [[maybe_unused]] int r) mutable {
-      PGRef pg = osds->osd->lookup_lock_pg(pgid);
-      if (!pg) {
-	lgeneric_subdout(g_ceph_context, osd, 10)
-	  << "scrub_requeue_callback: Could not find "
-	  << "PG " << pgid << " can't complete scrub requeue after sleep"
-	  << dendl;
-	return;
-      }
-      lgeneric_dout(scrbr->get_pg_cct(), 7)
-	<< "scrub_requeue_callback: slept for "
-	<< ceph_clock_now() - scrbr->m_sleep_started_at << ", re-queuing scrub"
-	<< dendl;
-
-      scrbr->m_sleep_started_at = utime_t{};
-      osds->queue_for_scrub_resched(&(*pg), Scrub::scrub_prio_t::low_priority);
-      pg->unlock();
-    });
-
-    std::lock_guard l(m_osds->sleep_lock);
-    m_osds->sleep_timer.add_event_after(sleep_time.count() / 1000.0f, callbk);
-
-  } else {
-    // just a requeue
-    m_osds->queue_for_scrub_resched(m_pg, Scrub::scrub_prio_t::high_priority);
-  }
-}
-
 eversion_t PgScrubber::search_log_for_updates() const
 {
   auto& projected = m_pg->projected_log.log;
@@ -2381,6 +2327,17 @@ void PgScrubber::replica_handling_done()
   reset_internal_state();
 }
 
+std::chrono::milliseconds PgScrubber::get_scrub_sleep_time() const
+{
+  return m_osds->get_scrub_services().scrub_sleep_time(
+    m_flags.required);
+}
+
+void PgScrubber::queue_for_scrub_resched(Scrub::scrub_prio_t prio)
+{
+  m_osds->queue_for_scrub_resched(m_pg, prio);
+}
+
 /*
  * note: performs run_callbacks()
  * note: reservations-related variables are not reset here
@@ -2406,7 +2363,6 @@ void PgScrubber::reset_internal_state()
   m_primary_scrubmap_pos.reset();
   replica_scrubmap = ScrubMap{};
   replica_scrubmap_pos.reset();
-  m_sleep_started_at = utime_t{};
 
   m_active = false;
   clear_queued_or_active();

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -852,27 +852,6 @@ bool PgScrubber::range_intersects_scrub(const hobject_t& start,
   return (start < m_max_end && end >= m_start);
 }
 
-Scrub::BlockedRangeWarning PgScrubber::acquire_blocked_alarm()
-{
-  int grace = get_pg_cct()->_conf->osd_blocked_scrub_grace_period;
-  if (grace == 0) {
-    // we will not be sending any alarms re the blocked object
-    dout(10)
-      << __func__
-      << ": blocked-alarm disabled ('osd_blocked_scrub_grace_period' set to 0)"
-      << dendl;
-    return nullptr;
-  }
-  ceph::timespan grace_period{m_debug_blockrange ? 4s : seconds{grace}};
-  dout(20) << fmt::format(": timeout:{}",
-			  std::chrono::duration_cast<seconds>(grace_period))
-	   << dendl;
-  return std::make_unique<blocked_range_t>(m_osds,
-					   grace_period,
-					   *this,
-					   m_pg_id);
-}
-
 /**
  *  if we are required to sleep:
  *	arrange a callback sometimes later.
@@ -2970,47 +2949,6 @@ ostream& operator<<(ostream& out, const MapsCollectionStatus& sf)
     out << " local ";
   }
   return out << " ] ";
-}
-
-// ///////////////////// blocked_range_t ///////////////////////////////
-
-blocked_range_t::blocked_range_t(OSDService* osds,
-				 ceph::timespan waittime,
-				 ScrubMachineListener& scrubber,
-				 spg_t pg_id)
-    : m_osds{osds}
-    , m_scrubber{scrubber}
-    , m_pgid{pg_id}
-{
-  auto now_is = std::chrono::system_clock::now();
-  m_callbk = new LambdaContext([this, now_is]([[maybe_unused]] int r) {
-    std::time_t now_c = std::chrono::system_clock::to_time_t(now_is);
-    char buf[50];
-    strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", std::localtime(&now_c));
-    lgeneric_subdout(g_ceph_context, osd, 10)
-      << "PgScrubber: " << m_pgid
-      << " blocked on an object for too long (since " << buf << ")" << dendl;
-    m_osds->clog->warn() << "osd." << m_osds->whoami
-			 << " PgScrubber: " << m_pgid
-			 << " blocked on an object for too long (since " << buf
-			 << ")";
-
-    m_warning_issued = true;
-    m_scrubber.set_scrub_blocked(utime_t{now_c,0});
-    return;
-  });
-
-  std::lock_guard l(m_osds->sleep_lock);
-  m_osds->sleep_timer.add_event_after(waittime, m_callbk);
-}
-
-blocked_range_t::~blocked_range_t()
-{
-  if (m_warning_issued) {
-    m_scrubber.clear_scrub_blocked();
-  }
-  std::lock_guard l(m_osds->sleep_lock);
-  m_osds->sleep_timer.cancel_event(m_callbk);
 }
 
 }  // namespace Scrub

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -735,10 +735,6 @@ class PgScrubber : public ScrubPgIF,
 
   epoch_t m_last_aborted{};  // last time we've noticed a request to abort
 
-  bool m_needs_sleep{true};  ///< should we sleep before being rescheduled?
-			     ///< always 'true', unless we just got out of a
-			     ///< sleep period
-
   utime_t m_sleep_started_at;
 
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -500,6 +500,11 @@ class PgScrubber : public ScrubPgIF,
   // the I/F used by the state-machine (i.e. the implementation of
   // ScrubMachineListener)
 
+  CephContext* get_cct() const final { return m_pg->cct; }
+  LogChannelRef &get_clog() const final;
+  int get_whoami() const final;
+  spg_t get_spgid() const final { return m_pg->get_pgid(); }
+
   scrubber_callback_cancel_token_t schedule_callback_after(
     ceph::timespan duration, scrubber_callback_t &&cb);
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -539,11 +539,9 @@ class PgScrubber : public ScrubPgIF,
   /// services (thus can be called from FSM reactions)
   void clear_pgscrub_state() final;
 
-  /*
-   * Send an 'InternalSchedScrub' FSM event either immediately, or - if
-   * 'm_need_sleep' is asserted - after a configuration-dependent timeout.
-   */
-  void add_delayed_scheduling() final;
+
+  std::chrono::milliseconds get_scrub_sleep_time() const final;
+  void queue_for_scrub_resched(Scrub::scrub_prio_t prio) final;
 
   void get_replicas_maps(bool replica_can_preempt) final;
 
@@ -734,9 +732,6 @@ class PgScrubber : public ScrubPgIF,
   [[nodiscard]] bool check_interval(epoch_t epoch_to_verify);
 
   epoch_t m_last_aborted{};  // last time we've noticed a request to abort
-
-  utime_t m_sleep_started_at;
-
 
   // 'optional', as 'ReplicaReservations' & 'LocalReservation' are
   // 'RAII-designed' to guarantee un-reserving when deleted.

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -500,6 +500,11 @@ class PgScrubber : public ScrubPgIF,
   // the I/F used by the state-machine (i.e. the implementation of
   // ScrubMachineListener)
 
+  scrubber_callback_cancel_token_t schedule_callback_after(
+    ceph::timespan duration, scrubber_callback_t &&cb);
+
+  void cancel_callback(scrubber_callback_cancel_token_t);
+
   [[nodiscard]] bool is_primary() const final
   {
     return m_pg->recovery_state.is_primary();

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -123,22 +123,6 @@ class ReplicaReservations {
   using clock = std::chrono::system_clock;
   using tpoint_t = std::chrono::time_point<clock>;
 
-  /// a no-reply timeout handler
-  struct no_reply_t {
-    explicit no_reply_t(
-      OSDService* osds,
-      const ConfigProxy& conf,
-      ReplicaReservations& parent,
-      std::string_view log_prfx);
-
-    ~no_reply_t();
-    OSDService* m_osds;
-    const ConfigProxy& m_conf;
-    ReplicaReservations& m_parent;
-    std::string m_log_prfx;
-    Context* m_abort_callback{nullptr};
-  };
-
   PG* m_pg;
   std::set<pg_shard_t> m_acting_set;
   OSDService* m_osds;
@@ -153,9 +137,6 @@ class ReplicaReservations {
   // detecting slow peers (see 'slow-secondary' above)
   std::chrono::milliseconds m_timeout;
   std::optional<tpoint_t> m_timeout_point;
-
-  // detecting & handling a "no show" of a replica
-  std::unique_ptr<no_reply_t> m_no_reply;
 
   void release_replica(pg_shard_t peer, epoch_t epoch);
 
@@ -400,6 +381,8 @@ class PgScrubber : public ScrubPgIF,
   void discard_replica_reservations() final;
   void clear_scrub_reservations() final;  // PG::clear... fwds to here
   void unreserve_replicas() final;
+  void on_replica_reservation_timeout() final;
+
 
   // managing scrub op registration
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -510,6 +510,18 @@ class PgScrubber : public ScrubPgIF,
 
   void cancel_callback(scrubber_callback_cancel_token_t);
 
+  ceph::timespan get_range_blocked_grace() {
+    int grace = get_pg_cct()->_conf->osd_blocked_scrub_grace_period;
+    if (grace == 0) {
+      return ceph::timespan{};
+    }
+    ceph::timespan grace_period{
+      m_debug_blockrange ?
+      std::chrono::seconds(4) :
+      std::chrono::seconds{grace}};
+    return grace_period;
+  }
+
   [[nodiscard]] bool is_primary() const final
   {
     return m_pg->recovery_state.is_primary();
@@ -522,7 +534,6 @@ class PgScrubber : public ScrubPgIF,
 
   void select_range_n_notify() final;
 
-  Scrub::BlockedRangeWarning acquire_blocked_alarm() final;
   void set_scrub_blocked(utime_t since) final;
   void clear_scrub_blocked() final;
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -77,6 +77,8 @@ MEV(Unblocked)
 
 MEV(InternalSchedScrub)
 
+MEV(RangeBlockedAlarm)
+
 MEV(SelectedChunkFree)
 
 MEV(ChunkIsBusy)
@@ -364,9 +366,14 @@ struct ActiveScrubbing
 
 struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
   explicit RangeBlocked(my_context ctx);
-  using reactions = mpl::list<sc::transition<Unblocked, PendingTimer>>;
+  using reactions = mpl::list<
+    sc::custom_reaction<RangeBlockedAlarm>,
+    sc::transition<Unblocked, PendingTimer>>;
 
-  Scrub::BlockedRangeWarning m_timeout;
+  ceph::coarse_real_clock::time_point entered_at =
+    ceph::coarse_real_clock::now();
+  ScrubMachine::timer_event_token_t m_timeout_token;
+  sc::result react(const RangeBlockedAlarm &);
 };
 
 struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -65,6 +65,9 @@ MEV(RemotesReserved)
 /// a reservation request has failed
 MEV(ReservationFailure)
 
+/// reservations have timed out
+MEV(ReservationTimeout)
+
 /// initiate a new scrubbing session (relevant if we are a Primary)
 MEV(StartScrub)
 
@@ -313,15 +316,21 @@ struct NotActive : sc::state<NotActive, ScrubMachine>, NamedSimply {
 
 struct ReservingReplicas : sc::state<ReservingReplicas, ScrubMachine>,
 			   NamedSimply {
-
   explicit ReservingReplicas(my_context ctx);
   ~ReservingReplicas();
   using reactions = mpl::list<sc::custom_reaction<FullReset>,
 			      // all replicas granted our resources request
 			      sc::transition<RemotesReserved, ActiveScrubbing>,
+			      sc::custom_reaction<ReservationTimeout>,
 			      sc::custom_reaction<ReservationFailure>>;
 
+  ceph::coarse_real_clock::time_point entered_at =
+    ceph::coarse_real_clock::now();
+  ScrubMachine::timer_event_token_t m_timeout_token;
+
   sc::result react(const FullReset&);
+
+  sc::result react(const ReservationTimeout&);
 
   /// at least one replica denied us the scrub resources we've requested
   sc::result react(const ReservationFailure&);

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -82,6 +82,8 @@ MEV(InternalSchedScrub)
 
 MEV(RangeBlockedAlarm)
 
+MEV(SleepComplete)
+
 MEV(SelectedChunkFree)
 
 MEV(ChunkIsBusy)
@@ -385,11 +387,25 @@ struct RangeBlocked : sc::state<RangeBlocked, ActiveScrubbing>, NamedSimply {
   sc::result react(const RangeBlockedAlarm &);
 };
 
+/**
+ * PendingTimer
+ *
+ * Represents period between chunks.  Waits get_scrub_sleep_time() (if non-zero)
+ * by scheduling a SleepComplete event and then queues an InternalSchedScrub
+ * to start the next chunk.
+ */
 struct PendingTimer : sc::state<PendingTimer, ActiveScrubbing>, NamedSimply {
 
   explicit PendingTimer(my_context ctx);
 
-  using reactions = mpl::list<sc::transition<InternalSchedScrub, NewChunk>>;
+  using reactions = mpl::list<
+    sc::transition<InternalSchedScrub, NewChunk>,
+    sc::custom_reaction<SleepComplete>>;
+
+  ceph::coarse_real_clock::time_point entered_at =
+    ceph::coarse_real_clock::now();
+  ScrubMachine::timer_event_token_t m_sleep_timer;
+  sc::result react(const SleepComplete&);
 };
 
 struct NewChunk : sc::state<NewChunk, ActiveScrubbing>, NamedSimply {

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -156,6 +156,126 @@ class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
   void assert_not_active() const;
   [[nodiscard]] bool is_reserving() const;
   [[nodiscard]] bool is_accepting_updates() const;
+
+private:
+  /**
+   * scheduled_event_state_t
+   *
+   * Heap allocated, ref-counted state shared between scheduled event callback
+   * and timer_event_token_t.  Ensures that callback and timer_event_token_t
+   * can be safetly destroyed in either order while still allowing for
+   * cancellation.
+   */
+  struct scheduled_event_state_t {
+    bool canceled = false;
+    ScrubMachineListener::scrubber_callback_cancel_token_t cb_token = nullptr;
+
+    operator bool() const {
+      return nullptr != cb_token;
+    }
+
+    ~scheduled_event_state_t() {
+      /* For the moment, this assert encodes an assumption that we always
+       * retain the token until the event either fires or is canceled.
+       * If a user needs/wants to relaxt that requirement, this assert can
+       * be removed */
+      assert(!cb_token);
+    }
+  };
+public:
+  /**
+   * timer_event_token_t
+   *
+   * Represents in-flight timer event.  Destroying the object or invoking
+   * release() directly will cancel the in-flight timer event preventing it
+   * from being delivered.  The intended usage is to invoke
+   * schedule_timer_event_after in the constructor of the state machine state
+   * intended to handle the event and assign the returned timer_event_token_t
+   * to a member of that state. That way, exiting the state will implicitely
+   * cancel the event.  See RangedBlocked::m_timeout_token and
+   * RangeBlockedAlarm for an example usage.
+   */
+  class timer_event_token_t {
+    friend ScrubMachine;
+
+    // invariant: (bool)parent == (bool)event_state
+    ScrubMachine *parent = nullptr;
+    std::shared_ptr<scheduled_event_state_t> event_state;
+
+    timer_event_token_t(
+      ScrubMachine *parent,
+      std::shared_ptr<scheduled_event_state_t> event_state)
+      :  parent(parent), event_state(event_state) {
+      assert(*this);
+    }
+
+    void swap(timer_event_token_t &rhs) {
+      std::swap(parent, rhs.parent);
+      std::swap(event_state, rhs.event_state);
+    }
+
+  public:
+    timer_event_token_t() = default;
+    timer_event_token_t(timer_event_token_t &&rhs) {
+      swap(rhs);
+      assert(static_cast<bool>(parent) == static_cast<bool>(event_state));
+    }
+
+    timer_event_token_t &operator=(timer_event_token_t &&rhs) {
+      swap(rhs);
+      assert(static_cast<bool>(parent) == static_cast<bool>(event_state));
+      return *this;
+    }
+
+    operator bool() const {
+      assert(static_cast<bool>(parent) == static_cast<bool>(event_state));
+      return parent;
+    }
+
+    void release() {
+      if (*this) {
+	if (*event_state) {
+	  parent->m_scrbr->cancel_callback(event_state->cb_token);
+	  event_state->canceled = true;
+	  event_state->cb_token = nullptr;
+	}
+	event_state.reset();
+	parent = nullptr;
+      }
+    }
+
+    ~timer_event_token_t() {
+      release();
+    }
+  };
+
+  /**
+   * schedule_timer_event_after
+   *
+   * Schedules event EventT{Args...} to be delivered duration in the future.
+   * The implementation implicitely drops the event on interval change.  The
+   * returned timer_event_token_t can be used to cancel the event prior to
+   * its delivery -- it should generally be embedded as a member in the state
+   * intended to handle the event.  See the comment on timer_event_token_t
+   * for further information.
+   */
+  template <typename EventT, typename... Args>
+  timer_event_token_t schedule_timer_event_after(
+    ceph::timespan duration, Args&&... args) {
+    auto token = std::make_shared<scheduled_event_state_t>();
+    token->cb_token = m_scrbr->schedule_callback_after(
+      duration,
+      [this, token, event=EventT(std::forward<Args>(args)...)] {
+	if (!token->canceled) {
+	  token->cb_token = nullptr;
+	  process_event(std::move(event));
+	} else {
+	  assert(nullptr == token->cb_token);
+	}
+      }
+    );
+    return timer_event_token_t{this, token};
+  }
 };
 
 /**

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -72,6 +72,11 @@ using BlockedRangeWarning = std::unique_ptr<blocked_range_t>;
 }  // namespace Scrub
 
 struct ScrubMachineListener {
+  virtual CephContext *get_cct() const = 0;
+  virtual LogChannelRef &get_clog() const = 0;
+  virtual int get_whoami() const = 0;
+  virtual spg_t get_spgid() const = 0;
+
   using scrubber_callback_t = std::function<void(void)>;
   using scrubber_callback_cancel_token_t = Context*;
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -179,6 +179,8 @@ struct ScrubMachineListener {
 
   virtual void unreserve_replicas() = 0;
 
+  virtual void on_replica_reservation_timeout() = 0;
+
   virtual void set_scrub_begin_time() = 0;
 
   virtual void set_scrub_duration() = 0;

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -118,11 +118,11 @@ struct ScrubMachineListener {
   /// services (thus can be called from FSM reactions)
   virtual void clear_pgscrub_state() = 0;
 
-  /*
-   * Send an 'InternalSchedScrub' FSM event either immediately, or - if
-   * 'm_need_sleep' is asserted - after a configuration-dependent timeout.
-   */
-  virtual void add_delayed_scheduling() = 0;
+  /// Get time to sleep before next scrub
+  virtual std::chrono::milliseconds get_scrub_sleep_time() const = 0;
+
+  /// Queues InternalSchedScrub for later
+  virtual void queue_for_scrub_resched(Scrub::scrub_prio_t prio) = 0;
 
   /**
    * Ask all replicas for their scrub maps for the current chunk.


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
