### PR TITLE
pacific: ceph-volume: fix issue with fast device allocs when there are multiple PVs per VG

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -114,16 +114,23 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
 
     ret = []
     vg_device_map = group_devices_by_vg(devices)
-    for vg_devices in vg_device_map.values():
+    for vg_name, vg_devices in vg_device_map.items():
         for dev in vg_devices:
             if not dev.available_lvm:
                 continue
             # any LV present is considered a taken slot
             occupied_slots = len(dev.lvs)
+            # prior to v15.2.8, db/wal deployments were grouping multiple fast devices into single VGs - we need to
+            # multiply requested_slots (per device) by the number of devices in the VG in order to ensure that
+            # abs_size is calculated correctly from vg_size
+            if vg_name == 'unused_devices':
+                slots_for_vg = requested_slots
+            else:
+                slots_for_vg = len(vg_devices) * requested_slots
             dev_size = dev.vg_size[0]
             # this only looks at the first vg on device, unsure if there is a better
             # way
-            abs_size = disk.Size(b=int(dev_size / requested_slots))
+            abs_size = disk.Size(b=int(dev_size / slots_for_vg))
             free_size = dev.vg_free[0]
             relative_size = int(abs_size) / dev_size
             if requested_size:
@@ -149,7 +156,6 @@ def group_devices_by_vg(devices):
     result['unused_devices'] = []
     for dev in devices:
         if len(dev.vgs) > 0:
-            # already using assumption that a PV only belongs to single VG in other places
             vg_name = dev.vgs[0].name
             if vg_name in result:
                 result[vg_name].append(dev)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -71,11 +71,15 @@ def mock_device():
     dev.lvs = []
     return dev
 
-@pytest.fixture(params=range(1,3))
+@pytest.fixture(params=range(1,4))
 def mock_devices_available(request):
     ret = []
-    for _ in range(request.param):
-        ret.append(mock_device())
+    for n in range(request.param):
+        dev = mock_device()
+        # after v15.2.8, a single VG is created for each PV
+        dev.vg_name = f'vg_foo_{n}'
+        dev.vgs = [lvm.VolumeGroup(vg_name=dev.vg_name, lv_name=dev.lv_name)]
+        ret.append(dev)
     return ret
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -5,6 +5,7 @@ import random
 from argparse import ArgumentError
 from mock import MagicMock, patch
 
+from ceph_volume.api import lvm
 from ceph_volume.devices.lvm import batch
 from ceph_volume.util import arg_validators
 
@@ -225,6 +226,47 @@ class TestBatch(object):
                                               'block_db', 2, 2, args)
         for fast, dev in zip(fasts, mock_devices_available):
             assert fast[2] == int(dev.vg_size[0] / 2)
+
+    def test_get_physical_fast_allocs_abs_size_unused_devs(self, factory,
+                                               conf_ceph_stub,
+                                               mock_devices_available):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        args = factory(block_db_slots=None, get_block_db_size=None)
+        dev_size = 21474836480
+        vg_size = dev_size
+        for dev in mock_devices_available:
+            dev.vg_name = None
+            dev.vg_size = [vg_size]
+            dev.vg_free = dev.vg_size
+            dev.vgs = []
+        slots_per_device = 2
+        fasts = batch.get_physical_fast_allocs(mock_devices_available,
+                                              'block_db', slots_per_device, 2, args)
+        expected_slot_size = int(dev_size / slots_per_device)
+        for (_, _, slot_size, _) in fasts:
+            assert slot_size == expected_slot_size
+
+    def test_get_physical_fast_allocs_abs_size_multi_pvs_per_vg(self, factory,
+                                               conf_ceph_stub,
+                                               mock_devices_available):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        args = factory(block_db_slots=None, get_block_db_size=None)
+        dev_size = 21474836480
+        num_devices = len(mock_devices_available)
+        vg_size = dev_size * num_devices
+        vg_name = 'vg_foo'
+        for dev in mock_devices_available:
+            dev.vg_name = vg_name
+            dev.vg_size = [vg_size]
+            dev.vg_free = dev.vg_size
+            dev.vgs = [lvm.VolumeGroup(vg_name=dev.vg_name, lv_name=dev.lv_name)]
+        slots_per_device = 2
+        slots_per_vg = slots_per_device * num_devices
+        fasts = batch.get_physical_fast_allocs(mock_devices_available,
+                                              'block_db', slots_per_device, 2, args)
+        expected_slot_size = int(vg_size / slots_per_vg)
+        for (_, _, slot_size, _) in fasts:
+            assert slot_size == expected_slot_size
 
     def test_batch_fast_allocations_one_block_db_length(self, factory, conf_ceph_stub,
                                                   mock_lv_device_generator):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59311

---

backport of https://github.com/ceph/ceph/pull/50279
parent tracker: https://tracker.ceph.com/issues/58857

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh