### PR TITLE
script: add 'reef' release to backport-create-issue

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -136,7 +136,8 @@ def connect_to_redmine(a):
 def releases():
     return ('argonaut', 'bobtail', 'cuttlefish', 'dumpling', 'emperor',
             'firefly', 'giant', 'hammer', 'infernalis', 'jewel', 'kraken',
-            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific', 'quincy')
+            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific', 'quincy',
+            'reef')
 
 def populate_status_dict(r):
     for status in r.issue_status.all():


### PR DESCRIPTION
now that we've forked a reef branch, we need the redmine script to create backport trackers for it

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
