### PR TITLE
osd: ECTransactions.cc: remove __func__ used inside a lambda

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -414,12 +414,13 @@ void ECTransaction::generate_transactions(
 
       uint64_t new_size = orig_size;
       uint64_t append_after = new_size;
-      ldpp_dout(dpp, 20) << __func__ << ": new_size start " << new_size << dendl;
+      ldpp_dout(dpp, 20) << "generate_transactions: new_size start "
+        << new_size << dendl;
       if (op.truncate && op.truncate->first < new_size) {
 	ceph_assert(!op.is_fresh_object());
 	new_size = sinfo.logical_to_next_stripe_offset(
 	  op.truncate->first);
-	ldpp_dout(dpp, 20) << __func__ << ": new_size truncate down "
+	ldpp_dout(dpp, 20) << "generate_transactions: new_size truncate down "
 			   << new_size << dendl;
 	if (new_size != op.truncate->first) { // 0 the unaligned part
 	  bufferlist bl;
@@ -445,10 +446,10 @@ void ECTransaction::generate_transactions(
 	    sinfo.logical_to_prev_stripe_offset(op.truncate->first));
 	  ceph_assert(rollback_extents.empty());
 
-	  ldpp_dout(dpp, 20) << __func__ << ": saving extent "
+	  ldpp_dout(dpp, 20) << "generate_transactions: saving extent "
 			     << make_pair(restore_from, restore_len)
 			     << dendl;
-	  ldpp_dout(dpp, 20) << __func__ << ": truncating to "
+	  ldpp_dout(dpp, 20) << "generate_transactions: truncating to "
 			     << new_size
 			     << dendl;
 	  rollback_extents.emplace_back(
@@ -467,8 +468,8 @@ void ECTransaction::generate_transactions(
 	    
 	  }
 	} else {
-	  ldpp_dout(dpp, 20) << __func__ << ": not saving extents, fresh object"
-			     << dendl;
+	  ldpp_dout(dpp, 20) << "generate_transactions: not saving extents"
+                                ", fresh object" << dendl;
 	}
 	for (auto &&st : *transactions) {
 	  st.second.truncate(
@@ -500,7 +501,7 @@ void ECTransaction::generate_transactions(
 	uint64_t off = extent.get_off();
 	uint64_t len = extent.get_len();
 	uint64_t end = off + len;
-	ldpp_dout(dpp, 20) << __func__ << ": adding buffer_update "
+	ldpp_dout(dpp, 20) << "generate_transactions: adding buffer_update "
 			   << make_pair(off, len)
 			   << dendl;
 	ceph_assert(len > 0);
@@ -508,7 +509,7 @@ void ECTransaction::generate_transactions(
 	  ceph_assert(off > append_after);
 	  bl.prepend_zero(off - new_size);
 	  len += off - new_size;
-	  ldpp_dout(dpp, 20) << __func__ << ": prepending zeroes to align "
+	  ldpp_dout(dpp, 20) << "generate_transactions: prepending zeroes to align "
 			     << off << "->" << new_size
 			     << dendl;
 	  off = new_size;
@@ -518,7 +519,7 @@ void ECTransaction::generate_transactions(
 	    end);
 	  uint64_t tail = aligned_end - end;
 	  bl.append_zero(tail);
-	  ldpp_dout(dpp, 20) << __func__ << ": appending zeroes to align end "
+	  ldpp_dout(dpp, 20) << "generate_transactions: appending zeroes to align end "
 			     << end << "->" << end+tail
 			     << ", len: " << len << "->" << len+tail
 			     << dendl;
@@ -545,7 +546,7 @@ void ECTransaction::generate_transactions(
 	  zeroes,
 	  bl);
 	new_size = truncate_to;
-	ldpp_dout(dpp, 20) << __func__ << ": truncating out to "
+	ldpp_dout(dpp, 20) << "generate_transactions: truncating out to "
 			   << truncate_to
 			   << dendl;
       }
@@ -555,7 +556,7 @@ void ECTransaction::generate_transactions(
 	want.insert(i);
       }
       auto to_overwrite = to_write.intersect(0, append_after);
-      ldpp_dout(dpp, 20) << __func__ << ": to_overwrite: "
+      ldpp_dout(dpp, 20) << "generate_transactions: to_overwrite: "
 			 << to_overwrite
 			 << dendl;
       for (auto &&extent: to_overwrite) {
@@ -567,7 +568,7 @@ void ECTransaction::generate_transactions(
 	    extent.get_off());
 	  uint64_t restore_len = sinfo.aligned_logical_offset_to_chunk_offset(
 	    extent.get_len());
-	  ldpp_dout(dpp, 20) << __func__ << ": overwriting "
+	  ldpp_dout(dpp, 20) << "generate_transactions: overwriting "
 			     << restore_from << "~" << restore_len
 			     << dendl;
 	  if (rollback_extents.empty()) {
@@ -606,13 +607,13 @@ void ECTransaction::generate_transactions(
       auto to_append = to_write.intersect(
 	append_after,
 	std::numeric_limits<uint64_t>::max() - append_after);
-      ldpp_dout(dpp, 20) << __func__ << ": to_append: "
+      ldpp_dout(dpp, 20) << "generate_transactions: to_append: "
 			 << to_append
 			 << dendl;
       for (auto &&extent: to_append) {
 	ceph_assert(sinfo.logical_offset_is_stripe_aligned(extent.get_off()));
 	ceph_assert(sinfo.logical_offset_is_stripe_aligned(extent.get_len()));
-	ldpp_dout(dpp, 20) << __func__ << ": appending "
+	ldpp_dout(dpp, 20) << "generate_transactions: appending "
 			   << extent.get_off() << "~" << extent.get_len()
 			   << dendl;
 	encode_and_write(
@@ -630,13 +631,13 @@ void ECTransaction::generate_transactions(
 	  dpp);
       }
 
-      ldpp_dout(dpp, 20) << __func__ << ": " << oid
+      ldpp_dout(dpp, 20) << "generate_transactions: " << oid
 			 << " resetting hinfo to logical size "
 			 << new_size
 			 << dendl;
       if (!rollback_extents.empty() && entry) {
 	if (entry) {
-	  ldpp_dout(dpp, 20) << __func__ << ": " << oid
+	  ldpp_dout(dpp, 20) << "generate_transactions: " << oid
 			     << " marking rollback extents "
 			     << rollback_extents
 			     << dendl;
@@ -650,7 +651,7 @@ void ECTransaction::generate_transactions(
       }
 
       if (entry && !to_append.empty()) {
-	ldpp_dout(dpp, 20) << __func__ << ": marking append "
+	ldpp_dout(dpp, 20) << "generate_transactions: marking append "
 			   << append_after
 			   << dendl;
 	entry->mod_desc.append(append_after);


### PR DESCRIPTION

In generate_transactions(), __func__ was used in log messages when inside a lambda.
Replaced with the function name text.