### PR TITLE
quincy: mgr/dashboard: move service_instances logic to backend

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -52,9 +52,11 @@
 <div [ngbNavOutlet]="nav"></div>
 
 <ng-template #servicesTpl
-             let-value="value">
-  <span *ngFor="let instance of value; last as isLast">
-    <span class="badge badge-background-primary ms-1" >{{ instance }}</span>
+             let-services="value">
+  <span *ngFor="let service of services">
+    <cd-label [key]="service['type']"
+              [value]="service['count']"
+              class="me-1"></cd-label>
   </span>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -121,30 +121,18 @@ describe('HostsComponent', () => {
     const hostname = 'ceph.dev';
     const payload = [
       {
-        services: [
+        service_instances: [
           {
             type: 'mgr',
-            id: 'x'
-          },
-          {
-            type: 'mgr',
-            id: 'y'
+            count: 2
           },
           {
             type: 'osd',
-            id: '0'
-          },
-          {
-            type: 'osd',
-            id: '1'
-          },
-          {
-            type: 'osd',
-            id: '2'
+            count: 3
           },
           {
             type: 'rgw',
-            id: 'rgw'
+            count: 1
           }
         ],
         hostname: hostname,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -3,8 +3,8 @@ import { Router } from '@angular/router';
 
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
-import { Observable, Subscription } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 
 import { HostService } from '~/app/shared/api/host.service';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
@@ -22,7 +22,6 @@ import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
-import { Daemon } from '~/app/shared/models/daemon.interface';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { OrchestratorFeature } from '~/app/shared/models/orchestrator.enum';
 import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
@@ -491,37 +490,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
           this.orchStatus = orchStatus;
           const factsAvailable = this.checkHostsFactsAvailable();
           return this.hostService.list(`${factsAvailable}`);
-        }),
-        map((hostList: object[]) =>
-          hostList.map((host) => {
-            const counts = {};
-            host['service_instances'] = new Set<string>();
-            if (this.orchStatus?.available) {
-              let daemons: Daemon[] = [];
-              let observable: Observable<Daemon[]>;
-              observable = this.hostService.getDaemons(host['hostname']);
-              observable.subscribe((dmns: Daemon[]) => {
-                daemons = dmns;
-                daemons.forEach((daemon: any) => {
-                  counts[daemon.daemon_type] = (counts[daemon.daemon_type] || 0) + 1;
-                });
-                daemons.map((daemon: any) => {
-                  host['service_instances'].add(
-                    `${daemon.daemon_type}: ${counts[daemon.daemon_type]}`
-                  );
-                });
-              });
-            } else {
-              host['services'].forEach((service: any) => {
-                counts[service.type] = (counts[service.type] || 0) + 1;
-              });
-              host['services'].map((service: any) => {
-                host['service_instances'].add(`${service.type}: ${counts[service.type]}`);
-              });
-            }
-            return host;
-          })
-        )
+        })
       )
       .subscribe(
         (hostList) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
@@ -29,7 +29,7 @@ export class HostService extends ApiClient {
 
   list(facts: string): Observable<object[]> {
     return this.http.get<object[]>(this.baseURL, {
-      headers: { Accept: 'application/vnd.ceph.api.v1.1+json' },
+      headers: { Accept: this.getVersionHeaderValue(1, 2) },
       params: { facts: facts }
     });
   }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3466,7 +3466,7 @@ paths:
       responses:
         '200':
           content:
-            application/vnd.ceph.api.v1.1+json:
+            application/vnd.ceph.api.v1.2+json:
               schema:
                 properties:
                   addr:
@@ -3482,6 +3482,21 @@ paths:
                     description: Labels related to the host
                     items:
                       type: string
+                    type: array
+                  service_instances:
+                    description: Service instances related to the host
+                    items:
+                      properties:
+                        count:
+                          description: Number of instances of the service
+                          type: integer
+                        type:
+                          description: type of service
+                          type: string
+                      required:
+                      - type
+                      - count
+                      type: object
                     type: array
                   service_type:
                     description: ''
@@ -3520,6 +3535,7 @@ paths:
                 required:
                 - hostname
                 - services
+                - service_instances
                 - ceph_version
                 - addr
                 - labels

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -14,7 +14,7 @@ import cherrypy
 from cherrypy._cptools import HandlerWrapperTool
 from cherrypy.test import helper
 from mgr_module import HandleCommandResult
-from orchestrator import HostSpec, InventoryHost
+from orchestrator import DaemonDescription, HostSpec, InventoryHost
 from pyfakefs import fake_filesystem
 
 from .. import mgr
@@ -347,12 +347,22 @@ class Waiter(threading.Thread):
 @contextlib.contextmanager
 def patch_orch(available: bool, missing_features: Optional[List[str]] = None,
                hosts: Optional[List[HostSpec]] = None,
-               inventory: Optional[List[dict]] = None):
+               inventory: Optional[List[dict]] = None,
+               daemons: Optional[List[DaemonDescription]] = None):
     with mock.patch('dashboard.controllers.orchestrator.OrchClient.instance') as instance:
         fake_client = mock.Mock()
         fake_client.available.return_value = available
         fake_client.get_missing_features.return_value = missing_features
 
+        if not daemons:
+            daemons = [
+                DaemonDescription(
+                    daemon_type='mon',
+                    daemon_id='a',
+                    hostname='node0'
+                )
+            ]
+        fake_client.services.list_daemons.return_value = daemons
         if hosts is not None:
             fake_client.hosts.list.return_value = hosts
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58720

---

backport of https://github.com/ceph/ceph/pull/49801
parent tracker: https://tracker.ceph.com/issues/58504

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh