### PR TITLE
quincy: osd/cls_rgw: drop the incorrect log in deleting version obj 

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1274,7 +1274,9 @@ public:
                                                                               keep separate instance entry for the delete markers */
 
     if (ret < 0) {
-      CLS_LOG(0, "ERROR: read_key_entry() idx=%s ret=%d", instance_idx.c_str(), ret);
+      // return ENOENT is proper when inserting a delete marker
+      if (ret != -ENOENT || !check_delete_marker)
+        CLS_LOG(0, "ERROR: read_key_entry() idx=%s ret=%d", instance_idx.c_str(), ret);
       return ret;
     }
     initialized = true;


### PR DESCRIPTION
When deleting a version obj, calling set_olh with a generated marker that does not exists in disk, lead to Error log print after read_key_entry.

Fixes: https://tracker.ceph.com/issues/58886

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>

(cherry-picked from commit 2ec53a9db01dc2b385a5abd2604ccb7a6f7b9f08)