### PR TITLE
pacific: cephfs-top: Handle `METRIC_TYPE_NONE` fields for sorting

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -734,6 +734,7 @@ class FSTop(object):
                                         f'{speed}', curses.A_DIM)
                 else:
                     # display 0th element from metric tuple
+                    metrics_dict[fs_name][client_id][self.items(item)] = m[0]
                     self.fsstats.addstr(y_coord, coord[0], f'{m[0]}', curses.A_DIM)
             else:
                 self.fsstats.addstr(y_coord, coord[0], "N/A", curses.A_DIM)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58986

---

backport of https://github.com/ceph/ceph/pull/50195
parent tracker: https://tracker.ceph.com/issues/58814

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh