### PR TITLE
osd/scrub: convey scrub urgency in replica-reservation messages

### DIFF
--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -181,7 +181,8 @@ class ReplicaReservations {
   ReplicaReservations(PG* pg,
                       pg_shard_t whoami,
                       ScrubQueue::ScrubJobRef scrubjob,
-                      const ConfigProxy& conf); 
+                      const ConfigProxy& conf,
+                      bool is_urgent);
 
   ~ReplicaReservations();
 

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -20,7 +20,7 @@ namespace Scrub {
   class ReplicaReservations;
 }
 
-/// Facilitating scrub-realated object access to private PG data
+/// Facilitating scrub-related object access to private PG data
 class ScrubberPasskey {
 private:
   friend class Scrub::ReplicaReservations;


### PR DESCRIPTION
 so that replicas know to identify reservation requests for high priority
(e.g. operator initiated) scrubs and grant them regardless of concurrent scrubs limit.
