### PR TITLE
[WIP] os/bluestore: Implement kv sync interval/item accumulation

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4610,6 +4610,73 @@ options:
   flags:
   - runtime
   with_legacy: true
+- name: bluestore_kv_sync_interval
+  type: size
+  level: dev
+  long_desc: Bluestore syncronizes key/value data and deferred writes to the RocksDB
+    write-ahead-log in a dedicated background thread.  This paramater specifies in
+    microseconds how long the kv sync thread should wait to accumulate IO before
+    flushing data the the write-ahead-log.  The higher this value is set, the longer
+    the kv sync thread will wait.  This can increase minimum latency, but may also
+    reduce the number of syncs necessary to flush data to disk.  The effect on
+    average and tail latency are likely to be device dependent. A value of 0 means
+    not to wait and let the kv_sync thread run as fast as possible.
+  default: 0
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluestore_kv_sync_interval_hdd
+  type: size
+  level: dev
+  default: 8000
+  see_also:
+  - bluestore_kv_sync_interval
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluestore_kv_sync_interval_ssd
+  type: size
+  level: dev
+  default: 0
+  see_also:
+  - bluestore_kv_sync_interval
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluestore_kv_sync_items
+  type: size
+  level: dev
+  long_desc: Bluestore syncronizes key/value data and deferred writes to the RocksDB
+    write-ahead-log in a dedicated background thread.  This paramater specifies the 
+    the number of queued items the kv sync thread should try to accumulate before
+    flushing data the the write-ahead-log.  The higher this value is set, the more
+    items the kv sync thread will try to collect.  This can increase minimum latency,
+    but may also reduce the number of syncs necessary to flush data to disk.  The
+    effect on average and tail latency are likely to be device dependent. A value of
+    0 means not to try to accumulate queued items and let the kv_sync thread run as
+    fast as possible.
+  default: 0
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluestore_kv_sync_items_hdd
+  type: size
+  level: dev
+  default: 32 
+  see_also:
+  - bluestore_kv_sync_items
+  flags:
+  - runtime
+  with_legacy: true
+- name: bluestore_kv_sync_items_ssd
+  type: size
+  level: dev
+  default: 0
+  see_also:
+  - bluestore_kv_sync_items
+  flags:
+  - runtime
+  with_legacy: true
 - name: bluestore_max_blob_size
   type: size
   level: dev

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2335,6 +2335,12 @@ private:
 
   std::atomic<uint64_t> max_blob_size = {0};  ///< maximum blob size
 
+  ////< Maximum time in microseconds to wait between kv syncs
+  std::atomic<uint64_t> kv_sync_interval = {0};
+
+  ////< Maximum number of kv items to queue between kv syncs
+  std::atomic<uint64_t> kv_sync_items = {0};
+
   uint64_t kv_ios = 0;
   uint64_t kv_throttle_costs = 0;
 
@@ -2620,6 +2626,8 @@ private:
   void _set_alloc_sizes();
   void _set_blob_size();
   void _set_finisher_num();
+  void _set_kv_sync_interval();
+  void _set_kv_sync_items();
   void _set_per_pool_omap();
   void _update_osd_memory_options();
 


### PR DESCRIPTION
Goal: See if we can easily improve Ceph performance on slow drives.

This PR artificially inserts configurable (separately for flash and HDD) latency when syncing in _kv_sync_thread to accumulate more WAL items prior to fdatasync.  Appears to function as desired, though the only testing I've done so far has been on NVMe drives with power-loss-protection and fast fdatasync behavior at high io depth which is a little silly.  There's no obvious reason to use this on these kinds of systems (disabled by default for flash), but here's some tests anyway just for fun.  The real experiment should be on HDD-only or flash drives with slow fdatasync behavior to see if it helps.  If we do something like this for real, we might want to explore alternate approaches that accomplish the same effect.

Single OSD, RBD 4K random write, io_depth=4*128 IOPS
Release | max kv interval time (us) | max kv queue times | Trial 1 IOPS | Trial 2 IOPS
-- | -- | -- | -- | --
Stock Main | NA | NA | 77345 | NA
wip-bs-kv-sync-interval | 0 | 0 | 77356 | 81842
wip-bs-kv-sync-interval | 250 | 16 | 78583 | 78729
wip-bs-kv-sync-interval | 500 | 32 | 78397 | 81894
wip-bs-kv-sync-interval | 750 | 48 | 79005 | 79726
wip-bs-kv-sync-interval | 1000 | 64 | 80301 | 77250
wip-bs-kv-sync-interval | 1250 | 80 | 76666 | 79088
wip-bs-kv-sync-interval | 1500 | 96 | 75466 | 78535
wip-bs-kv-sync-interval | 1750 | 112 | 76196 | 73918
wip-bs-kv-sync-interval | 2000 | 128 | **69043** | **67614**

Single OSD, RBD 4K random write, io_depth=4*128 Average Latency
Release | max kv interval time (us) | max kv queue times | Trial 1 ms | Trial 2 ms
-- | -- | -- | -- | --
Stock Main | NA | NA | 7.265 | NA
wip-bs-kv-sync-interval | 0 | 0 | 7.650 | 6.863
wip-bs-kv-sync-interval | 250 | 16 | 8.812 | 7.394
wip-bs-kv-sync-interval | 500 | 32 | 7.275 | 7.620
wip-bs-kv-sync-interval | 750 | 48 | 7.508 | 7.126
wip-bs-kv-sync-interval | 1000 | 64 | 7.234 | 7.323
wip-bs-kv-sync-interval | 1250 | 80 | 8.001 | 7.642
wip-bs-kv-sync-interval | 1500 | 96 | 8.476 | 7.361
wip-bs-kv-sync-interval | 1750 | 112 | 7.268 | 8.585
wip-bs-kv-sync-interval | 2000 | 128 | **9.182** | **8.861**

Single OSD, RBD 4K random write, io_depth=4*128 99.99% Latency
Release | max kv interval time (us) | max kv queue times | Trial 1 ms | Trial 2 ms
-- | -- | -- | -- | --
Stock Main | NA | NA | 302.5 | NA
wip-bs-kv-sync-interval | 0 | 0 | 319.7 | 302.3
wip-bs-kv-sync-interval | 250 | 16 | 307.2 | 306.8
wip-bs-kv-sync-interval | 500 | 32 | 319.8 | 305.7
wip-bs-kv-sync-interval | 750 | 48 | 308.6 | 311.5
wip-bs-kv-sync-interval | 1000 | 64 | 313.2 | 301.8
wip-bs-kv-sync-interval | 1250 | 80 | 298.5 | 309.7
wip-bs-kv-sync-interval | 1500 | 96 | 294.3 | 306.7
wip-bs-kv-sync-interval | 1750 | 112 | 297.6 | 288.8
wip-bs-kv-sync-interval | 2000 | 128 | **269.6** | **264.1**

Only point of note is that once we hit the point where we are throttling, we see lower IOPS, higher average latency, but lower tail latency.  The big question is what this does on HDDs both with deferred writes and non-deferred writes.  The goal would be to trade higher min (and maybe in some cases avg) latency for better seek behavior on disk, higher throughput, and better tail latency.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
