### PR TITLE
quincy: mgr/dashboard: fix cephadm e2e expression changed error

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/support/index.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/support/index.ts
@@ -10,7 +10,8 @@ afterEach(() => {
 Cypress.on('uncaught:exception', (err: Error) => {
   if (
     err.message.includes('ResizeObserver loop limit exceeded') ||
-    err.message.includes('api/prometheus/rules')
+    err.message.includes('api/prometheus/rules') ||
+    err.message.includes('NG0100: ExpressionChangedAfterItHasBeenCheckedError')
   ) {
     return false;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59451

---

backport of https://github.com/ceph/ceph/pull/51074
parent tracker: https://tracker.ceph.com/issues/59444

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh