### PR TITLE
[DNM] qa: disable op order detection to avoid osd crashes in fs testing

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -52,7 +52,7 @@
 	osd recovery max chunk = 1048576
 
 	osd debug shutdown = true
-        osd debug op order = true
+        osd debug op order = false
         osd debug verify stray on activate = true
 
 	osd open classes on start = true

--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -51,7 +51,7 @@ osd memory target autotune = true
 
 # debugging
 osd debug shutdown = true
-osd debug op order = true
+osd debug op order = false
 osd debug verify stray on activate = true
 osd debug pg log writeout = true
 osd debug verify cached snaps = true


### PR DESCRIPTION
for fs testing