### PR TITLE
quincy: rgw: rgw_parse_url_bucket() rejects empty bucket names after 'tenant:'

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -141,8 +141,8 @@ std::string rgw_make_bucket_entry_name(const std::string& tenant_name,
  * Tenants are separated from buckets in URLs by a colon in S3.
  * This function is not to be used on Swift URLs, not even for COPY arguments.
  */
-void rgw_parse_url_bucket(const string &bucket, const string& auth_tenant,
-                          string &tenant_name, string &bucket_name) {
+int rgw_parse_url_bucket(const string &bucket, const string& auth_tenant,
+                         string &tenant_name, string &bucket_name) {
 
   int pos = bucket.find(':');
   if (pos >= 0) {
@@ -153,10 +153,14 @@ void rgw_parse_url_bucket(const string &bucket, const string& auth_tenant,
      */
     tenant_name = bucket.substr(0, pos);
     bucket_name = bucket.substr(pos + 1);
+    if (bucket_name.empty()) {
+      return -ERR_INVALID_BUCKET_NAME;
+    }
   } else {
     tenant_name = auth_tenant;
     bucket_name = bucket;
   }
+  return 0;
 }
 
 int rgw_bucket_parse_bucket_instance(const string& bucket_instance, string *bucket_name, string *bucket_id, int *shard_id)

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -47,9 +47,10 @@ extern int rgw_bucket_parse_bucket_key(CephContext *cct, const std::string& key,
 extern std::string rgw_make_bucket_entry_name(const std::string& tenant_name,
                                               const std::string& bucket_name);
 
-extern void rgw_parse_url_bucket(const std::string& bucket,
-                                 const std::string& auth_tenant,
-                                 std::string &tenant_name, std::string &bucket_name);
+[[nodiscard]] int rgw_parse_url_bucket(const std::string& bucket,
+                                       const std::string& auth_tenant,
+                                       std::string &tenant_name,
+                                       std::string &bucket_name);
 
 extern int rgw_chown_bucket_and_objects(rgw::sal::Store* store,
 					rgw::sal::Bucket* bucket,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4871,9 +4871,11 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
 {
   struct req_init_state *t = &s->init_state;
 
-  rgw_parse_url_bucket(t->url_bucket, s->user->get_tenant(),
-		      s->bucket_tenant, s->bucket_name);
-
+  int ret = rgw_parse_url_bucket(t->url_bucket, s->user->get_tenant(),
+                                 s->bucket_tenant, s->bucket_name);
+  if (ret) {
+    return ret;
+  }
   if (s->auth.identity->get_identity_type() == TYPE_ROLE) {
     s->bucket_tenant = s->auth.identity->get_role_tenant();
   }
@@ -4881,7 +4883,6 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
   ldpp_dout(s, 10) << "s->object=" << s->object
            << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
 
-  int ret;
   ret = rgw_validate_tenant_name(s->bucket_tenant);
   if (ret)
     return ret;
@@ -4898,8 +4899,11 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
     } else {
       auth_tenant = s->user->get_tenant();
     }
-    rgw_parse_url_bucket(t->src_bucket, auth_tenant,
-			s->src_tenant_name, s->src_bucket_name);
+    ret = rgw_parse_url_bucket(t->src_bucket, auth_tenant,
+                               s->src_tenant_name, s->src_bucket_name);
+    if (ret) {
+      return ret;
+    }
     ret = rgw_validate_tenant_name(s->src_tenant_name);
     if (ret)
       return ret;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58276

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
