### PR TITLE
rgw: add default Server response header

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -14,12 +14,10 @@ using namespace rgw::asio;
 
 ClientIO::ClientIO(parser_type& parser, bool is_ssl,
                    const endpoint_type& local_endpoint,
-                   const endpoint_type& remote_endpoint,
-                   std::string_view extra_response_headers)
+                   const endpoint_type& remote_endpoint)
   : parser(parser), is_ssl(is_ssl),
     local_endpoint(local_endpoint),
     remote_endpoint(remote_endpoint),
-    extra_response_headers(extra_response_headers),
     txbuf(*this)
 {
 }
@@ -149,11 +147,6 @@ size_t ClientIO::complete_header()
   char timestr[TIME_BUF_SIZE];
   if (dump_date_header(timestr)) {
     sent += txbuf.sputn(timestr, strlen(timestr));
-  }
-
-  if (extra_response_headers.size()) {
-    sent += txbuf.sputn(extra_response_headers.data(),
-                        extra_response_headers.size());
   }
 
   if (parser.keep_alive()) {

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -25,7 +25,6 @@ class ClientIO : public io::RestfulClient,
   using endpoint_type = boost::asio::ip::tcp::endpoint;
   endpoint_type local_endpoint;
   endpoint_type remote_endpoint;
-  std::string_view extra_response_headers;
 
   RGWEnv env;
 
@@ -35,8 +34,7 @@ class ClientIO : public io::RestfulClient,
  public:
   ClientIO(parser_type& parser, bool is_ssl,
            const endpoint_type& local_endpoint,
-           const endpoint_type& remote_endpoint,
-           std::string_view extra_response_headers);
+           const endpoint_type& remote_endpoint);
   ~ClientIO() override;
 
   int init_env(CephContext *cct) override;

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -16,7 +16,6 @@
 #include "common/async/shared_mutex.h"
 #include "common/errno.h"
 #include "common/strtol.h"
-#include "ceph_ver.h"
 
 #include "rgw_asio_client.h"
 #include "rgw_asio_frontend.h"
@@ -79,10 +78,8 @@ class StreamIO : public rgw::asio::ClientIO {
            rgw::asio::parser_type& parser, yield_context yield,
            parse_buffer& buffer, bool is_ssl,
            const tcp::endpoint& local_endpoint,
-           const tcp::endpoint& remote_endpoint,
-           std::string_view extra_response_headers)
-      : ClientIO(parser, is_ssl, local_endpoint, remote_endpoint,
-                 extra_response_headers),
+           const tcp::endpoint& remote_endpoint)
+      : ClientIO(parser, is_ssl, local_endpoint, remote_endpoint),
         cct(cct), stream(stream), timeout(timeout), yield(yield),
         buffer(buffer)
   {}
@@ -196,7 +193,6 @@ void handle_connection(boost::asio::io_context& context,
                        SharedMutex& pause_mutex,
                        rgw::dmclock::Scheduler *scheduler,
                        const std::string& uri_prefix,
-                       std::string_view extra_response_headers,
                        boost::system::error_code& ec,
                        yield_context yield)
 {
@@ -269,8 +265,7 @@ void handle_connection(boost::asio::io_context& context,
       }
 
       StreamIO real_client{cct, stream, timeout, parser, yield, buffer,
-                           is_ssl, local_endpoint, remote_endpoint,
-                           extra_response_headers};
+                           is_ssl, local_endpoint, remote_endpoint};
 
       auto real_client_io = rgw::io::add_reordering(
                               rgw::io::add_buffering(cct,
@@ -442,8 +437,6 @@ class AsioFrontend {
   std::unique_ptr<dmc::ClientConfig> client_config;
   void accept(Listener& listener, boost::system::error_code ec);
 
-  std::string extra_response_headers;
-
  public:
   AsioFrontend(RGWProcessEnv& env, RGWFrontendConfig* conf,
 	       dmc::SchedulerCtx& sched_ctx)
@@ -564,9 +557,6 @@ int AsioFrontend::init()
 {
   boost::system::error_code ec;
   auto& config = conf->get_config_map();
-
-  // format the Server response header
-  extra_response_headers = "Server: Ceph Object Gateway (" CEPH_RELEASE_NAME ")\r\n";
 
   if (auto i = config.find("prefix"); i != config.end()) {
     uri_prefix = i->second;
@@ -1045,7 +1035,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         conn->buffer.consume(bytes);
         handle_connection(context, env, stream, timeout, header_limit,
                           conn->buffer, true, pause_mutex, scheduler.get(),
-                          uri_prefix, extra_response_headers, ec, yield);
+                          uri_prefix, ec, yield);
         if (!ec) {
           // ssl shutdown (ignoring errors)
           stream.async_shutdown(yield[ec]);
@@ -1064,7 +1054,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         boost::system::error_code ec;
         handle_connection(context, env, conn->socket, timeout, header_limit,
                           conn->buffer, false, pause_mutex, scheduler.get(),
-                          uri_prefix, extra_response_headers, ec, yield);
+                          uri_prefix, ec, yield);
         conn->socket.shutdown(tcp_socket::shutdown_both, ec);
       }, make_stack_allocator());
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -7,6 +7,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
+#include "ceph_ver.h"
 #include "common/Formatter.h"
 #include "common/HTMLFormatter.h"
 #include "common/utf8.h"
@@ -615,7 +616,13 @@ void end_header(req_state* s, RGWOp* op, const char *content_type,
   if (content_type) {
     dump_header(s, "Content-Type", content_type);
   }
-  dump_header_if_nonempty(s, "Server", g_conf()->rgw_service_provider_name);
+
+  std::string srv = g_conf().get_val<std::string>("rgw_service_provider_name");
+  if (!srv.empty()) {
+    dump_header(s, "Server", srv);
+  } else {
+    dump_header(s, "Server", "Ceph Object Gateway (" CEPH_RELEASE_NAME ")");
+  }
 
   try {
     RESTFUL_IO(s)->complete_header();


### PR DESCRIPTION
if a specific `rgw_service_provider_name` is not configured, add a default Server response header that includes the ceph release name:
> Server: Ceph Object Gateway (reef)

note: updates https://github.com/ceph/ceph/pull/50483 which was specific to the beast frontend and didn't take `rgw_service_provider_name` into account

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
