### PR TITLE
reef: qa/rgw: unpin centos for verify suite

### DIFF
--- a/qa/suites/rgw/verify/centos_latest.yaml
+++ b/qa/suites/rgw/verify/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/rgw/verify/supported-random-distro$
+++ b/qa/suites/rgw/verify/supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59220

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
