### PR TITLE
reef: rgw: experimental support for restoring a lost bucket index 

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2131,6 +2131,7 @@ fi
 %{_bindir}/rgw-gap-list-comparator
 %{_bindir}/rgw-orphan-list
 %{_bindir}/rgw-policy-check
+%{_bindir}/rgw-restore-bucket-index
 %{_mandir}/man8/radosgw.8*
 %{_mandir}/man8/rgw-policy-check.8*
 %dir %{_localstatedir}/lib/ceph/radosgw

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -7,6 +7,7 @@ usr/bin/radosgw-token
 usr/bin/rgw-gap-list
 usr/bin/rgw-gap-list-comparator
 usr/bin/rgw-orphan-list
+usr/bin/rgw-restore-bucket-index
 usr/share/man/man8/ceph-diff-sorted.8
 usr/share/man/man8/radosgw.8
 usr/share/man/man8/rgw-orphan-list.8

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -578,4 +578,5 @@ install(PROGRAMS
   rgw-gap-list
   rgw-gap-list-comparator
   rgw-orphan-list
+  rgw-restore-bucket-index
   DESTINATION bin)

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1079,6 +1079,10 @@ public:
   D3nDataCache* d3n_data_cache{nullptr};
 
   int rewrite_obj(rgw::sal::Object* obj, const DoutPrefixProvider *dpp, optional_yield y);
+  int reindex_obj(const RGWBucketInfo& dest_bucket_info,
+		  const rgw_obj& obj,
+		  const DoutPrefixProvider* dpp,
+		  optional_yield y);
 
   int stat_remote_obj(const DoutPrefixProvider *dpp,
                RGWObjectCtx& obj_ctx,

--- a/src/rgw/rgw-restore-bucket-index
+++ b/src/rgw/rgw-restore-bucket-index
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+# version 2023-03-07
+
+# rgw-restore-bucket-index is an EXPERIMENTAL tool to use in case
+# bucket index entries for objects in the bucket are somehow lost. It
+# is expected to be needed and used rarely. A bucket name is provided
+# and the data pool for that bucket is scanned for all head objects
+# matching the bucket's marker. The rgw object name is then extracted
+# from the rados object name, and `radosgw-admin bucket reindex ...`
+# is used to add the bucket index entry.
+#
+# Because this script must process json objects, the `jq` tool must be
+# installed on the system.
+#
+# Usage: $0 [--proceed] <bucket-name> [data-pool-name]
+#
+# This tool is designed to be interactive, allowing the user to
+# examine the list of objects to be reindexed before
+# proceeding. However, if the "--proceed" option is provided, the
+# script will not prompt the user and simply proceed.
+
+trap "clean ; exit 1" TERM
+export TOP_PID=$$
+
+# IMPORTANT: affects order produced by 'sort' and 'ceph-diff-sorted'
+# relies on this ordering
+export LC_ALL=C
+
+export bkt_entry=/tmp/rgwrbi-bkt-entry.$$
+export bkt_inst=/tmp/rgwrbi-bkt-inst.$$
+export bkt_inst_new=/tmp/rgwrbi-bkt-inst-new.$$
+export obj_list=/tmp/rgwrbi-object-list.$$
+export zone_info=/tmp/rgwrbi-zone-info.$$
+export clean_temps=1
+
+# make sure jq is available
+if which jq > /dev/null ;then
+  :
+else
+  echo 'Error: must have command `jq` installed and on $PATH for json parsing.'
+  exit 1
+fi
+
+clean() {
+  if [ -n "$clean_temps" ] ;then
+    rm -f $bkt_entry $bkt_inst $bkt_inst_new $obj_list $zone_info
+  fi
+}
+
+super_exit() {
+   kill -s TERM $TOP_PID
+}
+
+usage() {
+  >&2 cat << EOF
+
+Usage: $0 [--proceed] <bucket-name> [data-pool-name]
+  NOTE: This tool is currently considered EXPERIMENTAL.
+  NOTE: If a data-pool-name is not supplied then it will be inferred from bucket and zone information.
+  NOTE: If --proceed is provided then user will not be prompted to proceed. Use with caution.
+EOF
+  super_exit
+}
+
+# strips the starting and ending double quotes from a string, so:
+#   "dog"   -> dog
+#   "dog    -> "dog
+#   d"o"g   -> d"o"g
+#   "do"g"  -> do"g
+strip_quotes() {
+  echo "$1" | sed 's/^"\(.*\)"$/\1/'
+}
+
+# Determines the name of the data pool. Expects the optional
+# command-line argument to appear as $1 if there is one. The
+# command-line has the highest priority, then the "explicit_placement"
+# in the bucket instance data, and finally the "placement_rule" in the
+# bucket instance data.
+get_pool() {
+  # command-line
+  if [ -n "$1" ] ;then
+    echo "$1"
+    exit 0
+  fi
+
+  # explicit_placement
+  expl_pool=$(strip_quotes $(jq '.data.bucket_info.bucket.explicit_placement.data_pool' $bkt_inst))
+  if [ -n "$expl_pool" ] ;then
+    echo "$expl_pool"
+    exit 0
+  fi
+
+  # placement_rule
+  plmt_rule=$(strip_quotes $(jq '.data.bucket_info.placement_rule' $bkt_inst))
+  plmt_pool=$(echo "$plmt_rule" | awk -F / '{print $1}')
+  plmt_class=$(echo "$plmt_rule" | awk -F / '{print $2}')
+  if [ -z "$plmt_class" ] ;then
+    plmt_class=STANDARD
+  fi
+
+  radosgw-admin zone get >$zone_info 2>/dev/null
+  pool=$(strip_quotes $(jq ".placement_pools [] | select(.key | contains(\"${plmt_pool}\")) .val .storage_classes.${plmt_class}.data_pool" $zone_info))
+
+  if [ -z "$pool" ] ;then
+      echo ERROR: unable to determine pool.
+      super_exit
+  fi
+  echo "$pool"
+}
+
+if [ $1 == "--proceed" ] ;then
+    echo "NOTICE: This tool is currently considered EXPERIMENTAL."
+    proceed=1
+    shift
+fi
+
+# expect 1 or 2 arguments
+if [ $# -eq 0 -o $# -gt 2 ] ;then
+   usage
+fi
+
+bucket=$1
+
+# read bucket entry metadata
+radosgw-admin metadata get bucket:$bucket >$bkt_entry 2>/dev/null
+marker=$(strip_quotes $(jq ".data.bucket.marker" $bkt_entry))
+bucket_id=$(strip_quotes $(jq ".data.bucket.bucket_id" $bkt_entry))
+echo marker is $marker
+echo bucket_id is $bucket_id
+
+# read bucket instance metadata
+radosgw-admin metadata get bucket.instance:${bucket}:$bucket_id >$bkt_inst 2>/dev/null
+
+# handle versioned buckets
+bkt_flags=$(jq ".data.bucket_info.flags" $bkt_inst)
+is_versioned=$(( $bkt_flags & 2)) # mask bit indicating it's a versioned bucket
+if [ "$is_versioned" -ne 0 ] ;then
+   echo "Error: this bucket appears to be versioned, and this tool cannot work with versioned buckets."
+   clean
+   exit 1
+fi
+
+# examine number of bucket index shards
+num_shards=$(jq ".data.bucket_info.num_shards" $bkt_inst)
+echo number of bucket index shards is $num_shards
+
+# determine data pool
+pool=$(get_pool $2)
+echo data pool is $pool
+
+# search the data pool for all of the head objects that begin with the
+# marker that are not in namespaces (indicated by an extra underscore)
+# and then strip away all but the rgw object name
+( rados -p $pool ls | grep "^${marker}_[^_]" | sed "s/^${marker}_\(.*\)/\1/" >$obj_list ) 2>/dev/null
+
+# handle the case where the resulting object list file is empty
+if [ -s $obj_list ] ;then
+  :
+else
+  echo "NOTICE: No head objects for bucket \"$bucket\" were found in pool \"$pool\", so nothing was recovered."
+  clean
+  exit 0
+fi
+
+if [ -z "$proceed" ] ;then
+    # warn user and get permission to proceed
+    echo "NOTICE: This tool is currently considered EXPERIMENTAL."
+    echo "The list of objects that we will attempt to restore can be found in \"$obj_list\"."
+    echo "Please review the object names in that file (either below or in another window/terminal) before proceeding."
+    while true ; do
+	read -p "Type \"proceed!\" to proceed, \"view\" to view object list, or \"q\" to quit: " action
+	if [ "$action" == "q" ] ;then
+	    echo "Exiting..."
+	    clean
+	    exit 0
+	elif [ "$action" == "view" ] ;then
+	    echo "Viewing..."
+	    less $obj_list
+	elif [ "$action" == "proceed!" ] ;then
+	    echo "Proceeding..."
+	    break
+	else
+	    echo "Error: response \"$action\" is not understood."
+	fi
+    done
+fi
+
+# execute object rewrite on all of the head objects
+radosgw-admin object reindex --bucket=$bucket --objects-file=$obj_list 2>/dev/null
+
+clean
+echo Done

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -42,6 +42,7 @@
     object stat                stat an object for its metadata
     object unlink              unlink object from bucket index
     object rewrite             rewrite the specified object
+    object reindex             reindex the object(s) indicated by --bucket and either --object or --objects-file
     objects expire             run expired objects cleanup
     objects expire-stale list  list stale expired objects (caused by reshard)
     objects expire-stale rm    remove stale expired objects
@@ -211,6 +212,7 @@
      --bucket=<bucket>         Specify the bucket name. Also used by the quota command.
      --pool=<pool>             Specify the pool name. Also used to scan for leaked rados objects.
      --object=<object>         object name
+     --objects-file=<file>     file containing a list of object names to process
      --object-version=<version>         object version
      --date=<date>             date in the format yyyy-mm-dd
      --start-date=<date>       start date in the format yyyy-mm-dd
@@ -296,7 +298,7 @@
      --show-log-sum=<flag>     enable/disable dump of log summation on log show
      --skip-zero-entries       log show only dumps entries that don't have zero value
                                in one of the numeric field
-     --infile=<file>           specify a file to read in when setting data
+     --infile=<file>           file to read in when setting data
      --categories=<list>       comma separated list of categories, used in usage show
      --caps=<caps>             list of caps (e.g., "usage=read, write; user=read")
      --op-mask=<op-mask>       permission of user's operations (e.g., "read, write, delete, *")


### PR DESCRIPTION
Adds an "object reindex" subcommand to radosgw-admin. This subcommand will take a bucket and an object (or a list of objects in a file) and add those objects to the bucket's index. It does so by preparing the bucket index entry update and then allowing the so-called "dir suggest" mechanism, which is triggered by listing the bucket, to completing the bucket index entry. This mechanism is triggered by listing the bucket. Using this mechanism has the advantage of doing this lazily that both allows the reindex operation to run more quickly and distributes the workload over time.

Adds an experimental script that allows a bucket index of a non-versioned bucket to be restored by applying radosgw-admin object reindex ... to all objects in the specified bucket. The objects in the bucket are determined by scanning the data pool for head objects containing the bucket's marker.

Fixes: https://tracker.ceph.com/issues/59055


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
