### PR TITLE
CODEOWNERS: assign qa/workunits/windows to RBD

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,6 +104,7 @@ README*                                         @ceph/doc-writers
 /qa/workunits/cls/test_cls_lock.sh              @ceph/rbd
 /qa/workunits/cls/test_cls_rbd.sh               @ceph/rbd
 /qa/workunits/rbd                               @ceph/rbd
+/qa/workunits/windows                           @ceph/rbd
 /src/ceph-rbdnamer                              @ceph/rbd
 /src/cls/journal                                @ceph/rbd
 /src/cls/lock                                   @ceph/rbd @ceph/rgw


### PR DESCRIPTION
Assume ownership of qa/workunits/windows.  Despite the generic name, currently it has just rbd-wnbd tests.