### PR TITLE
quincy: mgr: Add one finisher thread per module

### DIFF
--- a/qa/suites/fs/volumes/tasks/volumes/test/finisher_per_module.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/finisher_per_module.yaml
@@ -1,0 +1,13 @@
+tasks:
+  - check-counter:
+      counters:
+        mgr:
+            - name: "finisher-volumes.complete_latency.avgcount"
+              min: 4
+            - name: "finisher-volumes.queue_len"
+              expected_val: 0
+
+  - cephfs_test_runner:
+      fail_on_skip: false
+      modules:
+        - tasks.cephfs.test_volumes.TestPerModuleFinsherThread

--- a/qa/suites/rados/mgr/tasks/per_module_finisher_stats.yaml
+++ b/qa/suites/rados/mgr/tasks/per_module_finisher_stats.yaml
@@ -1,0 +1,43 @@
+tasks:
+  - install:
+  - ceph:
+      wait-for-scrub: false
+  - check-counter:
+      counters:
+        mgr:
+            - name: "finisher-balancer.complete_latency.avgcount"
+              min: 1
+            - name: "finisher-balancer.queue_len"
+              expected_val: 0
+            - name: "finisher-crash.complete_latency.avgcount"
+              min: 2
+            - name: "finisher-crash.queue_len"
+              expected_val: 0
+            - name: "finisher-devicehealth.complete_latency.avgcount"
+              min: 1
+            - name: "finisher-devicehealth.queue_len"
+              expected_val: 0
+            - name: "finisher-iostat.complete_latency.avgcount"
+              min: 1
+            - name: "finisher-iostat.queue_len"
+              expected_val: 0
+            - name: "finisher-pg_autoscaler.complete_latency.avgcount"
+              min: 1
+            - name: "finisher-pg_autoscaler.queue_len"
+              expected_val: 0
+            - name: "finisher-progress.complete_latency.avgcount"
+              min: 2
+            - name: "finisher-progress.queue_len"
+              expected_val: 0
+            - name: "finisher-status.complete_latency.avgcount"
+              min: 2
+            - name: "finisher-status.queue_len"
+              expected_val: 0
+            - name: "finisher-telemetry.complete_latency.avgcount"
+              min: 2
+            - name: "finisher-telemetry.queue_len"
+              expected_val: 0
+  - workunit:
+      clients:
+        client.0:
+          - mgr/test_per_module_finisher.sh

--- a/qa/suites/rados/mgr/tasks/workunits.yaml
+++ b/qa/suites/rados/mgr/tasks/workunits.yaml
@@ -13,4 +13,4 @@ tasks:
   - workunit:
       clients:
         client.0:
-          - mgr
+          - mgr/test_localpool.sh

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -7888,3 +7888,29 @@ class TestMisc(TestVolumesHelper):
 
         # remove group
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+class TestPerModuleFinsherThread(TestVolumesHelper):
+    """
+    Per module finisher thread tests related to mgr/volume cmds.
+    This is used in conjuction with check_counter with min val being 4
+    as four subvolume cmds are run
+    """
+    def test_volumes_module_finisher_thread(self):
+        subvol1, subvol2, subvol3 = self._generate_random_subvolume_name(3)
+        group = self._generate_random_group_name()
+
+        # create group
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+
+        # create subvolumes in group
+        self._fs_cmd("subvolume", "create", self.volname, subvol1, "--group_name", group)
+        self._fs_cmd("subvolume", "create", self.volname, subvol2, "--group_name", group)
+        self._fs_cmd("subvolume", "create", self.volname, subvol3, "--group_name", group)
+
+        self._fs_cmd("subvolume", "rm", self.volname, subvol1, group)
+        self._fs_cmd("subvolume", "rm", self.volname, subvol2, group)
+        self._fs_cmd("subvolume", "rm", self.volname, subvol3, group)
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()

--- a/qa/tasks/check_counter.py
+++ b/qa/tasks/check_counter.py
@@ -30,6 +30,9 @@ class CheckCounter(Task):
         counters:
             mds:
                 - "mds.dir_split"
+                -
+                    name: "mds.dir_update"
+                    min: 3
     - workunit: ...
     """
 
@@ -54,6 +57,7 @@ class CheckCounter(Task):
                              self.ctx.daemons.get_daemon(daemon_type, daemon_id))
                             for daemon_id in daemon_ids])
 
+            expected = set()
             seen = set()
 
             for daemon_id, daemon in daemons.items():
@@ -73,22 +77,29 @@ class CheckCounter(Task):
                     continue
 
                 for counter in counters:
-                    subsys, counter_id = counter.split(".")
+                    if isinstance(counter, dict):
+                        name = counter['name']
+                        minval = counter['min']
+                    else:
+                        name = counter
+                        minval = 1
+                    expected.add(name)
+                    subsys, counter_id = name.split(".")
                     if subsys not in perf_dump or counter_id not in perf_dump[subsys]:
                         log.warning("Counter '{0}' not found on daemon {1}.{2}".format(
-                            counter, daemon_type, daemon_id))
+                            name, daemon_type, daemon_id))
                         continue
                     value = perf_dump[subsys][counter_id]
 
                     log.info("Daemon {0}.{1} {2}={3}".format(
-                        daemon_type, daemon_id, counter, value
+                        daemon_type, daemon_id, name, value
                     ))
 
-                    if value > 0:
-                        seen.add(counter)
+                    if value >= minval:
+                        seen.add(name)
 
             if not dry_run:
-                unseen = set(counters) - set(seen)
+                unseen = set(expected) - set(seen)
                 if unseen:
                     raise RuntimeError("The following counters failed to be set "
                                        "on {0} daemons: {1}".format(

--- a/qa/tasks/check_counter.py
+++ b/qa/tasks/check_counter.py
@@ -84,19 +84,20 @@ class CheckCounter(Task):
                         name = counter
                         minval = 1
                     expected.add(name)
-                    subsys, counter_id = name.split(".")
-                    if subsys not in perf_dump or counter_id not in perf_dump[subsys]:
-                        log.warning("Counter '{0}' not found on daemon {1}.{2}".format(
-                            name, daemon_type, daemon_id))
-                        continue
-                    value = perf_dump[subsys][counter_id]
 
-                    log.info("Daemon {0}.{1} {2}={3}".format(
-                        daemon_type, daemon_id, name, value
-                    ))
+                    val = perf_dump
+                    for key in name.split('.'):
+                        if key not in val:
+                            log.warning(f"Counter '{name}' not found on daemon {daemon_type}.{daemon_id}")
+                            val = None
+                            break
 
-                    if value >= minval:
-                        seen.add(name)
+                        val = val[key]
+
+                    if val is not None:
+                        log.info(f"Daemon {daemon_type}.{daemon_id} {name}={val}")
+                        if val >= minval:
+                            seen.add(name)
 
             if not dry_run:
                 unseen = set(expected) - set(seen)

--- a/qa/workunits/mgr/test_per_module_finisher.sh
+++ b/qa/workunits/mgr/test_per_module_finisher.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -ex
+
+# This testcase tests the per module finisher stats for enabled modules
+# using check counter (qa/tasks/check_counter.py).
+
+# 'balancer' commands
+ceph balancer pool ls
+
+# 'crash' commands
+ceph crash ls
+ceph crash ls-new
+
+# 'device' commands
+ceph device query-daemon-health-metrics mon.a
+
+# 'iostat' command
+ceph iostat &
+pid=$!
+sleep 3
+kill -SIGTERM $pid
+
+# 'pg_autoscaler' command
+ceph osd pool autoscale-status
+
+# 'progress' command
+ceph progress
+ceph progress json
+
+# 'status' commands
+ceph fs status
+ceph osd status
+
+# 'telemetry' commands
+ceph telemetry status
+ceph telemetry diff
+
+echo OK

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -544,6 +544,9 @@ void ActivePyModules::start_one(PyModuleRef py_module)
 
       dout(4) << "Starting thread for " << name << dendl;
       active_module->thread.create(active_module->get_thread_name());
+      dout(4) << "Starting active module " << name <<" finisher thread "
+        << active_module->get_fin_thread_name() << dendl;
+      active_module->finisher.start();
     }
   }));
 }
@@ -551,6 +554,13 @@ void ActivePyModules::start_one(PyModuleRef py_module)
 void ActivePyModules::shutdown()
 {
   std::lock_guard locker(lock);
+
+  // Stop per active module finisher thread
+  for (auto& [name, module] : modules) {
+      dout(4) << "Stopping active module " << name << " finisher thread" << dendl;
+      module->finisher.wait_for_empty();
+      module->finisher.stop();
+  }
 
   // Signal modules to drop out of serve() and/or tear down resources
   for (auto& [name, module] : modules) {
@@ -590,8 +600,9 @@ void ActivePyModules::notify_all(const std::string &notify_type,
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
     dout(15) << "queuing notify (" << notify_type << ") to " << name << dendl;
+    Finisher& mod_finisher = py_module_registry.get_active_module_finisher(name);
     // workaround for https://bugs.llvm.org/show_bug.cgi?id=35984
-    finisher.queue(new LambdaContext([module=module, notify_type, notify_id]
+    mod_finisher.queue(new LambdaContext([module=module, notify_type, notify_id]
       (int r){
         module->notify(notify_type, notify_id);
     }));
@@ -614,8 +625,9 @@ void ActivePyModules::notify_all(const LogEntry &log_entry)
     // log_entry: we take a copy because caller's instance is
     // probably ephemeral.
     dout(15) << "queuing notify (clog) to " << name << dendl;
+    Finisher& mod_finisher = py_module_registry.get_active_module_finisher(name);
     // workaround for https://bugs.llvm.org/show_bug.cgi?id=35984
-    finisher.queue(new LambdaContext([module=module, log_entry](int r){
+    mod_finisher.queue(new LambdaContext([module=module, log_entry](int r){
       module->notify_clog(log_entry);
     }));
   }
@@ -1308,8 +1320,9 @@ void ActivePyModules::config_notify()
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
     dout(15) << "notify (config) " << name << dendl;
+    Finisher& mod_finisher = py_module_registry.get_active_module_finisher(name);
     // workaround for https://bugs.llvm.org/show_bug.cgi?id=35984
-    finisher.queue(new LambdaContext([module=module](int r){
+    mod_finisher.queue(new LambdaContext([module=module](int r){
       module->config_notify();
     }));
   }

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -189,6 +189,10 @@ public:
                   const std::string &notify_id);
   void notify_all(const LogEntry &log_entry);
 
+  auto& get_module_finisher(const std::string &name) {
+    return modules.at(name)->finisher;
+  }
+
   bool is_pending(std::string_view name) const {
     return pending_modules.count(name) > 0;
   }

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -227,5 +227,15 @@ public:
     return v;
   }
 
+  bool is_module_active(const std::string &name) {
+    ceph_assert(active_modules);
+    return active_modules->module_exists(name);
+  }
+
+  auto& get_active_module_finisher(const std::string &name) {
+    ceph_assert(active_modules);
+    return active_modules->get_module_finisher(name);
+  }
+
   // <<< (end of ActivePyModules cheeky call-throughs)
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59416

---
Added following dependent qa commits from main branch:
   1. 8114bdd964d5a442802ed120c851ff8028bc6baa
   2. d8ec1bd8e65542d2fb8ccf6103ce3b2768d1551b
   
backport of https://github.com/ceph/ceph/pull/47893
parent tracker: https://tracker.ceph.com/issues/51177

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh