### PR TITLE
rgw: determine bucket index oid correctly

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -477,8 +477,9 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
   call.max = max;
   encode(call, in);
   int r = io_ctx.exec(oid, RGW_CLASS, RGW_BI_LIST, in, out);
-  if (r < 0)
+  if (r < 0) {
     return r;
+  }
 
   rgw_cls_bi_list_ret op_ret;
   auto iter = out.cbegin();

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2763,7 +2763,7 @@ int RGWRados::BucketShard::init(const DoutPrefixProvider *dpp,
     ldpp_dout(dpp, 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
   }
-  ldpp_dout(dpp, 20) << " bucket index object: " << bucket_obj << dendl;
+  ldpp_dout(dpp, 20) << "INFO: bucket index object: " << bucket_obj << dendl;
 
   return 0;
 }
@@ -8392,8 +8392,9 @@ int RGWRados::bi_list(BucketShard& bs, const string& obj_name_filter, const stri
 {
   auto& ref = bs.bucket_obj.get_ref();
   int ret = cls_rgw_bi_list(ref.pool.ioctx(), ref.obj.oid, obj_name_filter, marker, max, entries, is_truncated);
-  if (ret < 0)
+  if (ret < 0) {
     return ret;
+  }
 
   return 0;
 }
@@ -9617,13 +9618,14 @@ int RGWRados::check_quota(const DoutPrefixProvider *dpp, const rgw_user& bucket_
   return quota_handler->check_quota(dpp, bucket_owner, bucket, quota, 1, obj_size, y);
 }
 
-int RGWRados::get_target_shard_id(const rgw::bucket_index_normal_layout& layout, const string& obj_key,
-                                  int *shard_id)
+int RGWRados::get_target_shard_id(const rgw::bucket_index_normal_layout& layout,
+				  const string& obj_key,
+                                  int* shard_id)
 {
   int r = 0;
   switch (layout.hash_type) {
     case rgw::BucketHashType::Mod:
-      if (!layout.num_shards) {
+      if (rgw::has_single_shard(layout.num_shards)) {
         if (shard_id) {
           *shard_id = -1;
         }

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -278,5 +278,9 @@ inline uint32_t current_num_shards(const BucketLayout& layout) {
 inline bool is_layout_indexless(const bucket_index_layout_generation& layout) {
   return layout.layout.type == BucketIndexType::Indexless;
 }
+inline bool has_single_shard(uint32_t num_shards) {
+  // due to historic reasons, one shard is represented as both 0 and 1 sometimes
+  return num_shards <= 1;
+}
 
 } // namespace rgw

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -135,7 +135,7 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
                                      int shard_id = -1)
 {
   auto& bucket_objects = *_bucket_objects;
-  if (!num_shards) {
+  if (rgw::has_single_shard(num_shards)) {
     bucket_objects[0] = bucket_oid_base;
   } else {
     char buf[bucket_oid_base.size() + 64];
@@ -171,7 +171,7 @@ static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
   const rgw_bucket& bucket = bucket_info.bucket;
   string plain_id = bucket.name + ":" + bucket.bucket_id;
 
-  if (!num_shards) {
+  if (rgw::has_single_shard(num_shards)) {
     (*result)[0] = plain_id;
   } else {
     char buf[16];
@@ -222,7 +222,7 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(
     uint64_t gen_id, int shard_id,
     std::string* bucket_obj)
 {
-  if (!normal.num_shards) {
+  if (rgw::has_single_shard(normal.num_shards)) { // 0 or 1, which are equivalent
     // By default with no sharding, we use the bucket oid as itself
     (*bucket_obj) = bucket_oid_base;
   } else {
@@ -230,7 +230,7 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(
     if (gen_id) {
       bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, shard_id);
       (*bucket_obj) = buf;
-	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
+      ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
     } else {
       // for backward compatibility, gen_id(0) will not be added in the object name
       bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, shard_id);
@@ -248,7 +248,7 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(
   int r = 0;
   switch (normal.hash_type) {
     case rgw::BucketHashType::Mod:
-      if (!normal.num_shards) {
+      if (rgw::has_single_shard(normal.num_shards)) {
         // By default with no sharding, we use the bucket oid as itself
         (*bucket_obj) = bucket_oid_base;
         if (shard_id) {


### PR DESCRIPTION
Due to historical reasons a bucket index shard count of 0 is equivalent to a count of 1. Recent changes have favored indicating this with 1 rather than 0. Therefore logic that strictly tests for 0 no longer works.

Additionally this commit fixes other bits of code that strictly tests for a bucket index shard count of 0 and tries to consolidate this "knowledge" into a single place in the code.

Fixes: https://tracker.ceph.com/issues/59427

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
