### PR TITLE
reef: rgw: use unique_ptr for flat_map emplace in BucketTrimWatcher

### DIFF
--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -253,8 +253,10 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   BucketTrimWatcher(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                     TrimCounters::Server *counters)
     : store(store), obj(obj) {
-    handlers.emplace(NotifyTrimCounters, new TrimCounters::Handler(counters));
-    handlers.emplace(NotifyTrimComplete, new TrimComplete::Handler(counters));
+    handlers.emplace(NotifyTrimCounters,
+        std::make_unique<TrimCounters::Handler>(counters));
+    handlers.emplace(NotifyTrimComplete,
+        std::make_unique<TrimComplete::Handler>(counters));
   }
 
   ~BucketTrimWatcher() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59028

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
