### PR TITLE
osd: avoid out-of-bound vector access in PeeringState::init_hb_stamps

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -852,7 +852,7 @@ void PeeringState::init_hb_stamps()
 {
   if (is_primary()) {
     // we care about all other osds in the acting set
-    hb_stamps.resize(acting.size() - 1);
+    hb_stamps.resize(acting.size());
     unsigned i = 0;
     for (auto p : acting) {
       if (p == CRUSH_ITEM_NONE || p == get_primary().osd) {


### PR DESCRIPTION
When tricking cluster with 'primary-temp' command coupled with OSD adding/removal an OSD might get to a state when it considers itself as primary for a certain PG while received acting set doesn't include this OSD. As a result PeeringState::init_hb_stamps() might allocate too short hb_stamps vector and erroneusly access out-of-bound entries. E.g. primary OSD.0 gets acting set [3,5,1], performs hb_stamps.resize(2) and then trying to add three hb stamps as no primary entry is omitted in the loop over the acting set.

Fixes: https://tracker.ceph.com/issues/59491

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
