### PR TITLE
mgr/dashboard: force TLS 1.3

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -178,9 +178,9 @@ class CherryPyConfig(object):
             context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             context.load_cert_chain(cert_fname, pkey_fname)
             if sys.version_info >= (3, 7):
-                context.minimum_version = ssl.TLSVersion.TLSv1_2
+                context.minimum_version = ssl.TLSVersion.TLSv1_3
             else:
-                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
 
             config['server.ssl_module'] = 'builtin'
             config['server.ssl_certificate'] = cert_fname


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58942

### Before
```
Every 1,0s: nmap --script ssl-enum-ciphers -p 11000 0.0.0.0     theseus.localhost.localdomain: Mon Mar 13 11:11:09 2023

Starting Nmap 7.93 ( https://nmap.org ) at 2023-03-13 11:11 CET
Nmap scan report for 0.0.0.0
Host is up (0.000095s latency).

PORT	  STATE SERVICE
11000/tcp open  irisa
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|	TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (ecdh_x25519) - A
|	TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
|	TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
|	TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|	TLS_RSA_WITH_AES_256_CCM (rsa 2048) - A
|	TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|	TLS_RSA_WITH_AES_128_CCM (rsa 2048) - A
|	TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 2048) - A
|	TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
|	TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|	TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|     compressors:
|	NULL
|     cipher preference: server
|   TLSv1.3:
|     ciphers:
|	TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|	TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|	TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|	TLS_AKE_WITH_AES_128_CCM_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.27 seconds

```

### After

```
Every 1,0s: nmap --script ssl-enum-ciphers -p 11000 0.0.0.0     theseus.localhost.localdomain: Mon Mar 13 11:09:48 2023

Starting Nmap 7.93 ( https://nmap.org ) at 2023-03-13 11:09 CET
Nmap scan report for 0.0.0.0
Host is up (0.000092s latency).

PORT	  STATE SERVICE
11000/tcp open  irisa
| ssl-enum-ciphers:
|   TLSv1.3:
|     ciphers:
|	TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|	TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|	TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|	TLS_AKE_WITH_AES_128_CCM_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.31 seconds

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
