### PR TITLE
quincy: mgr/dashboard: remove unncessary hyperlink in landing page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -117,7 +117,6 @@
       <li *ngIf="healthData.mgr_map"
           class="list-group-item">
         <cd-card-row [data]="healthData.mgr_map | mgrSummary"
-                     link="/manager"
                      title="Manager"
                      *ngIf="healthData.mgr_map"></cd-card-row>
       </li>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59464

---

backport of https://github.com/ceph/ceph/pull/51115
parent tracker: https://tracker.ceph.com/issues/59462

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh