### PR TITLE
mgr/cephadm: use a dedicated cephadm tmp dir to copy remote files

### DIFF
--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -223,14 +223,15 @@ class SSHManager:
                                  addr: Optional[str] = None,
                                  ) -> None:
         try:
+            cephadm_tmp_dir = f"/tmp/cephadm-{self.mgr._cluster_fsid}"
             dirname = os.path.dirname(path)
             await self._check_execute_command(host, ['mkdir', '-p', dirname], addr=addr)
-            await self._check_execute_command(host, ['mkdir', '-p', '/tmp' + dirname], addr=addr)
-            tmp_path = '/tmp' + path + '.new'
+            await self._check_execute_command(host, ['mkdir', '-p', cephadm_tmp_dir + dirname], addr=addr)
+            tmp_path = cephadm_tmp_dir + path + '.new'
             await self._check_execute_command(host, ['touch', tmp_path], addr=addr)
             if self.mgr.ssh_user != 'root':
                 assert self.mgr.ssh_user
-                await self._check_execute_command(host, ['chown', '-R', self.mgr.ssh_user, tmp_path], addr=addr)
+                await self._check_execute_command(host, ['chown', '-R', self.mgr.ssh_user, cephadm_tmp_dir], addr=addr)
                 await self._check_execute_command(host, ['chmod', str(644), tmp_path], addr=addr)
             with NamedTemporaryFile(prefix='cephadm-write-remote-file-') as f:
                 os.fchmod(f.fileno(), 0o600)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/59189

Just to give some context of this issue. Prior to this change, when copying files remotely to a node, cephadm normally uses the directory `tmp` to first copy the file then move it to its final destination on `/var/lib/ceph/<fsid>/path_to_file`. This works without issues when using root user as it has full permissions. However, using a normal user (by using the `--ssh-user` bootstrap option) when we try to copy cephadm binary we end up with a directory structure as the following:

```
[root@ceph-node-2 ~]# namei -om /tmp/var/lib/ceph/e7a4e1c0-cd4b-11ed-970e-525400415a6d/cephadm.caef6ace916e24dc2b4fc5083871e0d999819cf226149c52017567284f104ebc.new 
f: /tmp/var/lib/ceph/e7a4e1c0-cd4b-11ed-970e-525400415a6d/cephadm.caef6ace916e24dc2b4fc5083871e0d999819cf226149c52017567284f104ebc.new
 dr-xr-xr-x root root /
 drwxrwxrwt root root tmp
 drwxr-x--- root root var
 drwxr-x--- root root lib
 drwxr-x--- root root ceph
 drwxr-x--- root root e7a4e1c0-cd4b-11ed-970e-525400415a6d
 -rw-r--r-- myuser root cephadm.caef6ace916e24dc2b4fc5083871e0d999819cf226149c52017567284f104ebc.new

```
As consequence, when cephadm tries to copy the tmp file to `cephadm.caef6ace916e24dc2b4fc5083871e0d999819cf226149c52017567284f104ebc.new` it fails with a `permission denied` error because even if the file is owned by the normal user ( `myuser`  in the above capture), this user doesn't have read/enter permissions on the directories `var/lib/ceph/e7a4e1c0-cd4b-11ed-970e-525400415a6d` owned by root. 

The fix consists in using a dedicated cephadm temporal directory (instead of using `/tmp/`). This directory is per fsid to avoid conflicts in case of a multi-cluster setup. This way we can chown the whole temporal directory to the normal user without fear of messing with anything (we couldn't do that when `tmp` was used).

**Testing**
1) create a new normal user and set its mask to 027
2) bootstrap a ceph cluster with the new user (using `--ssh-user` option)
3) add a new node to the cluster (ceph-node-1 in this case)

With this PR fix we endu p with a tmp cephadm directory on `/tmp/cephadm-5ccf2c0a-ce0d-11ed-a75b-525400415a6d` which has the right permissions so files can be copied to the remote node without issues and the node is added correctly to the cluster.

```
[root@ceph-node-1 ~]# namei -om /tmp/cephadm-5ccf2c0a-ce0d-11ed-a75b-525400415a6d/var/lib/ceph/5ccf2c0a-ce0d-11ed-a75b-525400415a6d/
f: /tmp/cephadm-5ccf2c0a-ce0d-11ed-a75b-525400415a6d/var/lib/ceph/5ccf2c0a-ce0d-11ed-a75b-525400415a6d/
 dr-xr-xr-x root root /
 drwxrwxrwt root root tmp
 drwxr-x--- redo root cephadm-5ccf2c0a-ce0d-11ed-a75b-525400415a6d
 drwxr-x--- redo root var
 drwxr-x--- redo root lib
 drwxr-x--- redo root ceph
 drwxr-x--- redo root 5ccf2c0a-ce0d-11ed-a75b-525400415a6d
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
