### PR TITLE
quincy: ceph-volume: fix drive-group issue that expects the batch_args to be a string

### DIFF
--- a/src/ceph-volume/ceph_volume/drive_group/main.py
+++ b/src/ceph-volume/ceph_volume/drive_group/main.py
@@ -78,7 +78,7 @@ class Deploy(object):
             print(cmd)
         else:
             logger.info('Running ceph-volume command: {}'.format(cmd))
-            batch_args = cmd.split(' ')[2:]
+            batch_args = cmd[0].split(' ')[2:]
             b = Batch(batch_args)
             b.main()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59257

---

backport of https://github.com/ceph/ceph/pull/49586
parent tracker: https://tracker.ceph.com/issues/59203

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh