### PR TITLE
quincy: rgw/admin: 'bucket stats' displays non-empty mtime

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1066,7 +1066,6 @@ static int bucket_stats(rgw::sal::Store* store,
   std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
 
-  real_time mtime;
   int ret = store->get_bucket(dpp, nullptr, tenant_name, bucket_name, &bucket, null_yield);
   if (ret < 0) {
     return ret;
@@ -1080,7 +1079,7 @@ static int bucket_stats(rgw::sal::Store* store,
     return ret;
   }
 
-  utime_t ut(mtime);
+  utime_t ut(bucket->get_modification_time());
   utime_t ctime_ut(bucket->get_creation_time());
 
   formatter->open_object_section("stats");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58955

only one of the commits from https://github.com/ceph/ceph/pull/50429 was needed here

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
