### PR TITLE
RGW: add new cap 'keys'

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -184,6 +184,10 @@
   than the number mentioned against the config tunable `mds_max_snaps_per_dir`
   so that a new snapshot can be created and retained during the next schedule
   run.
+* RGW: A new "keys" capability was added to the /admin/user REST APIs.
+  The "keys=write" capability is now required to create users or modify a users
+  keys or a subusers keys. The "keys=read" is required to read them.
+
 
 >=17.2.1
 

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -311,7 +311,7 @@ To add administrative capabilities to a user, execute the following::
 You can add read, write or all capabilities to users, buckets, metadata and 
 usage (utilization). For example::
 
-	--caps="[users|buckets|metadata|usage|zone|amz-cache|info|bilog|mdlog|datalog|user-policy|oidc-provider|roles|ratelimit]=[*|read|write|read, write]"
+	--caps="[users|keys|buckets|metadata|usage|zone|amz-cache|info|bilog|mdlog|datalog|user-policy|oidc-provider|roles|ratelimit]=[*|read|write|read, write]"
 
 For example::
 

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -275,7 +275,7 @@ Get User Info
 
 Get user information.
 
-:caps: users=read
+:caps: users=read; keys=read
 
 
 Syntax
@@ -340,13 +340,13 @@ If successful, the response contains the user information.
 
 ``keys``
 
-:Description: S3 keys associated with this user account.
+:Description: S3 keys associated with this user account. This content can only be viewed if the user has the cap ``keys=read``.
 :Type: Container
 :Parent: ``user``
 
 ``swift_keys``
 
-:Description: Swift keys associated with this user account.
+:Description: Swift keys associated with this user account. This content can only be viewed if the user has the cap ``keys=read``.
 :Type: Container
 :Parent: ``user``
 
@@ -376,7 +376,7 @@ then it will be modified.
 A ``tenant`` may either be specified as a part of uid or as an additional
 request param.
 
-:caps: users=write
+:caps: users=write; keys=write
 
 Syntax
 ~~~~~~
@@ -588,7 +588,7 @@ Modify User
 
 Modify a user.
 
-:caps: users=write
+:caps: users=write; keys=write
 
 Syntax
 ~~~~~~
@@ -625,21 +625,21 @@ Request Parameters
 
 ``generate-key``
 
-:Description: Generate a new key pair and add to the existing keyring.
+:Description: Generate a new key pair and add to the existing keyring. Generating keys requires the cap ``keys=write``.
 :Type: Boolean
 :Example: True [False]
 :Required: No
 
 ``access-key``
 
-:Description: Specify access key.
+:Description: Specify access key. Specifying the access key requires the cap ``keys=write``. A ``secret-key`` must also be a parameter in the request. 
 :Type: String
 :Example: ``ABCD0EF12GHIJ2K34LMN``
 :Required: No
 
 ``secret-key``
 
-:Description: Specify secret key.
+:Description: Specify secret key. Specifying the access key requires the cap ``keys=write``. An ``access-key`` must also be a parameter in the request.
 :Type: String
 :Example: ``0AbCDEFg1h2i34JklM5nop6QrSTUV+WxyzaBC7D8``
 :Required: No
@@ -718,14 +718,14 @@ If successful, the response contains the user information.
 
 ``keys``
 
-:Description: S3 keys associated with this user account.
+:Description: S3 keys associated with this user account. S3 keys will not be visible without the cap ``keys=read``.
 :Type: Container
 :Parent: ``user``
 
 
 ``swift_keys``
 
-:Description: Swift keys associated with this user account.
+:Description: Swift keys associated with this user account. Swift keys will not be visible without the cap ``keys=read``.
 :Type: Container
 :Parent: ``user``
 
@@ -932,7 +932,7 @@ Modify Subuser
 
 Modify an existing subuser
 
-:caps: users=write
+:caps: users=write; keys=write
 
 Syntax
 ~~~~~~
@@ -963,14 +963,16 @@ Request Parameters
 ``generate-secret``
 
 :Description: Generate a new secret key for the subuser,
-              replacing the existing key.
+              replacing the existing key. To generate a new secret
+              key the cap ``keys=write`` must be set.
 :Type: Boolean
 :Example: True [False]
 :Required: No
 
 ``secret``
 
-:Description: Specify secret key.
+:Description: Specify secret key. To specify a secret key the cap
+              ``keys=write`` must be set.
 :Type: String
 :Example: ``0AbCDEFg1h2i34JklM5nop6QrSTUV+WxyzaBC7D8``
 :Required: No
@@ -1037,7 +1039,7 @@ Remove Subuser
 
 Remove an existing subuser
 
-:caps: users=write
+:caps: users=write; keys=write
 
 Syntax
 ~~~~~~
@@ -1069,6 +1071,7 @@ Request Parameters
 ``purge-keys``
 
 :Description: Remove keys belonging to the subuser.
+              To purge keys the cap ``keys=write`` must be set.
 :Type: Boolean
 :Example: True [True]
 :Required: No
@@ -1096,7 +1099,7 @@ type as the key created. Note that when creating a swift key, specifying the opt
 ``access-key`` will have no effect. Additionally, only one swift key may be held by
 each user or subuser.
 
-:caps: users=write
+:caps: users=write; keys=read, write
 
 
 Syntax
@@ -1214,7 +1217,7 @@ Remove Key
 
 Remove an existing key.
 
-:caps: users=write
+:caps: users=write; keys=write
 
 Syntax
 ~~~~~~

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -41,7 +41,7 @@ class RgwTestCase(DashboardTestCase):
             ])
             cls._radosgw_admin_cmd([
                 'caps', 'add', '--uid', 'teuth-test-user', '--caps',
-                'metadata=write'
+                'metadata=write;keys=*'
             ])
             cls._radosgw_admin_cmd([
                 'subuser', 'create', '--uid', 'teuth-test-user', '--subuser',
@@ -656,7 +656,9 @@ class RgwUserCapabilityTest(RgwTestCase):
             '/api/rgw/user/teuth-test-user/capability',
             params={
                 'type': 'metadata',
-                'perm': 'write'
+                'perm': 'write',
+                'type': 'keys',
+                'perm': '*'
             })
         self.assertStatus(204)
 

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -651,32 +651,19 @@ class RgwUserCapabilityTest(RgwTestCase):
         self.assertEqual(data['caps'][0]['type'], 'usage')
         self.assertEqual(data['caps'][0]['perm'], 'read')
 
-    def test_delete(self):
-        self._post(
-            '/api/rgw/user/teuth-test-user/capability',
-            params={
-                'type': 'metadata',
-                'perm': 'read',
-            })
-        self.assertStatus(201)
-        data = self.jsonBody()
-        self.assertEqual(len(data), 1)
-        data = data[0]
-        self.assertEqual(data['type'], 'metadata')
-        self.assertEqual(data['perm'], 'read')
-
-        self._delete(
-            '/api/rgw/user/teuth-test-user/capability',
-            params={
-                'type': 'metadata',
-                'perm': 'read',
-            })
-        self.assertStatus(204)
+    #def test_delete(self):
+        #self._delete(
+            #'/api/rgw/user/teuth-test-user/capability',
+            #params={
+                #'type': 'metadata',
+                #'perm': 'read',
+            #})
+        #self.assertStatus(204)
 
         # Get the user data to validate the capabilities.
-        data = self.get_rgw_user('teuth-test-user')
-        self.assertStatus(200)
-        self.assertEqual(len(data['caps']), 0)
+        #data = self.get_rgw_user('teuth-test-user')
+        #self.assertStatus(200)
+        #self.assertEqual(len(data['caps']), 0)
 
 
 class RgwUserKeyTest(RgwTestCase):

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -652,13 +652,24 @@ class RgwUserCapabilityTest(RgwTestCase):
         self.assertEqual(data['caps'][0]['perm'], 'read')
 
     def test_delete(self):
+        self._post(
+            '/api/rgw/user/teuth-test-user/capability',
+            params={
+                'type': 'metadata',
+                'perm': 'read',
+            })
+        self.assertStatus(201)
+        data = self.jsonBody()
+        self.assertEqual(len(data), 1)
+        data = data[0]
+        self.assertEqual(data['type'], 'metadata')
+        self.assertEqual(data['perm'], 'read')
+
         self._delete(
             '/api/rgw/user/teuth-test-user/capability',
             params={
                 'type': 'metadata',
-                'perm': 'write',
-                'type': 'keys',
-                'perm': '*'
+                'perm': 'read',
             })
         self.assertStatus(204)
 

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -223,6 +223,7 @@ def _get_user_keys(user: str, realm: Optional[str] = None) -> Tuple[str, str]:
                 'user', 'create',
                 '--uid', user,
                 '--display-name', 'Ceph Dashboard',
+                '--caps', 'keys=*'
                 '--system',
             ] + cmd_realm_option
             _, out, err = mgr.send_rgwadmin_command(rgw_create_user_cmd)

--- a/src/rgw/driver/rados/rgw_cr_tools.cc
+++ b/src/rgw/driver/rados/rgw_cr_tools.cc
@@ -88,7 +88,12 @@ int RGWUserCreateCR::Request::_send_request(const DoutPrefixProvider *dpp)
   }
 
   RGWNullFlusher flusher;
-  return RGWUserAdminOp_User::create(dpp, store, op_state, flusher, null_yield);
+  bool dump_keys = true;
+  int keys_perm = op_state.get_caps_obj()->check_cap("keys", RGW_CAP_READ);
+  if(keys_perm < 0) {
+    dump_keys = false;
+  }
+  return RGWUserAdminOp_User::create(dpp, store, op_state, flusher, dump_keys, null_yield);
 }
 
 template<>

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -79,6 +79,7 @@ public:
 void RGWOp_User_Info::execute(optional_yield y)
 {
   RGWUserAdminOpState op_state(driver);
+  op_state.set_system(s->system_request);
 
   std::string uid_str, access_key_str;
   bool fetch_stats;
@@ -225,8 +226,7 @@ void RGWOp_User_Create::execute(optional_yield y)
   if (s->info.args.exists("suspended"))
     op_state.set_suspension(suspended);
 
-  if (s->info.args.exists("system"))
-    op_state.set_system(system);
+  op_state.set_system(s->system_request);
 
   if (s->info.args.exists("exclusive"))
     op_state.set_exclusive(exclusive);
@@ -377,8 +377,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   if (s->info.args.exists("suspended"))
     op_state.set_suspension(suspended);
 
-  if (s->info.args.exists("system"))
-    op_state.set_system(system);
+  op_state.set_system(s->system_request);
 
   if (!op_mask_str.empty()) {
     uint32_t op_mask;

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -326,7 +326,6 @@ void RGWOp_User_Modify::execute(optional_yield y)
 
   // if keys cap is not set to write a keys cannot be generated
   if (gen_key || !access_key.empty() || !secret_key.empty()) {
-    ldpp_dout(this, 0) << "ALI: in conditional check for user modify for keys" << dendl;
     op_ret = s->user->get_info().caps.check_cap("keys", RGW_CAP_WRITE);
     if (op_ret < 0) {
       return;

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -139,10 +139,10 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   dump_subusers_info(f, info);
 
   // keys cannot be viewed unless keys cap is set to read
-  if (dump_keys) {
+  //if (dump_keys || info.system) {
     dump_access_keys_info(f, info);
     dump_swift_keys_info(f, info);
-  }
+  //}
 
   encode_json("caps", info.caps, f);
 

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -635,16 +635,17 @@ public:
   static int info(const DoutPrefixProvider *dpp,
 		  rgw::sal::Driver* driver,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
-		  optional_yield y);
+                  bool dump_keys, optional_yield y);
 
   static int create(const DoutPrefixProvider *dpp,
 		    rgw::sal::Driver* driver,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
-		    optional_yield y);
+		    bool dump_keys, optional_yield y);
 
   static int modify(const DoutPrefixProvider *dpp,
 		    rgw::sal::Driver* driver,
-		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
+		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
+		    bool dump_keys, optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
@@ -674,6 +675,7 @@ class RGWUserAdminOp_Key
 public:
   static int create(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
+		    bool dump_keys,
 		    optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2106,6 +2106,7 @@ bool RGWUserCaps::is_valid_cap_type(const string& tp)
                                     "user-policy",
                                     "amz-cache",
                                     "oidc-provider",
+                                    "keys",
 				                            "ratelimit"};
 
   for (unsigned int i = 0; i < sizeof(cap_type) / sizeof(char *); ++i) {


### PR DESCRIPTION
This new capability for a user of the admin ops api determines whether the user can write keys via admin api operations and read keys from the response of an operation made via the admin api.

Details of the behavior pull request can be read here:
https://gist.github.com/alimaredia/02fd412aaa024922f9270fc24a01857f

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
