### PR TITLE
rgw: fix rgw cache invalidation after unregister_watch() error

### DIFF
--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -32,6 +32,7 @@ class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
   RGWSI_RADOS::Obj obj;
   uint64_t watch_handle;
   int register_ret{0};
+  bool unregister_done{false};
   librados::AioCompletion *register_completion{nullptr};
 
   class C_ReinitWatch : public Context {
@@ -85,20 +86,23 @@ public:
   }
 
   void reinit() {
-    int ret = unregister_watch();
-    if (ret < 0) {
-      ldout(cct, 0) << "ERROR: unregister_watch() returned ret=" << ret << dendl;
-      return;
+    if(!unregister_done) {
+      int ret = unregister_watch();
+      if (ret < 0) {
+        ldout(cct, 0) << "ERROR: unregister_watch() returned ret=" << ret << dendl;
+      }
     }
-    ret = register_watch();
+    int ret = register_watch();
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: register_watch() returned ret=" << ret << dendl;
+      svc->schedule_context(new C_ReinitWatch(this));
       return;
     }
   }
 
   int unregister_watch() {
     int r = svc->unwatch(obj, watch_handle);
+    unregister_done = true;
     if (r < 0) {
       return r;
     }
@@ -135,6 +139,7 @@ public:
       return r;
     }
     svc->add_watcher(index);
+    unregister_done = false;
     return 0;
   }
 
@@ -144,6 +149,7 @@ public:
       return r;
     }
     svc->add_watcher(index);
+    unregister_done = false;
     return 0;
   }
 };


### PR DESCRIPTION
When a metadata osd fails, an unregister_watch() error may occur, resulting in an rgw cache invalidation.
the log is as follows.
```log
rgw0
2023-03-21 03:06:35.662 7fd5ae072700 -1 RGWWatcher::handle_error cookie 94773602585728 err (107) Transport endpoint is not connected
2023-03-21 03:07:40.664 7fd5b207a700  0 ERROR: rados->unwatch2() returned r=-110
2023-03-21 03:07:40.664 7fd5b207a700  0 ERROR: unregister_watch() returned ret=-110
rgw1
2023-03-21 03:06:30.609 7f40a7675700 -1 RGWWatcher::handle_error cookie 94210480657408 err (107) Transport endpoint is not connected
2023-03-21 03:07:35.611 7f40ab67d700  0 ERROR: rados->unwatch2() returned r=-110
2023-03-21 03:07:35.611 7f40ab67d700  0 ERROR: unregister_watch() returned ret=-110
```

By adding an unregister_done flag and when a register_watch() error , performing a reinit() operation again,
After the first reinit() failure, the register_watch() will be performed again

Fixes: https://tracker.ceph.com/issues/59217

Signed-off-by: lichaochao <lichaochao2_yewu@cmss.chinamobile.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
