### PR TITLE
quincy: doc/rgw: refine "Setting a Zonegroup"

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1011,7 +1011,7 @@ Making a Zonegroup the Default
 One zonegroup in the list of zonegroups must be the default zonegroup.  There
 can be only one default zonegroup. In the case that there is only one zonegroup
 which was not designated the default zonegroup when it was created, use the
-folloiwng command to make it the default zonegroup. Commands of this form can
+following command to make it the default zonegroup. Commands of this form can
 be used to change which zonegroup is the default. 
 
 #. Designate a zonegroup as the default zonegroup:
@@ -1184,8 +1184,8 @@ The zonegroup configuration looks like this:
 Setting a Zonegroup
 ~~~~~~~~~~~~~~~~~~~~
 
-The process of defining a zonegroup consists of creating a JSON object and, at
-a minimum, specifying the required settings:
+The process of defining a zonegroup consists of creating a JSON object and
+specifying the required settings. Here is a list of the required settings:
 
 1. ``name``: The name of the zonegroup. Required.
 
@@ -1223,26 +1223,26 @@ a minimum, specifying the required settings:
    object data. Set to ``default-placement`` by default. It is  also possible
    to set a per-user default placement in the user info for each user.
 
-To set a zonegroup, create a JSON object that contains the required fields,
-save the object to a file (e.g., ``zonegroup.json``), and run the following
-command:
+Setting a Zonegroup - Procedure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. prompt:: bash #
+#. To set a zonegroup, create a JSON object that contains the required fields,
+   save the object to a file (for example, ``zonegroup.json``), and run the
+   following command:
+
+   .. prompt:: bash #
    
-   radosgw-admin zonegroup set --infile zonegroup.json
+      radosgw-admin zonegroup set --infile zonegroup.json
 
-Where ``zonegroup.json`` is the JSON file you created.
+   Where ``zonegroup.json`` is the JSON file you created.
 
-.. important:: The ``default`` zonegroup ``is_master`` setting is ``true`` by
-   default. If you create a new zonegroup and want to make it the master
-   zonegroup, you must either set the ``default`` zonegroup ``is_master``
-   setting to ``false``, or delete the ``default`` zonegroup.
+   .. important:: The ``default`` zonegroup ``is_master`` setting is ``true`` by default. If you create an additional zonegroup and want to make it the master zonegroup, you must either set the ``default`` zonegroup ``is_master`` setting to ``false`` or delete the ``default`` zonegroup.
 
-Finally, update the period:
+#. Update the period:
 
-.. prompt:: bash #
+   .. prompt:: bash #
    
-   radosgw-admin period update --commit
+      radosgw-admin period update --commit
 
 Setting a Zonegroup Map
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Streamline the "Setting a Zonegroup" section by separating out the necessary prerequisite reading from the procedure itself.

I also corrected a typo in the word "following" in an unrelated section.

Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 6e6010a31352ecce2c4c0fdd6ed11fba43165b6b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
