### PR TITLE
quincy: qa: "1 MDSs behind on trimming (MDS_TRIM)"

### DIFF
--- a/qa/suites/fs/thrash/workloads/tasks/1-thrash/osd.yaml
+++ b/qa/suites/fs/thrash/workloads/tasks/1-thrash/osd.yaml
@@ -4,5 +4,6 @@ overrides:
       - but it is still running
       - objects unfound and apparently lost
       - MDS_SLOW_METADATA_IO
+      - MDS_TRIM
 tasks:
 - thrashosds:


### PR DESCRIPTION
https://tracker.ceph.com/issues/57713