### PR TITLE
osd/cls: expose cls_rmxattr()

### DIFF
--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -44,6 +44,7 @@ extern int cls_getxattr(cls_method_context_t hctx, const char *name,
                                  char **outdata, int *outdatalen);
 extern int cls_setxattr(cls_method_context_t hctx, const char *name,
                                  const char *value, int val_len);
+extern int cls_rmxattr(cls_method_context_t hctx, const char *name);
 /** This will fill in the passed origin pointer with the origin of the
  * request which activated your class call. */
 extern int cls_get_request_origin(cls_method_context_t hctx,

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -102,6 +102,18 @@ int cls_setxattr(cls_method_context_t hctx, const char *name,
   return r;
 }
 
+int cls_rmxattr(cls_method_context_t hctx, const char *name)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
+  vector<OSDOp> nops(1);
+  OSDOp& op = nops[0];
+
+  op.op.op = CEPH_OSD_OP_RMXATTR;
+  op.op.xattr.name_len = strlen(name);
+  op.indata.append(name, op.op.xattr.name_len);
+  return (*pctx)->pg->do_osd_ops(*pctx, nops);
+}
+
 int cls_read(cls_method_context_t hctx, int ofs, int len,
 	     char **outdata, int *outdatalen)
 {


### PR DESCRIPTION
expose `CEPH_OSD_OP_RMXATTR` to cls, in addition to the existing functions for `GETXATTR` and `SETXATTR`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
