### PR TITLE
quincy: mgr/volumes: avoid returning -ESHUTDOWN back to cli

### DIFF
--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -70,8 +70,6 @@ class VolumeClient(CephfsClient["Module"]):
     def shutdown(self):
         # Overrides CephfsClient.shutdown()
         log.info("shutting down")
-        # first, note that we're shutting down
-        self.stopping.set()
         # stop clones
         self.cloner.shutdown()
         # stop purge threads
@@ -96,14 +94,9 @@ class VolumeClient(CephfsClient["Module"]):
     ### volume operations -- create, rm, ls
 
     def create_fs_volume(self, volname, placement):
-        if self.is_stopping():
-            return -errno.ESHUTDOWN, "", "shutdown in progress"
         return create_volume(self.mgr, volname, placement)
 
     def delete_fs_volume(self, volname, confirm):
-        if self.is_stopping():
-            return -errno.ESHUTDOWN, "", "shutdown in progress"
-
         if confirm != "--yes-i-really-mean-it":
             return -errno.EPERM, "", "WARNING: this will *PERMANENTLY DESTROY* all data " \
                 "stored in the filesystem '{0}'. If you are *ABSOLUTELY CERTAIN* " \
@@ -130,15 +123,10 @@ class VolumeClient(CephfsClient["Module"]):
         return delete_volume(self.mgr, volname, metadata_pool, data_pools)
 
     def list_fs_volumes(self):
-        if self.stopping.is_set():
-            return -errno.ESHUTDOWN, "", "shutdown in progress"
         volumes = list_volumes(self.mgr)
         return 0, json.dumps(volumes, indent=4, sort_keys=True), ""
 
     def rename_fs_volume(self, volname, newvolname, sure):
-        if self.is_stopping():
-            return -errno.ESHUTDOWN, "", "shutdown in progress"
-
         if not sure:
             return (
                 -errno.EPERM, "",


### PR DESCRIPTION
https://tracker.ceph.com/issues/59002

I think mgr/volumes is acting a bit fancy by checking if the ceph-mgr daemon and plugins are under termination, thereby returning -ESHUTDOWN to cli commands. This seems unnecessary. None of the other mgr plugins do anything like this.

Handling of commands when the ceph-mgr is under termination is possibly handled in one of the upper layers.

Fixes: http://tracker.ceph.com/issues/58651
Signed-off-by: Venky Shankar <vshankar@redhat.com>
(cherry picked from commit 32ffcfdcdedf18cae654752e22fa7bf327314372)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
