### PR TITLE
quincy: rgw: LDAP fix resource leak with wrong credentials

### DIFF
--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -83,10 +83,8 @@ namespace rgw {
 			      (void*) &ldap_ver);
 	if (ret == LDAP_SUCCESS) {
 	  ret = ldap_simple_bind_s(tldap, dn, pwd.c_str());
-	  if (ret == LDAP_SUCCESS) {
-	    (void) ldap_unbind(tldap);
-	  }
 	}
+	(void) ldap_unbind(tldap);
       }
       return ret; // OpenLDAP client error space
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59092

---

backport of https://github.com/ceph/ceph/pull/48509
parent tracker: https://tracker.ceph.com/issues/57881

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh