### PR TITLE
quincy: cephadm: set --ulimit nofiles with Docker

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4018,6 +4018,9 @@ class CephContainer:
             if os.path.exists('/etc/ceph/podman-auth.json'):
                 cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
 
+        if isinstance(self.ctx.container_engine, Docker):
+            cmd_args.extend(['--ulimit', 'nofile=1048576'])
+
         envs: List[str] = [
             '-e', 'CONTAINER_IMAGE=%s' % self.image,
             '-e', 'NODE_NAME=%s' % get_hostname(),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58982

---

backport of https://github.com/ceph/ceph/pull/50270
parent tracker: https://tracker.ceph.com/issues/58855

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh