### PR TITLE
Fix is_device to handle properly symlinks to block devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -359,6 +359,10 @@ def is_device(dev):
         if not allow_loop_devices():
             return False
 
+    # stat fails to recognize a device through a symlink
+    if os.path.islink(dev):
+        dev = os.path.realpath(dev)
+
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
 


### PR DESCRIPTION
is_device calls stat.S_ISBLK on a lstat output. which will obviously fail if dev is a symlink, as the stat object is essentially giving intel on the actual symlink and not its target. Yet the backend mechanisms called by ceph-volume do handle properly symlinks. It is therefore better to dereference the actual symlink, otherwise the, eg, multipath support will be broken as it'll need people to call realpath and pass the /dev/dm-X path to ceph-volume, while ceph-volume inventory function actually sees /dev/mapper/XXXX

Feel free to take this and put it the way you like in the code or to drop the PR.