### PR TITLE
quincy: pybind/mgr: use memory temp_store for sqlite3 db

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1197,6 +1197,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         db.execute('PRAGMA JOURNAL_MODE = PERSIST')
         db.execute('PRAGMA PAGE_SIZE = 65536')
         db.execute('PRAGMA CACHE_SIZE = 64')
+        db.execute('PRAGMA TEMP_STORE = memory')
         db.row_factory = sqlite3.Row
         self.load_schema(db)
 

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -193,6 +193,7 @@ class SnapSchedClient(CephfsClient):
             db.execute('PRAGMA JOURNAL_MODE = PERSIST')
             db.execute('PRAGMA PAGE_SIZE = 65536')
             db.execute('PRAGMA CACHE_SIZE = 256')
+            db.execute('PRAGMA TEMP_STORE = memory')
             db.row_factory = sqlite3.Row
             # check for legacy dump store
             pool_param = cast(Union[int, str], poolid)


### PR DESCRIPTION
https://tracker.ceph.com/issues/58261