### PR TITLE
pacific: mgr/dashboard: API docs UI does not work with Angular dev server

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
+++ b/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
@@ -8,5 +8,10 @@
     "target": "https://localhost:8443",
     "secure": false,
     "logLevel": "debug"
+  },
+  "/docs/": {
+    "target": "https://localhost:8443",
+    "secure": false,
+    "logLevel": "debug"
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53566

---

backport of https://github.com/ceph/ceph/pull/44001
parent tracker: https://tracker.ceph.com/issues/53317

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh