### PR TITLE
mgr/nfs,qa: enhance logging cephfs path failure and align two test cases

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -852,8 +852,7 @@ class TestNFS(MgrTestCase):
                                                             '--path',
                                                             '/testfile'])
         except CommandFailedError as e:
-            # NotADirectoryError is raised as EINVAL
-            if e.exitstatus != errno.EINVAL:
+            if e.exitstatus != errno.ENOTDIR:
                 raise
         self.ctx.cluster.run(args=['rm', '-rf', '/mnt/testfile'])
         self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)
@@ -875,7 +874,7 @@ class TestNFS(MgrTestCase):
                                            '--path',
                                            f'{mnt_pt}/testdir_symlink'])
         except CommandFailedError as e:
-            if e.exitstatus != errno.ENOENT:
+            if e.exitstatus != errno.ENOTDIR:
                 raise
         self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}/*'])
         self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -826,7 +826,9 @@ class TestNFS(MgrTestCase):
         """
         Test that nfs exports can't be created with invalid path
         """
-        self._test_create_cluster()
+        mnt_pt = '/mnt'
+        preserve_mode = self._sys_cmd(['stat', '-c', '%a', mnt_pt])
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
         try:
             self._create_export(export_id='123',
                                 extra_cmd=['--pseudo-path', self.pseudo_path,
@@ -834,7 +836,7 @@ class TestNFS(MgrTestCase):
         except CommandFailedError as e:
             if e.exitstatus != errno.ENOENT:
                 raise
-        self._test_delete_cluster()
+        self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)
 
     def test_nfs_export_creation_at_filepath(self):
         """

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -865,14 +865,14 @@ class TestNFS(MgrTestCase):
         preserve_mode = self._sys_cmd(['stat', '-c', '%a', mnt_pt])
         self._create_cluster_with_fs(self.fs_name, mnt_pt)
         self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir'])
-        self.ctx.cluster.run(args=['ln', '-s', 'testdir', 'testdir_symlink'],
-                             cwd=f'{mnt_pt}')
+        self.ctx.cluster.run(args=['ln', '-s', f'{mnt_pt}/testdir',
+                                   f'{mnt_pt}/testdir_symlink'])
         try:
             self._create_export(export_id='123',
                                 extra_cmd=['--pseudo-path',
                                            self.pseudo_path,
                                            '--path',
-                                           f'{mnt_pt}/testdir_symlink'])
+                                           '/testdir_symlink'])
         except CommandFailedError as e:
             if e.exitstatus != errno.ENOTDIR:
                 raise

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -12,6 +12,7 @@ from typing import (
     Set,
     cast)
 from os.path import normpath
+import cephfs
 
 from rados import TimedOut, ObjectNotFound, Rados, LIBRADOS_ALL_NSPACES
 
@@ -26,7 +27,7 @@ from .ganesha_conf import (
     RGWFSAL,
     RawBlock,
     format_block)
-from .exception import NFSException, NFSInvalidOperation, FSNotFound
+from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
     CONF_PREFIX,
     EXPORT_PREFIX,
@@ -36,7 +37,7 @@ from .utils import (
     conf_obj_name,
     available_clusters,
     check_fs,
-    restart_nfs_service, check_cephfs_path)
+    restart_nfs_service, cephfs_path_is_dir)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -659,7 +660,14 @@ class ExportMgr:
                              clients: list = [],
                              sectype: Optional[List[str]] = None) -> Dict[str, Any]:
 
-        check_cephfs_path(self.mgr, fs_name, path)
+        try:
+            cephfs_path_is_dir(self.mgr, fs_name, path)
+        except NotADirectoryError:
+            raise NFSException(f"path {path} is not a dir", -errno.ENOTDIR)
+        except cephfs.ObjectNotFound:
+            raise NFSObjectNotFound(f"path {path} does not exist")
+        except cephfs.Error as e:
+            raise NFSException(e.args[1], -e.args[0])
 
         pseudo_path = normalize_path(pseudo_path)
 

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -252,7 +252,7 @@ EXPORT {
                 mock.patch('nfs.ganesha_conf.check_fs', return_value=True), \
                 mock.patch('nfs.export.ExportMgr._create_user_key',
                            return_value='thekeyforclientabc'), \
-                mock.patch('nfs.export.check_cephfs_path'):
+                mock.patch('nfs.export.cephfs_path_is_dir'):
 
             rados.open_ioctx.return_value.__enter__.return_value = self.io_mock
             rados.open_ioctx.return_value.__exit__ = mock.Mock(return_value=None)


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
