### PR TITLE
include: move ALLPERMS definition to compat.h

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -28,8 +28,17 @@
 #endif 
 
 #include <sys/stat.h>
+
+#ifdef _WIN32
+#include "include/win32/fs_compat.h"
+#endif
+
 #ifndef ACCESSPERMS
 #define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
+#ifndef ALLPERMS
+#define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
 #endif
 
 #if defined(__FreeBSD__)
@@ -233,7 +242,6 @@ int ceph_memzero_s(void *dest, size_t destsz, size_t count);
 #include <time.h>
 
 #include "include/win32/win32_errno.h"
-#include "include/win32/fs_compat.h"
 
 // There are a few name collisions between Windows headers and Ceph.
 // Updating Ceph definitions would be the prefferable fix in order to avoid

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -43,10 +43,6 @@
 #include <thread>
 #include <regex>
 
-#ifndef ALLPERMS
-#define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
-#endif
-
 using namespace std;
 
 TEST(LibCephFS, OpenEmptyComponent) {

--- a/src/test/libcephfs/vxattr.cc
+++ b/src/test/libcephfs/vxattr.cc
@@ -47,10 +47,6 @@
 #include <regex>
 #include <string>
 
-#ifndef ALLPERMS
-#define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
-#endif
-
 using namespace std;
 
 TEST(LibCephFS, LayoutVerifyDefaultLayout) {


### PR DESCRIPTION
The Windows CI job started to fail as some libcephfs tests that use
ALLPERMS have been moved [1] to a separate file which doesn't have
the ALLPERMS definition.

```
/ceph/src/test/libcephfs/suidsgid.cc:240:36: error: ‘ALLPERMS’ was not declared in this scope
240 |   ASSERT_EQ(stx.stx_mode & (mode_t)ALLPERMS, before_mode);
```

We'll move this definition to compat.h so that we won't have to
redefine it in each file that uses it.

Note that we're moving the Windows "fs_compat.h" include up,
ensuring that the constants used by ALLPERMS are defined.

[1] https://github.com/ceph/ceph/commit/254eeb2730881ee48b4743e1422749d5b643f52a





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
