### PR TITLE
pacific: librbd: don't wait for a watch in send_acquire_lock() if client is blocklisted

### DIFF
--- a/src/librbd/ManagedLock.cc
+++ b/src/librbd/ManagedLock.cc
@@ -139,7 +139,7 @@ void ManagedLock<I>::shut_down(Context *on_shut_down) {
     Action active_action = get_active_action();
     ceph_assert(active_action == ACTION_TRY_LOCK ||
                 active_action == ACTION_ACQUIRE_LOCK);
-    complete_active_action(STATE_UNLOCKED, -ESHUTDOWN);
+    complete_active_action(STATE_UNLOCKED, -ERESTART);
   }
 
   execute_action(ACTION_SHUT_DOWN, on_shut_down);
@@ -151,7 +151,7 @@ void ManagedLock<I>::acquire_lock(Context *on_acquired) {
   {
     std::lock_guard locker{m_lock};
     if (is_state_shutdown()) {
-      r = -ESHUTDOWN;
+      r = -ERESTART;
     } else if (m_state != STATE_LOCKED || !m_actions_contexts.empty()) {
       ldout(m_cct, 10) << dendl;
       execute_action(ACTION_ACQUIRE_LOCK, on_acquired);
@@ -170,7 +170,7 @@ void ManagedLock<I>::try_acquire_lock(Context *on_acquired) {
   {
     std::lock_guard locker{m_lock};
     if (is_state_shutdown()) {
-      r = -ESHUTDOWN;
+      r = -ERESTART;
     } else if (m_state != STATE_LOCKED || !m_actions_contexts.empty()) {
       ldout(m_cct, 10) << dendl;
       execute_action(ACTION_TRY_LOCK, on_acquired);
@@ -189,7 +189,7 @@ void ManagedLock<I>::release_lock(Context *on_released) {
   {
     std::lock_guard locker{m_lock};
     if (is_state_shutdown()) {
-      r = -ESHUTDOWN;
+      r = -ERESTART;
     } else if (m_state != STATE_UNLOCKED || !m_actions_contexts.empty()) {
       ldout(m_cct, 10) << dendl;
       execute_action(ACTION_RELEASE_LOCK, on_released);
@@ -241,7 +241,7 @@ void ManagedLock<I>::get_locker(managed_lock::Locker *locker,
   {
     std::lock_guard l{m_lock};
     if (is_state_shutdown()) {
-      r = -ESHUTDOWN;
+      r = -ERESTART;
     } else {
       on_finish = new C_Tracked(m_async_op_tracker, on_finish);
       auto req = managed_lock::GetLockerRequest<I>::create(
@@ -263,7 +263,7 @@ void ManagedLock<I>::break_lock(const managed_lock::Locker &locker,
   {
     std::lock_guard l{m_lock};
     if (is_state_shutdown()) {
-      r = -ESHUTDOWN;
+      r = -ERESTART;
     } else if (is_lock_owner(m_lock)) {
       r = -EBUSY;
     } else {
@@ -490,7 +490,7 @@ void ManagedLock<I>::send_acquire_lock() {
 
       // shut down might race w/ release/re-acquire of the lock
       if (is_state_shutdown()) {
-        complete_active_action(STATE_UNLOCKED, -ESHUTDOWN);
+        complete_active_action(STATE_UNLOCKED, -ERESTART);
       }
     }
     return;

--- a/src/librbd/exclusive_lock/ImageDispatch.cc
+++ b/src/librbd/exclusive_lock/ImageDispatch.cc
@@ -8,6 +8,7 @@
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
+#include "librbd/asio/ContextWQ.h"
 #include "librbd/exclusive_lock/Policy.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
@@ -22,6 +23,7 @@ namespace librbd {
 namespace exclusive_lock {
 
 using util::create_context_callback;
+using util::create_async_context_callback;
 
 template <typename I>
 ImageDispatch<I>::ImageDispatch(I* image_ctx)
@@ -271,8 +273,9 @@ bool ImageDispatch<I>::needs_exclusive_lock(bool read_op, uint64_t tid,
     locker.unlock();
 
     *dispatch_result = io::DISPATCH_RESULT_RESTART;
-    auto ctx = create_context_callback<
-      ImageDispatch<I>, &ImageDispatch<I>::handle_acquire_lock>(this);
+    auto ctx = create_async_context_callback(
+      *m_image_ctx, create_context_callback<
+        ImageDispatch<I>, &ImageDispatch<I>::handle_acquire_lock>(this));
     m_image_ctx->exclusive_lock->acquire_lock(ctx);
     return true;
   }

--- a/src/librbd/exclusive_lock/ImageDispatch.cc
+++ b/src/librbd/exclusive_lock/ImageDispatch.cc
@@ -293,7 +293,7 @@ void ImageDispatch<I>::handle_acquire_lock(int r) {
 
   Context* failed_dispatch = nullptr;
   Contexts on_dispatches;
-  if (r == -ESHUTDOWN) {
+  if (r == -ERESTART) {
     ldout(cct, 5) << "IO raced with exclusive lock shutdown" << dendl;
   } else if (r < 0) {
     lderr(cct) << "failed to acquire exclusive lock: " << cpp_strerror(r)

--- a/src/test/librados_test_stub/TestMemCluster.cc
+++ b/src/test/librados_test_stub/TestMemCluster.cc
@@ -174,10 +174,13 @@ bool TestMemCluster::is_blocklisted(uint32_t nonce) const {
 }
 
 void TestMemCluster::blocklist(uint32_t nonce) {
-  m_watch_notify.blocklist(nonce);
+  {
+    std::lock_guard locker{m_lock};
+    m_blocklist.insert(nonce);
+  }
 
-  std::lock_guard locker{m_lock};
-  m_blocklist.insert(nonce);
+  // after blocklisting the client, disconnect and drop its watches
+  m_watch_notify.blocklist(nonce);
 }
 
 void TestMemCluster::transaction_start(const ObjectLocator& locator) {

--- a/src/test/librbd/test_mock_ManagedLock.cc
+++ b/src/test/librbd/test_mock_ManagedLock.cc
@@ -714,7 +714,7 @@ TEST_F(TestMockManagedLock, ShutDownWhileWaiting) {
   managed_lock.acquire_lock(&acquire_ctx);
 
   ASSERT_EQ(0, when_shut_down(managed_lock));
-  ASSERT_EQ(-ESHUTDOWN, acquire_ctx.wait());
+  ASSERT_EQ(-ERESTART, acquire_ctx.wait());
   ASSERT_FALSE(is_lock_owner(managed_lock));
 }
 

--- a/src/test/librbd/test_mock_ManagedLock.cc
+++ b/src/test/librbd/test_mock_ManagedLock.cc
@@ -192,6 +192,11 @@ public:
                   .WillOnce(QueueRequest(&acquire_request, r, work_queue));
   }
 
+  void expect_is_blocklisted(MockImageWatcher &watcher,
+                             bool blocklisted) {
+    EXPECT_CALL(watcher, is_blocklisted()).WillOnce(Return(blocklisted));
+  }
+
   void expect_release_lock(asio::ContextWQ *work_queue,
                            MockReleaseRequest &release_request, int r) {
     EXPECT_CALL(release_request, send())
@@ -391,6 +396,26 @@ TEST_F(TestMockManagedLock, AcquireLockBlocklist) {
   ASSERT_EQ(0, when_shut_down(managed_lock));
 }
 
+TEST_F(TestMockManagedLock, AcquireLockBlocklistedWatch) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockManagedLockImageCtx mock_image_ctx(*ictx);
+  MockManagedLock managed_lock(ictx->md_ctx, *ictx->asio_engine,
+                               ictx->header_oid, mock_image_ctx.image_watcher,
+                               librbd::managed_lock::EXCLUSIVE, true, 0);
+
+  InSequence seq;
+
+  expect_get_watch_handle(*mock_image_ctx.image_watcher, 0);
+  expect_is_blocklisted(*mock_image_ctx.image_watcher, true);
+
+  ASSERT_EQ(-EBLOCKLISTED, when_acquire_lock(managed_lock));
+  ASSERT_FALSE(is_lock_owner(managed_lock));
+
+  ASSERT_EQ(0, when_shut_down(managed_lock));
+}
+
 TEST_F(TestMockManagedLock, ReleaseLockUnlockedState) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
@@ -561,6 +586,7 @@ TEST_F(TestMockManagedLock, AttemptReacquireBlocklistedLock) {
   expect_release_lock(ictx->op_work_queue, request_release, 0);
 
   expect_get_watch_handle(*mock_image_ctx.image_watcher, 0);
+  expect_is_blocklisted(*mock_image_ctx.image_watcher, false);
 
   managed_lock.reacquire_lock(nullptr);
 
@@ -682,6 +708,7 @@ TEST_F(TestMockManagedLock, ShutDownWhileWaiting) {
   InSequence seq;
 
   expect_get_watch_handle(*mock_image_ctx.image_watcher, 0);
+  expect_is_blocklisted(*mock_image_ctx.image_watcher, false);
 
   C_SaferCond acquire_ctx;
   managed_lock.acquire_lock(&acquire_ctx);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59370

---

backport of https://github.com/ceph/ceph/pull/50630
parent tracker: https://tracker.ceph.com/issues/59115

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh