### PR TITLE
ceph-volume: quick fix in zap.py

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -168,7 +168,6 @@ class Zap(object):
         """
         lv = api.get_single_lv(filters={'lv_name': device.lv_name, 'vg_name':
                                         device.vg_name})
-        pv = api.get_single_pv(filters={'lv_uuid': lv.lv_uuid})
         self.unmount_lv(lv)
 
         wipefs(device.path)
@@ -182,8 +181,10 @@ class Zap(object):
             elif len(lvs) <= 1:
                 mlogger.info('Only 1 LV left in VG, will proceed to destroy '
                              'volume group %s', device.vg_name)
+                pvs = api.get_pvs(filters={'lv_uuid': lv.lv_uuid})
                 api.remove_vg(device.vg_name)
-                api.remove_pv(pv.pv_name)
+                for pv in pvs:
+                    api.remove_pv(pv.pv_name)
             else:
                 mlogger.info('More than 1 LV left in VG, will proceed to '
                              'destroy LV only')


### PR DESCRIPTION
`api.get_single_pv(filters={'lv_uuid': lv.lv_uuid})` needs to be called only if `--destroy` is passed in order to remove vg and pv when there's nothing left.

With old deployments, it is possible that a lv_uuid matches more than 1 PV.
Given that `get_single_pv()` is only needed when `--destroy` is passed, let's move this call where it is actually needed.

This makes `ceph-volume lvm zap` fail even though

Fixes: https://tracker.ceph.com/issues/59210
