### PR TITLE
osd/scrubber: simplify scrub resource handling and interval changes

### DIFF
--- a/qa/standalone/scrub/osd-scrub-dump.sh
+++ b/qa/standalone/scrub/osd-scrub-dump.sh
@@ -85,7 +85,6 @@ function TEST_recover_unexpected() {
 
     for qpg in $(ceph pg dump pgs --format=json-pretty | jq '.pg_stats[].pgid')
     do
-	primary=$(ceph pg dump pgs --format=json | jq ".pg_stats[] | select(.pgid == $qpg) | .acting_primary")
 	eval pg=$qpg   # strip quotes around qpg
 	ceph tell $pg scrub
     done

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -159,10 +159,6 @@ public:
     bool need_write_epoch,
     ceph::os::Transaction &t) final;
 
-  /// Need to reschedule next scrub. Assuming no change in role
-  void reschedule_scrub() final {
-  }
-
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final;
 
   uint64_t get_snap_trimq_size() const final {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -163,10 +163,6 @@ public:
     // Not needed yet -- mainly for scrub scheduling
   }
 
-  /// Notify PG that Primary/Replica status has changed (to update scrub registration)
-  void on_primary_status_change(bool was_primary, bool now_primary) final {
-  }
-
   /// Need to reschedule next scrub. Assuming no change in role
   void reschedule_scrub() final {
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -159,10 +159,6 @@ public:
     bool need_write_epoch,
     ceph::os::Transaction &t) final;
 
-  void on_info_history_change() final {
-    // Not needed yet -- mainly for scrub scheduling
-  }
-
   /// Need to reschedule next scrub. Assuming no change in role
   void reschedule_scrub() final {
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8766,13 +8766,6 @@ bool OSD::advance_pg(
       double old_max_interval = 0, new_max_interval = 0;
       oldpool->second.opts.get(pool_opts_t::SCRUB_MAX_INTERVAL, &old_max_interval);
       newpool->second.opts.get(pool_opts_t::SCRUB_MAX_INTERVAL, &new_max_interval);
-
-      // Assume if an interval is change from set to unset or vice versa the actual config
-      // is different.  Keep it simple even if it is possible to call resched_all_scrub()
-      // unnecessarily.
-      if (old_min_interval != new_min_interval || old_max_interval != new_max_interval) {
-	pg->on_info_history_change();
-      }
     }
 
     if (new_pg_num && old_pg_num != new_pg_num) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7626,10 +7626,9 @@ void OSD::resched_all_scrubs()
     if (!pg)
       continue;
 
-    if (!pg->get_planned_scrub().must_scrub && !pg->get_planned_scrub().need_auto) {
-      dout(15) << __func__ << ": reschedule " << job.pgid << dendl;
-      pg->reschedule_scrub();
-    }
+    dout(15) << __func__ << ": updating scrub schedule on " << job.pgid << dendl;
+    pg->on_scrub_schedule_input_change();
+
     pg->unlock();
   }
   dout(10) << __func__ << ": done" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1679,17 +1679,14 @@ std::optional<requested_scrub_t> PG::validate_scrub_mode() const
   return upd_flags;
 }
 
-void PG::reschedule_scrub()
+void PG::on_scrub_schedule_input_change()
 {
-  dout(20) << fmt::format(
-		  "{} for a {}", __func__,
-		  (is_primary() ? "Primary" : "non-primary"))
-	   << dendl;
-
-  // we are assuming no change in primary status
-  if (is_primary()) {
+  if (is_active() && is_primary()) {
+    dout(20) << __func__ << ": active/primary" << dendl;
     ceph_assert(m_scrubber);
     m_scrubber->update_scrub_job(m_planned_scrub);
+  } else {
+    dout(20) << __func__ << ": inactive or non-primary" << dendl;
   }
 }
 
@@ -2562,6 +2559,9 @@ void PG::handle_activate_map(PeeringCtx &rctx)
   recovery_state.activate_map(rctx);
 
   requeue_map_waiters();
+
+  // pool options affecting scrub may have changed
+  on_scrub_schedule_input_change();
 }
 
 void PG::handle_initialize(PeeringCtx &rctx)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1692,7 +1692,10 @@ void PG::on_info_history_change()
 
 void PG::reschedule_scrub()
 {
-  dout(20) << __func__ << " for a " << (is_primary() ? "Primary" : "non-primary") <<dendl;
+  dout(20) << fmt::format(
+		  "{} for a {}", __func__,
+		  (is_primary() ? "Primary" : "non-primary"))
+	   << dendl;
 
   // we are assuming no change in primary status
   if (is_primary()) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1687,7 +1687,11 @@ std::optional<requested_scrub_t> PG::validate_scrub_mode() const
 void PG::on_info_history_change()
 {
   ceph_assert(m_scrubber);
-  m_scrubber->on_primary_change(__func__, m_planned_scrub);
+  dout(20) << fmt::format(
+		  "{} for a {}", __func__,
+		  (is_primary() ? "Primary" : "non-primary"))
+	   << dendl;
+  reschedule_scrub();
 }
 
 void PG::reschedule_scrub()
@@ -1701,15 +1705,6 @@ void PG::reschedule_scrub()
   if (is_primary()) {
     ceph_assert(m_scrubber);
     m_scrubber->update_scrub_job(m_planned_scrub);
-  }
-}
-
-void PG::on_primary_status_change(bool was_primary, bool now_primary)
-{
-  // make sure we have a working scrubber when becoming a primary
-  if (was_primary != now_primary) {
-    ceph_assert(m_scrubber);
-    m_scrubber->on_primary_change(__func__, m_planned_scrub);
   }
 }
 
@@ -1740,13 +1735,7 @@ void PG::on_new_interval()
 {
   projected_last_update = eversion_t();
   cancel_recovery();
-
-  ceph_assert(m_scrubber);
-  // log some scrub data before we react to the interval
-  dout(20) << __func__ << (is_scrub_queued_or_active() ? " scrubbing " : " ")
-           << "flags: " << m_planned_scrub << dendl;
-
-  m_scrubber->on_primary_change(__func__, m_planned_scrub);
+  m_scrubber->on_new_interval();
 }
 
 epoch_t PG::cluster_osdmap_trim_lower_bound() {
@@ -1833,6 +1822,7 @@ void PG::on_activate(interval_set<snapid_t> snaps)
   snap_trimq = snaps;
   release_pg_backoffs();
   projected_last_update = info.last_update;
+  m_scrubber->on_pg_activate(m_planned_scrub);
 }
 
 void PG::on_active_exit()

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1679,21 +1679,6 @@ std::optional<requested_scrub_t> PG::validate_scrub_mode() const
   return upd_flags;
 }
 
-/*
- * Note: on_info_history_change() is used in those two cases where we're not sure
- * whether the role of the PG was changed, and if so - was this change relayed to the
- * scrub-queue.
- */
-void PG::on_info_history_change()
-{
-  ceph_assert(m_scrubber);
-  dout(20) << fmt::format(
-		  "{} for a {}", __func__,
-		  (is_primary() ? "Primary" : "non-primary"))
-	   << dendl;
-  reschedule_scrub();
-}
-
 void PG::reschedule_scrub()
 {
   dout(20) << fmt::format(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -269,6 +269,7 @@ public:
 	set_last_scrub_stamp(t, history, stats);
 	return true;
       });
+    on_scrub_schedule_input_change();
   }
 
   static void set_last_deep_scrub_stamp(
@@ -283,6 +284,7 @@ public:
 	set_last_deep_scrub_stamp(t, history, stats);
 	return true;
       });
+    on_scrub_schedule_input_change();
   }
 
   static void add_objects_scrubbed_count(
@@ -538,7 +540,18 @@ public:
   void on_pool_change() override;
   virtual void plpg_on_pool_change() = 0;
 
-  void reschedule_scrub() override;
+  /**
+   * on_scrub_schedule_input_change
+   *
+   * To be called when inputs to scrub scheduling may have changed.
+   * - OSD config params related to scrub such as  osd_scrub_min_interval,
+   *   osd_scrub_max_interval
+   * - Pool params related to scrub such as osd_scrub_min_interval,
+   *   osd_scrub_max_interval
+   * - pg stat scrub timestamps
+   * - etc
+   */
+  void on_scrub_schedule_input_change();
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -540,8 +540,6 @@ public:
 
   void on_info_history_change() override;
 
-  void on_primary_status_change(bool was_primary, bool now_primary) override;
-
   void reschedule_scrub() override;
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -538,8 +538,6 @@ public:
   void on_pool_change() override;
   virtual void plpg_on_pool_change() = 0;
 
-  void on_info_history_change() override;
-
   void reschedule_scrub() override;
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -711,8 +711,6 @@ void PeeringState::start_peering_interval(
     // did primary change?
     if (was_old_primary != is_primary()) {
       state_clear(PG_STATE_CLEAN);
-      // queue/dequeue the scrubber
-      pl->on_primary_status_change(was_old_primary, is_primary());
     }
 
     pl->on_role_change();

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -732,10 +732,6 @@ void PeeringState::start_peering_interval(
     }
   }
 
-  if (is_primary() && was_old_primary) {
-    pl->reschedule_scrub();
-  }
-
   if (acting.empty() && !up.empty() && up_primary == pg_whoami) {
     psdout(10) << " acting empty, but i am up[0], clearing pg_temp" << dendl;
     pl->queue_want_pg_temp(acting);
@@ -4026,7 +4022,6 @@ void PeeringState::update_stats(
   if (f(info.history, info.stats)) {
     pl->publish_stats_to_osd();
   }
-  pl->reschedule_scrub();
 
   if (t) {
     dirty_info = true;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -226,7 +226,6 @@ void PeeringState::update_history(const pg_history_t& new_history)
 	       << info.history.prior_readable_until_ub << ")" << dendl;
     }
   }
-  pl->on_info_history_change();
 }
 
 hobject_t PeeringState::earliest_backfill() const
@@ -667,7 +666,6 @@ void PeeringState::start_peering_interval(
   }
 
   on_new_interval();
-  pl->on_info_history_change();
 
   psdout(1) << "up " << oldup << " -> " << up
 	    << ", acting " << oldacting << " -> " << acting
@@ -6570,7 +6568,6 @@ boost::statechart::result PeeringState::Stray::react(const MLogRec& logevt)
   if (msg->info.last_backfill == hobject_t()) {
     // restart backfill
     ps->info = msg->info;
-    pl->on_info_history_change();
     ps->dirty_info = true;
     ps->dirty_big_info = true;  // maybe.
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -279,9 +279,6 @@ public:
       bool need_write_epoch,
       ObjectStore::Transaction &t) = 0;
 
-    /// Need to reschedule next scrub. Assuming no change in role
-    virtual void reschedule_scrub() = 0;
-
     /// Notify that a scrub has been requested
     virtual void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) = 0;
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -282,9 +282,6 @@ public:
     /// Notify that info/history changed (generally to update scrub registration)
     virtual void on_info_history_change() = 0;
 
-    /// Notify PG that Primary/Replica status has changed (to update scrub registration)
-    virtual void on_primary_status_change(bool was_primary, bool now_primary) = 0;
-
     /// Need to reschedule next scrub. Assuming no change in role
     virtual void reschedule_scrub() = 0;
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -279,9 +279,6 @@ public:
       bool need_write_epoch,
       ObjectStore::Transaction &t) = 0;
 
-    /// Notify that info/history changed (generally to update scrub registration)
-    virtual void on_info_history_change() = 0;
-
     /// Need to reschedule next scrub. Assuming no change in role
     virtual void reschedule_scrub() = 0;
 

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -276,6 +276,12 @@ class ScrubQueue {
     }
 
     /**
+     * access the 'state' directly, for when a distinction between 'registered'
+     * and 'unregistering' is needed (both have in_queues() == true)
+     */
+    bool is_state_registered() const { return state == qu_state_t::registered; }
+
+    /**
      * a text description of the "scheduling intentions" of this PG:
      * are we already scheduled for a scrub/deep scrub? when?
      */

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -557,7 +557,7 @@ void PgScrubber::update_scrub_job(const requested_scrub_t& request_flags)
   if (is_primary() && m_scrub_job) {
     ceph_assert(m_pg->is_locked());
     auto suggested = m_osds->get_scrub_services().determine_scrub_time(
-      request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
+	request_flags, m_pg->info, m_pg->get_pgpool().info.opts);
     m_osds->get_scrub_services().update_job(m_scrub_job, suggested);
     m_pg->publish_stats_to_osd();
   }
@@ -2380,7 +2380,9 @@ void PgScrubber::reset_internal_state()
 // note that only applicable to the Replica:
 void PgScrubber::advance_token()
 {
-  dout(10) << __func__ << " was: " << m_current_token << dendl;
+  dout(10) << fmt::format("{}: prev. token:{}", __func__, m_current_token)
+	   << dendl;
+
   m_current_token++;
 
   // when advance_token() is called, it is assumed that no scrubbing takes
@@ -2566,11 +2568,12 @@ ReplicaReservations::ReplicaReservations(
     , m_conf{conf}
 {
   epoch_t epoch = m_pg->get_osdmap_epoch();
-  m_timeout = conf.get_val<std::chrono::milliseconds>(
-    "osd_scrub_slow_reservation_response");
   m_log_msg_prefix = fmt::format(
-    "osd.{} ep: {} scrubber::ReplicaReservations pg[{}]: ", m_osds->whoami,
-    epoch, pg->pg_id);
+      "osd.{} ep: {} scrubber::ReplicaReservations pg[{}]: ", m_osds->whoami,
+      epoch, pg->pg_id);
+
+  m_timeout = conf.get_val<std::chrono::milliseconds>(
+      "osd_scrub_slow_reservation_response");
 
   if (m_pending <= 0) {
     // A special case of no replicas.

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -356,16 +356,6 @@ void PgScrubber::send_reservation_failure(epoch_t epoch_queued)
   dout(10) << "scrubber event --<< " << __func__ << dendl;
 }
 
-void PgScrubber::send_full_reset(epoch_t epoch_queued)
-{
-  dout(10) << "scrubber event -->> " << __func__ << " epoch: " << epoch_queued
-	   << dendl;
-
-  m_fsm->process_event(Scrub::FullReset{});
-
-  dout(10) << "scrubber event --<< " << __func__ << dendl;
-}
-
 void PgScrubber::send_chunk_free(epoch_t epoch_queued)
 {
   dout(10) << "scrubber event -->> " << __func__ << " epoch: " << epoch_queued

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -89,7 +89,7 @@ ostream& operator<<(ostream& out, const requested_scrub_t& sf)
  * PrimaryLogPG::on_change() was called when that interval ended. We can safely
  * discard the stale message.
  */
-bool PgScrubber::check_interval(epoch_t epoch_to_verify)
+bool PgScrubber::check_interval(epoch_t epoch_to_verify) const
 {
   return epoch_to_verify >= m_pg->get_same_interval_since();
 }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1600,7 +1600,6 @@ void PgScrubber::handle_scrub_reserve_request(OpRequestRef op)
   /* The primary may unilaterally restart the scrub process without notifying
    * replicas.  Unconditionally clear any existing state prior to handling
    * the new reservation. */
-  m_remote_osd_resource.reset();
   advance_token();
   
   bool granted{false};
@@ -1663,7 +1662,6 @@ void PgScrubber::handle_scrub_reserve_release(OpRequestRef op)
    *  the old tag will be discarded.
    */
   advance_token();
-  m_remote_osd_resource.reset();
 }
 
 void PgScrubber::discard_replica_reservations()
@@ -2352,6 +2350,7 @@ void PgScrubber::advance_token()
   // place. We will, though, verify that. And if we are actually still handling
   // a stale request - both our internal state and the FSM state will be
   // cleared.
+  m_remote_osd_resource.reset();
   replica_handling_done();
   m_fsm->process_event(FullReset{});
 }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1935,6 +1935,7 @@ void PgScrubber::scrub_finish()
     int tr = m_osds->store->queue_transaction(m_pg->ch, std::move(t), nullptr);
     ceph_assert(tr == 0);
   }
+  update_scrub_job(m_planned_scrub);
 
   if (has_error) {
     m_pg->queue_peering_event(PGPeeringEventRef(

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -690,6 +690,14 @@ class PgScrubber : public ScrubPgIF,
   // -----     methods used to verify the relevance of incoming events:
 
   /**
+   * should_drop_message
+   *
+   * Returns false if message was sent in the current epoch.  Otherwise,
+   * returns true and logs a debug message.
+   */
+  bool should_drop_message(OpRequestRef &op) const;
+
+  /**
    *  is the incoming event still relevant and should be forwarded to the FSM?
    *
    *  It isn't if:

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -728,7 +728,7 @@ class PgScrubber : public ScrubPgIF,
    */
   [[nodiscard]] bool verify_against_abort(epoch_t epoch_to_verify);
 
-  [[nodiscard]] bool check_interval(epoch_t epoch_to_verify);
+  [[nodiscard]] bool check_interval(epoch_t epoch_to_verify) const;
 
   epoch_t m_last_aborted{};  // last time we've noticed a request to abort
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -394,9 +394,10 @@ class PgScrubber : public ScrubPgIF,
     std::string_view caller,
     const requested_scrub_t& request_flags) final;
 
-  void scrub_requested(scrub_level_t scrub_level,
-		       scrub_type_t scrub_type,
-		       requested_scrub_t& req_flags) final;
+  void scrub_requested(
+      scrub_level_t scrub_level,
+      scrub_type_t scrub_type,
+      requested_scrub_t& req_flags) final;
 
   /**
    * Reserve local scrub resources (managed by the OSD)
@@ -477,6 +478,7 @@ class PgScrubber : public ScrubPgIF,
 		 std::string param,
 		 Formatter* f,
 		 std::stringstream& ss) override;
+
   int m_debug_blockrange{0};
 
   // --------------------------------------------------------------------------

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -387,9 +387,7 @@ class PgScrubber : public ScrubPgIF,
 
   void rm_from_osd_scrubbing() final;
 
-  void on_primary_change(
-    std::string_view caller,
-    const requested_scrub_t& request_flags) final;
+  void on_pg_activate(const requested_scrub_t& request_flags) final;
 
   void scrub_requested(
       scrub_level_t scrub_level,
@@ -438,6 +436,8 @@ class PgScrubber : public ScrubPgIF,
 
   /// handle a message carrying a replica map
   void map_from_replica(OpRequestRef op) final;
+
+  void on_new_interval() final;
 
   void scrub_clear_state() final;
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -669,7 +669,7 @@ class PgScrubber : public ScrubPgIF,
    *  the current scrubbing operation is done. We should mark that fact, so that
    *  all events related to the previous operation can be discarded.
    */
-  void advance_token();
+  void reset_replica_state();
 
   bool is_token_current(Scrub::act_token_t received_token);
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -887,8 +887,6 @@ class PgScrubber : public ScrubPgIF,
    */
   void request_rescrubbing(requested_scrub_t& req_flags);
 
-  void unregister_from_osd();
-
   /*
    * Select a range of objects to scrub.
    *

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -344,8 +344,6 @@ class PgScrubber : public ScrubPgIF,
    */
   void on_applied_when_primary(const eversion_t& applied_version) final;
 
-  void send_full_reset(epoch_t epoch_queued) final;
-
   void send_chunk_free(epoch_t epoch_queued) final;
 
   void send_chunk_busy(epoch_t epoch_queued) final;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -211,8 +211,7 @@ class ReservedByRemotePrimary {
     return m_reserved_by_remote_primary;
   }
 
-  /// compare the remembered reserved-at epoch to the current interval
-  [[nodiscard]] bool is_stale() const;
+  epoch_t get_reservation_epoch() const { return m_reserved_at; }
 
   std::ostream& gen_prefix(std::ostream& out) const;
 };

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -629,7 +629,7 @@ sc::result ReplicaWaitUpdates::react(const ReplicaPushesUpd&)
   if (scrbr->pending_active_pushes() == 0) {
 
     // done waiting
-    return transit<ActiveReplica>();
+    return transit<ReplicaBuildingMap>();
   }
 
   return discard_event();
@@ -644,23 +644,23 @@ sc::result ReplicaWaitUpdates::react(const FullReset&)
   return transit<NotActive>();
 }
 
-// ----------------------- ActiveReplica -----------------------------------
+// ----------------------- ReplicaBuildingMap -----------------------------------
 
-ActiveReplica::ActiveReplica(my_context ctx)
+ReplicaBuildingMap::ReplicaBuildingMap(my_context ctx)
     : my_base(ctx)
-    , NamedSimply(context<ScrubMachine>().m_scrbr, "ActiveReplica")
+    , NamedSimply(context<ScrubMachine>().m_scrbr, "ReplicaBuildingMap")
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  dout(10) << "-- state -->> ActiveReplica" << dendl;
+  dout(10) << "-- state -->> ReplicaBuildingMap" << dendl;
   // and as we might have skipped ReplicaWaitUpdates:
   scrbr->on_replica_init();
   post_event(SchedReplica{});
 }
 
-sc::result ActiveReplica::react(const SchedReplica&)
+sc::result ReplicaBuildingMap::react(const SchedReplica&)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  dout(10) << "ActiveReplica::react(const SchedReplica&). is_preemptable? "
+  dout(10) << "ReplicaBuildingMap::react(const SchedReplica&). is_preemptable? "
 	   << scrbr->get_preemptor().is_preemptable() << dendl;
 
   if (scrbr->get_preemptor().was_preempted()) {
@@ -683,9 +683,9 @@ sc::result ActiveReplica::react(const SchedReplica&)
 /**
  * the event poster is handling the scrubber reset
  */
-sc::result ActiveReplica::react(const FullReset&)
+sc::result ReplicaBuildingMap::react(const FullReset&)
 {
-  dout(10) << "ActiveReplica::react(const FullReset&)" << dendl;
+  dout(10) << "ReplicaBuildingMap::react(const FullReset&)" << dendl;
   return transit<NotActive>();
 }
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -115,6 +115,9 @@ MEV(DigestUpdate)
 /// maps_compare_n_cleanup() transactions are done
 MEV(MapsCompared)
 
+/// event emitted when the replica grants a reservation to the primary
+MEV(ReplicaGrantReservation)
+
 /// initiating replica scrub
 MEV(StartReplica)
 
@@ -143,8 +146,7 @@ MEV(ScrubFinished)
 struct NotActive;	    ///< the quiescent state. No active scrubbing.
 struct ReservingReplicas;   ///< securing scrub resources from replicas' OSDs
 struct ActiveScrubbing;	    ///< the active state for a Primary. A sub-machine.
-struct ReplicaWaitUpdates;  ///< an active state for a replica. Waiting for all
-			    ///< active operations to finish.
+struct ReplicaIdle;         ///< Initial reserved replica state
 struct ReplicaBuildingMap;	    ///< an active state for a replica.
 
 
@@ -310,8 +312,7 @@ struct NotActive : sc::state<NotActive, ScrubMachine>, NamedSimply {
     mpl::list<sc::custom_reaction<StartScrub>,
 	      // a scrubbing that was initiated at recovery completion:
 	      sc::custom_reaction<AfterRepairScrub>,
-	      sc::transition<StartReplica, ReplicaWaitUpdates>,
-	      sc::transition<StartReplicaNoWait, ReplicaBuildingMap>>;
+	      sc::transition<ReplicaGrantReservation, ReplicaIdle>>;
   sc::result react(const StartScrub&);
   sc::result react(const AfterRepairScrub&);
 };
@@ -510,6 +511,49 @@ struct WaitDigestUpdate : sc::state<WaitDigestUpdate, ActiveScrubbing>,
 
 // ----------------------------- the "replica active" states
 
+/**
+ * ReservedReplica
+ *
+ * Parent state for replica states,  Controls lifecycle for
+ * PgScrubber::m_reservations.
+ */
+struct ReservedReplica : sc::state<ReservedReplica, ScrubMachine, ReplicaIdle>,
+			 NamedSimply {
+  explicit ReservedReplica(my_context ctx);
+  ~ReservedReplica();
+
+  using reactions = mpl::list<sc::transition<FullReset, NotActive>>;
+};
+
+struct ReplicaWaitUpdates;
+
+/**
+ * ReplicaIdle
+ *
+ * Replica is waiting for a map request.
+ */
+struct ReplicaIdle : sc::state<ReplicaIdle, ReservedReplica>,
+		     NamedSimply {
+  explicit ReplicaIdle(my_context ctx);
+  ~ReplicaIdle();
+
+  using reactions = mpl::list<
+    sc::transition<StartReplica, ReplicaWaitUpdates>,
+    sc::transition<StartReplicaNoWait, ReplicaBuildingMap>>;
+};
+
+/**
+ * ReservedActiveOp
+ *
+ * Lifetime matches handling for a single map request op
+ */
+struct ReplicaActiveOp
+  : sc::state<ReplicaActiveOp, ReservedReplica, ReplicaWaitUpdates>,
+    NamedSimply {
+  explicit ReplicaActiveOp(my_context ctx);
+  ~ReplicaActiveOp();
+};
+
 /*
  * Waiting for 'active_pushes' to complete
  *
@@ -517,24 +561,21 @@ struct WaitDigestUpdate : sc::state<WaitDigestUpdate, ActiveScrubbing>,
  * - the details of the Primary's request were internalized by PgScrubber;
  * - 'active' scrubbing is set
  */
-struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ScrubMachine>,
+struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ReservedReplica>,
 			    NamedSimply {
   explicit ReplicaWaitUpdates(my_context ctx);
-  using reactions = mpl::list<sc::custom_reaction<ReplicaPushesUpd>,
-			      sc::custom_reaction<FullReset>>;
+  using reactions = mpl::list<sc::custom_reaction<ReplicaPushesUpd>>;
 
   sc::result react(const ReplicaPushesUpd&);
-  sc::result react(const FullReset&);
 };
 
 
-struct ReplicaBuildingMap : sc::state<ReplicaBuildingMap, ScrubMachine>, NamedSimply {
+struct ReplicaBuildingMap : sc::state<ReplicaBuildingMap, ReservedReplica>
+			  , NamedSimply {
   explicit ReplicaBuildingMap(my_context ctx);
-  using reactions = mpl::list<sc::custom_reaction<SchedReplica>,
-			      sc::custom_reaction<FullReset>>;
+  using reactions = mpl::list<sc::custom_reaction<SchedReplica>>;
 
   sc::result react(const SchedReplica&);
-  sc::result react(const FullReset&);
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -145,7 +145,7 @@ struct ReservingReplicas;   ///< securing scrub resources from replicas' OSDs
 struct ActiveScrubbing;	    ///< the active state for a Primary. A sub-machine.
 struct ReplicaWaitUpdates;  ///< an active state for a replica. Waiting for all
 			    ///< active operations to finish.
-struct ActiveReplica;	    ///< an active state for a replica.
+struct ReplicaBuildingMap;	    ///< an active state for a replica.
 
 
 class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
@@ -311,7 +311,7 @@ struct NotActive : sc::state<NotActive, ScrubMachine>, NamedSimply {
 	      // a scrubbing that was initiated at recovery completion:
 	      sc::custom_reaction<AfterRepairScrub>,
 	      sc::transition<StartReplica, ReplicaWaitUpdates>,
-	      sc::transition<StartReplicaNoWait, ActiveReplica>>;
+	      sc::transition<StartReplicaNoWait, ReplicaBuildingMap>>;
   sc::result react(const StartScrub&);
   sc::result react(const AfterRepairScrub&);
 };
@@ -528,8 +528,8 @@ struct ReplicaWaitUpdates : sc::state<ReplicaWaitUpdates, ScrubMachine>,
 };
 
 
-struct ActiveReplica : sc::state<ActiveReplica, ScrubMachine>, NamedSimply {
-  explicit ActiveReplica(my_context ctx);
+struct ReplicaBuildingMap : sc::state<ReplicaBuildingMap, ScrubMachine>, NamedSimply {
+  explicit ReplicaBuildingMap(my_context ctx);
   using reactions = mpl::list<sc::custom_reaction<SchedReplica>,
 			      sc::custom_reaction<FullReset>>;
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -200,6 +200,12 @@ struct ScrubMachineListener {
   virtual void set_queued_or_active() = 0;
   virtual void clear_queued_or_active() = 0;
 
+  /// Release remote scrub reservation
+  virtual void dec_scrubs_remote() = 0;
+
+  /// Advance replica token
+  virtual void advance_token() = 0;
+
   /**
    * Our scrubbing is blocked, waiting for an excessive length of time for
    * our target chunk to be unlocked. We will set the corresponding flags,

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -223,8 +223,6 @@ struct ScrubPgIF {
   virtual void send_sched_replica(epoch_t epoch_queued,
 				  Scrub::act_token_t token) = 0;
 
-  virtual void send_full_reset(epoch_t epoch_queued) = 0;
-
   virtual void send_chunk_free(epoch_t epoch_queued) = 0;
 
   virtual void send_chunk_busy(epoch_t epoch_queued) = 0;

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -280,6 +280,10 @@ struct ScrubPgIF {
 
   virtual void set_op_parameters(const requested_scrub_t&) = 0;
 
+  /// stop any active scrubbing (on interval end) and unregister from
+  /// the OSD scrub queue
+  virtual void on_new_interval() = 0;
+
   virtual void scrub_clear_state() = 0;
 
   virtual void handle_query_state(ceph::Formatter* f) = 0;
@@ -380,13 +384,10 @@ struct ScrubPgIF {
   virtual bool reserve_local() = 0;
 
   /**
-   * Register/de-register with the OSD scrub queue
-   *
-   * Following our status as Primary or replica.
+   * if activated as a Primary - register the scrub job with the OSD
+   * scrub queue
    */
-  virtual void on_primary_change(
-    std::string_view caller,
-    const requested_scrub_t& request_flags) = 0;
+  virtual void on_pg_activate(const requested_scrub_t& request_flags) = 0;
 
   /**
    * Recalculate the required scrub time.


### PR DESCRIPTION
The main goal here is to simplify the interval change and reset machinery in scrub and limit cross-dependencies with the rest of PG and PeeringState.  A theme of this and following PRs will be to gradually shift resource lifetimes to being modeled by scrub state lifetimes as literally as possible.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
