### PR TITLE
reef: rgw/notifications: fetch object state to get size, in rgw_lc.cc

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -548,6 +548,13 @@ static int remove_expired_obj(
   }
 
   obj = bucket->get_object(obj_key);
+
+  RGWObjState* obj_state{nullptr};
+  ret = obj->get_obj_state(dpp, &obj_state, null_yield, true);
+  if (ret < 0) {
+    return ret;
+  }
+
   std::unique_ptr<rgw::sal::Object::DeleteOp> del_op
     = obj->get_delete_op();
   del_op->params.versioning_status
@@ -578,7 +585,7 @@ static int remove_expired_obj(
       "ERROR: publishing notification failed, with error: " << ret << dendl;
   } else {
     // send request to notification manager
-    (void) notify->publish_commit(dpp, obj->get_obj_size(),
+    (void) notify->publish_commit(dpp, obj_state->size,
 				  ceph::real_clock::now(),
 				  obj->get_attrs()[RGW_ATTR_ETAG].to_str(),
 				  version_id);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -587,7 +587,7 @@ static int remove_expired_obj(
     // send request to notification manager
     (void) notify->publish_commit(dpp, obj_state->size,
 				  ceph::real_clock::now(),
-				  obj->get_attrs()[RGW_ATTR_ETAG].to_str(),
+				  obj_state->attrset[RGW_ATTR_ETAG].to_str(),
 				  version_id);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59013

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
