### PR TITLE
pacific: mds: scrub locates mismatch between child accounted_rstats and self rstats

### DIFF
--- a/qa/suites/fs/functional/tasks/forward-scrub.yaml
+++ b/qa/suites/fs/functional/tasks/forward-scrub.yaml
@@ -5,6 +5,7 @@ overrides:
       - bad backtrace on inode
       - inode table repaired for inode
       - Scrub error on inode
+      - Scrub error on dir
       - Metadata damage detected
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
https://tracker.ceph.com/issues/57714