### PR TITLE
librbd: on notify_quiesce() show attempts in a better format

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -393,37 +393,35 @@ void ImageWatcher<I>::notify_quiesce(uint64_t *request_id,
 
   AsyncRequestId async_request_id(get_client_id(), *request_id);
 
-  auto attempts = m_image_ctx.config.template get_val<uint64_t>(
+  auto total_attempts = m_image_ctx.config.template get_val<uint64_t>(
     "rbd_quiesce_notification_attempts");
 
-  notify_quiesce(async_request_id, attempts, prog_ctx, on_finish);
+  notify_quiesce(async_request_id, 1, total_attempts, prog_ctx, on_finish);
 }
 
 template <typename I>
 void ImageWatcher<I>::notify_quiesce(const AsyncRequestId &async_request_id,
-                                     size_t attempts, ProgressContext &prog_ctx,
+                                     size_t attempt, size_t total_attempts,
+                                     ProgressContext &prog_ctx,
                                      Context *on_finish) {
+  ceph_assert(attempt <= total_attempts);
   ldout(m_image_ctx.cct, 10) << this << " " << __func__ << ": async_request_id="
-                             << async_request_id << " attempts=" << attempts
-                             << dendl;
+                             << async_request_id << " attempts @ "
+                             << attempt << "/" << total_attempts << dendl;
 
-  ceph_assert(attempts > 0);
   auto notify_response = new watcher::NotifyResponse();
   auto on_notify = new LambdaContext(
     [notify_response=std::unique_ptr<watcher::NotifyResponse>(notify_response),
-     this, async_request_id, &prog_ctx, on_finish, attempts=attempts-1](int r) {
-      auto total_attempts = m_image_ctx.config.template get_val<uint64_t>(
-        "rbd_quiesce_notification_attempts");
-      if (total_attempts < attempts) {
-        total_attempts = attempts;
-      }
-      prog_ctx.update_progress(total_attempts - attempts, total_attempts);
-
+     this, async_request_id, attempt, total_attempts, &prog_ctx,
+     on_finish](int r) {
+      prog_ctx.update_progress(attempt, total_attempts);
       if (r == -ETIMEDOUT) {
-        ldout(m_image_ctx.cct, 10) << this << " " << __func__ << ": async_request_id="
-                                   << async_request_id << " timed out" << dendl;
-        if (attempts > 0) {
-          notify_quiesce(async_request_id, attempts, prog_ctx, on_finish);
+        ldout(m_image_ctx.cct, 10) << this << " " << __func__
+                                   << ": async_request_id=" << async_request_id
+                                   << " timed out" << dendl;
+        if (attempt < total_attempts) {
+          notify_quiesce(async_request_id, attempt + 1, total_attempts,
+                         prog_ctx, on_finish);
           return;
         }
       } else if (r == 0) {

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -241,8 +241,8 @@ private:
   void cancel_quiesce_requests();
 
   void notify_quiesce(const watch_notify::AsyncRequestId &async_request_id,
-                      size_t attempts, ProgressContext &prog_ctx,
-                      Context *on_finish);
+                      size_t attempt, size_t total_attempts,
+                      ProgressContext &prog_ctx, Context *on_finish);
 
   bool handle_operation_request(
     const watch_notify::AsyncRequestId& async_request_id,


### PR DESCRIPTION


notify_quiesce currently shows number of attempts in descending order, this might be bit confusing to read.

Example:
```
2023-04-04T19:45:56.096+0530 7ff8ba7fc640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=10
```
I initially thought the above meant 10 attempts where done.

Logs:
```
2023-04-04T19:45:56.096+0530 7ff8ba7fc640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=10
2023-04-04T19:46:01.235+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=9
2023-04-04T19:46:06.236+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=8
2023-04-04T19:46:11.238+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=7
2023-04-04T19:46:16.239+0530 7ff8ba7fc640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=6
2023-04-04T19:46:21.240+0530 7ff8ba7fc640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=5
2023-04-04T19:46:26.243+0530 7ff8ba7fc640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=4
2023-04-04T19:46:31.245+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=3
2023-04-04T19:46:36.246+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=2
2023-04-04T19:46:41.251+0530 7ff8b9ffb640 10 librbd::ImageWatcher: 0x7ff898008b30 notify_quiesce: async_request_id=[4151,140705343226832,23] attempts=1
```
If you had seen logs from ImageWatcher\<I\>::handle_payload() they are easy to read:
```
2023-04-04T19:45:09.965+0530 7f9e11650640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 1/10
2023-04-04T19:45:14.999+0530 7f9e11650640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 2/10
2023-04-04T19:45:20.000+0530 7f9e11650640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 3/10
2023-04-04T19:45:25.011+0530 7f9e11650640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 4/10
2023-04-04T19:45:30.013+0530 7f9e11650640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 5/10
2023-04-04T19:45:33.178+0530 7f9e11e51640 20 librbd::ImageWatcher: 0x7f9de8008cb0 request progress: [4199,140315843435136,1] @ 6/10
```
or even ImageWatcher\<I\>::notify_async_progress() logs nice:

```
3765824 2023-04-04T19:45:09.963+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 1/10
3775548 2023-04-04T19:45:14.965+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 2/10
3785273 2023-04-04T19:45:19.998+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 3/10
3794988 2023-04-04T19:45:25.000+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 4/10
3804770 2023-04-04T19:45:30.011+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 5/10
3810819 2023-04-04T19:45:33.175+0530 7ff8b17fa640 20 librbd::ImageWatcher: 0x7ff898008b30 remote async request progress: [4199,140315843435136,1] @ 6/10
```

Fixes: https://tracker.ceph.com/issues/59379
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
