### PR TITLE
mon, osd: set subsystem prefix for logging MonCap and OSDCap

### DIFF
--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -32,6 +32,11 @@
 
 #include "include/ceph_assert.h"
 
+#define dout_subsys ceph_subsys_mon
+
+#undef dout_prefix
+#define dout_prefix *_dout << "MonCap "
+
 using std::list;
 using std::map;
 using std::ostream;

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -23,6 +23,11 @@
 #include "common/debug.h"
 #include "include/ipaddr.h"
 
+#define dout_subsys ceph_subsys_osd
+
+#undef dout_prefix
+#define dout_prefix *_dout << "OSDCap "
+
 using std::ostream;
 using std::string;
 using std::vector;


### PR DESCRIPTION
Set subsys and prefix for logging in MonCap and OSDCap

Figured out this set of changes while working on PR #41779.


With this patch following is how log entries from MonCap.cc look -

```
2023-04-10T22:15:25.746+0530 7fa5debf46c0 20 MonCap is_capable service=mon command= read addr v2:192.168.29.90:40719/0 on cap allow *
2023-04-10T22:15:25.746+0530 7fa5debf46c0 20 MonCap  allow so far , doing grant allow *
2023-04-10T22:15:25.746+0530 7fa5debf46c0 20 MonCap  allow all
```

And this is how same log entries from MonCap.cc look without this patch -

```
2023-04-10T22:23:32.214+0530 7f1fb27f46c0 20 is_capable service=mon command= read addr v2:192.168.29.90:40164/0 on cap allow *
2023-04-10T22:23:32.214+0530 7f1fb27f46c0 20  allow so far , doing grant allow *
2023-04-10T22:23:32.214+0530 7f1fb27f46c0 20  allow all
```

Here are the links to these log entries in the codebase -
https://github.com/ceph/ceph/blob/main/src/mon/MonCap.cc#L459
https://github.com/ceph/ceph/blob/main/src/mon/MonCap.cc#L471
https://github.com/ceph/ceph/blob/main/src/mon/MonCap.cc#L484






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>