### PR TITLE
pacific: tools/ceph-kvstore-tool: fix segfaults when repair the rocksdb

### DIFF
--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -38,8 +38,8 @@ StoreTool::StoreTool(const string& type,
              << cpp_strerror(r) << std::endl;
         exit(1);
       }
-      db.reset(db_ptr);
     }
+    db.reset(db_ptr);
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52892

---

backport of https://github.com/ceph/ceph/pull/43346
parent tracker: https://tracker.ceph.com/issues/52756

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh