### PR TITLE
rgw: set init_check_compat when bucket sync status doesn't exist

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -5692,6 +5692,12 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
     yield call(new ReadCR(dpp, env->driver,
                           status_obj, &bucket_status, false, &objv));
     if (retcode == -ENOENT) {
+      // if the full sync status object didn't exist yet, run the backward
+      // compatability logic in InitBucketFullSyncStatusCR below. if it did
+      // exist, a `bucket sync init` probably requested its re-initialization,
+      // and shouldn't try to resume incremental sync
+      init_check_compat = true;
+
       // use exclusive create to set state=Init
       objv.generate_new_write_ver(cct);
       yield call(new WriteCR(dpp, env->driver, status_obj, bucket_status, &objv, true));


### PR DESCRIPTION
existing buckets aren't able to resume incremental sync after upgrade to multisite reshard, because the compatibility check wasn't being enabled

Fixes: https://tracker.ceph.com/issues/59211

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
