### PR TITLE
cmake: fix WITH_SYSTEM_LIBURING and make uring available outside of src/blk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,8 @@ if(WITH_LIBURING)
     include(Builduring)
     build_uring()
   endif()
+  # enable uring in boost::asio
+  add_compile_definitions("BOOST_ASIO_HAS_IO_URING")
 endif()
 
 CMAKE_DEPENDENT_OPTION(WITH_BLUESTORE_PMEM "Enable PMDK libraries" OFF

--- a/cmake/modules/Finduring.cmake
+++ b/cmake/modules/Finduring.cmake
@@ -5,7 +5,7 @@
 # uring_FOUND - True if uring found.
 
 find_path(URING_INCLUDE_DIR liburing.h)
-find_library(URING_LIBRARIES liburing.a liburing)
+find_library(URING_LIBRARIES uring)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(uring DEFAULT_MSG URING_LIBRARIES URING_INCLUDE_DIR)

--- a/src/common/Graylog.h
+++ b/src/common/Graylog.h
@@ -4,7 +4,8 @@
 #ifndef __CEPH_LOG_GRAYLOG_H
 #define __CEPH_LOG_GRAYLOG_H
 
-#include <boost/asio.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
 
@@ -66,7 +67,7 @@ class Graylog
   std::string m_logger;
 
   boost::asio::ip::udp::endpoint m_endpoint;
-  boost::asio::io_service m_io_service;
+  boost::asio::io_context m_io_service;
 
   std::unique_ptr<Formatter> m_formatter;
   std::unique_ptr<Formatter> m_formatter_section;

--- a/src/common/async/bind_handler.h
+++ b/src/common/async/bind_handler.h
@@ -16,7 +16,8 @@
 #define CEPH_ASYNC_BIND_HANDLER_H
 
 #include <tuple>
-#include <boost/asio.hpp>
+#include <boost/asio/associated_allocator.hpp>
+#include <boost/asio/associated_executor.hpp>
 
 namespace ceph::async {
 

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -17,6 +17,8 @@
 
 #include <memory>
 
+#include <boost/asio/executor_work_guard.hpp>
+
 #include "bind_handler.h"
 #include "forward_handler.h"
 

--- a/src/common/async/forward_handler.h
+++ b/src/common/async/forward_handler.h
@@ -15,7 +15,8 @@
 #ifndef CEPH_ASYNC_FORWARD_HANDLER_H
 #define CEPH_ASYNC_FORWARD_HANDLER_H
 
-#include <boost/asio.hpp>
+#include <boost/asio/associated_allocator.hpp>
+#include <boost/asio/associated_executor.hpp>
 
 namespace ceph::async {
 

--- a/src/common/error_code.cc
+++ b/src/common/error_code.cc
@@ -15,6 +15,7 @@
 
 #include <exception>
 
+#include <boost/asio/error.hpp>
 #include "common/error_code.h"
 
 #pragma GCC diagnostic push

--- a/src/common/error_code.h
+++ b/src/common/error_code.h
@@ -18,8 +18,7 @@
 
 #include <netdb.h>
 
-#include <boost/system/error_code.hpp>
-#include <boost/asio.hpp>
+#include <boost/system.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -17,6 +17,12 @@
 #include <bitset>
 #include <netdb.h>
 #include <netinet/in.h>
+#ifdef _WIN32
+#include <ws2ipdef.h>
+#else
+#include <arpa/inet.h> // inet_pton()
+#include <net/if.h> // IFF_UP
+#endif
 #include <string>
 #include <string.h>
 #include <vector>

--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -1,5 +1,6 @@
 #include "DaemonMetricCollector.h"
 
+#include <boost/asio/io_context.hpp>
 #include <boost/json/src.hpp>
 #include <chrono>
 #include <filesystem>
@@ -43,7 +44,7 @@ void DaemonMetricCollector::request_loop(boost::asio::steady_timer &timer) {
 void DaemonMetricCollector::main() {
   // time to wait before sending requests again
 
-  boost::asio::io_service io;
+  boost::asio::io_context io;
   boost::asio::steady_timer timer{io, std::chrono::seconds(0)};
   request_loop(timer);
   io.run();

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/asio.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/json/object.hpp>
 #include <filesystem>
 #include <map>

--- a/src/exporter/http_server.cc
+++ b/src/exporter/http_server.cc
@@ -5,7 +5,7 @@
 #include "global/global_context.h"
 #include "exporter/DaemonMetricCollector.h"
 
-#include <boost/asio.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -24,7 +24,8 @@
 #include <type_traits>
 #include <variant>
 
-#include <boost/asio.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>

--- a/src/librbd/migration/FileStream.h
+++ b/src/librbd/migration/FileStream.h
@@ -8,7 +8,7 @@
 #include "librbd/migration/StreamInterface.h"
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/strand.hpp>
-#include <boost/asio/posix/basic_stream_descriptor.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
 #include <json_spirit/json_spirit.h>
 #include <memory>
 #include <string>

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include <iterator>
 #include <random>
+
+#include <boost/asio/post.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/copy.hpp>

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -22,6 +22,10 @@
 #include <string>
 #include <vector>
 
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/io_context_strand.hpp>
+#include <boost/asio/steady_timer.hpp>
+
 #include "msg/Messenger.h"
 
 #include "MonMap.h"

--- a/src/neorados/RADOSImpl.h
+++ b/src/neorados/RADOSImpl.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <string>
 
-#include <boost/asio.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #include "common/ceph_context.h"

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -27,7 +27,11 @@
 #include <variant>
 
 #include <boost/container/small_vector.hpp>
-#include <boost/asio.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/defer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/io_context_strand.hpp>
+#include <boost/asio/post.hpp>
 
 #include <fmt/format.h>
 

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -6,6 +6,9 @@
 #include "cls/lock/cls_lock_client.h"
 #include <memory>
 #include <boost/algorithm/hex.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/context/protected_fixedsize_stack.hpp>
 #include <spawn/spawn.hpp>
 #include "rgw_sal_rados.h"

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6,7 +6,6 @@
 #include <sstream>
 #include <string>
 
-#include <boost/asio.hpp>
 #include <boost/optional.hpp>
 
 extern "C" {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -6,7 +6,13 @@
 #include <thread>
 #include <vector>
 
-#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ip/v6_only.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
+
 #include <boost/intrusive/list.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -8,7 +8,7 @@
 #pragma push_macro("_ASSERT_H")
 #endif
 
-#include <boost/asio.hpp>
+#include <boost/asio/coroutine.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #ifdef NEED_ASSERT_H

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -16,7 +16,8 @@
 
 #include "common/async/completion.h"
 
-#include <boost/asio.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/io_context.hpp>
 #include "rgw_dmclock_scheduler.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 

--- a/src/test/common/test_async_completion.cc
+++ b/src/test/common/test_async_completion.cc
@@ -13,6 +13,8 @@
  */
 
 #include "common/async/completion.h"
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
 #include <optional>
 #include <boost/intrusive/list.hpp>
 #include <gtest/gtest.h>

--- a/src/test/common/test_async_shared_mutex.cc
+++ b/src/test/common/test_async_shared_mutex.cc
@@ -13,7 +13,10 @@
  */
 
 #include "common/async/shared_mutex.h"
+#include <future>
 #include <optional>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/io_context.hpp>
 #include <gtest/gtest.h>
 
 namespace ceph::async {

--- a/src/test/common/test_blocked_completion.cc
+++ b/src/test/common/test_blocked_completion.cc
@@ -13,7 +13,9 @@
  */
 
 
-#include <boost/asio.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <gtest/gtest.h>

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -22,6 +22,7 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <spawn/spawn.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/use_future.hpp>
 
 #define dout_subsys ceph_subsys_rados
@@ -74,7 +75,7 @@ librados::IoCtx AsioRados::snapio;
 
 TEST_F(AsioRados, AsyncReadCallback)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   auto success_cb = [&] (boost::system::error_code ec, bufferlist bl) {
     EXPECT_FALSE(ec);
@@ -92,7 +93,7 @@ TEST_F(AsioRados, AsyncReadCallback)
 
 TEST_F(AsioRados, AsyncReadFuture)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   std::future<bufferlist> f1 = librados::async_read(service, io, "exist", 256,
                                                     0, boost::asio::use_future);
@@ -110,7 +111,7 @@ TEST_F(AsioRados, AsyncReadFuture)
 
 TEST_F(AsioRados, AsyncReadYield)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   auto success_cr = [&] (spawn::yield_context yield) {
     boost::system::error_code ec;
@@ -132,7 +133,7 @@ TEST_F(AsioRados, AsyncReadYield)
 
 TEST_F(AsioRados, AsyncWriteCallback)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");
@@ -154,7 +155,7 @@ TEST_F(AsioRados, AsyncWriteCallback)
 
 TEST_F(AsioRados, AsyncWriteFuture)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");
@@ -172,7 +173,7 @@ TEST_F(AsioRados, AsyncWriteFuture)
 
 TEST_F(AsioRados, AsyncWriteYield)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");
@@ -199,7 +200,7 @@ TEST_F(AsioRados, AsyncWriteYield)
 
 TEST_F(AsioRados, AsyncReadOperationCallback)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
@@ -222,7 +223,7 @@ TEST_F(AsioRados, AsyncReadOperationCallback)
 
 TEST_F(AsioRados, AsyncReadOperationFuture)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
   std::future<bufferlist> f1;
   {
     librados::ObjectReadOperation op;
@@ -248,7 +249,7 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
 
 TEST_F(AsioRados, AsyncReadOperationYield)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   auto success_cr = [&] (spawn::yield_context yield) {
     librados::ObjectReadOperation op;
@@ -276,7 +277,7 @@ TEST_F(AsioRados, AsyncReadOperationYield)
 
 TEST_F(AsioRados, AsyncWriteOperationCallback)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");
@@ -302,7 +303,7 @@ TEST_F(AsioRados, AsyncWriteOperationCallback)
 
 TEST_F(AsioRados, AsyncWriteOperationFuture)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");
@@ -329,7 +330,7 @@ TEST_F(AsioRados, AsyncWriteOperationFuture)
 
 TEST_F(AsioRados, AsyncWriteOperationYield)
 {
-  boost::asio::io_service service;
+  boost::asio::io_context service;
 
   bufferlist bl;
   bl.append("hello");

--- a/src/test/neorados/completions.cc
+++ b/src/test/neorados/completions.cc
@@ -1,6 +1,4 @@
-#include <cassert>
-#include <boost/asio.hpp>
-#include <boost/system/system_error.hpp>
+#include <boost/asio/io_context.hpp>
 
 constexpr int max_completions = 10'000'000;
 int completed = 0;

--- a/src/test/neorados/start_stop.cc
+++ b/src/test/neorados/start_stop.cc
@@ -16,6 +16,8 @@
 #include <thread>
 #include <vector>
 
+#include <boost/asio/use_future.hpp>
+
 #include "include/neorados/RADOS.hpp"
 
 #include "common/async/context_pool.h"

--- a/src/test/rgw/bench_rgw_ratelimit.cc
+++ b/src/test/rgw/bench_rgw_ratelimit.cc
@@ -3,9 +3,10 @@
 #include "random"
 #include <cstdlib>
 #include <string>
-#include <boost/asio.hpp>
-#include <spawn/spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <spawn/spawn.hpp>
 #include <chrono>
 #include <mutex>
 #include <unordered_map>

--- a/src/test/rgw/test_rgw_throttle.cc
+++ b/src/test/rgw/test_rgw_throttle.cc
@@ -16,6 +16,10 @@
 
 #include <optional>
 #include <thread>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
 #include "include/scope_guard.h"
 
 #include <spawn/spawn.hpp>

--- a/src/tools/immutable_object_cache/CacheClient.cc
+++ b/src/tools/immutable_object_cache/CacheClient.cc
@@ -1,6 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/asio/error.hpp>
+#include <boost/asio/placeholders.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
 #include <boost/bind/bind.hpp>
 #include "CacheClient.h"
 #include "common/Cond.h"
@@ -25,8 +29,8 @@ namespace immutable_obj_cache {
         "immutable_object_cache_client_dedicated_thread_num");
 
     if (m_worker_thread_num != 0) {
-      m_worker = new boost::asio::io_service();
-      m_worker_io_service_work = new boost::asio::io_service::work(*m_worker);
+      m_worker = new boost::asio::io_context();
+      m_worker_io_service_work = new boost::asio::io_context::work(*m_worker);
       for (uint64_t i = 0; i < m_worker_thread_num; i++) {
         std::thread* thd = new std::thread([this](){m_worker->run();});
         m_worker_threads.push_back(thd);

--- a/src/tools/immutable_object_cache/CacheClient.h
+++ b/src/tools/immutable_object_cache/CacheClient.h
@@ -5,8 +5,8 @@
 #define CEPH_CACHE_CACHE_CLIENT_H
 
 #include <atomic>
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include "include/ceph_assert.h"
@@ -16,10 +16,10 @@
 #include "SocketCommon.h"
 
 
-using boost::asio::local::stream_protocol;
-
 namespace ceph {
 namespace immutable_obj_cache {
+
+using boost::asio::local::stream_protocol;
 
 class CacheClient {
  public:
@@ -57,17 +57,17 @@ class CacheClient {
 
  private:
   CephContext* m_cct;
-  boost::asio::io_service m_io_service;
-  boost::asio::io_service::work m_io_service_work;
+  boost::asio::io_context m_io_service;
+  boost::asio::io_context::work m_io_service_work;
   stream_protocol::socket m_dm_socket;
   stream_protocol::endpoint m_ep;
   std::shared_ptr<std::thread> m_io_thread;
   std::atomic<bool> m_session_work;
 
   uint64_t m_worker_thread_num;
-  boost::asio::io_service* m_worker;
+  boost::asio::io_context* m_worker;
   std::vector<std::thread*> m_worker_threads;
-  boost::asio::io_service::work* m_worker_io_service_work;
+  boost::asio::io_context::work* m_worker_io_service_work;
 
   std::atomic<bool> m_writing;
   std::atomic<bool> m_reading;

--- a/src/tools/immutable_object_cache/CacheServer.cc
+++ b/src/tools/immutable_object_cache/CacheServer.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/asio/error.hpp>
+#include <boost/asio/placeholders.hpp>
 #include <boost/bind/bind.hpp>
 #include "common/debug.h"
 #include "common/ceph_context.h"

--- a/src/tools/immutable_object_cache/CacheServer.h
+++ b/src/tools/immutable_object_cache/CacheServer.h
@@ -4,18 +4,18 @@
 #ifndef CEPH_CACHE_CACHE_SERVER_H
 #define CEPH_CACHE_CACHE_SERVER_H
 
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 
 #include "Types.h"
 #include "SocketCommon.h"
 #include "CacheSession.h"
 
 
-using boost::asio::local::stream_protocol;
-
 namespace ceph {
 namespace immutable_obj_cache {
+
+using boost::asio::local::stream_protocol;
 
 class CacheServer {
  public:
@@ -33,7 +33,7 @@ class CacheServer {
 
  private:
   CephContext* cct;
-  boost::asio::io_service m_io_service;
+  boost::asio::io_context m_io_service;
   ProcessMsg m_server_process_msg;
   stream_protocol::endpoint m_local_path;
   stream_protocol::acceptor m_acceptor;

--- a/src/tools/immutable_object_cache/CacheSession.cc
+++ b/src/tools/immutable_object_cache/CacheSession.cc
@@ -1,6 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/asio/error.hpp>
+#include <boost/asio/placeholders.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
 #include <boost/bind/bind.hpp>
 #include "common/debug.h"
 #include "common/ceph_context.h"
@@ -16,7 +20,7 @@
 namespace ceph {
 namespace immutable_obj_cache {
 
-CacheSession::CacheSession(io_service& io_service,
+CacheSession::CacheSession(io_context& io_service,
                            ProcessMsg processmsg,
                            CephContext* cct)
     : m_dm_socket(io_service),

--- a/src/tools/immutable_object_cache/CacheSession.h
+++ b/src/tools/immutable_object_cache/CacheSession.h
@@ -4,21 +4,21 @@
 #ifndef CEPH_CACHE_SESSION_H
 #define CEPH_CACHE_SESSION_H
 
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 
 #include "Types.h"
 #include "SocketCommon.h"
 
-using boost::asio::local::stream_protocol;
-using boost::asio::io_service;
-
 namespace ceph {
 namespace immutable_obj_cache {
 
+using boost::asio::local::stream_protocol;
+using boost::asio::io_context;
+
 class CacheSession : public std::enable_shared_from_this<CacheSession> {
  public:
-  CacheSession(io_service& io_service, ProcessMsg process_msg,
+  CacheSession(io_context& io_service, ProcessMsg process_msg,
                 CephContext* ctx);
   ~CacheSession();
   stream_protocol::socket& socket();

--- a/src/tools/neorados.cc
+++ b/src/tools/neorados.cc
@@ -23,7 +23,6 @@
 #include <tuple>
 #include <vector>
 
-#include <boost/asio.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/program_options.hpp>
 #include <boost/system/system_error.hpp>


### PR DESCRIPTION
this is preparation for the use of boost::asio's uring-based file abstractions in https://github.com/ceph/ceph/pull/50635

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
