### PR TITLE
mClockScheduler: Set priority cutoff in the mClock Scheduler

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -386,12 +386,11 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
 {
   auto id = get_scheduler_id(item);
   unsigned priority = item.get_priority();
-  unsigned cutoff = get_io_prio_cut(cct);
   
   // TODO: move this check into OpSchedulerItem, handle backwards compat
   if (op_scheduler_class::immediate == id.class_id) {
     enqueue_high(immediate_class_priority, std::move(item));
-  } else if (priority >= cutoff) {
+  } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item));
   } else {
     auto cost = calc_scaled_cost(item.get_cost());
@@ -424,12 +423,11 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
 void mClockScheduler::enqueue_front(OpSchedulerItem&& item)
 {
   unsigned priority = item.get_priority();
-  unsigned cutoff = get_io_prio_cut(cct);
   auto id = get_scheduler_id(item);
 
   if (op_scheduler_class::immediate == id.class_id) {
     enqueue_high(immediate_class_priority, std::move(item), true);
-  } else if (priority >= cutoff) {
+  } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item), true);
   } else {
     // mClock does not support enqueue at front, so we use

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -197,6 +197,8 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     }
   }
 
+  unsigned cutoff_priority = get_io_prio_cut(cct);
+
   /**
    * set_osd_capacity_params_from_config
    *
@@ -214,7 +216,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   // Set the mclock related config params based on the profile
   void set_config_defaults_from_profile();
 
-public:
+public: 
   mClockScheduler(CephContext *cct, int whoami, uint32_t num_shards,
     int shard_id, bool is_rotational, MonClient *monc);
   ~mClockScheduler() override;


### PR DESCRIPTION
We check the priority of an op before deciding if it gets enqueued in the high_priority_queue or the mClock scheduler queue. Instead of checking what osd_op_queue_cut_off is set to each time, we should be checking the cutoff only once and set that as the priority_cutoff. This will avoid any issues when osd_op_queue_cut_off is set to debug_random.

Fixes: https://tracker.ceph.com/issues/58940





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
