### PR TITLE
reef: qa/distros: add ubuntu 22 as supported distro

### DIFF
--- a/qa/distros/all/ubuntu_latest.yaml
+++ b/qa/distros/all/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+ubuntu_22.04.yaml

--- a/qa/distros/supported-random-distro$/ubuntu_20.04.yaml
+++ b/qa/distros/supported-random-distro$/ubuntu_20.04.yaml
@@ -1,0 +1,1 @@
+../all/ubuntu_20.04.yaml

--- a/qa/distros/supported-random-distro$/ubuntu_latest.yaml
+++ b/qa/distros/supported-random-distro$/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_latest.yaml

--- a/qa/distros/supported/ubuntu_20.04.yaml
+++ b/qa/distros/supported/ubuntu_20.04.yaml
@@ -1,0 +1,1 @@
+../all/ubuntu_20.04.yaml

--- a/qa/distros/supported/ubuntu_latest.yaml
+++ b/qa/distros/supported/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_latest.yaml

--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -11,7 +11,7 @@ git clone https://github.com/qemu/qemu.git
 cd qemu
 
 
-if grep -iqE '(bionic|focal)' /etc/os-release; then
+if grep -iqE '(bionic|focal|jammy)' /etc/os-release; then
     # Bionic requires a matching test harness
     git checkout v2.11.0
 elif grep -iqE '(xenial|platform:el8)' /etc/os-release; then


### PR DESCRIPTION
backport for https://github.com/ceph/ceph/pull/49443


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
