### PR TITLE
pacific: mon/MgrMap: dump last_failure_osd_epoch and active_clients at top level

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -32,10 +32,17 @@
   in certain recovery scenarios, e.g., monitor database lost and rebuilt, and
   the restored file system is expected to have the same ID as before.
 
+>=16.2.12
+---------
+
 * CEPHFS: Rename the `mds_max_retries_on_remount_failure` option to
   `client_max_retries_on_remount_failure` and move it from mds.yaml.in to
   mds-client.yaml.in because this option was only used by MDS client from its
   birth.
+
+* `ceph mgr dump` command now outputs `last_failure_osd_epoch` and
+  `active_clients` fields at the top level.  Previously, these fields were
+  output under `always_on_modules` field.
 
 >=16.2.11
 --------

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -514,13 +514,13 @@ public:
       }
       f->close_section();
     }
+    f->close_section(); // always_on_modules
     f->dump_int("last_failure_osd_epoch", last_failure_osd_epoch);
     f->open_array_section("active_clients");
     for (const auto &c : clients) {
       f->dump_object("client", c);
     }
-    f->close_section();
-    f->close_section();
+    f->close_section(); // active_clients
   }
 
   static void generate_test_instances(std::list<MgrMap*> &l) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58875

---

backport of https://github.com/ceph/ceph/pull/50006
parent tracker: https://tracker.ceph.com/issues/58647