### PR TITLE
quincy: qa: data-scan/journal-tool do not output debugging in upstream testing

### DIFF
--- a/qa/suites/fs/functional/tasks/alternate-pool.yaml
+++ b/qa/suites/fs/functional/tasks/alternate-pool.yaml
@@ -1,4 +1,3 @@
-
 overrides:
   ceph:
     log-ignorelist:

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1499,7 +1499,7 @@ class Filesystem(MDSCluster):
         if quiet:
             base_args = [os.path.join(self._prefix, tool), '--debug-mds=1', '--debug-objecter=1']
         else:
-            base_args = [os.path.join(self._prefix, tool), '--debug-mds=4', '--debug-objecter=1']
+            base_args = [os.path.join(self._prefix, tool), '--debug-mds=20', '--debug-ms=1', '--debug-objecter=1']
 
         if rank is not None:
             base_args.extend(["--rank", "%s" % str(rank)])


### PR DESCRIPTION
https://tracker.ceph.com/issues/57720