### PR TITLE
rgw/sts: AssumeRole no longer writes to user metadata

### DIFF
--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -193,7 +193,6 @@ struct DBOpUserPrepareInfo {
   static constexpr const char* user_quota = ":user_quota";
   static constexpr const char* type = ":type";
   static constexpr const char* mfa_ids = ":mfa_ids";
-  static constexpr const char* assumed_role_arn = ":assumed_role_arn";
   static constexpr const char* user_attrs = ":user_attrs";
   static constexpr const char* user_ver = ":user_vers";
   static constexpr const char* user_ver_tag = ":user_ver_tag";
@@ -725,10 +724,10 @@ class InsertUserOp : virtual public DBOp {
                            AccessKeysID, AccessKeysSecret, AccessKeys, SwiftKeys,\
                            SubUsers, Suspended, MaxBuckets, OpMask, UserCaps, Admin, \
                            System, PlacementName, PlacementStorageClass, PlacementTags, \
-                           BucketQuota, TempURLKeys, UserQuota, Type, MfaIDs, AssumedRoleARN, \
+                           BucketQuota, TempURLKeys, UserQuota, Type, MfaIDs, \
                            UserAttrs, UserVersion, UserVersionTag) \
                           VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, \
-                              {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});";
+                              {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});";
 
   public:
     virtual ~InsertUserOp() {}
@@ -746,8 +745,8 @@ class InsertUserOp : virtual public DBOp {
           params.op.user.placement_tags, params.op.user.bucket_quota,
           params.op.user.temp_url_keys, params.op.user.user_quota,
           params.op.user.type, params.op.user.mfa_ids,
-          params.op.user.assumed_role_arn, params.op.user.user_attrs,
-          params.op.user.user_ver, params.op.user.user_ver_tag);
+          params.op.user.user_attrs, params.op.user.user_ver,
+          params.op.user.user_ver_tag);
     }
 
 };

--- a/src/rgw/driver/dbstore/dbstore_main.cc
+++ b/src/rgw/driver/dbstore/dbstore_main.cc
@@ -50,7 +50,6 @@ void* process(void *arg)
   params.op.user.uinfo.user_id.id = user1;
   params.op.user.uinfo.suspended = 123;
   params.op.user.uinfo.max_buckets = 456;
-  params.op.user.uinfo.assumed_role_arn = "role";
   params.op.user.uinfo.placement_tags.push_back("tags1");
   params.op.user.uinfo.placement_tags.push_back("tags2");
 
@@ -73,7 +72,6 @@ void* process(void *arg)
 
   cout << "tenant: " << params2.op.user.uinfo.user_id.tenant << "\n";
   cout << "suspended: " << (int)params2.op.user.uinfo.suspended << "\n";
-  cout << "assumed_role_arn: " << params2.op.user.uinfo.assumed_role_arn << "\n";
 
   list<string>::iterator it = params2.op.user.uinfo.placement_tags.begin();
 

--- a/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/driver/dbstore/sqlite/sqliteDB.cc
@@ -395,8 +395,6 @@ static int list_user(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *
 
   SQL_DECODE_BLOB_PARAM(dpp, stmt, MfaIDs, op.user.uinfo.mfa_ids, sdb);
 
-  op.user.uinfo.assumed_role_arn = (const char*)sqlite3_column_text(stmt, AssumedRoleARN);
-
   SQL_DECODE_BLOB_PARAM(dpp, stmt, UserAttrs, op.user.user_attrs, sdb);
   op.user.user_version.ver = sqlite3_column_int(stmt, UserVersion);
   op.user.user_version.tag = (const char*)sqlite3_column_text(stmt, UserVersionTag);
@@ -1178,9 +1176,6 @@ int SQLInsertUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.mfa_ids, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.mfa_ids, sdb);
-
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.assumed_role_arn, sdb);
-  SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.assumed_role_arn.c_str(), sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_attrs, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.user_attrs, sdb);

--- a/src/rgw/driver/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/driver/dbstore/tests/dbstore_tests.cc
@@ -147,7 +147,6 @@ TEST_F(DBStoreTest, InsertUser) {
   params.op.user.uinfo.user_email = "user1@dbstore.com";
   params.op.user.uinfo.suspended = 123;
   params.op.user.uinfo.max_buckets = 456;
-  params.op.user.uinfo.assumed_role_arn = "role";
   params.op.user.uinfo.placement_tags.push_back("tags");
   RGWAccessKey k1("id1", "key1");
   RGWAccessKey k2("id2", "key2");
@@ -171,7 +170,6 @@ TEST_F(DBStoreTest, GetUser) {
   ASSERT_EQ(params.op.user.uinfo.user_id.id, "user_id1");
   ASSERT_EQ(params.op.user.uinfo.suspended, 123);
   ASSERT_EQ(params.op.user.uinfo.max_buckets, 456);
-  ASSERT_EQ(params.op.user.uinfo.assumed_role_arn, "role");
   ASSERT_EQ(params.op.user.uinfo.placement_tags.back(), "tags");
   RGWAccessKey k;
   map<string, RGWAccessKey>::iterator it2 = params.op.user.uinfo.access_keys.begin();
@@ -199,7 +197,6 @@ TEST_F(DBStoreTest, GetUserQuery) {
   ASSERT_EQ(params.op.user.uinfo.user_id.id, "user_id1");
   ASSERT_EQ(params.op.user.uinfo.suspended, 123);
   ASSERT_EQ(params.op.user.uinfo.max_buckets, 456);
-  ASSERT_EQ(params.op.user.uinfo.assumed_role_arn, "role");
   ASSERT_EQ(params.op.user.uinfo.placement_tags.back(), "tags");
   RGWAccessKey k;
   map<string, RGWAccessKey>::iterator it2 = params.op.user.uinfo.access_keys.begin();
@@ -227,7 +224,6 @@ TEST_F(DBStoreTest, GetUserQueryByEmail) {
   ASSERT_EQ(uinfo.user_id.id, "user_id1");
   ASSERT_EQ(uinfo.suspended, 123);
   ASSERT_EQ(uinfo.max_buckets, 456);
-  ASSERT_EQ(uinfo.assumed_role_arn, "role");
   ASSERT_EQ(uinfo.placement_tags.back(), "tags");
   RGWAccessKey k;
   map<string, RGWAccessKey>::iterator it2 = uinfo.access_keys.begin();
@@ -253,7 +249,6 @@ TEST_F(DBStoreTest, GetUserQueryByAccessKey) {
   ASSERT_EQ(uinfo.user_id.id, "user_id1");
   ASSERT_EQ(uinfo.suspended, 123);
   ASSERT_EQ(uinfo.max_buckets, 456);
-  ASSERT_EQ(uinfo.assumed_role_arn, "role");
   ASSERT_EQ(uinfo.placement_tags.back(), "tags");
   RGWAccessKey k;
   map<string, RGWAccessKey>::iterator it2 = uinfo.access_keys.begin();
@@ -284,7 +279,6 @@ TEST_F(DBStoreTest, StoreUser) {
   uinfo.user_email = "user2@dbstore.com";
   uinfo.suspended = 123;
   uinfo.max_buckets = 456;
-  uinfo.assumed_role_arn = "role";
   uinfo.placement_tags.push_back("tags");
   RGWAccessKey k1("id1", "key1");
   RGWAccessKey k2("id2", "key2");
@@ -336,7 +330,6 @@ TEST_F(DBStoreTest, GetUserQueryByUserID) {
   ASSERT_EQ(uinfo.user_id.id, "user_id2");
   ASSERT_EQ(uinfo.suspended, 123);
   ASSERT_EQ(uinfo.max_buckets, 456);
-  ASSERT_EQ(uinfo.assumed_role_arn, "role");
   ASSERT_EQ(uinfo.placement_tags.back(), "tags");
   RGWAccessKey k;
   map<string, RGWAccessKey>::iterator it = uinfo.access_keys.begin();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -560,7 +560,6 @@ struct RGWUserInfo
   RGWQuota quota;
   uint32_t type;
   std::set<std::string> mfa_ids;
-  std::string assumed_role_arn;
 
   RGWUserInfo()
     : suspended(0),
@@ -625,7 +624,10 @@ struct RGWUserInfo
      encode(admin, bl);
      encode(type, bl);
      encode(mfa_ids, bl);
-     encode(assumed_role_arn, bl);
+     {
+       std::string assumed_role_arn; // removed
+       encode(assumed_role_arn, bl);
+     }
      encode(user_id.ns, bl);
      ENCODE_FINISH(bl);
   }
@@ -709,6 +711,7 @@ struct RGWUserInfo
       decode(mfa_ids, bl);
     }
     if (struct_v >= 21) {
+      std::string assumed_role_arn; // removed
       decode(assumed_role_arn, bl);
     }
     if (struct_v >= 22) {

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -319,23 +319,6 @@ std::tuple<int, rgw::sal::RGWRole*> STSService::getRoleInfo(const DoutPrefixProv
   }
 }
 
-int STSService::storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y)
-{
-  int ret = 0;
-  std::unique_ptr<rgw::sal::User> user = driver->get_user(user_id);
-  if ((ret = user->load_user(dpp, y)) < 0) {
-    return -ERR_NO_SUCH_ENTITY;
-  }
-
-  user->get_info().assumed_role_arn = arn;
-
-  ret = user->store_user(dpp, y, false, &user->get_info());
-  if (ret < 0) {
-    return -ERR_INTERNAL_ERROR;
-  }
-  return ret;
-}
-
 AssumeRoleWithWebIdentityResponse STSService::assumeRoleWithWebIdentity(const DoutPrefixProvider *dpp, AssumeRoleWithWebIdentityRequest& req)
 {
   AssumeRoleWithWebIdentityResponse response;
@@ -443,13 +426,6 @@ AssumeRoleResponse STSService::assumeRole(const DoutPrefixProvider *dpp,
                                               boost::none,
                                               boost::none,
                                               user_id, nullptr);
-  if (response.retCode < 0) {
-    return response;
-  }
-
-  //Save ARN with the user
-  string arn = response.user.getARN();
-  response.retCode = storeARN(dpp, arn, y);
   if (response.retCode < 0) {
     return response;
   }

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -238,7 +238,6 @@ class STSService {
   rgw_user user_id;
   std::unique_ptr<rgw::sal::RGWRole> role;
   rgw::auth::Identity* identity;
-  int storeARN(const DoutPrefixProvider *dpp, std::string& arn, optional_yield y);
 public:
   STSService() = default;
   STSService(CephContext* cct, rgw::sal::Driver* driver, rgw_user user_id,


### PR DESCRIPTION
`storeARN()` was storing the role's ARN in `RGWUserInfo::assumed_role_arn`, but that field was unused

Fixes: https://tracker.ceph.com/issues/59495

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
