### PR TITLE
qa: make the xfstests tmp directories to be readable and excutable

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -302,7 +302,7 @@ class XFSTestsDev(CephFSTestCase):
         # These tests will fail or take too much time and will
         # make the test timedout, just skip them for now.
         xfstests_exclude_contents = dedent('''\
-            {c}/001 {g}/003 {g}/020 {g}/075 {g}/317 {g}/538 {g}/531
+            {c}/001 {g}/003 {g}/020 {g}/075 {g}/538 {g}/531
             ''').format(g="generic", c="ceph")
 
         self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'ceph.exclude'),

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -129,6 +129,10 @@ class XFSTestsDev(CephFSTestCase):
         remoteurl = 'https://git.ceph.com/xfstests-dev.git'
         self.xfstests_repo_path = self.mount_a.client_remote.mkdtemp(suffix=
                                                             'xfstests-dev')
+        # Make the xfstests_repo_path to be readable and excutable for other
+        # users at all places, this will allow the xfstests to run the user
+        # namespace test cases, such as the generic/317.
+        self.mount_a.run_shell(['sudo', 'chmod', 'a+rx', self.xfstests_repo_path])
         self.mount_a.run_shell(['git', 'clone', remoteurl, '--depth', '1',
                                 self.xfstests_repo_path])
 
@@ -136,6 +140,10 @@ class XFSTestsDev(CephFSTestCase):
             remoteurl = 'https://git.ceph.com/xfsprogs-dev.git'
             self.xfsprogs_repo_path = self.mount_a.client_remote.mkdtemp(suffix=
                                                                 'xfsprogs-dev')
+            # Make the xfsprogs_repo_path to be readable and excutable for other
+            # users at all places, this will allow the xfstests to run the user
+            # namespace test cases.
+            self.mount_a.run_shell(['sudo', 'chmod', 'a+rx', self.xfsprogs_repo_path])
             self.mount_a.run_shell(['git', 'clone', remoteurl, '--depth', '1',
                                     self.xfsprogs_repo_path])
 


### PR DESCRIPTION
The user namespace test case will excute some commands as the other user. And the temporary direcotry have now the rx permission for other users by default and then will fail the tests.

This will chmod by making it to be readable and excutable.

Fixes: https://tracker.ceph.com/issues/58760





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
