### PR TITLE
quincy: mgr/dashboard: fix eviction of all FS clients

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -328,8 +328,9 @@ class CephFS(RESTController):
             raise cherrypy.HTTPError(404,
                                      "Client {0} does not exist in cephfs {1}".format(client_id,
                                                                                       fs_id))
+        filters = [f'id={client_id}']
         CephService.send_command('mds', 'client evict',
-                                 srv_spec='{0}:0'.format(fs_id), id=client_id)
+                                 srv_spec='{0}:0'.format(fs_id), filters=filters)
 
     @staticmethod
     def _cephfs_instance(fs_id):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59421

---

backport of https://github.com/ceph/ceph/pull/50885
parent tracker: https://tracker.ceph.com/issues/59418

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh