### PR TITLE
test/librados/snapshots*: Enable supported tests

### DIFF
--- a/src/test/librados/snapshots.cc
+++ b/src/test/librados/snapshots.cc
@@ -18,7 +18,6 @@ typedef RadosTestEC LibRadosSnapshotsSelfManagedEC;
 const int bufsize = 128;
 
 TEST_F(LibRadosSnapshots, SnapList) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -33,7 +32,6 @@ TEST_F(LibRadosSnapshots, SnapList) {
 }
 
 TEST_F(LibRadosSnapshots, SnapRemove) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -46,7 +44,6 @@ TEST_F(LibRadosSnapshots, SnapRemove) {
 }
 
 TEST_F(LibRadosSnapshots, Rollback) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -62,7 +59,6 @@ TEST_F(LibRadosSnapshots, Rollback) {
 }
 
 TEST_F(LibRadosSnapshots, SnapGetName) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -80,7 +76,6 @@ TEST_F(LibRadosSnapshots, SnapGetName) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
@@ -127,7 +122,6 @@ TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -20,7 +20,6 @@ typedef RadosTestECPP LibRadosSnapshotsSelfManagedECPP;
 const int bufsize = 128;
 
 TEST_F(LibRadosSnapshotsPP, SnapListPP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -40,7 +39,6 @@ TEST_F(LibRadosSnapshotsPP, SnapListPP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapRemovePP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -54,7 +52,6 @@ TEST_F(LibRadosSnapshotsPP, SnapRemovePP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, RollbackPP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -74,7 +71,6 @@ TEST_F(LibRadosSnapshotsPP, RollbackPP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapGetNamePP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -93,7 +89,6 @@ TEST_F(LibRadosSnapshotsPP, SnapGetNamePP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapCreateRemovePP) {
-  SKIP_IF_CRIMSON();
   // reproduces http://tracker.ceph.com/issues/10262
   bufferlist bl;
   bl.append("foo");
@@ -112,7 +107,6 @@ TEST_F(LibRadosSnapshotsPP, SnapCreateRemovePP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, SnapPP) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_FALSE(cluster.get_pool_is_selfmanaged_snaps_mode(pool_name));
@@ -244,6 +238,7 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, RollbackPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, SnapOverlapPP) {
+  // WIP https://tracker.ceph.com/issues/58263
   SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   IoCtx readioctx;
@@ -374,7 +369,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, SnapOverlapPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, Bug11677) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps.back()));
@@ -466,7 +460,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, OrderSnap) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, ReusePurgedSnap) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps.back()));


### PR DESCRIPTION
`ceph_test_rados_api_snapshots`:
```
[----------] Global test environment tear-down                                                                                                                              
[==========] 12 tests from 4 test suites ran. (22032 ms total)                                                                                                              
[  PASSED  ] 6 tests.                                                                                                                                                       
[  SKIPPED ] 6 tests, listed below:                                                                                                                                         
[  SKIPPED ] LibRadosSnapshotsEC.SnapList                                                                                                                                   
[  SKIPPED ] LibRadosSnapshotsEC.SnapRemove                                                                                                                                 
[  SKIPPED ] LibRadosSnapshotsEC.Rollback                                                                                                                                   
[  SKIPPED ] LibRadosSnapshotsEC.SnapGetName                                                                                                                                
[  SKIPPED ] LibRadosSnapshotsSelfManagedEC.Snap                                                                                                                            
[  SKIPPED ] LibRadosSnapshotsSelfManagedEC.Rollback 
```
`ceph_test_rados_api_snapshots_pp`:
```
[----------] Global test environment tear-down
[==========] 18 tests from 4 test suites ran. (43154 ms total)
[  PASSED  ] 8 tests.
[  SKIPPED ] 10 tests, listed below:
[  SKIPPED ] LibRadosSnapshotsSelfManagedPP.RollbackPP
[  SKIPPED ] LibRadosSnapshotsSelfManagedPP.SnapOverlapPP
[  SKIPPED ] LibRadosSnapshotsSelfManagedPP.OrderSnap
[  SKIPPED ] LibRadosSnapshotsECPP.SnapListPP
[  SKIPPED ] LibRadosSnapshotsECPP.SnapRemovePP
[  SKIPPED ] LibRadosSnapshotsECPP.RollbackPP
[  SKIPPED ] LibRadosSnapshotsECPP.SnapGetNamePP
[  SKIPPED ] LibRadosSnapshotsSelfManagedECPP.SnapPP
[  SKIPPED ] LibRadosSnapshotsSelfManagedECPP.RollbackPP
[  SKIPPED ] LibRadosSnapshotsSelfManagedECPP.Bug11677
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
