### PR TITLE
quincy: mon: avoid exception when setting require-osd-release more than 2

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11628,7 +11628,13 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = 0;
       goto reply;
     }
-    ceph_assert(osdmap.require_osd_release >= ceph_release_t::octopus);
+    if (osdmap.require_osd_release < ceph_release_t::octopus && !sure) {
+      ss << "Not advisable to continue since current 'require_osd_release' "
+         << "refers to a very old Ceph release. Pass "
+	 << "--yes-i-really-mean-it if you really wish to continue.";
+      err = -EPERM;
+      goto reply;
+    }
     if (!osdmap.get_num_up_osds() && !sure) {
       ss << "Not advisable to continue since no OSDs are up. Pass "
 	 << "--yes-i-really-mean-it if you really wish to continue.";


### PR DESCRIPTION
versions up.

Request for additional confirmation instead.

Fixes: https://tracker.ceph.com/issues/59456

Signed-off-by: RaminNietzsche <Ramin.Najarbashi@gmail.com>

(cherry picked from commit https://github.com/ceph/ceph/commit/9021e57d83d7d35c95a43e13320b13d530453f03)
## Checklist

- Tracker
  - [x] References tracker ticket https://tracker.ceph.com/issues/58156
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
