### PR TITLE
pacific: ceph_test_rados_api_watch_notify: extend Watch3Timeout test

### DIFF
--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -541,7 +541,7 @@ TEST_F(LibRadosWatchNotify, Watch3Timeout) {
   rados_conf_set(cluster, "objecter_inject_no_watch_ping", "true");
   // allow a long time here since an osd peering event will renew our
   // watch.
-  int left = 16 * timeout;
+  int left = 256 * timeout;
   std::cout << "waiting up to " << left << " for osd to time us out ..."
 	    << std::endl;
   while (notify_err == 0 && --left) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53166

---

backport of https://github.com/ceph/ceph/pull/43700
parent tracker: https://tracker.ceph.com/issues/24990

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh