### PR TITLE
qa/cephfs: improvements in caps_helper

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -119,7 +119,10 @@ class CapTester:
     run_mon_cap_tests() or run_mds_cap_tests() as per the need.
     """
 
-    def write_test_files(self, mounts, testpath=''):
+    def __init__(self, mount=None, path=''):
+        self._create_test_files(mount, path)
+
+    def _create_test_files(self, mount, path):
         """
         Exercising 'r' and 'w' access levels on a file on CephFS mount is
         pretty routine across all tests for caps. Adding to method to write
@@ -129,39 +132,47 @@ class CapTester:
         at the path passed in testpath for the given list of mounts. If
         testpath is empty, the file is created at the root of the CephFS.
         """
-        dirname, filename = 'testdir', 'testfile'
-        self.test_set = []
-        # XXX: The reason behind testpath[1:] below is that the testpath is
+        # CephFS mount where read/write test will be conducted.
+        self.mount = mount
+        # Path where out test file located.
+        self.path = self._gen_test_file_path(path)
+        # Data that out test file will contain.
+        self.data = self._gen_test_file_data()
+
+        self.mount.write_file(self.path, self.data)
+        log.info(f'Test file has been created on FS '
+                 f'"{self.mount.cephfs_name}" at path "{self.path}" with the '
+                 f'following data -\n{self.data}')
+
+    def _gen_test_file_path(self, path=''):
+        # XXX: The reason behind path[1:] below is that the path is
         # supposed to contain a path inside CephFS (which might be passed as
         # an absolute path). os.path.join() deletes all previous path
         # components when it encounters a path component starting with '/'.
-        # Deleting the first '/' from the string in testpath ensures that
+        # Deleting the first '/' from the string in path ensures that
         # previous path components are not deleted by os.path.join().
-        if testpath:
-            testpath = testpath[1:] if testpath[0] == '/' else testpath
-        # XXX: passing just '/' screw up os.path.join() ahead.
-        if testpath == '/':
-            testpath = ''
+        if path:
+            path = path[1:] if path[0] == '/' else path
+        # XXX: passing just '/' messes up os.path.join() ahead.
+        if path == '/':
+            path = ''
 
-        for mount_x in mounts:
-            log.info(f'creating test file on FS {mount_x.cephfs_name} '
-                     f'mounted at {mount_x.mountpoint}...')
-            dirpath = os_path_join(mount_x.hostfs_mntpt, testpath, dirname)
-            mount_x.run_shell(f'mkdir {dirpath}')
-            filepath = os_path_join(dirpath, filename)
-            # XXX: the reason behind adding filepathm, cephfs_name and both
-            # mntpts is to avoid a test bug where we mount cephfs1 but what
-            # ends up being mounted cephfs2. since filepath and filedata are
-            # identical, how would tests figure otherwise that they are
-            # accessing the right filename but on wrong CephFS.
-            filedata = (f'filepath = {filepath}\n'
-                        f'cephfs_name = {mount_x.cephfs_name}\n'
-                        f'cephfs_mntpt = {mount_x.cephfs_mntpt}\n'
-                        f'hostfs_mntpt = {mount_x.hostfs_mntpt}')
-            mount_x.write_file(filepath, filedata)
-            self.test_set.append([mount_x, filepath, filedata])
-            log.info(f'Test file created at "{filepath}" with the following '
-                     f'data -\n"{filedata}"')
+        dirname, filename = 'testdir', 'testfile'
+        dirpath = os_path_join(self.mount.hostfs_mntpt, path, dirname)
+        self.mount.run_shell(f'mkdir {dirpath}')
+        return os_path_join(dirpath, filename)
+
+    def _gen_test_file_data(self):
+        # XXX: the reason behind adding path, cephfs_name and both
+        # mntpts is to avoid a test bug where we mount cephfs1 but what
+        # ends up being mounted cephfs2. since self.path and self.data are
+        # identical, how would tests figure otherwise that they are
+        # accessing the right filename but on wrong CephFS.
+        return dedent(f'''\
+            self.path = {self.path}
+            cephfs_name = {self.mount.cephfs_name}
+            cephfs_mntpt = {self.mount.cephfs_mntpt}
+            hostfs_mntpt = {self.mount.hostfs_mntpt}''')
 
     def run_cap_tests(self, perm, mntpt=None):
         # TODO
@@ -235,15 +246,17 @@ class CapTester:
         Run test for read perm and, for write perm, run positive test if it
         is present and run negative test if not.
         """
-        # XXX: mntpt is path inside cephfs that serves as root for current
-        # mount. Therefore, this path must me deleted from self.filepaths.
-        # Example -
-        #   orignal path: /mnt/cephfs_x/dir1/dir2/testdir
-        #   cephfs dir serving as root for current mnt: /dir1/dir2
-        #   therefore, final path: /mnt/cephfs_x/testdir
         if mntpt:
-            self.test_set = [(x, y.replace(mntpt, ''), z) for x, y, z in \
-                             self.test_set]
+            # beacaue we want to value of mntpt from test_set.path along with
+            # slash that precedes it.
+            mntpt = '/' + mntpt if mntpt[0] != '/' else mntpt
+            # XXX: mntpt is path inside cephfs that serves as root for current
+            # mount. Therefore, this path must me deleted from self.path.
+            # Example -
+            #   orignal path: /mnt/cephfs_x/dir1/dir2/testdir
+            #   cephfs dir serving as root for current mnt: /dir1/dir2
+            #   therefore, final path: /mnt/cephfs_x/testdir
+            self.path = self.path.replace(mntpt, '')
 
         self.conduct_pos_test_for_read_caps()
 
@@ -255,23 +268,22 @@ class CapTester:
             raise RuntimeError(f'perm = {perm}\nIt should be "r" or "rw".')
 
     def conduct_pos_test_for_read_caps(self):
-        for mount, path, data in self.test_set:
-            log.info(f'test read perm: read file {path} and expect data '
-                     f'"{data}"')
-            contents = mount.read_file(path)
-            assert_equal(data, contents)
-            log.info(f'read perm was tested successfully: "{data}" was '
-                     f'successfully read from path {path}')
+        log.info(f'test read perm: read file {self.path} and expect data '
+                 f'"{self.data}"')
+        contents = self.mount.read_file(self.path)
+        assert_equal(self.data, contents)
+        log.info(f'read perm was tested successfully: "{self.data}" was '
+                 f'successfully read from path {self.path}')
 
     def conduct_pos_test_for_write_caps(self):
-        for mount, path, data in self.test_set:
-            log.info(f'test write perm: try writing data "{data}" to '
-                     f'file {path}.')
-            mount.write_file(path=path, data=data)
-            contents = mount.read_file(path=path)
-            assert_equal(data, contents)
-            log.info(f'write perm was tested was successfully: data '
-                     f'"{data}" was successfully written to file "{path}".')
+        log.info(f'test write perm: try writing data "{self.data}" to '
+                 f'file {self.path}.')
+        self.mount.write_file(path=self.path, data=self.data)
+        contents = self.mount.read_file(path=self.path)
+        assert_equal(self.data, contents)
+        log.info(f'write perm was tested was successfully: self.data '
+                 f'"{self.data}" was successfully written to file '
+                 f'"{self.path}".')
 
     def conduct_neg_test_for_write_caps(self, sudo_write=False):
         possible_errmsgs = ('permission denied', 'operation not permitted')
@@ -279,11 +291,10 @@ class CapTester:
         cmdargs += ['sudo', 'tee'] if sudo_write else ['tee']
 
         # don't use data, cmd args to write are set already above.
-        for mount, path, data in self.test_set:
-            log.info('test absence of write perm: expect failure '
-                     f'writing data to file {path}.')
-            cmdargs.append(path)
-            mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
-            cmdargs.pop(-1)
-            log.info('absence of write perm was tested successfully: '
-                     f'failed to be write data to file {path}.')
+        log.info('test absence of write perm: expect failure '
+                 f'writing data to file {self.path}.')
+        cmdargs.append(self.path)
+        self.mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
+        cmdargs.pop(-1)
+        log.info('absence of write perm was tested successfully: '
+                 f'failed to be write data to file {self.path}.')

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -88,6 +88,41 @@ def gen_mds_cap_str(caps):
     return mds_cap
 
 
+def get_mon_cap_from_keyring(keyring):
+    '''
+    Extract MON cap for keyring and return it.
+    '''
+    moncap = None
+    for line in keyring.split('\n'):
+        if 'caps mon' in line:
+            moncap = line[line.find(' = "') + 4 : -1]
+            break
+    else:
+        raise RuntimeError('mon cap not found in keyring below -\n{keyring}')
+    return moncap
+
+
+def get_fsnames_from_moncap(moncap):
+    '''
+    Extract FS names from MON cap and return all of them.
+    '''
+    fsnames = []
+    while moncap.find('fsname=') != -1:
+        fsname_first_char = moncap.index('fsname=') + len('fsname=')
+
+        if ',' in moncap:
+            last = moncap.index(',')
+            fsname = moncap[fsname_first_char : last]
+            moncap = moncap.replace(moncap[0 : last+1], '')
+        else:
+            fsname = moncap[fsname_first_char : ]
+            moncap = moncap.replace(moncap[0 : ], '')
+
+        fsnames.append(fsname)
+
+    return fsnames
+
+
 def assert_equal(first, second):
     msg = f'Variables are not equal.\nfirst = {first}\nsecond = {second}'
     assert first == second, msg
@@ -179,34 +214,6 @@ class CapTester:
         #self.run_mon_cap_tests()
         self.run_mds_cap_tests(perm, mntpt=mntpt)
 
-    def _get_fsnames_from_moncap(self, moncap):
-        fsnames = []
-        while moncap.find('fsname=') != -1:
-            fsname_first_char = moncap.index('fsname=') + len('fsname=')
-
-            if ',' in moncap:
-                last = moncap.index(',')
-                fsname = moncap[fsname_first_char : last]
-                moncap = moncap.replace(moncap[0 : last+1], '')
-            else:
-                fsname = moncap[fsname_first_char : ]
-                moncap = moncap.replace(moncap[0 : ], '')
-
-            fsnames.append(fsname)
-
-        return fsnames
-
-    def _get_mon_cap_from_keyring(self, keyring):
-        moncap = None
-        for line in keyring.split('\n'):
-            if 'caps mon' in line:
-                moncap = line[line.find(' = "') + 4 : -1]
-                break
-        else:
-            raise RuntimeError('run_mon_cap_tests(): mon cap not found in '
-                               'keyring. keyring -\n' + keyring)
-        return moncap
-
     def run_mon_cap_tests(self, fs, client_id):
         """
         Check that MON cap is enforced for a client by searching for a Ceph
@@ -216,14 +223,14 @@ class CapTester:
         """
         get_cluster_cmd_op = fs.mon_manager.raw_cluster_cmd
         keyring = get_cluster_cmd_op(args=f'auth get client.{client_id}')
-        moncap = self._get_mon_cap_from_keyring(keyring)
+        moncap = get_mon_cap_from_keyring(keyring)
         keyring_path = fs.admin_remote.mktemp(data=keyring)
 
         fsls = get_cluster_cmd_op(
             args=f'fs ls --id {client_id} -k {keyring_path}')
         log.info(f'output of fs ls cmd run by client.{client_id} -\n{fsls}')
 
-        fsnames = self._get_fsnames_from_moncap(moncap)
+        fsnames = get_fsnames_from_moncap(moncap)
         if fsnames == []:
             log.info('no FS name is mentioned in moncap, client has '
                      'permission to list all files. moncap -\n{moncap}')

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -209,9 +209,8 @@ class CapTester:
             cephfs_mntpt = {self.mount.cephfs_mntpt}
             hostfs_mntpt = {self.mount.hostfs_mntpt}''')
 
-    def run_cap_tests(self, perm, mntpt=None):
-        # TODO
-        #self.run_mon_cap_tests()
+    def run_cap_tests(self, fs, client_id, perm, mntpt=None):
+        self.run_mon_cap_tests(fs, client_id)
         self.run_mds_cap_tests(perm, mntpt=mntpt)
 
     def run_mon_cap_tests(self, fs, client_id):

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -144,7 +144,7 @@ class CapTester(CephFSTestCase):
                         f'cephfs_mntpt = {mount_x.cephfs_mntpt}\n'
                         f'hostfs_mntpt = {mount_x.hostfs_mntpt}')
             mount_x.write_file(filepath, filedata)
-            self.test_set.append((mount_x, filepath, filedata))
+            self.test_set.append([mount_x, filepath, filedata])
             log.info(f'Test file created at "{filepath}" with the following '
                      f'data -\n"{filedata}"')
 

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -139,19 +139,53 @@ def assert_in(member, container):
     assert member in container, msg
 
 
-class CapTester:
+class MonCapTester:
+    '''
+    Tested that MON caps are enforced on client by checking if the name of
+    CephFS, which client is authorized for, is listed in output of commmand
+    "ceph fs ls".
+
+    USAGE: Create object of this class at the beginning of the test method
+    and when MON cap needs to be tested, call the method run_mon_cap_tests().
+    '''
+
+    def run_mon_cap_tests(self, fs, client_id):
+        """
+        Check that MON cap is enforced for a client by searching for a Ceph
+        FS name in output of cmd "fs ls" executed with that client's caps.
+
+        fs is any fs object so that ceph commands can be exceuted.
+        """
+        get_cluster_cmd_op = fs.mon_manager.raw_cluster_cmd
+        keyring = get_cluster_cmd_op(args=f'auth get client.{client_id}')
+        moncap = get_mon_cap_from_keyring(keyring)
+        keyring_path = fs.admin_remote.mktemp(data=keyring)
+
+        fsls = get_cluster_cmd_op(
+            args=f'fs ls --id {client_id} -k {keyring_path}')
+        log.info(f'output of fs ls cmd run by client.{client_id} -\n{fsls}')
+
+        fsnames = get_fsnames_from_moncap(moncap)
+        if fsnames == []:
+            log.info('no FS name is mentioned in moncap, client has '
+                     'permission to list all files. moncap -\n{moncap}')
+            return
+
+        log.info('FS names are mentioned in moncap. moncap -\n{moncap}')
+        log.info('testing for presence of these FS names in output of '
+                 '"fs ls" command run by client.')
+        for fsname in fsnames:
+            fsname_cap_str = f'name: {fsname}'
+            assert_in(fsname_cap_str, fsls)
+
+
+class MdsCapTester:
     """
-    Test that MON and MDS caps are enforced.
+    Test that MDS caps are enforced on the client by exercising read-write
+    permissions.
 
-    MDS caps are tested by exercising read-write permissions and MON caps are
-    tested using output of command "ceph fs ls". Besides, it provides
-    write_test_files() which creates test files at the given path on CephFS
-    mounts passed to it.
-
-    USAGE: Call write_test_files() method at the beginning of the test and
-    once the caps that needs to be tested are assigned to the client and
-    CephFS be remount for caps to effective, call run_cap_tests(),
-    run_mon_cap_tests() or run_mds_cap_tests() as per the need.
+    USAGE: Create object of this class at the beginning of the test method
+    and when MDS cap needs to be tested, call the method run_mds_cap_tests().
     """
 
     def __init__(self, mount=None, path=''):
@@ -208,39 +242,6 @@ class CapTester:
             cephfs_name = {self.mount.cephfs_name}
             cephfs_mntpt = {self.mount.cephfs_mntpt}
             hostfs_mntpt = {self.mount.hostfs_mntpt}''')
-
-    def run_cap_tests(self, fs, client_id, perm, mntpt=None):
-        self.run_mon_cap_tests(fs, client_id)
-        self.run_mds_cap_tests(perm, mntpt=mntpt)
-
-    def run_mon_cap_tests(self, fs, client_id):
-        """
-        Check that MON cap is enforced for a client by searching for a Ceph
-        FS name in output of cmd "fs ls" executed with that client's caps.
-
-        fs is any fs object so that ceph commands can be exceuted.
-        """
-        get_cluster_cmd_op = fs.mon_manager.raw_cluster_cmd
-        keyring = get_cluster_cmd_op(args=f'auth get client.{client_id}')
-        moncap = get_mon_cap_from_keyring(keyring)
-        keyring_path = fs.admin_remote.mktemp(data=keyring)
-
-        fsls = get_cluster_cmd_op(
-            args=f'fs ls --id {client_id} -k {keyring_path}')
-        log.info(f'output of fs ls cmd run by client.{client_id} -\n{fsls}')
-
-        fsnames = get_fsnames_from_moncap(moncap)
-        if fsnames == []:
-            log.info('no FS name is mentioned in moncap, client has '
-                     'permission to list all files. moncap -\n{moncap}')
-            return
-
-        log.info('FS names are mentioned in moncap. moncap -\n{moncap}')
-        log.info('testing for presence of these FS names in output of '
-                 '"fs ls" command run by client.')
-        for fsname in fsnames:
-            fsname_cap_str = f'name: {fsname}'
-            assert_in(fsname_cap_str, fsls)
 
     def run_mds_cap_tests(self, perm, mntpt=None):
         """
@@ -299,3 +300,22 @@ class CapTester:
         cmdargs.pop(-1)
         log.info('absence of write perm was tested successfully: '
                  f'failed to be write data to file {self.path}.')
+
+
+class CapTester(MonCapTester, MdsCapTester):
+    '''
+    Test MON caps as well as MDS caps. For usage see docstrings of class
+    MDSCapTester.
+
+    USAGE: Create object of this class at the beginning of the test method
+    and when MON and MDS cap needs to be tested, call the method
+    run_cap_tests().
+    '''
+
+    def __init__(self, mount=None, path='', create_test_files=True):
+        if create_test_files:
+            self._create_test_files(mount, path)
+
+    def run_cap_tests(self, fs, client_id, perm, mntpt=None):
+        self.run_mon_cap_tests(fs, client_id)
+        self.run_mds_cap_tests(perm, mntpt)

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -196,17 +196,7 @@ class CapTester:
 
         return fsnames
 
-    def run_mon_cap_tests(self, def_fs, client_id):
-        """
-        Check that MON cap is enforced for a client by searching for a Ceph
-        FS name in output of cmd "fs ls" executed with that client's caps.
-
-        def_fs stands for default FS on Ceph cluster.
-        """
-        get_cluster_cmd_op = def_fs.mon_manager.raw_cluster_cmd
-
-        keyring = get_cluster_cmd_op(args=f'auth get client.{client_id}')
-
+    def _get_mon_cap_from_keyring(self, keyring):
         moncap = None
         for line in keyring.split('\n'):
             if 'caps mon' in line:
@@ -215,29 +205,34 @@ class CapTester:
         else:
             raise RuntimeError('run_mon_cap_tests(): mon cap not found in '
                                'keyring. keyring -\n' + keyring)
+        return moncap
 
-        keyring_path = def_fs.admin_remote.mktemp(data=keyring)
+    def run_mon_cap_tests(self, fs, client_id):
+        """
+        Check that MON cap is enforced for a client by searching for a Ceph
+        FS name in output of cmd "fs ls" executed with that client's caps.
+
+        fs is any fs object so that ceph commands can be exceuted.
+        """
+        get_cluster_cmd_op = fs.mon_manager.raw_cluster_cmd
+        keyring = get_cluster_cmd_op(args=f'auth get client.{client_id}')
+        moncap = self._get_mon_cap_from_keyring(keyring)
+        keyring_path = fs.admin_remote.mktemp(data=keyring)
 
         fsls = get_cluster_cmd_op(
             args=f'fs ls --id {client_id} -k {keyring_path}')
         log.info(f'output of fs ls cmd run by client.{client_id} -\n{fsls}')
 
-        if 'fsname=' not in moncap:
+        fsnames = self._get_fsnames_from_moncap(moncap)
+        if fsnames == []:
             log.info('no FS name is mentioned in moncap, client has '
                      'permission to list all files. moncap -\n{moncap}')
-            log.info('testing for presence of all FS names in output of '
-                     '"fs ls" command run by client.')
-
-            fsls_admin = get_cluster_cmd_op(args='fs ls')
-            log.info('output of fs ls cmd run by admin -\n{fsls_admin}')
-
-            assert_equal(fsls, fsls_admin)
             return
 
         log.info('FS names are mentioned in moncap. moncap -\n{moncap}')
         log.info('testing for presence of these FS names in output of '
                  '"fs ls" command run by client.')
-        for fsname in self._get_fsnames_from_moncap(moncap):
+        for fsname in fsnames:
             fsname_cap_str = f'name: {fsname}'
             assert_in(fsname_cap_str, fsls)
 

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -3,8 +3,7 @@ Helper methods to test that MON and MDS caps are enforced properly.
 """
 from os.path import join as os_path_join
 from logging import getLogger
-
-from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from textwrap import dedent
 
 from teuthology.orchestra.run import Raw
 
@@ -89,7 +88,23 @@ def gen_mds_cap_str(caps):
     return mds_cap
 
 
-class CapTester(CephFSTestCase):
+def assert_equal(first, second):
+    msg = f'Variables are not equal.\nfirst = {first}\nsecond = {second}'
+    assert first == second, msg
+
+
+def assert_in(member, container):
+    msg = dedent(f'''
+        First value is absent in second value.
+        First value -
+        {member}
+        Second value -
+        {container}
+        ''')
+    assert member in container, msg
+
+
+class CapTester:
     """
     Test that MON and MDS caps are enforced.
 
@@ -205,14 +220,15 @@ class CapTester(CephFSTestCase):
             fsls_admin = get_cluster_cmd_op(args='fs ls')
             log.info('output of fs ls cmd run by admin -\n{fsls_admin}')
 
-            self.assertEqual(fsls, fsls_admin)
+            assert_equal(fsls, fsls_admin)
             return
 
         log.info('FS names are mentioned in moncap. moncap -\n{moncap}')
         log.info('testing for presence of these FS names in output of '
                  '"fs ls" command run by client.')
         for fsname in self._get_fsnames_from_moncap(moncap):
-            self.assertIn('name: ' + fsname, fsls)
+            fsname_cap_str = f'name: {fsname}'
+            assert_in(fsname_cap_str, fsls)
 
     def run_mds_cap_tests(self, perm, mntpt=None):
         """
@@ -243,7 +259,7 @@ class CapTester(CephFSTestCase):
             log.info(f'test read perm: read file {path} and expect data '
                      f'"{data}"')
             contents = mount.read_file(path)
-            self.assertEqual(data, contents)
+            assert_equal(data, contents)
             log.info(f'read perm was tested successfully: "{data}" was '
                      f'successfully read from path {path}')
 
@@ -253,7 +269,7 @@ class CapTester(CephFSTestCase):
                      f'file {path}.')
             mount.write_file(path=path, data=data)
             contents = mount.read_file(path=path)
-            self.assertEqual(data, contents)
+            assert_equal(data, contents)
             log.info(f'write perm was tested was successfully: data '
                      f'"{data}" was successfully written to file "{path}".')
 

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1206,27 +1206,30 @@ class TestFsAuthorize(CephFSTestCase):
     def test_single_path_r(self):
         PERM = 'r'
         FS_AUTH_CAPS = (('/', PERM),)
-        self.captester = CapTester()
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captester = CapTester(self.mount_a, '/')
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
+        self._remount(keyring)
         self.captester.run_mon_cap_tests(self.fs, self.client_id)
         self.captester.run_mds_cap_tests(PERM)
 
     def test_single_path_rw(self):
         PERM = 'rw'
         FS_AUTH_CAPS = (('/', PERM),)
-        self.captester = CapTester()
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captester = CapTester(self.mount_a, '/')
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
+        self._remount(keyring)
         self.captester.run_mon_cap_tests(self.fs, self.client_id)
         self.captester.run_mds_cap_tests(PERM)
 
     def test_single_path_rootsquash(self):
         PERM = 'rw'
         FS_AUTH_CAPS = (('/', PERM, 'root_squash'),)
-        self.captester = CapTester()
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captester = CapTester(self.mount_a, '/')
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
+        self._remount(keyring)
         # testing MDS caps...
         # Since root_squash is set in client caps, client can read but not
         # write even thought access level is set to "rw".
@@ -1250,8 +1253,10 @@ class TestFsAuthorize(CephFSTestCase):
         self.mount_a.remount(cephfs_name=self.fs.name)
         PERM = 'rw'
         FS_AUTH_CAPS = (('/', PERM),)
-        self.captester = CapTester()
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captester = CapTester(self.mount_a, '/')
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
+
+        self._remount(keyring)
         self.captester.run_mds_cap_tests(PERM)
 
     def test_multiple_path_r(self):
@@ -1259,23 +1264,24 @@ class TestFsAuthorize(CephFSTestCase):
         FS_AUTH_CAPS = (('/dir1/dir12', PERM), ('/dir2/dir22', PERM))
         for c in FS_AUTH_CAPS:
             self.mount_a.run_shell(f'mkdir -p .{c[0]}')
-        self.captesters = (CapTester(), CapTester())
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captesters = (CapTester(self.mount_a, '/dir1/dir12'),
+                           CapTester(self.mount_a, '/dir2/dir22'))
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
-        self.run_cap_test_one_by_one(FS_AUTH_CAPS)
+        self._remount_and_run_tests(FS_AUTH_CAPS, keyring)
 
     def test_multiple_path_rw(self):
         PERM = 'rw'
         FS_AUTH_CAPS = (('/dir1/dir12', PERM), ('/dir2/dir22', PERM))
         for c in FS_AUTH_CAPS:
             self.mount_a.run_shell(f'mkdir -p .{c[0]}')
-        self.captesters = (CapTester(), CapTester())
-        self.setup_test_env(FS_AUTH_CAPS)
+        self.captesters = (CapTester(self.mount_a, '/dir1/dir12'),
+                           CapTester(self.mount_a, '/dir2/dir22'))
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
-        self.run_cap_test_one_by_one(FS_AUTH_CAPS)
+        self._remount_and_run_tests(FS_AUTH_CAPS, keyring)
 
-    def run_cap_test_one_by_one(self, fs_auth_caps):
-        keyring = self.run_cluster_cmd(f'auth get {self.client_name}')
+    def _remount_and_run_tests(self, fs_auth_caps, keyring):
         for i, c in enumerate(fs_auth_caps):
             self.assertIn(i, (0, 1))
             PATH = c[0]
@@ -1296,24 +1302,6 @@ class TestFsAuthorize(CephFSTestCase):
         self.mount_a.remount(client_id=self.client_id,
                              client_keyring_path=keyring_path,
                              cephfs_mntpt=path)
-
-    def setup_for_single_path(self, fs_auth_caps):
-        self.captester.write_test_files((self.mount_a,), '/')
-        keyring = self.fs.authorize(self.client_id, fs_auth_caps)
-        self._remount(keyring)
-
-    def setup_for_multiple_paths(self, fs_auth_caps):
-        for i, c in enumerate(fs_auth_caps):
-            PATH = c[0]
-            self.captesters[i].write_test_files((self.mount_a,), PATH)
-
-        self.fs.authorize(self.client_id, fs_auth_caps)
-
-    def setup_test_env(self, fs_auth_caps):
-        if len(fs_auth_caps) == 1:
-            self.setup_for_single_path(fs_auth_caps[0])
-        else:
-            self.setup_for_multiple_paths(fs_auth_caps)
 
 
 class TestAdminCommandIdempotency(CephFSTestCase):

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1210,8 +1210,7 @@ class TestFsAuthorize(CephFSTestCase):
         keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
         self._remount(keyring)
-        self.captester.run_mon_cap_tests(self.fs, self.client_id)
-        self.captester.run_mds_cap_tests(PERM)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
 
     def test_single_path_rw(self):
         PERM = 'rw'
@@ -1220,8 +1219,7 @@ class TestFsAuthorize(CephFSTestCase):
         keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
 
         self._remount(keyring)
-        self.captester.run_mon_cap_tests(self.fs, self.client_id)
-        self.captester.run_mds_cap_tests(PERM)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
 
     def test_single_path_rootsquash(self):
         PERM = 'rw'
@@ -1288,8 +1286,8 @@ class TestFsAuthorize(CephFSTestCase):
             PERM = c[1]
             self._remount(keyring, PATH)
             # actual tests...
-            self.captesters[i].run_mon_cap_tests(self.fs, self.client_id)
-            self.captesters[i].run_mds_cap_tests(PERM, PATH)
+            self.captesters[i].run_cap_tests(self.fs, self.client_id, PERM,
+                                             PATH)
 
     def tearDown(self):
         self.mount_a.umount_wait()

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -4,8 +4,9 @@ Test for Ceph clusters with multiple FSs.
 import logging
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
-from tasks.cephfs.caps_helper import (CapTester, gen_mon_cap_str,
-                                      gen_osd_cap_str, gen_mds_cap_str)
+from tasks.cephfs.caps_helper import (MonCapTester, MdsCapTester,
+                                      gen_mon_cap_str, gen_osd_cap_str,
+                                      gen_mds_cap_str)
 
 from teuthology.exceptions import CommandFailedError
 
@@ -40,21 +41,21 @@ class TestMultiFS(CephFSTestCase):
 class TestMONCaps(TestMultiFS):
 
     def test_moncap_with_one_fs_names(self):
-        self.captester = CapTester()
+        self.captester = MonCapTester()
         moncap = gen_mon_cap_str((('r', self.fs1.name),))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_multiple_fs_names(self):
-        self.captester = CapTester()
+        self.captester = MonCapTester()
         moncap = gen_mon_cap_str((('r', self.fs1.name), ('r', self.fs2.name)))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_blanket_allow(self):
-        self.captester = CapTester()
+        self.captester = MonCapTester()
         moncap = 'allow r'
         self.create_client(self.client_id, moncap)
 
@@ -72,7 +73,8 @@ class TestMDSCaps(TestMultiFS):
     """
     def test_rw_with_fsname_and_no_path_in_cap(self):
         PERM = 'rw'
-        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
+        self.captesters = (MdsCapTester(self.mount_a),
+                           MdsCapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, both_fsnames=True)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -83,7 +85,8 @@ class TestMDSCaps(TestMultiFS):
 
     def test_r_with_fsname_and_no_path_in_cap(self):
         PERM = 'r'
-        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
+        self.captesters = (MdsCapTester(self.mount_a),
+                           MdsCapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, both_fsnames=True)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -96,8 +99,8 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'rw', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
-                           CapTester(self.mount_b, CEPHFS_MNTPT))
+        self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
+                           MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, True, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -110,8 +113,8 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'r', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
-                           CapTester(self.mount_b, CEPHFS_MNTPT))
+        self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
+                           MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, True, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -126,8 +129,8 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'rw', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
-                           CapTester(self.mount_b, CEPHFS_MNTPT))
+        self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
+                           MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, False, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -142,8 +145,8 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'r', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
-                           CapTester(self.mount_b, CEPHFS_MNTPT))
+        self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
+                           MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, False, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -154,7 +157,8 @@ class TestMDSCaps(TestMultiFS):
 
     def test_rw_with_no_fsname_and_no_path(self):
         PERM = 'rw'
-        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
+        self.captesters = (MdsCapTester(self.mount_a),
+                           MdsCapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
@@ -165,7 +169,8 @@ class TestMDSCaps(TestMultiFS):
 
     def test_r_with_no_fsname_and_no_path(self):
         PERM = 'r'
-        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
+        self.captesters = (MdsCapTester(self.mount_a),
+                           MdsCapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -23,8 +23,6 @@ class TestMultiFS(CephFSTestCase):
     def setUp(self):
         super(TestMultiFS, self).setUp()
 
-        self.captester = CapTester()
-
         # we might have it - the client - if the same cluster was used for a
         # different vstart_runner.py run.
         self.run_cluster_cmd(f'auth rm {self.client_name}')
@@ -42,18 +40,21 @@ class TestMultiFS(CephFSTestCase):
 class TestMONCaps(TestMultiFS):
 
     def test_moncap_with_one_fs_names(self):
+        self.captester = CapTester()
         moncap = gen_mon_cap_str((('r', self.fs1.name),))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_multiple_fs_names(self):
+        self.captester = CapTester()
         moncap = gen_mon_cap_str((('r', self.fs1.name), ('r', self.fs2.name)))
         self.create_client(self.client_id, moncap)
 
         self.captester.run_mon_cap_tests(self.fs1, self.client_id)
 
     def test_moncap_with_blanket_allow(self):
+        self.captester = CapTester()
         moncap = 'allow r'
         self.create_client(self.client_id, moncap)
 
@@ -69,53 +70,55 @@ class TestMDSCaps(TestMultiFS):
     3. Remount the current mounts with this new client.
     4. Test read and write on both FSs.
     """
-    def setUp(self):
-        super(self.__class__, self).setUp()
-        self.mounts = (self.mount_a, self.mount_b)
-
     def test_rw_with_fsname_and_no_path_in_cap(self):
         PERM = 'rw'
-        self.captester.write_test_files(self.mounts)
+        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, both_fsnames=True)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring)
 
-        self.captester.run_mds_cap_tests(PERM)
+        self.captesters[0].run_mds_cap_tests(PERM)
+        self.captesters[1].run_mds_cap_tests(PERM)
 
     def test_r_with_fsname_and_no_path_in_cap(self):
         PERM = 'r'
-        self.captester.write_test_files(self.mounts)
+        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, both_fsnames=True)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring)
 
-        self.captester.run_mds_cap_tests(PERM)
+        self.captesters[0].run_mds_cap_tests(PERM)
+        self.captesters[1].run_mds_cap_tests(PERM)
 
     def test_rw_with_fsname_and_path_in_cap(self):
         PERM, CEPHFS_MNTPT = 'rw', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
+        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
+                           CapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, True, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring, CEPHFS_MNTPT)
 
-        self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[0].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[1].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     def test_r_with_fsname_and_path_in_cap(self):
         PERM, CEPHFS_MNTPT = 'r', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
+        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
+                           CapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, True, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring, CEPHFS_MNTPT)
 
-        self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[0].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[1].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     # XXX: this tests the backward compatibility; "allow rw path=<dir1>" is
     # treated as "allow rw fsname=* path=<dir1>"
@@ -123,13 +126,15 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'rw', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
+        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
+                           CapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, False, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring, CEPHFS_MNTPT)
 
-        self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[0].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[1].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     # XXX: this tests the backward compatibility; "allow r path=<dir1>" is
     # treated as "allow r fsname=* path=<dir1>"
@@ -137,33 +142,37 @@ class TestMDSCaps(TestMultiFS):
         PERM, CEPHFS_MNTPT = 'r', 'dir1'
         self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
         self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.captester.write_test_files(self.mounts, CEPHFS_MNTPT)
+        self.captesters = (CapTester(self.mount_a, CEPHFS_MNTPT),
+                           CapTester(self.mount_b, CEPHFS_MNTPT))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM, False, CEPHFS_MNTPT)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring, CEPHFS_MNTPT)
 
-        self.captester.run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[0].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
+        self.captesters[1].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     def test_rw_with_no_fsname_and_no_path(self):
         PERM = 'rw'
-        self.captester.write_test_files(self.mounts)
+        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring)
 
-        self.captester.run_mds_cap_tests(PERM)
+        self.captesters[0].run_mds_cap_tests(PERM)
+        self.captesters[1].run_mds_cap_tests(PERM)
 
     def test_r_with_no_fsname_and_no_path(self):
         PERM = 'r'
-        self.captester.write_test_files(self.mounts)
+        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
 
         moncap, osdcap, mdscap = self._gen_caps(PERM)
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         self.remount_with_new_client(keyring)
 
-        self.captester.run_mds_cap_tests(PERM)
+        self.captesters[0].run_mds_cap_tests(PERM)
+        self.captesters[1].run_mds_cap_tests(PERM)
 
     def tearDown(self):
         self.mount_a.umount_wait()


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] Change in test code
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>