### PR TITLE
mgr/cephadm: set OSD flags during upgrade

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -197,6 +197,43 @@ you need. For example, the following command upgrades to a development build:
 
 For more information about available container images, see :ref:`containers`.
 
+Setting OSD flags during upgrade
+================================
+
+Cephadm can set specified OSD flags as it upgrades and then unset these flags upon
+upgrade completion. To see the OSD flags cephadm is currently configured to set, check
+
+.. prompt:: bash #
+
+  ceph config get mgr mgr/cephadm/upgrade_osd_flags
+
+The config option is a comma separated list of the flags to be set, and can be modified
+by running
+
+.. prompt:: bash #
+
+  ceph config set mgr mgr/cephadm/upgrade_osd_flags <flag1>,<flag2>, . . . ,<flagN>
+
+Note that setting the config option totally overwrites the set of flags cephadm will
+set. So if it is currently configured to set flag1 and flag2 and you do a config set
+to have it set flag3 and flag4 it will ONLY be configured to set flag3 and flag4, NOT
+flag1, flag2, flag3, and flag4.
+
+Cephadm is configured to set these OSD flags by default on upgrade in versions that
+support it. To have cephadm skip setting these flags, you can pass ``--no-osd-flags``
+to the upgrade command
+
+.. prompt:: bash #
+
+  ceph orch upgrade start --image <image> --no-osd-flags
+
+.. note::
+
+   To check if the current version of cephadm supports setting the osd flags, check
+   ``ceph orch upgrade start --help`` and look to see if ``--no-osd-flags`` is available
+   as a command argument. If so, it is supported and cephadm will set these flags by
+   default during the upgrade.
+
 Staggered Upgrade
 =================
 

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -109,11 +109,25 @@ tasks:
       # verify now 8 daemons have been upgraded
       - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
       # upgrade the rest of the osds
+      # use this opportunity to check we can set osd flags properly
       - ceph orch upgrade status
       - ceph health detail
+      # make sure noout is listed as a flag to be set as that is what we'll test with
+      - ceph config get mgr mgr/cephadm/upgrade_osd_flags | grep noout
+      # upgrade osds and crash daemons.
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd
+      # wait for upgrade to be started and in progress to check for osd flags
+      # To test noout being set during upgrade, want to loop here until either the upgrade completes,
+      # fails with an error, or noout is set, but in the noout case, we need to do something to mark
+      # that that was the condition that we stopped looping on. Doing that here by having
+      # it create a file whose existence we can check for once the loop is over
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do if ceph osd dump -f json | jq '.flags_set' | grep noout; then touch saw_noout.txt; break; else echo "no noout yet"; fi; sleep 1; done
+      - ls | grep saw_noout
+      # wait for upgrade to complete
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
+      # verify noout was unset once upgrade completed
+      - if ceph osd dump -f json | jq '.flags_set' | grep noout; then (exit 1); else (exit 0); fi
       # verify all osds are now on same version and version hash matches what we are upgrading to
       - ceph versions | jq -e '.osd | length == 1'
       - ceph versions | jq -e '.osd | keys' | grep $sha1

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -2,145 +2,160 @@ tasks:
 - cephadm.shell:
     env: [sha1]
     mon.a:
-      # setup rgw
-      - radosgw-admin realm create --rgw-realm=r --default
-      - radosgw-admin zonegroup create --rgw-zonegroup=default --master --default
-      - radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=z --master --default
-      - radosgw-admin period update --rgw-realm=r --commit
-      - ceph orch apply rgw foo --realm r --zone z --placement=2 --port=8000
-      # setup iscsi
-      - ceph osd pool create foo
-      - rbd pool init foo
-      - ceph orch apply iscsi foo u p
-      - sleep 180
-      - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
-      - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
-      - ceph config set global log_to_journald false --force
-      # get some good info on the state of things pre-upgrade. Useful for debugging
-      - ceph orch ps
-      - ceph versions
-      - ceph -s
-      - ceph orch ls
-      # doing staggered upgrade requires mgr daemons being on a version that contains the staggered upgrade code
-      # until there is a stable version that contains it, we can test by manually upgrading a mgr daemon
-      - ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay.ceph.io/ceph-ci/ceph:$sha1
-      - ceph orch ps --refresh
-      - sleep 180
-      # gather more possible debugging info
-      - ceph orch ps
-      - ceph versions
-      - ceph -s
-      - ceph health detail
-      # check that there are two different versions found for mgr daemon (which implies we upgraded one)
-      - ceph versions | jq -e '.mgr | length == 2'
-      - ceph mgr fail
-      - sleep 180
-      # now try upgrading the other mgr
-      - ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay.ceph.io/ceph-ci/ceph:$sha1
-      - ceph orch ps --refresh
-      - sleep 180
-      # gather more possible debugging info
-      - ceph orch ps
-      - ceph versions
-      - ceph health detail
-      - ceph -s
-      - ceph mgr fail
-      - sleep 180
-      # gather more debugging info
-      - ceph orch ps
-      - ceph versions
-      - ceph -s
-      - ceph health detail
-      # now that both mgrs should have been redeployed with the new version, we should be back on only 1 version for the mgrs
-      - ceph versions | jq -e '.mgr | length == 1'
-      - ceph mgr fail
-      - sleep 180
-      # debugging info
-      - ceph orch ps
-      - ceph orch ls
-      - ceph versions
-      # to make sure mgr daemons upgrade is fully completed, including being deployed by a mgr on a new version
-      # also serves as an early failure if manually upgrading the mgrs failed as --daemon-types won't be recognized
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      # verify only one version found for mgrs and that their version hash matches what we are upgrading to
-      - ceph versions | jq -e '.mgr | length == 1'
-      - ceph versions | jq -e '.mgr | keys' | grep $sha1
-      # verify overall we still see two versions, basically to make sure --daemon-types wasn't ignored and all daemons upgraded
-      - ceph versions | jq -e '.overall | length == 2'
-      # check that exactly two daemons have been upgraded to the new image (our 2 mgr daemons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
-      - ceph orch upgrade status
-      - ceph health detail
-      # upgrade only the mons on one of the two hosts
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.x | awk '{print $2}')
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      # verify two different version seen for mons
-      - ceph versions | jq -e '.mon | length == 2'
-      - ceph orch upgrade status
-      - ceph health detail
-      # upgrade mons on the other hosts
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.y | awk '{print $2}')
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      # verify all mons now on same version and version hash matches what we are upgrading to
-      - ceph versions | jq -e '.mon | length == 1'
-      - ceph versions | jq -e '.mon | keys' | grep $sha1
-      # verify exactly 5 daemons are now upgraded (2 mgrs, 3 mons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'
-      - ceph orch upgrade status
-      - ceph health detail
-      # upgrade exactly 2 osd daemons
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types osd --limit 2
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      # verify two different versions now seen for osds
-      - ceph versions | jq -e '.osd | length == 2'
-      # verify exactly 7 daemons have been upgraded (2 mgrs, 3 mons, 2 osds)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'
-      - ceph orch upgrade status
-      - ceph health detail
-      # upgrade one more osd
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd --limit 1
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      - ceph versions | jq -e '.osd | length == 2'
-      # verify now 8 daemons have been upgraded
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
-      # upgrade the rest of the osds
-      # use this opportunity to check we can set osd flags properly
-      - ceph orch upgrade status
-      - ceph health detail
-      # make sure noout is listed as a flag to be set as that is what we'll test with
-      - ceph config get mgr mgr/cephadm/upgrade_osd_flags | grep noout
-      # upgrade osds and crash daemons.
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd
-      # wait for upgrade to be started and in progress to check for osd flags
-      # To test noout being set during upgrade, want to loop here until either the upgrade completes,
-      # fails with an error, or noout is set, but in the noout case, we need to do something to mark
-      # that that was the condition that we stopped looping on. Doing that here by having
-      # it create a file whose existence we can check for once the loop is over
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do if ceph osd dump -f json | jq '.flags_set' | grep noout; then touch saw_noout.txt; break; else echo "no noout yet"; fi; sleep 1; done
-      - ls | grep saw_noout
-      # wait for upgrade to complete
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      # verify noout was unset once upgrade completed
-      - if ceph osd dump -f json | jq '.flags_set' | grep noout; then (exit 1); else (exit 0); fi
-      # verify all osds are now on same version and version hash matches what we are upgrading to
-      - ceph versions | jq -e '.osd | length == 1'
-      - ceph versions | jq -e '.osd | keys' | grep $sha1
-      - ceph orch upgrade status
-      - ceph health detail
-      # upgrade the rgw daemons using --services
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --services rgw.foo
-      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-      - ceph orch ps
-      # verify all rgw daemons on same version and version hash matches what we are upgrading to
-      - ceph versions | jq -e '.rgw | length == 1'
-      - ceph versions | jq -e '.rgw | keys' | grep $sha1
-      - ceph orch upgrade status
-      - ceph health detail
-      # run upgrade one more time with no filter parameters to make sure anything left gets upgraded
-      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - |
+        set -ex
+        # setup rgw
+        radosgw-admin realm create --rgw-realm=r --default
+        radosgw-admin zonegroup create --rgw-zonegroup=default --master --default
+        radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=z --master --default
+        radosgw-admin period update --rgw-realm=r --commit
+        ceph orch apply rgw foo --realm r --zone z --placement=2 --port=8000
+        # setup iscsi
+        ceph osd pool create foo
+        rbd pool init foo
+        ceph orch apply iscsi foo u p
+        sleep 180
+        ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
+        ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
+        ceph config set global log_to_journald false --force
+        # get some good info on the state of things pre-upgrade. Useful for debugging
+        ceph orch ps
+        ceph versions
+        ceph -s
+        ceph orch ls
+        # collect the target id for the container we are upgrading to
+        TARGET_ID="$(ceph orch upgrade check --image quay.ceph.io/ceph-ci/ceph:$sha1 | jq -r '.target_id')"
+        echo "$TARGET_ID"
+        # doing staggered upgrade requires mgr daemons being on a version that contains the staggered upgrade code
+        # until there is a stable version that contains it, we can test by manually upgrading a mgr daemon
+        ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay.ceph.io/ceph-ci/ceph:$sha1
+        ceph orch ps --refresh
+        sleep 180
+        # gather more possible debugging info
+        ceph orch ps
+        ceph versions
+        ceph -s
+        ceph health detail
+        # verify we have upgraded exactly 1 of the 2 mgr daemons to the new image id
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mgr") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "1" ]; then echo "Found unexpected number of upgraded manager daemons"; exit 1; else echo "Matched 1 mgr with new container image id"; fi
+        # verify exactly 1 mgr is not upgraded
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mgr") | select(.container_image_id!=$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "1" ]; then echo "Found unexpected number of upgraded manager daemons"; exit 1; else echo "Matched 1 mgr with old container image id"; fi
+        ceph mgr fail
+        sleep 180
+        # now try upgrading the other mgr
+        ceph orch daemon redeploy "mgr.$(ceph mgr dump -f json | jq .standbys | jq .[] | jq -r .name)" --image quay.ceph.io/ceph-ci/ceph:$sha1
+        ceph orch ps --refresh
+        sleep 180
+        # gather more possible debugging info
+        ceph orch ps
+        ceph versions
+        ceph health detail
+        ceph -s
+        ceph mgr fail
+        sleep 180
+        # gather more debugging info
+        ceph orch ps
+        ceph versions
+        ceph -s
+        ceph health detail
+        # now that both mgrs should have been redeployed with the new version, so should find 2 daemons
+        # when matching against mgr daemons on the correct image id
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mgr") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "2" ]; then echo "Found unexpected number of upgraded manager daemons"; exit 1; else echo "Matched 2 mgr with new container image id"; fi
+        ceph mgr fail
+        sleep 180
+        # debugging info
+        ceph orch ps
+        ceph orch ls
+        ceph versions
+        # to make sure mgr daemons upgrade is fully completed, including being deployed by a mgr on new version
+        # also serves as an early failure if manually upgrading the mgrs failed as --daemon-types won't be recognized
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        # verify 2 mgr daemons both on the new container image id
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mgr") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "2" ]; then echo "Found unexpected number of upgraded manager daemons"; exit 1; else echo "Matched 2 mgr with new container image id"; fi
+        # verify non-mgr daemons are still on old image id to make sure --daemon-types was respected
+        ! ceph orch ps --format json | jq -e '.[] | select(.daemon_type!="mgr") | .container_image_id' | grep $TARGET_ID
+        # check that exactly two daemons have been upgraded to the new image (our 2 mgr daemons)
+        ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
+        ceph orch upgrade status
+        ceph health detail
+        # upgrade only the mons on one of the two hosts
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.x | awk '{print $2}')
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify exactly 1 off the 2 mon daemons was upgraded
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mon") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "1" ]; then echo "Found unexpected number of upgraded mon daemons"; exit 1; else echo "Matched 1 mon with new container image id"; fi
+        ceph orch upgrade status
+        ceph health detail
+        # upgrade mons on the other hosts
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mon --hosts $(ceph orch ps | grep mgr.y | awk '{print $2}')
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify all mons (3) now on same version and version hash matches what we are upgrading to
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="mon") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "3" ]; then echo "Found unexpected number of upgraded mon daemons"; exit 1; else echo "Matched 3 mon with new container image id"; fi
+        # verify exactly 5 daemons are now upgraded (2 mgrs, 3 mons)
+        ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'
+        ceph orch upgrade status
+        ceph health detail
+        # upgrade exactly 2 osd daemons
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types osd --limit 2
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify exactly 2 of the 8 OSDs were upgraded
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="osd") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "2" ]; then echo "Found unexpected number of upgraded osd daemons"; exit 1; else echo "Matched 2 osd with new container image id"; fi
+        # verify exactly 7 daemons have been upgraded (2 mgrs, 3 mons, 2 osds)
+        ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'
+        ceph orch upgrade status
+        ceph health detail
+        # upgrade one more osd
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd --limit 1
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify 3 osd daemons have been upgraded
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="osd") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "3" ]; then echo "Found unexpected number of upgraded osd daemons"; exit 1; else echo "Matched 3 osd with new container image id"; fi
+        # verify now 8 daemons have been upgraded
+        ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
+        # upgrade the rest of the osds
+        # use this opportunity to check we can set osd flags properly
+        ceph orch upgrade status
+        ceph health detail
+        # make sure noout is listed as a flag to be set as that is what we'll test with
+        ceph config get mgr mgr/cephadm/upgrade_osd_flags | grep noout
+        # upgrade osds and crash daemons.
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd
+        # wait for upgrade to be started and in progress to check for osd flags
+        # To test noout being set during upgrade, want to loop here until either the upgrade completes,
+        # fails with an error, or noout is set, but in the noout case, we need to do something to mark
+        # that that was the condition that we stopped looping on. Doing that here by having
+        # it create a file whose existence we can check for once the loop is over
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do if ceph osd dump -f json | jq '.flags_set' | grep noout; then touch saw_noout.txt; break; else echo "no noout yet"; fi; sleep 1; done
+        ls | grep saw_noout
+        # wait for upgrade to complete
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify noout was unset once upgrade completed
+        if ceph osd dump -f json | jq '.flags_set' | grep noout; then (exit 1); else (exit 0); fi
+        # verify all 8 osds are on the new container image id
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="osd") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "8" ]; then echo "Found unexpected number of upgraded osd daemons"; exit 1; else echo "Matched 8 osd with new container image id"; fi
+        ceph orch upgrade status
+        ceph health detail
+        # upgrade the rgw daemons using --services
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --services rgw.foo
+        while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
+        ceph orch ps
+        # verify all 2 rgw daemons were upgraded
+        matching_daemon_count=$(ceph orch ps --format json | jq --arg TARGET_ID "$TARGET_ID" -e '.[] | select(.daemon_type=="rgw") | select(.container_image_id==$TARGET_ID)' | grep "container_image_id" | wc -l)
+        if [ "$matching_daemon_count" != "2" ]; then echo "Found unexpected number of upgraded rgw daemons"; exit 1; else echo "Matched 2 rgw with new container image id"; fi
+        ceph orch upgrade status
+        ceph health detail
+        # run upgrade one more time with no filter parameters to make sure anything left gets upgraded
+        ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -737,7 +737,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def upgrade_start(self, image: Optional[str], version: Optional[str], daemon_types: Optional[List[str]],
-                      hosts: Optional[str], services: Optional[List[str]], limit: Optional[int]) -> OrchResult[str]:
+                      hosts: Optional[str], services: Optional[List[str]], limit: Optional[int], set_osd_flags: bool = False) -> OrchResult[str]:
         raise NotImplementedError()
 
     def upgrade_pause(self) -> OrchResult[str]:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1734,12 +1734,13 @@ Usage:
                        hosts: Optional[str] = None,
                        services: Optional[str] = None,
                        limit: Optional[int] = None,
-                       ceph_version: Optional[str] = None) -> HandleCommandResult:
+                       ceph_version: Optional[str] = None,
+                       no_osd_flags: bool = False) -> HandleCommandResult:
         """Initiate upgrade"""
         self._upgrade_check_image_name(image, ceph_version)
         dtypes = daemon_types.split(',') if daemon_types is not None else None
         service_names = services.split(',') if services is not None else None
-        completion = self.upgrade_start(image, ceph_version, dtypes, hosts, service_names, limit)
+        completion = self.upgrade_start(image, ceph_version, dtypes, hosts, service_names, limit, no_osd_flags)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 


### PR DESCRIPTION
    in this commit at least, this means the noout, noscrub,
    and nodeep-scrub flags, although it's configurable with
    the mgr/cephadm/osd_upgrade_flags conf option. The idea
    is that during upgrade there may be situations that cause
    OSDs to get marked down and out (see the linked tracker)
    and so it's good practice to have these set during upgrade.
    This also gets us in line with ceph-ansible, which set
    these flags itself during upgrade.
    
    Using the staggered upgrade test to test this since we
    need to be upgrading from a mgr with upgrade code
    that contains these changes.
    
    Fixes: https://tracker.ceph.com/issues/56670
    
    Signed-off-by: Adam King <adking@redhat.com>

Additionally, the staggered upgrade test is currently broken, so included an additional commit to attempt to fix that. Would recommend looking at the two commits separately when reviewing, especially since they both modify the staggered upgrade teuthology test
    
    "ceph versions" has stopped being a reliable way of checking
    if daemons have been upgraded (see linked tracker). The idea
    of this commit is to instead rely on the container image id
    that cephadm tracks for each daemon, since we have more control
    over that.
    
    Fixes: https://tracker.ceph.com/issues/58535



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
