### PR TITLE
rgw/posix: add file read/write ops for rgw::Aio

### DIFF
--- a/src/common/buffer_sequence.h
+++ b/src/common/buffer_sequence.h
@@ -1,0 +1,137 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <boost/asio/buffer.hpp>
+#include "include/buffer.h"
+
+namespace ceph::buffer {
+
+// adapts ceph::buffer::list to satisfy the asio ConstBufferSequence concept
+class const_sequence {
+ public:
+  explicit const_sequence(const list& bl)
+    : begin_(bl.buffers().begin()),
+      end_(bl.buffers().end())
+  {}
+
+  class iterator {
+   public:
+    using value_type = boost::asio::const_buffer;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    iterator(const iterator&) = default;
+    iterator& operator=(const iterator&) = default;
+    iterator(iterator&&) = default;
+    iterator& operator=(iterator&&) = default;
+
+    bool operator==(const iterator& rhs) const { return i == rhs.i; }
+
+    iterator& operator++() {
+      ++i;
+      return *this;
+    }
+    iterator operator++(int) {
+      const iterator tmp(*this);
+      ++*this;
+      return tmp;
+    }
+
+    value_type& operator*() const {
+      buffer = {i->c_str(), i->length()};
+      return buffer;
+    }
+    value_type* operator->() const {
+      buffer = {i->c_str(), i->length()};
+      return &buffer;
+    }
+
+   private:
+    using base_iterator = list::buffers_t::const_iterator;
+    base_iterator i;
+    mutable value_type buffer;
+
+    friend class const_sequence;
+    explicit iterator(base_iterator i) : i(i) {}
+  };
+  using const_iterator = iterator;
+
+  const_iterator begin() const { return begin_; }
+  const_iterator end() const { return end_; }
+ private:
+  const_iterator begin_;
+  const_iterator end_;
+};
+static_assert(boost::asio::is_const_buffer_sequence<const_sequence>::value);
+
+// adapts ceph::buffer::list to satisfy the asio MutableBufferSequence concept
+class mutable_sequence {
+ public:
+  explicit mutable_sequence(list& bl)
+    : begin_(bl.mut_buffers().begin()),
+      end_(bl.mut_buffers().end())
+  {}
+
+  class iterator {
+   public:
+    using value_type = boost::asio::mutable_buffer;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    iterator(const iterator&) = default;
+    iterator& operator=(const iterator&) = default;
+    iterator(iterator&&) = default;
+    iterator& operator=(iterator&&) = default;
+
+    bool operator==(const iterator& rhs) const { return i == rhs.i; }
+
+    iterator& operator++() {
+      ++i;
+      return *this;
+    }
+    iterator operator++(int) {
+      const iterator tmp(*this);
+      ++*this;
+      return tmp;
+    }
+
+    value_type& operator*() {
+      buffer = {i->c_str(), i->length()};
+      return buffer;
+    }
+    value_type* operator->() {
+      buffer = {i->c_str(), i->length()};
+      return &buffer;
+    }
+
+   private:
+    using base_iterator = list::buffers_t::iterator;
+    base_iterator i;
+    mutable value_type buffer;
+
+    friend class mutable_sequence;
+    explicit iterator(base_iterator i) : i(i) {}
+  };
+  using const_iterator = iterator;
+
+  iterator begin() { return begin_; }
+  const_iterator begin() const { return begin_; }
+  iterator end() { return end_; }
+  const_iterator end() const { return end_; }
+ private:
+  const_iterator begin_;
+  const_iterator end_;
+};
+static_assert(boost::asio::is_mutable_buffer_sequence<mutable_sequence>::value);
+
+} // namespace ceph::buffer

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -398,6 +398,10 @@ if(WITH_RADOSGW_DAOS)
   link_directories( ${PC_DAOS_LIBRARY_DIRS} )
 endif()
 
+find_package(uring REQUIRED)
+target_link_libraries(rgw_common PUBLIC uring::uring)
+target_compile_definitions(rgw_common PUBLIC "BOOST_ASIO_HAS_IO_URING")
+
 set(rgw_a_srcs
   rgw_appmain.cc
   rgw_asio_client.cc

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -141,6 +141,7 @@ set(librgw_common_srcs
   rgw_bucket_encryption.cc
   rgw_tracer.cc
   rgw_lua_background.cc
+  driver/posix/aio.cc
   rgw_data_access.cc
   rgw_realm_watcher.cc
   rgw_bucket_logging.cc

--- a/src/rgw/driver/posix/aio.cc
+++ b/src/rgw/driver/posix/aio.cc
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "aio.h"
+#include "common/buffer_sequence.h"
+
+namespace rgw {
+
+struct FileReadHandler {
+  Aio* throttle = nullptr;
+  AioResult& r;
+  buffer::ptr buffer;
+  void operator()(boost::system::error_code ec, size_t bytes) {
+    r.result = -ec.value();
+    buffer.set_length(bytes);
+    r.data.append(std::move(buffer));
+    throttle->put(r);
+  }
+};
+
+Aio::OpFunc file_read_op(boost::asio::random_access_file& file,
+                         uint64_t offset, uint64_t len)
+{
+  return [&file, offset, len] (Aio* aio, AioResult& r) mutable {
+    buffer::ptr p = buffer::create(len);
+    auto buffer = boost::asio::mutable_buffer{p.c_str(), p.length()};
+    file.async_read_some_at(offset, buffer,
+                            FileReadHandler{aio, r, std::move(p)});
+  };
+}
+
+
+struct FileWriteHandler {
+  Aio* throttle = nullptr;
+  AioResult& r;
+  buffer::list bl;
+  void operator()(boost::system::error_code ec, size_t bytes) const {
+    r.result = -ec.value();
+    throttle->put(r);
+  }
+};
+
+Aio::OpFunc file_write_op(boost::asio::random_access_file& file,
+                          uint64_t offset, bufferlist bl)
+{
+  return [&file, offset, bl=std::move(bl)] (Aio* aio, AioResult& r) mutable {
+    auto buffers = ceph::buffer::const_sequence{bl};
+    file.async_write_some_at(offset, buffers,
+                             FileWriteHandler{aio, r, std::move(bl)});
+  };
+}
+
+} // namespace rgw

--- a/src/rgw/driver/posix/aio.h
+++ b/src/rgw/driver/posix/aio.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/random_access_file.hpp>
+#include "rgw_aio.h"
+
+namespace rgw {
+
+Aio::OpFunc file_read_op(boost::asio::random_access_file& file,
+                         uint64_t offset, uint64_t len);
+
+Aio::OpFunc file_write_op(boost::asio::random_access_file& file,
+                          uint64_t offset, bufferlist bl);
+
+} // namespace rgw

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8729,7 +8729,7 @@ void RGWBulkUploadOp::execute(optional_yield y)
 
   auto status = rgw::tar::StatusIndicator::create();
   do {
-    op_ret = stream->get_exactly(rgw::tar::BLOCK_SIZE, buffer);
+    op_ret = stream->get_exactly(rgw::tar::TAR_BLOCK_SIZE, buffer);
     if (op_ret < 0) {
       ldpp_dout(this, 2) << "cannot read header" << dendl;
       return;
@@ -8757,7 +8757,7 @@ void RGWBulkUploadOp::execute(optional_yield y)
 	  else
 	    filename = file_prefix + std::string(header->get_filename());
 	  auto body = AlignedStreamGetter(0, header->get_filesize(),
-                                          rgw::tar::BLOCK_SIZE, *stream);
+                                          rgw::tar::TAR_BLOCK_SIZE, *stream);
           op_ret = handle_file(filename,
                                header->get_filesize(),
                                body, y);

--- a/src/rgw/rgw_tar.h
+++ b/src/rgw/rgw_tar.h
@@ -16,7 +16,7 @@
 namespace rgw {
 namespace tar {
 
-static constexpr size_t BLOCK_SIZE = 512;
+static constexpr size_t TAR_BLOCK_SIZE = 512;
 
 
 static inline std::pair<class StatusIndicator,
@@ -82,8 +82,8 @@ protected:
     char __padding[355];
   } *header;
 
-  static_assert(sizeof(*header) == BLOCK_SIZE,
-                "The TAR header must be exactly BLOCK_SIZE length");
+  static_assert(sizeof(*header) == TAR_BLOCK_SIZE,
+                "The TAR header must be exactly TAR_BLOCK_SIZE length");
 
   /* The label is far more important from what the code really does. */
   static size_t pos2len(const size_t pos) {
@@ -91,7 +91,7 @@ protected:
   }
 
 public:
-  explicit HeaderView(const char (&header)[BLOCK_SIZE])
+  explicit HeaderView(const char (&header)[TAR_BLOCK_SIZE])
     : header(reinterpret_cast<const header_t*>(header)) {
   }
 
@@ -138,11 +138,11 @@ public:
 static inline std::pair<StatusIndicator,
                         boost::optional<HeaderView>>
 interpret_block(const StatusIndicator& status, ceph::bufferlist& bl) {
-  static constexpr std::array<char, BLOCK_SIZE> zero_block = {0, };
-  const char (&block)[BLOCK_SIZE] = \
-    reinterpret_cast<const char (&)[BLOCK_SIZE]>(*bl.c_str());
+  static constexpr std::array<char, TAR_BLOCK_SIZE> zero_block = {0, };
+  const char (&block)[TAR_BLOCK_SIZE] = \
+    reinterpret_cast<const char (&)[TAR_BLOCK_SIZE]>(*bl.c_str());
 
-  if (std::memcmp(zero_block.data(), block, BLOCK_SIZE) == 0) {
+  if (std::memcmp(zero_block.data(), block, TAR_BLOCK_SIZE) == 0) {
     return std::make_pair(StatusIndicator(status, true), boost::none);
   } else {
     return std::make_pair(StatusIndicator(status, false), HeaderView(block));


### PR DESCRIPTION
enables asio's uring interfaces, adds bufferlist adapters for asio's `ConstBufferSequence` and `MutableBufferSequence` concepts, then implements simple async ops for use with `rgw::Aio`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
