### PR TITLE
mon/AuthMonitor: log when parsing caps fails

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1334,6 +1334,7 @@ bool AuthMonitor::valid_caps(
   if (type == "mon") {
     MonCap moncap;
     if (!moncap.parse(caps, out)) {
+      dout(20) << "Parsing MON caps failed. MON cap: " << caps << dendl;
       return false;
     }
     return true;
@@ -1346,16 +1347,19 @@ bool AuthMonitor::valid_caps(
   if (type == "mgr") {
     MgrCap mgrcap;
     if (!mgrcap.parse(caps, out)) {
+      dout(20) << "Parsing MGR caps failed. MGR cap: " << caps << dendl;
       return false;
     }
   } else if (type == "osd") {
     OSDCap ocap;
     if (!ocap.parse(caps, out)) {
+      dout(20) << "Parsing OSD caps failed. OSD cap: " << caps << dendl;
       return false;
     }
   } else if (type == "mds") {
     MDSAuthCaps mdscap;
     if (!mdscap.parse(g_ceph_context, caps, out)) {
+      dout(20) << "Parsing MDS caps failed. MDS cap: " << caps << dendl;
       return false;
     }
   } else {


### PR DESCRIPTION
The commit originally belongs to PR #41779. These log entries were very useful while debugging PR #41779 for parsing failures. So it's worth to get this patch merged.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] Minor change (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>