### PR TITLE
quincy: Revert "ceph-exporter: cephadm changes"

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -372,7 +372,7 @@ class UnauthorizedRegistryError(Error):
 
 class Ceph(object):
     daemons = ('mon', 'mgr', 'osd', 'mds', 'rgw', 'rbd-mirror',
-               'crash', 'cephfs-mirror', 'ceph-exporter')
+               'crash', 'cephfs-mirror')
     gateways = ('iscsi', 'nfs')
 
 ##################################
@@ -934,64 +934,6 @@ class CephIscsi(object):
         tcmu_container.container_args = []
         set_pids_limit_unlimited(self.ctx, tcmu_container.container_args)
         return tcmu_container
-
-##################################
-
-
-class CephExporter(object):
-    """Defines a Ceph exporter container"""
-
-    daemon_type = 'ceph-exporter'
-    entrypoint = '/usr/bin/ceph-exporter'
-    DEFAULT_PORT = 9926
-    port_map = {
-        'ceph-exporter': DEFAULT_PORT,
-    }
-
-    def __init__(self,
-                 ctx: CephadmContext,
-                 fsid: str, daemon_id: Union[int, str],
-                 config_json: Dict[str, Any],
-                 image: str = DEFAULT_IMAGE) -> None:
-        self.ctx = ctx
-        self.fsid = fsid
-        self.daemon_id = daemon_id
-        self.image = image
-
-        self.sock_dir = config_json.get('sock-dir', '/var/run/ceph/')
-        self.addrs = config_json.get('addrs', socket.gethostbyname(socket.gethostname()))
-        self.port = config_json.get('port', self.DEFAULT_PORT)
-        self.prio_limit = config_json.get('prio-limit', 5)
-        self.stats_period = config_json.get('stats-period', 5)
-
-        self.validate()
-
-    @classmethod
-    def init(cls, ctx: CephadmContext, fsid: str,
-             daemon_id: Union[int, str]) -> 'CephExporter':
-        return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
-
-    @staticmethod
-    def get_container_mounts() -> Dict[str, str]:
-        mounts = dict()
-        mounts['/var/run/ceph'] = '/var/run/ceph:z'
-        return mounts
-
-    def get_daemon_args(self) -> List[str]:
-        args = [
-            f'--sock-dir={self.sock_dir}',
-            f'--addrs={self.addrs}',
-            f'--port={self.port}',
-            f'--prio-limit={self.prio_limit}',
-            f'--stats-period={self.stats_period}',
-        ]
-        return args
-
-    def validate(self) -> None:
-        if not os.path.isdir(self.sock_dir):
-            raise Error(f'Directory does not exist. Got: {self.sock_dir}')
-
 
 ##################################
 
@@ -2630,7 +2572,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
     # type: (CephadmContext, str, str, Union[int, str]) -> List[str]
     r = list()  # type: List[str]
 
-    if daemon_type in Ceph.daemons and daemon_type not in ['crash', 'ceph-exporter']:
+    if daemon_type in Ceph.daemons and daemon_type != 'crash':
         r += [
             '--setuser', 'ceph',
             '--setgroup', 'ceph',
@@ -2704,9 +2646,6 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
     elif daemon_type == NFSGanesha.daemon_type:
         nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
         r += nfs_ganesha.get_daemon_args()
-    elif daemon_type == CephExporter.daemon_type:
-        ceph_exporter = CephExporter.init(ctx, fsid, daemon_id)
-        r.extend(ceph_exporter.get_daemon_args())
     elif daemon_type == HAproxy.daemon_type:
         haproxy = HAproxy.init(ctx, fsid, daemon_id)
         r += haproxy.get_daemon_args()
@@ -2968,7 +2907,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
             mounts[data_dir] = cdata_dir + ':z'
         if not no_config:
             mounts[data_dir + '/config'] = '/etc/ceph/ceph.conf:z'
-        if daemon_type in ['rbd-mirror', 'cephfs-mirror', 'crash', 'ceph-exporter']:
+        if daemon_type in ['rbd-mirror', 'cephfs-mirror', 'crash']:
             # these do not search for their keyrings in a data directory
             mounts[data_dir + '/keyring'] = '/etc/ceph/ceph.client.%s.%s.keyring' % (daemon_type, daemon_id)
 
@@ -3155,9 +3094,6 @@ def get_container(ctx: CephadmContext,
         entrypoint = NFSGanesha.entrypoint
         name = '%s.%s' % (daemon_type, daemon_id)
         envs.extend(NFSGanesha.get_container_envs())
-    elif daemon_type == CephExporter.daemon_type:
-        entrypoint = CephExporter.entrypoint
-        name = 'client.ceph-exporter.%s' % daemon_id
     elif daemon_type == HAproxy.daemon_type:
         name = '%s.%s' % (daemon_type, daemon_id)
         container_args.extend(['--user=root'])  # haproxy 2.4 defaults to a different user
@@ -5317,7 +5253,7 @@ def prepare_ssh(
         cli(['orch', 'apply', 'crash'])
 
     if not ctx.skip_monitoring_stack:
-        for t in ['ceph-exporter', 'prometheus', 'grafana', 'node-exporter', 'alertmanager']:
+        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
             logger.info('Deploying %s service with default placement...' % t)
             try:
                 cli(['orch', 'apply', t])

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -15,7 +15,7 @@ from orchestrator._interface import daemon_type_to_service
 from ceph.utils import datetime_now
 from ceph.deployment.inventory import Devices
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
-from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephExporterService
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.services.ingress import IngressSpec
 
 from datetime import datetime, timedelta
@@ -183,8 +183,6 @@ class Root(object):
             return self.node_exporter_sd_config()
         elif service == 'haproxy':
             return self.haproxy_sd_config()
-        elif service == 'ceph-exporter':
-            return self.ceph_exporter_sd_config()
         else:
             return []
 
@@ -237,19 +235,6 @@ class Root(object):
                         'targets': [f"{build_url(host=addr, port=spec.monitor_port).lstrip('/')}"],
                         'labels': {'instance': dd.service_name()}
                     })
-        return srv_entries
-
-    def ceph_exporter_sd_config(self) -> List[Dict[str, Collection[str]]]:
-        """Return <http_sd_config> compatible prometheus config for ceph-exporter service."""
-        srv_entries = []
-        for dd in self.mgr.cache.get_daemons_by_service('ceph-exporter'):
-            assert dd.hostname is not None
-            addr = dd.ip if dd.ip else self.mgr.inventory.get_addr(dd.hostname)
-            port = dd.ports[0] if dd.ports else CephExporterService.DEFAULT_SERVICE_PORT
-            srv_entries.append({
-                'targets': [build_url(host=addr, port=port).lstrip('/')],
-                'labels': {'instance': dd.hostname}
-            })
         return srv_entries
 
     @cherrypy.expose(alias='prometheus/rules')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -47,8 +47,7 @@ from . import utils
 from . import ssh
 from .migrations import Migrations
 from .services.cephadmservice import MonService, MgrService, MdsService, RgwService, \
-    RbdMirrorService, CrashService, CephadmService, CephfsMirrorService, CephadmAgent, \
-    CephExporterService
+    RbdMirrorService, CrashService, CephadmService, CephfsMirrorService, CephadmAgent
 from .services.ingress import IngressService
 from .services.container import CustomContainerService
 from .services.iscsi import IscsiService
@@ -546,7 +545,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             RgwService, RbdMirrorService, GrafanaService, AlertmanagerService,
             PrometheusService, NodeExporterService, LokiService, PromtailService, CrashService, IscsiService,
             IngressService, CustomContainerService, CephfsMirrorService,
-            CephadmAgent, SNMPGatewayService, CephExporterService
+            CephadmAgent, SNMPGatewayService
         ]
 
         # https://github.com/python/mypy/issues/8993
@@ -701,7 +700,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         Generate a unique random service name
         """
         suffix = daemon_type not in [
-            'mon', 'crash', 'ceph-exporter',
+            'mon', 'crash',
             'prometheus', 'node-exporter', 'grafana', 'alertmanager',
             'container', 'agent', 'snmp-gateway', 'loki', 'promtail'
         ]
@@ -2455,7 +2454,7 @@ Then run the following:
                 deps = [self.get_mgr_ip()]
         else:
             need = {
-                'prometheus': ['mgr', 'alertmanager', 'node-exporter', 'ingress', 'ceph-exporter'],
+                'prometheus': ['mgr', 'alertmanager', 'node-exporter', 'ingress'],
                 'grafana': ['prometheus', 'loki'],
                 'alertmanager': ['mgr', 'alertmanager', 'snmp-gateway'],
                 'promtail': ['loki'],
@@ -2753,7 +2752,6 @@ Then run the following:
                 'alertmanager': PlacementSpec(count=1),
                 'prometheus': PlacementSpec(count=1),
                 'node-exporter': PlacementSpec(host_pattern='*'),
-                'ceph-exporter': PlacementSpec(host_pattern='*'),
                 'loki': PlacementSpec(count=1),
                 'promtail': PlacementSpec(host_pattern='*'),
                 'crash': PlacementSpec(host_pattern='*'),
@@ -2862,10 +2860,6 @@ Then run the following:
 
     @handle_orch_error
     def apply_node_exporter(self, spec: ServiceSpec) -> str:
-        return self._apply(spec)
-
-    @handle_orch_error
-    def apply_ceph_exporter(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -371,24 +371,11 @@ class PrometheusService(CephadmService):
                         "service": dd.service_name(),
                     })
 
-        # scrape ceph-exporters
-        ceph_exporter_targets = []
-        for dd in self.mgr.cache.get_daemons_by_service('ceph-exporter'):
-            assert dd.hostname is not None
-            deps.append(dd.name())
-            addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
-            port = dd.ports[0] if dd.ports else 9926
-            ceph_exporter_targets.append({
-                'url': build_url(host=addr, port=port).lstrip('/'),
-                'hostname': dd.hostname
-            })
-
         # generate the prometheus configuration
         context = {
             'alertmgr_targets': alertmgr_targets,
             'mgr_scrape_list': mgr_scrape_list,
             'haproxy_targets': haproxy_targets,
-            'ceph_exporter_targets': ceph_exporter_targets,
             'nodes': nodes,
         }
         r: Dict[str, Any] = {

--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -39,14 +39,3 @@ scrape_configs:
           instance: '{{ haproxy.service }}'
 {% endfor %}
 {% endif %}
-
-{% if ceph_exporter_targets %}
-  - job_name: 'ceph-exporter'
-    honor_labels: true
-    static_configs:
-{% for ceph_exporter in ceph_exporter_targets %}
-    - targets: ['{{ ceph_exporter.url }}']
-      labels:
-        instance: '{{ ceph_exporter.hostname }}'
-{% endfor %}
-{% endif %}

--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -16,10 +16,6 @@ class FakeDaemonDescription:
 
 class FakeCache:
     def get_daemons_by_service(self, service_type):
-        if service_type == 'ceph-exporter':
-            return [FakeDaemonDescription('1.2.3.4', [9926], 'node0'),
-                    FakeDaemonDescription('1.2.3.5', [9926], 'node1')]
-
         return [FakeDaemonDescription('1.2.3.4', [9100], 'node0'),
                 FakeDaemonDescription('1.2.3.5', [9200], 'node1')]
 
@@ -153,20 +149,6 @@ class TestCephadmService:
         # check content
         assert cfg[0]['targets'] == ['1.2.3.4:9049']
         assert cfg[0]['labels'] == {'instance': 'ingress'}
-
-    def test_get_sd_config_ceph_exporter(self):
-        mgr = FakeMgr()
-        root = Root(mgr)
-        cfg = root.get_sd_config('ceph-exporter')
-
-        # check response structure
-        assert cfg
-        for entry in cfg:
-            assert 'labels' in entry
-            assert 'targets' in entry
-
-        # check content
-        assert cfg[0]['targets'] == ['1.2.3.4:9926']
 
     def test_get_sd_config_invalid_service(self):
         mgr = FakeMgr()

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -17,7 +17,7 @@ from cephadm.services.monitoring import GrafanaService, AlertmanagerService, Pro
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import IscsiServiceSpec, MonitoringSpec, AlertManagerSpec, \
     ServiceSpec, RGWSpec, GrafanaSpec, SNMPGatewaySpec, IngressSpec, PlacementSpec, \
-    PrometheusSpec, CephExporterSpec, NFSServiceSpec
+    PrometheusSpec, NFSServiceSpec
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect
 
 from ceph.utils import datetime_now
@@ -447,7 +447,6 @@ class TestMonitoring:
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, MonitoringSpec('node-exporter')) as _, \
-                    with_service(cephadm_module, CephExporterSpec('ceph-exporter')) as _, \
                     with_service(cephadm_module, PrometheusSpec('prometheus')) as _:
 
                 y = dedent("""
@@ -470,13 +469,6 @@ class TestMonitoring:
                       labels:
                         instance: 'test'
 
-
-                  - job_name: 'ceph-exporter'
-                    honor_labels: true
-                    static_configs:
-                    - targets: ['[1::4]:9926']
-                      labels:
-                        instance: 'test'
                 """).lstrip()
 
                 _run_cephadm.assert_called_with(

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -21,8 +21,7 @@ class CephadmNoImage(Enum):
 
 # ceph daemon types that use the ceph container image.
 # NOTE: order important here as these are used for upgrade order
-CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw',
-              'rbd-mirror', 'cephfs-mirror', 'ceph-exporter']
+CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw', 'rbd-mirror', 'cephfs-mirror']
 GATEWAY_TYPES = ['iscsi', 'nfs']
 MONITORING_STACK_TYPES = ['node-exporter', 'prometheus',
                           'alertmanager', 'grafana', 'loki', 'promtail']
@@ -48,7 +47,7 @@ def name_to_config_section(name: str) -> ConfEntity:
     Map from daemon names to ceph entity names (as seen in config)
     """
     daemon_type = name.split('.', 1)[0]
-    if daemon_type in ['rgw', 'rbd-mirror', 'nfs', 'crash', 'iscsi', 'ceph-exporter']:
+    if daemon_type in ['rgw', 'rbd-mirror', 'nfs', 'crash', 'iscsi']:
         return ConfEntity('client.' + name)
     elif daemon_type in ['mon', 'osd', 'mds', 'mgr', 'client']:
         return ConfEntity(name)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -475,7 +475,6 @@ class Orchestrator(object):
             'mon': self.apply_mon,
             'nfs': self.apply_nfs,
             'node-exporter': self.apply_node_exporter,
-            'ceph-exporter': self.apply_ceph_exporter,
             'osd': lambda dg: self.apply_drivegroups([dg]),  # type: ignore
             'prometheus': self.apply_prometheus,
             'loki': self.apply_loki,
@@ -656,10 +655,6 @@ class Orchestrator(object):
         """Update existing a Node-Exporter daemon(s)"""
         raise NotImplementedError()
 
-    def apply_ceph_exporter(self, spec: ServiceSpec) -> OrchResult[str]:
-        """Update existing a ceph exporter daemon(s)"""
-        raise NotImplementedError()
-
     def apply_loki(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update existing a Loki daemon(s)"""
         raise NotImplementedError()
@@ -769,7 +764,6 @@ def daemon_type_to_service(dtype: str) -> str:
         'alertmanager': 'alertmanager',
         'prometheus': 'prometheus',
         'node-exporter': 'node-exporter',
-        'ceph-exporter': 'ceph-exporter',
         'loki': 'loki',
         'promtail': 'promtail',
         'crash': 'crash',
@@ -799,7 +793,6 @@ def service_to_daemon_types(stype: str) -> List[str]:
         'loki': ['loki'],
         'promtail': ['promtail'],
         'node-exporter': ['node-exporter'],
-        'ceph-exporter': ['ceph-exporter'],
         'crash': ['crash'],
         'container': ['container'],
         'agent': ['agent'],

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -138,7 +138,6 @@ class ServiceType(enum.Enum):
     alertmanager = 'alertmanager'
     grafana = 'grafana'
     node_exporter = 'node-exporter'
-    ceph_exporter = 'ceph-exporter'
     prometheus = 'prometheus'
     loki = 'loki'
     promtail = 'promtail'

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -498,7 +498,7 @@ class ServiceSpec(object):
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi loki promtail mds mgr mon nfs ' \
                           'node-exporter osd prometheus rbd-mirror rgw agent ' \
-                          'container ingress cephfs-mirror snmp-gateway ceph-exporter'.split()
+                          'container ingress cephfs-mirror snmp-gateway'.split()
     REQUIRES_SERVICE_ID = 'iscsi mds nfs rgw container ingress '.split()
     MANAGED_CONFIG_OPTIONS = [
         'mds_join_fs',
@@ -519,7 +519,6 @@ class ServiceSpec(object):
             'container': CustomContainerSpec,
             'grafana': GrafanaSpec,
             'node-exporter': MonitoringSpec,
-            'ceph-exporter': CephExporterSpec,
             'prometheus': PrometheusSpec,
             'loki': MonitoringSpec,
             'promtail': MonitoringSpec,
@@ -1560,46 +1559,3 @@ class TunedProfileSpec():
         # for making deep copies so you can edit the settings in one without affecting the other
         # mostly for testing purposes
         return TunedProfileSpec(self.profile_name, self.placement, self.settings.copy())
-
-
-class CephExporterSpec(ServiceSpec):
-    def __init__(self,
-                 service_type: str = 'ceph-exporter',
-                 sock_dir: Optional[str] = None,
-                 addrs: str = '',
-                 port: Optional[int] = None,
-                 prio_limit: Optional[int] = 5,
-                 stats_period: Optional[int] = 5,
-                 placement: Optional[PlacementSpec] = None,
-                 unmanaged: bool = False,
-                 preview_only: bool = False,
-                 extra_container_args: Optional[List[str]] = None,
-                 ):
-        assert service_type == 'ceph-exporter'
-
-        super(CephExporterSpec, self).__init__(
-            service_type,
-            placement=placement,
-            unmanaged=unmanaged,
-            preview_only=preview_only,
-            extra_container_args=extra_container_args)
-
-        self.service_type = service_type
-        self.sock_dir = sock_dir
-        self.addrs = addrs
-        self.port = port
-        self.prio_limit = prio_limit
-        self.stats_period = stats_period
-
-    def validate(self) -> None:
-        super(CephExporterSpec, self).validate()
-
-        if not isinstance(self.prio_limit, int):
-            raise SpecValidationError(
-                    f'prio_limit must be an integer. Got {type(self.prio_limit)}')
-        if not isinstance(self.stats_period, int):
-            raise SpecValidationError(
-                    f'stats_period must be an integer. Got {type(self.stats_period)}')
-
-
-yaml.add_representer(CephExporterSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
This reverts commit 5f04222cba320665e45726f14be321813d0a6ed2.

Issues were found with the ceph-exporter service in 17.2.6.

---

- Ceph metrics could be duplicated: from the existing centralized mgr/prometheus exporter (legacy approach), and from the new ceph-exporter, which is deployed as a side-car container on each node and reports Ceph metrics for all colocated services in that node.

- In a few cases (e.g.: ceph_mds_mem_cap+), where those metrics contain characters not supported by Prometheus (e.g.: +), Prometheus would complain about malformed metric names (however those metrics will still be properly reported via mgr/prometheus as ceph_mds_mem_cap_plus).

- In a few cases (e.g.: ceph_mds_mem_cap_minus), with metrics ending in -, they would have different names in Prometheus (e.g.: ceph_mds_mem_cap_minus when coming from mgr/prometheus and ceph_mds_mem_cap_ when coming from ceph-exporter).

---

Therefore we've decided it's best to revert cephadm's support for ceph-exporter in quincy

Conflicts:
	src/cephadm/cephadm
	src/pybind/mgr/cephadm/tests/test_services.py


---

I tested this change using an image based on the 17.2.6 release plus this reversion. The branch used for that can be found here https://github.com/adk3798/ceph/commits/17-2-6-cephadm-ceph-exporter-reversion. The testing deployed a 17.2.6 cluster, including the ceph-exporter service, and then upgraded to an image based on the linked branch that includes the ceph-exporter reversion. Before upgrade daemons and services were

```
[ceph: root@vm-00 /]# ceph orch ps
NAME                 HOST   PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
alertmanager.vm-00   vm-00  *:9093,9094  running (85m)     6m ago  89m    20.9M        -  0.23.0   ba2b418f427c  7706462e3cb7  
ceph-exporter.vm-00  vm-00               running (79m)     6m ago  79m    7344k        -  17.2.6   9cea3956c04b  47b2a6bd0212  
ceph-exporter.vm-01  vm-01               running (78m)     6m ago  78m    7402k        -  17.2.6   9cea3956c04b  73fe9aed14dc  
ceph-exporter.vm-02  vm-02               running (79m)     6m ago  79m    7319k        -  17.2.6   9cea3956c04b  e20ea3a4b85a  
crash.vm-00          vm-00               running (89m)     6m ago  89m    7415k        -  17.2.6   9cea3956c04b  bb0514e714c8  
crash.vm-01          vm-01               running (87m)     6m ago  87m    7428k        -  17.2.6   9cea3956c04b  20c9f6c8969a  
crash.vm-02          vm-02               running (86m)     6m ago  86m    7419k        -  17.2.6   9cea3956c04b  84b8dd65649e  
grafana.vm-00        vm-00  *:3000       running (85m)     6m ago  88m    56.4M        -  8.3.5    dad864ee21e9  300c43bc851d  
mgr.vm-00.omfhaj     vm-00  *:9283       running (90m)     6m ago  90m     436M        -  17.2.6   9cea3956c04b  ab4f32f01014  
mgr.vm-01.ojvcxa     vm-01  *:8443,9283  running (87m)     6m ago  87m     475M        -  17.2.6   9cea3956c04b  c35e352ddabd  
mon.vm-00            vm-00               running (90m)     6m ago  90m    69.9M    2048M  17.2.6   9cea3956c04b  f588c90066e1  
mon.vm-01            vm-01               running (87m)     6m ago  87m    65.1M    2048M  17.2.6   9cea3956c04b  e464653ca34d  
mon.vm-02            vm-02               running (86m)     6m ago  86m    63.9M    2048M  17.2.6   9cea3956c04b  40f0dae4f643  
node-exporter.vm-00  vm-00  *:9100       running (88m)     6m ago  88m    13.5M        -  1.3.1    1dbe0e931976  9cfe7d2c4bf9  
node-exporter.vm-01  vm-01  *:9100       running (87m)     6m ago  87m    23.0M        -  1.3.1    1dbe0e931976  5c59aae80dd4  
node-exporter.vm-02  vm-02  *:9100       running (86m)     6m ago  86m    19.9M        -  1.3.1    1dbe0e931976  bbcd2965b854  
prometheus.vm-01     vm-01  *:9095       running (78m)     6m ago  86m    77.0M        -  2.33.4   514e6a882f6e  5c1406872133  
```
```
[ceph: root@vm-00 /]# ceph orch ls
NAME           PORTS        RUNNING  REFRESHED  AGE  PLACEMENT  
alertmanager   ?:9093,9094      1/1  7m ago     90m  count:1    
ceph-exporter                   3/3  7m ago     79m  *          
crash                           3/3  7m ago     90m  *          
grafana        ?:3000           1/1  7m ago     90m  count:1    
mgr                             2/2  7m ago     90m  count:2    
mon                             3/5  7m ago     90m  count:5    
node-exporter  ?:9100           3/3  7m ago     90m  *          
prometheus     ?:9095           1/1  7m ago     90m  count:1    
```

Luckily, it seems the impact of the reversion was minimal. I saw a single log message

```
[WRN] unable to load spec for ceph-exporter: ServiceSpec: __init__() got an unexpected keyword argument 'prio_limit
```

followed by cephadm discarding the ceph-exporter spec as it can't load it and the ceph-exporter daemons being subsequently removed as they no longer had a matching service spec. No other issues were seen. Daemons and services post upgrade were

```
[ceph: root@vm-00 /]# ceph orch ps
NAME                 HOST   PORTS        STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION               IMAGE ID      CONTAINER ID  
alertmanager.vm-00   vm-00  *:9093,9094  running (3m)     3m ago  97m    16.0M        -  0.23.0                ba2b418f427c  7460239b02bb  
crash.vm-00          vm-00               running (4m)     3m ago  97m    7424k        -  17.2.6-129-g2e256435  e49ad829f207  3617d5f2746c  
crash.vm-01          vm-01               running (4m)     4m ago  95m    7482k        -  17.2.6-129-g2e256435  e49ad829f207  702aef98c870  
crash.vm-02          vm-02               running (4m)     4m ago  94m    7448k        -  17.2.6-129-g2e256435  e49ad829f207  b461874595d5  
grafana.vm-00        vm-00  *:3000       running (3m)     3m ago  96m    35.8M        -  8.3.5                 dad864ee21e9  5e887c0ed520  
mgr.vm-00.omfhaj     vm-00  *:8443,9283  running (6m)     3m ago  98m     438M        -  17.2.6-129-g2e256435  e49ad829f207  f1cd5e3ab612  
mgr.vm-01.ojvcxa     vm-01  *:8443,9283  running (6m)     4m ago  95m     479M        -  17.2.6-129-g2e256435  e49ad829f207  5799f00c3046  
mon.vm-00            vm-00               running (5m)     3m ago  98m    51.0M    2048M  17.2.6-129-g2e256435  e49ad829f207  f57d6bce57fd  
mon.vm-01            vm-01               running (5m)     4m ago  95m    41.6M    2048M  17.2.6-129-g2e256435  e49ad829f207  f3a1eef00d51  
mon.vm-02            vm-02               running (4m)     4m ago  94m    26.4M    2048M  17.2.6-129-g2e256435  e49ad829f207  9f192be8abe6  
node-exporter.vm-00  vm-00  *:9100       running (4m)     3m ago  96m    10.6M        -  1.3.1                 1dbe0e931976  82a108beffa6  
node-exporter.vm-01  vm-01  *:9100       running (4m)     4m ago  95m    16.7M        -  1.3.1                 1dbe0e931976  a28e91a8aae9  
node-exporter.vm-02  vm-02  *:9100       running (4m)     4m ago  94m    3623k        -  1.3.1                 1dbe0e931976  acbf509b02fc  
prometheus.vm-01     vm-01  *:9095       running (4m)     4m ago  94m    24.7M        -  2.33.4                514e6a882f6e  5ddad65370ac  
```
```
[ceph: root@vm-00 /]# ceph orch ls
NAME           PORTS        RUNNING  REFRESHED  AGE  PLACEMENT  
alertmanager   ?:9093,9094      1/1  3m ago     98m  count:1    
crash                           3/3  4m ago     98m  *          
grafana        ?:3000           1/1  3m ago     98m  count:1    
mgr                             2/2  4m ago     98m  count:2    
mon                             3/5  4m ago     98m  count:5    
node-exporter  ?:9100           3/3  4m ago     98m  *          
prometheus     ?:9095           1/1  4m ago     98m  count:1    
```
which is the same as before but with the ceph-exporter daemons/service removed. Given the minimal impact of a single warning level log message (no health warnings were seen either) I think upgrading from a 17.2.6 cluster with the ceph-exporter deployed to one with cephadm's support for it reverted should be fine.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
