### PR TITLE
common: Add CINIT_FLAG_NO_CRYPTO_INIT to skip OpenSSL init

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -839,6 +839,9 @@ void CephContext::put() {
 
 void CephContext::init_crypto()
 {
+  if (get_init_flags() & CINIT_FLAG_NO_CRYPTO_INIT)
+    return;
+
   if (_crypto_inited++ == 0) {
     TOPNSPC::crypto::init();
   }

--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -41,6 +41,9 @@ enum common_init_flags_t {
 
   // don't expose default cct perf counters
   CINIT_FLAG_NO_CCT_PERF_COUNTERS = 0x40,
+
+  // don't initialize crypto
+  CINIT_FLAG_NO_CRYPTO_INIT = 0x80
 };
 
 #ifndef WITH_SEASTAR

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -88,6 +88,14 @@ enum {
   LIBRADOS_OP_FLAG_FADVISE_FUA        = 0x80,
 };
 
+/*
+ * Flags for rados_create2.
+ */
+enum {
+  // don't initialize/shutdown crypto library
+  LIBRADOS_CREATE_FLAG_NO_CRYPTO_INIT  = 0x1
+};
+
 #define CEPH_RADOS_API
 
 /**
@@ -440,7 +448,7 @@ CEPH_RADOS_API int rados_create(rados_t *cluster, const char * const id);
  * Like rados_create, but 
  * 1) don't assume 'client\.'+id; allow full specification of name
  * 2) allow specification of cluster name
- * 3) flags for future expansion
+ * 3) flags for (see librados.h constants beginning with LIBRADOS_CREATE_FLAG)
  */
 CEPH_RADOS_API int rados_create2(rados_t *pcluster,
                                  const char *const clustername,


### PR DESCRIPTION
This will skip initialization and shutdown of OpenSSL.

This can be useful/required when using librados in a project which already uses OpenSSL. Otherwise, librados will uninitialize OpenSSL (< 1.1) on rados_shutdown() and cause issues when the application uses OpenSSL afterwards.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket **waiting for tracker account**
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
