### PR TITLE
 qa/cephfs: upgrade gen_mds_cap_str() in caps_helper 

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -19,19 +19,7 @@ def gen_mon_cap_str(caps):
 
     caps = ((perm1, fsname1), (perm2, fsname2))
     """
-    def _unpack_tuple(c):
-        if len(c) == 1:
-            perm, fsname = c[0], None
-        elif len(c) == 2:
-            perm, fsname = c
-        elif len(c) < 1:
-            raise RuntimeError('received no items caps tuple')
-        else: # len(c) > 2
-            raise RuntimeError('received too many items in caps tuple')
-        return perm, fsname
-
-    def _gen_mon_cap_str(c):
-        perm, fsname = _unpack_tuple(c)
+    def _gen_mon_cap_str(perm, fsname=None):
         mon_cap = f'allow {perm}'
         if fsname:
             mon_cap += f' fsname={fsname}'
@@ -42,7 +30,7 @@ def gen_mon_cap_str(caps):
 
     mon_cap = ''
     for i, c in enumerate(caps):
-        mon_cap += _gen_mon_cap_str(c)
+        mon_cap += _gen_mon_cap_str(*c)
         if i != len(caps) - 1:
             mon_cap += ', '
 
@@ -55,8 +43,7 @@ def gen_osd_cap_str(caps):
 
     caps = ((perm1, fsname1), (perm2, fsname2))
     """
-    def _gen_osd_cap_str(c):
-        perm, fsname = c
+    def _gen_osd_cap_str(perm, fsname):
         osd_cap = f'allow {perm} tag cephfs'
         if fsname:
             osd_cap += f' data={fsname}'
@@ -67,7 +54,7 @@ def gen_osd_cap_str(caps):
 
     osd_cap = ''
     for i, c in enumerate(caps):
-        osd_cap += _gen_osd_cap_str(c)
+        osd_cap += _gen_osd_cap_str(*c)
         if i != len(caps) - 1:
             osd_cap += ', '
 
@@ -80,22 +67,7 @@ def gen_mds_cap_str(caps):
 
     caps = ((perm1, fsname1, cephfs_mntpt1), (perm2, fsname2, cephfs_mntpt2))
     """
-    def _unpack_tuple(c):
-        if len(c) == 1:
-            perm, fsname, cephfs_mntpt = c[0], None, '/'
-        elif len(c) == 2:
-            perm, fsname, cephfs_mntpt = c[0], c[1], '/'
-        elif len(c) == 3:
-            perm, fsname, cephfs_mntpt = c
-        elif len(c) < 1:
-            raise RuntimeError('received no items caps tuple')
-        else: # len(c) > 3
-            raise RuntimeError('received too many items in caps tuple')
-
-        return perm, fsname, cephfs_mntpt
-
-    def _gen_mds_cap_str(c):
-        perm, fsname, cephfs_mntpt = _unpack_tuple(c)
+    def _gen_mds_cap_str(perm, fsname=None, cephfs_mntpt='/'):
         mds_cap = f'allow {perm}'
         if fsname:
             mds_cap += f' fsname={fsname}'
@@ -110,7 +82,7 @@ def gen_mds_cap_str(caps):
 
     mds_cap = ''
     for i, c in enumerate(caps):
-        mds_cap +=  _gen_mds_cap_str(c)
+        mds_cap +=  _gen_mds_cap_str(*c)
         if i != len(caps) - 1:
             mds_cap += ', '
 

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -24,8 +24,10 @@ def gen_mon_cap_str(caps):
             perm, fsname = c[0], None
         elif len(c) == 2:
             perm, fsname = c
-        else:
-            raise RuntimeError('caps tuple received isn\'t right')
+        elif len(c) < 1:
+            raise RuntimeError('received no items caps tuple')
+        else: # len(c) > 2
+            raise RuntimeError('received too many items in caps tuple')
         return perm, fsname
 
     def _gen_mon_cap_str(c):
@@ -79,14 +81,16 @@ def gen_mds_cap_str(caps):
     caps = ((perm1, fsname1, cephfs_mntpt1), (perm2, fsname2, cephfs_mntpt2))
     """
     def _unpack_tuple(c):
-        if len(c) == 2:
+        if len(c) == 1:
+            perm, fsname, cephfs_mntpt = c[0], None, '/'
+        elif len(c) == 2:
             perm, fsname, cephfs_mntpt = c[0], c[1], '/'
         elif len(c) == 3:
             perm, fsname, cephfs_mntpt = c
-        elif len(c) < 2:
-            raise RuntimeError('received items are too less in caps')
+        elif len(c) < 1:
+            raise RuntimeError('received no items caps tuple')
         else: # len(c) > 3
-            raise RuntimeError('received items are too many in caps')
+            raise RuntimeError('received too many items in caps tuple')
 
         return perm, fsname, cephfs_mntpt
 


### PR DESCRIPTION
Modify get_mds_cap_str() to accept a tuple with a single member. In this
case, the only member is assumed to be a permission, FS name is assigned
None type and cephfs_mntpt is assigned '/'.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>