### PR TITLE
crimson/os/seastore/journal: allow pending i/o in a full record_submitter when rolling the segment 2

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -32,7 +32,8 @@ SegmentedOolWriter::alloc_write_ertr::future<>
 SegmentedOolWriter::write_record(
   Transaction& t,
   record_t&& record,
-  std::list<LogicalCachedExtentRef>&& extents)
+  std::list<LogicalCachedExtentRef>&& extents,
+  bool with_atomic_roll_segment)
 {
   LOG_PREFIX(SegmentedOolWriter::write_record);
   assert(extents.size());
@@ -46,7 +47,9 @@ SegmentedOolWriter::write_record(
   stats.md_bytes += record.size.get_raw_mdlength();
   stats.num_records += 1;
 
-  return record_submitter.submit(std::move(record)
+  return record_submitter.submit(
+    std::move(record),
+    with_atomic_roll_segment
   ).safe_then([this, FNAME, &t, extents=std::move(extents)
               ](record_locator_t ret) mutable {
     DEBUGT("{} finish with {} and {} extents",
@@ -101,7 +104,8 @@ SegmentedOolWriter::do_write(
         assert(record_submitter.check_action(record.size) !=
                action_t::ROLL);
         fut_write = write_record(
-            t, std::move(record), std::move(pending_extents));
+            t, std::move(record), std::move(pending_extents),
+            true/* with_atomic_roll_segment */);
       }
       return trans_intr::make_interruptible(
         record_submitter.roll_segment(

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -84,7 +84,8 @@ private:
   alloc_write_ertr::future<> write_record(
     Transaction& t,
     record_t&& record,
-    std::list<LogicalCachedExtentRef> &&extents);
+    std::list<LogicalCachedExtentRef> &&extents,
+    bool with_atomic_roll_segment=false);
 
   journal::SegmentAllocator segment_allocator;
   journal::RecordSubmitter record_submitter;

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -468,11 +468,11 @@ RecordSubmitter::roll_segment_ertr::future<>
 RecordSubmitter::roll_segment()
 {
   LOG_PREFIX(RecordSubmitter::roll_segment);
-  assert(p_current_batch->needs_flush() ||
-         is_available());
+  ceph_assert(p_current_batch->needs_flush() ||
+              is_available());
   // #1 block concurrent submissions due to rolling
   wait_available_promise = seastar::shared_promise<>();
-  assert(!wait_unfull_flush_promise.has_value());
+  ceph_assert(!wait_unfull_flush_promise.has_value());
   return [FNAME, this] {
     if (p_current_batch->is_pending()) {
       if (state == state_t::FULL) {
@@ -529,7 +529,7 @@ RecordSubmitter::submit(
     bool with_atomic_roll_segment)
 {
   LOG_PREFIX(RecordSubmitter::submit);
-  assert(is_available());
+  ceph_assert(is_available());
   assert(check_action(record.size) != action_t::ROLL);
   segment_allocator.get_provider().update_modify_time(
       segment_allocator.get_segment_id(),
@@ -585,7 +585,7 @@ RecordSubmitter::submit(
         assert(p_current_batch->is_pending());
       } else {
         wait_available_promise = seastar::shared_promise<>();
-        assert(!wait_unfull_flush_promise.has_value());
+        ceph_assert(!wait_unfull_flush_promise.has_value());
         wait_unfull_flush_promise = seastar::promise<>();
         // flush and mark available in background
         std::ignore = wait_unfull_flush_promise->get_future(
@@ -675,14 +675,14 @@ RecordSubmitter::open(bool is_mkfs)
 RecordSubmitter::close_ertr::future<>
 RecordSubmitter::close()
 {
-  assert(state == state_t::IDLE);
-  assert(num_outstanding_io == 0);
+  ceph_assert(state == state_t::IDLE);
+  ceph_assert(num_outstanding_io == 0);
   committed_to = JOURNAL_SEQ_NULL;
-  assert(p_current_batch != nullptr);
-  assert(p_current_batch->is_empty());
-  assert(!wait_available_promise.has_value());
+  ceph_assert(p_current_batch != nullptr);
+  ceph_assert(p_current_batch->is_empty());
+  ceph_assert(!wait_available_promise.has_value());
   has_io_error = false;
-  assert(!wait_unfull_flush_promise.has_value());
+  ceph_assert(!wait_unfull_flush_promise.has_value());
   metrics.clear();
   return segment_allocator.close();
 }
@@ -719,7 +719,7 @@ void RecordSubmitter::decrement_io_with_flush()
       return;
     }
   } else {
-    assert(!wait_unfull_flush_promise.has_value());
+    ceph_assert(!wait_unfull_flush_promise.has_value());
   }
 
   auto needs_flush = (

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -348,7 +348,7 @@ public:
   // when available, submit the record if possible
   using submit_ertr = base_ertr;
   using submit_ret = submit_ertr::future<record_locator_t>;
-  submit_ret submit(record_t&&);
+  submit_ret submit(record_t&&, bool with_atomic_roll_segment=false);
 
   void update_committed_to(const journal_seq_t& new_committed_to) {
     assert(new_committed_to != JOURNAL_SEQ_NULL);


### PR DESCRIPTION
An alternate fix to https://github.com/ceph/ceph/pull/50249

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
