### PR TITLE
qa: wait for 100 seconds to make sure the quota to be enforced

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1247,7 +1247,7 @@ class TestSubvolumeGroups(TestVolumesHelper):
             # For quota to be enforced
             time.sleep(20)
             # create 400 files of 1MB to exceed quota
-            self._do_subvolume_io(subvolname, subvolume_group=group, number_of_files=400)
+            self._do_subvolume_io(subvolname, subvolume_group=group, create_dir='dir2', number_of_files=400)
         except CommandFailedError:
             # remove with snapshot retention
             self._fs_cmd("subvolume", "rm", self.volname, subvolname, "--group_name", group, "--retain-snapshots")

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1244,8 +1244,10 @@ class TestSubvolumeGroups(TestVolumesHelper):
         try:
             # write two files of 1MB file to exceed the quota
             self._do_subvolume_io(subvolname, subvolume_group=group, create_dir='dir1', number_of_files=2)
-            # For quota to be enforced
-            time.sleep(20)
+            # For quota to be enforced. Just wait for 100 seconds because the worst case in kclient the
+            # dirty caps will be held for 60 seconds, and also the MDS may defer updating the dir rstat
+            # for 5 seconds, which is per tick, maybe longer if need to wait for mdlog to flush.
+            time.sleep(100)
             # create 400 files of 1MB to exceed quota
             self._do_subvolume_io(subvolname, subvolume_group=group, create_dir='dir2', number_of_files=400)
         except CommandFailedError:


### PR DESCRIPTION
The worst case in kclient the dirty caps will be held for 60 seconds,
and also the MDS may defer updating the directory rstat for 5 seconds,
which is per tick, maybe longer if needs to wait for mdlog to flush.

Fixes: https://tracker.ceph.com/issues/59349
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] QA change
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
