### PR TITLE
quincy: mgr/dashboard: rbd-mirror force promotion

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -170,7 +170,7 @@ class Rbd(RESTController):
     @RbdTask('edit', ['{image_spec}', '{name}'], 4.0)
     def set(self, image_spec, name=None, size=None, features=None,
             configuration=None, enable_mirror=None, primary=None,
-            resync=False, mirror_mode=None, schedule_interval='',
+            force=False, resync=False, mirror_mode=None, schedule_interval='',
             remove_scheduling=False):
 
         pool_name, namespace, image_name = parse_image_spec(image_spec)
@@ -220,7 +220,7 @@ class Rbd(RESTController):
 
             if primary and not mirror_image_info['primary']:
                 RbdMirroringService.promote_image(
-                    image_name, pool_name, namespace)
+                    image_name, pool_name, namespace, force)
             elif primary is False and mirror_image_info['primary']:
                 RbdMirroringService.demote_image(
                     image_name, pool_name, namespace)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form-edit-request.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form-edit-request.model.ts
@@ -9,6 +9,7 @@ export class RbdFormEditRequestModel {
   enable_mirror?: boolean;
   mirror_mode?: string;
   primary?: boolean;
+  force?: boolean;
   schedule_interval: string;
   remove_scheduling? = false;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -132,3 +132,13 @@
      title="RBD in status 'Removing'"
      class="{{ icons.warning }} warn"></i>
 </ng-template>
+
+<ng-template #forcePromoteConfirmation>
+  <cd-alert-panel type="warning">{{ errorMessage }}</cd-alert-panel>
+  <div class="m-4"
+       i18n>
+    <strong>
+       Do you want to force the operation?
+    </strong>
+  </div>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -67,6 +67,8 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   provisionedNotAvailableTooltipTpl: TemplateRef<any>;
   @ViewChild('totalProvisionedNotAvailableTooltipTpl', { static: true })
   totalProvisionedNotAvailableTooltipTpl: TemplateRef<any>;
+  @ViewChild('forcePromoteConfirmation', { static: true })
+  forcePromoteConfirmation: TemplateRef<any>;
 
   permission: Permission;
   tableActions: CdTableAction[];
@@ -79,6 +81,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   count = 0;
   private tableContext: CdTableFetchDataContext = null;
   modalRef: NgbModalRef;
+  errorMessage: string;
 
   builders = {
     'rbd/create': (metadata: object) =>
@@ -571,7 +574,31 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         }),
         call: this.rbdService.update(imageSpec, request)
       })
-      .subscribe();
+      .subscribe(
+        () => {},
+        (error) => {
+          if (primary) {
+            this.errorMessage = error.error['detail'].replace(/\[.*?\]\s*/, '');
+            request.force = true;
+            this.modalRef = this.modalService.show(ConfirmationModalComponent, {
+              titleText: $localize`Warning`,
+              buttonText: $localize`Enforce`,
+              warning: true,
+              bodyTpl: this.forcePromoteConfirmation,
+              onSubmit: () => {
+                this.rbdService.update(imageSpec, request).subscribe(
+                  () => {
+                    this.modalRef.close();
+                  },
+                  () => {
+                    this.modalRef.close();
+                  }
+                );
+              }
+            });
+          }
+        }
+      );
   }
 
   hasSnapshots() {

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -566,6 +566,9 @@ paths:
                   type: string
                 features:
                   type: string
+                force:
+                  default: false
+                  type: boolean
                 mirror_mode:
                   type: string
                 name:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59435

---

backport of https://github.com/ceph/ceph/pull/50877
parent tracker: https://tracker.ceph.com/issues/59327

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh