### PR TITLE
[DNM] mgr/cephadm: proof of concept for command timeouts

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -6556,6 +6556,29 @@ def command_list_networks(ctx):
 ##################################
 
 
+def command_sleep_90_seconds(ctx):
+    # type: (CephadmContext) -> None
+    time.sleep(90)
+
+##################################
+
+
+def command_sleep_90_seconds_error(ctx):
+    # type: (CephadmContext) -> None
+    time.sleep(90)
+    raise Exception('Slept 90 seconds, now raising an exception')
+
+#################################
+
+
+def command_sleep_90_seconds_forever(ctx):
+    # type: (CephadmContext) -> None
+    while True:
+        time.sleep(90)
+
+#################################
+
+
 def command_ls(ctx):
     # type: (CephadmContext) -> None
     ls = list_daemons(ctx, detail=not ctx.no_detail,
@@ -9347,6 +9370,18 @@ def _get_parser():
         '--legacy-dir',
         default='/',
         help='base directory for legacy daemon data')
+
+    parser_sleep_90 = subparsers.add_parser(
+        'sleep-90-seconds', help='sleep for 90 seconds then return')
+    parser_sleep_90.set_defaults(func=command_sleep_90_seconds)
+
+    parser_sleep_90_error = subparsers.add_parser(
+        'sleep-90-seconds-error', help='sleep for 90 seconds then raise Exception')
+    parser_sleep_90_error.set_defaults(func=command_sleep_90_seconds_error)
+
+    parser_sleep_forever = subparsers.add_parser(
+        'sleep-90-seconds-forever', help='sleep for 90 seconds on loop forever')
+    parser_sleep_forever.set_defaults(func=command_sleep_90_seconds_forever)
 
     parser_list_networks = subparsers.add_parser(
         'list-networks', help='list IP networks')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -472,6 +472,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             default=False,
             desc='Enable TLS security for all the monitoring stack daemons'
         ),
+        Option(
+            'default_cephadm_command_timeout',
+            type='secs',
+            default=15 * 60,
+            desc='Default timeout applied to cephadm commands run directly on '
+            'the host (in seconds)'
+        ),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -554,6 +561,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.device_enhanced_scan = False
             self.cgroups_split = True
             self.log_refresh_metadata = False
+            self.default_cephadm_command_timeout = 0
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -694,8 +694,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         serve = CephadmServe(self)
         serve.serve()
 
-    def wait_async(self, coro: Awaitable[T]) -> T:
-        return self.event_loop.get_result(coro)
+    def wait_async(self, coro: Awaitable[T], timeout: Optional[int] = None) -> T:
+        return self.event_loop.get_result(coro, timeout)
 
     def set_container_image(self, entity: str, image: str) -> None:
         self.check_mon_command({

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1421,6 +1421,7 @@ class CephadmServe:
                            image: Optional[str] = "",
                            env_vars: Optional[List[str]] = None,
                            log_output: Optional[bool] = True,
+                           timeout: Optional[int] = None,  # timeout in seconds
                            ) -> Tuple[List[str], List[str], int]:
         """
         Run cephadm on the remote host with the given command + args
@@ -1458,6 +1459,11 @@ class CephadmServe:
 
         if not self.mgr.cgroups_split:
             final_args += ['--no-cgroups-split']
+
+        if not timeout:
+            # 15 minute global timeout if no timeout was passed
+            timeout = self.mgr.default_cephadm_command_timeout
+        final_args += ['--timeout', str(timeout)]
 
         # subcommand
         final_args.append(command)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1469,14 +1469,21 @@ class CephadmServe:
                                  use_json: bool = False, timeout: Optional[int] = None, ) -> Any:
         if not timeout:
             timeout = self.mgr.default_cephadm_command_timeout
+        if 'sleep-90-seconds' in cmd_name:
+            self.log.error(f'Starting {cmd_name} on host {hostname} at {datetime_now()} (timeout set to {timeout})')
         try:
             if use_json:
                 result = self.mgr.wait_async(self._run_cephadm_json(*args, **kwargs), timeout)
             else:
                 result = self.mgr.wait_async(self._run_cephadm(*args, **kwargs), timeout)
         except asyncio.TimeoutError:
+            if 'sleep-90-seconds' in cmd_name:
+                self.log.error(f'Passed thread join for {cmd_name} on host {hostname} at {datetime_now()}')
             self.log.error(f'Command `cephadm {cmd_name}` on host {hostname} timed out. ({timeout} seconds timeout)')
             raise OrchestratorError(f'Command `cephadm {cmd_name}` on host {hostname} timed out. ({timeout} seconds timeout)')
+
+        if 'sleep-90-seconds' in cmd_name:
+            self.log.error(f'Passed thread join for {cmd_name} on host {hostname} at {datetime_now()}')
         return result
 
     async def _run_cephadm(self,

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -50,7 +50,7 @@ def match_glob(val, pat):
 
 
 class MockEventLoopThread:
-    def get_result(self, coro):
+    def get_result(self, coro, timeout):
         if sys.version_info >= (3, 7):
             return asyncio.run(coro)
 


### PR DESCRIPTION
This PR is to show a couple ideas for starting to introduce timeouts into cepham binary commands called from the cephadm mgr module.

The first commit is straightforward and just passed `--timeout <time-in-seconds>`  to the commands. This makes it so any calls to `call` within the cephadm binary will timeout and, as long as the coroutine created during `call` can be killed, will get the command to eventually return.

The only issue with that approach is it doesn't cover all cases. Anything that hangs running something internal in the binary or just generally doesn't use `call` is unaffected. Also, as mentioned, things that cannot be killed will still cause the command to hang forever. This means this approach won't cover 2 of the common cases of these commands hanging from the past, the cephadm binary command somehow ending up in D state (the known case where this would happen within ceph-volume has been fixed to be fair) and hangs related to the root fs of the host being full. For these reasons, this PR also includes a second commit that shows an approach using threads. The commit message explains what's currently being added there

---

This commit currently:
- implements the "run_cephadm_with_timeout" function that creates
  a thread for the _run_cephadm call, allowing it to timeout if the
  thread does not return in time. (inspired by part of
  https://github.com/ceph/ceph/commit/89cad1f33b30bf9237734ee3595eb000facfc7d8)
- converts the daemon refresh and facts refresh ("cephadm ls" and
  "cephadm gather-facts") to use the "run_cephadm_with_timeout" function.
- Adds 3 testing commands. One sleeps 90 seconds and returns, the second
  sleeps 90 seconds then raises and error and the third sleeps forever
- adds the three testing commands to the regular metadata refresh
  cycle so they will run, in order to test the timeout works in all
  3 cases (returns late, throws error late, never returns)

With the three test commands in, the health status ends up at

------------------------------------------------------------------------
```
[ceph: root@vm-00 /]# ceph health detail
HEALTH_WARN failed to probe daemons or devices; OSD count 0 < osd_pool_default_size 3
[WRN] CEPHADM_REFRESH_FAILED: failed to probe daemons or devices
    Command `cephadm sleep-90-seconds` on host vm-01 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds` on host vm-00 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds` on host vm-02 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-error` on host vm-01 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-error` on host vm-00 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-error` on host vm-02 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-forever` on host vm-01 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-forever` on host vm-00 timed out. (60 seconds timeout)
    Command `cephadm sleep-90-seconds-forever` on host vm-02 timed out. (60 seconds timeout)
[WRN] TOO_FEW_OSDS: OSD count 0 < osd_pool_default_size 3
```
-------------------------------------------------------------------------

Obviously those commands and any logging related to them are meant to be
removed. They are in this commit currently to show the types of things I
was using to test this.

---

Right now, just using this for discussion about how best to handle this, and will eventually have a proper patch (perhaps something totally different from what's in here now, who knows) once we know what we want to do.

---

EDIT: have since mostly split off the test commands into their own commit. Additionally, added another commit that converts the threaded approach into an approach using asyncio timeouts. It got to the same result in `ceph health detail` as the threaded approach, but does have the ability to cancel the future, while the threaded approach just leaves the thread around. That approach does need some additional error handling though that is not currently implemented in the commit as cancelling the future causes the asyncssh internal functions to raise an Exception
```
future: <Task finished coro=<CephadmServe._run_cephadm() done, defined at /usr/share/ceph/mgr/cephadm/serve.py:1489> exception=HostConnectionError('Unable to reach remote host vm-01. ',)>
Traceback (most recent call last):
  File "/usr/share/ceph/mgr/cephadm/ssh.py", line 160, in _execute_command
    r = await conn.run(cmd, input=stdin)
  File "/lib/python3.6/site-packages/asyncssh/connection.py", line 3637, in run
    return await process.wait(check, timeout)
  File "/lib/python3.6/site-packages/asyncssh/process.py", line 1245, in wait
    await asyncio.wait_for(self.communicate(), timeout)
  File "/lib64/python3.6/asyncio/tasks.py", line 339, in wait_for
    return (yield from fut)
  File "/lib/python3.6/site-packages/asyncssh/process.py", line 1136, in communicate
    await self._chan.wait_closed()
  File "/lib/python3.6/site-packages/asyncssh/channel.py", line 717, in wait_closed
    await self._close_event.wait()
  File "/lib64/python3.6/asyncio/locks.py", line 283, in wait
    yield from fut
concurrent.futures._base.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/ceph/mgr/cephadm/serve.py", line 1568, in _run_cephadm
    host, cmd, stdin=stdin, addr=addr)
  File "/usr/share/ceph/mgr/cephadm/ssh.py", line 172, in _execute_command
    raise HostConnectionError(f'Unable to reach remote host {host}. {str(e)}', host, addr)
cephadm.ssh.HostConnectionError: Unable to reach remote host vm-01. 
2023-03-20T21:41:05.336595+0000 mgr.vm-00.kcddfs [ERR] Task exception was never retrieved
future: <Task finished coro=<CephadmServe._run_cephadm() done, defined at /usr/share/ceph/mgr/cephadm/serve.py:1489> exception=HostConnectionError('Unable to reach remote host vm-02. ',)>
Traceback (most recent call last):
  File "/usr/share/ceph/mgr/cephadm/ssh.py", line 160, in _execute_command
    r = await conn.run(cmd, input=stdin)
  File "/lib/python3.6/site-packages/asyncssh/connection.py", line 3637, in run
    return await process.wait(check, timeout)
  File "/lib/python3.6/site-packages/asyncssh/process.py", line 1245, in wait
    await asyncio.wait_for(self.communicate(), timeout)
  File "/lib64/python3.6/asyncio/tasks.py", line 339, in wait_for
    return (yield from fut)
  File "/lib/python3.6/site-packages/asyncssh/process.py", line 1136, in communicate
    await self._chan.wait_closed()
  File "/lib/python3.6/site-packages/asyncssh/channel.py", line 717, in wait_closed
    await self._close_event.wait()
  File "/lib64/python3.6/asyncio/locks.py", line 283, in wait
    yield from fut
concurrent.futures._base.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/ceph/mgr/cephadm/serve.py", line 1568, in _run_cephadm
    host, cmd, stdin=stdin, addr=addr)
  File "/usr/share/ceph/mgr/cephadm/ssh.py", line 172, in _execute_command
    raise HostConnectionError(f'Unable to reach remote host {host}. {str(e)}', host, addr)
cephadm.ssh.HostConnectionError: Unable to reach remote host vm-02. 
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
