### PR TITLE
quincy: backport commit 70425c7 -- client/fuse: set max_idle_threads to the correct value (critical, ceph-fuse with libfuse3 is nearly useless without it)

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1605,9 +1605,10 @@ int CephFuse::Handle::loop()
   if (fuse_multithreaded) {
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
     {
-      struct fuse_loop_config conf = { 0 };
-
-      conf.clone_fd = opts.clone_fd;
+      struct fuse_loop_config conf = {
+        clone_fd: opts.clone_fd,
+        max_idle_threads: opts.max_idle_threads
+      };
       return fuse_session_loop_mt(se, &conf);
     }
 #elif FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)


### PR DESCRIPTION
This backports the solution for [issue 58109](https://tracker.ceph.com/issues/58109) to fix [issue 56725](https://tracker.ceph.com/issues/56725): 

Quincy's `ceph-fuse` client is pretty much useless without this -- it will hang at the first FORGET op (for example, with the first file created and then opened by `vi`) if used in multi-threaded mode (which is the default) -- and can work in single-threaded mode only (!) . 

And since Quincy is "the" version for the current Ubuntu LTS - Jammy Jellyfish (22.04) - without this patch the latter becomes effectively deprived of a ceph-fuse client.

===== original commit message follows =====

When the version of the libfuse is 3.1 or later,
the fuse worker thread of ceph-fuse keeps recreating and deleting file or directory will be blocked forever. It is caused by parameter 'max_idle_threads' being set to 0 and the relevant logic is in function 'fuse_do_work' of libfuse. Parameter 'max_idle_threads' can be set by function 'fuse_parse_cmdline', it may be the default value(10 before version 3.12 and -1 after) or a value set by user. It should not be set to 0.

Fixes: https://tracker.ceph.com/issues/58109
