### PR TITLE
pacific: client: do not dump mds twice in Inode::dump()

### DIFF
--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -471,7 +471,6 @@ void Inode::dump(Formatter *f) const
   f->open_array_section("caps");
   for (const auto &pair : caps) {
     f->open_object_section("cap");
-    f->dump_int("mds", pair.first);
     if (&pair.second == auth_cap)
       f->dump_int("auth", 1);
     pair.second.dump(f);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52442

---

backport of https://github.com/ceph/ceph/pull/42899
parent tracker: https://tracker.ceph.com/issues/52386

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh