### PR TITLE
quincy: common: avoid redefining clock type on Windows

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -31,9 +31,22 @@ int clock_gettime(int clk_id, struct timespec *tp);
 #endif
 
 #ifdef _WIN32
-#define CLOCK_REALTIME_COARSE CLOCK_REALTIME
-#define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
-// MINGW uses the QueryPerformanceCounter API behind the scenes.
+// Clock precision:
+// mingw < 8.0.1:
+//   * CLOCK_REALTIME: ~10-55ms (GetSystemTimeAsFileTime)
+// mingw >= 8.0.1:
+//   * CLOCK_REALTIME: <1us (GetSystemTimePreciseAsFileTime)
+//   * CLOCK_REALTIME_COARSE: ~10-55ms (GetSystemTimeAsFileTime)
+//
+// * CLOCK_MONOTONIC: <1us if TSC is usable, ~10-55ms otherwise
+//                    (QueryPerformanceCounter)
+// https://github.com/mirror/mingw-w64/commit/dcd990ed423381cf35702df9495d44f1979ebe50
+#ifndef CLOCK_REALTIME_COARSE
+  #define CLOCK_REALTIME_COARSE CLOCK_REALTIME
+#endif
+#ifndef CLOCK_MONOTONIC_COARSE
+  #define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
+#endif
 #endif
 
 struct ceph_timespec;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59097

---

backport of https://github.com/ceph/ceph/pull/50559
parent tracker: https://tracker.ceph.com/issues/59096

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh