### PR TITLE
qa/ceph_manager: preserve newline char at EOF in keyring

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1607,8 +1607,7 @@ class CephManager:
             client_id = client_id.replace('client.', '')
 
         keyring = self.run_cluster_cmd(args=f'auth get client.{client_id}',
-                                       stdout=StringIO()).\
-            stdout.getvalue().strip()
+                                       stdout=StringIO()).stdout.getvalue()
 
         assert isinstance(keyring, str) and keyring != ''
         return keyring

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -287,7 +287,7 @@ class XFSTestsDev(CephFSTestCase):
             ceph_fuse_bin_path = join(os_getcwd(), 'bin', 'ceph-fuse')
 
         keyring_path = self.mount_a.client_remote.mktemp(
-            data=self.fs.mon_manager.get_keyring('client.admin')+'\n')
+            data=self.fs.mon_manager.get_keyring('client.admin'))
 
         lastline = (f'export CEPHFS_MOUNT_OPTIONS="-m {mon_sock} -k '
                     f'{keyring_path} --client_mountpoint /{self.test_dirname}')


### PR DESCRIPTION
Lack of newline character at the end of keyring file makes CephFS mount
command end with error.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>