### PR TITLE
contrib: update keepalived Dockerfile

### DIFF
--- a/src/cephadm/containers/keepalived/Dockerfile
+++ b/src/cephadm/containers/keepalived/Dockerfile
@@ -1,10 +1,9 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-RUN microdnf install --nodocs \
+RUN microdnf install --assumeyes --nodocs \
     bash       \
-    curl       \
     iproute    \
-    keepalived-2.1.5 \
+    keepalived-2.2.4 \
  && rm /etc/keepalived/keepalived.conf && microdnf clean all
 
 COPY /skel /
@@ -16,9 +15,9 @@ CMD ["./init.sh"]
 # Build specific labels
 LABEL maintainer="Guillaume Abrioux <gabrioux@redhat.com>"
 LABEL com.redhat.component="keepalived-container"
-LABEL version=2.1.5
+LABEL version=2.2.4
 LABEL name="keepalived"
 LABEL description="keepalived for Ceph"
-LABEL summary="Provides keepalived on RHEL 8 for Ceph."
-LABEL io.k8s.display-name="Keepalived on RHEL 8"
+LABEL summary="Provides keepalived on RHEL 9 for Ceph."
+LABEL io.k8s.display-name="Keepalived on RHEL 9"
 LABEL io.openshift.tags="Ceph keepalived"


### PR DESCRIPTION
This updates the Dockerfile hosted in cephadm source code in order to build a newer image based on keepalived 2.2.4
