### PR TITLE
fmt: remove FMT_HEADER_ONLY defines

### DIFF
--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -12,8 +12,6 @@
 #include <optional>
 #include <string>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/buffer.h"

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -25,8 +25,6 @@
 
 #include <boost/container/flat_set.hpp>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 #if FMT_VERSION >= 90000
 #include <fmt/ostream.h>

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -9,8 +9,6 @@
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "rgw/rgw_basic_types.h"

--- a/src/librbd/migration/S3Stream.cc
+++ b/src/librbd/migration/S3Stream.cc
@@ -17,8 +17,6 @@
 #include "librbd/migration/HttpProcessorInterface.h"
 #include <boost/beast/http.hpp>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 

--- a/src/mds/cephfs_features.cc
+++ b/src/mds/cephfs_features.cc
@@ -5,8 +5,6 @@
 #include "cephfs_features.h"
 #include "mdstypes.h"
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 static const std::array feature_names

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -231,8 +231,6 @@ endif(WITH_RADOSGW_ARROW_FLIGHT)
 
 
 add_library(rgw_common STATIC ${librgw_common_srcs})
-target_compile_definitions(rgw_common
-  PUBLIC "FMT_HEADER_ONLY")
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wimplicit-const-int-float-conversion"

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -256,7 +256,6 @@ target_link_libraries(rgw_common
     cls_version_client
     librados
     rt
-    fmt::fmt
     ICU::uc
     OATH::OATH
     dmclock::dmclock

--- a/src/rgw/driver/dbstore/CMakeLists.txt
+++ b/src/rgw/driver/dbstore/CMakeLists.txt
@@ -26,7 +26,6 @@ set(dbstore_mgr_srcs
 
 add_library(dbstore_lib ${dbstore_srcs})
 target_include_directories(dbstore_lib
-    PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include"
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/rados"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -17,8 +17,6 @@
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/variant.hpp>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "common/ceph_time.h"

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -119,7 +119,7 @@ EOM
     fi
     cmake_opts+=" -DWITH_RBD_SSD_CACHE=ON"
 
-    cmake_opts+=$(detect_ceph_dev_pkgs)
+    cmake_opts+=" $(detect_ceph_dev_pkgs)"
 
     ci_debug "Our cmake_opts are: $cmake_opts"
     ci_debug "Running ./configure"

--- a/src/test/fio/fio_librgw.cc
+++ b/src/test/fio/fio_librgw.cc
@@ -21,8 +21,6 @@
 
 #include <semaphore.h> // XXX kill this?
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include "fmt/include/fmt/format.h"
 
 #include "include/rados/librgw.h"

--- a/src/test/rgw/rgw_cr_test.cc
+++ b/src/test/rgw/rgw_cr_test.cc
@@ -6,8 +6,6 @@
 #include <sstream>
 #include <string>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/rados/librados.hpp"

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -18,8 +18,6 @@
 #include <iostream>
 #include <string_view>
 
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 
 #include "include/types.h"


### PR DESCRIPTION
a `WITH_FMT_HEADER_ONLY` cmake option controls which version of the library to use. individual sources/targets shouldn't override that, or they'll end up including/linking against both versions

Fixes: https://tracker.ceph.com/issues/58953

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
