### PR TITLE
quincy: mgr/dashboard: fix Cannot read properties of undefined (reading 'filter')

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -487,7 +487,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
   getServiceIds(selectedServiceType: string) {
     this.serviceIds = this.serviceList
-      .filter((service) => service['service_type'] === selectedServiceType)
+      ?.filter((service) => service['service_type'] === selectedServiceType)
       .map((service) => service['service_id']);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57483

---

backport of https://github.com/ceph/ceph/pull/47959
parent tracker: https://tracker.ceph.com/issues/57434

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh