### PR TITLE
doc/cephfs: add missing "ceph fs" commands to man page

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -23,7 +23,7 @@ Synopsis
 
 | **ceph** **df** *{detail}*
 
-| **ceph** **fs** [ *ls* \| *new* \| *reset* \| *rm* \| *authorize* ] ...
+| **ceph** **fs** [ *add_data_pool* \| *authorize* \| *dump* \| *feature ls* \| *flag set* \| *get* \| *ls* \| *lsflags* \| *new* \| *rename* \| *reset* \| *required_client_features add* \| *required_client_features rm* \| *rm* \| *rm_data_pool* \| *set*] ...
 
 | **ceph** **fsid**
 
@@ -361,11 +361,62 @@ fs
 
 Manage cephfs file systems. It uses some additional subcommands.
 
+Subcommand ``add_data_pool`` adds an new data pool to the FS. Ths pool can
+be used for file layouts as an alternate location to store the file data.
+
+Usage::
+
+    ceph fs add_data_pool <fs-name> <pool name/id>
+
+Subcommand ``authorize`` creates a new client that will be authorized for the
+given path in ``<fs_name>``. Pass ``/`` to authorize for the entire FS.
+``<perms>`` below can be ``r``, ``rw`` or ``rwp``.
+
+Usage::
+
+    ceph fs authorize <fs_name> client.<client_id> <path> <perms> [<path> <perms>...]
+
+Subcommand ``dump`` displays the FSMap at the given epoch (default: current).
+This includes all file system settings, MDS daemons and the ranks they hold
+and list of standby MDS daemons.
+
+Usage::
+
+    ceph fs dump [epoch]
+
+Subcommand ``feature ls`` lists all CephFS features supported by current
+version of Ceph.
+
+Usage::
+
+    ceph fs feature ls
+
+Subcommand ``flag set`` sets a global CephFS flag. Right now the only flag
+is ``enable_multiple`` which allows multiple CephFSs on a Ceph cluster.
+
+Usage::
+
+    ceph fs flag set <flag-name> <flag-val> --yes-i-really-mean-it
+
+Subcommand ``get`` displays the information about FS, including settings and
+ranks. Information printed here in subset of same information from the
+``fs dump`` command.
+
+Usage::
+
+    ceph fs get <fs-name>
+
 Subcommand ``ls`` to list file systems
 
 Usage::
 
 	ceph fs ls
+
+Subcommand ``lsflags`` displays all the flags set on the given FS.
+
+Usage::
+
+    ceph fs lsflags <fs-name>
 
 Subcommand ``new`` to make a new file system using named pools <metadata> and <data>
 
@@ -373,7 +424,24 @@ Usage::
 
 	ceph fs new <fs_name> <metadata> <data>
 
-Subcommand ``reset`` is used for disaster recovery only: reset to a single-MDS map
+Subcommand ``rename`` assigns a new name to CephFS and also updates
+application tags on the pools of this CephFS.
+
+Usage::
+
+    ceph fs rename <fs-name> <new-fs-name> {--yes-i-really-mean-it}
+
+Subcommand ``required_client_features`` disables a client that doesn't
+possess a certain feature from connecting. This subcommand has two
+subcommands, one to add a requirement and other to remove the requirement.
+
+Usage::
+
+    ceph fs required_client_features <fs name> add <feature-name>
+    ceph fs required_client_features <fs name> rm <feature-name>
+
+Subcommand ``reset`` is used for disaster recovery only: reset to a single-MDS
+map
 
 Usage::
 
@@ -385,13 +453,19 @@ Usage::
 
 	ceph fs rm <fs_name> {--yes-i-really-mean-it}
 
-Subcommand ``authorize`` creates a new client that will be authorized for the
-given path in ``<fs_name>``. Pass ``/`` to authorize for the entire FS.
-``<perms>`` below can be ``r``, ``rw`` or ``rwp``.
+Subcommand ``rm_data_pool``  removes the specified pool from FS's list of
+data pools. File data on this pool will become unavailable. Default data pool
+cannot be removed.
 
 Usage::
 
-    ceph fs authorize <fs_name> client.<client_id> <path> <perms> [<path> <perms>...]
+    ceph fs rm_data_pool <fs-name> <pool name/id>
+
+Subcommand ``set`` sets or updates a FS setting value for given FS name.
+
+Usage::
+
+    ceph fs set <fs-name> <fs-setting> <value>
 
 fsid
 ----


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>