### PR TITLE
quincy: cephfs-top: navigate to home screen when no fs

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -160,7 +160,7 @@ class FSTop(object):
     def __init__(self, args):
         self.rados = None
         self.stdscr = None  # curses instance
-        self.current_screen = ""
+        self.active_screen = ""
         self.client_name = args.id
         self.cluster_name = args.cluster
         self.conffile = args.conffile
@@ -306,7 +306,7 @@ class FSTop(object):
                 endmenu = True
             elif key == ord('q'):
                 self.stdscr.erase()
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -346,20 +346,19 @@ class FSTop(object):
                 curr_row1 += 1
             elif key == curses.KEY_ENTER or key in [10, 13]:
                 self.stdscr.erase()
-                last_fs = current_states["last_fs"]
                 if curr_row1 != len(field_menu) - 1:
                     current_states["last_field"] = (field_menu[curr_row1].split('='))[0]
                 else:
                     current_states["last_field"] = 'chit'
                 self.header.erase()  # erase the previous text
-                if isinstance(last_fs, list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
                 endwhile = True
             elif key == ord('q'):
                 self.stdscr.erase()
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -454,7 +453,7 @@ class FSTop(object):
                         current_states["limit"] = key[:-1]
                 self.stdscr.erase()
                 self.header.erase()  # erase the previous text
-                if isinstance(current_states['last_fs'], list):
+                if self.active_screen == FS_TOP_ALL_FS_APP:
                     self.run_all_display()
                 else:
                     self.run_display()
@@ -832,7 +831,7 @@ class FSTop(object):
         self.header.erase()
         self.fsstats.erase()
 
-        self.current_screen = FS_TOP_FS_SELECTED_APP
+        self.active_screen = FS_TOP_FS_SELECTED_APP
         screen_title = "Selected Filesystem Info"
         help_commands = "m - select a filesystem | s - sort menu | l - limit number of clients"\
                         " | r - reset to default | q - home (All Filesystem Info) screen"
@@ -955,10 +954,10 @@ class FSTop(object):
 
     def run_all_display(self):
         # clear text from the previous screen
-        if self.current_screen == FS_TOP_FS_SELECTED_APP:
+        if self.active_screen == FS_TOP_FS_SELECTED_APP:
             self.header.erase()
 
-        self.current_screen = FS_TOP_ALL_FS_APP
+        self.active_screen = FS_TOP_ALL_FS_APP
         screen_title = "All Filesystem Info"
         curses.init_pair(2, curses.COLOR_CYAN, -1)
 

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -351,6 +351,7 @@ class FSTop(object):
                     current_states["last_field"] = (field_menu[curr_row1].split('='))[0]
                 else:
                     current_states["last_field"] = 'chit'
+                self.header.erase()  # erase the previous text
                 if isinstance(last_fs, list):
                     self.run_all_display()
                 else:
@@ -452,6 +453,7 @@ class FSTop(object):
                     elif int(key) != 0:
                         current_states["limit"] = key[:-1]
                 self.stdscr.erase()
+                self.header.erase()  # erase the previous text
                 if isinstance(current_states['last_fs'], list):
                     self.run_all_display()
                 else:
@@ -820,7 +822,9 @@ class FSTop(object):
                                                                  num_mounts=num_mounts,
                                                                  num_kclients=num_kclients,
                                                                  num_libs=num_libs), curses.A_DIM)
-        self.header.addstr(4, 0, help, curses.A_DIM)
+        self.header.addstr(4, 0, f"Filters: Sort - {current_states['last_field']}, "
+                           f"Limit - {current_states['limit']}", curses.A_DIM)
+        self.header.addstr(5, 0, help, curses.A_DIM)
         return True
 
     def run_display(self):

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -278,7 +278,7 @@ class FSTop(object):
         stdscr.clear()
         h, w = stdscr.getmaxyx()
         title = ['No filesystem available',
-                 'Press "q" to go back to home (all filesystem info) screen']
+                 'Press "q" to go back to home (All Filesystem Info) screen']
         pos_x1 = w // 2 - len(title[0]) // 2
         pos_x2 = w // 2 - len(title[1]) // 2
         stdscr.addstr(1, pos_x1, title[0], curses.A_STANDOUT | curses.A_BOLD)
@@ -306,10 +306,10 @@ class FSTop(object):
                 endmenu = True
             elif key == ord('q'):
                 self.stdscr.erase()
-                if self.active_screen == FS_TOP_ALL_FS_APP:
-                    self.run_all_display()
-                else:
+                if fs_list and self.active_screen == FS_TOP_FS_SELECTED_APP:
                     self.run_display()
+                else:
+                    self.run_all_display()
                 endmenu = True
 
             try:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58983






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>