### PR TITLE
quincy: win32_deps_build: avoid pip

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -72,7 +72,7 @@ case "$OS" in
         sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
             mingw-w64 cmake pkg-config \
             python3-dev python3-pip python3-yaml \
-                autoconf libtool ninja-build zip
+                autoconf libtool ninja-build wget zip
         sudo python3 -m pip install cython
         ;;
     suse)

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -69,7 +69,8 @@ echo "Installing required packages."
 case "$OS" in
     ubuntu)
         sudo apt-get update
-        sudo apt-get -y install mingw-w64 cmake pkg-config \
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
+            mingw-w64 cmake pkg-config \
             python3-dev python3-pip python3-yaml \
                 autoconf libtool ninja-build zip
         sudo python3 -m pip install cython

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -70,15 +70,15 @@ case "$OS" in
     ubuntu)
         sudo apt-get update
         sudo env DEBIAN_FRONTEND=noninteractive apt-get -y install \
-            mingw-w64 cmake pkg-config \
-            python3-dev python3-pip python3-yaml \
-                autoconf libtool ninja-build wget zip
-        sudo python3 -m pip install cython
+            mingw-w64 g++ cmake pkg-config \
+            python3-dev python3-yaml \
+                autoconf libtool ninja-build wget zip \
+                git
         ;;
     suse)
         for PKG in mingw64-cross-gcc-c++ mingw64-libgcc_s_seh1 mingw64-libstdc++6 \
                 cmake pkgconf python3-devel autoconf libtool ninja zip \
-                python3-Cython python3-PyYAML \
+                python3-PyYAML \
                 gcc patch wget git; do
             rpm -q $PKG >/dev/null || zypper -n install $PKG
         done


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59479

---

backport of https://github.com/ceph/ceph/pull/50916
backport of https://github.com/ceph/ceph/pull/48147
parent tracker: https://tracker.ceph.com/issues/59354

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh