### PR TITLE
mon/FSCommands: batch propose changes with osdmon

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -93,6 +93,10 @@ class FailHandler : public FileSystemCommandHandler
   {
   }
 
+  bool batched_propose() override {
+    return true;
+  }
+
   int handle(
       Monitor* mon,
       FSMap& fsmap,
@@ -320,6 +324,10 @@ public:
   SetHandler()
     : FileSystemCommandHandler("fs set")
   {}
+
+  bool batched_propose() override {
+    return true;
+  }
 
   int handle(
       Monitor *mon,
@@ -1038,6 +1046,10 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
   RemoveFilesystemHandler()
     : FileSystemCommandHandler("fs rm")
   {}
+
+  bool batched_propose() override {
+    return true;
+  }
 
   int handle(
       Monitor *mon,


### PR DESCRIPTION
This makes the race much smaller where an MDS may continue doing work and find out it's been blocklisted in the OSDMap (for `fs fail`) when it could have learned that from the MDSMap (where its proposal is delayed because it was not batched).

Fixes: https://tracker.ceph.com/issues/59185





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
