### PR TITLE
pacific: mgr/dashboard: ignore the rules 400 error in dashboard kcli e2e

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/support/index.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/support/index.ts
@@ -7,5 +7,11 @@ afterEach(() => {
 });
 
 Cypress.on('uncaught:exception', (err: Error) => {
-  return !err.message.includes('ResizeObserver loop limit exceeded');
+  if (
+    err.message.includes('ResizeObserver loop limit exceeded') ||
+    err.message.includes('api/prometheus/rules')
+  ) {
+    return false;
+  }
+  return true;
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59347

---

backport of https://github.com/ceph/ceph/pull/50114
parent tracker: https://tracker.ceph.com/issues/58722

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh