### PR TITLE
quincy: mon/MgrMap: dump last_failure_osd_epoch and active_clients at top level

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+>=17.2.6
+--------
+
+* `ceph mgr dump` command now outputs `last_failure_osd_epoch` and
+  `active_clients` fields at the top level.  Previously, these fields were
+  output under `always_on_modules` field.
+
 >=17.2.5
 --------
 

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -514,13 +514,13 @@ public:
       }
       f->close_section();
     }
+    f->close_section(); // always_on_modules
     f->dump_int("last_failure_osd_epoch", last_failure_osd_epoch);
     f->open_array_section("active_clients");
     for (const auto &c : clients) {
       f->dump_object("client", c);
     }
-    f->close_section();
-    f->close_section();
+    f->close_section(); // active_clients
   }
 
   static void generate_test_instances(std::list<MgrMap*> &l) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58876

---

backport of https://github.com/ceph/ceph/pull/50006
parent tracker: https://tracker.ceph.com/issues/58647