### PR TITLE
[DNM] mgr/cephadm: well defined daemon suffixes

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -12,13 +12,11 @@ from threading import Event
 
 from cephadm.service_discovery import ServiceDiscovery
 
-import string
 from typing import List, Dict, Optional, Callable, Tuple, TypeVar, \
     Any, Set, TYPE_CHECKING, cast, NamedTuple, Sequence, Type, Awaitable
 
 import datetime
 import os
-import random
 import multiprocessing.pool
 import subprocess
 from prettytable import PrettyTable
@@ -789,6 +787,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         if '.' in host:
             host = host.split('.')[0]
+        enumeration: int = 0
         while True:
             if prefix:
                 name = prefix + '.'
@@ -798,8 +797,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 name += f'{rank}.{rank_generation}.'
             name += host
             if suffix:
-                name += '.' + ''.join(random.choice(string.ascii_lowercase)
-                                      for _ in range(6))
+                name += '.' + str(enumeration)
+                enumeration += 1
             if len([d for d in existing if d.daemon_id == name]):
                 if not suffix:
                     raise orchestrator.OrchestratorValidationError(


### PR DESCRIPTION
Testing the effect of using numerical suffixes that just count up instead of randomly generated suffixes. Deployed a cluster with this change with 2 RGW services and an MDS service all deploying multipled daemons per host (and some overlap between what hosts they were deployed on) and it seemed to be okay. Can see names like rgw.foobar.vm-01.0, rgw.foobar.vm-01.1, rgw.bar.vm-01.0, rgw.bar.vm-01.1, etc. Both RGW services were deploying 3 daemons per host, MDS service was setup for 2 daemons per host. One mgr still has random suffix since I didn't modify bootstrap

```
[ceph: root@vm-00 /]# ceph orch ps
NAME                 HOST   PORTS             STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
alertmanager.vm-00   vm-00  *:9093,9094       running (20m)    60s ago  23m    23.5M        -  0.23.0                 ba2b418f427c  2f0a51dc15f0  
ceph-exporter.vm-00  vm-00                    running (23m)    60s ago  23m    9592k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  f45465e06856  
ceph-exporter.vm-01  vm-01                    running (21m)    60s ago  21m    9831k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  bcbef5ccbe3a  
ceph-exporter.vm-02  vm-02                    running (20m)     9m ago  20m    8908k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  a76a3615a4d7  
crash.vm-00          vm-00                    running (23m)    60s ago  23m    7448k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  20cee38bb208  
crash.vm-01          vm-01                    running (21m)    60s ago  21m    7461k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  22cd6a7d6a5f  
crash.vm-02          vm-02                    running (20m)     9m ago  20m    7461k        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  7ca324e6c7ab  
grafana.vm-00        vm-00  *:3000            running (20m)    60s ago  22m    51.6M        -  8.3.5                  dad864ee21e9  4abe46cdbd18  
mds.foo.vm-00.0      vm-00                    running (17m)    60s ago  17m    22.8M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  487248ad574e  
mds.foo.vm-00.1      vm-00                    running (15m)    60s ago  15m    19.3M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  e57183be1f2d  
mds.foo.vm-02.0      vm-02                    running (17m)     9m ago  17m    19.7M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  c228c3eb1a58  
mds.foo.vm-02.1      vm-02                    running (15m)     9m ago  15m    19.3M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  115ad703f778  
mgr.vm-00.oulhug     vm-00  *:9283,8765,8443  running (24m)    60s ago  24m     515M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  738128f2cdc9  
mgr.vm-01.0          vm-01  *:8443,9283,8765  running (21m)    60s ago  21m     438M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  48aba1191c74  
mon.vm-00            vm-00                    running (24m)    60s ago  24m    99.9M    2048M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  892b2d38b2d8  
mon.vm-01            vm-01                    running (21m)    60s ago  21m    86.7M    2048M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  dfe8958ee492  
mon.vm-02            vm-02                    running (20m)     9m ago  20m    64.4M    2048M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  c451f98f9e31  
node-exporter.vm-00  vm-00  *:9100            running (22m)    60s ago  22m    20.8M        -  1.3.1                  1dbe0e931976  b1b469f63db7  
node-exporter.vm-01  vm-01  *:9100            running (21m)    60s ago  21m    20.8M        -  1.3.1                  1dbe0e931976  d7f62f2fbe40  
node-exporter.vm-02  vm-02  *:9100            running (20m)     9m ago  20m    22.2M        -  1.3.1                  1dbe0e931976  9429740c8bfb  
osd.0                vm-01                    running (19m)    60s ago  19m     145M    8311M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  b556799a4ae4  
osd.1                vm-01                    running (18m)    60s ago  19m     154M    8311M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  7e199690352c  
osd.2                vm-00                    running (19m)    60s ago  19m     150M    5239M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  0bb2a3e8524d  
osd.3                vm-00                    running (18m)    60s ago  19m     150M    5239M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  e3ff641b346c  
osd.4                vm-02                    running (18m)     9m ago  18m     121M    6775M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  bf01d8a83b35  
osd.5                vm-02                    running (18m)     9m ago  18m     118M    6775M  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  3b20453e561b  
prometheus.vm-01     vm-01  *:9095            running (19m)    60s ago  21m    65.1M        -  2.33.4                 514e6a882f6e  c80fc9074507  
rgw.bar.vm-01.0      vm-01  *:80              running (14m)    60s ago  14m    91.3M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  a2d786283a4c  
rgw.bar.vm-01.1      vm-01  *:82              running (12m)    60s ago  12m    90.5M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  98b7a80e1231  
rgw.bar.vm-01.2      vm-01  *:81              running (11m)    60s ago  11m    89.6M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  e0226829e40a  
rgw.bar.vm-02.0      vm-02  *:82              running (11m)     9m ago  12m    89.4M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  a0944d1d2a73  
rgw.bar.vm-02.1      vm-02  *:81              running (11m)     9m ago  11m    86.9M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  5cd3ed0dbbe8  
rgw.bar.vm-02.2      vm-02  *:80              running (11m)     9m ago  11m    85.9M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  8bfed89805e0  
rgw.foobar.vm-00.0   vm-00  *:9992            running (2m)     60s ago   3m    86.7M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  a7e78ecdff0f  
rgw.foobar.vm-00.1   vm-00  *:9991            running (2m)     60s ago   2m    86.6M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  0c1eda293914  
rgw.foobar.vm-00.2   vm-00  *:9990            running (2m)     60s ago   2m    86.1M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  1958eb8e4d2a  
rgw.foobar.vm-01.0   vm-01  *:9992            running (2m)     60s ago   3m    85.7M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  57a31c73631a  
rgw.foobar.vm-01.1   vm-01  *:9991            running (2m)     60s ago   2m    86.3M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  073b6bfd6d95  
rgw.foobar.vm-01.2   vm-01  *:9990            running (2m)     60s ago   2m    86.4M        -  18.0.0-1891-g55b99b5b  3c6d1c53e0ea  3e9a73b5563c  

[ceph: root@vm-00 /]# ceph -s
  cluster:
    id:     c83a10d8-ddf1-11ed-aada-5254007e5618
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum vm-00,vm-01,vm-02 (age 23m)
    mgr: vm-00.oulhug(active, since 25m), standbys: vm-01.0
    mds: 1/1 daemons up, 3 standby
    osd: 6 osds: 6 up (since 21m), 6 in (since 22m)
    rgw: 12 daemons active (3 hosts, 1 zones)
 
  data:
    volumes: 1/1 healthy
    pools:   7 pools, 177 pgs
    objects: 216 objects, 456 KiB
    usage:   293 MiB used, 450 GiB / 450 GiB avail
    pgs:     177 active+clean
 

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
