### PR TITLE
quincy: cephfs-top: fixing the -d [--delay] option in cephfs-top

### DIFF
--- a/doc/cephfs/cephfs-top.rst
+++ b/doc/cephfs/cephfs-top.rst
@@ -78,7 +78,7 @@ By default, `cephfs-top` connects to cluster name `ceph`. To use a non-default c
 
   $ cephfs-top -d <seconds>
 
-Interval should be greater than or equal to 0.5 seconds. Fractional seconds are honoured.
+Refresh interval should be a positive integer.
 
 Interactive Commands
 --------------------

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -45,8 +45,6 @@ FS_TOP_SUPPORTED_VER = 2
 ITEMS_PAD_LEN = 3
 ITEMS_PAD = " " * ITEMS_PAD_LEN
 DEFAULT_REFRESH_INTERVAL = 1
-# min refresh interval allowed
-MIN_REFRESH_INTERVAL = 0.5
 
 # metadata provided by mgr/stats
 FS_TOP_MAIN_WINDOW_COL_CLIENT_ID = "client_id"
@@ -1081,14 +1079,6 @@ class FSTop(object):
 
 
 if __name__ == '__main__':
-    def float_greater_than(x):
-        value = float(x)
-        if value < MIN_REFRESH_INTERVAL:
-            raise argparse.ArgumentTypeError(
-                'Refresh interval should be greater than or equal to'
-                f' {MIN_REFRESH_INTERVAL}')
-        return value
-
     parser = argparse.ArgumentParser(description='Ceph Filesystem top utility')
     parser.add_argument('--cluster', nargs='?', const='ceph', default='ceph',
                         help='Ceph cluster to connect (default: ceph)')
@@ -1098,9 +1088,9 @@ if __name__ == '__main__':
                         help='Path to cluster configuration file')
     parser.add_argument('--selftest', dest='selftest', action='store_true',
                         help='Run in selftest mode')
-    parser.add_argument('-d', '--delay', nargs='?',
+    parser.add_argument('-d', '--delay', dest='delay', choices=range(1, 26),
                         default=DEFAULT_REFRESH_INTERVAL,
-                        type=float_greater_than,
+                        type=int,
                         help='Refresh interval in seconds '
                         f'(default: {DEFAULT_REFRESH_INTERVAL})')
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59396

---

backport of https://github.com/ceph/ceph/pull/50716
parent tracker: https://tracker.ceph.com/issues/59188

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh