### PR TITLE
ceph-volume: update the OS before deploying Ceph (pacific)

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
@@ -31,3 +31,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
     osd_pool_default_size: 1
+  osd:
+    bluefs_buffered_io: false

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -87,6 +87,12 @@
       set_fact:
         is_atomic: '{{ stat_ostree.stat.exists }}'
 
+    - name: force rpm pkg upgrade
+      package:
+        name: rpm
+        state: latest
+      when: not is_atomic | bool
+
     - name: update the system
       command: dnf update -y
       changed_when: false

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -87,6 +87,11 @@
       set_fact:
         is_atomic: '{{ stat_ostree.stat.exists }}'
 
+    - name: update the system
+      command: dnf update -y
+      changed_when: false
+      when: not is_atomic | bool
+
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
ceph-volume tests are failing, OSDs never get up and running. For some reason, updating the OS early in the testing workflow addresses that issue in the CI.

-- to be continued ... --