### PR TITLE
posixdriver: don't re-use root_fd filp in list_buckets()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ option(WITH_RADOSGW_LUA_PACKAGES "Rados Gateway's support for dynamically adding
 option(WITH_RADOSGW_DBSTORE "DBStore backend for Rados Gateway" ON)
 option(WITH_RADOSGW_MOTR "CORTX-Motr backend for Rados Gateway" OFF)
 option(WITH_RADOSGW_DAOS "DAOS backend for RADOS Gateway" OFF)
+option(WITH_RADOSGW_POSIX "POSIX backend for Rados Gateway" ON)
 option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" ON)
 
 option(WITH_SYSTEM_ARROW "Use system-provided arrow" OFF)

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3569,7 +3569,7 @@ options:
   enum_values:
   - none
   - base
-  - trace
+  - posix
 - name: dbstore_db_dir
   type: str
   level: advanced
@@ -3639,6 +3639,15 @@ options:
   level: advanced
   desc: Set to true when Motr client debugging is needed
   default: false
+  services:
+  - rgw
+- name: rgw_posix_base_path
+  type: str
+  level: advanced
+  desc: experimental Option to set base path for POSIX Driver
+  long_desc: Base path for the POSIX driver.  All operations are relative to this path.
+    Defaults to /tmp/rgw_posix_driver
+  default: /tmp/rgw_posix_driver
   services:
   - rgw
 - name: rgw_luarocks_location

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -357,6 +357,9 @@
 /* Backend CORTX-DAOS for Rados Gateway */
 #cmakedefine WITH_RADOSGW_DAOS
 
+/* Backend POSIX for Rados Gateway */
+#cmakedefine WITH_RADOSGW_POSIX
+
 /* Defined if std::map::merge() is supported */
 #cmakedefine HAVE_STDLIB_MAP_SPLICING
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -210,6 +210,10 @@ endif()
 if(WITH_RADOSGW_DAOS)
   list(APPEND librgw_common_srcs rgw_sal_daos.cc)
 endif()
+if(WITH_RADOSGW_POSIX)
+  #add_subdirectory(driver/posix)
+  list(APPEND librgw_common_srcs driver/posix/rgw_sal_posix.cc)
+endif()
 if(WITH_JAEGER)
   list(APPEND librgw_common_srcs rgw_tracer.cc)
 endif()
@@ -310,6 +314,10 @@ if(WITH_RADOSGW_DAOS)
   target_include_directories(rgw_common PRIVATE ${PC_DAOS_INCLUDEDIR} )
   link_directories( ${PC_DAOS_LIBRARY_DIRS} )
 endif()
+
+#if(WITH_RADOSGW_POSIX)
+  #target_link_libraries(rgw_common PRIVATE global dbstore)
+#endif()
 
 set(rgw_a_srcs
   rgw_appmain.cc

--- a/src/rgw/driver/posix/CMakeLists.txt
+++ b/src/rgw/driver/posix/CMakeLists.txt
@@ -1,0 +1,70 @@
+#need to update cmake version here
+cmake_minimum_required(VERSION 3.14.0)
+project(posixdriver)
+
+#set (CMAKE_INCLUDE_DIR ${CMAKE_INCLUDE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/common")
+
+set(dbstore_srcs
+    common/dbstore_log.h
+    common/dbstore.h
+    common/dbstore.cc
+    config/store.cc)
+IF(USE_SQLITE)
+  list(APPEND dbstore_srcs
+      config/sqlite.cc
+      sqlite/connection.cc
+      sqlite/error.cc
+      sqlite/statement.cc)
+endif()
+
+set(dbstore_mgr_srcs
+    dbstore_mgr.h
+    dbstore_mgr.cc
+    )
+
+add_library(dbstore_lib ${dbstore_srcs})
+target_include_directories(dbstore_lib
+    PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include"
+    PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
+    PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/rados"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+set(link_targets spawn)
+if(WITH_JAEGER)
+  list(APPEND link_targets jaeger_base)
+endif()
+list(APPEND link_targets rgw_common)
+target_link_libraries(dbstore_lib PUBLIC ${link_targets})
+
+set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} dbstore_lib)
+
+IF(USE_SQLITE)
+  add_subdirectory(sqlite)
+  set(CMAKE_INCLUDE_DIR ${CMAKE_INCLUDE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/sqlite")
+  add_compile_definitions(SQLITE_ENABLED=1)
+  set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} rgw_common)
+  set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} sqlite_db)
+  add_dependencies(sqlite_db dbstore_lib)
+ENDIF()
+
+# add pthread library
+set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} pthread)
+
+find_package(gtest QUIET)
+if(WITH_TESTS)
+    add_subdirectory(tests)
+else()
+	message(WARNING "Gtest not enabled")
+endif()
+
+include_directories(${CMAKE_INCLUDE_DIR})
+add_library(dbstore STATIC ${dbstore_mgr_srcs})
+target_link_libraries(dbstore ${CMAKE_LINK_LIBRARIES})
+
+# testing purpose
+set(dbstore_main_srcs
+    dbstore_main.cc)
+
+set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} dbstore)
+add_executable(dbstore-bin ${dbstore_main_srcs})
+add_dependencies(dbstore-bin dbstore)
+target_link_libraries(dbstore-bin ${CMAKE_LINK_LIBRARIES})

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1,0 +1,573 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_sal_posix.h"
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+namespace rgw { namespace sal {
+
+static inline User* nextUser(User* t)
+{
+  if (!t)
+    return nullptr;
+
+  return dynamic_cast<FilterUser*>(t)->get_next();
+}
+
+static inline Bucket* nextBucket(Bucket* t)
+{
+  if (!t)
+    return nullptr;
+
+  return dynamic_cast<POSIXBucket*>(t)->get_next();
+}
+
+static inline Object* nextObject(Object* t)
+{
+  if (!t)
+    return nullptr;
+  
+  return dynamic_cast<POSIXObject*>(t)->get_next();
+}  
+
+int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
+{
+  POSIXDriver::initialize(cct, dpp);
+  
+  return 0;
+}
+
+std::unique_ptr<User> POSIXDriver::get_user(const rgw_user &u)
+{
+  std::unique_ptr<User> user = next->get_user(u);
+
+  return std::make_unique<POSIXUser>(std::move(user), this);
+}
+
+int POSIXDriver::get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
+{
+  std::unique_ptr<User> nu;
+  int ret;
+
+  ret = next->get_user_by_access_key(dpp, key, y, &nu);
+  if (ret != 0)
+    return ret;
+
+  User* u = new FilterUser(std::move(nu));
+  user->reset(u);
+  return 0;
+}
+
+int POSIXDriver::get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user)
+{
+  std::unique_ptr<User> nu;
+  int ret;
+
+  ret = next->get_user_by_email(dpp, email, y, &nu);
+  if (ret != 0)
+    return ret;
+
+  User* u = new FilterUser(std::move(nu));
+  user->reset(u);
+  return 0;
+}
+
+int POSIXDriver::get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
+{
+  std::unique_ptr<User> nu;
+  int ret;
+
+  ret = next->get_user_by_swift(dpp, user_str, y, &nu);
+  if (ret != 0)
+    return ret;
+
+  User* u = new FilterUser(std::move(nu));
+  user->reset(u);
+  return 0;
+}
+
+std::unique_ptr<Object> POSIXDriver::get_object(const rgw_obj_key& k)
+{
+  std::unique_ptr<Object> o = next->get_object(k);
+
+  return std::make_unique<POSIXObject>(std::move(o), this);
+}
+
+int POSIXDriver::get_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y)
+{
+  std::unique_ptr<Bucket> nb;
+  int ret;
+  User* nu = nextUser(u);
+
+  ret = next->get_bucket(dpp, nu, b, &nb, y);
+  if (ret != 0)
+    return ret;
+
+  Bucket* fb = new FilterBucket(std::move(nb), u);
+  bucket->reset(fb);
+  return 0;
+}
+
+int POSIXDriver::get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket)
+{
+  std::unique_ptr<Bucket> nb;
+  int ret;
+  User* nu = nextUser(u);
+
+  ret = next->get_bucket(nu, i, &nb);
+  if (ret != 0)
+    return ret;
+
+  Bucket* fb = new FilterBucket(std::move(nb), u);
+  bucket->reset(fb);
+  return 0;
+}
+
+int POSIXDriver::get_bucket(const DoutPrefixProvider* dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y)
+{
+  std::unique_ptr<Bucket> nb;
+  int ret;
+  User* nu = nextUser(u);
+
+  ret = next->get_bucket(dpp, nu, tenant, name, &nb, y);
+  if (ret != 0)
+    return ret;
+
+  Bucket* fb = new FilterBucket(std::move(nb), u);
+  bucket->reset(fb);
+  return 0;
+}
+
+std::unique_ptr<Writer> POSIXDriver::get_append_writer(const DoutPrefixProvider *dpp,
+				  optional_yield y,
+				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  const rgw_user& owner,
+				  const rgw_placement_rule *ptail_placement_rule,
+				  const std::string& unique_tag,
+				  uint64_t position,
+				  uint64_t *cur_accounted_size)
+{
+  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+
+  std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, std::move(no),
+							   owner, ptail_placement_rule,
+							   unique_tag, position,
+							   cur_accounted_size);
+
+  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+}
+
+std::unique_ptr<Writer> POSIXDriver::get_atomic_writer(const DoutPrefixProvider *dpp,
+				  optional_yield y,
+				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  const rgw_user& owner,
+				  const rgw_placement_rule *ptail_placement_rule,
+				  uint64_t olh_epoch,
+				  const std::string& unique_tag)
+{
+  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+
+  std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, std::move(no),
+							   owner, ptail_placement_rule,
+							   olh_epoch, unique_tag);
+
+  return std::make_unique<POSIXWriter>(std::move(writer), std::move(_head_obj), this);
+}
+
+void POSIXDriver::finalize(void)
+{
+  next->finalize();
+}
+
+void POSIXDriver::register_admin_apis(RGWRESTMgr* mgr)
+{
+  return next->register_admin_apis(mgr);
+}
+
+int POSIXUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& marker,
+			     const std::string& end_marker, uint64_t max,
+			     bool need_stats, BucketList &buckets, optional_yield y)
+{
+  BucketList bl;
+  int ret;
+
+  buckets.clear();
+  ret = next->list_buckets(dpp, marker, end_marker, max, need_stats, bl, y);
+  if (ret < 0)
+    return ret;
+
+  buckets.set_truncated(bl.is_truncated());
+  for (auto& ent : bl.get_buckets()) {
+    buckets.add(std::make_unique<POSIXBucket>(std::move(ent.second), this, driver));
+  }
+
+  return 0;
+}
+
+int POSIXUser::create_bucket(const DoutPrefixProvider* dpp,
+			      const rgw_bucket& b,
+			      const std::string& zonegroup_id,
+			      rgw_placement_rule& placement_rule,
+			      std::string& swift_ver_location,
+			      const RGWQuotaInfo * pquota_info,
+			      const RGWAccessControlPolicy& policy,
+			      Attrs& attrs,
+			      RGWBucketInfo& info,
+			      obj_version& ep_objv,
+			      bool exclusive,
+			      bool obj_lock_enabled,
+			      bool* existed,
+			      req_info& req_info,
+			      std::unique_ptr<Bucket>* bucket_out,
+			      optional_yield y)
+{
+  std::unique_ptr<Bucket> nb;
+  int ret;
+
+  ret = next->create_bucket(dpp, b, zonegroup_id, placement_rule, swift_ver_location, pquota_info, policy, attrs, info, ep_objv, exclusive, obj_lock_enabled, existed, req_info, &nb, y);
+  if (ret < 0)
+    return ret;
+
+  Bucket* fb = new POSIXBucket(std::move(nb), this, driver);
+  bucket_out->reset(fb);
+  return 0;
+}
+
+int POSIXUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  return next->read_attrs(dpp, y);
+}
+
+int POSIXUser::merge_and_store_attrs(const DoutPrefixProvider* dpp,
+				      Attrs& new_attrs, optional_yield y)
+{
+  return next->merge_and_store_attrs(dpp, new_attrs, y);
+}
+
+int POSIXUser::load_user(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  return next->load_user(dpp, y);
+}
+
+int POSIXUser::store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
+{
+  return next->store_user(dpp, y, exclusive, old_info);
+}
+
+int POSIXUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  return next->remove_user(dpp, y);
+}
+
+std::unique_ptr<Object> POSIXBucket::get_object(const rgw_obj_key& k)
+{
+  std::unique_ptr<Object> o = next->get_object(k);
+
+  return std::make_unique<POSIXObject>(std::move(o), this, driver);
+}
+
+int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max,
+		       ListResults& results, optional_yield y)
+{
+  return next->list(dpp, params, max, results, y);
+}
+
+int POSIXBucket::merge_and_store_attrs(const DoutPrefixProvider* dpp,
+					Attrs& new_attrs, optional_yield y)
+{
+  return next->merge_and_store_attrs(dpp, new_attrs, y);
+}
+
+int POSIXBucket::remove_bucket(const DoutPrefixProvider* dpp,
+				bool delete_children,
+				bool forward_to_master,
+				req_info* req_info,
+				optional_yield y)
+{
+  return next->remove_bucket(dpp, delete_children, forward_to_master, req_info, y);
+}
+
+int POSIXBucket::load_bucket(const DoutPrefixProvider* dpp, optional_yield y,
+			      bool get_stats)
+{
+  return next->load_bucket(dpp, y, get_stats);
+}
+
+std::unique_ptr<MultipartUpload> POSIXBucket::get_multipart_upload(
+				  const std::string& oid,
+				  std::optional<std::string> upload_id,
+				  ACLOwner owner, ceph::real_time mtime)
+{
+  std::unique_ptr<MultipartUpload> nmu =
+    next->get_multipart_upload(oid, upload_id, owner, mtime);
+
+  return std::make_unique<POSIXMultipartUpload>(std::move(nmu), this, driver);
+}
+
+int POSIXBucket::list_multiparts(const DoutPrefixProvider *dpp,
+				  const std::string& prefix,
+				  std::string& marker,
+				  const std::string& delim,
+				  const int& max_uploads,
+				  std::vector<std::unique_ptr<MultipartUpload>>& uploads,
+				  std::map<std::string, bool> *common_prefixes,
+				  bool *is_truncated)
+{
+  std::vector<std::unique_ptr<MultipartUpload>> nup;
+  int ret;
+
+  ret = next->list_multiparts(dpp, prefix, marker, delim, max_uploads, nup,
+			      common_prefixes, is_truncated);
+  if (ret < 0)
+    return ret;
+
+  for (auto& ent : nup) {
+    uploads.emplace_back(std::make_unique<POSIXMultipartUpload>(std::move(ent), this, driver));
+  }
+
+  return 0;
+}
+
+int POSIXBucket::abort_multiparts(const DoutPrefixProvider* dpp, CephContext* cct)
+{
+  return next->abort_multiparts(dpp, cct);
+}
+
+int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
+				optional_yield y,
+				bool prevent_versioning)
+{
+  return next->delete_object(dpp, y, prevent_versioning);
+}
+
+int POSIXObject::copy_object(User* user,
+                              req_info* info,
+                              const rgw_zone_id& source_zone,
+                              rgw::sal::Object* dest_object,
+                              rgw::sal::Bucket* dest_bucket,
+                              rgw::sal::Bucket* src_bucket,
+                              const rgw_placement_rule& dest_placement,
+                              ceph::real_time* src_mtime,
+                              ceph::real_time* mtime,
+                              const ceph::real_time* mod_ptr,
+                              const ceph::real_time* unmod_ptr,
+                              bool high_precision_time,
+                              const char* if_match,
+                              const char* if_nomatch,
+                              AttrsMod attrs_mod,
+                              bool copy_if_newer,
+                              Attrs& attrs,
+                              RGWObjCategory category,
+                              uint64_t olh_epoch,
+                              boost::optional<ceph::real_time> delete_at,
+                              std::string* version_id,
+                              std::string* tag,
+                              std::string* etag,
+                              void (*progress_cb)(off_t, void *),
+                              void* progress_data,
+                              const DoutPrefixProvider* dpp,
+                              optional_yield y)
+{
+  return next->copy_object(user, info, source_zone,
+                           nextObject(dest_object),
+                           nextBucket(dest_bucket),
+                           nextBucket(src_bucket),
+                           dest_placement, src_mtime, mtime,
+                           mod_ptr, unmod_ptr, high_precision_time, if_match,
+                           if_nomatch, attrs_mod, copy_if_newer, attrs,
+                           category, olh_epoch, delete_at, version_id, tag,
+                           etag, progress_cb, progress_data, dpp, y);
+}
+
+int POSIXObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
+                            Attrs* delattrs, optional_yield y) 
+{
+  return next->set_obj_attrs(dpp, setattrs, delattrs, y);  
+}
+
+int POSIXObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
+                                rgw_obj* target_obj)
+{
+  return next->get_obj_attrs(y, dpp, target_obj);
+}
+
+int POSIXObject::modify_obj_attrs(const char* attr_name, bufferlist& attr_val,
+                               optional_yield y, const DoutPrefixProvider* dpp) 
+{
+  return next->modify_obj_attrs(attr_name, attr_val, y, dpp);  
+}
+
+int POSIXObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name,
+                               optional_yield y) 
+{
+  return next->delete_obj_attrs(dpp, attr_name, y);  
+}
+
+std::unique_ptr<Object::ReadOp> POSIXObject::get_read_op()
+{
+  std::unique_ptr<ReadOp> r = next->get_read_op();
+  return std::make_unique<POSIXReadOp>(std::move(r), this);
+}
+
+std::unique_ptr<Object::DeleteOp> POSIXObject::get_delete_op()
+{
+  std::unique_ptr<DeleteOp> d = next->get_delete_op();
+  return std::make_unique<POSIXDeleteOp>(std::move(d), this);
+}
+
+int POSIXObject::POSIXReadOp::prepare(optional_yield y, const DoutPrefixProvider* dpp)
+{
+  return next->prepare(y, dpp);
+}
+
+int POSIXObject::POSIXReadOp::read(int64_t ofs, int64_t end, bufferlist& bl,
+				     optional_yield y, const DoutPrefixProvider* dpp)
+{
+  int ret = next->read(ofs, end, bl, y, dpp);
+  if (ret < 0)
+    return ret;
+
+  /* Copy params out of next */
+  params = next->params;
+  return ret;
+}
+
+int POSIXObject::POSIXReadOp::iterate(const DoutPrefixProvider* dpp, int64_t ofs,
+					int64_t end, RGWGetDataCB* cb, optional_yield y)
+{
+  int ret = next->iterate(dpp, ofs, end, cb, y);
+  if (ret < 0)
+    return ret;
+
+  /* Copy params out of next */
+  params = next->params;
+  return ret;
+}
+
+int POSIXObject::POSIXReadOp::get_attr(const DoutPrefixProvider* dpp, const char* name, bufferlist& dest, optional_yield y)
+{
+  return next->get_attr(dpp, name, dest, y);
+}
+
+int POSIXObject::POSIXDeleteOp::delete_obj(const DoutPrefixProvider* dpp,
+					   optional_yield y)
+{
+  return next->delete_obj(dpp, y);
+}
+
+int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
+				ACLOwner& owner, rgw_placement_rule& dest_placement,
+				rgw::sal::Attrs& attrs)
+{
+  return next->init(dpp, y, owner, dest_placement, attrs);
+}
+
+int POSIXMultipartUpload::list_parts(const DoutPrefixProvider *dpp, CephContext *cct,
+				      int num_parts, int marker,
+				      int *next_marker, bool *truncated,
+				      bool assume_unsorted)
+{
+  int ret;
+
+  ret = next->list_parts(dpp, cct, num_parts, marker, next_marker, truncated,
+			 assume_unsorted);
+  if (ret < 0)
+    return ret;
+
+  parts.clear();
+
+  for (auto& ent : next->get_parts()) {
+    parts.emplace(ent.first, std::make_unique<FilterMultipartPart>(std::move(ent.second)));
+  }
+
+  return 0;
+}
+
+int POSIXMultipartUpload::abort(const DoutPrefixProvider *dpp, CephContext *cct)
+{
+  return next->abort(dpp, cct);
+}
+
+int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
+				    optional_yield y, CephContext* cct,
+				    std::map<int, std::string>& part_etags,
+				    std::list<rgw_obj_index_key>& remove_objs,
+				    uint64_t& accounted_size, bool& compressed,
+				    RGWCompressionInfo& cs_info, off_t& ofs,
+				    std::string& tag, ACLOwner& owner,
+				    uint64_t olh_epoch,
+				    rgw::sal::Object* target_obj)
+{
+  return next->complete(dpp, y, cct, part_etags, remove_objs, accounted_size,
+			compressed, cs_info, ofs, tag, owner, olh_epoch,
+			nextObject(target_obj));
+}
+
+std::unique_ptr<Writer> POSIXMultipartUpload::get_writer(
+				  const DoutPrefixProvider *dpp,
+				  optional_yield y,
+				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  const rgw_user& owner,
+				  const rgw_placement_rule *ptail_placement_rule,
+				  uint64_t part_num,
+				  const std::string& part_num_str)
+{
+  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+
+  std::unique_ptr<Writer> writer;
+  writer = next->get_writer(dpp, y, std::move(no), owner,
+			    ptail_placement_rule, part_num, part_num_str);
+
+  return std::make_unique<POSIXWriter>(std::move(writer), std::move(_head_obj), driver);
+}
+
+int POSIXWriter::prepare(optional_yield y) 
+{
+  return next->prepare(y);
+}
+
+int POSIXWriter::process(bufferlist&& data, uint64_t offset)
+{
+  return next->process(std::move(data), offset);
+}
+
+int POSIXWriter::complete(size_t accounted_size, const std::string& etag,
+                       ceph::real_time *mtime, ceph::real_time set_mtime,
+                       std::map<std::string, bufferlist>& attrs,
+                       ceph::real_time delete_at,
+                       const char *if_match, const char *if_nomatch,
+                       const std::string *user_data,
+                       rgw_zone_set *zones_trace, bool *canceled,
+                       optional_yield y)
+{
+  return next->complete(accounted_size, etag, mtime, set_mtime, attrs,
+			delete_at, if_match, if_nomatch, user_data, zones_trace,
+			canceled, y);
+}
+
+} } // namespace rgw::sal
+
+extern "C" {
+
+rgw::sal::Driver* newPOSIXDriver(rgw::sal::Driver* next)
+{
+  rgw::sal::POSIXDriver* driver = new rgw::sal::POSIXDriver(next);
+
+  return driver;
+}
+
+}

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -14,11 +14,19 @@
  */
 
 #include "rgw_sal_posix.h"
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/xattr.h>
+#include <unistd.h>
 
 #define dout_subsys ceph_subsys_rgw
 #define dout_context g_ceph_context
 
 namespace rgw { namespace sal {
+
+const int64_t READ_SIZE = 8 * 1024;
+char read_buf[READ_SIZE];
+const std::string ATTR_PREFIX = "user.X-RGW-";
 
 static inline User* nextUser(User* t)
 {
@@ -28,26 +36,61 @@ static inline User* nextUser(User* t)
   return dynamic_cast<FilterUser*>(t)->get_next();
 }
 
-static inline Bucket* nextBucket(Bucket* t)
+static inline std::string decode_name(const char* name)
 {
-  if (!t)
-    return nullptr;
-
-  return dynamic_cast<POSIXBucket*>(t)->get_next();
+  std::string decoded_name(name);
+  return decoded_name;
 }
 
-static inline Object* nextObject(Object* t)
+static inline void bucket_statx_save(struct statx& stx, RGWBucketEnt& ent, ceph::real_time& mtime)
 {
-  if (!t)
-    return nullptr;
-  
-  return dynamic_cast<POSIXObject*>(t)->get_next();
-}  
+  mtime = ceph::real_clock::from_time_t(stx.stx_mtime.tv_sec);
+  ent.creation_time = ceph::real_clock::from_time_t(stx.stx_btime.tv_sec);
+  ent.size = stx.stx_size;
+  ent.size_rounded = stx.stx_blocks * 512;
+}
+
+static inline void object_statx_save(struct statx& stx, RGWObjState& state)
+{
+  state.exists = true;
+  state.accounted_size = state.size = stx.stx_size;
+  state.mtime = ceph::real_clock::from_time_t(stx.stx_mtime.tv_sec);
+}
 
 int POSIXDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
 {
-  POSIXDriver::initialize(cct, dpp);
-  
+  FilterDriver::initialize(cct, dpp);
+
+  base_path = g_conf().get_val<std::string>("rgw_posix_base_path");
+
+  ldpp_dout(dpp, 20) << "Initializing POSIX driver: " << base_path << dendl;
+  root_fd = openat(-1, base_path.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (root_fd == -1) {
+    int err = errno;
+    if (err == ENOTDIR) {
+      ldpp_dout(dpp, 0) << " ERROR: base path (" << base_path
+	<< "): was not a directory." << dendl;
+      return -err;
+    } else if (err == ENOENT) {
+      err = mkdir(base_path.c_str(), S_IRWXU);
+      if (err < 0) {
+	err = errno;
+	ldpp_dout(dpp, 0) << " ERROR: could not create base path ("
+	  << base_path << "): " << cpp_strerror(err) << dendl;
+	return -err;
+      }
+      root_fd = open(base_path.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    }
+  }
+  ldpp_dout(dpp, 20) << "root_fd: " << root_fd << dendl;
+  if (root_fd == -1) {
+    int err = errno;
+    ldpp_dout(dpp, 0) << " ERROR: could not open base path ("
+      << base_path << "): " << cpp_strerror(err) << dendl;
+    return -err;
+  }
+
+  ldpp_dout(dpp, 20) << "SUCCESS" << dendl;
   return 0;
 }
 
@@ -102,54 +145,44 @@ int POSIXDriver::get_user_by_swift(const DoutPrefixProvider* dpp, const std::str
 
 std::unique_ptr<Object> POSIXDriver::get_object(const rgw_obj_key& k)
 {
-  std::unique_ptr<Object> o = next->get_object(k);
-
-  return std::make_unique<POSIXObject>(std::move(o), this);
+  return std::make_unique<POSIXObject>(this, k);
 }
 
 int POSIXDriver::get_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
-  std::unique_ptr<Bucket> nb;
   int ret;
-  User* nu = nextUser(u);
+  Bucket* bp;
 
-  ret = next->get_bucket(dpp, nu, b, &nb, y);
-  if (ret != 0)
+  bp = new POSIXBucket(this, b, u);
+  ret = bp->load_bucket(dpp, y);
+  if (ret < 0) {
+    delete bp;
     return ret;
+  }
 
-  Bucket* fb = new FilterBucket(std::move(nb), u);
-  bucket->reset(fb);
+  bucket->reset(bp);
   return 0;
 }
 
 int POSIXDriver::get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket)
 {
-  std::unique_ptr<Bucket> nb;
-  int ret;
-  User* nu = nextUser(u);
+  Bucket* bp;
 
-  ret = next->get_bucket(nu, i, &nb);
-  if (ret != 0)
-    return ret;
+  bp = new POSIXBucket(this, i, u);
+  /* Don't need to fetch the bucket info, use the provided one */
 
-  Bucket* fb = new FilterBucket(std::move(nb), u);
-  bucket->reset(fb);
+  bucket->reset(bp);
   return 0;
 }
 
 int POSIXDriver::get_bucket(const DoutPrefixProvider* dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
-  std::unique_ptr<Bucket> nb;
-  int ret;
-  User* nu = nextUser(u);
+  rgw_bucket b;
 
-  ret = next->get_bucket(dpp, nu, tenant, name, &nb, y);
-  if (ret != 0)
-    return ret;
+  b.tenant = tenant;
+  b.name = name;
 
-  Bucket* fb = new FilterBucket(std::move(nb), u);
-  bucket->reset(fb);
-  return 0;
+  return get_bucket(dpp, u, b, bucket, y);
 }
 
 std::unique_ptr<Writer> POSIXDriver::get_append_writer(const DoutPrefixProvider *dpp,
@@ -161,7 +194,7 @@ std::unique_ptr<Writer> POSIXDriver::get_append_writer(const DoutPrefixProvider 
 				  uint64_t position,
 				  uint64_t *cur_accounted_size)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+  std::unique_ptr<Object> no;
 
   std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, std::move(no),
 							   owner, ptail_placement_rule,
@@ -179,7 +212,7 @@ std::unique_ptr<Writer> POSIXDriver::get_atomic_writer(const DoutPrefixProvider 
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+  std::unique_ptr<Object> no;
 
   std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, std::move(no),
 							   owner, ptail_placement_rule,
@@ -202,17 +235,72 @@ int POSIXUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& ma
 			     const std::string& end_marker, uint64_t max,
 			     bool need_stats, BucketList &buckets, optional_yield y)
 {
-  BucketList bl;
+  DIR* dir;
+  struct dirent* entry;
   int ret;
 
   buckets.clear();
-  ret = next->list_buckets(dpp, marker, end_marker, max, need_stats, bl, y);
-  if (ret < 0)
-    return ret;
 
-  buckets.set_truncated(bl.is_truncated());
-  for (auto& ent : bl.get_buckets()) {
-    buckets.add(std::make_unique<POSIXBucket>(std::move(ent.second), this, driver));
+  dir = fdopendir(driver->get_root_fd());
+  if (dir == NULL) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open root to list buckets: "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  errno = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    struct statx stx;
+
+    ret = statx(driver->get_root_fd(), entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << entry->d_name << ": "
+	<< cpp_strerror(ret) << dendl;
+      buckets.clear();
+      return -ret;
+    }
+
+    if (!S_ISDIR(stx.stx_mode)) {
+      /* Not a bucket, skip it */
+      errno = 0;
+      continue;
+    }
+    if (entry->d_name[0] == '.') {
+      /* Skip dotfiles */
+      errno = 0;
+      continue;
+    }
+
+    /* TODO Use stat_to_ent */
+    //RGWBucketEnt ent;
+    //ent.bucket.name = decode_name(entry->d_name);
+    //bucket_statx_save(stx, ent, mtime);
+    RGWBucketInfo info;
+    info.bucket.name = decode_name(entry->d_name);
+    info.owner.id = std::to_string(stx.stx_uid); // TODO convert to owner name
+    info.creation_time = ceph::real_clock::from_time_t(stx.stx_btime.tv_sec);
+
+    std::unique_ptr<rgw::sal::Bucket> bucket;
+    ret = driver->get_bucket(this, info, &bucket);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket " << info.bucket << ": "
+	<< cpp_strerror(ret) << dendl;
+      buckets.clear();
+      return -ret;
+    }
+
+    buckets.add(std::move(bucket));
+
+    errno = 0;
+  }
+  ret = errno;
+  if (ret != 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not list buckets for " << get_display_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    buckets.clear();
+    return -ret;
   }
 
   return 0;
@@ -235,14 +323,20 @@ int POSIXUser::create_bucket(const DoutPrefixProvider* dpp,
 			      std::unique_ptr<Bucket>* bucket_out,
 			      optional_yield y)
 {
-  std::unique_ptr<Bucket> nb;
-  int ret;
+  POSIXBucket* fb = new POSIXBucket(driver, info, this);
 
-  ret = next->create_bucket(dpp, b, zonegroup_id, placement_rule, swift_ver_location, pquota_info, policy, attrs, info, ep_objv, exclusive, obj_lock_enabled, existed, req_info, &nb, y);
-  if (ret < 0)
-    return ret;
+  int ret = fb->create(dpp, y, existed);
+  if (ret < 0) {
+    delete fb;
+    return  ret;
+  }
 
-  Bucket* fb = new POSIXBucket(std::move(nb), this, driver);
+  ret = fb->set_attrs(attrs);
+  if (ret < 0) {
+    delete fb;
+    return  ret;
+  }
+
   bucket_out->reset(fb);
   return 0;
 }
@@ -275,21 +369,92 @@ int POSIXUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
 
 std::unique_ptr<Object> POSIXBucket::get_object(const rgw_obj_key& k)
 {
-  std::unique_ptr<Object> o = next->get_object(k);
-
-  return std::make_unique<POSIXObject>(std::move(o), this, driver);
+  return std::make_unique<POSIXObject>(driver, k, this);
 }
 
 int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max,
 		       ListResults& results, optional_yield y)
 {
-  return next->list(dpp, params, max, results, y);
+  //return next->list(dpp, params, max, results, y);
+  DIR* dir;
+  struct dirent* entry;
+  int ret;
+
+  ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  dir = fdopendir(dir_fd);
+  if (dir == NULL) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open bucket " << get_name() << " for listing: "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  errno = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    struct statx stx;
+
+    if (entry->d_name[0] == '.') {
+      /* Skip dotfiles */
+      errno = 0;
+      continue;
+    }
+
+    ret = statx(dir_fd, entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_ALL, &stx);
+    if (ret < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not stat object " << entry->d_name << ": "
+	<< cpp_strerror(ret) << dendl;
+      results.objs.clear();
+      return -ret;
+    }
+
+    if (!S_ISREG(stx.stx_mode)) {
+      /* Not an object, skip it */
+      errno = 0;
+      continue;
+    }
+
+    rgw_bucket_dir_entry *e = new rgw_bucket_dir_entry;
+    e->key.name = decode_name(entry->d_name);
+    e->ver.pool = 1;
+    e->ver.epoch = 1;
+    e->exists = true;
+    e->meta.category = RGWObjCategory::Main;
+    e->meta.size = stx.stx_size;
+    e->meta.mtime = ceph::real_clock::from_time_t(stx.stx_mtime.tv_sec);
+    e->meta.owner = std::to_string(stx.stx_uid); // TODO convert to owner name
+    e->meta.owner_display_name = std::to_string(stx.stx_uid); // TODO convert to owner name
+    e->meta.accounted_size = stx.stx_blksize * stx.stx_blocks;
+    e->meta.storage_class = RGW_STORAGE_CLASS_STANDARD;
+    e->meta.appendable = true;
+
+    results.objs.push_back(*e);
+
+    errno = 0;
+  }
+  ret = errno;
+  if (ret != 0) {
+    ldpp_dout(dpp, 0) << "ERROR: could not list bucket " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    results.objs.clear();
+    return -ret;
+  }
+
+  return 0;
 }
 
 int POSIXBucket::merge_and_store_attrs(const DoutPrefixProvider* dpp,
 					Attrs& new_attrs, optional_yield y)
 {
-  return next->merge_and_store_attrs(dpp, new_attrs, y);
+  for(auto& it : new_attrs) {
+	  attrs[it.first] = it.second;
+  }
+  /* TODO store attributes */
+  return 0;
 }
 
 int POSIXBucket::remove_bucket(const DoutPrefixProvider* dpp,
@@ -298,13 +463,219 @@ int POSIXBucket::remove_bucket(const DoutPrefixProvider* dpp,
 				req_info* req_info,
 				optional_yield y)
 {
-  return next->remove_bucket(dpp, delete_children, forward_to_master, req_info, y);
+  /* TODO dang delete_children */
+  int ret = unlinkat(driver->get_root_fd(), get_fname().c_str(), AT_REMOVEDIR);
+  if (ret < 0) {
+    ret = errno;
+    if (errno != ENOENT) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove bucket " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+  }
+
+  return 0;
+}
+
+int POSIXBucket::remove_bucket_bypass_gc(int concurrent_max,
+					 bool keep_index_consistent,
+					 optional_yield y,
+					 const DoutPrefixProvider *dpp)
+{
+  return remove_bucket(dpp, true, false, nullptr, y);
 }
 
 int POSIXBucket::load_bucket(const DoutPrefixProvider* dpp, optional_yield y,
 			      bool get_stats)
 {
-  return next->load_bucket(dpp, y, get_stats);
+  int ret;
+
+  if (get_name()[0] == '.') {
+    /* Skip dotfiles */
+    return -ERR_INVALID_OBJECT_NAME;
+  }
+  ret = stat(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  bucket_statx_save(stx, ent, mtime);
+  info.creation_time = ent.creation_time;
+
+  if (owner) {
+    info.owner = owner->get_id();
+  }
+  /* TODO Load attrs */
+
+  return 0;
+}
+
+int POSIXBucket::set_acl(const DoutPrefixProvider* dpp,
+			 RGWAccessControlPolicy& acl,
+			 optional_yield y)
+{
+  bufferlist aclbl;
+
+  acls = acl;
+  acl.encode(aclbl);
+
+  attrs[RGW_ATTR_ACL] = aclbl;
+  info.owner = acl.get_owner().get_id();
+
+  return 0;
+}
+
+int POSIXBucket::read_stats(const DoutPrefixProvider *dpp,
+			    const bucket_index_layout_generation& idx_layout,
+			    int shard_id, std::string* bucket_ver, std::string* master_ver,
+			    std::map<RGWObjCategory, RGWStorageStats>& stats,
+			    std::string* max_marker, bool* syncstopped)
+{
+  return 0;
+}
+
+int POSIXBucket::read_stats_async(const DoutPrefixProvider *dpp,
+				  const bucket_index_layout_generation& idx_layout,
+				  int shard_id, RGWGetBucketStats_CB* ctx)
+{
+  return 0;
+}
+
+int POSIXBucket::sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y)
+{
+  return 0;
+}
+
+int POSIXBucket::update_container_stats(const DoutPrefixProvider* dpp)
+{
+  /* Force re-stat */
+  stat_done = false;
+  int ret = stat(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  bucket_statx_save(stx, ent, mtime);
+  info.creation_time = ent.creation_time;
+
+  return 0;
+}
+
+int POSIXBucket::check_bucket_shards(const DoutPrefixProvider* dpp)
+{
+      return 0;
+}
+
+int POSIXBucket::chown(const DoutPrefixProvider* dpp, User& new_user, optional_yield y)
+{
+  /* TODO map user to UID/GID, and change it */
+  return 0;
+}
+
+int POSIXBucket::put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time _mtime)
+{
+  mtime = _mtime;
+
+  struct timespec ts[2];
+  ts[0].tv_nsec = UTIME_OMIT;
+  ts[1] = ceph::real_clock::to_timespec(mtime);
+  int ret = utimensat(driver->get_root_fd(), get_fname().c_str(), ts, AT_SYMLINK_NOFOLLOW);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not set mtime on bucket " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  /* TODO Write out attributes */
+  return 0;
+}
+
+int POSIXBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  DIR* dir;
+  struct dirent* entry;
+  int ret;
+
+  ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  dir = fdopendir(dir_fd);
+  if (dir == NULL) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open bucket " << get_name() << " for listing: "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  errno = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    if (entry->d_name[0] != '.') {
+      return -ENOTEMPTY;
+    }
+    if (entry->d_name[1] == '.' || entry->d_name[1] == '\0') {
+      continue;
+    }
+  }
+  return 0;
+}
+
+int POSIXBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size,
+				optional_yield y, bool check_size_only)
+{
+    return 0;
+}
+
+int POSIXBucket::try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime)
+{
+  int ret = update_container_stats(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *pmtime = mtime;
+  /* TODO Get attributes */
+  return 0;
+}
+
+int POSIXBucket::read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch,
+			    uint64_t end_epoch, uint32_t max_entries,
+			    bool* is_truncated, RGWUsageIter& usage_iter,
+			    std::map<rgw_user_bucket, rgw_usage_log_entry>& usage)
+{
+  return 0;
+}
+
+int POSIXBucket::trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch)
+{
+  return 0;
+}
+
+int POSIXBucket::remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink)
+{
+  return 0;
+}
+
+int POSIXBucket::check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
+{
+  return 0;
+}
+
+int POSIXBucket::rebuild_index(const DoutPrefixProvider *dpp)
+{
+  return 0;
+}
+
+int POSIXBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+{
+  return 0;
+}
+
+int POSIXBucket::purge_instance(const DoutPrefixProvider* dpp)
+{
+  return 0;
 }
 
 std::unique_ptr<MultipartUpload> POSIXBucket::get_multipart_upload(
@@ -312,8 +683,7 @@ std::unique_ptr<MultipartUpload> POSIXBucket::get_multipart_upload(
 				  std::optional<std::string> upload_id,
 				  ACLOwner owner, ceph::real_time mtime)
 {
-  std::unique_ptr<MultipartUpload> nmu =
-    next->get_multipart_upload(oid, upload_id, owner, mtime);
+  std::unique_ptr<MultipartUpload> nmu;
 
   return std::make_unique<POSIXMultipartUpload>(std::move(nmu), this, driver);
 }
@@ -327,31 +697,125 @@ int POSIXBucket::list_multiparts(const DoutPrefixProvider *dpp,
 				  std::map<std::string, bool> *common_prefixes,
 				  bool *is_truncated)
 {
-  std::vector<std::unique_ptr<MultipartUpload>> nup;
-  int ret;
-
-  ret = next->list_multiparts(dpp, prefix, marker, delim, max_uploads, nup,
-			      common_prefixes, is_truncated);
-  if (ret < 0)
-    return ret;
-
-  for (auto& ent : nup) {
-    uploads.emplace_back(std::make_unique<POSIXMultipartUpload>(std::move(ent), this, driver));
-  }
+  //std::vector<std::unique_ptr<MultipartUpload>> nup;
+  //int ret;
+//
+  //ret = next->list_multiparts(dpp, prefix, marker, delim, max_uploads, nup,
+			      //common_prefixes, is_truncated);
+  //if (ret < 0)
+    //return ret;
+//
+  //for (auto& ent : nup) {
+    //uploads.emplace_back(std::make_unique<POSIXMultipartUpload>(std::move(ent), this, driver));
+  //}
 
   return 0;
 }
 
 int POSIXBucket::abort_multiparts(const DoutPrefixProvider* dpp, CephContext* cct)
 {
-  return next->abort_multiparts(dpp, cct);
+  return 0;
+}
+
+int POSIXBucket::create(const DoutPrefixProvider* dpp, optional_yield y, bool* existed)
+{
+  int ret = mkdirat(driver->get_root_fd(), get_fname().c_str(), S_IRWXU);
+  if (ret < 0) {
+    ret = errno;
+    if (ret != EEXIST) {
+      ldpp_dout(dpp, 0) << "ERROR: could not create bucket " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    } else {
+      *existed = true;
+    }
+  }
+
+  return open(dpp);
+}
+
+int POSIXBucket::open(const DoutPrefixProvider* dpp)
+{
+  if (dir_fd >= 0) {
+    return 0;
+  }
+
+  int ret = openat(driver->get_root_fd(), get_fname().c_str(),
+		   O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open bucket " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  dir_fd = ret;
+
+  return 0;
+}
+
+int POSIXBucket::close(const DoutPrefixProvider* dpp)
+{
+  if (dir_fd < 0) {
+    return 0;
+  }
+
+  ::close(dir_fd);
+
+  return 0;
+}
+
+int POSIXBucket::stat(const DoutPrefixProvider* dpp)
+{
+  if (stat_done) {
+    return 0;
+  }
+
+  int ret = statx(driver->get_root_fd(), get_fname().c_str(), AT_SYMLINK_NOFOLLOW,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not stat bucket " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+  if (!S_ISDIR(stx.stx_mode)) {
+    /* Not a bucket */
+    return -EINVAL;
+  }
+
+  stat_done = true;
+  return 0;
 }
 
 int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
 				optional_yield y,
 				bool prevent_versioning)
 {
-  return next->delete_object(dpp, y, prevent_versioning);
+  POSIXBucket *b = dynamic_cast<POSIXBucket*>(get_bucket());
+  if (!b) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << get_name() << dendl;
+      return -EINVAL;
+  }
+
+  int ret = unlinkat(b->get_dir_fd(dpp), get_fname().c_str(), 0);
+  if (ret < 0) {
+    ret = errno;
+    if (errno != ENOENT) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove object " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+  }
+  return 0;
+}
+
+int POSIXObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
+				Completions* aio, bool keep_index_consistent,
+				optional_yield y)
+{
+  /* Appears to be unused? */
+  return delete_object(dpp, y, false);
 }
 
 int POSIXObject::copy_object(User* user,
@@ -382,91 +846,402 @@ int POSIXObject::copy_object(User* user,
                               const DoutPrefixProvider* dpp,
                               optional_yield y)
 {
-  return next->copy_object(user, info, source_zone,
-                           nextObject(dest_object),
-                           nextBucket(dest_bucket),
-                           nextBucket(src_bucket),
-                           dest_placement, src_mtime, mtime,
-                           mod_ptr, unmod_ptr, high_precision_time, if_match,
-                           if_nomatch, attrs_mod, copy_if_newer, attrs,
-                           category, olh_epoch, delete_at, version_id, tag,
-                           etag, progress_cb, progress_data, dpp, y);
+  POSIXBucket *db = dynamic_cast<POSIXBucket*>(dest_bucket);
+  POSIXBucket *sb = dynamic_cast<POSIXBucket*>(src_bucket);
+
+  if (!db || !sb) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket to copy " << get_name() << dendl;
+      return -EINVAL;
+  }
+
+  /* TODO Open and copy; set attrs */
+  return 0;
+}
+
+int POSIXObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjState **pstate, optional_yield y, bool follow_olh)
+{
+  stat(dpp); // This sets state data
+  *pstate = &state;
+
+  return 0;
 }
 
 int POSIXObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
                             Attrs* delattrs, optional_yield y) 
 {
-  return next->set_obj_attrs(dpp, setattrs, delattrs, y);  
+  for (auto& it : *delattrs) {
+	  attrs.erase(it.first);
+  }
+  for (auto& it : *setattrs) {
+	  attrs[it.first] = it.second;
+  }
+  /* TODO Write out attrs */
+  return 0;  
 }
 
 int POSIXObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
                                 rgw_obj* target_obj)
 {
-  return next->get_obj_attrs(y, dpp, target_obj);
+  char namebuf[64 * 1024]; // Max list size supported on linux
+  ssize_t buflen;
+  int ret;
+
+  ret = open(dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
+  buflen = flistxattr(obj_fd, namebuf, sizeof(namebuf));
+  if (buflen < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not list attributes for object " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  char *keyptr = namebuf;
+  while (buflen > 0) {
+    std::string value;
+    ssize_t vallen, keylen;
+
+    keylen = strlen(keyptr) + 1;
+    std::string key(keyptr);
+    std::string::size_type prefixloc = key.find(ATTR_PREFIX);
+
+    if (prefixloc == std::string::npos) {
+      /* Not one of our attributes */
+      buflen -= keylen;
+      keyptr += keylen;
+      continue;
+    }
+
+    /* Make a key that has just the attribute name */
+    key.erase(prefixloc, ATTR_PREFIX.length());
+
+    vallen = fgetxattr(obj_fd, keyptr, nullptr, 0);
+    if (vallen < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for object " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    } else if (vallen == 0) {
+      /* No attribute value for this name */
+      buflen -= keylen;
+      keyptr += keylen;
+      continue;
+    }
+
+    value.reserve(vallen + 1);
+
+    vallen = fgetxattr(obj_fd, keyptr, &value[0], vallen);
+    if (vallen < 0) {
+      ret = errno;
+      ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << keyptr << " for object " << get_name() << ": "
+	<< cpp_strerror(ret) << dendl;
+      return -ret;
+    }
+
+    bufferlist bl;
+    bl.append(value);
+    state.attrset.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
+
+    buflen -= keylen;
+    keyptr += keylen;
+  }
+
+  return 0;
 }
 
 int POSIXObject::modify_obj_attrs(const char* attr_name, bufferlist& attr_val,
                                optional_yield y, const DoutPrefixProvider* dpp) 
 {
-  return next->modify_obj_attrs(attr_name, attr_val, y, dpp);  
+  attrs[attr_name] = attr_val;
+  /* TODO Write out attrs */
+  return 0;  
 }
 
 int POSIXObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name,
                                optional_yield y) 
 {
-  return next->delete_obj_attrs(dpp, attr_name, y);  
+  attrs.erase(attr_name);
+  /* TODO Write out attrs */
+  return 0;  
+}
+
+bool POSIXObject::is_expired()
+{
+  auto iter = attrs.find(RGW_ATTR_DELETE_AT);
+  if (iter != attrs.end()) {
+    utime_t delete_at;
+    try {
+      auto bufit = iter->second.cbegin();
+      decode(delete_at, bufit);
+    } catch (buffer::error& err) {
+      ldout(driver->ctx(), 0) << "ERROR: " << __func__ << ": failed to decode " RGW_ATTR_DELETE_AT " attr" << dendl;
+      return false;
+    }
+
+    if (delete_at <= ceph_clock_now() && !delete_at.is_zero()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void POSIXObject::gen_rand_obj_instance_name()
+{
+  enum { OBJ_INSTANCE_LEN = 32 };
+  char buf[OBJ_INSTANCE_LEN + 1];
+
+  gen_rand_alphanumeric_no_underscore(driver->ctx(), buf, OBJ_INSTANCE_LEN);
+  state.obj.key.set_instance(buf);
+}
+
+std::unique_ptr<MPSerializer> POSIXObject::get_serializer(const DoutPrefixProvider *dpp, const std::string& lock_name)
+{
+  return std::make_unique<MPPOSIXSerializer>(dpp, driver, this, lock_name);
+}
+
+int POSIXObject::transition(Bucket* bucket,
+			    const rgw_placement_rule& placement_rule,
+			    const real_time& mtime,
+			    uint64_t olh_epoch,
+			    const DoutPrefixProvider* dpp,
+			    optional_yield y)
+{
+  return -ERR_NOT_IMPLEMENTED;
+}
+
+int POSIXObject::transition_to_cloud(Bucket* bucket,
+			   rgw::sal::PlacementTier* tier,
+			   rgw_bucket_dir_entry& o,
+			   std::set<std::string>& cloud_targets,
+			   CephContext* cct,
+			   bool update_object,
+			   const DoutPrefixProvider* dpp,
+			   optional_yield y)
+{
+  return -ERR_NOT_IMPLEMENTED;
+}
+
+bool POSIXObject::placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2)
+{
+  return (r1 == r2);
+}
+
+int POSIXObject::dump_obj_layout(const DoutPrefixProvider *dpp, optional_yield y, Formatter* f)
+{
+    return 0;
+}
+
+int POSIXObject::swift_versioning_restore(bool& restored,
+				       const DoutPrefixProvider* dpp)
+{
+  return 0;
+}
+
+int POSIXObject::swift_versioning_copy(const DoutPrefixProvider* dpp,
+				    optional_yield y)
+{
+  return 0;
+}
+
+int POSIXObject::omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker, uint64_t count,
+				  std::map<std::string, bufferlist> *m,
+				  bool* pmore, optional_yield y)
+{
+  /* TODO Figure out omap */
+  return 0;
+}
+
+int POSIXObject::omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
+				 optional_yield y)
+{
+  /* TODO Figure out omap */
+  return 0;
+}
+
+int POSIXObject::omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
+					  const std::set<std::string>& keys,
+					  Attrs* vals)
+{
+  /* TODO Figure out omap */
+  return 0;
+}
+
+int POSIXObject::omap_set_val_by_key(const DoutPrefixProvider *dpp, const std::string& key, bufferlist& val,
+					bool must_exist, optional_yield y)
+{
+  /* TODO Figure out omap */
+  return 0;
+}
+
+int POSIXObject::chown(User& new_user, const DoutPrefixProvider* dpp, optional_yield y)
+{
+  POSIXBucket *b = dynamic_cast<POSIXBucket*>(get_bucket());
+  if (!b) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << get_name() << dendl;
+      return -EINVAL;
+  }
+  /* TODO Get UID from user */
+  int uid = 0;
+  int gid = 0;
+
+  int ret = fchownat(b->get_dir_fd(dpp), get_fname().c_str(), uid, gid, AT_SYMLINK_NOFOLLOW);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not remove object " << get_name() << ": "
+      << cpp_strerror(ret) << dendl;
+    return -ret;
+    }
+
+  return 0;
+}
+
+int POSIXObject::stat(const DoutPrefixProvider* dpp)
+{
+  if (stat_done) {
+    return 0;
+  }
+
+  POSIXBucket *b = dynamic_cast<POSIXBucket*>(get_bucket());
+  if (!b) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << get_name() << dendl;
+      return -EINVAL;
+  }
+
+  int ret = statx(b->get_dir_fd(dpp), get_fname().c_str(), AT_SYMLINK_NOFOLLOW,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not stat bucket " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+  if (!S_ISREG(stx.stx_mode)) {
+    /* Not an object */
+    return -EINVAL;
+  }
+
+  stat_done = true;
+  object_statx_save(stx, state);
+  return 0;
 }
 
 std::unique_ptr<Object::ReadOp> POSIXObject::get_read_op()
 {
-  std::unique_ptr<ReadOp> r = next->get_read_op();
-  return std::make_unique<POSIXReadOp>(std::move(r), this);
+  return std::make_unique<POSIXReadOp>(this);
 }
 
 std::unique_ptr<Object::DeleteOp> POSIXObject::get_delete_op()
 {
-  std::unique_ptr<DeleteOp> d = next->get_delete_op();
-  return std::make_unique<POSIXDeleteOp>(std::move(d), this);
+  return std::make_unique<POSIXDeleteOp>(this);
+}
+
+int POSIXObject::open(const DoutPrefixProvider* dpp)
+{
+  if (obj_fd >= 0) {
+    return 0;
+  }
+
+  POSIXBucket *b = dynamic_cast<POSIXBucket*>(get_bucket());
+  if (!b) {
+      ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << get_name() << dendl;
+      return -EINVAL;
+  }
+
+  int ret = openat(b->get_dir_fd(dpp), get_fname().c_str(), O_RDWR | O_NOFOLLOW);
+  if (ret < 0) {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not open object " << get_name() << ": "
+                  << cpp_strerror(ret) << dendl;
+    return -ret;
+  }
+
+  obj_fd = ret;
+
+  return 0;
+}
+
+int POSIXObject::close(const DoutPrefixProvider* dpp)
+{
+  if (obj_fd < 0) {
+    return 0;
+  }
+
+  ::close(obj_fd);
+
+  return 0;
+}
+
+int POSIXObject::read(int64_t ofs, int64_t end, bufferlist& bl,
+		      const DoutPrefixProvider* dpp, optional_yield y)
+{
+  int64_t len = std::min(end - ofs, READ_SIZE);
+
+  return ::read(obj_fd, read_buf, len);
 }
 
 int POSIXObject::POSIXReadOp::prepare(optional_yield y, const DoutPrefixProvider* dpp)
 {
-  return next->prepare(y, dpp);
+  return source->open(dpp);
 }
 
 int POSIXObject::POSIXReadOp::read(int64_t ofs, int64_t end, bufferlist& bl,
 				     optional_yield y, const DoutPrefixProvider* dpp)
 {
-  int ret = next->read(ofs, end, bl, y, dpp);
-  if (ret < 0)
-    return ret;
-
-  /* Copy params out of next */
-  params = next->params;
-  return ret;
+  return source->read(ofs, end, bl, dpp, y);
 }
 
 int POSIXObject::POSIXReadOp::iterate(const DoutPrefixProvider* dpp, int64_t ofs,
 					int64_t end, RGWGetDataCB* cb, optional_yield y)
 {
-  int ret = next->iterate(dpp, ofs, end, cb, y);
-  if (ret < 0)
-    return ret;
+  int64_t left = end - ofs;
+  int64_t cur_ofs = ofs;
 
-  /* Copy params out of next */
-  params = next->params;
-  return ret;
+  while (left > 0) {
+    bufferlist bl;
+    int len = source->read(cur_ofs, end, bl, dpp, y);
+    if (len < 0) {
+	ldpp_dout(dpp, 0) << " ERROR: could not read " << source->get_name() <<
+	  " ofs: " << ofs << " error: " << cpp_strerror(len) << dendl;
+	return len;
+    } else if (len == 0) {
+      /* Done */
+      return 0;
+    }
+    /* Read some */
+    int ret = cb->handle_data(bl, cur_ofs, cur_ofs + len);
+    if (ret < 0) {
+	ldpp_dout(dpp, 0) << " ERROR: callback failed on " << source->get_name() << dendl;
+	return ret;
+    }
+
+    left -= len;
+    cur_ofs += len;
+  }
+
+  /* Doesn't seem to be anything needed from params */
+  return 0;
 }
 
 int POSIXObject::POSIXReadOp::get_attr(const DoutPrefixProvider* dpp, const char* name, bufferlist& dest, optional_yield y)
 {
-  return next->get_attr(dpp, name, dest, y);
+  auto& attrs = source->get_attrs();
+  auto iter = attrs.find(name);
+  if (iter == attrs.end()) {
+    return -ENODATA;
+  }
+
+  dest = iter->second;
+  return 0;
 }
 
 int POSIXObject::POSIXDeleteOp::delete_obj(const DoutPrefixProvider* dpp,
 					   optional_yield y)
 {
-  return next->delete_obj(dpp, y);
+  return source->delete_object(dpp, y, false);
 }
 
 int POSIXMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y,
@@ -514,7 +1289,7 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
 {
   return next->complete(dpp, y, cct, part_etags, remove_objs, accounted_size,
 			compressed, cs_info, ofs, tag, owner, olh_epoch,
-			nextObject(target_obj));
+			target_obj);
 }
 
 std::unique_ptr<Writer> POSIXMultipartUpload::get_writer(
@@ -526,7 +1301,7 @@ std::unique_ptr<Writer> POSIXMultipartUpload::get_writer(
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
+  std::unique_ptr<Object> no = _head_obj.get()->clone();
 
   std::unique_ptr<Writer> writer;
   writer = next->get_writer(dpp, y, std::move(no), owner,

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <sys/xattr.h>
 #include <unistd.h>
+#include "include/scope_guard.h"
 
 #define dout_subsys ceph_subsys_rgw
 #define dout_context g_ceph_context
@@ -237,17 +238,36 @@ int POSIXUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& ma
 {
   DIR* dir;
   struct dirent* entry;
+  int dfd;
   int ret;
 
   buckets.clear();
 
-  dir = fdopendir(driver->get_root_fd());
+  /* it's not sufficient to dup(root_fd), as as the new fd would share
+   * the file position of root_fd */
+  dfd = openat(-1, driver->get_base_path().c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (dfd == -1) {
+    ldpp_dout(dpp, 0) << "ERROR: could not open root to list buckets: "
+      << cpp_strerror(ret) << dendl;
+    return -errno;
+  }
+
+  dir = fdopendir(dfd);
   if (dir == NULL) {
     ret = errno;
     ldpp_dout(dpp, 0) << "ERROR: could not open root to list buckets: "
       << cpp_strerror(ret) << dendl;
+    close(dfd);
     return -ret;
   }
+
+  auto cleanup_guard = make_scope_guard(
+    [&dir]
+      {
+	closedir(dir);
+	// dfd is also closed
+      }
+    );
 
   errno = 0;
   while ((entry = readdir(dir)) != NULL) {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -16,12 +16,15 @@
 #pragma once
 
 #include "rgw_sal_filter.h"
+#include "rgw_sal_store.h"
 #include "common/dout.h" 
 
 namespace rgw { namespace sal {
 
 class POSIXDriver : public FilterDriver {
 private:
+  std::string base_path;
+  int root_fd;
 
 public:
   POSIXDriver(Driver* _next) : FilterDriver(_next) 
@@ -68,6 +71,9 @@ public:
 
   virtual void finalize(void) override;
   virtual void register_admin_apis(RGWRESTMgr* mgr) override;
+
+  /* Internal APIs */
+  int get_root_fd() { return root_fd; }
 };
 
 class POSIXUser : public FilterUser {
@@ -111,33 +117,86 @@ public:
   virtual int remove_user(const DoutPrefixProvider* dpp, optional_yield y) override;
 };
 
-class POSIXBucket : public FilterBucket {
+class POSIXBucket : public StoreBucket {
 private:
   POSIXDriver* driver;
+  int dir_fd{-1};
+  struct statx stx;
+  bool stat_done{false};
+  RGWAccessControlPolicy acls;
 
 public:
-  POSIXBucket(std::unique_ptr<Bucket> _next, User* _user,
-		    POSIXDriver* _driver) :
-    FilterBucket(std::move(_next), _user), 
-    driver(_driver) {}
+  POSIXBucket(POSIXDriver *_dr, const rgw_bucket& _b, User* _u)
+    : StoreBucket(_b, _u),
+    driver(_dr),
+    acls()
+    { }
+
+  POSIXBucket(POSIXDriver *_dr, const RGWBucketEnt& _e, User* _u)
+    : StoreBucket(_e, _u),
+    driver(_dr),
+    acls()
+    { }
+
+  POSIXBucket(POSIXDriver *_dr, const RGWBucketInfo& _i, User* _u)
+    : StoreBucket(_i, _u),
+    driver(_dr),
+    acls()
+    { }
+
   virtual ~POSIXBucket() = default;
 
+  virtual void set_owner(rgw::sal::User* _owner) override {
+    StoreBucket::set_owner(_owner);
+    info.owner = owner->get_id();
+  }
   virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) override;
   virtual int list(const DoutPrefixProvider* dpp, ListParams&, int,
 		   ListResults&, optional_yield y) override;
-  virtual Attrs& get_attrs(void) override { return next->get_attrs(); }
-  virtual int set_attrs(Attrs a) override { return next->set_attrs(a); }
   virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp,
 				    Attrs& new_attrs, optional_yield y) override;
   virtual int remove_bucket(const DoutPrefixProvider* dpp, bool delete_children,
 			    bool forward_to_master, req_info* req_info,
 			    optional_yield y) override;
+  virtual int remove_bucket_bypass_gc(int concurrent_max,
+				      bool keep_index_consistent,
+				      optional_yield y,
+				      const DoutPrefixProvider *dpp) override;
   virtual int load_bucket(const DoutPrefixProvider* dpp, optional_yield y,
 			  bool get_stats = false) override;
+  virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
+  virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl,
+		      optional_yield y) override;
+  virtual int read_stats(const DoutPrefixProvider *dpp,
+			 const bucket_index_layout_generation& idx_layout,
+			 int shard_id, std::string* bucket_ver, std::string* master_ver,
+			 std::map<RGWObjCategory, RGWStorageStats>& stats,
+			 std::string* max_marker = nullptr,
+			 bool* syncstopped = nullptr) override;
+  virtual int read_stats_async(const DoutPrefixProvider *dpp,
+			       const bucket_index_layout_generation& idx_layout,
+			       int shard_id, RGWGetBucketStats_CB* ctx) override;
+  virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
+  virtual int update_container_stats(const DoutPrefixProvider* dpp) override;
+  virtual int check_bucket_shards(const DoutPrefixProvider* dpp) override;
+  virtual int chown(const DoutPrefixProvider* dpp, User& new_user, optional_yield y) override;
+  virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive,
+		       ceph::real_time mtime) override;
+  virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
+  virtual int try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime) override;
+  virtual int read_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch,
+			 uint64_t end_epoch, uint32_t max_entries, bool* is_truncated,
+			 RGWUsageIter& usage_iter, std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
+  virtual int trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch) override;
+  virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
+  virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
+  virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
+  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+  virtual int purge_instance(const DoutPrefixProvider* dpp) override;
 
   virtual std::unique_ptr<Bucket> clone() override {
-    std::unique_ptr<Bucket> nb = next->clone();
-    return std::make_unique<POSIXBucket>(std::move(nb), get_owner(), driver);
+    return std::make_unique<POSIXBucket>(*this);
   }
 
   virtual std::unique_ptr<MultipartUpload> get_multipart_upload(
@@ -155,18 +214,31 @@ public:
   virtual int abort_multiparts(const DoutPrefixProvider* dpp,
 			       CephContext* cct) override;
 
+  /* Internal APIs */
+  int create(const DoutPrefixProvider *dpp, optional_yield y, bool* existed);
+  void set_stat(struct statx _stx) { stx = _stx; stat_done = true; }
+  int get_dir_fd(const DoutPrefixProvider *dpp) { open(dpp); return dir_fd; }
+private:
+  int open(const DoutPrefixProvider *dpp);
+  int close(const DoutPrefixProvider* dpp);
+  int stat(const DoutPrefixProvider *dpp);
+  /* TODO dang Escape the bucket name for file use */
+  const std::string& get_fname() { return get_name(); }
 };
 
-class POSIXObject : public FilterObject {
+class POSIXObject : public StoreObject {
 private:
   POSIXDriver* driver;
+  RGWAccessControlPolicy acls;
+  int obj_fd{-1};
+  struct statx stx;
+  bool stat_done{false};
 
 public:
-  struct POSIXReadOp : FilterReadOp {
+  struct POSIXReadOp : StoreReadOp {
     POSIXObject* source;
 
-    POSIXReadOp(std::unique_ptr<ReadOp> _next, POSIXObject* _source) :
-      FilterReadOp(std::move(_next)),
+    POSIXReadOp(POSIXObject* _source) :
       source(_source) {}
     virtual ~POSIXReadOp() = default;
 
@@ -179,31 +251,38 @@ public:
 			 bufferlist& dest, optional_yield y) override;
   };
 
-  struct POSIXDeleteOp : FilterDeleteOp {
+  struct POSIXDeleteOp : StoreDeleteOp {
     POSIXObject* source;
 
-    POSIXDeleteOp(std::unique_ptr<DeleteOp> _next, POSIXObject* _source) :
-      FilterDeleteOp(std::move(_next)),
+    POSIXDeleteOp(POSIXObject* _source) :
       source(_source) {}
     virtual ~POSIXDeleteOp() = default;
 
     virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y) override;
   };
 
-  POSIXObject(std::unique_ptr<Object> _next, POSIXDriver* _driver) :
-    FilterObject(std::move(_next)),
-    driver(_driver) {}
-  POSIXObject(std::unique_ptr<Object> _next, Bucket* _bucket, POSIXDriver* _driver) :
-    FilterObject(std::move(_next), _bucket),
-    driver(_driver) {}
+  POSIXObject(POSIXDriver *_dr, const rgw_obj_key& _k)
+    : StoreObject(_k),
+    driver(_dr),
+    acls() {}
+
+  POSIXObject(POSIXDriver* _driver, const rgw_obj_key& _k, Bucket* _b) :
+    StoreObject(_k, _b),
+    driver(_driver),
+    acls() {}
+
   POSIXObject(POSIXObject& _o) :
-    FilterObject(_o),
+    StoreObject(_o),
     driver(_o.driver) {}
+
   virtual ~POSIXObject() = default;
 
   virtual int delete_object(const DoutPrefixProvider* dpp,
 			    optional_yield y,
 			    bool prevent_versioning = false) override;
+  virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
+			     Completions* aio, bool keep_index_consistent,
+			     optional_yield y) override;
   virtual int copy_object(User* user,
                req_info* info, const rgw_zone_id& source_zone,
                rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
@@ -219,6 +298,9 @@ public:
                std::string* version_id, std::string* tag, std::string* etag,
                void (*progress_cb)(off_t, void *), void* progress_data,
                const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
+  virtual int set_acl(const RGWAccessControlPolicy& acl) override { acls = acl; return 0; }
+  virtual int get_obj_state(const DoutPrefixProvider* dpp, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
   virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
 			    Attrs* delattrs, optional_yield y) override;
   virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
@@ -227,10 +309,55 @@ public:
 			       optional_yield y, const DoutPrefixProvider* dpp) override;
   virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name,
 			       optional_yield y) override;
-
+  virtual bool is_expired() override;
+  virtual void gen_rand_obj_instance_name() override;
+  virtual std::unique_ptr<MPSerializer> get_serializer(const DoutPrefixProvider *dpp,
+						       const std::string& lock_name) override;
+  virtual int transition(Bucket* bucket,
+			 const rgw_placement_rule& placement_rule,
+			 const real_time& mtime,
+			 uint64_t olh_epoch,
+			 const DoutPrefixProvider* dpp,
+			 optional_yield y) override;
+  virtual int transition_to_cloud(Bucket* bucket,
+			 rgw::sal::PlacementTier* tier,
+			 rgw_bucket_dir_entry& o,
+			 std::set<std::string>& cloud_targets,
+			 CephContext* cct,
+			 bool update_object,
+			 const DoutPrefixProvider* dpp,
+			 optional_yield y) override;
+  virtual bool placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2) override;
+  virtual int dump_obj_layout(const DoutPrefixProvider *dpp, optional_yield y, Formatter* f) override;
+  virtual int swift_versioning_restore(bool& restored,
+				       const DoutPrefixProvider* dpp) override;
+  virtual int swift_versioning_copy(const DoutPrefixProvider* dpp,
+				    optional_yield y) override;
   virtual std::unique_ptr<ReadOp> get_read_op() override;
   virtual std::unique_ptr<DeleteOp> get_delete_op() override;
+  virtual int omap_get_vals(const DoutPrefixProvider *dpp, const std::string& marker,
+			    uint64_t count, std::map<std::string, bufferlist> *m,
+			    bool* pmore, optional_yield y) override;
+  virtual int omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string,
+			   bufferlist> *m, optional_yield y) override;
+  virtual int omap_get_vals_by_keys(const DoutPrefixProvider *dpp, const std::string& oid,
+				    const std::set<std::string>& keys,
+				    Attrs* vals) override;
+  virtual int omap_set_val_by_key(const DoutPrefixProvider *dpp, const std::string& key,
+				  bufferlist& val, bool must_exist, optional_yield y) override;
+  virtual int chown(User& new_user, const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual std::unique_ptr<Object> clone() override {
+    return std::unique_ptr<Object>(new POSIXObject(*this));
+  }
 
+protected:
+  int open(const DoutPrefixProvider *dpp);
+  int close(const DoutPrefixProvider* dpp);
+  int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y);
+private:
+  /* TODO dang Escape the object name for file use */
+  const std::string& get_fname() { return get_name(); }
+  int stat(const DoutPrefixProvider *dpp);
 };
 
 class POSIXMultipartUpload : public FilterMultipartUpload {
@@ -293,6 +420,15 @@ public:
 		       const std::string *user_data,
 		       rgw_zone_set *zones_trace, bool *canceled,
 		       optional_yield y) override;
+};
+
+class MPPOSIXSerializer : public StoreMPSerializer {
+
+public:
+  MPPOSIXSerializer(const DoutPrefixProvider *dpp, POSIXDriver* driver, POSIXObject* obj, const std::string& lock_name) {}
+
+  virtual int try_lock(const DoutPrefixProvider *dpp, utime_t dur, optional_yield y) override { return 0; }
+  virtual int unlock() override { return 0; }
 };
 
 } } // namespace rgw::sal

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -74,6 +74,7 @@ public:
 
   /* Internal APIs */
   int get_root_fd() { return root_fd; }
+  const std::string& get_base_path() const { return base_path; }
 };
 
 class POSIXUser : public FilterUser {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -1,0 +1,298 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "rgw_sal_filter.h"
+#include "common/dout.h" 
+
+namespace rgw { namespace sal {
+
+class POSIXDriver : public FilterDriver {
+private:
+
+public:
+  POSIXDriver(Driver* _next) : FilterDriver(_next) 
+  { }
+  virtual ~POSIXDriver() { }
+
+  virtual int initialize(CephContext *cct, const DoutPrefixProvider *dpp) override;
+  virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
+  virtual int get_user_by_access_key(const DoutPrefixProvider* dpp, const
+				     std::string& key, optional_yield y,
+				     std::unique_ptr<User>* user) override;
+  virtual int get_user_by_email(const DoutPrefixProvider* dpp, const
+				std::string& email, optional_yield y,
+				std::unique_ptr<User>* user) override;
+  virtual int get_user_by_swift(const DoutPrefixProvider* dpp, const
+				std::string& user_str, optional_yield y,
+				std::unique_ptr<User>* user) override;
+  virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
+  virtual int get_bucket(User* u, const RGWBucketInfo& i,
+			 std::unique_ptr<Bucket>* bucket) override;
+  virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const
+			 rgw_bucket& b, std::unique_ptr<Bucket>* bucket,
+			 optional_yield y) override;
+  virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const
+			 std::string& tenant, const std::string& name,
+			 std::unique_ptr<Bucket>* bucket, optional_yield y) override;
+
+  virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
+				  optional_yield y,
+				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  const rgw_user& owner,
+				  const rgw_placement_rule
+				  *ptail_placement_rule,
+				  const std::string& unique_tag,
+				  uint64_t position,
+				  uint64_t *cur_accounted_size) override;
+  virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
+				  optional_yield y,
+				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  const rgw_user& owner,
+				  const rgw_placement_rule *ptail_placement_rule,
+				  uint64_t olh_epoch,
+				  const std::string& unique_tag) override;
+
+  virtual void finalize(void) override;
+  virtual void register_admin_apis(RGWRESTMgr* mgr) override;
+};
+
+class POSIXUser : public FilterUser {
+private:
+  POSIXDriver* driver;
+
+public:
+  POSIXUser(std::unique_ptr<User> _next, POSIXDriver* _driver) : 
+    FilterUser(std::move(_next)),
+    driver(_driver) {}
+  virtual ~POSIXUser() = default;
+
+  virtual int list_buckets(const DoutPrefixProvider* dpp,
+			   const std::string& marker, const std::string& end_marker,
+			   uint64_t max, bool need_stats, BucketList& buckets,
+			   optional_yield y) override;
+  virtual int create_bucket(const DoutPrefixProvider* dpp,
+                            const rgw_bucket& b,
+                            const std::string& zonegroup_id,
+                            rgw_placement_rule& placement_rule,
+                            std::string& swift_ver_location,
+                            const RGWQuotaInfo* pquota_info,
+                            const RGWAccessControlPolicy& policy,
+                            Attrs& attrs,
+                            RGWBucketInfo& info,
+                            obj_version& ep_objv,
+                            bool exclusive,
+                            bool obj_lock_enabled,
+                            bool* existed,
+                            req_info& req_info,
+                            std::unique_ptr<Bucket>* bucket,
+                            optional_yield y) override;
+  virtual Attrs& get_attrs() override { return next->get_attrs(); }
+  virtual void set_attrs(Attrs& _attrs) override { next->set_attrs(_attrs); }
+  virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs&
+				    new_attrs, optional_yield y) override;
+  virtual int load_user(const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int store_user(const DoutPrefixProvider* dpp, optional_yield y, bool
+			 exclusive, RGWUserInfo* old_info = nullptr) override;
+  virtual int remove_user(const DoutPrefixProvider* dpp, optional_yield y) override;
+};
+
+class POSIXBucket : public FilterBucket {
+private:
+  POSIXDriver* driver;
+
+public:
+  POSIXBucket(std::unique_ptr<Bucket> _next, User* _user,
+		    POSIXDriver* _driver) :
+    FilterBucket(std::move(_next), _user), 
+    driver(_driver) {}
+  virtual ~POSIXBucket() = default;
+
+  virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) override;
+  virtual int list(const DoutPrefixProvider* dpp, ListParams&, int,
+		   ListResults&, optional_yield y) override;
+  virtual Attrs& get_attrs(void) override { return next->get_attrs(); }
+  virtual int set_attrs(Attrs a) override { return next->set_attrs(a); }
+  virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp,
+				    Attrs& new_attrs, optional_yield y) override;
+  virtual int remove_bucket(const DoutPrefixProvider* dpp, bool delete_children,
+			    bool forward_to_master, req_info* req_info,
+			    optional_yield y) override;
+  virtual int load_bucket(const DoutPrefixProvider* dpp, optional_yield y,
+			  bool get_stats = false) override;
+
+  virtual std::unique_ptr<Bucket> clone() override {
+    std::unique_ptr<Bucket> nb = next->clone();
+    return std::make_unique<POSIXBucket>(std::move(nb), get_owner(), driver);
+  }
+
+  virtual std::unique_ptr<MultipartUpload> get_multipart_upload(
+				const std::string& oid,
+				std::optional<std::string> upload_id=std::nullopt,
+				ACLOwner owner={}, ceph::real_time mtime=real_clock::now()) override;
+  virtual int list_multiparts(const DoutPrefixProvider *dpp,
+			      const std::string& prefix,
+			      std::string& marker,
+			      const std::string& delim,
+			      const int& max_uploads,
+			      std::vector<std::unique_ptr<MultipartUpload>>& uploads,
+			      std::map<std::string, bool> *common_prefixes,
+			      bool *is_truncated) override;
+  virtual int abort_multiparts(const DoutPrefixProvider* dpp,
+			       CephContext* cct) override;
+
+};
+
+class POSIXObject : public FilterObject {
+private:
+  POSIXDriver* driver;
+
+public:
+  struct POSIXReadOp : FilterReadOp {
+    POSIXObject* source;
+
+    POSIXReadOp(std::unique_ptr<ReadOp> _next, POSIXObject* _source) :
+      FilterReadOp(std::move(_next)),
+      source(_source) {}
+    virtual ~POSIXReadOp() = default;
+
+    virtual int prepare(optional_yield y, const DoutPrefixProvider* dpp) override;
+    virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y,
+		     const DoutPrefixProvider* dpp) override;
+    virtual int iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end,
+			RGWGetDataCB* cb, optional_yield y) override;
+    virtual int get_attr(const DoutPrefixProvider* dpp, const char* name,
+			 bufferlist& dest, optional_yield y) override;
+  };
+
+  struct POSIXDeleteOp : FilterDeleteOp {
+    POSIXObject* source;
+
+    POSIXDeleteOp(std::unique_ptr<DeleteOp> _next, POSIXObject* _source) :
+      FilterDeleteOp(std::move(_next)),
+      source(_source) {}
+    virtual ~POSIXDeleteOp() = default;
+
+    virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y) override;
+  };
+
+  POSIXObject(std::unique_ptr<Object> _next, POSIXDriver* _driver) :
+    FilterObject(std::move(_next)),
+    driver(_driver) {}
+  POSIXObject(std::unique_ptr<Object> _next, Bucket* _bucket, POSIXDriver* _driver) :
+    FilterObject(std::move(_next), _bucket),
+    driver(_driver) {}
+  POSIXObject(POSIXObject& _o) :
+    FilterObject(_o),
+    driver(_o.driver) {}
+  virtual ~POSIXObject() = default;
+
+  virtual int delete_object(const DoutPrefixProvider* dpp,
+			    optional_yield y,
+			    bool prevent_versioning = false) override;
+  virtual int copy_object(User* user,
+               req_info* info, const rgw_zone_id& source_zone,
+               rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
+               const rgw_placement_rule& dest_placement,
+               ceph::real_time* src_mtime, ceph::real_time* mtime,
+               const ceph::real_time* mod_ptr, const ceph::real_time* unmod_ptr,
+               bool high_precision_time,
+               const char* if_match, const char* if_nomatch,
+               AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
+               RGWObjCategory category, uint64_t olh_epoch,
+               boost::optional<ceph::real_time> delete_at,
+               std::string* version_id, std::string* tag, std::string* etag,
+               void (*progress_cb)(off_t, void *), void* progress_data,
+               const DoutPrefixProvider* dpp, optional_yield y) override;
+  virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
+			    Attrs* delattrs, optional_yield y) override;
+  virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
+			    rgw_obj* target_obj = NULL) override;
+  virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val,
+			       optional_yield y, const DoutPrefixProvider* dpp) override;
+  virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name,
+			       optional_yield y) override;
+
+  virtual std::unique_ptr<ReadOp> get_read_op() override;
+  virtual std::unique_ptr<DeleteOp> get_delete_op() override;
+
+};
+
+class POSIXMultipartUpload : public FilterMultipartUpload {
+protected:
+  POSIXDriver* driver; 
+
+public:
+  POSIXMultipartUpload(std::unique_ptr<MultipartUpload> _next,
+		       Bucket* _b,
+		       POSIXDriver* _driver) :
+    FilterMultipartUpload(std::move(_next), _b),
+    driver(_driver) {}
+  virtual ~POSIXMultipartUpload() = default;
+
+  virtual int init(const DoutPrefixProvider* dpp, optional_yield y, ACLOwner& owner, rgw_placement_rule& dest_placement, rgw::sal::Attrs& attrs) override;
+  virtual int list_parts(const DoutPrefixProvider* dpp, CephContext* cct,
+			 int num_parts, int marker,
+			 int* next_marker, bool* truncated,
+			 bool assume_unsorted = false) override;
+  virtual int abort(const DoutPrefixProvider* dpp, CephContext* cct) override;
+  virtual int complete(const DoutPrefixProvider* dpp,
+		       optional_yield y, CephContext* cct,
+		       std::map<int, std::string>& part_etags,
+		       std::list<rgw_obj_index_key>& remove_objs,
+		       uint64_t& accounted_size, bool& compressed,
+		       RGWCompressionInfo& cs_info, off_t& ofs,
+		       std::string& tag, ACLOwner& owner,
+		       uint64_t olh_epoch,
+		       rgw::sal::Object* target_obj) override;
+
+  virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
+			  optional_yield y,
+			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  const rgw_user& owner,
+			  const rgw_placement_rule *ptail_placement_rule,
+			  uint64_t part_num,
+			  const std::string& part_num_str) override;
+};
+
+class POSIXWriter : public FilterWriter {
+private:
+  POSIXDriver* driver; 
+
+public:
+  POSIXWriter(std::unique_ptr<Writer> _next,
+		    std::unique_ptr<Object> _head_obj, 
+		    POSIXDriver* _driver) :
+    FilterWriter(std::move(_next),
+		 std::move(_head_obj)),
+    driver(_driver) {}
+  virtual ~POSIXWriter() = default;
+
+  virtual int prepare(optional_yield y);
+  virtual int process(bufferlist&& data, uint64_t offset) override;
+  virtual int complete(size_t accounted_size, const std::string& etag,
+                       ceph::real_time *mtime, ceph::real_time set_mtime,
+		       std::map<std::string, bufferlist>& attrs,
+		       ceph::real_time delete_at,
+		       const char *if_match, const char *if_nomatch,
+		       const std::string *user_data,
+		       rgw_zone_set *zones_trace, bool *canceled,
+		       optional_yield y) override;
+};
+
+} } // namespace rgw::sal

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -771,12 +771,6 @@ int RadosBucket::put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::r
   return store->getRados()->put_bucket_instance_info(info, exclusive, mtime, &attrs, dpp);
 }
 
-/* Make sure to call get_bucket_info() if you need it first */
-bool RadosBucket::is_owner(User* user)
-{
-  return (info.owner.compare(user->get_id()) == 0);
-}
-
 int RadosBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 {
   return store->getRados()->check_bucket_empty(dpp, info, y);

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -577,7 +577,6 @@ class RadosBucket : public StoreBucket {
     virtual int check_bucket_shards(const DoutPrefixProvider* dpp) override;
     virtual int chown(const DoutPrefixProvider* dpp, User& new_user, optional_yield y) override;
     virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime) override;
-    virtual bool is_owner(User* user) override;
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
     virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp, Attrs& attrs, optional_yield y) override;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -180,7 +180,7 @@ static int decode_policy(const DoutPrefixProvider *dpp,
     policy->decode(iter);
   } catch (buffer::error& err) {
     ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
-    return -EIO;
+    return -ENODATA;
   }
   if (cct->_conf->subsys.should_gather<ceph_subsys_rgw, 15>()) {
     ldpp_dout(dpp, 15) << __func__ << " Read AccessControlPolicy";

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -239,6 +239,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
     }
   }
 #endif
+  ldpp_dout(dpp, 20) << "Filter name: " << cfg.filter_name << dendl;
 
   if (cfg.filter_name.compare("base") == 0) {
     rgw::sal::Driver* next = driver;
@@ -253,6 +254,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
 #ifdef WITH_RADOSGW_POSIX
   else if (cfg.filter_name.compare("posix") == 0) {
     rgw::sal::Driver* next = driver;
+    ldpp_dout(dpp, 20) << "Creating POSIX driver" << dendl;
     driver = newPOSIXDriver(next);
 
     if (driver->initialize(cct, dpp) < 0) {
@@ -387,6 +389,8 @@ DriverManager::Config DriverManager::get_config(bool admin, CephContext* cct)
   const auto& config_filter = g_conf().get_val<std::string>("rgw_filter");
   if (config_filter == "base") {
     cfg.filter_name = "base";
+  } else if (config_filter == "posix") {
+    cfg.filter_name = "posix";
   }
 
   return cfg;

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -53,6 +53,9 @@ extern rgw::sal::Driver* newMotrStore(CephContext *cct);
 #ifdef WITH_RADOSGW_DAOS
 extern rgw::sal::Driver* newDaosStore(CephContext *cct);
 #endif
+#ifdef WITH_RADOSGW_POSIX
+extern rgw::sal::Driver* newPOSIXDriver(rgw::sal::Driver* next);
+#endif
 extern rgw::sal::Driver* newBaseFilter(rgw::sal::Driver* next);
 
 }
@@ -247,6 +250,18 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
       return nullptr;
     }
   }
+#ifdef WITH_RADOSGW_POSIX
+  else if (cfg.filter_name.compare("posix") == 0) {
+    rgw::sal::Driver* next = driver;
+    driver = newPOSIXDriver(next);
+
+    if (driver->initialize(cct, dpp) < 0) {
+      delete driver;
+      delete next;
+      return nullptr;
+    }
+  }
+#endif
 
   return driver;
 }

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -339,12 +339,6 @@ namespace rgw::sal {
 
   }
 
-  /* Make sure to call get_bucket_info() if you need it first */
-  bool DBBucket::is_owner(User* user)
-  {
-    return (info.owner.compare(user->get_id()) == 0);
-  }
-
   int DBBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
   {
     /* XXX: Check if bucket contains any objects */

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -204,7 +204,6 @@ protected:
       virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
       virtual int chown(const DoutPrefixProvider *dpp, User& new_user, optional_yield y) override;
       virtual int put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) override;
-      virtual bool is_owner(User* user) override;
       virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;
       virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
       virtual int merge_and_store_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) override;

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "rgw_sal.h"
+#include "rgw_sal_store.h"
 #include "rgw_oidc_provider.h"
 #include "rgw_role.h"
 

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -107,6 +107,8 @@ class StoreBucket : public Bucket {
       owner = _owner;
     }
     virtual User* get_owner(void) override { return owner; };
+    /* Make sure to call get_bucket_info() if you need it first */
+    virtual bool is_owner(User* user) override { return (info.owner.compare(user->get_id()) == 0); }
     virtual ACLOwner get_acl_owner(void) override { return ACLOwner(info.owner); };
     virtual bool empty() const override { return info.bucket.name.empty(); }
     virtual const std::string& get_name() const override { return info.bucket.name; }
@@ -148,6 +150,7 @@ class StoreBucket : public Bucket {
     }
 
     friend class BucketList;
+
   protected:
     virtual void set_ent(RGWBucketEnt& _ent) { ent = _ent; info.bucket = ent.bucket; info.placement_rule = ent.placement_rule; }
 };


### PR DESCRIPTION
The file position associated with root_fd has advanced past the end of the corresponding directory, after the first list_buckets() execution. Also, omitting closedir() appears to leak memory.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
