### PR TITLE
quincy: mon/LogMonitor: Fix log last

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -913,7 +913,7 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
 	  } else {
 	    start = from;
 	  }
-	  dout(10) << __func__ << " channnel " << p.first
+	  dout(10) << __func__ << " channel " << p.first
 		   << " from " << from << " to " << to << dendl;
 	  for (version_t v = start; v < to; ++v) {
 	    bufferlist ebl;
@@ -934,6 +934,9 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
 	  entries.erase(entries.begin());
 	}
 	for (auto& p : entries) {
+	  if (!match(p.second)) {
+	    continue;
+	  }
 	  if (f) {
 	    f->dump_object("entry", p.second);
 	  } else {
@@ -965,10 +968,12 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
 	    LogEntry le;
 	    auto p = ebl.cbegin();
 	    decode(le, p);
-	    if (f) {
-	      f->dump_object("entry", le);
-	    } else {
-	      ss << le << "\n";
+	    if (match(le)) {
+	      if (f) {
+	        f->dump_object("entry", le);
+	      } else {
+	        ss << le << "\n";
+	      }
 	    }
 	  }
 	}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57696

---

backport of https://github.com/ceph/ceph/pull/47873
parent tracker: https://tracker.ceph.com/issues/57340

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh