### PR TITLE
cephfs: allow fs authorize to update auth

### DIFF
--- a/qa/suites/fs/functional/tasks/admin-fs-auth.yaml
+++ b/qa/suites/fs/functional/tasks/admin-fs-auth.yaml
@@ -1,0 +1,12 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        lockdep: true
+    log-ignorelist:
+      - missing required features
+tasks:
+  - cephfs_test_runner:
+      fail_on_skip: false
+      modules:
+        - tasks.cephfs.admin.test_fs_authorize

--- a/qa/tasks/cephfs/admin/test_fs_authorize.py
+++ b/qa/tasks/cephfs/admin/test_fs_authorize.py
@@ -1,0 +1,445 @@
+from logging import getLogger
+from io import StringIO
+
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from tasks.cephfs.caps_helper import CapTester
+
+
+log = getLogger(__name__)
+
+
+class FsAuthorizeUpdate(CephFSTestCase):
+    def setUp(self):
+        super(FsAuthorizeUpdate, self).setUp()
+        self.captester = CapTester()
+
+class ClientWithCapsForNoFs(FsAuthorizeUpdate):
+    """
+    Contains tests for cases where "ceph fs authorize" command is run for a
+    client that doesn't have any caps for any FS.
+    """
+
+    client_id = 'testuser'
+    client_name = f'client.{client_id}'
+    MDSS_REQUIRED = 1
+
+    def test_update_for_client_with_no_caps(self):
+        """
+        Test that "ceph fs authorize" adds caps to the keyring when the
+        entity already has a keyring but it contains no caps.
+        """
+        self.captester.write_test_files((self.mount_a,))
+        self.run_cluster_cmd(f'auth add {self.client_name}')
+
+        # testing begins here.
+        TEST_PERM = 'rw'
+        self.fs.authorize(self.client_id, ('/', TEST_PERM,))
+
+        keyring = self.run_cluster_cmd(f'auth get {self.client_name}')
+        mon_cap = f'caps mon = "allow r fsname={self.fs.name}"'
+        osd_cap = f'caps osd = "allow rw tag cephfs data={self.fs.name}"'
+        mds_cap = f'caps mds = "allow rw fsname={self.fs.name}"'
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+        self.captester.run_cap_tests(TEST_PERM)
+
+
+class ClientWithCapsForOneFs(FsAuthorizeUpdate):
+    """
+    Contains tests for the case where "ceph fs authorize" is executed for an
+    a client that has caps for one FS.
+    """
+
+    client_id = 'testuser'
+    client_name = f'client.{client_id}'
+    CLIENTS_REQUIRED = 2
+    MDSS_REQUIRED = 2
+
+    def test_add_caps_for_second_fs(self):
+        """
+        Test that "ceph fs authorize" adds caps for a second FS to a keyring
+        that already had caps for first FS.
+        """
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+        self.captester.write_test_files((self.mount_a, self.mount_b))
+
+        self.mount_a.umount()
+        self.mount_b.umount()
+        self.fs1.authorize(self.client_id, ('/', 'rw',))
+
+        # testing begins here.
+        TEST_PERM = 'rw'
+        self.fs2.authorize(self.client_id, ('/', TEST_PERM,))
+
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+                args=f'auth get {self.client_name}', stdout=StringIO()).\
+                stdout.getvalue()
+        mon_cap = (f'caps mon = "allow r fsname={self.fs1.name}, '
+                               f'allow r fsname={self.fs2.name}"')
+        osd_cap = (f'caps osd = "allow rw tag cephfs data={self.fs1.name}, '
+                               f'allow rw tag cephfs data={self.fs2.name}"')
+        mds_cap = (f'caps mds = "allow rw fsname={self.fs1.name}, '
+                               f'allow rw fsname={self.fs2.name}"')
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        keyring_path_b = self.mount_b.client_remote.mktemp(data=keyring)
+
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt='/', cephfs_name=self.fs1.name)
+        self.mount_b.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_b,
+                           cephfs_mntpt='/', cephfs_name=self.fs2.name)
+        self.captester.run_cap_tests(TEST_PERM)
+
+    def test_change_perms(self):
+        """
+        Test that "ceph fs authorize" updates the caps for a FS when the caps
+        for that FS were already present in that keyring.
+        """
+        OLD_PERM = 'rw'
+        NEW_PERM = 'r'
+        self.captester.write_test_files((self.mount_a,))
+        self.mount_a.umount()
+
+        self.fs.authorize(self.client_id, ('/', OLD_PERM,))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt='/', cephfs_name=self.fs.name)
+        self.mount_a.umount()
+
+        # testing begins here
+        self.fs.authorize(self.client_id, ('/', NEW_PERM,))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = f'caps mon = "allow r fsname={self.fs.name}"'
+        osd_cap = f'caps osd = "allow {NEW_PERM} tag cephfs data={self.fs.name}"'
+        mds_cap = f'caps mds = "allow {NEW_PERM} fsname={self.fs.name}"'
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt='/', cephfs_name=self.fs.name)
+        self.captester.run_cap_tests(NEW_PERM)
+
+    def test_change_path_from_default_path(self):
+        """
+        "fs authorize" is executed first time to add the default path, the
+        root path. So, there's no path mentioned in th MDS cap. Now, test
+        that running "fs authorize" second time with a specific path,
+        upgrades MDS cap with a new path.
+        """
+        PERM = 'rw'
+        OLD_MNTPT = '/'
+        NEW_MNTPT = '/dir1/dir2/dir3'
+        # XXX: The "." before "{OLD_MNTPT}" in following line is pretty
+        # crucial since otherwise these dirs will be created in "/" of
+        # host/local FS.
+        self.mount_a.run_shell(f'mkdir -p .{NEW_MNTPT}')
+        self.captester.write_test_files((self.mount_a,), NEW_MNTPT)
+        self.mount_a.umount()
+
+        # TODO: this block is redundant
+        OLD_MNTPT = '/'
+        self.fs.authorize(self.client_id, (OLD_MNTPT, PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=OLD_MNTPT, cephfs_name=self.fs.name)
+
+        self.mount_a.umount()
+
+        # testing begins here
+        self.fs.authorize(self.client_id, (NEW_MNTPT, PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = f'caps mon = "allow r fsname={self.fs.name}"'
+        osd_cap = f'caps osd = "allow rw tag cephfs data={self.fs.name}"'
+        mds_cap = f'caps mds = "allow rw fsname={self.fs.name} path={NEW_MNTPT}"'
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=NEW_MNTPT, cephfs_name=self.fs.name)
+        self.captester.run_cap_tests(PERM, mntpt=NEW_MNTPT)
+
+    def test_change_path_from_custom_path(self):
+        """
+        "fs authorize" is executed first time to add a custom path. Test
+        that running "fs authorize" second time with a new path, replaces
+        the first path by the new one in MDS cap.
+        """
+        PERM = 'rw'
+        OLD_MNTPT = '/dir1/dir2/dir3'
+        NEW_MNTPT = '/dir4/dir5/dir6'
+        # XXX: The "." before "{OLD_MNTPT}" and "{NEW_MNTPT}" in following
+        # two lines respectively is pretty crucial since otherwise these dirs
+        # will be created in "/" of host/local FS.
+        self.mount_a.run_shell(f'mkdir -p .{OLD_MNTPT}')
+        self.mount_a.run_shell(f'mkdir -p .{NEW_MNTPT}')
+        self.captester.write_test_files((self.mount_a,), NEW_MNTPT)
+        self.mount_a.umount()
+
+        self.fs.authorize(self.client_id, (OLD_MNTPT, PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=OLD_MNTPT, cephfs_name=self.fs.name)
+
+        self.mount_a.umount()
+
+        # testing begins here
+        self.fs.authorize(self.client_id, (NEW_MNTPT, PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = f'caps mon = "allow r fsname={self.fs.name}"'
+        osd_cap = f'caps osd = "allow rw tag cephfs data={self.fs.name}"'
+        mds_cap = f'caps mds = "allow rw fsname={self.fs.name} path={NEW_MNTPT}"'
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=NEW_MNTPT, cephfs_name=self.fs.name)
+        self.captester.run_cap_tests(PERM, mntpt=NEW_MNTPT)
+
+    def test_change_both_perm_and_path(self):
+        """
+        "fs authorize" is executed first time to add a custom path. Test
+        that running "fs authorize" second time with a new path, replaces
+        the first path by the new one in MDS cap.
+        """
+        OLD_PERM = 'rw'
+        NEW_PERM = 'r'
+        OLD_MNTPT = '/dir1/dir2/dir3'
+        NEW_MNTPT = '/dir4/dir5/dir6'
+        # XXX: The "." before "{OLD_MNTPT}" and "{NEW_MNTPT}" in following
+        # two lines respectively is pretty crucial since otherwise these dirs
+        # will be created in "/" of host/local FS.
+        self.mount_a.run_shell(f'mkdir -p .{OLD_MNTPT}')
+        self.mount_a.run_shell(f'mkdir -p .{NEW_MNTPT}')
+        self.captester.write_test_files((self.mount_a,), NEW_MNTPT)
+        self.mount_a.umount()
+
+        self.fs.authorize(self.client_id, (OLD_MNTPT, OLD_PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=OLD_MNTPT, cephfs_name=self.fs.name)
+        self.mount_a.umount()
+
+        # testing begins here
+        self.fs.authorize(self.client_id, (NEW_MNTPT, NEW_PERM))
+        keyring = self.fs.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = f'caps mon = "allow r fsname={self.fs.name}"'
+        osd_cap = f'caps osd = "allow {NEW_PERM} tag cephfs data={self.fs.name}"'
+        mds_cap = f'caps mds = "allow {NEW_PERM} fsname={self.fs.name} path={NEW_MNTPT}"'
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.mount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt=NEW_MNTPT, cephfs_name=self.fs.name)
+        self.captester.run_cap_tests(NEW_PERM, mntpt=NEW_MNTPT)
+
+    ##### Idempotency test
+
+    def test_caps_passed_same_as_current_caps(self):
+        """
+        Test that "ceph fs authorize" exits with the keyring on stdout and the
+        expected error message on stderr when caps supplied to the subcommand
+        are already present in the entity's keyring.
+        """
+        self.fs.authorize(self.client_id, ('/', 'rw')).strip()
+        keyring1 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        # testing begins here.
+        proc = self.fs.mon_manager.run_cluster_cmd(
+            args=f'fs authorize {self.fs.name} {self.client_name} / rw',
+            stdout=StringIO(), stderr=StringIO())
+        errmsg = proc.stderr.getvalue()
+        keyring2 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        self.assertIn(keyring1, keyring2)
+        self.assertIn(f'{self.client_name} already has caps that are same as '
+                       'those supplied', errmsg)
+
+
+# TODO: add more tests to check change of path and perms in case of caps
+# for two FSs
+# TODO: add similar tests to check change of path and perms in case of caps
+# for 3 FSs? C++ code has 3 4 cases - current MDS cap has only FS name
+# (first case), it has multiple name and new FS names matches first cap
+# (second case), or last cap (third case) or some cap in middle (fourth case)
+# BETTER TO UNDERTAKE THIS AFTER REGEX CODE IS REPLACED BY PARSER CODE.
+class ClientWithCapsForTwoFss(FsAuthorizeUpdate):
+    """
+    Contains tests for the case where "ceph fs authorize" is run against a
+    client containing caps for 2 FSs.
+    """
+
+    client_id = 'testuser'
+    client_name = f'client.{client_id}'
+    CLIENTS_REQUIRED = 2
+    MDSS_REQUIRED = 2
+
+    # TODO: definitely needs another review and some modifications.
+    def test_change_perms(self):
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+        # TODO: needs update?
+        OLD_PERM = 'rw'
+        NEW_PERM = 'r'
+        self.captester_a = self.captester
+        del self.captester # so there's no chance of bug due to typo ever.
+        self.captester_a.write_test_files((self.mount_a,))
+        self.captester_b = CapTester()
+        self.captester_b.write_test_files((self.mount_b,))
+        self.mount_a.umount()
+        self.mount_b.umount()
+        self.fs1.authorize(self.client_id, ('/', OLD_PERM,))
+        self.fs2.authorize(self.client_id, ('/', OLD_PERM,))
+
+
+        # testing begins here.
+        self.fs1.authorize(self.client_id, ('/', NEW_PERM,))
+
+        keyring = self.fs1.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = (f'caps mon = "allow r fsname={self.fs1.name}, '
+                               f'allow r fsname={self.fs2.name}"')
+        osd_cap = (f'caps osd = "allow {NEW_PERM} tag cephfs data={self.fs1.name}, '
+                               f'allow {OLD_PERM} tag cephfs data={self.fs2.name}"')
+        mds_cap = (f'caps mds = "allow {NEW_PERM} fsname={self.fs1.name}, '
+                               f'allow {OLD_PERM} fsname={self.fs2.name}"')
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        keyring_path_b = self.mount_b.client_remote.mktemp(data=keyring)
+        self.mount_a.remount(client_id=self.client_id,
+                             client_keyring_path=keyring_path_a,
+                             cephfs_mntpt='/', cephfs_name=self.fs1.name)
+        self.mount_b.remount(client_id=self.client_id,
+                             client_keyring_path=keyring_path_b,
+                             cephfs_mntpt='/', cephfs_name=self.fs2.name)
+        self.captester_a.run_cap_tests(NEW_PERM)
+
+
+        self.fs2.authorize(self.client_id, ('/', NEW_PERM,))
+
+        keyring = self.fs1.mon_manager.run_cluster_cmd(
+            args=f'auth get {self.client_name}', stdout=StringIO()).\
+            stdout.getvalue()
+        mon_cap = (f'caps mon = "allow r fsname={self.fs1.name}, '
+                               f'allow r fsname={self.fs2.name}"')
+        osd_cap = (f'caps osd = "allow {NEW_PERM} tag cephfs data={self.fs1.name}, '
+                               f'allow {NEW_PERM} tag cephfs data={self.fs2.name}"')
+        mds_cap = (f'caps mds = "allow {NEW_PERM} fsname={self.fs1.name}, '
+                               f'allow {NEW_PERM} fsname={self.fs2.name}"')
+        for cap in (mon_cap, osd_cap, mds_cap):
+            self.assertIn(cap, keyring)
+
+        keyring_path_a = self.mount_a.client_remote.mktemp(data=keyring)
+        keyring_path_b = self.mount_b.client_remote.mktemp(data=keyring)
+        self.mount_a.remount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_a,
+                           cephfs_mntpt='/', cephfs_name=self.fs1.name)
+        self.mount_b.remount(client_id=self.client_id,
+                           client_keyring_path=keyring_path_b,
+                           cephfs_mntpt='/', cephfs_name=self.fs2.name)
+        self.captester_b.run_cap_tests(NEW_PERM)
+
+
+    # XXX: is this redundant given same test in TestUpdateCapsForOneFs?
+    # TODO:
+    def _test_change_paths(self):
+        pass
+
+    ##### Idempotency tests
+
+    def test_fs_one_supplied_again(self):
+        """
+        For a client holding caps for 2 FSs, pass client caps for first of the
+        two FSs to "fs authorize" to test idempotency.
+        """
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+        self.mount_a.umount()
+        self.mount_b.umount()
+        self.fs1.authorize(self.client_id, ('/', 'rw',))
+        self.fs2.authorize(self.client_id, ('/', 'rw',))
+        keyring1 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        # actual testing begings here
+        proc = self.fs1.mon_manager.run_cluster_cmd(
+            args=f'fs authorize {self.fs1.name} {self.client_name} / rw',
+            stdout=StringIO(), stderr=StringIO())
+        errmsg = proc.stderr.getvalue()
+        keyring2 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        self.assertIn(keyring1, keyring2)
+        self.assertIn(f'{self.client_name} already has caps that are same as '
+                       'those supplied', errmsg)
+
+    def test_fs_two_supplied_again(self):
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+        self.mount_a.umount()
+        self.mount_b.umount()
+        self.fs1.authorize(self.client_id, ('/', 'rw',))
+        self.fs2.authorize(self.client_id, ('/', 'rw',))
+        keyring1 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        proc = self.fs2.mon_manager.run_cluster_cmd(
+            args=f'fs authorize {self.fs2.name} {self.client_name} / rw',
+            stdout=StringIO(), stderr=StringIO())
+        errmsg = proc.stderr.getvalue()
+        keyring2 = self.fs.mon_manager.get_keyring(f'{self.client_id}')
+
+        self.assertIn(keyring1, keyring2)
+        self.assertIn(f'{self.client_name} already has caps that are same as '
+                       'those supplied', errmsg)
+
+
+# TODO: vstart_runner run classes not starting with 'Test' as well? Is this
+# also how teuthology's test runner behaves? IMHO, this is not acceptible.
+# TODO: the idea of following class is to be able to group tests in a such
+# away that subgroups are in different classes so that they can be run
+# individually if and when needed and yet a single class can be used by the
+# test runner to run all related test groups together.
+#class TestFsAuthorizeUpdate(ClientWithCapsForNoFS, ClientWithCapsForOneFs,
+#                            ClientWithCapsForTwoFSs):
+#    pass

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -4,7 +4,7 @@ Test for Ceph clusters with multiple FSs.
 import logging
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
-from tasks.cephfs.caps_helper import CapTester
+from tasks.cephfs.caps_helper import CapTester, CapsUtil
 
 from teuthology.exceptions import CommandFailedError
 
@@ -12,7 +12,7 @@ from teuthology.exceptions import CommandFailedError
 log = logging.getLogger(__name__)
 
 
-class TestMultiFS(CephFSTestCase):
+class TestMultiFS(CephFSTestCase, CapsUtil):
     client_id = 'testuser'
     client_name = 'client.' + client_id
     # one dedicated for each FS
@@ -41,20 +41,19 @@ class TestMultiFS(CephFSTestCase):
 class TestMONCaps(TestMultiFS):
 
     def test_moncap_with_one_fs_names(self):
-        moncap = f'allow r fsname={self.fs1.name}'
+        moncap = self.gen_moncap_str((('r', self.fs1.name),))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_multiple_fs_names(self):
-        moncap = (f'allow r fsname={self.fs1.name}, '
-                  f'allow r fsname={self.fs2.name}')
+        moncap = self.gen_moncap_str((('r', self.fs1.name), ('r', self.fs2.name)))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_blanket_allow(self):
-        moncap = 'allow r'
+        moncap = self.gen_moncap_str((('r',),))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
@@ -72,11 +71,12 @@ class TestMDSCaps(TestMultiFS):
     def setUp(self):
         super(self.__class__, self).setUp()
         self.mounts = (self.mount_a, self.mount_b)
+        self.fss = (self.fs1.name, self.fs2.name)
 
     def test_rw_with_fsname_and_no_path_in_cap(self):
         PERM = 'rw'
         self.captester.write_test_files(self.mounts)
-        keyring_paths = self._create_client(PERM, fsname=True)
+        keyring_paths = self._create_client(PERM, self.fss)
         self.remount_with_new_client(keyring_paths)
 
         self.captester.run_mds_cap_tests(PERM)
@@ -84,27 +84,27 @@ class TestMDSCaps(TestMultiFS):
     def test_r_with_fsname_and_no_path_in_cap(self):
         PERM = 'r'
         self.captester.write_test_files(self.mounts)
-        keyring_paths = self._create_client(PERM, fsname=True)
+        keyring_paths = self._create_client(PERM, self.fss)
         self.remount_with_new_client(keyring_paths)
 
         self.captester.run_mds_cap_tests(PERM)
 
     def test_rw_with_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'rw', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'rw', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
-        keyring_paths = self._create_client(PERM, fsname=True)
+        keyring_paths = self._create_client(PERM, self.fss)
         self.remount_with_new_client(keyring_paths, CEPHFS_MNTPT)
 
         self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     def test_r_with_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'r', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'r', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
-        keyring_paths = self._create_client(PERM, fsname=True)
+        keyring_paths = self._create_client(PERM, self.fss)
         self.remount_with_new_client(keyring_paths, CEPHFS_MNTPT)
 
         self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
@@ -112,9 +112,9 @@ class TestMDSCaps(TestMultiFS):
     # XXX: this tests the backward compatibility; "allow rw path=<dir1>" is
     # treated as "allow rw fsname=* path=<dir1>"
     def test_rw_with_no_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'rw', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'rw', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
         keyring_paths = self._create_client(PERM)
         self.remount_with_new_client(keyring_paths, CEPHFS_MNTPT)
@@ -124,9 +124,9 @@ class TestMDSCaps(TestMultiFS):
     # XXX: this tests the backward compatibility; "allow r path=<dir1>" is
     # treated as "allow r fsname=* path=<dir1>"
     def test_r_with_no_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'r', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'r', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
         keyring_paths = self._create_client(PERM)
         self.remount_with_new_client(keyring_paths, CEPHFS_MNTPT)
@@ -155,41 +155,32 @@ class TestMDSCaps(TestMultiFS):
 
         super(type(self), self).tearDown()
 
-    def generate_caps(self, perm, fsname, cephfs_mntpt):
-        moncap = 'allow r'
-        osdcap = (f'allow {perm} tag cephfs data={self.fs1.name}, '
-                  f'allow {perm} tag cephfs data={self.fs2.name}')
-
-        if fsname:
-            if cephfs_mntpt == '/':
-                mdscap = (f'allow {perm} fsname={self.fs1.name}, '
-                          f'allow {perm} fsname={self.fs2.name}')
-            else:
-                mdscap = (f'allow {perm} fsname={self.fs1.name} '
-                          f'path=/{cephfs_mntpt}, '
-                          f'allow {perm} fsname={self.fs2.name} '
-                          f'path=/{cephfs_mntpt}')
+    def gen_caps(self, perm, fsnames=(), cephfs_mntpt='/'):
+        if fsnames:
+            mdscaps = self.gen_mdscap_str(
+                ((perm, self.fs1.name, cephfs_mntpt),
+                 (perm, self.fs2.name, cephfs_mntpt)))
         else:
-            if cephfs_mntpt == '/':
-                mdscap = f'allow {perm}'
-            else:
-                mdscap = f'allow {perm} path=/{cephfs_mntpt}'
+            mdscaps = self.gen_mdscap_str(((perm, None, cephfs_mntpt),))
 
-        return moncap, osdcap, mdscap
+        return (
+            self.gen_moncap_str((('r', ()),)),
+            self.gen_osdcap_str(((perm, self.fs1.name),
+                                 (perm, self.fs2.name))),
+            mdscaps,
+            )
 
-    def _create_client(self, perm, fsname=False, cephfs_mntpt='/'):
-        moncap, osdcap, mdscap = self.generate_caps(perm, fsname,
-                                                    cephfs_mntpt)
-
+    def _create_client(self, perm, fsnames=(), cephfs_mntpt='/'):
+        moncap, osdcap, mdscap = self.gen_caps(perm, fsnames, cephfs_mntpt)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         keyring_paths = []
         for mount_x in self.mounts:
             keyring_paths.append(mount_x.client_remote.mktemp(data=keyring))
-
         return keyring_paths
 
     def remount_with_new_client(self, keyring_paths, cephfs_mntpt='/'):
-        if isinstance(cephfs_mntpt, str) and cephfs_mntpt != '/' :
+        if (isinstance(cephfs_mntpt, str) and cephfs_mntpt != '/'  and
+            cephfs_mntpt[0] != '/'):
             cephfs_mntpt = '/' + cephfs_mntpt
 
         self.mount_a.remount(client_id=self.client_id,

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -169,6 +169,8 @@ private:
                   Formatter* fmtr);
   void _print_auth(EntityName& entity, EntityAuth& eauth, bufferlist& rdata,
                    Formatter* fmtr, bool just_key=false);
+  int _update_caps(EntityName& entity, std::vector<std::string>& caps_vec,
+		   MonOpRequestRef op);
 
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -171,6 +171,8 @@ private:
                    Formatter* fmtr, bool just_key=false);
   int _update_caps(EntityName& entity, std::vector<std::string>& caps_vec,
 		   MonOpRequestRef op);
+  bool _gen_wanted_caps(EntityAuth& e_auth, std::vector<std::string>& newcaps,
+			std::string& fs);
 
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -165,6 +165,10 @@ private:
 
   bool preprocess_command(MonOpRequestRef op);
   bool prepare_command(MonOpRequestRef op);
+  void _print_key(EntityName& entity, EntityAuth& eauth, bufferlist& rdata,
+                  Formatter* fmtr);
+  void _print_auth(EntityName& entity, EntityAuth& eauth, bufferlist& rdata,
+                   Formatter* fmtr, bool just_key=false);
 
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>