### PR TITLE
rgw: handle old clients with transfer-encoding: chunked.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2516,8 +2516,15 @@ static inline void map_qs_metadata(req_state* s, bool crypto_too)
 
 int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
 {
-  if (!s->length)
-    return -ERR_LENGTH_REQUIRED;
+  if (!s->length) {
+    const char *encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
+    if (!encoding || strcmp(encoding, "chunked") != 0) {
+      ldout(s->cct, 20) << "neither length nor chunked encoding" << dendl;
+      return -ERR_LENGTH_REQUIRED;
+    }
+
+    chunked_upload = true;
+  }
 
   int ret;
 


### PR DESCRIPTION
s3 clients *should* provide an x-amz-decoded-content-length field when they use transport-encoding: chunked.  Some clients do not. With swift we already allow chunked uploads that do not specify the
content length in advance.   This commit adds similar support
for s3.  Known client affected by this: boto2.

Fixes: https://tracker.ceph.com/issues/45789
Resolves: rhbz#2152801

Signed-off-by: Marcus Watts <mwatts@redhat.com>

= = = = =   8<   = = = = =

Additional details from the BZ:
Description of problem:

- Cu is getting error 411, missing content length error for  PutObject operations for clients accessing via aws-sdk
Cu confirmed following implementation details:

```
library is '@aws-sdk/client-s3' with the version 3.54.0
they use it in javascript (node)
specific request type is PutObject with a stream, the content I can't give but it happens for any file from their testing, but please try various of object sizes.
The exact error is: "MissigContentLength: UnknownError"
```

Cu script:

```
import fs from 'fs';
import { Readable } from 'stream';

import { S3, PutObjectCommandInput, PutObjectCommandOutput } from '@aws-sdk/client-s3';
import { SdkStream } from '@aws-sdk/types';

const file = fs.createReadStream('/file/path')


const s3client = new S3({
	region: 's3Region',
	tls: true,
	forcePathStyle: true
	credentials: {
		accessKeyId: 'access key',
		secretAccessKey: 'secret key'
	},
	endpoint: 'endpoint'
});


const params: PutObjectCommandInput = {
	Bucket: bucket,
	Key: key,
	Body: file
};

const upload: PutObjectCommandOutput = await s3client.putObject(params, {});

return upload;
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
