### PR TITLE
cmake: some fixes and suppressions for WITH_ASAN under vstart.sh

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -136,6 +136,9 @@ function(do_build_boost root_dir version)
   if(WITH_BOOST_VALGRIND)
     list(APPEND b2 valgrind=on)
   endif()
+  if(WITH_ASAN)
+    list(APPEND b2 context-impl=ucontext)
+  endif()
   set(build_command
     ${b2} headers stage
     #"--buildid=ceph" # changes lib names--can omit for static
@@ -231,6 +234,10 @@ macro(build_boost version)
     if((c MATCHES "coroutine|context") AND (WITH_BOOST_VALGRIND))
       set_target_properties(Boost::${c} PROPERTIES
         INTERFACE_COMPILE_DEFINITIONS "BOOST_USE_VALGRIND")
+    endif()
+    if((c MATCHES "context") AND (WITH_ASAN))
+      set_target_properties(Boost::${c} PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "BOOST_USE_ASAN;BOOST_USE_UCONTEXT")
     endif()
     list(APPEND Boost_LIBRARIES ${Boost_${upper_c}_LIBRARY})
   endforeach()

--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -34,6 +34,10 @@ if(Sanitizers_address_COMPILE_OPTIONS OR Sanitizers_leak_COMPILE_OPTIONS)
   # ASAN_LIBRARY will be read by ceph.in to preload the asan library
   find_library(ASAN_LIBRARY
     NAMES
+      libasan.so.10
+      libasan.so.9
+      libasan.so.8
+      libasan.so.7
       libasan.so.6
       libasan.so.5
       libasan.so.4

--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -1,0 +1,26 @@
+# leak suppressions needed to run vstart.sh with WITH_ASAN=ON
+# to enable, add this to the environment:
+# LSAN_OPTIONS="suppressions=../qa/lsan.supp"
+
+# from perfglue/heap_profiler.cc
+# gperftools allocates a singleton and never frees it
+leak:^MallocExtension::Register
+
+# from src/ceph.in
+# python3.6
+leak:^_PyObject_Alloc
+leak:^_PyObject_GC_Resize
+leak:^PyBytes_FromStringAndSize
+leak:^PyType_GenericAlloc
+leak:^set_table_resize
+# python3.7
+leak:^_PyObject_Realloc
+leak:^PyObject_Malloc
+# python3.8
+leak:^_PyBytes_FromSize
+leak:^_PyObject_GC_Alloc
+leak:^PyMem_Calloc
+leak:^PyUnicode_New
+# python3.9, 3.10, 3.11
+leak:^PyMem_Malloc
+# python3.12 doesn't leak anything


### PR DESCRIPTION
* `boost::context` understands a `BOOST_USE_ASAN` define to add asan annotations to its context switches. BuildBoost.cmake adds this define when our cmake variable `WITH_ASAN` is set

* src/ceph.in automatically adds libasan.so to `LD_PRELOAD`, but its detection logic in `FindSanitizers.cmake` wasn't looking for newer versions of the library. on fedora 37, i have libasan.so.8 installed

* memory leaks in `bin/ceph-mon` and the `bin/ceph` prevented vstart.sh from bootstrapping the cluster, so a `qa/lsan.supp` file was added to suppress them. the suppressions are enabled with the environment variable `LSAN_OPTIONS="suppressions=../qa/lsan.supp"`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
