### PR TITLE
quincy: rgw/notifications: send mtime in complete multipart upload event

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6409,7 +6409,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
   }
 
   // send request to notification manager
-  int ret = res->publish_commit(this, ofs, target_obj->get_mtime(), etag, target_obj->get_instance());
+  int ret = res->publish_commit(this, ofs, upload->get_mtime(), etag, target_obj->get_instance());
   if (ret < 0) {
     ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
     // too late to rollback operation, hence op_ret is not set here

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -2138,7 +2138,8 @@ def test_ps_s3_multipart_on_master():
     assert_equal(len(events), 1)
     assert_equal(events[0]['Records'][0]['eventName'], 'ObjectCreated:CompleteMultipartUpload')
     assert_equal(events[0]['Records'][0]['s3']['configurationId'], notification_name+'_3')
-    print(events[0]['Records'][0]['s3']['object']['size'])
+    assert_equal(events[0]['Records'][0]['s3']['object']['size'], object_size)
+    assert events[0]['Records'][0]['eventTime'] != '0.000000', 'invalid eventTime'
 
     # cleanup
     stop_amqp_receiver(receiver1, task1)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58284

---

backport of https://github.com/ceph/ceph/pull/48877
parent tracker: https://tracker.ceph.com/issues/58020

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh