### PR TITLE
qa/suites/crimson-rados/rbd: Add new rbd image format api tests

### DIFF
--- a/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
@@ -1,0 +1,21 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - overall HEALTH_
+      - \(CACHE_POOL_NO_HIT_SET\)
+      - \(POOL_APP_NOT_ENABLED\)
+      - is full \(reached quota
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(POOL_FULL\)
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/crimson/test_crimson_librbd.sh
+    env:
+      RBD_FEATURES: "61"
+

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
+#include "test/librados/crimson_utils.h"
 
 #include <errno.h>
 #include <string>
@@ -1797,6 +1798,7 @@ TEST_F(TestClsRbd, mirror_image) {
 }
 
 TEST_F(TestClsRbd, mirror_image_status) {
+  SKIP_IF_CRIMSON();
   struct WatchCtx : public librados::WatchCtx2 {
     librados::IoCtx *m_ioctx;
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
+#include "test/librados/crimson_utils.h"
 #include "include/rbd/librbd.h"
 #include "include/rbd/librbd.hpp"
 #include "test/librados/test.h"
@@ -219,6 +220,7 @@ TEST_F(TestGroup, add_imagePP)
 
 TEST_F(TestGroup, add_snapshot)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   rados_ioctx_t ioctx;
@@ -365,6 +367,7 @@ TEST_F(TestGroup, add_snapshot)
 
 TEST_F(TestGroup, add_snapshotPP)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   librados::IoCtx ioctx;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -29,6 +29,7 @@
 #include <boost/assign/list_of.hpp>
 #include <utility>
 #include <vector>
+#include "test/librados/crimson_utils.h"
 
 using namespace std;
 
@@ -267,6 +268,7 @@ TEST_F(TestInternal, SnapCreateFailsToLockImage) {
 }
 
 TEST_F(TestInternal, SnapRollbackLocksImage) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   ASSERT_EQ(0, create_snapshot("snap1", false));
@@ -378,6 +380,7 @@ TEST_F(TestInternal, FlattenFailsToLockImage) {
 }
 
 TEST_F(TestInternal, WriteFailsToLockImageBlocklisted) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::Rados blocklist_rados;
@@ -411,6 +414,7 @@ TEST_F(TestInternal, WriteFailsToLockImageBlocklisted) {
 }
 
 TEST_F(TestInternal, WriteFailsToLockImageBlocklistedWatch) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::Rados blocklist_rados;
@@ -654,6 +658,9 @@ TEST_F(TestInternal, MetadataConfApply) {
 
 TEST_F(TestInternal, SnapshotCopyup)
 {
+  //https://tracker.ceph.com/issues/58263
+  // Clone overlap is WIP
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1175,6 +1182,7 @@ TEST_F(TestInternal, ImageOptions) {
 }
 
 TEST_F(TestInternal, WriteFullCopyup) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1730,6 +1738,7 @@ TEST_F(TestInternal, Sparsify) {
 
 
 TEST_F(TestInternal, SparsifyClone) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -21,6 +21,7 @@
 #include "include/err.h"
 #include "common/ceph_mutex.h"
 #include "json_spirit/json_spirit.h"
+#include "test/librados/crimson_utils.h"
 
 #include "gtest/gtest.h"
 
@@ -6924,6 +6925,7 @@ TEST_F(TestLibRBD, ListChildren)
 
 TEST_F(TestLibRBD, ListChildrenTiered)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::RBD rbd;
@@ -8528,6 +8530,7 @@ TEST_F(TestLibRBD, SnapshotLimitPP)
 
 TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
 
   librados::IoCtx ioctx;
@@ -8580,6 +8583,7 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8620,6 +8624,7 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
 
 TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8664,6 +8669,7 @@ TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 
 TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   librados::IoCtx ioctx;
@@ -8704,7 +8710,7 @@ TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 }
 
 TEST_F(TestLibRBD, UpdateFeaturesViaLockOwner) {
-
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8955,6 +8961,7 @@ TEST_F(TestLibRBD, SnapUnprotectViaLockOwner)
 
 TEST_F(TestLibRBD, FlattenViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9003,6 +9010,7 @@ TEST_F(TestLibRBD, FlattenViaLockOwner)
 
 TEST_F(TestLibRBD, ResizeViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9039,6 +9047,7 @@ TEST_F(TestLibRBD, ResizeViaLockOwner)
 
 TEST_F(TestLibRBD, SparsifyViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9743,6 +9752,7 @@ TEST_F(TestLibRBD, BlockingAIO)
 
 TEST_F(TestLibRBD, ExclusiveLockTransition)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -10416,6 +10426,7 @@ TEST_F(TestLibRBD, FlushCacheWithCopyupOnExternalSnapshot) {
 
 TEST_F(TestLibRBD, ExclusiveLock)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   static char buf[10];
@@ -10559,6 +10570,7 @@ TEST_F(TestLibRBD, ExclusiveLock)
 
 TEST_F(TestLibRBD, BreakLock)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
   REQUIRE(!is_rbd_pwl_enabled((CephContext *)_rados.cct()));
 
@@ -11950,6 +11962,7 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
 
 TEST_F(TestLibRBD, QuiesceWatch)
 {
+  SKIP_IF_CRIMSON();
   rados_ioctx_t ioctx;
   rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
 
@@ -12041,6 +12054,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
 
 TEST_F(TestLibRBD, QuiesceWatchPP)
 {
+  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -12120,6 +12134,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
 
 TEST_F(TestLibRBD, QuiesceWatchError)
 {
+  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -12478,6 +12493,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
 
 TEST_F(TestLibRBD, ConcurrentOperations)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::RBD rbd;

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -13,6 +13,7 @@
  */
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
+#include "test/librados/crimson_utils.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
@@ -1223,6 +1224,7 @@ TEST_F(TestMirroring, SnapshotRemoveOnDisable)
 
 TEST_F(TestMirroring, SnapshotUnlinkPeer)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));


### PR DESCRIPTION
Use the second rbd image format while testing rbd api in the Crimson suite.
Currently the suite included only old format testing (`rbd_api_tests_old_format`).

https://shaman.ceph.com/builds/ceph/wip-matanb-crimson-only-new-rbd/
https://pulpito.ceph.com/matan-2023-03-09_15:12:05-crimson-rados-wip-matanb-crimson-only-new-rbd-distro-crimson-smithi/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
