### PR TITLE
quincy: qa/suites/rbd: install qemu-utils in addition to qemu-block-extra on Ubuntu

### DIFF
--- a/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
@@ -8,6 +8,7 @@ tasks:
       - qemu-kvm-block-rbd
       deb:
       - qemu-block-extra
+      - qemu-utils
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
@@ -8,6 +8,7 @@ tasks:
       - qemu-kvm-block-rbd
       deb:
       - qemu-block-extra
+      - qemu-utils
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
@@ -8,6 +8,7 @@ tasks:
       - qemu-kvm-block-rbd
       deb:
       - qemu-block-extra
+      - qemu-utils
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
@@ -8,6 +8,7 @@ tasks:
       - qemu-kvm-block-rbd
       deb:
       - qemu-block-extra
+      - qemu-utils
 - ceph:
     fs: xfs
     conf:

--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -164,19 +164,22 @@ def install_block_rbd_driver(ctx, config):
     """
     Make sure qemu rbd block driver (block-rbd.so) is installed
     """
-    for client, client_config in config.items():
+    packages = {}
+    for client, _ in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
         if remote.os.package_type == 'rpm':
-            block_rbd_pkg = 'qemu-kvm-block-rbd'
+            packages[client] = ['qemu-kvm-block-rbd']
         else:
-            block_rbd_pkg = 'qemu-block-extra'
-        install_package(block_rbd_pkg, remote)
+            packages[client] = ['qemu-block-extra', 'qemu-utils']
+        for pkg in packages[client]:
+            install_package(pkg, remote)
     try:
         yield
     finally:
-        for client, client_config in config.items():
+        for client, _ in config.items():
             (remote,) = ctx.cluster.only(client).remotes.keys()
-            remove_package(block_rbd_pkg, remote)
+            for pkg in packages[client]:
+                remove_package(pkg, remote)
 
 @contextlib.contextmanager
 def generate_iso(ctx, config):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59439

---

backport of https://github.com/ceph/ceph/pull/51051
parent tracker: https://tracker.ceph.com/issues/59431