### PR TITLE
pacific: doc: clarify use of `rados rm` command

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -264,8 +264,8 @@ Pool specific commands
 :command:`append` *name* *infile*
   Append object name to the cluster with contents from infile.
 
-:command:`rm` *name*
-  Remove object name.
+:command:`rm` [--force-full] *name* ...
+  Remove object(s) with name(s). With ``--force-full`` will remove when cluster is marked full.
 
 :command:`listwatchers` *name*
   List the watchers of object name.

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -91,7 +91,7 @@ void usage(ostream& out)
 "   append <obj-name> <infile>       append object\n"
 "   truncate <obj-name> length       truncate object\n"
 "   create <obj-name>                create object\n"
-"   rm <obj-name> ...[--force-full]  [force no matter full or not]remove object(s)\n"
+"   rm <obj-name> ... [--force-full] remove object(s), --force-full forces remove when cluster is full\n"
 "   cp <obj-name> [target-obj]       copy object\n"
 "   listxattr <obj-name>\n"
 "   getxattr <obj-name> attr\n"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52307

---

backport of https://github.com/ceph/ceph/pull/42801
parent tracker: https://tracker.ceph.com/issues/52288

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh