### PR TITLE
crimson/osd: add embedded suppression ruleset for LSan

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(crimson-osd
   backfill_state.cc
   ec_backend.cc
   heartbeat.cc
+  lsan_suppressions.cc
   main.cc
   main_config_bootstrap_helpers.cc
   osd.cc

--- a/src/crimson/osd/lsan_suppressions.cc
+++ b/src/crimson/osd/lsan_suppressions.cc
@@ -1,0 +1,18 @@
+#ifndef _NDEBUG
+// The callbacks we define here will be called from the sanitizer runtime, but
+// aren't referenced from the Chrome executable. We must ensure that those
+// callbacks are not sanitizer-instrumented, and that they aren't stripped by
+// the linker.
+#define SANITIZER_HOOK_ATTRIBUTE                                           \
+  extern "C"                                                               \
+  __attribute__((no_sanitize("address", "thread", "undefined")))           \
+  __attribute__((visibility("default")))                                   \
+  __attribute__((used))
+
+static char kLSanDefaultSuppressions[] =
+  "leak:InitModule\n";
+
+SANITIZER_HOOK_ATTRIBUTE const char *__lsan_default_suppressions() {
+  return kLSanDefaultSuppressions;
+}
+#endif // ! _NDEBUG


### PR DESCRIPTION
This commit, basing the idea from the Chromium browser, embdeds the suppression rules directly into the crimson executable. The benefit is simplicity and no need to modify the teuthology code to ship a file across all involved nodes like already happens for `valgrind.supp`.

From `teuthology/task/install/util.py`:

```
def _ship_utilities(ctx):
    """
    Write a copy of valgrind.supp to each of the remote sites.  Set executables
    used by Ceph in /usr/local/bin.  When finished (upon exit of the teuthology
    run), remove these files.

    :param ctx: Context
    """
    testdir = teuthology.get_testdir(ctx)
    filenames = []

    log.info('Shipping valgrind.supp...')
    assert 'suite_path' in ctx.config
    try:
        with open(
            os.path.join(ctx.config['suite_path'], 'valgrind.supp'),
            'rb'
                ) as f:
            fn = os.path.join(testdir, 'valgrind.supp')
            filenames.append(fn)
            for rem in ctx.cluster.remotes.keys():
                teuthology.sudo_write_file(
                    remote=rem,
                    path=fn,
                    data=f,
                    )
                f.seek(0)
    except IOError as e:
        log.info('Cannot ship supression file for valgrind: %s...', e.strerror)
```

With these suppressions `--mkfs` with crimson, BlueStore and tcmalloc starts returning the proper exit code:

```
[rzarzynski@o06 build]$ /home/rzarzynski/ceph1/build/bin/crimson-osd -i 0 -c /home/rzarzynski/ceph1/build/ceph.conf --mkfs --key AQCZsRBkM5CPIBAACmCbEiP3DPh+x9iiaRDZmA== --osd-uuid c3d4aea0-02de-459b-ad00-fe943906a9a8 --cpuset 0-0
...
created object store /home/rzarzynski/ceph1/build/dev/osd0 for osd.0 fsid 8c9aa852-1ba2-4800-9695-e0be4bf877dc
-----------------------------------------------------
Suppressions used:
  count      bytes template
      1          8 InitModule
-----------------------------------------------------
[rzarzynski@o06 build]$ echo $?
0
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
