### PR TITLE
mgr/dashboard/frontend:Ceph dashboard supports multiple languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,9 +679,8 @@ if(WITH_SYSTEM_NPM)
     message(FATAL_ERROR "Can't find npm.")
   endif()
 endif()
-set(DASHBOARD_FRONTEND_LANGS "" CACHE STRING
-  "List of comma separated ceph-dashboard frontend languages to build. \
-  Use value `ALL` to build all languages")
+set(DASHBOARD_FRONTEND_LANGS "cs,de,es,fr,id,it,ja,ko,pl,zh-Hans,zh-Hant,pt" CACHE STRING
+  "List of comma separated ceph-dashboard frontend languages to build.")
 CMAKE_DEPENDENT_OPTION(WITH_MGR_ROOK_CLIENT "Enable the mgr's Rook support" ON
   "WITH_MGR" OFF)
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,6 +24,7 @@
 %bcond_with zbd
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
+%bcond_without build_mgr_dashboard_frontend
 %ifarch s390
 %bcond_with tcmalloc
 %else
@@ -466,6 +467,9 @@ BuildRequires:  libnuma-devel
 %endif
 %if 0%{?rhel} >= 8
 BuildRequires:  /usr/bin/pathfix.py
+%endif
+%if 0%{with build_mgr_dashboard_frontend}
+BuildRequires:  npm
 %endif
 
 %description
@@ -1348,7 +1352,11 @@ cmake .. \
     -DSYSTEMD_SYSTEM_UNIT_DIR:PATH=%{_unitdir} \
     -DWITH_MANPAGE:BOOL=ON \
     -DWITH_PYTHON3:STRING=%{python3_version} \
-    -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF \
+%if 0%{with build_mgr_dashboard_frontend}
+    -DDASHBOARD_FRONTEND_LANGS:STRING="cs,de,es,fr,id,it,ja,ko,pl,zh-Hans,zh-Hant,pt" \
+    -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=ON \
+    -DWITH_SYSTEM_NPM:BOOL=ON \
+%endif
 %if 0%{?suse_version}
     -DWITH_RADOSGW_SELECT_PARQUET:BOOL=OFF \
 %endif


### PR DESCRIPTION
The Ceph Dashboard provides monitoring and management functions of the Ceph cluster through the WebUI, including but not limited to cluster health, device management, storage pool management, OSD monitoring, RBD management, CEPHFS management, object gateway management and other functions. It has been accepted and liked by ceph lovers. However, with the rapid development of Ceph, the Dashboard of Ceph native community only provides English environment and does not support other environments, such as Chinese, Japanese, etc., resulting in high requirements on operation and maintenance language. It is hoped that ceph native community can support multiple languages on ceph mgr dashboard.

Fixes: https://tracker.ceph.com/issues/58653#change-232261
Signed-off-by:  TomNewChao <chaotomzhu@gmail.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [√] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [√] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [√] No doc update is appropriate
- Tests (select at least one)
  - [√] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
