### PR TITLE
pacific: pybind/rados: don't close watch in dealloc if already closed

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -2056,6 +2056,8 @@ cdef class Watch(object):
         return False
 
     def __dealloc__(self):
+        if self.id == 0:
+            return
         self.ioctx.rados.require_state("connected")
         self.close()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52557

---

backport of https://github.com/ceph/ceph/pull/43107
parent tracker: https://tracker.ceph.com/issues/52553

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh