### PR TITLE
[bluestore] on/off switch for elastic shared blobs

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5274,11 +5274,6 @@ options:
   level: dev
   default: 0
   with_legacy: true
-- name: bluestore_debug_inject_bug21040
-  type: bool
-  level: dev
-  default: false
-  with_legacy: true
 - name: bluestore_debug_inject_csum_err_probability
   type: float
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4909,6 +4909,18 @@ options:
   flags:
   - create
   with_legacy: true
+- name: bluestore_reuse_shared_blobs
+  type: bool
+  level: advanced
+  desc: Let bluestore to reuse existing shared blobs if possible
+  long_desc: Overwrites on snapped objects cause shared blob count to grow.
+    It has a very negative performance effect. When enabled shared blob count
+    is significantly reduced. This option is false in Quincy, true in Reef
+    and removed in Squid.
+  default: false
+  flags:
+  - create
+  with_legacy: true
 - name: bluestore_allocator
   type: str
   level: advanced

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -62,6 +62,7 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/HybridAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/StupidAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueAdmin.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
 if(WITH_ZBD)
   list(APPEND alien_store_srcs

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -24,6 +24,7 @@ if(WITH_BLUESTORE)
     bluestore/AvlAllocator.cc
     bluestore/BtreeAllocator.cc
     bluestore/HybridAllocator.cc
+    bluestore/BlueAdmin.cc
   )
 endif(WITH_BLUESTORE)
 

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -46,7 +46,14 @@ int BlueStore::SocketHook::call(
 {
   int r = 0;
   if (command == "bluestore enable shared blob reuse") {
-    //out.append(s.str());
+    if (store.cct->_conf->bluestore_reuse_shared_blobs) {
+      ss << "Reuse shared blobs already enabled" << std::endl;
+      return 0;
+    }
+    store.write_meta("reuse_shared_blobs", "1");
+    store.reuse_shared_blobs = true;
+    store.cct->_conf->bluestore_reuse_shared_blobs = true;
+    out.append("reuse_shared_blobs enabled");
     return 0;
   } else {
     ss << "Invalid command" << std::endl;

--- a/src/os/bluestore/BlueAdmin.cc
+++ b/src/os/bluestore/BlueAdmin.cc
@@ -1,0 +1,56 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "BlueAdmin.h"
+#include "common/pretty_binary.h"
+#include "common/debug.h"
+//#include <vector>
+
+#define dout_subsys ceph_subsys_bluestore
+#define dout_context store.cct
+
+using std::string;
+using std::to_string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+using ceph::common::cmd_getval;
+
+BlueStore::SocketHook::SocketHook(BlueStore& store)
+    : store(store)
+{
+  AdminSocket *admin_socket = store.cct->get_admin_socket();
+  if (admin_socket) {
+    admin_socket->register_command(
+      "bluestore enable shared blob reuse",
+      this,
+      "enables the feature");
+  }
+}
+
+BlueStore::SocketHook::~SocketHook()
+{
+  AdminSocket *admin_socket = store.cct->get_admin_socket();
+  if (admin_socket) {
+    admin_socket->unregister_commands(this);
+  }
+}
+
+int BlueStore::SocketHook::call(
+  std::string_view command,
+  const cmdmap_t& cmdmap,
+  const ceph::buffer::list& inbl,
+  ceph::Formatter *f,
+  std::ostream& ss,
+  ceph::buffer::list& out)
+{
+  int r = 0;
+  if (command == "bluestore enable shared blob reuse") {
+    //out.append(s.str());
+    return 0;
+  } else {
+    ss << "Invalid command" << std::endl;
+    r = -ENOSYS;
+  }
+  return r;
+}

--- a/src/os/bluestore/BlueAdmin.h
+++ b/src/os/bluestore/BlueAdmin.h
@@ -1,0 +1,30 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_OSD_BLUEADMIN_H
+#define CEPH_OSD_BLUEADMIN_H
+
+
+#include "BlueStore.h"
+#include "common/admin_socket.h"
+
+using std::string;
+using std::to_string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
+class BlueStore::SocketHook : public AdminSocketHook {
+  BlueStore& store;
+
+public:
+  SocketHook(BlueStore& store);
+  virtual ~SocketHook();
+  int call(std::string_view command,
+	   const cmdmap_t& cmdmap,
+	   const ceph::buffer::list& inbl,
+	   ceph::Formatter *f,
+	   std::ostream& errss,
+	   ceph::buffer::list& out) override;
+};
+#endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1218,6 +1218,11 @@ struct LruOnodeCacheShard : public BlueStore::OnodeCacheShard {
     *onodes += num;
     *pinned_onodes += num - lru.size();
   }
+#ifdef DEBUG_CACHE
+  void _audit(const char *when) override
+  {
+  }
+#endif
 };
 
 // OnodeCacheShard
@@ -1318,7 +1323,7 @@ struct LruBufferCacheShard : public BlueStore::BufferCacheShard {
     *bytes += buffer_bytes;
   }
 #ifdef DEBUG_CACHE
-  void _audit(const char *s) override
+  void _audit(const char *when) override
   {
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;
@@ -1624,7 +1629,7 @@ public:
   }
 
 #ifdef DEBUG_CACHE
-  void _audit(const char *s) override
+  void _audit(const char *when) override
   {
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1898,7 +1898,6 @@ void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint64_t seq
 */
 bool BlueStore::BufferSpace::_dup_writing(BufferCacheShard* cache, BufferSpace* to)
 {
-  std::lock_guard lk(cache->lock);
   bool copied = false;
   if (!writing.empty()) {
     copied = true;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4189,6 +4189,15 @@ void BlueStore::Collection::split_cache(
 	bvec.push_back(b.second.get());
       }
       for (auto b : bvec) {
+	if (dest->cache != cache) {
+	  for (auto& i : b->bc.buffer_map) {
+	    if (!i.second->is_writing()) {
+	      ldout(store->cct, 20) << __func__ << "   moving " << *i.second
+				    << dendl;
+	      dest->cache->_move(cache, i.second.get());
+	    }
+	  }
+	}
 	SharedBlob* sb = b->shared_blob.get();
 	if (sb->coll == dest) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
@@ -4203,15 +4212,6 @@ void BlueStore::Collection::split_cache(
 	  dest->shared_blob_set.add(dest, sb);
 	}
 	sb->coll = dest;
-	if (dest->cache != cache) {
-	  for (auto& i : b->bc.buffer_map) {
-	    if (!i.second->is_writing()) {
-	      ldout(store->cct, 20) << __func__ << "   moving " << *i.second
-				    << dendl;
-	      dest->cache->_move(cache, i.second.get());
-	    }
-	  }
-	}
       }
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11021,6 +11021,9 @@ void BlueStore::inject_global_statfs(const store_statfs_t& new_statfs)
   v.encode(bl);
   t->set(PREFIX_STAT, BLUESTORE_GLOBAL_STATFS_KEY, bl);
   db->submit_transaction_sync(t);
+  // must set these; are needed at _close_db() statfs persisting
+  per_pool_stat_collection = false;
+  vstatfs = new_statfs;
 }
 
 void BlueStore::inject_misreference(coll_t cid1, ghobject_t oid1,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1634,6 +1634,7 @@ public:
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;
     for (auto i = hot.begin(); i != hot.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_HOT);
       s += i->length;
     }
 
@@ -1647,6 +1648,7 @@ public:
     }
 
     for (auto i = warm_in.begin(); i != warm_in.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_WARM_IN);
       s += i->length;
     }
 
@@ -1665,6 +1667,10 @@ public:
       ceph_assert(s == buffer_bytes);
     }
 
+    for (auto i = warm_out.begin(); i != warm_out.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_WARM_OUT);
+      ceph_assert(i->is_empty());
+    }
     dout(20) << __func__ << " " << when << " buffer_bytes " << buffer_bytes
              << " ok" << dendl;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2786,9 +2786,14 @@ void BlueStore::Blob::copy_extents_over_empty(
     padding = 0;
   } else {
     ceph_assert(!ito->is_valid()); // there can be no collision
-    ceph_assert(ito->length >= len); // for at least len
-    padding = len - ito->length; // add this much after copying
+    ceph_assert(ito->length >= sto + len); // for at least len, starting with remainder sto
+    padding = ito->length - (sto + len); // add this much after copying
     ito = exto.erase(ito); // cut a hole
+    if (sto > 0) {
+      ito = exto.insert(ito, bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, sto));
+      prev = ito;
+      ++ito;
+    }
   }
 
   auto& exfrom = from.blob.extents;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2709,8 +2709,8 @@ void BlueStore::Blob::copy_extents(
     ceph_assert(pos + len <= it->length); // post_len should be single au, and we do not split
     return it->offset + pos;
   };
-  PExtentVector& exfrom = from.blob.extents;
-  PExtentVector& exto = blob.extents;
+  const PExtentVector& exfrom = from.blob.get_extents();
+  PExtentVector& exto = blob.dirty_extents();
   dout(20) << __func__ << " 0x" << std::hex << start << " "
 	   << pre_len << "/" << main_len << "/" << post_len << std::dec << dendl;
 
@@ -2750,7 +2750,7 @@ void BlueStore::Blob::copy_extents_over_empty(
   dout(20) << __func__ << " to=" << *this << " from=" << from
 	   << "[0x" << std::hex << start << "~" << len << std::dec << "]" << dendl;
   uint32_t padding;
-  auto& exto = blob.extents;
+  auto& exto = blob.dirty_extents();
   auto ito = exto.begin();
   PExtentVector::iterator prev = exto.end();
   uint32_t sto = start;
@@ -2796,7 +2796,7 @@ void BlueStore::Blob::copy_extents_over_empty(
     }
   }
 
-  auto& exfrom = from.blob.extents;
+  const auto& exfrom = from.blob.get_extents();
   auto itf = exfrom.begin();
   uint32_t sf = start;
   while (itf != exfrom.end() && sf >= itf->length) {
@@ -2938,10 +2938,10 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
       skip_empty(src_extents, src_it, src_pos);
     }
   }
-  if (pos < dst_blob.logical_length) {
+  if (pos < dst_blob.get_logical_length()) {
     // this is a candidate for improvement;
     // instead of artifically add extents, trim blob
-    tmp_extents.emplace_back(bluestore_pextent_t::INVALID_OFFSET, dst_blob.logical_length - pos);
+    tmp_extents.emplace_back(bluestore_pextent_t::INVALID_OFFSET, dst_blob.get_logical_length() - pos);
   }
   // now apply freshly merged tmp_extents into dst blob
   dst_blob.dirty_extents().swap(tmp_extents);
@@ -2965,7 +2965,7 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
     dst->bc.writing.insert(wrt_dst_it, buf);
   }
   dout(20) << __func__ << " result=" << *dst << dendl;
-  return dst_blob.logical_length;
+  return dst_blob.get_logical_length();
 }
 
 #undef dout_context

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3056,12 +3056,13 @@ void BlueStore::ExtentMap::scan_shared_blobs(
     }
     if (ep->blob->last_encoded_id == -1) {
       const bluestore_blob_t& blob = ep->blob->get_blob();
-      if (blob.is_shared() && !blob.is_compressed()) {
+      if (blob.is_shared()) {
 	// excellent time to load the blob
 	c->load_shared_blob(ep->blob->shared_blob);
-
-	// todo consider change to emplace_hint
-	candidates.emplace(ep->blob_start(), ep->blob.get());
+	if (!blob.is_compressed()) {
+	  // todo consider change to emplace_hint
+	  candidates.emplace(ep->blob_start(), ep->blob.get());
+	}
       }
       // mark as processed
       ep->blob->last_encoded_id = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2416,6 +2416,112 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
   return true;
 }
 
+#undef dout_prefix
+#define dout_prefix *_dout << "bluestore.blob(" << this << ") "
+#undef dout_context
+#define dout_context cct
+
+// Cut Buffers that are not covered by extents.
+// It happens when we punch hole in Blob.
+// Normally it is not a problem (other then wasted memory),
+// but when 2 Blobs are merged Buffers might collide.
+// Todo: in future cut Buffers when we delete extents from Blobs,
+//       and get rid of this function.
+void BlueStore::Blob::sanitize_buffers(CephContext* cct, BufferCacheShard* cache)
+{
+  dout(25) << __func__ << " input " << *this << " bc=" << bc << dendl;
+  const PExtentVector& extents = get_blob().get_extents();
+  uint32_t epos = 0;
+  auto e = extents.begin();
+  auto b = bc.buffer_map.begin();
+
+  // start, end are offsets in blob
+  auto trim_buffer = [&](Buffer* buf, uint32_t start, uint32_t end) {
+    if (!buf->is_empty()) {
+      ceph::buffer::list new_data;
+      ceph_assert(start >= buf->offset);
+      ceph_assert(buf->data.length() >= end - buf->offset);
+      new_data.substr_of(buf->data, start - buf->offset, end - start);
+      buf->data.swap(new_data);
+    }
+    buf->length = end - start;
+    buf->offset = start;
+  };
+  // buffers are ordered, so are extents
+  while(e != extents.end() && b != bc.buffer_map.end())
+  {
+    if (b->second->is_empty()) {
+      // get rid of warm out buffers, its easier than handle them
+      ceph_assert(!b->second->is_writing());
+      b = bc._rm_buffer(cache, b);
+      continue;
+    }
+    if (epos + e->length <= b->first) {
+      //  extextext     bufbufbuf
+      //  ^ epos   ^    ^b.first
+      //           ^epos+e->length
+      epos += e->length;
+      ++e;
+      continue;
+    }
+    if (b->second->end() <= epos) {
+      // bufbuf        extextext
+      //       ^b.end  ^ epos
+      ++b;
+      continue;
+    }
+    if (e->is_valid()) {
+      // defined, cannot be a problem
+      epos += e->length;
+      ++e;
+      continue;
+    }
+    ceph_assert(!e->is_valid() && epos + e->length > b->first);
+    if (epos <= b->first) {
+      if (b->second->end() <= epos + e->length) {
+	//   bufbuf
+	// extextextext
+	b = bc._rm_buffer(cache, b);
+      } else {
+	//   bufbuf
+	// extext
+	// ========
+	//       uf
+	Buffer* buf = bc._extract_buffer(cache, b);
+	trim_buffer(buf, epos + e->length, buf->end());
+	bc._add_buffer(cache, buf, 0, nullptr);
+      }
+    } else {
+      if (epos + e->length < b->first + b->second->length) {
+	//     bufbufbufbuf
+	//       extext
+	// =================
+	//     bu      fbuf
+	Buffer* buf = bc._extract_buffer(cache, b);
+	ceph::buffer::list right_data;
+	ceph_assert(!buf->is_empty());
+	// 'right' copies state of original buf
+	// seq is same as original, which is necessary if buf is_writing()
+	Buffer* right = new Buffer(buf->space, buf->state, buf->seq,
+				   epos + e->length, right_data, buf->flags);
+	bc._add_buffer(cache, right, 0, nullptr);
+
+	trim_buffer(buf, buf->offset, epos);
+	bc._add_buffer(cache, buf, 0, nullptr);
+      } else {
+	// bufbuf
+	//   extext
+	// ========
+	// bu
+	Buffer* buf = bc._extract_buffer(cache, b);
+	trim_buffer(buf, buf->offset, epos);
+	bc._add_buffer(cache, buf, 0, nullptr);
+      }
+    }
+  }
+  dout(25) << __func__ << " output bc=" << bc << dendl;
+}
+
 // Checks if two Blobs can be joined together.
 // The important (unchecked) condition is that both Blobs belong to the same object.
 // Verifies if 'other' Blob can be deleted but its content moved to 'this' Blob.
@@ -2640,6 +2746,9 @@ void BlueStore::Blob::merge_blob(Blob* src)
     dst->bc.writing.insert(wrt_dst_it, buf);
   }
 }
+
+#undef dout_context
+#define dout_context coll->store->cct
 
 void BlueStore::Blob::finish_write(uint64_t seq)
 {
@@ -2890,7 +2999,9 @@ void BlueStore::ExtentMap::make_range_shared(
       Blob* b = blob.is_compressed() ? nullptr :
 	find_mergable_companion(e.blob.get(), e.blob_start(), blob_width, candidates);
       if (b) {
-	dout(20) << __func__ << " merging to: " << *b << dendl;
+	dout(20) << __func__ << " merging to: " << *b << " bc=" << b->bc << dendl;
+	e.blob->sanitize_buffers(store->cct, oldo->c->cache);
+	b->sanitize_buffers(store->cct, oldo->c->cache);
 	b->merge_blob(e.blob.get());
 	for (auto p : blob.get_extents()) {
 	  if (p.is_valid()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3171,6 +3171,7 @@ void BlueStore::ExtentMap::reblob_extents(uint32_t blob_start, uint32_t blob_end
 	  prev->blob_offset + prev->length == e.blob_offset &&
 	  prev->logical_offset + prev->length == e.logical_offset) {
 	prev->length += e.length;
+	e.blob = nullptr;	
 	ep = extent_map.erase(ep);
 	// prev still the same
 	continue;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3114,39 +3114,31 @@ void BlueStore::ExtentMap::reblob_extents(uint32_t blob_start, uint32_t blob_end
   }
 }
 
-
 // Convert blobs in selected range to shared blobs.
 void BlueStore::ExtentMap::make_range_shared(
   BlueStore* store, TransContext* txc, CollectionRef& c,
   OnodeRef& oldo, uint64_t srcoff, uint64_t length)
 {
   uint64_t end = srcoff + length;
-  uint32_t dirty_range_begin = 0;
+  uint32_t dirty_range_begin = OBJECT_MAX_SIZE;
   uint32_t dirty_range_end = 0;
-
+  // load entire object; in most cases we clone entire object anyway
+  oldo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);
   std::multimap<uint64_t /*blob_start*/, Blob*> candidates;
   scan_shared_blobs(c, oldo, srcoff, length, candidates);
-  // ^ also scan regular blobs to
-  // 1) find blob_start
-  // 2) make sure all extents have the same blob_start
 
-  bool src_dirty = false;
   for (auto ep = oldo->extent_map.seek_lextent(srcoff);
     ep != oldo->extent_map.extent_map.end(); ) {
     auto& e = *ep;
     if (e.logical_offset >= end) {
       break;
     }
-    dout(20) << __func__ << " src " << e
+    dout(25) << __func__ << " src " << e
 	     << " bc=" << e.blob->bc << dendl;
     const bluestore_blob_t& blob = e.blob->get_blob();
     // make sure it is shared
     if (!blob.is_shared()) {
-      if (!src_dirty) {
-	src_dirty = true;
-	dirty_range_begin = e.blob_start();
-      }
-
+      dirty_range_begin = std::min<uint32_t>(dirty_range_begin, e.blob_start());
       // first try to find a shared blob nearby
       // that can accomodate extra extents
       uint32_t blob_width; //to signal when extents end
@@ -3166,25 +3158,18 @@ void BlueStore::ExtentMap::make_range_shared(
 	    b->shared_blob->get_ref(p.offset, p.length);
 	  }
 	}
-	for (auto& i : extent_map) {
-	  dout(20) << " pre " << i << dendl;
-	}
 	// reblob extents might erase e
+	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.blob_start() + b_logical_length);
 	uint32_t logical_offset = e.logical_offset;
-	dirty_range_end = e.blob_start() + b_logical_length;
 	reblob_extents(e.blob_start(), e.blob_start() + blob_width,
 		       e.blob, b);
-	for (auto& i : extent_map) {
-	  dout(20) << " post " << i << dendl;
-	}
-	dout(20) << __func__ << " merged: " << *b << dendl;
 	ep = oldo->extent_map.seek_lextent(logical_offset);
+	dout(20) << __func__ << " merged: " << *b << dendl;
       } else {
 	// no candidate, has to convert to shared
 	c->make_blob_shared(store->_assign_blobid(txc), e.blob);
 	ceph_assert(e.logical_end() > 0);
-	// -1 to exclude next potential shard
-	dirty_range_end = e.logical_end() - 1;
+	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.logical_end());
 	++ep;
       }
     } else {
@@ -3192,9 +3177,11 @@ void BlueStore::ExtentMap::make_range_shared(
       ++ep;
     }
   }
-  if (src_dirty) {
+  if (dirty_range_begin < dirty_range_end) {
+    // source onode got modified in the process
     oldo->extent_map.dirty_range(dirty_range_begin,
-      dirty_range_end - dirty_range_begin);
+				 dirty_range_end - dirty_range_begin);
+    oldo->extent_map.maybe_reshard(dirty_range_begin, dirty_range_end);
     txc->write_onode(oldo);
   }
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4075,13 +4075,14 @@ void BlueStore::ExtentMap::fault_range(
 {
   dout(30) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
+  if (shards.size() == 0) {
+    // no sharding yet; everyting is loaded
+    return;
+  }
   auto start = seek_shard(offset);
   auto last = seek_shard(offset + length);
+  ceph_assert(last >= start && start >= 0);
 
-  if (start < 0)
-    return;
-
-  ceph_assert(last >= start);
   string key;
   while (start <= last) {
     ceph_assert((size_t)start < shards.size());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2538,7 +2538,7 @@ void BlueStore::ExtentMap::scan_shared_blobs_segmented(
       break;
     }
     const bluestore_blob_t& blob = e.blob->get_blob();
-    if (blob.is_shared()) {
+    if (blob.is_shared() && !blob.is_compressed()) {
       // make sure blob is loaded, todo why?
       c->load_shared_blob(e.blob->shared_blob);
 
@@ -2603,7 +2603,8 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       if (!blob.is_shared()) {
 	// first try to find a shared blob nearby
 	// that can accomodate extra extents
-	SharedBlob* sb = find_best_companion(e.logical_offset, segment_map);
+	SharedBlob* sb = blob.is_compressed() ? nullptr :
+	  find_best_companion(e.logical_offset, segment_map);
 	if (sb) {
 	  // overwrite previous (empty) shared blob
 	  // vv almost like make_blob_shared

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2522,9 +2522,56 @@ void BlueStore::ExtentMap::dump(Formatter* f) const
   f->close_section();
 }
 
+void BlueStore::ExtentMap::scan_shared_blobs_segmented(
+  CollectionRef& c, OnodeRef& oldo,
+  uint64_t start, uint64_t length, segment_map_t& segment_map) {
+  const uint64_t segment_size = 1 << 16; //todo read from conf blob size for pool
+  // align start, length to segment_size
+  uint64_t end = p2roundup(start + length, segment_size);
+  start = p2align(start, segment_size);
+
+  for (auto ep = oldo->extent_map.seek_lextent(start);
+    ep != oldo->extent_map.extent_map.end();
+    ++ep) {
+    Extent& e = *ep;
+    if (e.logical_offset >= end) {
+      break;
+    }
+    const bluestore_blob_t& blob = e.blob->get_blob();
+    if (blob.is_shared()) {
+      // make sure blob is loaded, todo why?
+      c->load_shared_blob(e.blob->shared_blob);
+
+      // todo change below code to loop able to touch multiple segments
+      uint32_t segment_id = e.logical_offset / segment_size;
+      segment_t& segment = segment_map[segment_id];
+      uint64_t& size_in_shared_blob = segment[e.blob->shared_blob.get()];
+      size_in_shared_blob += e.length;
+    }
+  }
+}
+
+BlueStore::SharedBlob* BlueStore::ExtentMap::find_best_companion(
+  uint64_t logical_offset, segment_map_t& segment_map) {
+  const uint64_t segment_size = 1 << 16; //todo read from conf blob size for pool
+  uint32_t segment_id = logical_offset / segment_size;
+  segment_t& segment = segment_map[segment_id];
+  SharedBlob* sb = nullptr;
+  uint64_t max = 0;
+  for (auto i : segment) {
+    if (i.second > max) {
+      sb = i.first;
+    }
+  }
+  return sb;
+}
+
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {
+
+  segment_map_t segment_map;
+  scan_shared_blobs_segmented(c, oldo, srcoff, length, segment_map);
 
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
@@ -2554,7 +2601,24 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       const bluestore_blob_t& blob = e.blob->get_blob();
       // make sure it is shared
       if (!blob.is_shared()) {
-        c->make_blob_shared(b->_assign_blobid(txc), e.blob);
+	// first try to find a shared blob nearby
+	// that can accomodate extra extents
+	SharedBlob* sb = find_best_companion(e.logical_offset, segment_map);
+	if (sb) {
+	  // overwrite previous (empty) shared blob
+	  // vv almost like make_blob_shared
+	  bluestore_blob_t& blob = e.blob->dirty_blob();
+	  blob.set_flag(bluestore_blob_t::FLAG_SHARED);
+	  e.blob->shared_blob = sb;
+	  for (auto p : blob.get_extents()) {
+	    if (p.is_valid()) {
+	      e.blob->shared_blob->get_ref(p.offset, p.length);
+	    }
+	  }
+	} else {
+	  // no candidate, has to convert to shared
+	  c->make_blob_shared(b->_assign_blobid(txc), e.blob);
+	}
 	if (!src_dirty) {
           src_dirty = true;
           dirty_range_begin = e.logical_offset;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3212,6 +3212,11 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   oldo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//srcoff, length);
   newo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//dstoff, length);
 
+  dout(25) << __func__ << "start oldo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *oldo);
+  dout(25) << __func__ << "start newo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *newo);
+
   make_range_shared(b, txc, c, oldo, srcoff, length);
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
@@ -3325,6 +3330,10 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     newo->onode.size = dstoff + length;
   }
   newo->extent_map.dirty_range(dstoff, length);
+  dout(25) << __func__ << "end oldo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *oldo);
+  dout(25) << __func__ << "end newo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *newo);
   bcs->lock.unlock();
 }
 void BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
@@ -3378,6 +3387,7 @@ void BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
 	if (encode_some(p->shard_info->offset, endoff - p->shard_info->offset,
 			bl, &p->extents)) {
 	  if (force) {
+	    _dump_extent_map<-1>(cct, *this);
 	    derr << __func__ << "  encode_some needs reshard" << dendl;
 	    ceph_assert(!force);
 	  }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2408,6 +2408,7 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
     }
 
     if (new_blen > blen) {
+      ceph_assert(dirty_blob().is_mutable());
       dirty_blob().add_tail(new_blen);
       used_in_blob.add_tail(new_blen,
                             get_blob().get_release_size(min_alloc_size));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12969,10 +12969,10 @@ void BlueStore::_txc_finish(TransContext *txc)
   dout(20) << __func__ << " " << txc << " onodes " << txc->onodes << dendl;
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
-  for (auto& sb : txc->shared_blobs_written) {
-    sb->finish_write(txc->seq);
+  for (auto& sb : txc->blobs_written) {
+    sb->shared_blob->finish_write(txc->seq);
   }
-  txc->shared_blobs_written.clear();
+  txc->blobs_written.clear();
 
   while (!txc->removed_collections.empty()) {
     _queue_reap_collection(txc->removed_collections.front());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3267,7 +3267,14 @@ void BlueStore::ExtentMap::make_range_shared(
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {
-
+  OnodeCacheShard* ocs = c->get_onode_cache();
+  ocs->lock.lock();
+  // It is possible that during waiting split_cache moved us to different OnodeCacheShard.
+  while (ocs != c->get_onode_cache()) {
+    ocs->lock.unlock();
+    ocs = c->get_onode_cache();
+    ocs->lock.lock();
+  }
   make_range_shared(b, txc, c, oldo, srcoff, length);
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
@@ -3381,6 +3388,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     newo->onode.size = dstoff + length;
   }
   newo->extent_map.dirty_range(dstoff, length);
+  ocs->lock.unlock();
 }
 void BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
                                   bool force)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3494,6 +3494,12 @@ void BlueStore::ExtentMap::reshard(
     dout(20) << __func__ << "   shards [" << si_begin << "," << si_end << ")"
 	     << " over 0x[" << std::hex << needs_reshard_begin << ","
 	     << needs_reshard_end << ")" << std::dec << dendl;
+  } else {
+    // When sharding is not applied yet, it is an error to request reshard on range.
+    // The problem is that reshard() function will not touch any extent outside the range.
+    // Thus initial reshard() must encompass whole object.
+    needs_reshard_begin = 0;
+    needs_reshard_end = OBJECT_MAX_SIZE;
   }
 
   fault_range(db, needs_reshard_begin, (needs_reshard_end - needs_reshard_begin));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3098,18 +3098,18 @@ void BlueStore::ExtentMap::reblob_extents(uint32_t blob_start, uint32_t blob_end
   }
   auto prev = extent_map.end();
   for (auto ep = seek_lextent(blob_start); ep != extent_map.end();) {
-    auto& e = *ep;
-    if (e.logical_offset > blob_end) break;
-    if (e.blob == from_blob) {
-      e.blob = to_blob;
+    Extent* e = &(*ep);
+    if (e->logical_offset > blob_end) break;
+    if (e->blob == from_blob) {
+      e->blob = to_blob;
     }
     if (prev != extent_map.end()) {
-      if (prev->blob == e.blob &&
-	  prev->blob_offset + prev->length == e.blob_offset &&
-	  prev->logical_offset + prev->length == e.logical_offset) {
-	prev->length += e.length;
-	e.blob = nullptr;	
+      if (prev->blob == e->blob &&
+	  prev->blob_offset + prev->length == e->blob_offset &&
+	  prev->logical_offset + prev->length == e->logical_offset) {
+	prev->length += e->length;
 	ep = extent_map.erase(ep);
+	delete e;
 	// prev still the same
 	continue;
       }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3196,12 +3196,10 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     bcs = c->cache;
     bcs->lock.lock();
   }
-  oldo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//srcoff, length);
-  newo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//dstoff, length);
 
-  dout(25) << __func__ << "start oldo=" << dendl;
+  dout(25) << __func__ << " start oldo=" << dendl;
   _dump_onode<25>(onode->c->store->cct, *oldo);
-  dout(25) << __func__ << "start newo=" << dendl;
+  dout(25) << __func__ << " start newo=" << dendl;
   _dump_onode<25>(onode->c->store->cct, *newo);
 
   make_range_shared(b, txc, c, oldo, srcoff, length);
@@ -3311,15 +3309,16 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       dirty_range_end - dirty_range_begin);
     txc->write_onode(oldo);
   }
-  txc->write_onode(newo);
 
   if (dstoff + length > newo->onode.size) {
     newo->onode.size = dstoff + length;
   }
   newo->extent_map.dirty_range(dstoff, length);
-  dout(25) << __func__ << "end oldo=" << dendl;
+  newo->extent_map.maybe_reshard(dstoff, dstoff + length);
+  txc->write_onode(newo);
+  dout(25) << __func__ << " end oldo=" << dendl;
   _dump_onode<25>(onode->c->store->cct, *oldo);
-  dout(25) << __func__ << "end newo=" << dendl;
+  dout(25) << __func__ << " end newo=" << dendl;
   _dump_onode<25>(onode->c->store->cct, *newo);
   bcs->lock.unlock();
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3209,6 +3209,9 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     bcs = c->cache;
     bcs->lock.lock();
   }
+  oldo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//srcoff, length);
+  newo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);//dstoff, length);
+
   make_range_shared(b, txc, c, oldo, srcoff, length);
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8021,6 +8021,65 @@ void BlueStore::_fsck_check_statfs(
   }
 }
 
+void BlueStore::_fsck_foreach_shared_blob(
+  std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb) {
+  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+  if (it) {
+    CollectionRef c;
+    spg_t pgid;
+    for (it->lower_bound(string()); it->valid(); it->next()) {
+      dout(30) << __func__ << " key "
+	       << pretty_binary_string(it->key())
+	       << dendl;
+      if (is_extent_shard_key(it->key())) {
+	continue;
+      }
+
+      ghobject_t oid;
+      int r = get_key_object(it->key(), &oid);
+      if (r < 0) {
+	continue;
+      }
+
+      if (!c ||
+	  oid.shard_id != pgid.shard ||
+	  oid.hobj.get_logical_pool() != (int64_t)pgid.pool() ||
+	  !c->contains(oid)) {
+	c = nullptr;
+	for (auto& p : coll_map) {
+	  if (p.second->contains(oid)) {
+	    c = p.second;
+	    break;
+	  }
+	}
+	if (!c) {
+	  continue;
+	}
+      }
+      dout(20) << __func__
+	       << " inspecting shared blob refs for col:" << c->cid
+	       << " obj:" << oid
+	       << dendl;
+
+      OnodeRef o;
+      o.reset(Onode::create_decode(c, oid, it->key(), it->value()));
+      o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+
+      _dump_onode<30>(cct, *o);
+
+      mempool::bluestore_fsck::set<BlobRef> passed_sbs;
+      for (auto& e : o->extent_map.extent_map) {
+	auto& b = e.blob->get_blob();
+	if (b.is_shared() && passed_sbs.count(e.blob) == 0) {
+	  auto sbid = e.blob->shared_blob->get_sbid();
+	  cb(c->cid, oid, sbid, b);
+	  passed_sbs.emplace(e.blob);
+	}
+      } // for ... extent_map
+    } // for ... it->valid
+  } //if (it(PREFIX_OBJ))
+}
+
 void BlueStore::_fsck_repair_shared_blobs(
   BlueStoreRepairer& repairer,
   shared_blob_2hash_tracker_t& sb_ref_counts,
@@ -8032,73 +8091,10 @@ void BlueStore::_fsck_repair_shared_blobs(
   if (!sb_ref_mismatches) // not expected to succeed, just in case
     return;
 
-
-  auto foreach_shared_blob = [&](std::function<
-    void (coll_t,
-          ghobject_t,
-          uint64_t,
-          const bluestore_blob_t&)> cb) {
-      auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
-      if (it) {
-        CollectionRef c;
-        spg_t pgid;
-        for (it->lower_bound(string()); it->valid(); it->next()) {
-          dout(30) << __func__ << " key "
-	           << pretty_binary_string(it->key())
-	           << dendl;
-          if (is_extent_shard_key(it->key())) {
-	    continue;
-          }
-
-          ghobject_t oid;
-          int r = get_key_object(it->key(), &oid);
-          if (r < 0) {
-	    continue;
-          }
-
-          if (!c ||
-	    oid.shard_id != pgid.shard ||
-	    oid.hobj.get_logical_pool() != (int64_t)pgid.pool() ||
-	    !c->contains(oid)) {
-	    c = nullptr;
-	    for (auto& p : coll_map) {
-	      if (p.second->contains(oid)) {
-	        c = p.second;
-	        break;
-	      }
-	    }
-	    if (!c) {
-	      continue;
-	    }
-          }
-          dout(20) << __func__
-                   << " inspecting shared blob refs for col:" << c->cid
-	           << " obj:" << oid
-	           << dendl;
-
-          OnodeRef o;
-          o.reset(Onode::create_decode(c, oid, it->key(), it->value()));
-          o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
-
-          _dump_onode<30>(cct, *o);
-
-          mempool::bluestore_fsck::set<BlobRef> passed_sbs;
-          for (auto& e : o->extent_map.extent_map) {
-	    auto& b = e.blob->get_blob();
-	    if (b.is_shared() && passed_sbs.count(e.blob) == 0) {
-	      auto sbid = e.blob->shared_blob->get_sbid();
-	      cb(c->cid, oid, sbid, b);
-	      passed_sbs.emplace(e.blob);
-	    }
-          } // for ... extent_map
-        } // for ... it->valid
-      } //if (it(PREFIX_OBJ))
-    }; //foreach_shared_blob fn declaration
-
   mempool::bluestore_fsck::map<uint64_t, bluestore_extent_ref_map_t> refs_map;
 
   // first iteration over objects to identify all the broken sbids
-  foreach_shared_blob( [&](coll_t cid,
+  _fsck_foreach_shared_blob( [&](coll_t cid,
                            ghobject_t oid,
                            uint64_t sbid,
                            const bluestore_blob_t& b) {
@@ -8123,7 +8119,7 @@ void BlueStore::_fsck_repair_shared_blobs(
   });
 
   // second iteration over objects to build new ref map for the broken sbids
-  foreach_shared_blob( [&](coll_t cid,
+  _fsck_foreach_shared_blob( [&](coll_t cid,
                            ghobject_t oid,
                            uint64_t sbid,
                            const bluestore_blob_t& b) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2957,7 +2957,9 @@ void BlueStore::Blob::merge_blob(Blob* src)
   while(!src->bc.buffer_map.empty()) {
     auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
     buf.mapped()->space = &dst->bc;
-    dst->bc.buffer_map.insert(std::move(buf));
+    if (dst->bc.buffer_map.count(buf.key()) == 0) {
+      dst->bc.buffer_map[buf.key()] = std::move(buf.mapped());
+    }
   }
   // move BufferSpace writing
   auto wrt_dst_it = dst->bc.writing.begin();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3235,7 +3235,6 @@ void BlueStore::ExtentMap::make_range_shared(
 	  dout(20) << " pre " << i << dendl;
 	}
 	// reblob extents might erase e
-	// uint32_t blob_start = e.blob_start();
 	uint32_t logical_offset = e.logical_offset;
 	dirty_range_end = e.blob_start() + b_logical_length;
 	reblob_extents(e.blob_start(), e.blob_start() + blob_width,
@@ -3253,17 +3252,6 @@ void BlueStore::ExtentMap::make_range_shared(
 	dirty_range_end = e.logical_end() - 1;
 	++ep;
       }
-#if 0
-      if (!src_dirty) {
-	src_dirty = true;
-	dirty_range_begin = e.logical_offset;
-      }
-#endif
-#if 0
-      ceph_assert(e.logical_end() > 0);
-      // -1 to exclude next potential shard
-      dirty_range_end = e.logical_end() - 1;
-#endif
     } else {
       c->load_shared_blob(e.blob->shared_blob);
       ++ep;
@@ -3324,6 +3312,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       } else {
 	// we must copy source blob diligently region-by-region
 	// initialize shared_blob
+	cb->dirty_blob().set_flag(bluestore_blob_t::FLAG_SHARED);
 	cb->shared_blob = e.blob->shared_blob;
       }
       // By default do not copy buffers to clones, and let them read data by themselves.

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3091,6 +3091,11 @@ BlueStore::Blob* BlueStore::ExtentMap::find_mergable_companion(
 void BlueStore::ExtentMap::reblob_extents(uint32_t blob_start, uint32_t blob_end,
 					  BlobRef from_blob, BlobRef to_blob)
 {
+  if (from_blob->is_spanning()) {
+    dout(20) << __func__ << " removing spanning blob" << dendl;
+    spanning_blob_map.erase(from_blob->id);
+    from_blob->id = -1;
+  }
   auto prev = extent_map.end();
   for (auto ep = seek_lextent(blob_start); ep != extent_map.end();) {
     auto& e = *ep;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1955,6 +1955,23 @@ void BlueStore::BufferSpace::split(BufferCacheShard* cache, size_t pos, BlueStor
   cache->_trim();
 }
 
+// lists content of BufferSpace
+// BufferSpace must be under exclusive access
+std::ostream& operator<<(std::ostream& out, const BlueStore::BufferSpace& bc)
+{
+  for (auto& [i, j] : bc.buffer_map) {
+    out << " [0x" << std::hex << i << "]=" << *j << std::dec;
+  }
+  if (!bc.writing.empty()) {
+    out << " writing:";
+    for (auto i = bc.writing.begin(); i != bc.writing.end(); ++i) {
+      out << " " << *i;
+    }
+  }
+  return out;
+}
+
+
 // OnodeSpace
 
 #undef dout_prefix

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -17904,7 +17904,11 @@ int BlueStore::_do_clone_range(
   _dump_onode<30>(cct, *oldo);
   _dump_onode<30>(cct, *newo);
 
-  oldo->extent_map.dup(this, txc, c, oldo, newo, srcoff, length, dstoff);
+  if (!reuse_shared_blobs) {
+    oldo->extent_map.dup_original(this, txc, c, oldo, newo, srcoff, length, dstoff);
+  } else {
+    oldo->extent_map.dup(this, txc, c, oldo, newo, srcoff, length, dstoff);
+  }
 
 #ifdef HAVE_LIBZBD
   if (bdev->is_smr()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3192,6 +3192,113 @@ void BlueStore::ExtentMap::make_range_shared(
   }
 }
 
+// re-introduction of the original dup function
+void BlueStore::ExtentMap::dup_original(BlueStore* b, TransContext* txc,
+  CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
+  uint64_t& length, uint64_t& dstoff) {
+
+  auto cct = onode->c->store->cct;
+  bool inject_21040 =
+    cct->_conf->bluestore_debug_inject_bug21040;
+  vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
+  for (auto& e : oldo->extent_map.extent_map) {
+    e.blob->last_encoded_id = -1;
+  }
+
+  int n = 0;
+  uint64_t end = srcoff + length;
+  uint32_t dirty_range_begin = 0;
+  uint32_t dirty_range_end = 0;
+  bool src_dirty = false;
+  for (auto ep = oldo->extent_map.seek_lextent(srcoff);
+    ep != oldo->extent_map.extent_map.end();
+    ++ep) {
+    auto& e = *ep;
+    if (e.logical_offset >= end) {
+      break;
+    }
+    dout(20) << __func__ << "  src " << e << dendl;
+    BlobRef cb;
+    bool blob_duped = true;
+    if (e.blob->last_encoded_id >= 0) {
+      cb = id_to_blob[e.blob->last_encoded_id];
+      blob_duped = false;
+    } else {
+      // dup the blob
+      const bluestore_blob_t& blob = e.blob->get_blob();
+      // make sure it is shared
+      if (!blob.is_shared()) {
+        c->make_blob_shared(b->_assign_blobid(txc), e.blob);
+	if (!inject_21040 && !src_dirty) {
+          src_dirty = true;
+          dirty_range_begin = e.logical_offset;
+	} else if (inject_21040 &&
+	           dirty_range_begin == 0 && dirty_range_end == 0) {
+	  dirty_range_begin = e.logical_offset;
+	}
+        ceph_assert(e.logical_end() > 0);
+        // -1 to exclude next potential shard
+        dirty_range_end = e.logical_end() - 1;
+      } else {
+        c->load_shared_blob(e.blob->shared_blob);
+      }
+      cb = new Blob();
+      e.blob->last_encoded_id = n;
+      id_to_blob[n] = cb;
+      e.blob->dup(*cb);
+      // bump the extent refs on the copied blob's extents
+      for (auto p : blob.get_extents()) {
+        if (p.is_valid()) {
+          e.blob->shared_blob->get_ref(p.offset, p.length);
+        }
+      }
+      txc->write_shared_blob(e.blob->shared_blob);
+      dout(20) << __func__ << "    new " << *cb << dendl;
+    }
+
+    int skip_front, skip_back;
+    if (e.logical_offset < srcoff) {
+      skip_front = srcoff - e.logical_offset;
+    } else {
+      skip_front = 0;
+    }
+    if (e.logical_end() > end) {
+      skip_back = e.logical_end() - end;
+    } else {
+      skip_back = 0;
+    }
+
+    Extent* ne = new Extent(e.logical_offset + skip_front + dstoff - srcoff,
+      e.blob_offset + skip_front, e.length - skip_front - skip_back, cb);
+    newo->extent_map.extent_map.insert(*ne);
+    ne->blob->get_ref(c.get(), ne->blob_offset, ne->length);
+    // fixme: we may leave parts of new blob unreferenced that could
+    // be freed (relative to the shared_blob).
+    txc->statfs_delta.stored() += ne->length;
+    if (e.blob->get_blob().is_compressed()) {
+      txc->statfs_delta.compressed_original() += ne->length;
+      if (blob_duped) {
+        txc->statfs_delta.compressed() +=
+          cb->get_blob().get_compressed_payload_length();
+      }
+    }
+    dout(20) << __func__ << "  dst " << *ne << dendl;
+    ++n;
+  }
+  if ((!inject_21040 && src_dirty) ||
+       (inject_21040 && dirty_range_end > dirty_range_begin)) {
+    oldo->extent_map.dirty_range(dirty_range_begin,
+      dirty_range_end - dirty_range_begin);
+    txc->write_onode(oldo);
+  }
+  txc->write_onode(newo);
+
+  if (dstoff + length > newo->onode.size) {
+    newo->onode.size = dstoff + length;
+  }
+  newo->extent_map.dirty_range(dstoff, length);
+}
+
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3197,9 +3197,6 @@ void BlueStore::ExtentMap::dup_original(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {
 
-  auto cct = onode->c->store->cct;
-  bool inject_21040 =
-    cct->_conf->bluestore_debug_inject_bug21040;
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
     e.blob->last_encoded_id = -1;
@@ -3229,12 +3226,9 @@ void BlueStore::ExtentMap::dup_original(BlueStore* b, TransContext* txc,
       // make sure it is shared
       if (!blob.is_shared()) {
         c->make_blob_shared(b->_assign_blobid(txc), e.blob);
-	if (!inject_21040 && !src_dirty) {
+	if (!src_dirty) {
           src_dirty = true;
           dirty_range_begin = e.logical_offset;
-	} else if (inject_21040 &&
-	           dirty_range_begin == 0 && dirty_range_end == 0) {
-	  dirty_range_begin = e.logical_offset;
 	}
         ceph_assert(e.logical_end() > 0);
         // -1 to exclude next potential shard
@@ -3285,8 +3279,7 @@ void BlueStore::ExtentMap::dup_original(BlueStore* b, TransContext* txc,
     dout(20) << __func__ << "  dst " << *ne << dendl;
     ++n;
   }
-  if ((!inject_21040 && src_dirty) ||
-       (inject_21040 && dirty_range_end > dirty_range_begin)) {
+  if (src_dirty) {
     oldo->extent_map.dirty_range(dirty_range_begin,
       dirty_range_end - dirty_range_begin);
     txc->write_onode(oldo);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -51,6 +51,7 @@
 #include "common/numa.h"
 #include "common/pretty_binary.h"
 #include "kv/KeyValueHistogram.h"
+#include "BlueAdmin.h"
 
 #ifdef HAVE_LIBZBD
 #include "ZonedAllocator.h"
@@ -5519,10 +5520,13 @@ BlueStore::BlueStore(CephContext *cct,
   _init_logger();
   cct->_conf.add_observer(this);
   set_cache_shards(1);
+  asok_hook = new SocketHook(*this);
 }
 
 BlueStore::~BlueStore()
 {
+  delete asok_hook;
+  asok_hook = nullptr;
   cct->_conf.remove_observer(this);
   _shutdown_logger();
   ceph_assert(!mounted);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -17215,7 +17215,14 @@ int BlueStore::_do_remove(
   if (!h || !h->exists) {
     return 0;
   }
+  // Set maybe_unshared_blobs contains those shared blobs that have all nref=1.
+  // Is .head object is using all those segments?
+  // If it is using all, then no one else can use the shared blob,
+  // and we can fallback to regular non-shared blob.
 
+  // Note. We only process loaded shared blobs.
+  // This is very smart optimization - there is no way that we can unshare blob
+  // that is not yet loaded! We must have had inspected it to even check nrefs.
   dout(20) << __func__ << " checking for unshareable blobs on " << h
 	   << " " << h->oid << dendl;
   map<SharedBlob*,bluestore_extent_ref_map_t> expect;
@@ -17228,6 +17235,7 @@ int BlueStore::_do_remove(
       if (b.is_compressed()) {
 	expect[sb].get(0, b.get_ondisk_length());
       } else {
+	// todo: it seems to be an overkill to go through map()
 	b.map(e.blob_offset, e.length, [&](uint64_t off, uint64_t len) {
 	    expect[sb].get(off, len);
 	    return 0;
@@ -17236,11 +17244,13 @@ int BlueStore::_do_remove(
     }
   }
 
+  // expect has now refs set exactly as .head is using it
   vector<SharedBlob*> unshared_blobs;
   unshared_blobs.reserve(maybe_unshared_blobs.size());
   for (auto& p : expect) {
     dout(20) << " ? " << *p.first << " vs " << p.second << dendl;
     if (p.first->persistent->ref_map == p.second) {
+      // yup, .head is only one that is using the shared blob now
       SharedBlob *sb = p.first;
       dout(20) << __func__ << "  unsharing " << *sb << dendl;
       unshared_blobs.push_back(sb);
@@ -17256,6 +17266,7 @@ int BlueStore::_do_remove(
     return 0;
   }
 
+  // And now a run through .head extents to clear up freshly unshared blobs.
   for (auto& e : h->extent_map.extent_map) {
     const bluestore_blob_t& b = e.blob->get_blob();
     SharedBlob *sb = e.blob->shared_blob.get();
@@ -17265,6 +17276,18 @@ int BlueStore::_do_remove(
       dout(20) << __func__ << "  unsharing " << e << dendl;
       bluestore_blob_t& blob = e.blob->dirty_blob();
       blob.clear_flag(bluestore_blob_t::FLAG_SHARED);
+      if (e.blob->shared_blob->nref > 1) {
+	// Each blob on creation gets its own unique (empty) shared_blob.
+	// In function ExtentMap::dup() we sometimes merge 2 blobs,
+	// so they share common shared_blob used for ref counting.
+	// Imagine 2 blobs having same shared_blob, and shared blob gets just unshared.
+	// We cleared shared_blob content so it is now logically empty,
+	// but now those 2 blobs share it.
+	// This is illegal, as empty shared blobs should be unique.
+	// Fixing by re-creation.
+	e.blob->shared_blob = new SharedBlob(c.get());
+	dout(20) << __func__ << " recreated empty shared blob " << e << dendl;
+      }
       h->extent_map.dirty_range(e.logical_offset, 1);
     }
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -880,11 +880,11 @@ public:
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
 
-    using segment_t = std::map<SharedBlob*, uint64_t /*size*/>;
+    using segment_t = std::map<Blob*, uint64_t /*size*/>;
     using segment_map_t = std::map<uint64_t /*segment id*/, segment_t>;
     void scan_shared_blobs_segmented(CollectionRef& c, OnodeRef& onode,
       uint64_t start, uint64_t length, segment_map_t& segment_map);
-    SharedBlob* find_best_companion(
+    Blob* find_best_companion(
       uint64_t logical_offset, segment_map_t& segment_map);
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -464,6 +464,7 @@ public:
       discard(cache, offset, (uint32_t)-1 - offset);
     }
 
+    bool _dup_writing(BufferCacheShard* cache, BufferSpace* bc);
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
     void dump(BufferCacheShard* cache, ceph::Formatter *f) const {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -493,7 +493,6 @@ public:
       uint64_t sbid_unloaded;              ///< sbid if persistent isn't loaded
       bluestore_shared_blob_t *persistent; ///< persistent part of the shared blob if any
     };
-    BufferSpace bc;             ///< buffer cache
 
     SharedBlob(Collection *_coll) : coll(_coll), sbid_unloaded(0) {
       if (get_cache()) {
@@ -600,7 +599,7 @@ public:
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
-
+    BufferSpace bc;
   private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
 #ifdef CACHE_BLOB_BL
@@ -634,7 +633,7 @@ public:
     bool can_split() const {
       std::lock_guard l(shared_blob->get_cache()->lock);
       // splitting a BufferSpace writing list is too hard; don't try.
-      return shared_blob->bc.writing.empty() &&
+      return bc.writing.empty() &&
              used_in_blob.can_split() &&
              get_blob().can_split();
     }
@@ -687,7 +686,7 @@ public:
       if (--nref == 0)
 	delete this;
     }
-
+    ~Blob();
 
 #ifdef CACHE_BLOB_BL
     void _encode() const {
@@ -2813,7 +2812,7 @@ private:
     uint64_t offset,
     ceph::buffer::list& bl,
     unsigned flags) {
-    b->shared_blob->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
+    b->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
     txc->blobs_written.insert(b);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -880,6 +880,12 @@ public:
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
 
+    using segment_t = std::map<SharedBlob*, uint64_t /*size*/>;
+    using segment_map_t = std::map<uint64_t /*segment id*/, segment_t>;
+    void scan_shared_blobs_segmented(CollectionRef& c, OnodeRef& onode,
+      uint64_t start, uint64_t length, segment_map_t& segment_map);
+    SharedBlob* find_best_companion(
+      uint64_t logical_offset, segment_map_t& segment_map);
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -478,6 +478,7 @@ public:
       }
       f->close_section();
     }
+    friend std::ostream& operator<<(std::ostream& out, const BufferSpace& bc);
   };
 
   struct SharedBlobSet;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -525,8 +525,6 @@ public:
     void put_ref(uint64_t offset, uint32_t length,
 		 PExtentVector *r, bool *unshare);
 
-    void finish_write(uint64_t seq);
-
     friend bool operator==(const SharedBlob &l, const SharedBlob &r) {
       return l.get_sbid() == r.get_sbid();
     }
@@ -677,7 +675,8 @@ public:
     /// put logical references, and get back any released extents
     bool put_ref(Collection *coll, uint32_t offset, uint32_t length,
 		 PExtentVector *r);
-
+    // update caches to reflect content up to seq
+    void finish_write(uint64_t seq);
     /// split the blob
     void split(Collection *coll, uint32_t blob_offset, Blob *o);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -690,7 +690,7 @@ public:
       return blob;
     }
     /// clear buffers from unused sections
-    void sanitize_buffers(CephContext* cct, BufferCacheShard* cache);
+    void discard_unused_buffers(CephContext* cct, BufferCacheShard* cache);
 
     /// discard buffers for unallocated regions
     void discard_unallocated(Collection *coll);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -464,7 +464,7 @@ public:
       discard(cache, offset, (uint32_t)-1 - offset);
     }
 
-    bool _dup_writing(BufferCacheShard* cache, BufferSpace* bc);
+    bool _dup_writing(BufferCacheShard* cache, BufferSpace* to);
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
     void dump(BufferCacheShard* cache, ceph::Formatter *f) const {
@@ -886,12 +886,12 @@ public:
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
 
-    using segment_t = std::map<Blob*, uint64_t /*size*/>;
-    using segment_map_t = std::map<uint64_t /*segment id*/, segment_t>;
-    void scan_shared_blobs_segmented(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
-				     segment_map_t& segment_map, uint64_t segment_size);
-    Blob* find_best_companion(Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
-			      segment_map_t& segment_map, uint64_t segment_size);
+    void scan_shared_blobs(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
+			   std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
+
+    Blob* find_mergable_companion(Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
+				  std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
+
     void make_range_shared(BlueStore* store, TransContext* txc, CollectionRef& c,
 			   OnodeRef& oldo, uint64_t srcoff, uint64_t length);
     void reblob_extents(uint32_t blob_start, uint32_t blob_end,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2797,8 +2797,9 @@ private:
     int64_t& errors,
     int64_t &warnings,
     BlueStoreRepairer* repairer);
+  // When cb returns false stops iterating.
   void _fsck_foreach_shared_blob(
-    std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
+    std::function< bool (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
   void _fsck_repair_shared_blobs(
     BlueStoreRepairer& repairer,
     shared_blob_2hash_tracker_t& sb_ref_counts,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -933,6 +933,14 @@ public:
 	needs_reshard_end = end;
       }
     }
+    // signals that there was a modification on range <begin, end)
+    // if this spans over a shard boundary, then shards no longer
+    // can be encoded separately, and reshard run is needed
+    void maybe_reshard(uint32_t begin, uint32_t end) {
+      if (spans_shard(begin, end - begin)) {
+	request_reshard(begin, end);
+      }
+    }
 
     struct DeleteDisposer {
       void operator()(Extent *e) { delete e; }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2797,6 +2797,8 @@ private:
     int64_t& errors,
     int64_t &warnings,
     BlueStoreRepairer* repairer);
+  void _fsck_foreach_shared_blob(
+    std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
   void _fsck_repair_shared_blobs(
     BlueStoreRepairer& repairer,
     shared_blob_2hash_tracker_t& sb_ref_counts,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -673,13 +673,12 @@ public:
 			uint32_t b_offset,
 			uint32_t *length0);
 
-    void dup(Blob& o) {
-      o.shared_blob = shared_blob;
-      o.blob = blob;
-#ifdef CACHE_BLOB_BL
-      o.blob_bl = blob_bl;
-#endif
-    }
+    void dup(const Blob& from, bool copy_used_in_blob);
+    void copy_from(CephContext* cct, const Blob& from,
+		   uint32_t min_release_size, uint32_t start, uint32_t len);
+    void copy_extents(CephContext* cct, const Blob& from, uint32_t start,
+		      uint32_t pre_len, uint32_t main_len, uint32_t post_len);
+    void copy_extents_over_empty(CephContext* cct, const Blob& from, uint32_t start, uint32_t len);
 
     inline const bluestore_blob_t& get_blob() const {
       return blob;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -882,10 +882,12 @@ public:
 
     using segment_t = std::map<Blob*, uint64_t /*size*/>;
     using segment_map_t = std::map<uint64_t /*segment id*/, segment_t>;
-    void scan_shared_blobs_segmented(CollectionRef& c, OnodeRef& onode,
-      uint64_t start, uint64_t length, segment_map_t& segment_map);
-    Blob* find_best_companion(
-      uint64_t logical_offset, segment_map_t& segment_map);
+    void scan_shared_blobs_segmented(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
+				     segment_map_t& segment_map, uint64_t segment_size);
+    Blob* find_best_companion(uint64_t logical_offset,
+			      segment_map_t& segment_map, uint64_t segment_size);
+    void make_range_shared(BlueStore* store, TransContext* txc, CollectionRef& c,
+			   OnodeRef& oldo, uint64_t srcoff, uint64_t length);
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -661,7 +661,7 @@ public:
     }
 
     bool can_merge_blob(const Blob* other, uint32_t& blob_end) const;
-    void merge_blob(Blob* other);
+    uint32_t merge_blob(CephContext* cct, Blob* blob_to_dissolve);
 
     bool can_split_at(uint32_t blob_offset) const {
       return used_in_blob.can_split_at(blob_offset) &&

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -401,7 +401,8 @@ public:
     void _rm_buffer(BufferCacheShard* cache, Buffer *b) {
       _rm_buffer(cache, buffer_map.find(b->offset));
     }
-    void _rm_buffer(BufferCacheShard* cache,
+    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator
+    _rm_buffer(BufferCacheShard* cache,
 		    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator p) {
       ceph_assert(p != buffer_map.end());
       cache->_audit("_rm_buffer start");
@@ -410,8 +411,24 @@ public:
       } else {
 	cache->_rm(p->second.get());
       }
-      buffer_map.erase(p);
+      p = buffer_map.erase(p);
       cache->_audit("_rm_buffer end");
+      return p;
+    }
+    Buffer*
+    _extract_buffer(BufferCacheShard* cache,
+	    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator& p) {
+      ceph_assert(p != buffer_map.end());
+      cache->_audit("_rm_buffer start");
+      if (p->second->is_writing()) {
+        writing.erase(writing.iterator_to(*p->second));
+      } else {
+	cache->_rm(p->second.get());
+      }
+      Buffer* buf = p->second.release();
+      p = buffer_map.erase(p);
+      cache->_audit("_rm_buffer end");
+      return buf;
     }
 
     std::map<uint32_t,std::unique_ptr<Buffer>>::iterator _data_lower_bound(
@@ -673,6 +690,8 @@ public:
 #endif
       return blob;
     }
+    /// clear buffers from unused sections
+    void sanitize_buffers(CephContext* cct, BufferCacheShard* cache);
 
     /// discard buffers for unallocated regions
     void discard_unallocated(Collection *coll);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1780,7 +1780,7 @@ private:
 #endif
     
     std::set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
-    std::set<SharedBlobRef> shared_blobs_written; ///< update these on io completion
+    std::set<BlobRef> blobs_written; ///< update these on io completion
 
     KeyValueDB::Transaction t; ///< then we will commit this
     std::list<Context*> oncommits;  ///< more commit completions
@@ -2816,7 +2816,7 @@ private:
     unsigned flags) {
     b->shared_blob->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
-    txc->shared_blobs_written.insert(b->shared_blob);
+    txc->blobs_written.insert(b);
   }
 
   int _collection_list(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -673,6 +673,14 @@ public:
 			uint32_t b_offset,
 			uint32_t *length0);
 
+    void dup(Blob& o) {
+      o.shared_blob = shared_blob;
+      o.blob = blob;
+#ifdef CACHE_BLOB_BL
+      o.blob_bl = blob_bl;
+#endif
+    }
+
     void dup(const Blob& from, bool copy_used_in_blob);
     void copy_from(CephContext* cct, const Blob& from,
 		   uint32_t min_release_size, uint32_t start, uint32_t len);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -52,6 +52,7 @@
 #include "bluestore_types.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
+#include "common/admin_socket.h"
 
 #ifdef WITH_BLKIN
 #include "common/zipkin_trace.h"
@@ -2421,6 +2422,10 @@ private:
   osd_pools_map osd_pools; // protected by vstatfs_lock as well
 
   bool per_pool_stat_collection = true;
+
+  class SocketHook;
+  friend class SocketHook;
+  AdminSocketHook* asok_hook = nullptr;
 
   struct MempoolThread : public Thread {
   public:

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -916,6 +916,8 @@ public:
     void reblob_extents(uint32_t blob_start, uint32_t blob_end,
 			BlobRef from_blob, BlobRef to_blob);
 
+    void dup_original(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
+      uint64_t&, uint64_t&, uint64_t&);
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2347,6 +2347,7 @@ private:
   static_assert(std::numeric_limits<uint8_t>::max() >
 		std::numeric_limits<decltype(min_alloc_size)>::digits,
 		"not enough bits for min_alloc_size");
+  bool reuse_shared_blobs = false; ///< use smart ExtentMap::dup to reduce shared blob count
 
   // smr-only
   uint64_t zone_size = 0;              ///< number of SMR zones 
@@ -2959,6 +2960,9 @@ public:
 
   int write_meta(const std::string& key, const std::string& value) override;
   int read_meta(const std::string& key, std::string *value) override;
+  int read_meta_check(const std::string& key, std::string *value);
+
+  int read_meta_conf_check_env();
 
   // open in read-only and limited mode
   int cold_open();

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -735,6 +735,8 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
 	<< " -> 0x"
 	<< o.get_compressed_payload_length()
 	<< std::dec;
+  } else {
+    out << " llen=0x" << std::hex << o.get_logical_length() << std::dec;
   }
   if (o.flags) {
     out << " " << o.get_flags_string();

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -441,7 +441,9 @@ void bluestore_blob_use_tracker_t::get(
     total_bytes += length;
   } else {
     auto end = offset + length;
-
+    if (end / au_size >= num_au) {
+      add_tail(end, au_size);
+    }
     while (offset < end) {
       auto phase = offset % au_size;
       bytes_per_au[offset / au_size] += 

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -765,7 +765,8 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
   }
   if (o.has_csum()) {
     out << " " << Checksummer::get_csum_type_string(o.csum_type)
-	<< "/0x" << std::hex << (1ull << o.csum_chunk_order) << std::dec;
+	<< "/0x" << std::hex << (1ull << o.csum_chunk_order) << std::dec
+	<< "/" << o.csum_data.length();
   }
   if (o.has_unused())
     out << " unused=0x" << std::hex << o.unused << std::dec;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& out, const bluestore_cnode_t& l);
 template <typename OFFS_TYPE, typename LEN_TYPE>
 struct bluestore_interval_t
 {
-  static const uint64_t INVALID_OFFSET = ~0ull;
+  static constexpr uint64_t INVALID_OFFSET = ~0ull;
 
   OFFS_TYPE offset = 0;
   LEN_TYPE length = 0;
@@ -300,6 +300,29 @@ struct bluestore_blob_use_tracker_t {
   }
   bool is_empty() const {
     return !is_not_empty();
+  }
+  // Returns how many allocation units are currently tracked.
+  // Simplifies logic when num_au = 0, but in reality we track just one
+  uint32_t get_num_au() const {
+    return num_au == 0 ? 1 : num_au;
+  }
+  // Returns array of used sizes per au.
+  // It has at least get_num_au() elements.
+  const uint32_t* get_au_array() const {
+    if (num_au > 0) {
+      return bytes_per_au;
+    } else {
+      return &total_bytes;
+    }
+  }
+  // Returns array of used sizes per au.
+  // It has at least get_num_au() elements.
+  uint32_t* dirty_au_array() {
+    if (num_au > 0) {
+      return bytes_per_au;
+    } else {
+      return &total_bytes;
+    }
   }
   void prune_tail(uint32_t new_len) {
     if (num_au) {

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -486,6 +486,9 @@ public:
 
   void dup(const bluestore_blob_t& from);
 
+  // initialize blob to accomodate data from other blob, but do not copy yet
+  void adjust_to(const bluestore_blob_t& other, uint32_t new_logical_length);
+
   const PExtentVector& get_extents() const {
     return extents;
   }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -888,7 +888,6 @@ public:
     }
   }
   void add_tail(uint32_t new_len) {
-    ceph_assert(is_mutable());
     ceph_assert(!has_unused());
     ceph_assert(new_len > logical_length);
     extents.emplace_back(

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -395,7 +395,8 @@ struct bluestore_blob_use_tracker_t {
   void split(
     uint32_t blob_offset,
     bluestore_blob_use_tracker_t* r);
-
+  void dup(const bluestore_blob_use_tracker_t& from,
+	   uint32_t start, uint32_t len);
   bool equal(
     const bluestore_blob_use_tracker_t& other) const;
     
@@ -482,6 +483,8 @@ public:
   ceph::buffer::ptr csum_data;                ///< opaque std::vector of csum data
 
   bluestore_blob_t(uint32_t f = 0) : flags(f) {}
+
+  void dup(const bluestore_blob_t& from);
 
   const PExtentVector& get_extents() const {
     return extents;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5200,10 +5200,10 @@ void StoreTest::doSyntheticLimitedTest(
     if (option(1)) test_obj.fsck(false);
     if (option(1)) test_obj.scan();
     if (option(497)) test_obj.stat();
-    if (option(500)) test_obj.zero();
+    if (option(1000)) test_obj.zero();
     if (option(1500)) test_obj.read();
     if (option(1500)) test_obj.write();
-    if (option(1000)) test_obj.truncate();
+    if (option(500)) test_obj.truncate();
     if (option(1000)) test_obj.clone_range();
     if (option(1000)) test_obj.stash();
     if (option(1500)) test_obj.unlink();
@@ -5245,13 +5245,37 @@ TEST_P(StoreTestSpecificAUSize, SyntheticLimited) {
     return;
 
   const char *m[][10] = {
-    { "bluestore_min_alloc_size", "4096", 0 }, // must be the first!
+    { "bluestore_min_alloc_size", "65536", "4096", 0 }, // must be the first!
     { "num_ops", "10000", 0 },
     { "max_write", "65536", 0 },
     { "max_size", "262144", 0 },
     { "alignment", "4096", 0 },
-    { "start_object_count", "3000", "1000", "200", "50", 0 },
+    { "start_object_count", "1000", "200", "50", 0 },
     { "bluestore_max_blob_size", "65536", 0 },
+    { "bluestore_default_buffered_read", "true", 0 },
+    { "bluestore_default_buffered_write", "true", 0 },
+    { "bluestore_compression_mode", "force", "none", 0},
+    { "bluestore_prefer_deferred_size", "32768", "0", 0},
+    { 0 },
+  };
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticLimitedTest);
+}
+
+TEST_P(StoreTestSpecificAUSize, SyntheticShardingLimited) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  const char *m[][10] = {
+    { "bluestore_min_alloc_size", "65536", "4096", 0 }, // must be the first!
+    { "num_ops", "10000", 0 },
+    { "max_write", "65536", 0 },
+    { "max_size", "262144", 0 },
+    { "alignment", "4096", 0 },
+    { "start_object_count", "1000", "200", "50", 0 },
+    { "bluestore_max_blob_size", "65536", 0 },
+    { "bluestore_extent_map_shard_min_size", "60", 0 },
+    { "bluestore_extent_map_shard_max_size", "300", 0 },
+    { "bluestore_extent_map_shard_target_size", "150", 0 },
     { "bluestore_default_buffered_read", "true", 0 },
     { "bluestore_default_buffered_write", "true", 0 },
     { 0 },

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -9421,9 +9421,10 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
 
   //////////// verify invalid statfs ///////////
   cerr << "fix invalid statfs" << std::endl;
-  SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_stats", "true");
+  SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_stats", "false");
+  // disable allocation recovery - it will fix statfs too
   SetVal(g_conf(),
-    "bluestore_debug_inject_allocation_from_file_failure", "1");
+    "bluestore_debug_inject_allocation_from_file_failure", "0");
   store_statfs_t statfs0;
   store_statfs_t statfs;
   bstore->mount();
@@ -9433,7 +9434,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
   statfs.data_stored += 0x10000;
   ASSERT_FALSE(statfs0 == statfs);
   // this enforces global stats usage
-  bstore->inject_statfs("bluestore_statfs", statfs);
+  bstore->inject_global_statfs(statfs);
   bstore->umount();
 
   ASSERT_GE(bstore->fsck(false), 1); // global stats mismatch might omitted when
@@ -9457,10 +9458,10 @@ TEST_P(StoreTestSpecificAUSize, BluestoreRepairTest) {
   statfs.data_stored += 0x20000;
   ASSERT_FALSE(statfs0 == statfs);
   // this enforces global stats usage
-  bstore->inject_statfs("bluestore_statfs", statfs);
+  bstore->inject_global_statfs(statfs);
   bstore->umount();
 
-  ASSERT_EQ(bstore->fsck(false), 2);
+  ASSERT_EQ(bstore->fsck(false), 1);
   ASSERT_EQ(bstore->repair(false), 0);
   ASSERT_EQ(bstore->fsck(false), 0);
   ASSERT_EQ(bstore->mount(), 0);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -142,6 +142,12 @@ public:
   {}
   void doCompressionTest();
   void doSyntheticTest(
+    int initial_object_count,
+    int num_ops,
+    uint64_t max_obj, uint64_t max_wr, uint64_t align);
+  // a variant of test that keeps amount of active objects stable
+  void doSyntheticLimitedTest(
+    int initial_object_count,
     int num_ops,
     uint64_t max_obj, uint64_t max_wr, uint64_t align);
 };
@@ -163,16 +169,18 @@ public:
 class StoreTestSpecificAUSize : public StoreTestDeferredSetup {
 
 public:
-  typedef 
-    std::function<void(
-	   uint64_t num_ops,
-	   uint64_t max_obj,
-	   uint64_t max_wr,
-    	   uint64_t align)> MatrixTest;
-
+  typedef void(StoreTestSpecificAUSize::*MatrixTest)(void);
   void StartDeferred(size_t min_alloc_size) {
     SetVal(g_conf(), "bluestore_min_alloc_size", stringify(min_alloc_size).c_str());
     DeferredSetup();
+  }
+
+  void SyntheticTest() {
+    doSyntheticTest(start_object_count, num_ops, max_size, max_write, alignment);
+  }
+
+  void SyntheticLimitedTest() {
+    doSyntheticLimitedTest(start_object_count, num_ops, max_size, max_write, alignment);
   }
 
 private:
@@ -181,6 +189,7 @@ private:
   uint64_t max_size = 400 * 1024;
   uint64_t alignment = 0;
   uint64_t num_ops = 10000;
+  uint64_t start_object_count = 1000;
 
 protected:
   string matrix_get(const char *k) {
@@ -192,6 +201,8 @@ protected:
       return stringify(alignment);
     } else if (string(k) == "num_ops") {
       return stringify(num_ops);
+    } else if (string(k) == "start_object_count") {
+      return stringify(start_object_count);
     } else {
       char *buf;
       g_conf().get_val(k, &buf, -1);
@@ -210,6 +221,8 @@ protected:
       alignment = atoll(v);
     } else if (string(k) == "num_ops") {
       num_ops = atoll(v);
+    } else if (string(k) == "start_object_count") {
+      start_object_count = atoll(v);
     } else {
       SetVal(g_conf(), k, v);
     }
@@ -237,7 +250,7 @@ protected:
 	     << std::endl;
       }
       g_ceph_context->_conf.apply_changes(nullptr);
-      fn(num_ops, max_size, max_write, alignment);
+      (this->*fn)();
     }
   }
 
@@ -4178,7 +4191,8 @@ class SyntheticWorkloadState {
   };
 public:
   static const unsigned max_in_flight = 16;
-  static const unsigned max_objects = 3000;
+  static const unsigned min_objects = 20;
+  unsigned max_objects = 3000;
   static const unsigned max_attr_size = 5;
   static const unsigned max_attr_name_len = 100;
   static const unsigned max_attr_value_len = 1024 * 64;
@@ -4388,7 +4402,7 @@ public:
   }
 
   bool can_unlink() {
-    return (available_objects.size() + in_flight_objects.size()) > 0;
+    return (available_objects.size() + in_flight_objects.size()) > min_objects;
   }
 
   unsigned get_random_alloc_hints() {
@@ -5087,8 +5101,9 @@ public:
 
 
 void StoreTest::doSyntheticTest(
-		     int num_ops,
-		     uint64_t max_obj, uint64_t max_wr, uint64_t align)
+  int initial_object_count,
+  int num_ops,
+  uint64_t max_obj, uint64_t max_wr, uint64_t align)
 {
   MixedGenerator gen(555);
   gen_type rng(time(NULL));
@@ -5101,7 +5116,7 @@ void StoreTest::doSyntheticTest(
   SyntheticWorkloadState test_obj(store.get(), &gen, &rng, cid,
 				  max_obj, max_wr, align);
   test_obj.init();
-  for (int i = 0; i < num_ops/10; ++i) {
+  for (int i = 0; i < initial_object_count; ++i) {
     if (!(i % 500)) cerr << "seeding object " << i << std::endl;
     test_obj.touch();
   }
@@ -5142,8 +5157,65 @@ void StoreTest::doSyntheticTest(
   test_obj.shutdown();
 }
 
+void StoreTest::doSyntheticLimitedTest(
+  int initial_object_count,
+  int num_ops,
+  uint64_t max_obj, uint64_t max_wr, uint64_t align)
+{
+  MixedGenerator gen(555);
+  gen_type rng(time(NULL));
+  coll_t cid(spg_t(pg_t(0,555), shard_id_t::NO_SHARD));
+
+  SetVal(g_conf(), "bluestore_fsck_on_mount", "false");
+  SetVal(g_conf(), "bluestore_fsck_on_umount", "false");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  SyntheticWorkloadState test_obj(store.get(), &gen, &rng, cid,
+				  max_obj, max_wr, align);
+  test_obj.init();
+  for (int i = 0; i < initial_object_count; ++i) {
+    if (!(i % 500)) cerr << "seeding object " << i << std::endl;
+    test_obj.touch();
+  }
+  for (int i = 0; i < num_ops; ++i) {
+    if (!(i % 1000)) {
+      cerr << "Op " << i << std::endl;
+      test_obj.print_internal_state();
+    }
+    boost::uniform_int<> true_false(0, 9999 /*999*/);
+    int val = true_false(rng);
+    auto option = [&](int range) -> bool {
+      if (val == -1) {
+	return false;
+      }
+      if (val >= 0 && val < range) {
+	val = -1;
+	return true;
+      } else {
+	val -= range;
+	return false;
+      }
+    };
+    if (option(1)) test_obj.fsck(true);
+    if (option(1)) test_obj.fsck(false);
+    if (option(1)) test_obj.scan();
+    if (option(497)) test_obj.stat();
+    if (option(500)) test_obj.zero();
+    if (option(1500)) test_obj.read();
+    if (option(1500)) test_obj.write();
+    if (option(1000)) test_obj.truncate();
+    if (option(1000)) test_obj.clone_range();
+    if (option(1000)) test_obj.stash();
+    if (option(1500)) test_obj.unlink();
+    if (option(1500)) test_obj.clone();
+    ceph_assert(val == -1);
+  }
+  test_obj.wait_for_done();
+  test_obj.shutdown();
+}
+
 TEST_P(StoreTest, Synthetic) {
-  doSyntheticTest(10000, 400*1024, 40*1024, 0);
+  doSyntheticTest(1000, 10000, 400*1024, 40*1024, 0);
 }
 
 #if defined(WITH_BLUESTORE)
@@ -5165,7 +5237,26 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixSharding) {
     { "bluestore_default_buffered_write", "true", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
+}
+
+TEST_P(StoreTestSpecificAUSize, SyntheticLimited) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  const char *m[][10] = {
+    { "bluestore_min_alloc_size", "4096", 0 }, // must be the first!
+    { "num_ops", "10000", 0 },
+    { "max_write", "65536", 0 },
+    { "max_size", "262144", 0 },
+    { "alignment", "4096", 0 },
+    { "start_object_count", "3000", "1000", "200", "50", 0 },
+    { "bluestore_max_blob_size", "65536", 0 },
+    { "bluestore_default_buffered_read", "true", 0 },
+    { "bluestore_default_buffered_write", "true", 0 },
+    { 0 },
+  };
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticLimitedTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, ZipperPatternSharded) {
@@ -5225,7 +5316,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCsumAlgorithm) {
     { "bluestore_default_buffered_write", "false", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCsumVsCompression) {
@@ -5245,7 +5336,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCsumVsCompression) {
     { "bluestore_sync_submit_transaction", "false", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCompression) {
@@ -5262,7 +5353,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCompression) {
     { "bluestore_sync_submit_transaction", "true", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCompressionAlgorithm) {
@@ -5279,7 +5370,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixCompressionAlgorithm) {
     { "bluestore_default_buffered_write", "false", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixNoCsum) {
@@ -5299,7 +5390,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixNoCsum) {
     { "bluestore_sync_submit_transaction", "true", "false", 0 },
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixPreferDeferred) {
@@ -5316,7 +5407,7 @@ TEST_P(StoreTestSpecificAUSize, SyntheticMatrixPreferDeferred) {
     { "bluestore_prefer_deferred_size", "32768", "0", 0},
     { 0 },
   };
-  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticTest);
 }
 #endif // WITH_BLUESTORE
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4571,6 +4571,7 @@ public:
 
     if (srcoff > srcdata.length() - 1) {
       srcoff = srcdata.length() - 1;
+      dstoff = srcoff;
     }
     if (srcoff + len > srcdata.length()) {
       len = srcdata.length() - srcoff;

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -72,6 +72,7 @@ void StoreTestFixture::TearDown()
     int r = store->umount();
     EXPECT_EQ(0, r);
     rm_r(data_dir);
+    store.reset();
   }
   // we keep this stuff 'unsafe' out of test case scope to be able to update ANY
   // config settings. Hence setting it to 'unsafe' here as test case is closing.


### PR DESCRIPTION
This is extension of #49837.
We do not want a complicated modification of BlueStore to be unconditionally enabled.

Flag bluestore_elastic_shared_blob determines whether new shared blob handling is enabled.
This flag is used only on mkfs(), and gets reflected in superblock metadata variable "elastic_shared_blob".
There is no path to modify this flag after OSD is deployed.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
