### PR TITLE
script: fix release notes script to include cherry-picked commits

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -192,8 +192,15 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
                 else:
                     print(f"Could not fetch PR {number} in {retries} tries.")
                     raise
+        commit = None
+        if merges[number] == "cherry_pick":
+            try:
+                commit = repo.commit(pr['merge_commit_sha'])
+            except:
+                pass
         if merges[number] == "merge_commit":
             commit = merge_commits[number]
+        if commit:
             (title, message) = _title_message(commit, pr, strict)
         else:
             (title, message) = (pr['title'], pr['body'])
@@ -204,7 +211,7 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
             )
 
         authors = {}
-        if merges[number] == "merge_commit":
+        if commit:
             for c in repo.iter_commits(
                     "{sha1}^1..{sha1}^2".format(sha1=commit.hexsha)
                     ):
@@ -224,7 +231,7 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
         if authors:
             author = ", ".join(authors.keys())
         else:
-            if merges[number] == "merge_commit":
+            if commit:
                 author = commit.parents[-1].author.name
             else:
                 author = pr['user']['login']

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -51,7 +51,7 @@ prefixes = ['bluestore', 'build/ops', 'cephfs', 'cephx', 'cli', 'cmake',
 signed_off_re = re.compile("Signed-off-by: (.+) <")
 tracker_re = re.compile("http://tracker.ceph.com/issues/(\d+)")
 rst_link_re = re.compile(r"([a-zA-Z0-9])_(\W)")
-release_re = re.compile(r"^(nautilus|octopus|pacific|quincy):\s*")
+release_re = re.compile(r"^(nautilus|octopus|pacific|Pacific|quincy|Quincy|reef|Reef):\s*")
 
 tracker_uri = "http://tracker.ceph.com/issues/{0}.json"
 
@@ -144,17 +144,24 @@ def _title_message(commit, pr, strict):
     message = "    " + "\n    ".join(lines)
     return (title, message)
 
-def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict, use_tags, include_pr_messages):
+def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, verbose, strict, use_tags, include_pr_messages):
 
     issue2prs = {}
     pr2issues = {}
     pr2info = {}
 
+    merges = []
     for commit in repo.iter_commits(ref, merges=True):
         merge = merge_re.match(commit.summary)
         if not merge:
             continue
-        number = merge.group(2)
+        PR = merge.group(2)
+        merges.append(PR)
+    if cherry_picks:
+        for PR in cherry_picks.split(','):
+            merges.append(PR)
+
+    for number in merges:
         print ("Considering PR#" + number)
         # do not pick up ceph/ceph-qa-suite.git PRs
         if int(number) < 1311:
@@ -330,6 +337,8 @@ if __name__ == "__main__":
 
     parser.add_argument("--rev", "-r",
                         help="git revision range for creating release notes")
+    parser.add_argument("--cherry_picks", "-c",
+                        help="PRs associated with any last-minute cherry-picks. Provide PR numbers as a string separated by commas, i.e. '50575,50625'")
     parser.add_argument("--text", "-t",
                         action='store_true', default=None,
                         help="output plain text only, no links")
@@ -365,6 +374,7 @@ if __name__ == "__main__":
         gh,
         Repo(args.repo),
         args.rev,
+        args.cherry_picks,
         args.text,
         args.html,
         args.markdown,

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -150,16 +150,24 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
     pr2issues = {}
     pr2info = {}
 
-    merges = []
+    merges = {}
     for commit in repo.iter_commits(ref, merges=True):
         merge = merge_re.match(commit.summary)
         if not merge:
             continue
         PR = merge.group(2)
-        merges.append(PR)
+        merges[PR] = "merge_commit"
     if cherry_picks:
         for PR in cherry_picks.split(','):
-            merges.append(PR)
+            merges[PR] = "cherry_pick"
+
+    merge_commits = {}
+    for commit in repo.iter_commits(ref, merges=True):
+        merge = merge_re.match(commit.summary)
+        if not merge:
+            continue
+        number = merge.group(2)
+        merge_commits[number] = commit
 
     for number in merges:
         print ("Considering PR#" + number)
@@ -184,7 +192,11 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
                 else:
                     print(f"Could not fetch PR {number} in {retries} tries.")
                     raise
-        (title, message) = _title_message(commit, pr, strict)
+        if merges[number] == "merge_commit":
+            commit = merge_commits[number]
+            (title, message) = _title_message(commit, pr, strict)
+        else:
+            (title, message) = (pr['title'], pr['body'])
         issues = []
         if pr['body']:
             issues = fixes_re.findall(pr['body']) + tracker_re.findall(
@@ -192,19 +204,28 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
             )
 
         authors = {}
-        for c in repo.iter_commits(
-                     "{sha1}^1..{sha1}^2".format(sha1=commit.hexsha)
-                 ):
+        if merges[number] == "merge_commit":
+            for c in repo.iter_commits(
+                    "{sha1}^1..{sha1}^2".format(sha1=commit.hexsha)
+                    ):
+                for author in re.findall(
+                        "Signed-off-by:\s*(.*?)\s*<", c.message
+                        ):
+                    authors[author] = 1
+                    issues.extend(fixes_re.findall(c.message) +
+                            tracker_re.findall(c.message))
+        else:
             for author in re.findall(
-                              "Signed-off-by:\s*(.*?)\s*<", c.message
-                          ):
+                    "Signed-off-by:\s*(.*?)\s*<", message
+                    ):
                 authors[author] = 1
-            issues.extend(fixes_re.findall(c.message) +
-                          tracker_re.findall(c.message))
         if authors:
             author = ", ".join(authors.keys())
         else:
-            author = commit.parents[-1].author.name
+            if merges[number] == "merge_commit":
+                author = commit.parents[-1].author.name
+            else:
+                author = pr['user']['login']
 
         if strict and not issues:
             print ("ERROR: https://github.com/ceph/ceph/pull/" +

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -218,6 +218,8 @@ def make_release_notes(gh, repo, ref, cherry_picks, plaintext, html, markdown, v
             for author in re.findall(
                     "Signed-off-by:\s*(.*?)\s*<", message
                     ):
+                if author == "[Your Name]":
+                    continue
                 authors[author] = 1
         if authors:
             author = ", ".join(authors.keys())


### PR DESCRIPTION
There is a new parameter (`--cherry_picks`, `-c`) added to the
ceph-release-notes script that allows the user to input a list of PR numbers
associated with last-minute cherry-picks.

```
$ LANG=en_US.UTF-8 python3 ceph-release-notes -h
usage: ceph-release-notes [-h] [--rev REV] [--cherry_picks CHERRY_PICKS]
                          [--text] [--html] [--markdown] [--verbose]
                          [--strict] [--token TOKEN] [--use-tags USE_TAGS]
                          [--include-pr-messages]
                          repo

    Make ceph release notes for a given revision. Eg usage:

    $ ceph-release-notes -r tags/v0.87..origin/giant         $(git rev-parse --show-toplevel)

    It is recommended to set the github env. token in order to avoid
    hitting the api rate limits.

positional arguments:
  repo                  path to ceph git repo

optional arguments:
  -h, --help            show this help message and exit
  --rev REV, -r REV     git revision range for creating release notes
  --cherry_picks CHERRY_PICKS, -c CHERRY_PICKS
                        PRs associated with any last-minute cherry-picks. Provide PR numbers as a string separated by commas, i.e. '50575,50625'
  --text, -t            output plain text only, no links
  --html                output html format for (old wordpress) website blog
  --markdown            output markdown format for new ceph.io blog
  --verbose, -v         verbose
  --strict              strict, recommended only for backport releases
  --token TOKEN         Github Access Token ($GITHUB_ACCESS_TOKEN otherwise)
  --use-tags USE_TAGS   Use github tags to guess the component
  --include-pr-messages
                        Include full PR message in addition to PR title, if available
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
