### PR TITLE
rgw/archive: avoid duplicating objects when syncing from multiple zones

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -740,7 +740,15 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
 
   rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
   rgw::sal::RadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
-    
+
+  rgw_obj stat_dest_obj;
+
+  if (!stat_follow_olh) {
+    stat_dest_obj = dest_obj.get_obj();
+  } else {
+    stat_dest_obj = src_obj;
+  }
+
   std::string etag;
 
   std::optional<uint64_t> bytes_transferred;
@@ -772,6 +780,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
                        NULL, /* void *progress_data*); */
                        dpp,
                        filter.get(),
+                       stat_follow_olh,
+                       stat_dest_obj,
                        source_trace_entry,
                        &zones_trace,
                        &bytes_transferred);

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1069,6 +1069,7 @@ class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
 
   bool copy_if_newer;
   std::shared_ptr<RGWFetchObjFilter> filter;
+  bool stat_follow_olh;
   rgw_zone_set_entry source_trace_entry;
   rgw_zone_set zones_trace;
   PerfCounters* counters;
@@ -1088,9 +1089,11 @@ public:
                          std::optional<uint64_t> _versioned_epoch,
                          bool _if_newer,
                          std::shared_ptr<RGWFetchObjFilter> _filter,
+                         bool _stat_follow_olh,
                          const rgw_zone_set_entry& source_trace_entry,
                          rgw_zone_set *_zones_trace,
-                         PerfCounters* counters, const DoutPrefixProvider *dpp)
+                         PerfCounters* counters,
+                         const DoutPrefixProvider *dpp)
     : RGWAsyncRadosRequest(caller, cn), store(_store),
       source_zone(_source_zone),
       user_id(_user_id),
@@ -1102,6 +1105,7 @@ public:
       versioned_epoch(_versioned_epoch),
       copy_if_newer(_if_newer),
       filter(_filter),
+      stat_follow_olh(_stat_follow_olh),
       source_trace_entry(source_trace_entry),
       counters(counters),
       dpp(dpp)
@@ -1135,6 +1139,7 @@ class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   std::shared_ptr<RGWFetchObjFilter> filter;
 
   RGWAsyncFetchRemoteObj *req;
+  bool stat_follow_olh;
   const rgw_zone_set_entry& source_trace_entry;
   rgw_zone_set *zones_trace;
   PerfCounters* counters;
@@ -1152,9 +1157,11 @@ public:
                       std::optional<uint64_t> _versioned_epoch,
                       bool _if_newer,
                       std::shared_ptr<RGWFetchObjFilter> _filter,
+                      bool _stat_follow_olh,
                       const rgw_zone_set_entry& source_trace_entry,
                       rgw_zone_set *_zones_trace,
-                      PerfCounters* counters, const DoutPrefixProvider *dpp)
+                      PerfCounters* counters,
+                      const DoutPrefixProvider *dpp)
     : RGWSimpleCoroutine(_store->ctx()), cct(_store->ctx()),
       async_rados(_async_rados), store(_store),
       source_zone(_source_zone),
@@ -1168,6 +1175,7 @@ public:
       copy_if_newer(_if_newer),
       filter(_filter),
       req(NULL),
+      stat_follow_olh(_stat_follow_olh),
       source_trace_entry(source_trace_entry),
       zones_trace(_zones_trace), counters(counters), dpp(dpp) {}
 
@@ -1185,9 +1193,9 @@ public:
 
   int send_request(const DoutPrefixProvider *dpp) override {
     req = new RGWAsyncFetchRemoteObj(this, stack->create_completion_notifier(), store,
-				     source_zone, user_id, src_bucket, dest_placement_rule, dest_bucket_info,
+    source_zone, user_id, src_bucket, dest_placement_rule, dest_bucket_info,
                                      key, dest_key, versioned_epoch, copy_if_newer, filter,
-                                     source_trace_entry, zones_trace, counters, dpp);
+                                     stat_follow_olh, source_trace_entry, zones_trace, counters, dpp);
     async_rados->queue(req);
     return 0;
   }

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2792,6 +2792,7 @@ class RGWObjFetchCR : public RGWCoroutine {
   rgw_obj_key& key;
   std::optional<rgw_obj_key> dest_key;
   std::optional<uint64_t> versioned_epoch;
+  bool stat_follow_olh;
   const rgw_zone_set_entry& source_trace_entry;
   rgw_zone_set *zones_trace;
 
@@ -2821,6 +2822,7 @@ public:
                 rgw_obj_key& _key,
                 std::optional<rgw_obj_key> _dest_key,
                 std::optional<uint64_t> _versioned_epoch,
+                bool _stat_follow_olh,
                 const rgw_zone_set_entry& source_trace_entry,
                 rgw_zone_set *_zones_trace) : RGWCoroutine(_sc->cct),
                                               sc(_sc), sync_env(_sc->env),
@@ -2828,6 +2830,7 @@ public:
                                               key(_key),
                                               dest_key(_dest_key),
                                               versioned_epoch(_versioned_epoch),
+                                              stat_follow_olh(_stat_follow_olh),
                                               source_trace_entry(source_trace_entry),
                                               zones_trace(_zones_trace) {
   }
@@ -2949,11 +2952,12 @@ public:
 
           call(new RGWFetchRemoteObjCR(sync_env->async_rados, sync_env->driver, sc->source_zone,
                                        nullopt,
-                                       sync_pipe.info.source_bs.bucket,
+                                       sync_pipe.source_bucket_info.bucket,
                                        std::nullopt, sync_pipe.dest_bucket_info,
                                        key, dest_key, versioned_epoch,
                                        true,
                                        std::static_pointer_cast<RGWFetchObjFilter>(filter),
+                                       stat_follow_olh,
                                        source_trace_entry, zones_trace,
                                        sync_env->counters, dpp));
         }
@@ -2981,7 +2985,8 @@ RGWCoroutine *RGWDefaultDataSyncModule::sync_object(const DoutPrefixProvider *dp
                                                     const rgw_zone_set_entry& source_trace_entry,
                                                     rgw_zone_set *zones_trace)
 {
-  return new RGWObjFetchCR(sc, sync_pipe, key, std::nullopt, versioned_epoch,
+  bool stat_follow_olh = false;
+  return new RGWObjFetchCR(sc, sync_pipe, key, std::nullopt, versioned_epoch, stat_follow_olh,
                            source_trace_entry, zones_trace);
 }
 
@@ -3058,10 +3063,16 @@ RGWCoroutine *RGWArchiveDataSyncModule::sync_object(const DoutPrefixProvider *dp
   }
 
   std::optional<rgw_obj_key> dest_key;
+  bool stat_follow_olh = false;
+
 
   if (versioned_epoch.value_or(0) == 0) { /* force version if not set */
+    stat_follow_olh = true;
     versioned_epoch = 0;
     dest_key = key;
+    if (key.instance.empty()) {
+      sync_env->driver->getRados()->gen_rand_obj_instance_name(&(*dest_key));
+    }
   }
 
   if (key.instance.empty()) {
@@ -3070,7 +3081,7 @@ RGWCoroutine *RGWArchiveDataSyncModule::sync_object(const DoutPrefixProvider *dp
   }
 
   return new RGWObjFetchCR(sc, sync_pipe, key, dest_key, versioned_epoch,
-                           source_trace_entry, zones_trace);
+                           stat_follow_olh, source_trace_entry, zones_trace);
 }
 
 RGWCoroutine *RGWArchiveDataSyncModule::remove_object(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3890,6 +3890,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                void *progress_data,
                const DoutPrefixProvider *dpp,
                RGWFetchObjFilter *filter,
+               bool stat_follow_olh,
+               const rgw_obj& stat_dest_obj,
                const rgw_zone_set_entry& source_trace_entry,
                rgw_zone_set *zones_trace,
                std::optional<uint64_t>* bytes_transferred)
@@ -3990,7 +3992,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   if (copy_if_newer) {
     /* need to get mtime for destination */
-    ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, dest_obj, &dest_state, &manifest, false, null_yield);
+    ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, null_yield);
     if (ret < 0)
       goto set_err_state;
 
@@ -4179,7 +4181,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     if (copy_if_newer && canceled) {
       ldpp_dout(dpp, 20) << "raced with another write of obj: " << dest_obj << dendl;
       obj_ctx.invalidate(dest_obj); /* object was overwritten */
-      ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, dest_obj, &dest_state, &manifest, false, null_yield);
+      ret = get_obj_state(dpp, &obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, null_yield);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": get_err_state() returned ret=" << ret << dendl;
         goto set_err_state;
@@ -4317,6 +4319,9 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   bool remote_src;
   bool remote_dest;
 
+  bool stat_follow_olh = false;
+  rgw_obj stat_dest_obj = dest_obj;
+
   append_rand_alpha(cct, dest_obj.get_oid(), shadow_oid, 32);
   shadow_obj.init_ns(dest_obj.bucket, shadow_oid, shadow_ns);
 
@@ -4340,7 +4345,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                unmod_ptr, high_precision_time,
                if_match, if_nomatch, attrs_mod, copy_if_newer, attrs, category,
                olh_epoch, delete_at, ptag, petag, progress_cb, progress_data, dpp,
-               nullptr /* filter */, source_trace_entry);
+               nullptr /* filter */, stat_follow_olh, stat_dest_obj, source_trace_entry);
   }
 
   map<string, bufferlist> src_attrs;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1138,6 +1138,8 @@ public:
                        void *progress_data,
                        const DoutPrefixProvider *dpp,
                        RGWFetchObjFilter *filter,
+                       bool stat_follow_olh,
+                       const rgw_obj& stat_dest_obj,
                        const rgw_zone_set_entry& source_trace_entry,
                        rgw_zone_set *zones_trace = nullptr,
                        std::optional<uint64_t>* bytes_transferred = 0);


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/59184


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
