### PR TITLE
test/librbd: use GTEST_SKIP macro to skip tests

### DIFF
--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -724,8 +724,7 @@ TEST_F(TestMockOperationSnapshotRemoveRequest, RemoveChildError) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(clone_name, &ictx));
   if (ictx->test_features(RBD_FEATURE_DEEP_FLATTEN)) {
-    std::cout << "SKIPPING" << std::endl;
-    return SUCCEED();
+    GTEST_SKIP() << "Skipping due to enabled deep-flatten";
   }
 
   ASSERT_EQ(0, snap_create(*ictx, "snap1"));

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -1304,8 +1304,7 @@ TEST_F(TestInternal, TestCoR)
   std::string config_value;
   ASSERT_EQ(0, _rados.conf_get("rbd_clone_copy_on_read", config_value));
   if (config_value == "false") {
-    std::cout << "SKIPPING due to disabled rbd_copy_on_read" << std::endl;
-    return;
+    GTEST_SKIP() << "Skipping due to disabled copy-on-read";
   }
 
   m_image_name = get_temp_image_name();

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8114,8 +8114,7 @@ TEST_F(TestLibRBD, LargeCacheRead)
   std::string config_value;
   ASSERT_EQ(0, _rados.conf_get("rbd_cache", config_value));
   if (config_value == "false") {
-    std::cout << "SKIPPING due to disabled cache" << std::endl;
-    return;
+    GTEST_SKIP() << "Skipping due to disabled cache";
   }
 
   rados_ioctx_t ioctx;

--- a/src/test/librbd/test_support.h
+++ b/src/test/librbd/test_support.h
@@ -30,8 +30,7 @@ bool is_rbd_pwl_enabled(ceph::common::CephContext *ctx);
 
 #define REQUIRE(x) {			  \
   if (!(x)) {				  \
-    std::cout << "SKIPPING" << std::endl; \
-    return SUCCEED(); 			  \
+    GTEST_SKIP() << "Skipping due to unmet REQUIRE"; \
   } 					  \
 }
 


### PR DESCRIPTION
The use of SUCCEED macro predates the introduction of GTEST_SKIP macro to GTest 1.10.  Having skipped tests reported as passed is misleading!

Before:

[ RUN      ] TestMockOperationSnapshotRemoveRequest.FlattenedCloneRemovesChild
SKIPPING
[       OK ] TestMockOperationSnapshotRemoveRequest.FlattenedCloneRemovesChild (9 ms)
...
[ RUN      ] TestMockOperationSnapshotRemoveRequest.RemoveChildError
SKIPPING
[       OK ] TestMockOperationSnapshotRemoveRequest.RemoveChildError (112 ms)
...
[  PASSED  ] 16 tests.

After:

[ RUN      ] TestMockOperationSnapshotRemoveRequest.FlattenedCloneRemovesChild
../src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc:381: Skipped
Skipping due to unmet REQUIRE
[  SKIPPED ] TestMockOperationSnapshotRemoveRequest.FlattenedCloneRemovesChild (9 ms)
...
[ RUN      ] TestMockOperationSnapshotRemoveRequest.RemoveChildError
../src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc:727: Skipped
Skipping due to enabled deep-flatten
[  SKIPPED ] TestMockOperationSnapshotRemoveRequest.RemoveChildError (111 ms)
...
[  PASSED  ] 14 tests.
[  SKIPPED ] 2 tests, listed below:
[  SKIPPED ] TestMockOperationSnapshotRemoveRequest.FlattenedCloneRemovesChild
[  SKIPPED ] TestMockOperationSnapshotRemoveRequest.RemoveChildError





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
