### PR TITLE
pacific: qa: avoid explicit set to client mountpoint as "/"

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -87,14 +87,19 @@ class FuseMount(CephFSMount):
             'ceph-fuse', "-f",
             "--admin-socket", "/var/run/ceph/$cluster-$name.$pid.asok",
         ]
-        if self.client_id is not None:
-            fuse_cmd += ['--id', self.client_id]
-        if self.client_keyring_path and self.client_id is not None:
-            fuse_cmd += ['-k', self.client_keyring_path]
-        if self.cephfs_mntpt is not None:
-            fuse_cmd += ["--client_mountpoint=" + self.cephfs_mntpt]
-        if self.cephfs_name is not None:
-            fuse_cmd += ["--client_fs=" + self.cephfs_name]
+        mount_cmd += self._mount_bin + [self.hostfs_mntpt]
+        if self.client_id:
+            mount_cmd += ['--id', self.client_id]
+        if self.client_keyring_path and self.client_id:
+            mount_cmd += ['-k', self.client_keyring_path]
+
+        self.validate_subvol_options()
+
+        if self.cephfs_mntpt:
+            mount_cmd += ["--client_mountpoint=" + self.cephfs_mntpt]
+
+        if self.cephfs_name:
+            mount_cmd += ["--client_fs=" + self.cephfs_name]
         if mntopts:
             fuse_cmd += mntopts
         fuse_cmd.append(self.hostfs_mntpt)

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -40,13 +40,16 @@ class KernelMount(CephFSMount):
 
         self.setup_netns()
 
+        if not self.cephfs_mntpt:
+            self.cephfs_mntpt = '/'
+        if not self.cephfs_name:
+            self.cephfs_name = 'cephfs'
+
         # TODO: don't call setupfs() from within mount(), since it's
         # absurd. The proper order should be: create FS first and then
         # call mount().
         if createfs:
             self.setupfs(name=self.cephfs_name)
-        if not self.cephfs_mntpt:
-            self.cephfs_mntpt = '/'
 
         stderr = StringIO()
         try:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1327,3 +1327,19 @@ class CephFSMount(object):
         checksum_text = self.run_shell(cmd).stdout.getvalue().strip()
         checksum_sorted = sorted(checksum_text.split('\n'), key=lambda v: v.split()[1])
         return hashlib.md5(('\n'.join(checksum_sorted)).encode('utf-8')).hexdigest()
+
+    def validate_subvol_options(self):
+        mount_subvol_num = self.client_config.get('mount_subvol_num', None)
+        if self.cephfs_mntpt and mount_subvol_num is not None:
+            log.warning("You cannot specify both: cephfs_mntpt and mount_subvol_num")
+            log.info(f"Mounting subvol {mount_subvol_num} for now")
+
+        if mount_subvol_num is not None:
+            # mount_subvol must be an index into the subvol path array for the fs
+            if not self.cephfs_name:
+                self.cephfs_name = 'cephfs'
+            assert(hasattr(self.ctx, "created_subvols"))
+            # mount_subvol must be specified under client.[0-9] yaml section
+            subvol_paths = self.ctx.created_subvols[self.cephfs_name]
+            path_to_mount = subvol_paths[mount_subvol_num]
+            self.cephfs_mntpt = path_to_mount


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59032

---

backport of https://github.com/ceph/ceph/pull/49912
parent tracker: https://tracker.ceph.com/issues/56446

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh