### PR TITLE
quincy: rgw: Update "CEPH_RGW_DIR_SUGGEST_LOG_OP" for remove entries

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9526,7 +9526,7 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
     // encode a suggested removal of that key
     list_state.ver.epoch = io_ctx.get_last_version();
     list_state.ver.pool = io_ctx.get_id();
-    cls_rgw_encode_suggestion(CEPH_RGW_REMOVE, list_state, suggested_updates);
+    cls_rgw_encode_suggestion(CEPH_RGW_REMOVE | suggest_flag, list_state, suggested_updates);
     return -ENOENT;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55151

---

backport of https://github.com/ceph/ceph/pull/45300
parent tracker: https://tracker.ceph.com/issues/54499

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh