### PR TITLE
*: s/whitelist_externals/allowlist_externals/

### DIFF
--- a/monitoring/ceph-mixin/tox.ini
+++ b/monitoring/ceph-mixin/tox.ini
@@ -3,7 +3,7 @@ envlist = lint,jsonnet-{check,lint,fix},promql-query-{test,lint},alerts-check
 skipsdist = true
 
 [testenv:jsonnet-bundler-{install,update}]
-whitelist_externals =
+allowlist_externals =
     jb
 description =
     install: Install the jsonnet dependencies
@@ -14,7 +14,7 @@ commands =
 
 [testenv:jsonnet-{check,fix,lint}]
 basepython = python3
-whitelist_externals =
+allowlist_externals =
     find
     jb
     jsonnet
@@ -51,7 +51,7 @@ deps =
     -rrequirements-lint.txt
 depends = grafonnet-check
 setenv =
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     behave tests_dashboards/features 
@@ -61,7 +61,7 @@ deps =
     -rrequirements-alerts.txt
     pytest
 depends = grafonnet-check
-whitelist_externals =
+allowlist_externals =
   promtool
 commands =
     fix: jsonnet -J vendor -S alerts.jsonnet -o prometheus_alerts.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 deps = mock
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     git

--- a/src/ceph-volume/shell_tox.ini
+++ b/src/ceph-volume/shell_tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 
 [testenv]
 passenv=*
-whitelist_externals=
+allowlist_externals=
   bash
   grep
   mktemp


### PR DESCRIPTION
as allowlist_externals was introduced in
tox v4.0. see
https://github.com/tox-dev/tox/commit/5e33fda1a40ffb4973de3d607a572891eb3cb2d2 , but this option was backported to 3.18 as an alias of whitelist_externals, so we don't need to specify the minversion to 4.0 in this change.

as we started using tox 4.0 and up (v4.0.2 in specific). tox complains and fails like:

alerts-lint: failed with promtool is not allowed, use allowlist_externals to allow it
  alerts-lint: FAIL code 1 (9.25 seconds)

see https://tox.wiki/en/latest/faq.html#tox-4-removed-tox-ini-keys and https://tox.wiki/en/latest/config.html#allowlist_externals

it'd be nice to use a more inclusive language also. so, in this change, s/whitelist_externals/allowlist_externals/ in all tox.ini in this project.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit 34e2e33870b1ce381f9cd3eead882daa7b640b81) (cherry picked from commit a2bbfdc4374babcbd64efdf779d4cd0a1e6025a5)
