### PR TITLE
quincy: mon: fix a race between `mgr fail` and MgrMonitor::prepare_beacon()

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1272,13 +1272,17 @@ out:
   getline(ss, rs);
 
   if (r >= 0) {
+    bool do_update = false;
     if (prefix == "mgr fail" && is_writeable()) {
       propose_pending();
+      do_update = false;
+    } else {
+      do_update = true;
     }
     // success.. delay reply
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, r, rs,
 					      get_last_committed() + 1));
-    return true;
+    return do_update;
   } else {
     // reply immediately
     mon.reply_command(op, r, rs, rdata, get_last_committed());

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1144,9 +1144,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
   string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
-  string prefix;
-  cmd_getval(cmdmap, "prefix", prefix);
-
+  const auto prefix = cmd_getval_or<string>(cmdmap, "prefix", string{});
   int r = 0;
 
   if (prefix == "mgr fail") {
@@ -1274,6 +1272,9 @@ out:
   getline(ss, rs);
 
   if (r >= 0) {
+    if (prefix == "mgr fail" && is_writeable()) {
+      propose_pending();
+    }
     // success.. delay reply
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, r, rs,
 					      get_last_committed() + 1));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57117

---

backport of https://github.com/ceph/ceph/pull/46318 (and https://github.com/ceph/ceph/pull/47834).
parent tracker: https://tracker.ceph.com/issues/55711

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh