### PR TITLE
pacific: drive_group: fix limit filter in drive_selection.selector

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -128,6 +128,17 @@ class DriveSelection(object):
                 )
                 continue
 
+            if not disk.available and disk.ceph_device and disk.lvs:
+                other_osdspec_affinity = ''
+                for lv in disk.lvs:
+                    if lv['osdspec_affinity'] != self.spec.service_id:
+                        other_osdspec_affinity = lv['osdspec_affinity']
+                        break
+                if other_osdspec_affinity:
+                    logger.debug("{} is already used in spec {}, "
+                                 "skipping it.".format(disk.path, other_osdspec_affinity))
+                    continue
+
             if not self._has_mandatory_idents(disk):
                 logger.debug(
                     "Ignoring disk {}. Missing mandatory idents".format(

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -61,7 +61,7 @@ class Device(object):
                  sys_api=None,  # type: Optional[Dict[str, Any]]
                  available=None,  # type: Optional[bool]
                  rejected_reasons=None,  # type: Optional[List[str]]
-                 lvs=None,  # type: Optional[List[str]]
+                 lvs=None,  # type: Optional[List[Dict[str, str]]]
                  device_id=None,  # type: Optional[str]
                  lsm_data=None,  # type: Optional[Dict[str, Dict[str, str]]]
                  created=None,  # type: Optional[datetime.datetime]
@@ -120,7 +120,7 @@ class Device(object):
         return 'hdd' if self.sys_api["rotational"] == "1" else 'ssd'
 
     def __repr__(self) -> str:
-        device_desc: Dict[str, Union[str, List[str]]] = {
+        device_desc: Dict[str, Union[str, List[str], List[Dict[str, str]]]] = {
             'path': self.path if self.path is not None else 'unknown',
             'lvs': self.lvs if self.lvs else 'None',
             'available': str(self.available),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58909

---

backport of https://github.com/ceph/ceph/pull/49969
parent tracker: https://tracker.ceph.com/issues/58626

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh