### PR TITLE
crimson/os/seastore: promote read data to the faster device 

### DIFF
--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -182,6 +182,23 @@ using ``vstart.sh``,
 ``--memstore``
     use the alienized MemStore as the object store backend.
 
+``--seastore``
+    use the SeaStore as object store backend.
+
+``--seastore-devs``
+    specify the block device used by SeaStore.
+
+``--seastore-secondary-devs``
+    Optional.  SeaStore supports multiple devices.  Enable this feature by
+    passing the block device to this option.
+
+``--seastore-secondary-devs-type``
+    Optional.  Specify device type of secondary devices.  When the secondary
+    device is slower than main device passed to ``--seastore-devs``, the cold
+    data in faster device will be evicted to the slower devices over time.
+    Valid args include: HDD, SSD(default), ZNS and RANDOM_BLOCK_SSD.
+    Note secondary devices should not be faster than the main device.
+
 So, a typical command to start a single-crimson-node cluster is::
 
   $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \
@@ -190,6 +207,15 @@ So, a typical command to start a single-crimson-node cluster is::
     --osd-args "--memory 4G"
 
 Where we assign 4 GiB memory, a single thread running on core-0 to crimson-osd.
+
+Another SeaStore example::
+
+  $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \
+    --without-dashboard --seastore \
+    --crimson --redirect-output \
+    --seastore-devs /dev/sda \
+    --seastore-secondary-devs /dev/sdb \
+    --seastore-secondary-devs-type HDD
 
 You could stop the vstart cluster using::
 

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -82,6 +82,11 @@ options:
   level: advanced
   desc: Size in bytes of extents to keep in cache.
   default: 64_M
+- name: seastore_cache_pending_promote_size
+  type: size
+  level: advanced
+  desc: Size in bytes of extents pending to write back to the main device.
+  default: 2_M
 - name: seastore_obj_data_write_amplification
   type: float
   level: advanced

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -102,3 +102,18 @@ options:
   level: dev
   desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_main_device_type is RANDOM_BLOCK
   default: 5_G
+- name: seastore_multiple_tiers_stop_evict_ratio
+  type: float
+  level: advanced
+  desc: When the used ratio of main tier is less than this value, then stop evict cold data to the cold tier.
+  default: 0.5
+- name: seastore_multiple_tiers_default_evict_ratio
+  type: float
+  level: advanced
+  desc: start to evict cold data to the cold tier when the used ratio of main tier reach this ratio.
+  default: 0.6
+- name: seastore_multiple_tiers_fast_evict_ratio
+  type: float
+  level: advanced
+  desc: start fast eviction when the used ratio of main tier reach this ratio.
+  default: 0.7

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -7,6 +7,7 @@ set(crimson_seastore_srcs
   transaction_manager.cc
   transaction.cc
   cache.cc
+  cache/lru.cc
   lba_manager.cc
   async_cleaner.cc
   backref_manager.cc

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1149,6 +1149,7 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
 {
   LOG_PREFIX(SegmentCleaner::clean_space);
   assert(background_callback->is_ready());
+  ceph_assert(can_clean_space());
   if (!reclaim_state) {
     segment_id_t seg_id = get_next_reclaim_segment();
     auto &segment_info = segments[seg_id];

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1061,8 +1061,12 @@ SegmentCleaner::do_reclaim_space(
                         &pin_list, &reclaimed, &runs] {
     reclaimed = 0;
     runs++;
+    auto src = Transaction::src_t::CLEANER_MAIN;
+    if (is_cold) {
+      src = Transaction::src_t::CLEANER_COLD;
+    }
     return extent_callback->with_transaction_intr(
-      Transaction::src_t::CLEANER,
+      src,
       "clean_reclaim_space",
       [this, &backref_extents, &pin_list, &reclaimed](auto &t)
     {

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -831,8 +831,10 @@ SegmentCleaner::SegmentCleaner(
   SegmentManagerGroupRef&& sm_group,
   BackrefManager &backref_manager,
   SegmentSeqAllocator *segment_seq_allocator,
-  bool detailed)
+  bool detailed,
+  bool is_cold)
   : detailed(detailed),
+    is_cold(is_cold),
     config(config),
     sm_group(std::move(sm_group)),
     backref_manager(backref_manager),
@@ -854,7 +856,13 @@ void SegmentCleaner::register_metrics()
   i = get_bucket_index(UTIL_STATE_EMPTY);
   stats.segment_util.buckets[i].count = segments.get_num_segments();
 
-  metrics.add_group("segment_cleaner", {
+  std::string prefix;
+  if (is_cold) {
+    prefix.append("cold_");
+  }
+  prefix.append("segment_cleaner");
+
+  metrics.add_group(prefix, {
     sm::make_counter("segments_number",
 		     [this] { return segments.get_num_segments(); },
 		     sm::description("the number of segments")),

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -830,13 +830,13 @@ SegmentCleaner::SegmentCleaner(
   config_t config,
   SegmentManagerGroupRef&& sm_group,
   BackrefManager &backref_manager,
+  SegmentSeqAllocator *segment_seq_allocator,
   bool detailed)
   : detailed(detailed),
     config(config),
     sm_group(std::move(sm_group)),
     backref_manager(backref_manager),
-    ool_segment_seq_allocator(
-      new SegmentSeqAllocator(segment_type_t::OOL))
+    ool_segment_seq_allocator(segment_seq_allocator)
 {
   config.validate();
 }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1150,6 +1150,8 @@ public:
   using clean_space_ret = clean_space_ertr::future<>;
   virtual clean_space_ret clean_space() = 0;
 
+  virtual const std::set<device_id_t>& get_device_ids() const = 0;
+
   // test only
   virtual bool check_usage() = 0;
 
@@ -1328,6 +1330,10 @@ public:
   }
 
   clean_space_ret clean_space() final;
+
+  const std::set<device_id_t>& get_device_ids() const final {
+    return sm_group->get_device_ids();
+  }
 
   // Testing interfaces
 
@@ -1642,6 +1648,10 @@ public:
   }
 
   clean_space_ret clean_space() final;
+
+  const std::set<device_id_t>& get_device_ids() const final {
+    return rb_group->get_device_ids();
+  }
 
   RandomBlockManager* get_rbm(paddr_t paddr) {
     auto rbs = rb_group->get_rb_managers();

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -544,14 +544,6 @@ public:
     journal_alloc_tail = JOURNAL_SEQ_NULL;
   }
 
-  bool should_trim_dirty() const {
-    return get_dirty_tail_target() > journal_dirty_tail;
-  }
-
-  bool should_trim_alloc() const {
-    return get_alloc_tail_target() > journal_alloc_tail;
-  }
-
   bool should_trim() const {
     return should_trim_alloc() || should_trim_dirty();
   }
@@ -596,6 +588,14 @@ public:
   friend std::ostream &operator<<(std::ostream &, const stat_printer_t &);
 
 private:
+  bool should_trim_dirty() const {
+    return get_dirty_tail_target() > journal_dirty_tail;
+  }
+
+  bool should_trim_alloc() const {
+    return get_alloc_tail_target() > journal_alloc_tail;
+  }
+
   using trim_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
   trim_ertr::future<> trim_dirty();
@@ -1152,6 +1152,8 @@ public:
 
   virtual const std::set<device_id_t>& get_device_ids() const = 0;
 
+  virtual std::size_t get_reclaim_size_per_cycle() const = 0;
+
   // test only
   virtual bool check_usage() = 0;
 
@@ -1333,6 +1335,10 @@ public:
 
   const std::set<device_id_t>& get_device_ids() const final {
     return sm_group->get_device_ids();
+  }
+
+  std::size_t get_reclaim_size_per_cycle() const final {
+    return config.reclaim_bytes_per_cycle;
   }
 
   // Testing interfaces
@@ -1651,6 +1657,10 @@ public:
 
   const std::set<device_id_t>& get_device_ids() const final {
     return rb_group->get_device_ids();
+  }
+
+  std::size_t get_reclaim_size_per_cycle() const final {
+    return 0;
   }
 
   RandomBlockManager* get_rbm(paddr_t paddr) {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1144,6 +1144,8 @@ public:
 
   virtual bool should_block_io_on_clean() const = 0;
 
+  virtual bool can_clean_space() const = 0;
+
   virtual bool should_clean_space() const = 0;
 
   using clean_space_ertr = base_ertr;
@@ -1315,6 +1317,11 @@ public:
     }
     auto aratio = get_projected_available_ratio();
     return aratio < config.available_ratio_hard_limit;
+  }
+
+  bool can_clean_space() const final {
+    assert(background_callback->is_ready());
+    return get_segments_reclaimable() > 0;
   }
 
   bool should_clean_space() const final {
@@ -1646,6 +1653,10 @@ public:
   void release_projected_usage(size_t) final;
 
   bool should_block_io_on_clean() const final {
+    return false;
+  }
+
+  bool can_clean_space() const final {
     return false;
   }
 

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1211,7 +1211,8 @@ public:
     SegmentManagerGroupRef&& sm_group,
     BackrefManager &backref_manager,
     SegmentSeqAllocator *segment_seq_allocator,
-    bool detailed);
+    bool detailed,
+    bool is_cold);
 
   void set_journal_trimmer(JournalTrimmer &_trimmer) {
     trimmer = &_trimmer;
@@ -1222,9 +1223,11 @@ public:
       SegmentManagerGroupRef&& sm_group,
       BackrefManager &backref_manager,
       SegmentSeqAllocator *ool_seq_allocator,
-      bool detailed) {
+      bool detailed,
+      bool is_cold = false) {
     return std::make_unique<SegmentCleaner>(
-        config, std::move(sm_group), backref_manager, ool_seq_allocator, detailed);
+        config, std::move(sm_group), backref_manager,
+        ool_seq_allocator, detailed, is_cold);
   }
 
   /*
@@ -1524,6 +1527,7 @@ private:
   }
 
   const bool detailed;
+  const bool is_cold;
   const config_t config;
 
   SegmentManagerGroupRef sm_group;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1210,11 +1210,8 @@ public:
     config_t config,
     SegmentManagerGroupRef&& sm_group,
     BackrefManager &backref_manager,
+    SegmentSeqAllocator *segment_seq_allocator,
     bool detailed);
-
-  SegmentSeqAllocator& get_ool_segment_seq_allocator() {
-    return *ool_segment_seq_allocator;
-  }
 
   void set_journal_trimmer(JournalTrimmer &_trimmer) {
     trimmer = &_trimmer;
@@ -1224,9 +1221,10 @@ public:
       config_t config,
       SegmentManagerGroupRef&& sm_group,
       BackrefManager &backref_manager,
+      SegmentSeqAllocator *ool_seq_allocator,
       bool detailed) {
     return std::make_unique<SegmentCleaner>(
-        config, std::move(sm_group), backref_manager, detailed);
+        config, std::move(sm_group), backref_manager, ool_seq_allocator, detailed);
   }
 
   /*
@@ -1574,7 +1572,7 @@ private:
   BackgroundListener *background_callback = nullptr;
 
   // TODO: drop once paddr->journal_seq_t is introduced
-  SegmentSeqAllocatorRef ool_segment_seq_allocator;
+  SegmentSeqAllocator *ool_segment_seq_allocator;
 };
 
 class RBMCleaner;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -398,6 +398,7 @@ struct BackgroundListener {
   virtual ~BackgroundListener() = default;
   virtual void maybe_wake_background() = 0;
   virtual void maybe_wake_blocked_io() = 0;
+  virtual void maybe_wake_promotion() = 0;
   virtual state_t get_state() const = 0;
 
   bool is_ready() const {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -135,7 +135,8 @@ void Cache::register_metrics()
     {src_t::READ, sm::label_instance("src", "READ")},
     {src_t::TRIM_DIRTY, sm::label_instance("src", "TRIM_DIRTY")},
     {src_t::TRIM_ALLOC, sm::label_instance("src", "TRIM_ALLOC")},
-    {src_t::CLEANER, sm::label_instance("src", "CLEANER")},
+    {src_t::CLEANER_MAIN, sm::label_instance("src", "CLEANER_MAIN")},
+    {src_t::CLEANER_COLD, sm::label_instance("src", "CLEANER_COLD")},
   };
   assert(labels_by_src.size() == (std::size_t)src_t::MAX);
 
@@ -624,8 +625,10 @@ void Cache::register_metrics()
            src2 == Transaction::src_t::READ) ||
           (src1 == Transaction::src_t::TRIM_DIRTY &&
            src2 == Transaction::src_t::TRIM_DIRTY) ||
-          (src1 == Transaction::src_t::CLEANER &&
-           src2 == Transaction::src_t::CLEANER) ||
+          (src1 == Transaction::src_t::CLEANER_MAIN &&
+           src2 == Transaction::src_t::CLEANER_MAIN) ||
+          (src1 == Transaction::src_t::CLEANER_COLD &&
+           src2 == Transaction::src_t::CLEANER_COLD) ||
           (src1 == Transaction::src_t::TRIM_ALLOC &&
            src2 == Transaction::src_t::TRIM_ALLOC)) {
         continue;
@@ -1389,7 +1392,8 @@ record_t Cache::prepare_record(
   auto &rewrite_version_stats = t.get_rewrite_version_stats();
   if (trans_src == Transaction::src_t::TRIM_DIRTY) {
     stats.committed_dirty_version.increment_stat(rewrite_version_stats);
-  } else if (trans_src == Transaction::src_t::CLEANER) {
+  } else if (trans_src == Transaction::src_t::CLEANER_MAIN ||
+             trans_src == Transaction::src_t::CLEANER_COLD) {
     stats.committed_reclaim_version.increment_stat(rewrite_version_stats);
   } else {
     assert(rewrite_version_stats.is_clear());

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -46,6 +46,7 @@ Cache::Cache(
   LOG_PREFIX(Cache::Cache);
   INFO("created, lru_size={}", lru.get_capacity());
   register_metrics();
+  segment_providers_by_device_id.resize(DEVICE_ID_MAX, nullptr);
 }
 
 Cache::~Cache()
@@ -1027,6 +1028,15 @@ CachedExtentRef Cache::duplicate_for_write(
   return ret;
 }
 
+void Cache::set_segment_provider(AsyncCleaner *cleaner) {
+  auto provider = dynamic_cast<SegmentProvider*>(cleaner);
+  if (provider) {
+    for (auto id : cleaner->get_device_ids()) {
+      segment_providers_by_device_id[id] = provider;
+    }
+  }
+}
+
 record_t Cache::prepare_record(
   Transaction &t,
   const journal_seq_t &journal_head,
@@ -1116,12 +1126,13 @@ record_t Cache::prepare_record(
       auto stype = segment_type_t::NULL_SEG;
 
       // FIXME: This is specific to the segmented implementation
-      if (segment_provider != nullptr &&
-          i->get_paddr().get_addr_type() == paddr_types_t::SEGMENT) {
+      if (i->get_paddr().get_addr_type() == paddr_types_t::SEGMENT) {
         auto sid = i->get_paddr().as_seg_paddr().get_segment_id();
-        auto &sinfo = segment_provider->get_seg_info(sid);
-        sseq = sinfo.seq;
-        stype = sinfo.type;
+        auto sinfo = get_segment_info(sid);
+        if (sinfo) {
+          sseq = sinfo->seq;
+          stype = sinfo->type;
+        }
       }
 
       record.push_back(
@@ -1660,21 +1671,22 @@ Cache::replay_delta(
    * safetly skip these deltas because the extent must already
    * have been rewritten.
    */
-  if (segment_provider != nullptr &&
-      delta.paddr != P_ADDR_NULL &&
+  if (delta.paddr != P_ADDR_NULL &&
       delta.paddr.get_addr_type() == paddr_types_t::SEGMENT) {
     auto& seg_addr = delta.paddr.as_seg_paddr();
-    auto& seg_info = segment_provider->get_seg_info(seg_addr.get_segment_id());
-    auto delta_paddr_segment_seq = seg_info.seq;
-    auto delta_paddr_segment_type = seg_info.type;
-    if (delta_paddr_segment_seq != delta.ext_seq ||
-        delta_paddr_segment_type != delta.seg_type) {
-      DEBUG("delta is obsolete, delta_paddr_segment_seq={},"
-            " delta_paddr_segment_type={} -- {}",
-            segment_seq_printer_t{delta_paddr_segment_seq},
-            delta_paddr_segment_type,
-            delta);
-      return replay_delta_ertr::make_ready_future<bool>(false);
+    auto seg_info = get_segment_info(seg_addr.get_segment_id());
+    if (seg_info) {
+      auto delta_paddr_segment_seq = seg_info->seq;
+      auto delta_paddr_segment_type = seg_info->type;
+      if (delta_paddr_segment_seq != delta.ext_seq ||
+          delta_paddr_segment_type != delta.seg_type) {
+        DEBUG("delta is obsolete, delta_paddr_segment_seq={},"
+              " delta_paddr_segment_type={} -- {}",
+              segment_seq_printer_t{delta_paddr_segment_seq},
+              delta_paddr_segment_type,
+              delta);
+        return replay_delta_ertr::make_ready_future<bool>(false);
+      }
     }
   }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -40,11 +40,12 @@ std::ostream &operator<<(std::ostream &out, const backref_entry_t &ent) {
 Cache::Cache(
   ExtentPlacementManager &epm)
   : epm(epm),
-    lru(crimson::common::get_conf<Option::size_t>(
-	  "seastore_cache_lru_size"))
+    extents_in_memory(std::make_unique<LRUCachePolicy>(
+	crimson::common::get_conf<Option::size_t>(
+	  "seastore_cache_lru_size")))
 {
   LOG_PREFIX(Cache::Cache);
-  INFO("created, lru_size={}", lru.get_capacity());
+  INFO("created, cache_size={}", extents_in_memory->get_capacity());
   register_metrics();
   segment_providers_by_device_id.resize(DEVICE_ID_MAX, nullptr);
 }
@@ -483,14 +484,14 @@ void Cache::register_metrics()
       sm::make_counter(
 	"cache_lru_size_bytes",
 	[this] {
-	  return lru.get_current_contents_bytes();
+	  return extents_in_memory->get_current_contents_bytes();
 	},
 	sm::description("total bytes pinned by the lru")
       ),
       sm::make_counter(
 	"cache_lru_size_extents",
 	[this] {
-	  return lru.get_current_contents_extents();
+	  return extents_in_memory->get_current_contents_extents();
 	},
 	sm::description("total extents pinned by the lru")
       ),
@@ -721,7 +722,7 @@ void Cache::mark_dirty(CachedExtentRef ref)
     return;
   }
 
-  lru.remove_from_lru(*ref);
+  extents_in_memory->remove_from_cache(*ref);
   ref->state = CachedExtent::extent_state_t::DIRTY;
   add_to_dirty(ref);
 }
@@ -754,7 +755,7 @@ void Cache::remove_extent(CachedExtentRef ref)
   if (ref->is_dirty()) {
     remove_from_dirty(ref);
   } else if (!ref->is_placeholder()) {
-    lru.remove_from_lru(*ref);
+    extents_in_memory->remove_from_cache(*ref);
   }
   extents.erase(*ref);
 }
@@ -797,7 +798,7 @@ void Cache::commit_replace_extent(
     intrusive_ptr_release(&*prev);
     intrusive_ptr_add_ref(&*next);
   } else {
-    lru.remove_from_lru(*prev);
+    extents_in_memory->remove_from_cache(*prev);
     add_to_dirty(next);
   }
 
@@ -1631,8 +1632,8 @@ Cache::close_ertr::future<> Cache::close()
        stats.dirty_bytes,
        get_oldest_dirty_from().value_or(JOURNAL_SEQ_NULL),
        get_oldest_backref_dirty_from().value_or(JOURNAL_SEQ_NULL),
-       lru.get_current_contents_extents(),
-       lru.get_current_contents_bytes(),
+       extents_in_memory->get_current_contents_extents(),
+       extents_in_memory->get_current_contents_bytes(),
        extents.size(),
        extents.get_bytes());
   root.reset();
@@ -1645,7 +1646,7 @@ Cache::close_ertr::future<> Cache::close()
   backref_extents.clear();
   backref_entryrefs_by_seq.clear();
   assert(stats.dirty_bytes == 0);
-  lru.clear();
+  extents_in_memory->clear();
   return close_ertr::now();
 }
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1225,8 +1225,10 @@ private:
              src2 == Transaction::src_t::READ));
     assert(!(src1 == Transaction::src_t::TRIM_DIRTY &&
              src2 == Transaction::src_t::TRIM_DIRTY));
-    assert(!(src1 == Transaction::src_t::CLEANER &&
-             src2 == Transaction::src_t::CLEANER));
+    assert(!(src1 == Transaction::src_t::CLEANER_MAIN &&
+	     src2 == Transaction::src_t::CLEANER_MAIN));
+    assert(!(src1 == Transaction::src_t::CLEANER_COLD &&
+	     src2 == Transaction::src_t::CLEANER_COLD));
     assert(!(src1 == Transaction::src_t::TRIM_ALLOC &&
              src2 == Transaction::src_t::TRIM_ALLOC));
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -27,6 +27,7 @@ namespace crimson::os::seastore {
 
 class BackrefManager;
 class SegmentProvider;
+class AsyncCleaner;
 
 struct backref_entry_t {
   backref_entry_t(
@@ -567,6 +568,15 @@ private:
     return backref_entryrefs_by_seq;
   }
 
+  const segment_info_t* get_segment_info(segment_id_t sid) {
+    auto provider = segment_providers_by_device_id[sid.device_id()];
+    if (provider) {
+      return &provider->get_seg_info(sid);
+    } else {
+      return nullptr;
+    }
+  }
+
 public:
   /**
    * get_extent_by_type
@@ -685,10 +695,7 @@ public:
    *
    * FIXME: This is specific to the segmented implementation
    */
-  void set_segment_provider(SegmentProvider &sp) {
-    assert(segment_provider == nullptr);
-    segment_provider = &sp;
-  }
+  void set_segment_provider(AsyncCleaner *cleaner);
 
   /**
    * prepare_record
@@ -980,7 +987,7 @@ private:
   journal_seq_t last_commit = JOURNAL_SEQ_MIN;
 
   // FIXME: This is specific to the segmented implementation
-  SegmentProvider *segment_provider = nullptr;
+  std::vector<SegmentProvider*> segment_providers_by_device_id;
 
   /**
    * dirty

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -30,6 +30,7 @@ class BackrefManager;
 class SegmentProvider;
 class AsyncCleaner;
 class Cache;
+struct BackgroundListener;
 
 struct backref_entry_t {
   backref_entry_t(
@@ -1072,6 +1073,7 @@ private:
   CachePolicyRef extents_in_memory;
 
   std::unique_ptr<promotion_state_t> promotion_state;
+  BackgroundListener *listener;
 
   bool support_extents_promotion() const {
     return epm.has_cold_tier() && promotion_state.get() != nullptr;

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1168,6 +1168,7 @@ private:
 
     version_stat_t committed_dirty_version;
     version_stat_t committed_reclaim_version;
+    version_stat_t committed_promotion_version;
   } stats;
 
   template <typename CounterT>
@@ -1203,6 +1204,8 @@ private:
 	     src2 == Transaction::src_t::CLEANER_MAIN));
     assert(!(src1 == Transaction::src_t::CLEANER_COLD &&
 	     src2 == Transaction::src_t::CLEANER_COLD));
+    assert(!(src1 == Transaction::src_t::PROMOTE_COLD &&
+	     src2 == Transaction::src_t::PROMOTE_COLD));
     assert(!(src1 == Transaction::src_t::TRIM_ALLOC &&
              src2 == Transaction::src_t::TRIM_ALLOC));
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -18,6 +18,7 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/transaction.h"
+#include "crimson/os/seastore/cache/lru.h"
 
 namespace crimson::os::seastore::backref {
 class BtreeBackrefManager;
@@ -1032,83 +1033,7 @@ private:
    *
    * holds references to recently used extents
    */
-  class LRU {
-    // max size (bytes)
-    const size_t capacity = 0;
-
-    // current size (bytes)
-    size_t contents = 0;
-
-    CachedExtent::list lru;
-
-    void trim_to_capacity() {
-      while (contents > capacity) {
-	assert(lru.size() > 0);
-	remove_from_lru(lru.front());
-      }
-    }
-
-    void add_to_lru(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
-      
-      if (!extent.primary_ref_list_hook.is_linked()) {
-	contents += extent.get_length();
-	intrusive_ptr_add_ref(&extent);
-	lru.push_back(extent);
-      }
-      trim_to_capacity();
-    }
-
-  public:
-    LRU(size_t capacity) : capacity(capacity) {}
-
-    size_t get_capacity() const {
-      return capacity;
-    }
-
-    size_t get_current_contents_bytes() const {
-      return contents;
-    }
-
-    size_t get_current_contents_extents() const {
-      return lru.size();
-    }
-
-    void remove_from_lru(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
-
-      if (extent.primary_ref_list_hook.is_linked()) {
-	lru.erase(lru.s_iterator_to(extent));
-	assert(contents >= extent.get_length());
-	contents -= extent.get_length();
-	intrusive_ptr_release(&extent);
-      }
-    }
-
-    void move_to_top(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
-
-      if (extent.primary_ref_list_hook.is_linked()) {
-	lru.erase(lru.s_iterator_to(extent));
-	intrusive_ptr_release(&extent);
-	assert(contents >= extent.get_length());
-	contents -= extent.get_length();
-      }
-      add_to_lru(extent);
-    }
-
-    void clear() {
-      LOG_PREFIX(Cache::LRU::clear);
-      for (auto iter = lru.begin(); iter != lru.end();) {
-	SUBDEBUG(seastore_cache, "clearing {}", *iter);
-	remove_from_lru(*(iter++));
-      }
-    }
-
-    ~LRU() {
-      clear();
-    }
-  } lru;
+  CachePolicyRef extents_in_memory;
 
   struct query_counters_t {
     uint64_t access = 0;
@@ -1268,7 +1193,7 @@ private:
     if (p_src && is_background_transaction(*p_src))
       return;
     if (ext.is_clean() && !ext.is_placeholder()) {
-      lru.move_to_top(ext);
+      extents_in_memory->move_to_top(ext);
     }
   }
 

--- a/src/crimson/os/seastore/cache/lru.cc
+++ b/src/crimson/os/seastore/cache/lru.cc
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/cache/lru.h"
+#include "crimson/os/seastore/cache.h"
+
+namespace crimson::os::seastore {
+
+void LRUCachePolicy::remove(CachedExtent &extent, bool need_to_promote) {
+  assert(extent.is_clean() && !extent.is_placeholder());
+
+  if (extent.primary_ref_list_hook.is_linked()) {
+    lru.erase(lru.s_iterator_to(extent));
+    assert(contents >= extent.get_length());
+    contents -= extent.get_length();
+    if (need_to_promote && cache->promotion_state) {
+      cache->promotion_state->maybe_promote(extent);
+    }
+    intrusive_ptr_release(&extent);
+  }
+}
+
+}

--- a/src/crimson/os/seastore/cache/lru.h
+++ b/src/crimson/os/seastore/cache/lru.h
@@ -1,0 +1,106 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/os/seastore/logging.h"
+#include "crimson/os/seastore/cached_extent.h"
+
+namespace crimson::os::seastore {
+
+struct CachePolicy {
+  virtual ~CachePolicy() {}
+  virtual std::size_t get_capacity() const = 0;
+  virtual std::size_t get_current_contents_bytes() const = 0;
+  virtual std::size_t get_current_contents_extents() const = 0;
+  virtual void remove_from_cache(CachedExtent &extent) = 0;
+  virtual void move_to_top(CachedExtent &extent) = 0;
+  virtual void clear() = 0;
+};
+using CachePolicyRef = std::unique_ptr<CachePolicy>;
+
+// TODO: add ARC policy
+
+/**
+ * LRUCachePolicy
+ *
+ * holds references to recently used extents
+ */
+class LRUCachePolicy : public CachePolicy {
+  // max size (bytes)
+  const size_t capacity = 0;
+
+  // current size (bytes)
+  size_t contents = 0;
+
+  CachedExtent::list lru;
+
+  void trim_to_capacity() {
+    while (contents > capacity) {
+      assert(lru.size() > 0);
+      remove_from_cache(lru.front());
+    }
+  }
+
+  void add_to_lru(CachedExtent &extent) {
+    assert(extent.is_clean() && !extent.is_placeholder());
+
+    if (!extent.primary_ref_list_hook.is_linked()) {
+      contents += extent.get_length();
+      intrusive_ptr_add_ref(&extent);
+      lru.push_back(extent);
+    }
+    trim_to_capacity();
+  }
+
+public:
+  LRUCachePolicy(size_t capacity) : capacity(capacity) {}
+
+  size_t get_capacity() const final {
+    return capacity;
+  }
+
+  size_t get_current_contents_bytes() const final {
+    return contents;
+  }
+
+  size_t get_current_contents_extents() const final {
+    return lru.size();
+  }
+
+  void remove_from_cache(CachedExtent &extent) final {
+    assert(extent.is_clean() && !extent.is_placeholder());
+
+    if (extent.primary_ref_list_hook.is_linked()) {
+      lru.erase(lru.s_iterator_to(extent));
+      assert(contents >= extent.get_length());
+      contents -= extent.get_length();
+      intrusive_ptr_release(&extent);
+    }
+  }
+
+  void move_to_top(CachedExtent &extent) final {
+    assert(extent.is_clean() && !extent.is_placeholder());
+
+    if (extent.primary_ref_list_hook.is_linked()) {
+      lru.erase(lru.s_iterator_to(extent));
+      intrusive_ptr_release(&extent);
+      assert(contents >= extent.get_length());
+      contents -= extent.get_length();
+    }
+    add_to_lru(extent);
+  }
+
+  void clear() final {
+    LOG_PREFIX(LRUMemoryCache::clear);
+    for (auto iter = lru.begin(); iter != lru.end();) {
+      SUBDEBUG(seastore_cache, "clearing {}", *iter);
+      remove_from_cache(*(iter++));
+    }
+  }
+
+  ~LRUCachePolicy() {
+    clear();
+  }
+};
+}

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -23,6 +23,7 @@ using CachedExtentRef = boost::intrusive_ptr<CachedExtent>;
 class SegmentedAllocator;
 class TransactionManager;
 class ExtentPlacementManager;
+class LRUCachePolicy;
 
 // #define DEBUG_CACHED_EXTENT_REF
 #ifdef DEBUG_CACHED_EXTENT_REF
@@ -584,6 +585,7 @@ protected:
   friend class crimson::os::seastore::SegmentedAllocator;
   friend class crimson::os::seastore::TransactionManager;
   friend class crimson::os::seastore::ExtentPlacementManager;
+  friend class crimson::os::seastore::LRUCachePolicy;
 };
 
 std::ostream &operator<<(std::ostream &, CachedExtent::extent_state_t);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -24,6 +24,7 @@ class SegmentedAllocator;
 class TransactionManager;
 class ExtentPlacementManager;
 class LRUCachePolicy;
+class promotion_state_t;
 
 // #define DEBUG_CACHED_EXTENT_REF
 #ifdef DEBUG_CACHED_EXTENT_REF
@@ -447,6 +448,7 @@ private:
   using index = boost::intrusive::set<CachedExtent, index_member_options>;
   friend class ExtentIndex;
   friend class Transaction;
+  friend class promotion_state_t;
 
   bool is_linked() {
     return extent_index_hook.is_linked();
@@ -509,6 +511,8 @@ private:
   // the target rewrite generation for the followup rewrite
   // or the rewrite generation for the fresh write
   rewrite_gen_t rewrite_generation = NULL_GENERATION;
+
+  bool is_pending_promotion = false;
 
 protected:
   CachedExtent(CachedExtent &&other) = delete;

--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -36,7 +36,7 @@ seastar::future<DeviceRef>
 Device::make_device(const std::string& device, device_type_t dtype)
 {
   if (get_default_backend_of_device(dtype) == backend_type_t::SEGMENTED) {
-    return SegmentManager::get_segment_manager(device
+    return SegmentManager::get_segment_manager(device, dtype
     ).then([](DeviceRef ret) {
       return ret;
     });

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -190,7 +190,7 @@ void ExtentPlacementManager::init(
     for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::DATA, gen, *segment_cleaner,
-	    segment_cleaner->get_ool_segment_seq_allocator()));
+            *ool_segment_seq_allocator));
       data_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
     }
 
@@ -198,7 +198,7 @@ void ExtentPlacementManager::init(
     for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::METADATA, gen, *segment_cleaner,
-	    segment_cleaner->get_ool_segment_seq_allocator()));
+            *ool_segment_seq_allocator));
       md_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
     }
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -679,7 +679,7 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
     });
   } else {
     bool should_clean_main =
-      main_cleaner->should_clean_space() ||
+      main_cleaner_should_run() ||
       // make sure cleaner will start
       // when the trimmer should run but
       // failed to reserve space.

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -545,12 +545,71 @@ ExtentPlacementManager::BackgroundProcess::run()
   });
 }
 
+/**
+ * Reservation Process
+ *
+ * Most of transctions need to reserve its space usage before performing the
+ * ool writes and committing transactions. If the space reservation is
+ * unsuccessful, the current transaction is blocked, and waits for new
+ * background transactions to finish.
+ *
+ * The following are the reservation requirements for each transaction type:
+ * 1. MUTATE transaction:
+ *      (1) inline usage on the trimmer,
+ *      (2) inline usage with OOL usage on the main cleaner,
+ *      (3) cold OOL usage to the cold cleaner(if it exists).
+ * 2. TRIM_DIRTY/TRIM_ALLOC transaction:
+ *      (1) all extents usage on the main cleaner,
+ *      (2) usage on the cold cleaner(if it exists)
+ * 3. CLEANER_MAIN:
+ *      (1) cleaned extents size on the cold cleaner(if it exists).
+ * 4. CLEANER_COLD transction does not require space reservation.
+ *
+ * The reserve implementation should satisfy the following conditions:
+ * 1. The reservation should be atomic. If a reservation involves several reservations,
+ *    such as the MUTATE transaction that needs to reserve space on both the trimmer
+ *    and cleaner at the same time, the successful condition is that all of its
+ *    sub-reservations succeed. If one or more operations fail, the entire reservation
+ *    fails, and the successful operation should be reverted.
+ * 2. The reserve/block relationship should form a DAG to avoid deadlock. For example,
+ *    TRIM_ALLOC transaction might be blocked by cleaner due to the failure of reserving
+ *    on the cleaner. In such cases, the cleaner must not reserve space on the trimmer
+ *    since the trimmer is already blocked by itself.
+ *
+ * Finally the reserve relationship can be represented as follows:
+ *
+ *    +-------------------------+----------------+
+ *    |                         |                |
+ *    |                         v                v
+ * MUTATE ---> TRIM_* ---> CLEANER_MAIN ---> CLEANER_COLD
+ *              |                                ^
+ *              |                                |
+ *              +--------------------------------+
+ */
+bool ExtentPlacementManager::BackgroundProcess::try_reserve_cold(std::size_t usage)
+{
+  if (has_cold_tier()) {
+    return cold_cleaner->try_reserve_projected_usage(usage);
+  } else {
+    assert(usage == 0);
+    return true;
+  }
+}
+void ExtentPlacementManager::BackgroundProcess::abort_cold_usage(
+  std::size_t usage, bool success)
+{
+  if (has_cold_tier() && success) {
+    cold_cleaner->release_projected_usage(usage);
+  }
+}
+
 reserve_cleaner_result_t
 ExtentPlacementManager::BackgroundProcess::try_reserve_cleaner(
   const cleaner_usage_t &usage)
 {
   return {
-    main_cleaner->try_reserve_projected_usage(usage.main_usage)
+    main_cleaner->try_reserve_projected_usage(usage.main_usage),
+    try_reserve_cold(usage.cold_ool_usage)
   };
 }
 
@@ -561,6 +620,7 @@ void ExtentPlacementManager::BackgroundProcess::abort_cleaner_usage(
   if (result.reserve_main_success) {
     main_cleaner->release_projected_usage(usage.main_usage);
   }
+  abort_cold_usage(usage.cold_ool_usage, result.reserve_cold_success);
 }
 
 reserve_io_result_t
@@ -590,11 +650,22 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
   bool should_trim = trimmer->should_trim();
   bool proceed_trim = false;
   auto trim_size = trimmer->get_trim_size_per_cycle();
-  cleaner_usage_t trim_usage{trim_size};
+  cleaner_usage_t trim_usage{
+    trim_size,
+    // We take a cautious policy here that the trimmer also reserves
+    // the max value on cold cleaner even if no extents will be rewritten
+    // to the cold tier. Cleaner also takes the same policy.
+    // The reason is that we don't know the exact value of reservation until
+    // the construction of trimmer transaction completes after which the reservation
+    // might fail then the trimmer is possible to be invalidated by cleaner.
+    // Reserving the max size at first could help us avoid these trouble.
+    has_cold_tier() ? trim_size : 0
+  };
 
+  reserve_cleaner_result_t trim_reserve_res;
   if (should_trim) {
-    auto res = try_reserve_cleaner(trim_usage);
-    if (res.is_successful()) {
+    trim_reserve_res = try_reserve_cleaner(trim_usage);
+    if (trim_reserve_res.is_successful()) {
       proceed_trim = true;
     } else {
       abort_cleaner_usage(trim_usage, trim_reserve_res);
@@ -604,21 +675,65 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
   if (proceed_trim) {
     return trimmer->trim(
     ).finally([this, trim_usage] {
-      abort_cleaner_usage(trim_usage, {true});
+      abort_cleaner_usage(trim_usage, {true, true});
     });
-  } else if (main_cleaner->should_clean_space() ||
-             // make sure cleaner will start
-             // when the trimmer should run but
-             // failed to reserve space.
-             (should_trim && !proceed_trim)) {
-    return main_cleaner->clean_space(
-    ).handle_error(
-      crimson::ct_error::assert_all{
-	"do_background_cycle encountered invalid error in clean_space"
-      }
-    );
   } else {
-    return seastar::now();
+    bool should_clean_main =
+      main_cleaner->should_clean_space() ||
+      // make sure cleaner will start
+      // when the trimmer should run but
+      // failed to reserve space.
+      (should_trim && !proceed_trim &&
+       !trim_reserve_res.reserve_main_success);
+    bool proceed_clean_main = false;
+
+    auto main_cold_usage = main_cleaner->get_reclaim_size_per_cycle();
+    if (should_clean_main) {
+      if (has_cold_tier()) {
+        proceed_clean_main = try_reserve_cold(main_cold_usage);
+      } else {
+        proceed_clean_main = true;
+      }
+    }
+
+    bool proceed_clean_cold = false;
+    if (has_cold_tier() &&
+        (cold_cleaner->should_clean_space() ||
+         (should_trim && !proceed_trim &&
+          !trim_reserve_res.reserve_cold_success) ||
+         (should_clean_main && !proceed_clean_main))) {
+      proceed_clean_cold = true;
+    }
+
+    if (!proceed_clean_main && !proceed_clean_cold) {
+      ceph_abort("no background process will start");
+    }
+    return seastar::when_all(
+      [this, proceed_clean_main, main_cold_usage] {
+        if (!proceed_clean_main) {
+          return seastar::now();
+        }
+        return main_cleaner->clean_space(
+        ).handle_error(
+          crimson::ct_error::assert_all{
+            "do_background_cycle encountered invalid error in main clean_space"
+          }
+        ).finally([this, main_cold_usage] {
+          abort_cold_usage(main_cold_usage, true);
+        });
+      },
+      [this, proceed_clean_cold] {
+        if (!proceed_clean_cold) {
+          return seastar::now();
+        }
+        return cold_cleaner->clean_space(
+        ).handle_error(
+          crimson::ct_error::assert_all{
+            "do_background_cycle encountered invalid error in cold clean_space"
+          }
+        );
+      }
+    ).discard_result();
   }
 }
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -178,16 +178,24 @@ SegmentedOolWriter::alloc_write_ool_extents(
 }
 
 void ExtentPlacementManager::init(
-    JournalTrimmerImplRef &&trimmer, AsyncCleanerRef &&cleaner)
+    JournalTrimmerImplRef &&trimmer,
+    AsyncCleanerRef &&cleaner,
+    AsyncCleanerRef &&cold_cleaner)
 {
   writer_refs.clear();
+  auto cold_segment_cleaner = dynamic_cast<SegmentCleaner*>(cold_cleaner.get());
+  dynamic_max_rewrite_generation = MIN_COLD_GENERATION - 1;
+  if (cold_segment_cleaner) {
+    dynamic_max_rewrite_generation = MAX_REWRITE_GENERATION;
+  }
 
   if (trimmer->get_journal_type() == journal_type_t::SEGMENTED) {
     auto segment_cleaner = dynamic_cast<SegmentCleaner*>(cleaner.get());
     ceph_assert(segment_cleaner != nullptr);
-    auto num_writers = generation_to_writer(REWRITE_GENERATIONS);
+    auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);
+
     data_writers_by_gen.resize(num_writers, {});
-    for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+    for (rewrite_gen_t gen = OOL_GENERATION; gen < MIN_COLD_GENERATION; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::DATA, gen, *segment_cleaner,
             *ool_segment_seq_allocator));
@@ -195,7 +203,7 @@ void ExtentPlacementManager::init(
     }
 
     md_writers_by_gen.resize(num_writers, {});
-    for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+    for (rewrite_gen_t gen = OOL_GENERATION; gen < MIN_COLD_GENERATION; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::METADATA, gen, *segment_cleaner,
             *ool_segment_seq_allocator));
@@ -210,7 +218,7 @@ void ExtentPlacementManager::init(
     assert(trimmer->get_journal_type() == journal_type_t::RANDOM_BLOCK);
     auto rb_cleaner = dynamic_cast<RBMCleaner*>(cleaner.get());
     ceph_assert(rb_cleaner != nullptr);
-    auto num_writers = generation_to_writer(REWRITE_GENERATIONS);
+    auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);
     data_writers_by_gen.resize(num_writers, {});
     md_writers_by_gen.resize(num_writers, {});
     writer_refs.emplace_back(std::make_unique<RandomBlockOolWriter>(
@@ -223,7 +231,33 @@ void ExtentPlacementManager::init(
     }
   }
 
-  background_process.init(std::move(trimmer), std::move(cleaner));
+  if (cold_segment_cleaner) {
+    for (rewrite_gen_t gen = MIN_COLD_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+      writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
+            data_category_t::DATA, gen, *cold_segment_cleaner,
+            *ool_segment_seq_allocator));
+      data_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
+    }
+    for (rewrite_gen_t gen = MIN_COLD_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
+      writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
+            data_category_t::METADATA, gen, *cold_segment_cleaner,
+            *ool_segment_seq_allocator));
+      md_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
+    }
+    for (auto *device : cold_segment_cleaner->get_segment_manager_group()
+                                            ->get_segment_managers()) {
+      add_device(device);
+    }
+  }
+
+  background_process.init(std::move(trimmer),
+                          std::move(cleaner),
+                          std::move(cold_cleaner));
+  if (cold_segment_cleaner) {
+    ceph_assert(background_process.has_cold_tier());
+  } else {
+    ceph_assert(!background_process.has_cold_tier());
+  }
 }
 
 void ExtentPlacementManager::set_primary_device(Device *device)
@@ -269,11 +303,17 @@ ExtentPlacementManager::dispatch_delayed_extents(Transaction &t)
   }
 
   for (auto &extent : res.delayed_extents) {
-    res.usage.cleaner_usage.main_usage += extent->get_length();
     if (dispatch_delayed_extent(extent)) {
       res.usage.inline_usage += extent->get_length();
+      res.usage.cleaner_usage.main_usage += extent->get_length();
       t.mark_delayed_extent_inline(extent);
     } else {
+      if (extent->get_rewrite_generation() < MIN_COLD_GENERATION) {
+        res.usage.cleaner_usage.main_usage += extent->get_length();
+      } else {
+        assert(background_process.has_cold_tier());
+        res.usage.cleaner_usage.cold_ool_usage += extent->get_length();
+      }
       t.mark_delayed_extent_ool(extent);
       auto writer_ptr = get_writer(
           extent->get_user_hint(),
@@ -350,6 +390,11 @@ void ExtentPlacementManager::BackgroundProcess::log_state(const char *caller) co
         caller,
         JournalTrimmerImpl::stat_printer_t{*trimmer, true},
         AsyncCleaner::stat_printer_t{*main_cleaner, true});
+  if (has_cold_tier()) {
+    DEBUG("caller {}, cold_cleaner: {}",
+          caller,
+          AsyncCleaner::stat_printer_t{*cold_cleaner, true});
+  }
 }
 
 void ExtentPlacementManager::BackgroundProcess::start_background()
@@ -358,6 +403,10 @@ void ExtentPlacementManager::BackgroundProcess::start_background()
   INFO("{}, {}",
        JournalTrimmerImpl::stat_printer_t{*trimmer, true},
        AsyncCleaner::stat_printer_t{*main_cleaner, true});
+  if (has_cold_tier()) {
+    INFO("cold_cleaner: {}",
+         AsyncCleaner::stat_printer_t{*cold_cleaner, true});
+  }
   ceph_assert(trimmer->check_is_ready());
   ceph_assert(state == state_t::SCAN_SPACE);
   assert(!is_running());
@@ -388,6 +437,10 @@ ExtentPlacementManager::BackgroundProcess::stop_background()
     INFO("done, {}, {}",
          JournalTrimmerImpl::stat_printer_t{*trimmer, true},
          AsyncCleaner::stat_printer_t{*main_cleaner, true});
+    if (has_cold_tier()) {
+      INFO("done, cold_cleaner: {}",
+           AsyncCleaner::stat_printer_t{*cold_cleaner, true});
+    }
     // run_until_halt() can be called at HALT
   });
 }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -13,6 +13,8 @@
 #include "crimson/os/seastore/random_block_manager/block_rb_manager.h"
 #include "crimson/os/seastore/randomblock_manager_group.h"
 
+class transaction_manager_test_t;
+
 namespace crimson::os::seastore {
 
 /**
@@ -870,6 +872,8 @@ private:
     bool is_running_until_halt = false;
     state_t state = state_t::STOP;
     eviction_state_t eviction_state;
+
+    friend class ::transaction_manager_test_t;
   };
 
   std::vector<ExtentOolWriterRef> writer_refs;
@@ -881,10 +885,12 @@ private:
   Device* primary_device = nullptr;
   std::size_t num_devices = 0;
 
-  rewrite_gen_t dynamic_max_rewrite_generation;
+  rewrite_gen_t dynamic_max_rewrite_generation = REWRITE_GENERATIONS;
   BackgroundProcess background_process;
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;
+
+  friend class ::transaction_manager_test_t;
 };
 
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -364,6 +364,14 @@ public:
     return primary_device->get_backend_type();
   }
 
+  bool has_cold_tier() const {
+    return background_process.has_cold_tier();
+  }
+
+  bool is_cold_device(device_id_t id) const {
+    return background_process.is_cold_device(id);
+  }
+
   // Testing interfaces
 
   void test_init_no_background(Device *test_device) {
@@ -506,6 +514,12 @@ private:
 
     bool has_cold_tier() const {
       return cold_cleaner.get() != nullptr;
+    }
+
+    bool is_cold_device(device_id_t id) const {
+      return has_cold_tier() &&
+        (cleaners_by_device_id[id] &&
+         cleaners_by_device_id[id] != main_cleaner.get());
     }
 
     void set_extent_callback(ExtentCallbackInterface *cb) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -173,11 +173,18 @@ struct reserve_io_result_t {
 
 class ExtentPlacementManager {
 public:
-  ExtentPlacementManager() {
+  ExtentPlacementManager()
+    : ool_segment_seq_allocator(
+          std::make_unique<SegmentSeqAllocator>(segment_type_t::OOL))
+  {
     devices_by_id.resize(DEVICE_ID_MAX, nullptr);
   }
 
   void init(JournalTrimmerImplRef &&, AsyncCleanerRef &&);
+
+  SegmentSeqAllocator* get_ool_segment_seq_allocator() const {
+    return ool_segment_seq_allocator.get();
+  }
 
   void set_primary_device(Device *device);
 
@@ -645,6 +652,8 @@ private:
   std::size_t num_devices = 0;
 
   BackgroundProcess background_process;
+  // TODO: drop once paddr->journal_seq_t is introduced
+  SegmentSeqAllocatorRef ool_segment_seq_allocator;
 };
 
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -132,7 +132,8 @@ struct cleaner_usage_t {
   // The size of all extents write to the main devices, including inline extents
   // and out-of-line extents.
   std::size_t main_usage = 0;
-  // TODO: add cold_ool_usage
+  // The size of extents write to the cold devices
+  std::size_t cold_ool_usage = 0;
 };
 
 struct reserve_cleaner_result_t {
@@ -157,6 +158,7 @@ struct io_usage_t {
     return out << "io_usage_t("
                << "inline_usage=" << usage.inline_usage
                << ", main_cleaner_usage=" << usage.cleaner_usage.main_usage
+               << ", cold_cleaner_usage=" << usage.cleaner_usage.cold_ool_usage
                << ")";
   }
 };
@@ -180,7 +182,7 @@ public:
     devices_by_id.resize(DEVICE_ID_MAX, nullptr);
   }
 
-  void init(JournalTrimmerImplRef &&, AsyncCleanerRef &&);
+  void init(JournalTrimmerImplRef &&, AsyncCleanerRef &&, AsyncCleanerRef &&);
 
   SegmentSeqAllocator* get_ool_segment_seq_allocator() const {
     return ool_segment_seq_allocator.get();
@@ -302,8 +304,8 @@ public:
     } else {
       assert(get_extent_category(type) == data_category_t::DATA ||
              gen >= MIN_REWRITE_GENERATION);
-      if (gen > MAX_REWRITE_GENERATION) {
-        gen = MAX_REWRITE_GENERATION;
+      if (gen > dynamic_max_rewrite_generation) {
+        gen = dynamic_max_rewrite_generation;
       } else if (gen == INIT_GENERATION) {
         gen = OOL_GENERATION;
       }
@@ -442,6 +444,7 @@ private:
     assert(hint < placement_hint_t::NUM_HINTS);
     assert(is_rewrite_generation(gen));
     assert(gen != INLINE_GENERATION);
+    assert(gen <= dynamic_max_rewrite_generation);
     if (category == data_category_t::DATA) {
       return data_writers_by_gen[generation_to_writer(gen)];
     } else {
@@ -462,24 +465,40 @@ private:
     BackgroundProcess() = default;
 
     void init(JournalTrimmerImplRef &&_trimmer,
-              AsyncCleanerRef &&_cleaner) {
+              AsyncCleanerRef &&_cleaner,
+              AsyncCleanerRef &&_cold_cleaner) {
       trimmer = std::move(_trimmer);
       trimmer->set_background_callback(this);
       main_cleaner = std::move(_cleaner);
       main_cleaner->set_background_callback(this);
+      if (_cold_cleaner) {
+        cold_cleaner = std::move(_cold_cleaner);
+        cold_cleaner->set_background_callback(this);
+      }
     }
 
     journal_type_t get_journal_type() const {
       return trimmer->get_journal_type();
     }
 
+    bool has_cold_tier() const {
+      return cold_cleaner.get() != nullptr;
+    }
+
     void set_extent_callback(ExtentCallbackInterface *cb) {
       trimmer->set_extent_callback(cb);
       main_cleaner->set_extent_callback(cb);
+      if (has_cold_tier()) {
+        cold_cleaner->set_extent_callback(cb);
+      }
     }
 
     store_statfs_t get_stat() const {
-      return main_cleaner->get_stat();
+      auto stat = main_cleaner->get_stat();
+      if (has_cold_tier()) {
+        stat.add(cold_cleaner->get_stat());
+      }
+      return stat;
     }
 
     using mount_ret = ExtentPlacementManager::mount_ret;
@@ -489,13 +508,18 @@ private:
       trimmer->reset();
       stats = {};
       register_metrics();
-      return main_cleaner->mount();
+      return main_cleaner->mount(
+      ).safe_then([this] {
+        return has_cold_tier() ? cold_cleaner->mount() : mount_ertr::now();
+      });
     }
 
     void start_scan_space() {
       ceph_assert(state == state_t::MOUNT);
       state = state_t::SCAN_SPACE;
       ceph_assert(main_cleaner->check_usage_is_empty());
+      ceph_assert(!has_cold_tier() ||
+                  cold_cleaner->check_usage_is_empty());
     }
 
     void start_background();
@@ -541,7 +565,8 @@ private:
     // Testing interfaces
 
     bool check_usage() {
-      return main_cleaner->check_usage();
+      return main_cleaner->check_usage() &&
+        (!has_cold_tier() || cold_cleaner->check_usage());
     }
 
     seastar::future<> run_until_halt();
@@ -635,6 +660,11 @@ private:
     JournalTrimmerImplRef trimmer;
     AsyncCleanerRef main_cleaner;
 
+    /*
+     * cold tier (optional, see has_cold_tier())
+     */
+    AsyncCleanerRef cold_cleaner;
+
     std::optional<seastar::future<>> process_join;
     std::optional<seastar::promise<>> blocking_background;
     std::optional<seastar::promise<>> blocking_io;
@@ -651,6 +681,7 @@ private:
   Device* primary_device = nullptr;
   std::size_t num_devices = 0;
 
+  rewrite_gen_t dynamic_max_rewrite_generation;
   BackgroundProcess background_process;
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -249,72 +249,28 @@ public:
     assert(is_target_rewrite_generation(gen));
     assert(gen == INIT_GENERATION || hint == placement_hint_t::REWRITE);
 
+    data_category_t category = get_extent_category(type);
+    gen = adjust_generation(category, type, hint, gen);
+
     // XXX: bp might be extended to point to different memory (e.g. PMem)
     // according to the allocator.
-    auto alloc_paddr = [this](rewrite_gen_t gen, 
-      data_category_t category, extent_len_t length) 
-      -> alloc_result_t {
-      auto bp = ceph::bufferptr(
+    auto bp = ceph::bufferptr(
       buffer::create_page_aligned(length));
-      bp.zero();
-      paddr_t addr;
-      if (gen == INLINE_GENERATION) {
-	addr = make_record_relative_paddr(0);
-      } else if (category == data_category_t::DATA) {
-        gen = background_process.adjust_generation(gen);
-	assert(data_writers_by_gen[generation_to_writer(gen)]);
-	addr = data_writers_by_gen[
+    bp.zero();
+    paddr_t addr;
+    if (gen == INLINE_GENERATION) {
+      addr = make_record_relative_paddr(0);
+    } else if (category == data_category_t::DATA) {
+      assert(data_writers_by_gen[generation_to_writer(gen)]);
+      addr = data_writers_by_gen[
 	  generation_to_writer(gen)]->alloc_paddr(length);
-      } else {
-        gen = background_process.adjust_generation(gen);
-	assert(category == data_category_t::METADATA);
-	assert(md_writers_by_gen[generation_to_writer(gen)]);
-	addr = md_writers_by_gen[
-	  generation_to_writer(gen)]->alloc_paddr(length);
-      }
-      return {addr,
-	      std::move(bp),
-	      gen};
-    };
-
-    if (type == extent_types_t::ROOT) {
-      return alloc_paddr(INLINE_GENERATION, data_category_t::METADATA, length);
-    }
-
-    if (get_backend_type() == backend_type_t::SEGMENTED &&
-	is_lba_backref_node(type)) {
-      // with SEGMENTED, lba-backref extents must be INLINE
-      return alloc_paddr(INLINE_GENERATION, data_category_t::METADATA, length);
-    }
-
-    if (hint == placement_hint_t::COLD) {
-      assert(gen == INIT_GENERATION);
-      return alloc_paddr(MIN_REWRITE_GENERATION, get_extent_category(type), length);
-    }
-
-    if (get_extent_category(type) == data_category_t::METADATA &&
-        gen == INIT_GENERATION) {
-      if (get_backend_type() == backend_type_t::SEGMENTED) {
-	// with SEGMENTED, default not to ool metadata extents to reduce 
-	// padding overhead.
-	// TODO: improve padding so we can default to the ool path.
-	return alloc_paddr(INLINE_GENERATION, get_extent_category(type), length);
-      } else {
-	 // with RBM, all extents must be OOL
-	assert(get_backend_type() ==
-	       backend_type_t::RANDOM_BLOCK);
-	return alloc_paddr(OOL_GENERATION, get_extent_category(type), length);
-      }
     } else {
-      assert(get_extent_category(type) == data_category_t::DATA ||
-             gen >= MIN_REWRITE_GENERATION);
-      if (gen > dynamic_max_rewrite_generation) {
-        gen = dynamic_max_rewrite_generation;
-      } else if (gen == INIT_GENERATION) {
-        gen = OOL_GENERATION;
-      }
-      return alloc_paddr(gen, get_extent_category(type), length);
+      assert(category == data_category_t::METADATA);
+      assert(md_writers_by_gen[generation_to_writer(gen)]);
+      addr = md_writers_by_gen[
+	  generation_to_writer(gen)]->alloc_paddr(length);
     }
+    return {addr, std::move(bp), gen};
   }
 
   /**
@@ -423,6 +379,51 @@ public:
   }
 
 private:
+  rewrite_gen_t adjust_generation(
+      data_category_t category,
+      extent_types_t type,
+      placement_hint_t hint,
+      rewrite_gen_t gen) {
+    if (type == extent_types_t::ROOT) {
+      gen = INLINE_GENERATION;
+    } else if (get_backend_type() == backend_type_t::SEGMENTED &&
+               is_lba_backref_node(type)) {
+      gen = INLINE_GENERATION;
+    } else if (hint == placement_hint_t::COLD) {
+      assert(gen == INIT_GENERATION);
+      if (background_process.has_cold_tier()) {
+        gen = MIN_COLD_GENERATION;
+      } else {
+        gen = MIN_REWRITE_GENERATION;
+      }
+    } else if (gen == INIT_GENERATION) {
+      if (category == data_category_t::METADATA) {
+        if (get_backend_type() == backend_type_t::SEGMENTED) {
+          // with SEGMENTED, default not to ool metadata extents to reduce
+          // padding overhead.
+          // TODO: improve padding so we can default to the ool path.
+          gen = INLINE_GENERATION;
+        } else {
+          // with RBM, all extents must be OOL
+          assert(get_backend_type() ==
+                 backend_type_t::RANDOM_BLOCK);
+          gen = OOL_GENERATION;
+        }
+      } else {
+        assert(category == data_category_t::DATA);
+        gen = OOL_GENERATION;
+      }
+    } else if (background_process.has_cold_tier()) {
+      gen = background_process.adjust_generation(gen);
+    }
+
+    if (gen > dynamic_max_rewrite_generation) {
+      gen = dynamic_max_rewrite_generation;
+    }
+
+    return gen;
+  }
+
   void add_device(Device *device) {
     auto device_id = device->get_device_id();
     ceph_assert(devices_by_id[device_id] == nullptr);

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -399,8 +399,10 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
     return os << "TRIM_DIRTY";
   case transaction_type_t::TRIM_ALLOC:
     return os << "TRIM_ALLOC";
-  case transaction_type_t::CLEANER:
-    return os << "CLEANER";
+  case transaction_type_t::CLEANER_MAIN:
+    return os << "CLEANER_MAIN";
+  case transaction_type_t::CLEANER_COLD:
+    return os << "CLEANER_COLD";
   case transaction_type_t::MAX:
     return os << "TRANS_TYPE_NULL";
   default:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -797,8 +797,10 @@ std::ostream& operator<<(std::ostream& out, device_type_t t)
     return out << "SSD";
   case device_type_t::ZNS:
     return out << "ZNS";
-  case device_type_t::SEGMENTED_EPHEMERAL:
-    return out << "SEGMENTED_EPHEMERAL";
+  case device_type_t::EPHEMERAL_COLD:
+    return out << "EPHEMERAL_COLD";
+  case device_type_t::EPHEMERAL_MAIN:
+    return out << "EPHEMERAL_MAIN";
   case device_type_t::RANDOM_BLOCK_SSD:
     return out << "RANDOM_BLOCK_SSD";
   case device_type_t::RANDOM_BLOCK_EPHEMERAL:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -403,6 +403,8 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
     return os << "CLEANER_MAIN";
   case transaction_type_t::CLEANER_COLD:
     return os << "CLEANER_COLD";
+  case transaction_type_t::PROMOTE_COLD:
+    return os << "PROMOTE_COLD";
   case transaction_type_t::MAX:
     return os << "TRANS_TYPE_NULL";
   default:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1190,7 +1190,8 @@ enum class data_category_t : uint8_t {
 std::ostream &operator<<(std::ostream &out, data_category_t c);
 
 constexpr data_category_t get_extent_category(extent_types_t type) {
-  if (type == extent_types_t::OBJECT_DATA_BLOCK) {
+  if (type == extent_types_t::OBJECT_DATA_BLOCK ||
+      type == extent_types_t::TEST_BLOCK) {
     return data_category_t::DATA;
   } else {
     return data_category_t::METADATA;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -876,7 +876,8 @@ enum class device_type_t : uint8_t {
   HDD,
   SSD,
   ZNS,
-  SEGMENTED_EPHEMERAL,
+  EPHEMERAL_COLD,
+  EPHEMERAL_MAIN,
   RANDOM_BLOCK_SSD,
   RANDOM_BLOCK_EPHEMERAL,
   NUM_TYPES
@@ -899,7 +900,7 @@ constexpr backend_type_t get_default_backend_of_device(device_type_t dtype) {
   assert(dtype != device_type_t::NONE &&
 	 dtype != device_type_t::NUM_TYPES);
   if (dtype >= device_type_t::HDD &&
-      dtype <= device_type_t::SEGMENTED_EPHEMERAL) {
+      dtype <= device_type_t::EPHEMERAL_MAIN) {
     return backend_type_t::SEGMENTED;
   } else {
     return backend_type_t::RANDOM_BLOCK;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1189,8 +1189,7 @@ enum class data_category_t : uint8_t {
 std::ostream &operator<<(std::ostream &out, data_category_t c);
 
 constexpr data_category_t get_extent_category(extent_types_t type) {
-  if (type == extent_types_t::OBJECT_DATA_BLOCK ||
-      type == extent_types_t::COLL_BLOCK) {
+  if (type == extent_types_t::OBJECT_DATA_BLOCK) {
     return data_category_t::DATA;
   } else {
     return data_category_t::METADATA;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1746,7 +1746,8 @@ enum class transaction_type_t : uint8_t {
   READ, // including weak and non-weak read transactions
   TRIM_DIRTY,
   TRIM_ALLOC,
-  CLEANER,
+  CLEANER_MAIN,
+  CLEANER_COLD,
   MAX
 };
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1149,14 +1149,9 @@ constexpr rewrite_gen_t OOL_GENERATION = 2;
 
 // All the rewritten extents start with MIN_REWRITE_GENERATION
 constexpr rewrite_gen_t MIN_REWRITE_GENERATION = 3;
-constexpr rewrite_gen_t MAX_REWRITE_GENERATION = 4;
-
-/**
- * TODO:
- * For tiering, might introduce 5 and 6 for the cold tier, and 1 ~ 4 for the
- * hot tier.
- */
-
+// without cold tier, the largest generation is less than MIN_COLD_GENERATION
+constexpr rewrite_gen_t MIN_COLD_GENERATION = 5;
+constexpr rewrite_gen_t MAX_REWRITE_GENERATION = 7;
 constexpr rewrite_gen_t REWRITE_GENERATIONS = MAX_REWRITE_GENERATION + 1;
 constexpr rewrite_gen_t NULL_GENERATION =
   std::numeric_limits<rewrite_gen_t>::max();

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1749,6 +1749,7 @@ enum class transaction_type_t : uint8_t {
   TRIM_ALLOC,
   CLEANER_MAIN,
   CLEANER_COLD,
+  PROMOTE_COLD,
   MAX
 };
 

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -44,7 +44,7 @@ std::ostream& operator<<(std::ostream &out, Segment::segment_state_t s)
 
 seastar::future<crimson::os::seastore::SegmentManagerRef>
 SegmentManager::get_segment_manager(
-  const std::string &device)
+  const std::string &device, device_type_t dtype)
 {
 #ifdef HAVE_ZNS
 LOG_PREFIX(SegmentManager::get_segment_manager);
@@ -71,7 +71,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
 	} else {
 	  return std::make_unique<
 	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block");
+	    >(device + "/block", dtype);
 	}
       });
     });
@@ -79,7 +79,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
-    >(device + "/block"));
+    >(device + "/block", dtype));
 #endif
 }
 

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -180,7 +180,8 @@ public:
 
   virtual ~SegmentManager() {}
 
-  static seastar::future<SegmentManagerRef> get_segment_manager(const std::string &device);
+  static seastar::future<SegmentManagerRef>
+  get_segment_manager(const std::string &device, device_type_t dtype);
 };
 
 }

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -58,7 +58,8 @@ struct block_sm_superblock_t {
     ceph_assert(first_segment_offset > tracker_offset &&
                 first_segment_offset % block_size == 0);
     ceph_assert(config.spec.magic != 0);
-    ceph_assert(config.spec.dtype == device_type_t::SSD);
+    ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
+		backend_type_t::SEGMENTED);
     ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
     if (!config.major_dev) {
       ceph_assert(config.secondary_devices.size() == 0);
@@ -154,10 +155,6 @@ using SegmentManagerRef = std::unique_ptr<SegmentManager>;
 
 class SegmentManager : public Device {
 public:
-  device_type_t get_device_type() const final {
-    return device_type_t::SSD;
-  }
-
   backend_type_t get_backend_type() const final {
     return backend_type_t::SEGMENTED;
   }

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -516,6 +516,7 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
   device_config_t sm_config)
 {
   LOG_PREFIX(BlockSegmentManager::mkfs);
+  ceph_assert(sm_config.spec.dtype == superblock.config.spec.dtype);
   set_device_id(sm_config.spec.id);
   INFO("{} path={}, {}",
        device_id_printer_t{get_device_id()}, device_path, sm_config);

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -118,8 +118,12 @@ public:
   close_ertr::future<> close();
 
   BlockSegmentManager(
-    const std::string &path)
-  : device_path(path) {}
+    const std::string &path,
+    device_type_t dtype)
+  : device_path(path) {
+    ceph_assert(get_device_type() == device_type_t::NONE);
+    superblock.config.spec.dtype = dtype;
+  }
 
   ~BlockSegmentManager();
 

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -132,6 +132,9 @@ public:
     size_t len,
     ceph::bufferptr &out) final;
 
+  device_type_t get_device_type() const final {
+    return superblock.config.spec.dtype;
+  }
   size_t get_available_size() const final {
     return superblock.size;
   }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -69,6 +69,10 @@ class EphemeralSegmentManager final : public SegmentManager {
   const ephemeral_config_t config;
   std::optional<device_config_t> device_config;
 
+  device_type_t get_device_type() const final {
+    return device_type_t::SEGMENTED_EPHEMERAL;
+  }
+
   size_t get_offset(paddr_t addr) {
     auto& seg_addr = addr.as_seg_paddr();
     return (seg_addr.get_segment_id().device_segment_id() * config.segment_size) +

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -42,7 +42,9 @@ std::ostream &operator<<(std::ostream &, const ephemeral_config_t &);
 EphemeralSegmentManagerRef create_test_ephemeral();
 
 device_config_t get_ephemeral_device_config(
-    std::size_t index, std::size_t num_devices);
+    std::size_t index,
+    std::size_t num_main_devices,
+    std::size_t num_cold_devices);
 
 class EphemeralSegment final : public Segment {
   friend class EphemeralSegmentManager;
@@ -70,7 +72,8 @@ class EphemeralSegmentManager final : public SegmentManager {
   std::optional<device_config_t> device_config;
 
   device_type_t get_device_type() const final {
-    return device_type_t::SEGMENTED_EPHEMERAL;
+    assert(device_config);
+    return device_config->spec.dtype;
   }
 
   size_t get_offset(paddr_t addr) {

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -115,6 +115,10 @@ namespace crimson::os::seastore::segment_manager::zns {
       size_t len, 
       ceph::bufferptr &out) final;
 
+    device_type_t get_device_type() const final {
+      return device_type_t::ZNS;
+    }
+
     size_t get_available_size() const final {
       return metadata.size;
     };

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -35,6 +35,11 @@ public:
   void add_segment_manager(SegmentManager* segment_manager) {
     auto device_id = segment_manager->get_device_id();
     ceph_assert(!has_device(device_id));
+    if (!device_ids.empty()) {
+      auto existing_id = *device_ids.begin();
+      ceph_assert(segment_managers[existing_id]->get_device_type()
+                  == segment_manager->get_device_type());
+    }
     segment_managers[device_id] = segment_manager;
     device_ids.insert(device_id);
   }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -709,6 +709,7 @@ TransactionManagerRef make_transaction_manager(
       cleaner_config,
       std::move(sms),
       *backref_manager,
+      epm->get_ool_segment_seq_allocator(),
       cleaner_is_detailed);
     auto segment_cleaner = static_cast<SegmentCleaner*>(cleaner.get());
     cache->set_segment_provider(*segment_cleaner);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -722,6 +722,9 @@ TransactionManagerRef make_transaction_manager(
       epm->get_ool_segment_seq_allocator(),
       cleaner_is_detailed,
       /* is_cold = */ true);
+    if (journal_type == journal_type_t::SEGMENTED) {
+      cache->set_segment_provider(cold_segment_cleaner.get());
+    }
   }
 
   if (journal_type == journal_type_t::SEGMENTED) {
@@ -732,7 +735,7 @@ TransactionManagerRef make_transaction_manager(
       epm->get_ool_segment_seq_allocator(),
       cleaner_is_detailed);
     auto segment_cleaner = static_cast<SegmentCleaner*>(cleaner.get());
-    cache->set_segment_provider(*segment_cleaner);
+    cache->set_segment_provider(segment_cleaner);
     segment_cleaner->set_journal_trimmer(*journal_trimmer);
     journal = journal::make_segmented(
       *segment_cleaner,

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -647,6 +647,9 @@ TransactionManagerRef make_transaction_manager(
   auto p_backend_type = primary_device->get_backend_type();
 
   if (p_backend_type == backend_type_t::SEGMENTED) {
+    auto dtype = primary_device->get_device_type();
+    ceph_assert(dtype != device_type_t::HDD &&
+		dtype != device_type_t::EPHEMERAL_COLD);
     sms->add_segment_manager(static_cast<SegmentManager*>(primary_device));
   } else {
     auto rbm = std::make_unique<BlockRBManager>(

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -122,7 +122,7 @@ struct btree_test_base :
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       sms.reset(new SegmentManagerGroup());
       journal = journal::make_segmented(*this, *this);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -86,7 +86,7 @@ struct cache_test_t : public seastar_test_suite_t {
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       epm.reset(new ExtentPlacementManager());
       cache.reset(new Cache(*epm));

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -146,7 +146,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       block_size = segment_manager->get_block_size();
       sms.reset(new SegmentManagerGroup());

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -62,8 +62,8 @@ struct transaction_manager_test_t :
   std::random_device rd;
   std::mt19937 gen;
 
-  transaction_manager_test_t(std::size_t num_devices)
-    : TMTestState(num_devices), gen(rd()) {
+  transaction_manager_test_t(std::size_t num_main_devices, std::size_t num_cold_devices)
+    : TMTestState(num_main_devices, num_cold_devices), gen(rd()) {
   }
 
   laddr_t get_random_laddr(size_t block_size, laddr_t limit) {
@@ -600,21 +600,21 @@ struct transaction_manager_test_t :
     EXPECT_FALSE(success);
   }
 
-  auto allocate_sequentially(const size_t& size, int &num) {
-    return repeat_eagain([&, this] {
+  auto allocate_sequentially(const size_t size, const int num, bool run_clean = true) {
+    return repeat_eagain([this, size, num] {
       return seastar::do_with(
 	create_transaction(),
-	[&, this](auto &t) {
+	[this, size, num](auto &t) {
 	  return with_trans_intr(
 	    *t.t,
-	    [&, this](auto &) {
+	    [&t, this, size, num](auto &) {
 	      return trans_intr::do_for_each(
 		boost::make_counting_iterator(0),
 		boost::make_counting_iterator(num),
-		[&, this](auto) {
+		[&t, this, size](auto) {
 		  return tm->alloc_extent<TestBlock>(
 		    *(t.t), L_ADDR_MIN, size
-		  ).si_then([&, this](auto extent) {
+		  ).si_then([&t, this, size](auto extent) {
 		    extent->set_contents(get_random_contents());
 		    EXPECT_FALSE(
 		      test_mappings.contains(extent->get_laddr(), t.mapping_delta));
@@ -629,8 +629,12 @@ struct transaction_manager_test_t :
 	      test_mappings.consume(t.mapping_delta);
 	    });
 	});
-    }).safe_then([this]() {
-      return epm->run_background_work_until_halt();
+    }).safe_then([this, run_clean]() {
+      if (run_clean) {
+        return epm->run_background_work_until_halt();
+      } else {
+        return epm->background_process.trimmer->trim();
+      }
     }).handle_error(
       crimson::ct_error::assert_all{
 	"Invalid error in SeaStore::list_collections"
@@ -728,6 +732,194 @@ struct transaction_manager_test_t :
         writes,
         failures
       );
+    });
+  }
+
+  void test_evict() {
+    // only support segmented backend currently
+    ASSERT_EQ(epm->get_backend_type(), backend_type_t::SEGMENTED);
+    ASSERT_TRUE(epm->background_process.has_cold_tier());
+    constexpr size_t device_size =
+      segment_manager::DEFAULT_TEST_EPHEMERAL.size;
+    constexpr size_t block_size =
+      segment_manager::DEFAULT_TEST_EPHEMERAL.block_size;
+    constexpr size_t segment_size =
+      segment_manager::DEFAULT_TEST_EPHEMERAL.segment_size;
+    ASSERT_GE(segment_size, block_size * 20);
+
+    run_async([this] {
+      // indicates there is no available segments to reclaim
+      double stop_ratio = (double)segment_size / (double)device_size / 2;
+      // 1 segment
+      double default_ratio = stop_ratio * 2;
+      // 1.25 segment
+      double fast_ratio = stop_ratio * 2.5;
+
+      epm->background_process
+        .eviction_state
+        .init(stop_ratio, default_ratio, fast_ratio);
+
+      // these variables are described in
+      // EPM::BackgroundProcess::eviction_state_t::maybe_update_eviction_mode
+      size_t ratio_A_size = segment_size / 2 - block_size * 10;
+      size_t ratio_B_size = segment_size / 2 + block_size * 10;
+      size_t ratio_C_size = segment_size + block_size;
+      size_t ratio_D_size = segment_size * 1.25 + block_size;
+
+      auto run_until = [this](size_t size) -> seastar::future<> {
+        return seastar::repeat([this, size] {
+          size_t current_size = epm->background_process
+                                    .main_cleaner->get_stat().data_stored;
+          if (current_size >= size) {
+            return seastar::futurize_invoke([] {
+              return seastar::stop_iteration::yes;
+            });
+          } else {
+            int num = (size - current_size) / block_size;
+            return seastar::do_for_each(
+              boost::make_counting_iterator(0),
+              boost::make_counting_iterator(num),
+              [this](auto) {
+	        // don't start background process to test the behavior
+                // of generation changes during alloc new extents
+                return allocate_sequentially(block_size, 1, false);
+              }).then([] {
+                return seastar::stop_iteration::no;
+              });
+          }
+        });
+      };
+
+      std::vector<extent_types_t> all_extent_types{
+        extent_types_t::ROOT,
+        extent_types_t::LADDR_INTERNAL,
+        extent_types_t::LADDR_LEAF,
+        extent_types_t::OMAP_INNER,
+        extent_types_t::OMAP_LEAF,
+        extent_types_t::ONODE_BLOCK_STAGED,
+        extent_types_t::COLL_BLOCK,
+        extent_types_t::OBJECT_DATA_BLOCK,
+        extent_types_t::RETIRED_PLACEHOLDER,
+        extent_types_t::ALLOC_INFO,
+        extent_types_t::JOURNAL_TAIL,
+        extent_types_t::TEST_BLOCK,
+        extent_types_t::TEST_BLOCK_PHYSICAL,
+        extent_types_t::BACKREF_INTERNAL,
+        extent_types_t::BACKREF_LEAF
+      };
+
+      std::vector<rewrite_gen_t> all_generations;
+      for (auto i = INIT_GENERATION; i < REWRITE_GENERATIONS; i++) {
+        all_generations.push_back(i);
+      }
+
+      // input target-generation -> expected generation after the adjustment
+      using generation_mapping_t = std::map<rewrite_gen_t, rewrite_gen_t>;
+      std::map<extent_types_t, generation_mapping_t> expected_generations;
+
+      // this loop should be consistent with EPM::adjust_generation
+      for (auto t : all_extent_types) {
+        expected_generations[t] = {};
+        if (!is_logical_type(t)) {
+          for (auto gen : all_generations) {
+            expected_generations[t][gen] = INLINE_GENERATION;
+          }
+        } else {
+	  if (get_extent_category(t) == data_category_t::METADATA) {
+	    expected_generations[t][INIT_GENERATION] = INLINE_GENERATION;
+	  } else {
+	    expected_generations[t][INIT_GENERATION] = OOL_GENERATION;
+	  }
+
+          for (auto i = INIT_GENERATION + 1; i < REWRITE_GENERATIONS; i++) {
+	    expected_generations[t][i] = i;
+          }
+        }
+      }
+
+      auto update_data_gen_mapping = [&](std::function<rewrite_gen_t(rewrite_gen_t)> func) {
+        for (auto t : all_extent_types) {
+          if (!is_logical_type(t)) {
+            continue;
+          }
+          for (auto i = INIT_GENERATION + 1; i < REWRITE_GENERATIONS; i++) {
+            expected_generations[t][i] = func(i);
+          }
+        }
+        // since background process didn't start in allocate_sequentially
+        // we update eviction mode manually.
+        epm->background_process.maybe_update_eviction_mode();
+      };
+
+      auto test_gen = [&](const char *caller) {
+        for (auto t : all_extent_types) {
+          for (auto gen : all_generations) {
+            auto epm_gen = epm->adjust_generation(
+              get_extent_category(t),
+              t,
+              placement_hint_t::HOT,
+              gen);
+            if (expected_generations[t][gen] != epm_gen) {
+              logger().error("caller: {}, extent type: {}, input generation: {}, "
+			     "expected generation : {}, adjust result from EPM: {}",
+			     caller, t, gen, expected_generations[t][gen], epm_gen);
+            }
+            EXPECT_EQ(expected_generations[t][gen], epm_gen);
+          }
+        }
+      };
+
+      // verify that no data should go to the cold tier
+      update_data_gen_mapping([](rewrite_gen_t gen) -> rewrite_gen_t {
+        if (gen == MIN_COLD_GENERATION) {
+          return MIN_COLD_GENERATION - 1;
+        } else {
+          return gen;
+        }
+      });
+      test_gen("init");
+
+      run_until(ratio_A_size).get();
+      EXPECT_TRUE(epm->background_process.eviction_state.is_stop_mode());
+      test_gen("exceed ratio A");
+      epm->run_background_work_until_halt().get();
+
+      run_until(ratio_B_size).get();
+      EXPECT_TRUE(epm->background_process.eviction_state.is_stop_mode());
+      test_gen("exceed ratio B");
+      epm->run_background_work_until_halt().get();
+
+      // verify that data may go to the cold tier
+      run_until(ratio_C_size).get();
+      update_data_gen_mapping([](rewrite_gen_t gen) { return gen; });
+      EXPECT_TRUE(epm->background_process.eviction_state.is_default_mode());
+      test_gen("exceed ratio C");
+      epm->run_background_work_until_halt().get();
+
+      // verify that data must go to the cold tier
+      run_until(ratio_D_size).get();
+      update_data_gen_mapping([](rewrite_gen_t gen) {
+        if (gen >= MIN_REWRITE_GENERATION && gen < MIN_COLD_GENERATION) {
+          return MIN_COLD_GENERATION;
+        } else {
+          return gen;
+        }
+      });
+      EXPECT_TRUE(epm->background_process.eviction_state.is_fast_mode());
+      test_gen("exceed ratio D");
+
+      auto main_size = epm->background_process.main_cleaner->get_stat().data_stored;
+      auto cold_size = epm->background_process.cold_cleaner->get_stat().data_stored;
+      EXPECT_EQ(cold_size, 0);
+      epm->run_background_work_until_halt().get();
+      auto new_main_size = epm->background_process.main_cleaner->get_stat().data_stored;
+      auto new_cold_size = epm->background_process.cold_cleaner->get_stat().data_stored;
+      EXPECT_GE(main_size, new_main_size);
+      EXPECT_NE(new_cold_size, 0);
+
+      update_data_gen_mapping([](rewrite_gen_t gen) { return gen; });
+      EXPECT_TRUE(epm->background_process.eviction_state.is_default_mode());
+      test_gen("finish evict");
     });
   }
 
@@ -881,13 +1073,19 @@ struct transaction_manager_test_t :
 struct tm_single_device_test_t :
   public transaction_manager_test_t {
 
-  tm_single_device_test_t() : transaction_manager_test_t(1) {}
+  tm_single_device_test_t() : transaction_manager_test_t(1, 0) {}
 };
 
 struct tm_multi_device_test_t :
   public transaction_manager_test_t {
 
-  tm_multi_device_test_t() : transaction_manager_test_t(3) {}
+  tm_multi_device_test_t() : transaction_manager_test_t(3, 0) {}
+};
+
+struct tm_multi_tier_device_test_t :
+  public transaction_manager_test_t {
+
+  tm_multi_tier_device_test_t() : transaction_manager_test_t(1, 2) {}
 };
 
 TEST_P(tm_single_device_test_t, basic)
@@ -1247,6 +1445,11 @@ TEST_P(tm_multi_device_test_t, random_writes_concurrent)
   test_random_writes_concurrent();
 }
 
+TEST_P(tm_multi_tier_device_test_t, evict)
+{
+  test_evict();
+}
+
 TEST_P(tm_single_device_test_t, parallel_extent_read)
 {
   test_parallel_extent_read();
@@ -1272,6 +1475,14 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
   transaction_manager_test,
   tm_multi_device_test_t,
+  ::testing::Values (
+    "segmented"
+  )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  transaction_manager_test,
+  tm_multi_tier_device_test_t,
   ::testing::Values (
     "segmented"
   )

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -63,7 +63,7 @@ public:
       });
     }).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, get_num_devices()));
+        segment_manager::get_ephemeral_device_config(0, get_num_devices(), 0));
     }).safe_then([this] {
       return seastar::do_with(std::size_t(0), [this](auto &cnt) {
         return crimson::do_for_each(
@@ -73,7 +73,7 @@ public:
         {
           ++cnt;
           return sec_sm->mkfs(
-            segment_manager::get_ephemeral_device_config(cnt, get_num_devices()));
+            segment_manager::get_ephemeral_device_config(cnt, get_num_devices(), 0));
         });
       });
     }).handle_error(

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -187,6 +187,7 @@ filestore_path=
 kstore_path=
 declare -a block_devs
 declare -a secondary_block_devs
+secondary_block_devs_type="SSD"
 
 VSTART_SEC="client.vstart.sh"
 
@@ -255,7 +256,8 @@ options:
 	--no-restart: dont restart process when using ceph-run
 	--jaeger: use jaegertracing for tracing
 	--seastore-devs: comma-separated list of blockdevs to use for seastore
-	--seastore-secondary-des: comma-separated list of secondary blockdevs to use for seastore
+	--seastore-secondary-devs: comma-separated list of secondary blockdevs to use for seastore
+	--seastore-secondary-devs-type: device type of all secondary blockdevs, SSD or HDD
 	--crimson-smp: number of cores to use for crimson
 \n
 EOF
@@ -514,6 +516,10 @@ case $1 in
         ;;
     --seastore-secondary-devs)
         parse_secondary_devs --seastore-devs "$2"
+        shift
+        ;;
+    --seastore-secondary-devs-type)
+        secondary_block_devs_type="$2"
         shift
         ;;
     --crimson-smp)
@@ -1037,7 +1043,8 @@ EOF
                 fi
                 if [ -n "${secondary_block_devs[$osd]}" ]; then
                     dd if=/dev/zero of=${secondary_block_devs[$osd]} bs=1M count=1
-                    ln -s ${secondary_block_devs[$osd]} $CEPH_DEV_DIR/osd$osd/block.segmented.1
+                    mkdir -p $CEPH_DEV_DIR/osd$osd/block.${secondary_block_devs_type}.1
+                    ln -s ${secondary_block_devs[$osd]} $CEPH_DEV_DIR/osd$osd/block.${secondary_block_devs_type}.1/block
                 fi
             fi
             if [ "$objectstore" == "bluestore" ]; then


### PR DESCRIPTION
This PR implements the promotion as a part of the read cache based on the previous discussion. The basic idea is to rewrite the extent from LRU to the main device.

The next step might be:
1. Preventing cache pollution by replacing the current LRU algorithm with the ARC algorithm, as outlined in previous documentation.
2. Modifying the current GC/eviction policy to suit the promoted extent.

This PR relies on https://github.com/ceph/ceph/pull/47974

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
