### PR TITLE
ceph-volume: make disk.is_device follow symlinks

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -360,7 +360,7 @@ def is_device(dev):
             return False
 
     # fallback to stat
-    return _stat_is_device(os.lstat(dev).st_mode)
+    return _stat_is_device(os.stat(dev).st_mode)
 
 
 def is_partition(dev):


### PR DESCRIPTION
When calling ceph-volume on a symlink, the user intends to use the device which is the target of the symlink. Change disk.is_device() to use os.stat instead of os.lstat. This ensures we check whether the target of the symlink is a block device.

This fixes adding multipath devices which can be accessed via /dev/mapper/<id> but are symlinks to ../dm-<num>.

Fixes: https://tracker.ceph.com/issues/59375
