### PR TITLE
rgw/reshard: treat old RGWBucketInfo::num_shards=0 as 1 shard

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -3621,8 +3621,8 @@ public:
 	  }
 	  if (!no_zero) {
 	    yield {
-	      const int num_shards0 =
-		source_info.layout.logs.front().layout.in_index.layout.num_shards;
+	      const int num_shards0 = rgw::num_shards(
+		source_info.layout.logs.front().layout.in_index.layout);
 	      call(new CheckAllBucketShardStatusIsIncremental(sc, sync_pair,
 							      num_shards0,
 							      &all_incremental));

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2749,9 +2749,8 @@ int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
   bucket = bucket_info.bucket;
   shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(dpp, bucket_info, shard_id,
-                                                         num_shards(index), index.gen,
-                                                         &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(dpp, bucket_info, index,
+                                                         shard_id, &bucket_obj);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -837,7 +837,12 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
     while (is_truncated) {
       entries.clear();
       int ret = store->getRados()->bi_list(dpp, bucket_info, i, null_object_filter, marker, max_entries, &entries, &is_truncated);
-      if (ret < 0 && ret != -ENOENT) {
+      if (ret == -ENOENT) {
+        ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to find shard "
+            << i << ", skipping" << dendl;
+        // break out of the is_truncated loop and move on to the next shard
+        break;
+      } else if (ret < 0) {
         derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
         return ret;
       }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -504,6 +504,11 @@ static int init_reshard(rgw::sal::RadosStore* store,
                         uint32_t new_num_shards,
                         const DoutPrefixProvider *dpp)
 {
+  if (new_num_shards == 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " got invalid new_num_shards=0" << dendl;
+    return -EINVAL;
+  }
+
   int ret = init_target_layout(store, bucket_info, bucket_attrs, fault, new_num_shards, dpp);
   if (ret < 0) {
     return ret;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -194,9 +194,9 @@ public:
                        const rgw::bucket_index_layout_generation& target)
     : store(_store)
   {
-    const int num_shards = target.layout.normal.num_shards;
+    const uint32_t num_shards = rgw::num_shards(target.layout.normal);
     target_shards.reserve(num_shards);
-    for (int i = 0; i < num_shards; ++i) {
+    for (uint32_t i = 0; i < num_shards; ++i) {
       target_shards.emplace_back(dpp, store, bucket_info, target, i, completions);
     }
   }
@@ -647,7 +647,7 @@ static int commit_reshard(rgw::sal::RadosStore* store,
     // sync on the old shards will force them to detect the end-of-log for that
     // generation, and eventually transition to the next
     // TODO: use a log layout to support types other than BucketLogType::InIndex
-    for (uint32_t shard_id = 0; shard_id < prev.current_index.layout.normal.num_shards; ++shard_id) {
+    for (uint32_t shard_id = 0; shard_id < rgw::num_shards(prev.current_index.layout.normal); ++shard_id) {
       // This null_yield can stay, for now, since we're in our own thread
       ret = store->svc()->datalog_rados->add_entry(dpp, bucket_info, prev.logs.back(), shard_id,
 						   null_yield);
@@ -823,9 +823,9 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
     (*out) << "total entries:";
   }
 
-  const int num_source_shards = current.layout.normal.num_shards;
+  const uint32_t num_source_shards = rgw::num_shards(current.layout.normal);
   string marker;
-  for (int i = 0; i < num_source_shards; ++i) {
+  for (uint32_t i = 0; i < num_source_shards; ++i) {
     bool is_truncated = true;
     marker.clear();
     const std::string null_object_filter; // empty string since we're not filtering by object

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -507,7 +507,7 @@ void RGWOp_BILog_List::send_response_end() {
     if (next_log_layout) {
       s->formatter->open_object_section("next_log");
       encode_json("generation", next_log_layout->gen, s->formatter);
-      encode_json("num_shards", next_log_layout->layout.in_index.layout.num_shards, s->formatter);
+      encode_json("num_shards", rgw::num_shards(next_log_layout->layout.in_index.layout), s->formatter);
       s->formatter->close_section(); // next_log
     }
 
@@ -567,7 +567,7 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
   latest_gen = logs.back().gen;
 
   for (auto& log : logs) {
-      uint32_t num_shards = log.layout.in_index.layout.num_shards;
+      uint32_t num_shards = rgw::num_shards(log.layout.in_index.layout);
       generations.push_back({log.gen, num_shards});
   }
 }

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -262,7 +262,8 @@ void decode_json_obj(BucketLayout& l, JSONObj *obj);
 
 
 inline uint32_t num_shards(const bucket_index_normal_layout& index) {
-  return index.num_shards;
+  // old buckets used num_shards=0 to mean 1
+  return index.num_shards > 0 ? index.num_shards : 1;
 }
 inline uint32_t num_shards(const bucket_index_layout& index) {
   ceph_assert(index.type == BucketIndexType::Normal);

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -216,13 +216,13 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base,
-                                                      uint32_t num_shards,
-                                                      int shard_id,
-                                                      uint64_t gen_id,
-                                                      string *bucket_obj)
+void RGWSI_BucketIndex_RADOS::get_bucket_index_object(
+    const std::string& bucket_oid_base,
+    const rgw::bucket_index_normal_layout& normal,
+    uint64_t gen_id, int shard_id,
+    std::string* bucket_obj)
 {
-  if (!num_shards) {
+  if (!normal.num_shards) {
     // By default with no sharding, we use the bucket oid as itself
     (*bucket_obj) = bucket_oid_base;
   } else {
@@ -239,21 +239,23 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   }
 }
 
-int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
-                                                     uint32_t num_shards, rgw::BucketHashType hash_type,
-                                                     uint64_t gen_id, string *bucket_obj, int *shard_id)
+int RGWSI_BucketIndex_RADOS::get_bucket_index_object(
+    const std::string& bucket_oid_base,
+    const rgw::bucket_index_normal_layout& normal,
+    uint64_t gen_id, const std::string& obj_key,
+    std::string* bucket_obj, int* shard_id)
 {
   int r = 0;
-  switch (hash_type) {
+  switch (normal.hash_type) {
     case rgw::BucketHashType::Mod:
-      if (!num_shards) {
+      if (!normal.num_shards) {
         // By default with no sharding, we use the bucket oid as itself
         (*bucket_obj) = bucket_oid_base;
         if (shard_id) {
           *shard_id = -1;
         }
       } else {
-        uint32_t sid = bucket_shard_index(obj_key, num_shards);
+        uint32_t sid = bucket_shard_index(obj_key, normal.num_shards);
         char buf[bucket_oid_base.size() + 64];
         if (gen_id) {
           bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, sid);
@@ -291,8 +293,9 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *d
 
   string oid;
 
-  ret = get_bucket_index_object(bucket_oid_base, obj_key, bucket_info.layout.current_index.layout.normal.num_shards,
-        bucket_info.layout.current_index.layout.normal.hash_type, bucket_info.layout.current_index.gen, &oid, shard_id);
+  const auto& current_index = bucket_info.layout.current_index;
+  ret = get_bucket_index_object(bucket_oid_base, current_index.layout.normal,
+                                current_index.gen, obj_key, &oid, shard_id);
   if (ret < 0) {
     ldpp_dout(dpp, 10) << "get_bucket_index_object() returned ret=" << ret << dendl;
     return ret;
@@ -305,9 +308,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *d
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *dpp,
                                                      const RGWBucketInfo& bucket_info,
+                                                     const rgw::bucket_index_layout_generation& index,
                                                      int shard_id,
-                                                     uint32_t num_shards,
-                                                     uint64_t gen,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -321,8 +323,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *d
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, num_shards,
-                          shard_id, gen, &oid);
+  get_bucket_index_object(bucket_oid_base, index.layout.normal,
+                          index.gen, shard_id, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -56,15 +56,16 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                              RGWSI_RADOS::Pool *index_pool,
                              std::string *bucket_oid_base);
 
+  // return the index oid for the given shard id
   void get_bucket_index_object(const std::string& bucket_oid_base,
-                               uint32_t num_shards,
-                               int shard_id,
-                               uint64_t gen_id,
-                               std::string *bucket_obj);
+                               const rgw::bucket_index_normal_layout& normal,
+                               uint64_t gen_id, int shard_id,
+                               std::string* bucket_obj);
+  // return the index oid and shard id for the given object name
   int get_bucket_index_object(const std::string& bucket_oid_base,
-			      const std::string& obj_key,
-                              uint32_t num_shards, rgw::BucketHashType hash_type,
-                              uint64_t gen_id, std::string *bucket_obj, int *shard_id);
+                              const rgw::bucket_index_normal_layout& normal,
+                              uint64_t gen_id, const std::string& obj_key,
+                              std::string* bucket_obj, int* shard_id);
 
   int cls_bucket_head(const DoutPrefixProvider *dpp,
 		      const RGWBucketInfo& bucket_info,
@@ -145,10 +146,8 @@ public:
 
   int open_bucket_index_shard(const DoutPrefixProvider *dpp,
                               const RGWBucketInfo& bucket_info,
-                              int shard_id,
-                              uint32_t num_shards,
-                              uint64_t gen,
-                              RGWSI_RADOS::Obj *bucket_obj);
+                              const rgw::bucket_index_layout_generation& index,
+                              int shard_id, RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const DoutPrefixProvider *dpp,
                         const RGWBucketInfo& bucket_info,


### PR DESCRIPTION
for old upgraded buckets, the new resharding strategy for multisite was misinterpreting num_shards==0. this caused it to reshard from 0 shards to one empty shard, effectively hiding all of the existing index entries

> RGWRados::check_bucket_shards bucket testbucket needs resharding; current num shards 0; new num shards 1 (suggested 0)

this adds a check for num_shards==0 to helper function `rgw::num_shards()`, which is used by `check_bucket_shards()` query the current shard count. other places that accessed `layout.num_shards` directly were changed to use `rgw::num_shards()` instead

`RGWBucketInfo::decode()` and `RGWZone::decode()` were also updated to replace num_shards=0 with 1 to help protect against any other unknown bugs

Fixes: https://tracker.ceph.com/issues/58891

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
