### PR TITLE
crimson/os/seastore: add fine-grained cache

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -33,6 +33,7 @@ struct FixedKVNode : CachedExtent {
   btree_range_pin_t<node_key_t> pin;
 
   FixedKVNode(ceph::bufferptr &&ptr) : CachedExtent(std::move(ptr)), pin(this) {}
+  FixedKVNode(extent_len_t length) : CachedExtent(length), pin(this) {}
   FixedKVNode(const FixedKVNode &rhs)
     : CachedExtent(rhs), pin(rhs.pin, this) {}
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1435,13 +1435,14 @@ private:
           offset, length, old_length]() mutable {
         LOG_PREFIX(Cache::read_extent);
         extent->state = CachedExtent::extent_state_t::CLEAN;
-        /* TODO: crc should be checked against LBA manager */
-        extent->last_committed_crc = extent->get_crc32c();
 
         update_lru_size(*extent,
           extent->get_valid_length() - old_length);
         extent->on_clean_read();
         extent->check_and_rebuild();
+        if(extent->is_ptr()) {
+          extent->last_committed_crc = extent->get_crc32c();
+        }
         extent->complete_io();
         SUBDEBUG(seastore_cache, "read extent interval {} ~ {} done -- {}",
           offset, length, *extent);

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -106,4 +106,100 @@ std::ostream &operator<<(std::ostream &out, const lba_pin_list_t &rhs)
   return out << ']';
 }
 
+void BufferSpace::_add_buffer(extent_len_t offset, ceph::bufferlist&& buffer)
+{
+  const extent_len_t length_added = buffer.length();
+  const extent_len_t tail = offset + length_added;
+  auto i = buffer_map.find(tail);
+  if(i != buffer_map.end()) {
+    buffer.append(*i->second.release());
+    buffer_map.erase(i);
+    }
+  i = buffer_map.lower_bound(offset);
+  ceph_assert(i == buffer_map.end() || i->first > tail);
+  if (i != buffer_map.begin()) {
+	  --i;
+  }
+  if(i != buffer_map.end() &&
+    i->first + i->second->length() == offset) {
+    i->second->append(buffer);
+  }
+  else {
+    buffer_map[offset].reset(new bufferlist(std::move(buffer)));
+  }
+  space_length += length_added;
+}
+
+ceph::bufferlist BufferSpace::get_data(extent_len_t offset, extent_len_t length)
+{
+  auto i = buffer_map.upper_bound(offset);
+  --i;
+  ceph::bufferlist res;
+  res.substr_of(*i->second.get(), offset - i->first, length);
+  return res;
+}
+
+ceph::bufferptr BufferSpace::build_ptr()
+{
+  auto it = buffer_map[0].get();
+  if(!it->is_contiguous()) {
+    it->rebuild();
+  }
+  ceph::bufferptr ptr(it->buffers().front());
+  ptr.set_length(extent_length);
+  buffer_map.clear();
+  space_length = 0;
+  return ptr;
+}
+
+bool BufferSpace::check_buffer(extent_len_t offset, extent_len_t length)
+{
+  auto i = buffer_map.upper_bound(offset);
+  if (i == buffer_map.begin()) {
+    return false;
+  }
+  --i;
+  if (i-> first + i->second->length() < offset + length) {
+    return false;
+  }
+  return true;
+}
+
+region_list_t BufferSpace::read_buffer(extent_len_t offset, extent_len_t length)
+{
+  auto tail = offset + length;
+  ceph_assert(tail <= get_extent_length());
+  region_list_t r2r;
+  auto i = buffer_map.lower_bound(offset);
+  if (i != buffer_map.begin()) {
+    --i;
+    if(i->first + i->second->length() <= offset) {
+      ++i;
+    }
+  }
+  while(offset < tail){
+    if (i == buffer_map.end()) {
+      r2r.emplace_back(offset, length);
+      break;
+    }
+    auto i_off = i->first;
+    auto i_len = i->second->length();
+    if (i_off <= offset) {
+      extent_len_t skip = i_off + i_len - offset;
+	    extent_len_t l = std::min(length, skip);
+      offset += l;
+	    length -= l;
+    }
+    else {
+      extent_len_t hole = std::min(i_off - offset, length);
+      r2r.emplace_back(offset, hole);
+      extent_len_t l = std::min(length, i_len + hole);
+      offset += l;
+      length -= l;
+    }
+    ++i;
+  }
+  return r2r;
+}
+
 }

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -23,6 +23,8 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
     : LogicalCachedExtent(std::move(ptr)) {}
   ObjectDataBlock(const ObjectDataBlock &other)
     : LogicalCachedExtent(other) {}
+  ObjectDataBlock(extent_len_t length)
+    : LogicalCachedExtent(length, CachedExtent::build_space_t{}) {}
 
   CachedExtentRef duplicate_for_write() final {
     return CachedExtentRef(new ObjectDataBlock(*this));

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -551,7 +551,7 @@ TransactionManager::get_extents_if_live(
   return cache->get_extent_if_cached(t, paddr, type
   ).si_then([=, this, &t](auto extent)
 	    -> get_extents_if_live_ret {
-    if (extent && extent->get_length() == len) {
+    if (extent && extent->get_valid_length() == len) {
       DEBUGT("{} {}~{} {} is live in cache -- {}",
              t, type, laddr, len, paddr, *extent);
       std::list<CachedExtentRef> res;

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -51,6 +51,8 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
 
   TestBlock(ceph::bufferptr &&ptr)
     : LogicalCachedExtent(std::move(ptr)) {}
+  TestBlock(extent_len_t length)
+    : LogicalCachedExtent(length) {}
   TestBlock(const TestBlock &other)
     : LogicalCachedExtent(other) {}
 
@@ -90,6 +92,8 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   TestBlockPhysical(ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)) {}
+  TestBlockPhysical(extent_len_t length)
+    : CachedExtent(length) {}
   TestBlockPhysical(const TestBlockPhysical &other)
     : CachedExtent(other) {}
 


### PR DESCRIPTION
The fine-grained cache is introduced to improve the performance and reduce read amplification when reading small chunks of data from large extents. Overall, we add a structure named "BufferSpace" to control the small buffers in CachedExtent so that it can load the exact required data from disk. Now the ObjectDataBlock can be incomplete. Some paths are modified to adapt to this change.

Signed-off-by: Jianxin Li <jianxin1.li@intel.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
