### PR TITLE
mgr: block registration of a module's client

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -85,6 +85,14 @@ such as an HTTP server, the module may publish its address when it
 is loaded.  To see the addresses of such modules, use the command
 ``ceph mgr services``.
 
+.. note::
+
+   Enabling a module will asynchronously trigger the respawn of the ceph-mgr
+   daemon. The respawned daemon then loads enabled modules one by one. Hence
+   the loading of a (newly enabled) module is not immediate; any command issued
+   against the module before it is finished loading can fail with a transient
+   ENOTSUP error.
+
 Some modules may also implement a special standby mode which runs on
 standby ceph-mgr daemons as well as the active daemon.  This enables
 modules that provide services to redirect their clients to the active

--- a/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
+++ b/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
@@ -13,6 +13,8 @@ tasks:
 - exec:
     mon.a:
       - ceph mgr module enable snap_schedule
+      # Ensure snap_schedule module is loaded
+      - while ! ceph fs snap-schedule status; do sleep 5; done
       - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
       - ceph config set mgr mgr/snap_schedule/dump_on_update true
       - ceph fs snap-schedule add --fs=cephfs --path=/ --snap_schedule=1M

--- a/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
@@ -16,6 +16,8 @@ tasks:
 - cephadm.shell:
     host.a:
       - ceph mgr module enable rgw
+      # Ensure rgw module is loaded
+      - while ! ceph rgw realm tokens; do sleep 5; done
 - rgw_module.apply:
     specs:
       - rgw_realm: myrealm1

--- a/qa/workunits/fs/cephfs_mirror_ha_gen.sh
+++ b/qa/workunits/fs/cephfs_mirror_ha_gen.sh
@@ -25,6 +25,8 @@ trap cleanup EXIT
 configure_peer()
 {
     ceph mgr module enable mirroring
+    # Ensure mirroring module is loaded
+    while ! ceph fs snapshot mirror daemon status; do sleep 5; done
     ceph fs snapshot mirror enable $PRIMARY_FS
     ceph fs snapshot mirror peer_add $PRIMARY_FS client.mirror_remote@ceph $BACKUP_FS
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -1392,9 +1392,14 @@ ceph_register_client(BaseMgrModule *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "s:ceph_register_client", &addrs)) {
     return nullptr;
   }
-  without_gil([&] {
-    self->py_modules->register_client(self->this_module->get_name(), addrs);
-  });
+  try {
+    without_gil([&] {
+      self->py_modules->register_client(self->this_module->get_name(), addrs);
+    });
+  } catch (std::runtime_error& e) {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+    return nullptr;
+  }
   Py_RETURN_NONE;
 }
 

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -18,6 +18,7 @@
 #include "mgr/ClusterState.h"
 #include <time.h>
 #include <boost/range/adaptor/reversed.hpp>
+#include "include/Context.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
@@ -57,6 +58,7 @@ void ClusterState::set_mgr_map(MgrMap const &new_mgrmap)
 {
   std::lock_guard l(lock);
   mgr_map = new_mgrmap;
+  finish_contexts(g_ceph_context, waiting_for_mgrmap);
 }
 
 void ClusterState::set_service_map(ServiceMap const &new_service_map)

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -225,6 +225,18 @@ public:
     return clients;
   }
 
+  bool is_client_in_registry(std::string_view name,
+                             const entity_addrvec_t& client_addr) const {
+    std::lock_guard l(lock);
+    auto itp = clients.equal_range(std::string(name));
+    for (auto it = itp.first; it != itp.second; ++it) {
+      if (it->second == client_addr) {
+	return true;
+      }
+    }
+    return false;
+  }
+
   bool is_module_active(const std::string &name) {
     ceph_assert(active_modules);
     return active_modules->module_exists(name);


### PR DESCRIPTION
... until the registration is reflected in the new MgrMap received
from the monitor. This guarantees that the monitor can blocklist all
the registered clients of the mgr being dropped by the monitor.
And this also prevents the possible racing of the clients of the mgr
being failed that reconnect on being blocklisted against the clients
of the standby mgr being promoted during mgr failover.

When a module is registering a client, the client is first registered
in the mgr's py_module_registry. Next time the mgr sends a beacon to
the monitor, it requests the monitor to register the client in the
its py_module_registry onto the monitor's MgrMap. The monitor on
receiving the beacon registers the client in the MgrMap, and sends an
updated MgrMap to the mgr. It's possible that a mgr module registers
its client in the py_module_registy, and when waiting for the client
to be registered in the monitor's MgrMap another mgr thread deregisters
the client from the py_module_registry. Here, the mgr will never send
a beacon message requesting for the client to be registered in the
MgrMap as the client is no longer in the py_module_registry. So the
module will be stuck waiting for the MgrMap with the client registered
in it. To prevent such a scenario, error out of the module's client
registration after receiving the new MgrMap from the monitor and
noticing that the client is not in the mgr's py_module_registry.

Fixes: https://tracker.ceph.com/issues/58924


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
