### PR TITLE
quincy: cephadm: handle exceptions applying extra services during bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5272,12 +5272,22 @@ def prepare_ssh(
     if not ctx.skip_monitoring_stack:
         for t in ['ceph-exporter', 'prometheus', 'grafana', 'node-exporter', 'alertmanager']:
             logger.info('Deploying %s service with default placement...' % t)
-            cli(['orch', 'apply', t])
+            try:
+                cli(['orch', 'apply', t])
+            except RuntimeError:
+                ctx.error_code = -errno.EINVAL
+                logger.error(f'Failed to apply service type {t}. '
+                             'Perhaps the ceph version being bootstrapped does not support it')
 
     if ctx.with_centralized_logging:
         for t in ['loki', 'promtail']:
             logger.info('Deploying %s service with default placement...' % t)
-            cli(['orch', 'apply', t])
+            try:
+                cli(['orch', 'apply', t])
+            except RuntimeError:
+                ctx.error_code = -errno.EINVAL
+                logger.error(f'Failed to apply service type {t}. '
+                             'Perhaps the ceph version being bootstrapped does not support it')
 
 
 def enable_cephadm_mgr_module(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59302

---

backport of https://github.com/ceph/ceph/pull/50548
parent tracker: https://tracker.ceph.com/issues/59082

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh