### PR TITLE
rgw: Add log types to dencoder

### DIFF
--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -8,7 +8,11 @@
 
 #include "include/utime.h"
 
+#include "common/ceph_json.h"
+#include "common/Formatter.h"
+
 class JSONObj;
+class JSONDecoder;
 
 
 struct cls_log_entry {
@@ -39,6 +43,34 @@ struct cls_log_entry {
     if (struct_v >= 2)
       decode(id, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter* f) const {
+    encode_json("section", section, f);
+    encode_json("name", name, f);
+    encode_json("timestamp", timestamp, f);
+    encode_json("data", data, f);
+    encode_json("id", id, f);
+  }
+
+  void decode_json(JSONObj* obj) {
+    JSONDecoder::decode_json("section", section, obj);
+    JSONDecoder::decode_json("name", name, obj);
+    JSONDecoder::decode_json("timestamp", timestamp, obj);
+    JSONDecoder::decode_json("data", data, obj);
+    JSONDecoder::decode_json("id", id, obj);
+  }
+
+  static void generate_test_instances(std::list<cls_log_entry *>& l) {
+    l.push_back(new cls_log_entry{});
+    l.push_back(new cls_log_entry);
+    l.back()->id = "test_id";
+    l.back()->section = "test_section";
+    l.back()->name = "test_name";
+    l.back()->timestamp = utime_t();
+    ceph::buffer::list bl;
+    ceph::encode(std::string("Test"), bl, 0);
+    l.back()->data = bl;
   }
 };
 WRITE_CLASS_ENCODER(cls_log_entry)

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -61,6 +61,15 @@ void rgw_data_change::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("gen", gen, obj);
 }
 
+void rgw_data_change::generate_test_instances(std::list<rgw_data_change *>& l) {
+  l.push_back(new rgw_data_change{});
+  l.push_back(new rgw_data_change);
+  l.back()->entity_type = ENTITY_TYPE_BUCKET;
+  l.back()->key = "bucket_name";
+  l.back()->timestamp = ceph::real_clock::zero();
+  l.back()->gen = 0;
+}
+
 void rgw_data_change_log_entry::dump(Formatter *f) const
 {
   encode_json("log_id", log_id, f);

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -82,6 +82,7 @@ struct rgw_data_change {
 
   void dump(ceph::Formatter* f) const;
   void decode_json(JSONObj* obj);
+  static void generate_test_instances(std::list<rgw_data_change *>& l);
 };
 WRITE_CLASS_ENCODER(rgw_data_change)
 

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -159,6 +159,7 @@ struct RGWMetadataLogData {
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWMetadataLogData *>& l);
 };
 WRITE_CLASS_ENCODER(RGWMetadataLogData)
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -101,6 +101,16 @@ void RGWMetadataLogData::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("status", status, obj);
 }
 
+void RGWMetadataLogData::generate_test_instances(std::list<RGWMetadataLogData *>& l) {
+  l.push_back(new RGWMetadataLogData{});
+  l.push_back(new RGWMetadataLogData);
+  l.back()->read_version = obj_version();
+  l.back()->read_version.tag = "read_tag";
+  l.back()->write_version = obj_version();
+  l.back()->write_version.tag = "write_tag";
+  l.back()->status = MDLOG_STATUS_WRITE;
+}
+
 RGWMetadataHandler_GenericMetaBE::Put::Put(RGWMetadataHandler_GenericMetaBE *_handler,
 					   RGWSI_MetaBackend_Handler::Op *_op,
 					   string& _entry, RGWMetadataObject *_obj,

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -30,6 +30,9 @@ TYPE(RGWCacheNotifyInfo)
 #include "rgw_lc.h"
 TYPE(RGWLifecycleConfiguration)
 
+#include "cls/log/cls_log_types.h"
+TYPE(cls_log_entry)
+
 #include "cls/rgw/cls_rgw_types.h"
 TYPE(rgw_bucket_pending_info)
 TYPE(rgw_bucket_dir_entry_meta)
@@ -121,6 +124,12 @@ TYPE(rgw_obj)
 
 #include "rgw_log.h"
 TYPE(rgw_log_entry)
+
+#include "rgw_datalog.h"
+TYPE(rgw_data_change)
+
+#include "rgw_mdlog.h"
+TYPE(RGWMetadataLogData)
 
 #include "rgw_meta_sync_status.h"
 TYPE(rgw_meta_sync_info)


### PR DESCRIPTION
When debugging an issue in RGW multisite replication, we discovered that we had no way to deserialise data stored in the logs (in particular the datalog) when attempting to look inside the RADOS objects and work out what's going on. This commit adds the types to ceph-dencoder, to facilitate future efforts at debugging. As a bonus, this also allows serialisation for these types to be tested.

Adds the following types to ceph-dencoder:

- `RGWMetadataLogData`
- `rgw_data_change`
- `cls_log_entry`

This would be part of https://tracker.ceph.com/issues/54054


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
