### PR TITLE
qa/distros: add centos stream 9 as supported distro

### DIFF
--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,0 +1,2 @@
+os_type: centos
+os_version: "9.stream"

--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,2 +1,9 @@
 os_type: centos
 os_version: "9.stream"
+
+# enable the ceph/el9 copr for python packages that aren't in epel9 yet
+# see https://tracker.ceph.com/issues/58832
+overrides:
+  install:
+    ceph:
+      enable_coprs: [ceph/el9]

--- a/qa/distros/all/centos_latest.yaml
+++ b/qa/distros/all/centos_latest.yaml
@@ -1,0 +1,1 @@
+centos_9.stream.yaml

--- a/qa/distros/supported-random-distro$/centos_latest.yaml
+++ b/qa/distros/supported-random-distro$/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/distros/supported/centos_8.stream.yaml
+++ b/qa/distros/supported/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+../all/centos_8.stream.yaml

--- a/qa/distros/supported/centos_latest.yaml
+++ b/qa/distros/supported/centos_latest.yaml
@@ -1,1 +1,1 @@
-../all/centos_8.yaml
+../all/centos_latest.yaml


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
