### PR TITLE
quincy: rbd-mirror: switch to labeled perf counters

### DIFF
--- a/src/tools/rbd_mirror/Types.h
+++ b/src/tools/rbd_mirror/Types.h
@@ -21,14 +21,19 @@ template <typename> struct MirrorStatusUpdater;
 // Performance counters
 enum {
   l_rbd_mirror_journal_first = 27000,
-  l_rbd_mirror_replay,
-  l_rbd_mirror_replay_bytes,
-  l_rbd_mirror_replay_latency,
+  l_rbd_mirror_journal_entries,
+  l_rbd_mirror_journal_replay_bytes,
+  l_rbd_mirror_journal_replay_latency,
   l_rbd_mirror_journal_last,
   l_rbd_mirror_snapshot_first,
-  l_rbd_mirror_snapshot_replay_snapshots,
-  l_rbd_mirror_snapshot_replay_snapshots_time,
-  l_rbd_mirror_snapshot_replay_bytes,
+  l_rbd_mirror_snapshot_snapshots,
+  l_rbd_mirror_snapshot_sync_time,
+  l_rbd_mirror_snapshot_sync_bytes,
+  // per-image only counters below
+  l_rbd_mirror_snapshot_remote_timestamp,
+  l_rbd_mirror_snapshot_local_timestamp,
+  l_rbd_mirror_snapshot_last_sync_time,
+  l_rbd_mirror_snapshot_last_sync_bytes,
   l_rbd_mirror_snapshot_last,
 };
 

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -4,6 +4,8 @@
 #include "Replayer.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_key.h"
 #include "common/Timer.h"
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"
@@ -1159,9 +1161,11 @@ void Replayer<I>::handle_process_entry_safe(
 
   auto latency = ceph_clock_now() - replay_start_time;
   if (g_journal_perf_counters) {
-    g_journal_perf_counters->inc(l_rbd_mirror_replay);
-    g_journal_perf_counters->inc(l_rbd_mirror_replay_bytes, replay_bytes);
-    g_journal_perf_counters->tinc(l_rbd_mirror_replay_latency, latency);
+    g_journal_perf_counters->inc(l_rbd_mirror_journal_entries);
+    g_journal_perf_counters->inc(l_rbd_mirror_journal_replay_bytes,
+                                 replay_bytes);
+    g_journal_perf_counters->tinc(l_rbd_mirror_journal_replay_latency,
+                                  latency);
   }
 
   auto ctx = new LambdaContext(
@@ -1170,9 +1174,9 @@ void Replayer<I>::handle_process_entry_safe(
       schedule_flush_local_replay_task();
 
       if (m_perf_counters) {
-        m_perf_counters->inc(l_rbd_mirror_replay);
-        m_perf_counters->inc(l_rbd_mirror_replay_bytes, replay_bytes);
-        m_perf_counters->tinc(l_rbd_mirror_replay_latency, latency);
+        m_perf_counters->inc(l_rbd_mirror_journal_entries);
+        m_perf_counters->inc(l_rbd_mirror_journal_replay_bytes, replay_bytes);
+        m_perf_counters->tinc(l_rbd_mirror_journal_replay_latency, latency);
       }
 
       m_event_replay_tracker.finish_op();
@@ -1270,13 +1274,23 @@ void Replayer<I>::register_perf_counters() {
 
   auto cct = static_cast<CephContext *>(m_state_builder->local_image_ctx->cct);
   auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_image_perf_stats_prio");
-  PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_image_" + m_image_spec,
-                          l_rbd_mirror_journal_first, l_rbd_mirror_journal_last);
-  plb.add_u64_counter(l_rbd_mirror_replay, "replay", "Replays", "r", prio);
-  plb.add_u64_counter(l_rbd_mirror_replay_bytes, "replay_bytes",
-                      "Replayed data", "rb", prio, unit_t(UNIT_BYTES));
-  plb.add_time_avg(l_rbd_mirror_replay_latency, "replay_latency",
-                   "Replay latency", "rl", prio);
+
+  auto local_image_ctx = m_state_builder->local_image_ctx;
+  std::string labels = ceph::perf_counters::key_create(
+      "rbd_mirror_journal_image",
+      {{"pool", local_image_ctx->md_ctx.get_pool_name()},
+       {"namespace", local_image_ctx->md_ctx.get_namespace()},
+       {"image", local_image_ctx->name}});
+
+  PerfCountersBuilder plb(g_ceph_context, labels, l_rbd_mirror_journal_first,
+                          l_rbd_mirror_journal_last);
+  plb.add_u64_counter(l_rbd_mirror_journal_entries, "entries",
+                      "Number of entries replayed", nullptr, prio);
+  plb.add_u64_counter(l_rbd_mirror_journal_replay_bytes, "replay_bytes",
+                      "Total bytes replayed", nullptr, prio,
+                      unit_t(UNIT_BYTES));
+  plb.add_time_avg(l_rbd_mirror_journal_replay_latency, "replay_latency",
+                   "Replay latency", nullptr, prio);
   m_perf_counters = plb.create_perf_counters();
   g_ceph_context->get_perfcounters_collection()->add(m_perf_counters);
 }

--- a/src/tools/rbd_mirror/main.cc
+++ b/src/tools/rbd_mirror/main.cc
@@ -68,27 +68,30 @@ int main(int argc, const char **argv)
   auto prio =
       g_ceph_context->_conf.get_val<int64_t>("rbd_mirror_perf_stats_prio");
   {
-    PerfCountersBuilder plb(g_ceph_context, "rbd_mirror",
+    PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_journal",
                             rbd::mirror::l_rbd_mirror_journal_first,
                             rbd::mirror::l_rbd_mirror_journal_last);
-    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_replay, "replay", "Replays",
-                        "r", prio);
-    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_replay_bytes, "replay_bytes",
-                        "Replayed data", "rb", prio, unit_t(UNIT_BYTES));
-    plb.add_time_avg(rbd::mirror::l_rbd_mirror_replay_latency, "replay_latency",
-                     "Replay latency", "rl", prio);
+    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_journal_entries, "entries",
+                        "Number of entries replayed", nullptr, prio);
+    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_journal_replay_bytes,
+                        "replay_bytes", "Total bytes replayed", nullptr, prio,
+                        unit_t(UNIT_BYTES));
+    plb.add_time_avg(rbd::mirror::l_rbd_mirror_journal_replay_latency,
+                     "replay_latency", "Replay latency", nullptr, prio);
     g_journal_perf_counters = plb.create_perf_counters();
   }
   {
-    PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_snapshot",
-                            rbd::mirror::l_rbd_mirror_snapshot_first,
-                            rbd::mirror::l_rbd_mirror_snapshot_last);
-    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_snapshot_replay_snapshots,
-                        "snapshots", "Snapshots", "r", prio);
-    plb.add_time_avg(rbd::mirror::l_rbd_mirror_snapshot_replay_snapshots_time,
-                     "snapshots_time", "Snapshots time", "rl", prio);
-    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_snapshot_replay_bytes,
-                        "replay_bytes", "Replayed data", "rb", prio,
+    PerfCountersBuilder plb(
+        g_ceph_context, "rbd_mirror_snapshot",
+        rbd::mirror::l_rbd_mirror_snapshot_first,
+        rbd::mirror::l_rbd_mirror_snapshot_remote_timestamp);
+    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_snapshot_snapshots,
+                        "snapshots", "Number of snapshots synced", nullptr,
+                        prio);
+    plb.add_time_avg(rbd::mirror::l_rbd_mirror_snapshot_sync_time, "sync_time",
+                     "Average sync time", nullptr, prio);
+    plb.add_u64_counter(rbd::mirror::l_rbd_mirror_snapshot_sync_bytes,
+                        "sync_bytes", "Total bytes synced", nullptr, prio,
                         unit_t(UNIT_BYTES));
     g_snapshot_perf_counters = plb.create_perf_counters();
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59176

---

backport of https://github.com/ceph/ceph/pull/50302
parent tracker: https://tracker.ceph.com/issues/59173

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh