### PR TITLE
reef: qa: avoid explicit set to client mountpoint as "/"

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -114,8 +114,8 @@ class FuseMount(CephFSMount):
 
         self.validate_subvol_options()
 
-        assert(self.cephfs_mntpt)
-        mount_cmd += ["--client_mountpoint=" + self.cephfs_mntpt]
+        if self.cephfs_mntpt:
+            mount_cmd += ["--client_mountpoint=" + self.cephfs_mntpt]
 
         if self.cephfs_name:
             mount_cmd += ["--client_fs=" + self.cephfs_name]

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -49,6 +49,8 @@ class KernelMount(CephFSMount):
 
         self.setup_netns()
 
+        if not self.cephfs_mntpt:
+            self.cephfs_mntpt = '/'
         if not self.cephfs_name:
             self.cephfs_name = 'cephfs'
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1503,6 +1503,3 @@ class CephFSMount(object):
             subvol_paths = self.ctx.created_subvols[self.cephfs_name]
             path_to_mount = subvol_paths[mount_subvol_num]
             self.cephfs_mntpt = path_to_mount
-        elif not self.cephfs_mntpt:
-            # default to the "/" path
-            self.cephfs_mntpt = "/"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59430

---

backport of https://github.com/ceph/ceph/pull/49912
parent tracker: https://tracker.ceph.com/issues/56446

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh