### PR TITLE
mgr/telemetry: add leaderboard description and documentation

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -269,3 +269,20 @@ completely optional, and disabled by default.::
   ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'
   ceph config set mgr mgr/telemetry/channel_ident true
 
+Leaderboard
+-----------
+
+Users who are interested in participating in a leaderboard in the `public
+dashboards <https://telemetry-public.ceph.com/>`_ can do so with::
+
+  ceph config set mgr mgr/telemetry/leaderboard true
+
+The leaderboard displays basic information about the cluster, like total
+storage capacity, number of OSDs, etc. A description of the cluster can be
+added with::
+
+  ceph config set mgr mgr/telemetry/leaderboard_description 'Ceph cluster for Computational Biology at the University of XYZ'
+
+In case the 'ident' channel is enabled, its details will not be displayed in
+the leaderboard.
+

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -89,6 +89,7 @@ class MgrModuleTest(MgrModuleTestCase):
                     'interval': int,
                     'last_opt_revision': int,
                     'leaderboard': bool,
+                    'leaderboard_description': str,
                     'organization': str,
                     'proxy': str,
                     'url': str
@@ -110,6 +111,7 @@ class MgrModuleTest(MgrModuleTestCase):
             'interval': module_options_object_schema,
             'last_opt_revision': module_options_object_schema,
             'leaderboard': module_options_object_schema,
+            'leaderboard_description': module_options_object_schema,
             'log_level': module_options_object_schema,
             'log_to_cluster': module_options_object_schema,
             'log_to_cluster_level': module_options_object_schema,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -198,6 +198,9 @@ class Module(MgrModule):
         Option(name='leaderboard',
                type='bool',
                default=False),
+        Option(name='leaderboard_description',
+               type='str',
+               default=None),
         Option(name='description',
                type='str',
                default=None),
@@ -261,6 +264,7 @@ class Module(MgrModule):
             self.enabled = False
             self.last_opt_revision = 0
             self.leaderboard = ''
+            self.leaderboard_description = ''
             self.interval = 0
             self.proxy = ''
             self.channel_basic = True
@@ -980,6 +984,7 @@ class Module(MgrModule):
             channels = self.get_active_channels()
         report = {
             'leaderboard': self.leaderboard,
+            'leaderboard_description': self.leaderboard_description,
             'report_version': 1,
             'report_timestamp': datetime.utcnow().isoformat(),
             'report_id': self.report_id,


### PR DESCRIPTION
Users who are opted-in to telemetry can also opt-in to participating in a leaderboard in the telemetry public dashboards
(https://telemetry-public.ceph.com/).

Users can also add a description of the cluster to publicly appear in the leaderboard.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
