### PR TITLE
mgr/dashboard: fix rbd-mirror e2e test connection to second cluster

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress.json
+++ b/src/pybind/mgr/dashboard/frontend/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "https://localhost:4200/",
+  "baseUrl": "https://localhost:11000/",
   "ignoreTestFiles": [
     "*.po.ts",
     "**/orchestrator/**"
@@ -23,7 +23,7 @@
   "env": {
     "LOGIN_USER": "admin",
     "LOGIN_PWD": "admin",
-    "CEPH2_URL": "http://localhost:4202/"
+    "CEPH2_URL": "https://localhost:11002/"
   },
   "experimentalSessionAndOrigin": true,
   "chromeWebSecurity": false

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.e2e-spec.ts
@@ -70,7 +70,7 @@ describe('Mirroring page', () => {
           cy.get('.table-actions button.dropdown-toggle').first().click();
           cy.get('[aria-label="Import Bootstrap Token"]').click();
           cy.get('cd-bootstrap-import-modal').within(() => {
-            cy.get(`label[for=${name}]`).click();
+            cy.get(`label[for=${name}]`).wait(100).click();
             cy.get('textarea[id=token]').wait(100).type(token);
             cy.get('button[type=submit]').click();
           });


### PR DESCRIPTION
As per cypress documentation: https://docs.cypress.io/guides/guides/web-security#Insecure-Content

Added `.wait(100)`
To avoid this error:

```
Timed out retrying after 120050ms: cy.click() failed because this element is detached from the DOM.

<label _ngcontent-rtw-c333="" class="custom-control-label" for="rbd-mirror">rbd-mirror</label>

Cypress requires elements be attached in the DOM to interact with them.

The previous command that ran was:

cy.get()

This DOM element likely became detached somewhere between the previous and current command.
```

I could not reproduce the exact same issue on the tracker.

tracker: https://tracker.ceph.com/issues/58944
Signed-off-by: Pedro Gonzalez Gomez <pegonzal@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
