### PR TITLE
crimson/os/seastore: realize lazy read in split overwrite with overwrite refactor

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1462,6 +1462,7 @@ void SegmentCleaner::mark_space_used(
 {
   LOG_PREFIX(SegmentCleaner::mark_space_used);
   assert(background_callback->get_state() >= state_t::SCAN_SPACE);
+  assert(len);
   // TODO: drop
   if (addr.get_addr_type() != paddr_types_t::SEGMENT) {
     return;
@@ -1492,6 +1493,7 @@ void SegmentCleaner::mark_space_free(
 {
   LOG_PREFIX(SegmentCleaner::mark_space_free);
   assert(background_callback->get_state() >= state_t::SCAN_SPACE);
+  assert(len);
   // TODO: drop
   if (addr.get_addr_type() != paddr_types_t::SEGMENT) {
     return;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -40,14 +40,14 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
     } else {
       return {false,
 	      trans_intr::make_interruptible(
-		seastar::make_ready_future<
-		  CachedExtentRef>(CachedExtentRef()))};
+		Cache::get_extent_ertr::make_ready_future<
+		  CachedExtentRef>())};
     }
   } else {
     return {false,
 	    trans_intr::make_interruptible(
-	      seastar::make_ready_future<
-		CachedExtentRef>(CachedExtentRef()))};
+	      Cache::get_extent_ertr::make_ready_future<
+		CachedExtentRef>())};
   }
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1003,6 +1003,8 @@ CachedExtentRef Cache::duplicate_for_write(
   Transaction &t,
   CachedExtentRef i) {
   LOG_PREFIX(Cache::duplicate_for_write);
+  assert(i->is_fully_loaded());
+
   if (i->is_mutable())
     return i;
 
@@ -1838,6 +1840,8 @@ Cache::get_next_dirty_extents_ret Cache::get_next_dirty_extents(
        i != dirty.end() && bytes_so_far < max_bytes;
        ++i) {
     auto dirty_from = i->get_dirty_from();
+    //dirty extents must be fully loaded
+    assert(i->is_fully_loaded());
     if (unlikely(dirty_from == JOURNAL_SEQ_NULL)) {
       ERRORT("got dirty extent with JOURNAL_SEQ_NULL -- {}", t, *i);
       ceph_abort();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1012,6 +1012,12 @@ CachedExtentRef Cache::duplicate_for_write(
     i->version++;
     i->state = CachedExtent::extent_state_t::EXIST_MUTATION_PENDING;
     i->last_committed_crc = i->get_crc32c();
+    // deepcopy the buffer of exist clean extent beacuse it shares
+    // buffer with original clean extent.
+    auto bp = i->get_bptr();
+    auto nbp = ceph::bufferptr(bp.c_str(), bp.length());
+    i->set_bptr(std::move(nbp));
+
     t.add_mutated_extent(i);
     DEBUGT("duplicate existing extent {}", t, *i);
     return i;

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -332,6 +332,16 @@ public:
       extent_init_func(*ret);
       return read_extent<T>(
 	std::move(ret));
+    } else if (!cached->is_fully_loaded()) {
+      auto ret = TCachedExtentRef<T>(static_cast<T*>(cached.get()));
+      on_cache(*ret);
+      SUBDEBUG(seastore_cache,
+        "{} {}~{} is present without been fully loaded, reading ... -- {}",
+        T::TYPE, offset, length, *ret);
+      auto bp = alloc_cache_buf(length);
+      ret->set_bptr(std::move(bp));
+      return read_extent<T>(
+        std::move(ret));
     } else {
       SUBTRACE(seastore_cache,
           "{} {}~{} is present in cache -- {}",
@@ -377,31 +387,43 @@ public:
     auto result = t.get_extent(offset, &ret);
     if (result == Transaction::get_extent_ret::RETIRED) {
       SUBDEBUGT(seastore_cache, "{} {} is retired on t -- {}",
-          t, type, offset, *ret);
+                t, type, offset, *ret);
       return get_extent_if_cached_iertr::make_ready_future<
         CachedExtentRef>(ret);
     } else if (result == Transaction::get_extent_ret::PRESENT) {
-      SUBTRACET(seastore_cache, "{} {} is present on t -- {}",
-          t, type, offset, *ret);
-      return ret->wait_io().then([ret] {
-	return get_extent_if_cached_iertr::make_ready_future<
-	  CachedExtentRef>(ret);
-      });
+      if (ret->is_fully_loaded()) {
+        SUBTRACET(seastore_cache, "{} {} is present on t -- {}",
+                  t, type, offset, *ret);
+        return ret->wait_io().then([ret] {
+	  return get_extent_if_cached_iertr::make_ready_future<
+	    CachedExtentRef>(ret);
+        });
+      } else {
+        SUBDEBUGT(seastore_cache, "{} {} is present on t -- {}"
+                  " without being fully loaded", t, type, offset, *ret);
+        return get_extent_if_cached_iertr::make_ready_future<
+          CachedExtentRef>();
+      }
     }
 
     // get_extent_ret::ABSENT from transaction
     auto metric_key = std::make_pair(t.get_src(), type);
     ret = query_cache(offset, &metric_key);
-    if (!ret ||
-        // retired_placeholder is not really cached yet
-        ret->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
-      SUBDEBUGT(seastore_cache, "{} {} is absent{}",
-                t, type, offset, !!ret ? "(placeholder)" : "");
-      return get_extent_if_cached_iertr::make_ready_future<
-        CachedExtentRef>();
+    if (!ret) {
+      SUBDEBUGT(seastore_cache, "{} {} is absent", t, type, offset);
+      return get_extent_if_cached_iertr::make_ready_future<CachedExtentRef>();
+    } else if (ret->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
+      // retired_placeholder is not really cached yet
+      SUBDEBUGT(seastore_cache, "{} {} is absent(placeholder)",
+                t, type, offset);
+      return get_extent_if_cached_iertr::make_ready_future<CachedExtentRef>();
+    } else if (!ret->is_fully_loaded()) {
+      SUBDEBUGT(seastore_cache, "{} {} is present without "
+                "being fully loaded", t, type, offset);
+      return get_extent_if_cached_iertr::make_ready_future<CachedExtentRef>();
     }
 
-    // present in cache and is not a retired_placeholder
+    // present in cache(fully loaded) and is not a retired_placeholder
     SUBDEBUGT(seastore_cache, "{} {} is present in cache -- {}",
               t, type, offset, *ret);
     t.add_to_read_set(ret);
@@ -432,33 +454,41 @@ public:
     CachedExtentRef ret;
     LOG_PREFIX(Cache::get_extent);
     auto result = t.get_extent(offset, &ret);
-    if (result != Transaction::get_extent_ret::ABSENT) {
-      SUBTRACET(seastore_cache, "{} {}~{} is {} on t -- {}",
-	  t,
-	  T::TYPE,
-	  offset,
-	  length,
-	  result == Transaction::get_extent_ret::PRESENT ? "present" : "retired",
-	  *ret);
-      assert(result != Transaction::get_extent_ret::RETIRED);
-      return ret->wait_io().then([ret] {
-	return seastar::make_ready_future<TCachedExtentRef<T>>(
-	  ret->cast<T>());
-      });
+    if (result == Transaction::get_extent_ret::RETIRED) {
+      SUBERRORT(seastore_cache, "{} {}~{} is retired on t -- {}",
+                t, T::TYPE, offset, length, *ret);
+      ceph_abort("impossible");
+    } else if (result == Transaction::get_extent_ret::PRESENT) {
+      if (ret->is_fully_loaded()) {
+        SUBTRACET(seastore_cache, "{} {}~{} is present on t -- {}",
+                  t, T::TYPE, offset, length, *ret);
+        return ret->wait_io().then([ret] {
+	  return seastar::make_ready_future<TCachedExtentRef<T>>(
+            ret->cast<T>());
+        });
+      } else {
+        touch_extent(*ret);
+        SUBDEBUGT(seastore_cache, "{} {}~{} is present on t without been \
+          fully loaded, reading ...", t, T::TYPE, offset, length);
+        auto bp = alloc_cache_buf(ret->get_length());
+        ret->set_bptr(std::move(bp));
+        return read_extent<T>(
+          ret->cast<T>());
+      }
+    } else {
+      SUBTRACET(seastore_cache, "{} {}~{} is absent on t, query cache ...",
+                t, T::TYPE, offset, length);
+      auto f = [&t, this](CachedExtent &ext) {
+        t.add_to_read_set(CachedExtentRef(&ext));
+        touch_extent(ext);
+      };
+      auto metric_key = std::make_pair(t.get_src(), T::TYPE);
+      return trans_intr::make_interruptible(
+        get_extent<T>(
+	  offset, length, &metric_key,
+	  std::forward<Func>(extent_init_func), std::move(f))
+      );
     }
-
-    SUBTRACET(seastore_cache, "{} {}~{} is absent on t, query cache ...",
-	      t, T::TYPE, offset, length);
-    auto f = [&t, this](CachedExtent &ext) {
-      t.add_to_read_set(CachedExtentRef(&ext));
-      touch_extent(ext);
-    };
-    auto metric_key = std::make_pair(t.get_src(), T::TYPE);
-    return trans_intr::make_interruptible(
-      get_extent<T>(
-	offset, length, &metric_key,
-	std::forward<Func>(extent_init_func), std::move(f))
-    );
   }
 
   /*
@@ -522,7 +552,7 @@ public:
     return get_absent_extent<T>(t, offset, length, [](T &){});
   }
 
-  seastar::future<CachedExtentRef> get_extent_viewable_by_trans(
+  get_extent_ertr::future<CachedExtentRef> get_extent_viewable_by_trans(
     Transaction &t,
     CachedExtentRef extent)
   {
@@ -533,19 +563,33 @@ public:
 	touch_extent(*p_extent);
       }
     }
+    // user should not see RETIRED_PLACEHOLDER extents
+    ceph_assert(p_extent->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
+    if (!p_extent->is_fully_loaded()) {
+      touch_extent(*p_extent);
+      LOG_PREFIX(Cache::get_extent_viewable_by_trans);
+      SUBDEBUG(seastore_cache,
+        "{} {}~{} is present without been fully loaded, reading ... -- {}",
+        p_extent->get_type(), p_extent->get_paddr(),p_extent->get_length(),
+        *p_extent);
+      auto bp = alloc_cache_buf(p_extent->get_length());
+      p_extent->set_bptr(std::move(bp));
+      return read_extent<CachedExtent>(CachedExtentRef(p_extent));
+    }
     return p_extent->wait_io(
     ).then([p_extent] {
-      return CachedExtentRef(p_extent);
+      return get_extent_ertr::make_ready_future<CachedExtentRef>(
+        CachedExtentRef(p_extent));
     });
   }
 
   template <typename T>
-  seastar::future<TCachedExtentRef<T>> get_extent_viewable_by_trans(
+  get_extent_ertr::future<TCachedExtentRef<T>> get_extent_viewable_by_trans(
     Transaction &t,
     TCachedExtentRef<T> extent)
   {
     return get_extent_viewable_by_trans(t, CachedExtentRef(extent.get())
-    ).then([](auto p_extent) {
+    ).safe_then([](auto p_extent) {
       return p_extent->template cast<T>();
     });
   }
@@ -606,15 +650,25 @@ private:
     CachedExtentRef ret;
     auto status = t.get_extent(offset, &ret);
     if (status == Transaction::get_extent_ret::RETIRED) {
-      SUBDEBUGT(seastore_cache, "{} {}~{} {} is retired on t -- {}",
+      SUBERRORT(seastore_cache, "{} {}~{} {} is retired on t -- {}",
                 t, type, offset, length, laddr, *ret);
-      return seastar::make_ready_future<CachedExtentRef>();
+      ceph_abort("impossible");
     } else if (status == Transaction::get_extent_ret::PRESENT) {
-      SUBTRACET(seastore_cache, "{} {}~{} {} is present on t -- {}",
-                t, type, offset, length, laddr, *ret);
-      return ret->wait_io().then([ret] {
-	return seastar::make_ready_future<CachedExtentRef>(ret);
-      });
+      if (ret->is_fully_loaded()) {
+        SUBTRACET(seastore_cache, "{} {}~{} {} is present on t -- {}",
+                  t, type, offset, length, laddr, *ret);
+        return ret->wait_io().then([ret] {
+	  return seastar::make_ready_future<CachedExtentRef>(ret);
+        });
+      } else {
+        touch_extent(*ret);
+        SUBDEBUGT(seastore_cache, "{} {}~{} {} is present on t without been \
+                  fully loaded, reading ...", t, type, offset, length, laddr);
+        auto bp = alloc_cache_buf(ret->get_length());
+        ret->set_bptr(std::move(bp));
+        return read_extent<CachedExtent>(
+          std::move(ret));
+      }
     } else {
       SUBTRACET(seastore_cache, "{} {}~{} {} is absent on t, query cache ...",
                 t, type, offset, length, laddr);
@@ -1515,7 +1569,9 @@ private:
   get_extent_ret<T> read_extent(
     TCachedExtentRef<T>&& extent
   ) {
-    assert(extent->state == CachedExtent::extent_state_t::CLEAN_PENDING);
+    assert(extent->state == CachedExtent::extent_state_t::CLEAN_PENDING ||
+      extent->state == CachedExtent::extent_state_t::EXIST_CLEAN ||
+      extent->state == CachedExtent::extent_state_t::CLEAN);
     extent->set_io_wait();
     return epm.read(
       extent->get_paddr(),
@@ -1530,7 +1586,11 @@ private:
 	  extent->last_committed_crc = extent->get_crc32c();
 
 	  extent->on_clean_read();
-	} else {
+	} else if (extent->state == CachedExtent::extent_state_t::EXIST_CLEAN ||
+          extent->state == CachedExtent::extent_state_t::CLEAN) {
+	  /* TODO: crc should be checked against LBA manager */
+	  extent->last_committed_crc = extent->get_crc32c();
+        } else {
 	  ceph_assert(!extent->is_valid());
 	}
         extent->complete_io();

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -748,6 +748,12 @@ protected:
     return new T(std::forward<Args>(args)...);
   }
 
+  template <typename T>
+  static TCachedExtentRef<T> make_placeholder_cached_extent_ref(
+    extent_len_t length) {
+    return new T(length);
+  }
+
   void reset_prior_instance() {
     prior_instance.reset();
   }

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -64,14 +64,14 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
     } else {
       return {false,
 	      trans_intr::make_interruptible(
-		seastar::make_ready_future<
-		  CachedExtentRef>(CachedExtentRef()))};
+		Cache::get_extent_ertr::make_ready_future<
+		  CachedExtentRef>())};
     }
   } else {
     return {false,
 	    trans_intr::make_interruptible(
-	      seastar::make_ready_future<
-		CachedExtentRef>(CachedExtentRef()))};
+	      Cache::get_extent_ertr::make_ready_future<
+		CachedExtentRef>())};
   }
 }
 

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -41,7 +41,7 @@ struct RootBlock : CachedExtent {
   CachedExtent* lba_root_node = nullptr;
   CachedExtent* backref_root_node = nullptr;
 
-  RootBlock() : CachedExtent(0) {}
+  RootBlock() : CachedExtent(zero_length_t()) {};
 
   RootBlock(const RootBlock &rhs)
     : CachedExtent(rhs),

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -178,7 +178,7 @@ public:
   {
     auto v = pin->get_logical_extent(t);
     if (v.has_child()) {
-      return v.get_child_fut().then([](auto extent) {
+      return v.get_child_fut().safe_then([](auto extent) {
 	return extent->template cast<T>();
       });
     } else {
@@ -635,6 +635,7 @@ private:
       }
     ).si_then([FNAME, &t](auto ref) mutable -> ret {
       SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
+      assert(ref->is_fully_loaded());
       return pin_to_extent_ret<T>(
 	interruptible::ready_future_marker{},
 	std::move(ref));
@@ -675,6 +676,7 @@ private:
       }
     ).si_then([FNAME, &t](auto ref) {
       SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
+      assert(ref->is_fully_loaded());
       return pin_to_extent_by_type_ret(
 	interruptible::ready_future_marker{},
 	std::move(ref->template cast<LogicalCachedExtent>()));

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -410,68 +410,6 @@ public:
     });
   }
 
-  /**
-   * map_existing_extent
-   *
-   * Allocates a new extent at given existing_paddr that must be absolute and
-   * reads disk to fill the extent.
-   * The common usage is that remove the LogicalCachedExtent (laddr~length at paddr)
-   * and map extent to multiple new extents.
-   * placement_hint and generation should follow the original extent.
-   */
-  using map_existing_extent_iertr =
-    alloc_extent_iertr::extend_ertr<Device::read_ertr>;
-  template <typename T>
-  using map_existing_extent_ret =
-    map_existing_extent_iertr::future<TCachedExtentRef<T>>;
-  template <typename T>
-  map_existing_extent_ret<T> map_existing_extent(
-    Transaction &t,
-    laddr_t laddr_hint,
-    paddr_t existing_paddr,
-    extent_len_t length) {
-    LOG_PREFIX(TransactionManager::map_existing_extent);
-    // FIXME: existing_paddr can be absolute and pending
-    ceph_assert(existing_paddr.is_absolute());
-    assert(t.is_retired(existing_paddr, length));
-
-    SUBDEBUGT(seastore_tm, " laddr_hint: {} existing_paddr: {} length: {}",
-	      t, laddr_hint, existing_paddr, length);
-    auto bp = ceph::bufferptr(buffer::create_page_aligned(length));
-    bp.zero();
-
-    // ExtentPlacementManager::alloc_new_extent will make a new
-    // (relative/temp) paddr, so make extent directly
-    auto ext = CachedExtent::make_cached_extent_ref<T>(std::move(bp));
-
-    ext->init(CachedExtent::extent_state_t::EXIST_CLEAN,
-	      existing_paddr,
-	      PLACEMENT_HINT_NULL,
-	      NULL_GENERATION,
-	      t.get_trans_id());
-
-    t.add_fresh_extent(ext);
-
-    return lba_manager->alloc_extent(
-      t,
-      laddr_hint,
-      length,
-      existing_paddr,
-      ext.get()
-    ).si_then([ext=std::move(ext), laddr_hint, this](auto &&ref) {
-      ceph_assert(laddr_hint == ref->get_key());
-      return epm->read(
-        ext->get_paddr(),
-	ext->get_length(),
-	ext->get_bptr()
-      ).safe_then([ext=std::move(ext)] {
-	return map_existing_extent_iertr::make_ready_future<TCachedExtentRef<T>>
-	  (std::move(ext));
-      });
-    });
-  }
-
-
   using reserve_extent_iertr = alloc_extent_iertr;
   using reserve_extent_ret = reserve_extent_iertr::future<LBAMappingRef>;
   reserve_extent_ret reserve_region(


### PR DESCRIPTION
this PR:
1. Partially Implement lazy read for split overwrite. 
    This is the first PR for fully split overwrite lazy read implementation.
    This PR reduce once read when remapping an extent, but there is an another redundant read in original logic for the same extent before remapping in unaligned scenario, so this pr just bring a 38.1% improvement for comprehensive performance in overwrite for now.
    The solution is to split left/right extent to small prepend extent before overwrite. 
    I am working on this and will realize this in next PR.
2. Refactor overwrite according to the discussion.
    Separate remap, insert, retire logic in overwrite.
    Separate remapping in multiple extents and remapping in one extent for new transaction manager interface `remap_pin `and `overwrite_pin`.

# test
no performance regression in other situation.

The same test config as #45519
rand write to full image:
<html>
<body>
<!--StartFragment-->

  branch   | IOPS  | BW 
  --  | -- | --
 main  | 3234 | 12.6MiB/s
 split with lazy-read | 4457 | 17.4MiB/s

<!--EndFragment-->
</body>
</html>
Improved about 38.1%.

*updated test result of latest push

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
