### PR TITLE
cephadm: require --image is passed to inspect-image

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -19,7 +19,7 @@ Synopsis
 
 | **cephadm** **pull**
 
-| **cephadm** **inspect-image**
+| **cephadm** --image IMAGE_NAME **inspect-image**
 
 | **cephadm** **ls** [-h] [--no-detail] [--legacy-dir LEGACY_DIR]
 
@@ -334,7 +334,10 @@ Positional arguments:
 inspect-image
 -------------
 
-inspect local ceph container image.
+Inspect local Ceph container image. From Reef onward, requires specifying
+the image to inspect with ``--image``::
+
+    cephadm --image IMAGE_NAME inspect-image
 
 list-networks
 -------------

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2243,6 +2243,19 @@ def infer_image(func: FuncT) -> FuncT:
     return cast(FuncT, _infer_image)
 
 
+def require_image(func: FuncT) -> FuncT:
+    """
+    Require the global --image flag to be set
+    """
+    @wraps(func)
+    def _require_image(ctx: CephadmContext) -> Any:
+        if not ctx.image:
+            raise Error('This command requires the global --image option to be set')
+        return func(ctx)
+
+    return cast(FuncT, _require_image)
+
+
 def default_image(func: FuncT) -> FuncT:
     @wraps(func)
     def _default_image(ctx: CephadmContext) -> Any:
@@ -4882,6 +4895,7 @@ def _pull_image(ctx, image, insecure=False):
 ##################################
 
 
+@require_image
 @infer_image
 def command_inspect_image(ctx):
     # type: (CephadmContext) -> int

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -152,6 +152,18 @@ class TestCephAdm(object):
         args = _cephadm._parse_args(['--image', 'foo', 'version'])
         assert args.image == 'foo'
 
+    def test_check_required_global_args(self):
+        ctx = _cephadm.CephadmContext()
+        mock_fn = mock.Mock()
+        mock_fn.return_value = 0
+        require_image = _cephadm.require_image(mock_fn)
+
+        with pytest.raises(_cephadm.Error, match='This command requires the global --image option to be set'):
+            require_image(ctx)
+
+        ctx.image = 'sample-image'
+        require_image(ctx)
+
     @mock.patch('cephadm.logger')
     def test_parse_mem_usage(self, _logger):
         len, summary = _cephadm._parse_mem_usage(0, 'c6290e3f1489,-- / --')


### PR DESCRIPTION
The selection of an image by default was likely unused and has always been a bit of a flaky thing, especially if multiple clusters are making use of the host where this is run. It seems preferable to just require this argument. Additionally, the command without the image specified is currently untested and prone to being broken. All uses of inspect-image done through the cephadm mgr module specify the image.

Ideally this would be done directly through some functionality in the ArgumentParser library to make a certain subparser require an argument specified in the main parser, but I couldn't find any functionality for that, hence this more manual method.

A few things to note for review:

- If somebody _could_ find a way to do this directly through the ArgumentParser, that would be preferable to the current approach
- Do we also want to require the image be specified for `cephadm pull`? Note that `cephadm pull` infers an image (if it is not specified), pulls the image, and then calls into `command_inspect_image`
- This is not intended to be backported farther than reef.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
