### PR TITLE
reef: rgw/keystone: use secret key from EC2 for sigv4 streaming mode

### DIFF
--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -148,7 +148,13 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                     const std::string_view& access_key_id,
                     const std::string& string_to_sign,
                     const std::string_view& signature) const;
-  std::pair<boost::optional<token_envelope_t>, int>
+
+  struct access_token_result {
+    boost::optional<token_envelope_t> token;
+    boost::optional<std::string> secret_key;
+    int failure_reason = 0;
+  };
+  access_token_result
   get_access_token(const DoutPrefixProvider* dpp,
                    const std::string_view& access_key_id,
                    const std::string& string_to_sign,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59358

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
