### PR TITLE
rgw/beast: add extra_response_headers for Server name

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -127,15 +127,6 @@ Options
 :Type: Integer
 :Default: ``65000``
 
-``rgw_thread_pool_size``
-
-:Description: Sets the number of threads spawned by Beast to handle
-              incoming HTTP connections. This effectively limits the number
-              of concurrent connections that the frontend can service.
-
-:Type: Integer
-:Default: ``512``
-
 ``max_header_size``
 
 :Description: The maximum number of header bytes available for a single request.

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -14,10 +14,12 @@ using namespace rgw::asio;
 
 ClientIO::ClientIO(parser_type& parser, bool is_ssl,
                    const endpoint_type& local_endpoint,
-                   const endpoint_type& remote_endpoint)
+                   const endpoint_type& remote_endpoint,
+                   std::string_view extra_response_headers)
   : parser(parser), is_ssl(is_ssl),
     local_endpoint(local_endpoint),
     remote_endpoint(remote_endpoint),
+    extra_response_headers(extra_response_headers),
     txbuf(*this)
 {
 }
@@ -147,6 +149,11 @@ size_t ClientIO::complete_header()
   char timestr[TIME_BUF_SIZE];
   if (dump_date_header(timestr)) {
     sent += txbuf.sputn(timestr, strlen(timestr));
+  }
+
+  if (extra_response_headers.size()) {
+    sent += txbuf.sputn(extra_response_headers.data(),
+                        extra_response_headers.size());
   }
 
   if (parser.keep_alive()) {

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -25,6 +25,7 @@ class ClientIO : public io::RestfulClient,
   using endpoint_type = boost::asio::ip::tcp::endpoint;
   endpoint_type local_endpoint;
   endpoint_type remote_endpoint;
+  std::string_view extra_response_headers;
 
   RGWEnv env;
 
@@ -34,7 +35,8 @@ class ClientIO : public io::RestfulClient,
  public:
   ClientIO(parser_type& parser, bool is_ssl,
            const endpoint_type& local_endpoint,
-           const endpoint_type& remote_endpoint);
+           const endpoint_type& remote_endpoint,
+           std::string_view extra_response_headers);
   ~ClientIO() override;
 
   int init_env(CephContext *cct) override;


### PR DESCRIPTION
add a response header to every request:
```
Server: Ceph Object Gateway (reef)
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
