### PR TITLE
pacific: rgw/s3: dump Message field in Error response even if empty

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -360,8 +360,7 @@ void dump(struct req_state* s)
     s->formatter->open_object_section("Error");
   if (!s->err.err_code.empty())
     s->formatter->dump_string("Code", s->err.err_code);
-  if (!s->err.message.empty())
-    s->formatter->dump_string("Message", s->err.message);
+  s->formatter->dump_string("Message", s->err.message);
   if (!s->bucket_name.empty())	// TODO: connect to expose_bucket
     s->formatter->dump_string("BucketName", s->bucket_name);
   if (!s->trans_id.empty())	// TODO: connect to expose_bucket or another toggle


### PR DESCRIPTION
backport of: https://github.com/ceph/ceph/pull/51052

tracker: https://tracker.ceph.com/issues/59528
parent tracker: https://tracker.ceph.com/issues/59433
