### PR TITLE
quincy: mgr/orchestrator: allow deploying raw mode OSDs with --all-available-devices

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -738,6 +738,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                    unmanaged: Optional[bool] = None,
                    dry_run: bool = False,
                    no_overwrite: bool = False,
+                   method: Optional[OSDMethod] = None,
                    inbuf: Optional[str] = None  # deprecated. Was deprecated before Quincy
                    ) -> HandleCommandResult:
         """
@@ -780,7 +781,8 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                     placement=PlacementSpec(host_pattern='*'),
                     data_devices=DeviceSelection(all=True),
                     unmanaged=unmanaged,
-                    preview_only=dry_run
+                    preview_only=dry_run,
+                    method=method
                 )
             ]
             return self._apply_misc(dg_specs, dry_run, format, no_overwrite)

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -15,6 +15,9 @@ class OSDMethod(str, enum.Enum):
     raw = 'raw'
     lvm = 'lvm'
 
+    def to_json(self) -> str:
+        return self.value
+
 
 class DeviceSelection(object):
     """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58995

---

backport of https://github.com/ceph/ceph/pull/50101
parent tracker: https://tracker.ceph.com/issues/58714

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh