### PR TITLE
quincy: pybind/mgr/pg_autoscaler: Reorderd if statement for the func: _maybe_adjust

### DIFF
--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -137,10 +137,20 @@ ceph osd pool set bulk0 target_size_bytes 1000
 ceph osd pool set meta0 target_size_ratio 1
 wait_for 60 "ceph health detail | grep POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO"
 
+# test autoscale warn
+
+ceph osd pool create warn0 1 --autoscale-mode=warn
+wait_for 120 "ceph health detail | grep POOL_TOO_FEW_PGS"
+
+ceph osd pool create warn1 256 --autoscale-mode=warn
+wait_for 120 "ceph health detail | grep POOL_TOO_MANY_PGS"
+
 ceph osd pool rm meta0 meta0 --yes-i-really-really-mean-it
 ceph osd pool rm bulk0 bulk0 --yes-i-really-really-mean-it
 ceph osd pool rm bulk1 bulk1 --yes-i-really-really-mean-it
 ceph osd pool rm bulk2 bulk2 --yes-i-really-really-mean-it
+ceph osd pool rm warn0 warn0 --yes-i-really-really-mean-it
+ceph osd pool rm warn1 warn1 --yes-i-really-really-mean-it
 
 echo OK
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -719,8 +719,6 @@ class PgAutoscaler(MgrModule):
             if p['target_bytes'] > 0:
                 total_target_bytes[p['crush_root_id']] += p['target_bytes'] * p['raw_used_rate']
                 target_bytes_pools[p['crush_root_id']].append(p['pool_name'])
-            if not p['would_adjust']:
-                continue
             if p['pg_autoscale_mode'] == 'warn':
                 msg = 'Pool %s has %d placement groups, should have %d' % (
                     p['pool_name'],
@@ -730,7 +728,8 @@ class PgAutoscaler(MgrModule):
                     too_few.append(msg)
                 else:
                     too_many.append(msg)
-
+            if not p['would_adjust']:
+                continue
             if p['pg_autoscale_mode'] == 'on':
                 # Note that setting pg_num actually sets pg_num_target (see
                 # OSDMonitor.cc)


### PR DESCRIPTION
Problem:

In the func `_maybe_adjust` we have this condition where `if not p['would_adjust']: continue` which
would get triggered before `if p['pg_autoscale_mode'] == 'warn':` if we don't have `pg_autoscale_mode` as `on`. This causes: the autoscaler to not throw any warnings.

Solution:
Move `if p['pg_autoscale_mode'] == 'warn':` to be
higher than `if not p['would_adjust']: continue`.

Fixes: https://tracker.ceph.com/issues/58894
Backport Tracker: https://tracker.ceph.com/issues/59180

Back-porting relevant commits from main PR:

https://github.com/ceph/ceph/pull/50334

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
