### PR TITLE
reef: win32_deps_build: avoid pip

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -74,7 +74,6 @@ case "$OS" in
             libtool \
             ninja-build \
             zip \
-            python3-Cython \
             python3-PyYAML \
             gcc \
             diffutils \
@@ -86,15 +85,15 @@ case "$OS" in
     ubuntu)
         sudo apt-get update
         sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
-            mingw-w64 cmake pkg-config \
-            python3-dev python3-pip python3-yaml \
-                autoconf libtool ninja-build wget zip
-        sudo python3 -m pip install cython
+            mingw-w64 g++ cmake pkg-config \
+            python3-dev python3-yaml \
+                autoconf libtool ninja-build wget zip \
+                git
         ;;
     suse)
         for PKG in mingw64-cross-gcc-c++ mingw64-libgcc_s_seh1 mingw64-libstdc++6 \
                 cmake pkgconf python3-devel autoconf libtool ninja zip \
-                python3-Cython python3-PyYAML \
+                python3-PyYAML \
                 gcc patch wget git; do
             rpm -q $PKG >/dev/null || zypper -n install $PKG
         done


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59480

---

backport of https://github.com/ceph/ceph/pull/50916
parent tracker: https://tracker.ceph.com/issues/59354

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh