### PR TITLE
crimson/os/seastore: avoid segment nonce collision

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1314,6 +1314,7 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
         if (tail.segment_nonce != header.segment_nonce) {
           return scan_no_tail_segment(header, segment_id);
         }
+        ceph_assert(header.get_type() == tail.get_type());
 
         sea_time_point modify_time = mod_to_timepoint(tail.modify_time);
         std::size_t num_extents = tail.num_extents;


### PR DESCRIPTION
In some extreme scenarios, the header of a segment might not be consistent with the tail, but their segment_nonce are same:

```
DEBUG 2023-04-03 17:41:25,990 [shard 0] seastore_cleaner - SegmentCleaner::mount: segment_id=Seg[Dev(0),10] -- segment_header_t(Seg[Dev(0),10] JOURNAL sseq(7) MD GEN_INL, dirty_tail=jseq(sseq(5), paddr<Seg[Dev(0),0],2531328>), alloc_tail=jseq(sseq(5), paddr<Seg[Dev(0),0],307200>), segment_nonce=2922274838)
DEBUG 2023-04-03 17:41:25,990 [shard 0] seastore_device - BlockSegmentManager::read: Seg[Dev(0),10] offset=67104768~4096 poffset=738201600 ...
TRACE 2023-04-03 17:41:25,990 [shard 0] seastore_device - block_do_read: Dev(0) poffset=738201600~4096 ...
TRACE 2023-04-03 17:41:25,991 [shard 0] seastore_device - block_do_read: Dev(0) poffset=738201600~4096 done
DEBUG 2023-04-03 17:41:25,991 [shard 0] seastore_journal - SegmentManagerGroup::read_segment_tail: segment Seg[Dev(0),10] bptr size 4096
DEBUG 2023-04-03 17:41:25,991 [shard 0] seastore_journal - SegmentManagerGroup::read_segment_tail: segment Seg[Dev(0),10] block crc 1165570917
DEBUG 2023-04-03 17:41:25,991 [shard 0] seastore_journal - SegmentManagerGroup::read_segment_tail: segment Seg[Dev(0),10] tail segment_tail_t(Seg[Dev(0),10] OOL sseq(7), segment_nonce=2922274838, modify_time=mod_tp(NULL), num_extents=0)
DEBUG 2023-04-03 17:41:25,991 [shard 0] seastore_cleaner - segments_info_t::init_closed: initiating Seg[Dev(0),10] JOURNAL sseq(7) MD GEN_INL, seg_info_t(state=EMPTY, Seg[Dev(0),10]), num_segments(empty=1352, opened=0, closed=7)
```

Using the highest bit of uint32_t to represent to segment type is helpful to avoid segment_nonce collision


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
