### PR TITLE
quincy: qa: mirror tests should cleanup fs during unwind

### DIFF
--- a/qa/suites/fs/mirror-ha/workloads/cephfs-mirror-ha-workunit.yaml
+++ b/qa/suites/fs/mirror-ha/workloads/cephfs-mirror-ha-workunit.yaml
@@ -9,9 +9,16 @@ overrides:
 
 tasks:
   - exec:
-      client.1:
+      mon.a:
         - "ceph fs volume create dc"
         - "ceph fs volume create dc-backup"
+  # Remove volumes during unwind to avoid MDS replacement warnings:
+  - full_sequential_finally:
+    - exec:
+        mon.a:
+          - ceph config set mon mon_allow_pool_delete true
+          - ceph fs volume rm dc --yes-i-really-mean-it
+          - ceph fs volume rm dc-backup --yes-i-really-mean-it
   - ceph-fuse:
       client.1:
         cephfs_name: dc


### PR DESCRIPTION
https://tracker.ceph.com/issues/57824