### PR TITLE
quincy: mgr/dashboard: hide notification on force promote

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -577,6 +577,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
       .subscribe(
         () => {},
         (error) => {
+          error.preventDefault();
           if (primary) {
             this.errorMessage = error.error['detail'].replace(/\[.*?\]\s*/, '');
             request.force = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59501

---

backport of https://github.com/ceph/ceph/pull/51163
parent tracker: https://tracker.ceph.com/issues/59500

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh