### PR TITLE
mgr/prometheus: remove dependency on cephadm module

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -14,7 +14,6 @@ from collections import namedtuple
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
 from mgr_util import get_default_addr, profile_method, build_url
 from rbd import RBD
-from cephadm.ssl_cert_utils import SSLCerts
 
 from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable
 
@@ -637,7 +636,6 @@ class Module(MgrModule):
         _global_instance = self
         self.metrics_thread = MetricCollectionThread(_global_instance)
         self.health_history = HealthHistory(self)
-        self.ssl_certs = SSLCerts()
 
     def _setup_static_metrics(self) -> Dict[str, Metric]:
         metrics = {}
@@ -1726,48 +1724,67 @@ class Module(MgrModule):
         self.get_file_sd_config()
 
     def configure(self, server_addr: str, server_port: int) -> None:
-        secure_monitoring_stack = self.get_module_option_ex(
+        # cephadm deployments have a TLS monitoring stack setup option.
+        # If the cephadm module is on and the setting is true (defaults to false)
+        # we should have prometheus be set up to interact with that
+        cephadm_secure_monitoring_stack = self.get_module_option_ex(
             'cephadm', 'secure_monitoring_stack', False)
-        if secure_monitoring_stack:
-            self.generate_tls_certificates(self.get_mgr_ip())
-            cherrypy.config.update({
-                'server.socket_host': server_addr,
-                'server.socket_port': server_port,
-                'engine.autoreload.on': False,
-                'server.ssl_module': 'builtin',
-                'server.ssl_certificate': self.cert_file,
-                'server.ssl_private_key': self.key_file,
-            })
-            # Publish the URI that others may use to access the service we're about to start serving
-            self.set_uri(build_url(scheme='https', host=self.get_server_addr(),
-                         port=server_port, path='/'))
-        else:
-            cherrypy.config.update({
-                'server.socket_host': server_addr,
-                'server.socket_port': server_port,
-                'engine.autoreload.on': False,
-                'server.ssl_module': None,
-                'server.ssl_certificate': None,
-                'server.ssl_private_key': None,
-            })
-            # Publish the URI that others may use to access the service we're about to start serving
-            self.set_uri(build_url(scheme='http', host=self.get_server_addr(),
-                         port=server_port, path='/'))
+        if cephadm_secure_monitoring_stack:
+            try:
+                self.setup_cephadm_tls_config(server_addr, server_port)
+                return
+            except Exception as e:
+                self.log.exception(f'Failed to setup cephadm based secure monitoring stack: {e}\n',
+                                   'Falling back to default configuration')
+        self.setup_default_config(server_addr, server_port)
 
-    def generate_tls_certificates(self, host: str) -> None:
+    def setup_default_config(self, server_addr: str, server_port: int) -> None:
+        cherrypy.config.update({
+            'server.socket_host': server_addr,
+            'server.socket_port': server_port,
+            'engine.autoreload.on': False,
+            'server.ssl_module': None,
+            'server.ssl_certificate': None,
+            'server.ssl_private_key': None,
+        })
+        # Publish the URI that others may use to access the service we're about to start serving
+        self.set_uri(build_url(scheme='http', host=self.get_server_addr(),
+                     port=server_port, path='/'))
+
+    def setup_cephadm_tls_config(self, server_addr: str, server_port: int) -> None:
+        from cephadm.ssl_cert_utils import SSLCerts
+        # the ssl certs utils uses a NamedTemporaryFile for the cert files
+        # generated with generate_cert_files function. We need the SSLCerts
+        # object to not be cleaned up in order to have those temp files not
+        # be cleaned up, so making it an attribute of the module instead
+        # of just a standalone object
+        self.cephadm_monitoring_tls_ssl_certs = SSLCerts()
+        host = self.get_mgr_ip()
         try:
             old_cert = self.get_store('root/cert')
             old_key = self.get_store('root/key')
             if not old_cert or not old_key:
                 raise Exception('No old credentials for mgr-prometheus endpoint')
-            self.ssl_certs.load_root_credentials(old_cert, old_key)
+            self.cephadm_monitoring_tls_ssl_certs.load_root_credentials(old_cert, old_key)
         except Exception:
-            self.ssl_certs.generate_root_cert(host)
-            self.set_store('root/cert', self.ssl_certs.get_root_cert())
-            self.set_store('root/key', self.ssl_certs.get_root_key())
+            self.cephadm_monitoring_tls_ssl_certs.generate_root_cert(host)
+            self.set_store('root/cert', self.cephadm_monitoring_tls_ssl_certs.get_root_cert())
+            self.set_store('root/key', self.cephadm_monitoring_tls_ssl_certs.get_root_key())
 
-        self.cert_file, self.key_file = self.ssl_certs.generate_cert_files(
+        cert_file_path, key_file_path = self.cephadm_monitoring_tls_ssl_certs.generate_cert_files(
             self.get_hostname(), host)
+
+        cherrypy.config.update({
+            'server.socket_host': server_addr,
+            'server.socket_port': server_port,
+            'engine.autoreload.on': False,
+            'server.ssl_module': 'builtin',
+            'server.ssl_certificate': cert_file_path,
+            'server.ssl_private_key': key_file_path,
+        })
+        # Publish the URI that others may use to access the service we're about to start serving
+        self.set_uri(build_url(scheme='https', host=self.get_server_addr(),
+                     port=server_port, path='/'))
 
     def serve(self) -> None:
 


### PR DESCRIPTION
https://github.com/ceph/ceph/commit/f967ac061ebee362cdc82c458e955da75a9045e9 introduced an import of something in the cephadm module in the prometheus module. This seems to break the prometheus module in some non-cephadm setups. For example, the ceph-ansible ci hit

```
failed: [mgr0 -> mon0] (item=prometheus) => changed=true
  ansible_loop_var: item
  cmd:
  - ceph
  - -n
  - client.admin
  - -k
  - /etc/ceph/ceph.client.admin.keyring
  - --cluster
  - ceph
  - mgr
  - module
  - enable
  - prometheus delta: '0:00:00.389965' end: '2023-03-03 15:30:07.631308' item: prometheus rc: 2 start: '2023-03-03 15:30:07.241343' stderr: 'Error ENOENT: module ''prometheus'' reports that it cannot run on the active manager daemon: No module named ''cephadm'' (pass --force to force enablement)'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```
so we need to be a bit more careful with this import and make sure the prometheus module works fine without cephadm





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
