### PR TITLE
quincy: cephadm: using short hostname to create the initial mon and mgr

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1991,6 +1991,11 @@ def get_hostname():
     return socket.gethostname()
 
 
+def get_short_hostname():
+    # type: () -> str
+    return get_hostname().split('.', 1)[0]
+
+
 def get_fqdn():
     # type: () -> str
     return socket.getfqdn() or socket.gethostname()
@@ -2003,8 +2008,8 @@ def get_arch():
 
 def generate_service_id():
     # type: () -> str
-    return get_hostname() + '.' + ''.join(random.choice(string.ascii_lowercase)
-                                          for _ in range(6))
+    return get_short_hostname() + '.' + ''.join(random.choice(string.ascii_lowercase)
+                                                for _ in range(6))
 
 
 def generate_password():
@@ -5612,7 +5617,7 @@ def command_bootstrap(ctx):
     hostname = get_hostname()
     if '.' in hostname and not ctx.allow_fqdn_hostname:
         raise Error('hostname is a fully qualified domain name (%s); either fix (e.g., "sudo hostname %s" or similar) or pass --allow-fqdn-hostname' % (hostname, hostname.split('.')[0]))
-    mon_id = ctx.mon_id or hostname
+    mon_id = ctx.mon_id or get_short_hostname()
     mgr_id = ctx.mgr_id or generate_service_id()
 
     lock = FileLock(ctx, fsid)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58761

---

backport of https://github.com/ceph/ceph/pull/49866
parent tracker: https://tracker.ceph.com/issues/58466

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh