### PR TITLE
mon/MDSMonitor: plug paxos when maybe manipulating osdmap

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -146,10 +146,6 @@ class FsNewHandler : public FileSystemCommandHandler
   {
   }
 
-  bool batched_propose() override {
-    return true;
-  }
-
   int handle(
       Monitor *mon,
       FSMap& fsmap,
@@ -934,10 +930,6 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     : FileSystemCommandHandler("fs add_data_pool"), m_paxos(paxos)
   {}
 
-  bool batched_propose() override {
-    return true;
-  }
-
   int handle(
       Monitor *mon,
       FSMap& fsmap,
@@ -1157,10 +1149,6 @@ class RenameFilesystemHandler : public FileSystemCommandHandler
   explicit RenameFilesystemHandler(Paxos *paxos)
     : FileSystemCommandHandler("fs rename"), m_paxos(paxos)
   {
-  }
-
-  bool batched_propose() override {
-    return true;
   }
 
   int handle(

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -79,10 +79,6 @@ public:
 
   static std::list<std::shared_ptr<FileSystemCommandHandler> > load(Paxos *paxos);
 
-  virtual bool batched_propose() {
-    return false;
-  }
-
   virtual int handle(
     Monitor *mon,
     FSMap &fsmap,

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -804,6 +804,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
         last_beacon.erase(followergid);
       }
       request_proposal(mon.osdmon());
+      force_immediate_propose();
       pending.damaged(rankgid, blocklist_epoch);
       last_beacon.erase(rankgid);
 
@@ -1277,6 +1278,8 @@ bool MDSMonitor::fail_mds_gid(FSMap &fsmap, mds_gid_t gid)
     utime_t until = ceph_clock_now();
     until += g_conf().get_val<double>("mon_mds_blocklist_interval");
     blocklist_epoch = mon.osdmon()->blocklist(info.addrs, until);
+    /* do not delay when we are evicting an MDS */
+    force_immediate_propose();
   }
 
   fsmap.erase(gid, blocklist_epoch);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -550,28 +550,35 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
   auto m = op->get_req<PaxosServiceMessage>();
   dout(7) << "prepare_update " << *m << dendl;
 
+  bool r = false;
+
+  /* batch any changes to pending with any changes to osdmap */
+  paxos.plug();
+
   switch (m->get_type()) {
-    
-  case MSG_MDS_BEACON:
-    return prepare_beacon(op);
-
-  case MSG_MON_COMMAND:
-    try {
-      return prepare_command(op);
-    } catch (const bad_cmd_get& e) {
-      bufferlist bl;
-      mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
-      return false; /* nothing to propose */
-    }
-
-  case MSG_MDS_OFFLOAD_TARGETS:
-    return prepare_offload_targets(op);
-  
-  default:
-    ceph_abort();
+    case MSG_MDS_BEACON:
+      r = prepare_beacon(op);
+      break;
+    case MSG_MON_COMMAND:
+      try {
+        r = prepare_command(op);
+      } catch (const bad_cmd_get& e) {
+        bufferlist bl;
+        mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
+        r = false;
+      }
+      break;
+    case MSG_MDS_OFFLOAD_TARGETS:
+      r = prepare_offload_targets(op);
+      break;
+    default:
+      ceph_abort();
+      break;
   }
 
-  return false; /* nothing to propose! */
+  paxos.unplug();
+
+  return r;
 }
 
 bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
@@ -1389,7 +1396,6 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
 
   auto &pending = get_pending_fsmap_writeable();
 
-  bool batched_propose = false;
   for (const auto &h : handlers) {
     r = h->can_handle(prefix, op, pending, cmdmap, ss);
     if (r == 1) {
@@ -1400,14 +1406,7 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
       goto out;
     }
 
-    batched_propose = h->batched_propose();
-    if (batched_propose) {
-      paxos.plug();
-    }
     r = h->handle(&mon, pending, op, cmdmap, ss);
-    if (batched_propose) {
-      paxos.unplug();
-    }
 
     if (r == -EAGAIN) {
       // message has been enqueued for retry; return.
@@ -1448,9 +1447,6 @@ out:
     // success.. delay reply
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, r, rs,
 					      get_last_committed() + 1));
-    if (batched_propose) {
-      force_immediate_propose();
-    }
     return true;
   } else {
     // reply immediately
@@ -2321,6 +2317,9 @@ void MDSMonitor::tick()
 
   auto &pending = get_pending_fsmap_writeable();
 
+  /* batch any changes to pending with any changes to osdmap */
+  paxos.plug();
+
   bool do_propose = false;
   bool propose_osdmap = false;
 
@@ -2375,6 +2374,9 @@ void MDSMonitor::tick()
   if (propose_osdmap) {
     request_proposal(mon.osdmon());
   }
+
+  /* allow MDSMonitor::propose_pending() to push the proposal through */
+  paxos.unplug();
 
   if (do_propose) {
     propose_pending();


### PR DESCRIPTION
Instead of tracking where exactly we're plugging PAXOS, just do it unconditionally whenever we modify pending and may change the osdmap. There is no downside to doing so and simplifies the code.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
