### PR TITLE
quincy: rgw: Fix segfault due to concurrent socket use at timeout

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -336,6 +336,8 @@ struct Connection : boost::intrusive::list_base_hook<>,
   void close(boost::system::error_code& ec) {
     socket.close(ec);
   }
+
+  tcp_socket& get_socket() { return socket; }
 };
 
 class ConnectionList {

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -20,7 +20,8 @@ struct timeout_handler {
   void operator()(boost::system::error_code ec) {
     if (!ec) { // wait was not canceled
       boost::system::error_code ec_ignored;
-      stream->close(ec_ignored);
+      stream->get_socket().cancel();
+      stream->get_socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec_ignored);
     }
   }
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58772

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
