### PR TITLE
cephfs_mirror: fix segfault in PeerReplayer::pick_directory

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -299,6 +299,9 @@ boost::optional<std::string> PeerReplayer::pick_directory() {
 
   boost::optional<std::string> candidate;
   for (auto &dir_root : m_directories) {
+    if (m_directories.find(dir_root) == m_directories.end()) {
+      continue;
+    }
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
     if (sync_stat.failed) {
       std::chrono::duration<double> d = now - *sync_stat.last_failed;


### PR DESCRIPTION
if m_directories(a vector) is empty, std::rotate tries to access an index that doesn't exist.

From https://en.cppreference.com/w/cpp/algorithm/rotate:

Return value
An iterator that is equal to:
- last, if first middle is true,
- first, if middle last is true,
- first + (last - middle)[1] otherwise, i.e. the new location of the element pointed by first.

It performs swaps to make element at index middle (here m_directories.begin() + 1 i.e element at index 1) the first element of vector with range [first, last), where first = m_directories.begin() and last = m_directories.end(), if there is nothing in the vector m_directories, it basically tries to access value at index 1 that does not exist/doesn't belong to it and thus the segmentation fault.

Fixes: https://tracker.ceph.com/issues/56830





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
