### PR TITLE
reef: qa: test_rebuild_simple checks status on wrong file system

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1135,6 +1135,9 @@ class Filesystem(MDSCluster):
         if timeout is None:
             timeout = DAEMON_WAIT_TIMEOUT
 
+        if self.id is None:
+            status = self.getinfo(refresh=True)
+
         if status is None:
             status = self.status()
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/59366

Parent ticket: https://tracker.ceph.com/issues/59332
Original PR: https://github.com/ceph/ceph/pull/50896