### PR TITLE
pacific: rbd-mirror: add information about the last snapshot sync to image status

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
@@ -238,8 +238,11 @@ private:
   DeepCopyHandler* m_deep_copy_handler = nullptr;
 
   TimeRollingMean m_bytes_per_second;
+  uint64_t m_last_snapshot_sync_seconds = 0;
 
   uint64_t m_snapshot_bytes = 0;
+  uint64_t m_last_snapshot_bytes = 0;
+
   boost::accumulators::accumulator_set<
     uint64_t, boost::accumulators::stats<
       boost::accumulators::tag::rolling_mean>> m_bytes_per_snapshot{


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58850

---

backport of https://github.com/ceph/ceph/pull/49299
parent tracker: https://tracker.ceph.com/issues/58755