### PR TITLE
reef: mgr/dashboard: skip Create OSDs step in Cluster expansion

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/06-cluster-check.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/06-cluster-check.e2e-spec.ts
@@ -20,6 +20,11 @@ describe('when cluster creation is completed', () => {
     createCluster.navigateTo();
     createCluster.createCluster();
 
+    // Explicitly skip OSD Creation Step so that it prevents from
+    // deploying OSDs to the hosts automatically.
+    cy.get('.nav-link').contains('Create OSDs').click();
+    cy.get('button[aria-label="Skip this step"]').click();
+
     cy.get('.nav-link').contains('Review').click();
     cy.get('button[aria-label="Next"]').click();
     cy.get('cd-dashboard').should('exist');


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59468

---

backport of https://github.com/ceph/ceph/pull/51082
parent tracker: https://tracker.ceph.com/issues/59457

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh