### PR TITLE
dokan: handle std::stoul exceptions

### DIFF
--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -122,10 +122,21 @@ int parse_args(
       cfg->win_vol_name = to_wstring(win_vol_name);
     } else if (ceph_argparse_witharg(args, i, &win_vol_serial,
                                      "--win-vol-serial", (char *)NULL)) {
-      cfg->win_vol_serial = std::stoul(win_vol_serial);
+      try {
+        cfg->win_vol_serial = std::stoul(win_vol_serial);
+      } catch (std::logic_error&) {
+        *err_msg << "ceph-dokan: invalid volume serial number: " << win_vol_serial;
+        return -EINVAL;
+      }
     } else if (ceph_argparse_witharg(args, i, &max_path_len,
                                      "--max-path-len", (char*)NULL)) {
-      unsigned long max_path_length = std::stoul(max_path_len);
+      unsigned long max_path_length = 0;
+      try {
+        max_path_length = std::stoul(max_path_len);
+      } catch (std::logic_error&) {
+        *err_msg << "ceph-dokan: invalid maximum path length: " << max_path_len;
+        return -EINVAL;
+      }
 
       if (max_path_length > 32767) {
         *err_msg << "ceph-dokan: maximum path length should not "
@@ -141,18 +152,31 @@ int parse_args(
 
       cfg->max_path_len = max_path_length;
     } else if (ceph_argparse_witharg(args, i, &file_mode, "--file-mode", (char *)NULL)) {
-      mode_t mode = strtol(file_mode.c_str(), NULL, 8);
+      mode_t mode;
+      try {
+        mode = std::stol(file_mode, nullptr, 8);
+      } catch (std::logic_error&) {
+        *err_msg << "ceph-dokan: invalid file access mode: " << file_mode;
+        return -EINVAL;
+      }
+
       if (!std::regex_match(file_mode, std::regex("^[0-7]{3}$"))
           || mode < 01 || mode > 0777) {
-        *err_msg << "ceph-dokan: invalid file access mode";
+        *err_msg << "ceph-dokan: invalid file access mode: " << file_mode;
         return -EINVAL;
       }
       cfg->file_mode = mode;
     } else if (ceph_argparse_witharg(args, i, &dir_mode, "--dir-mode", (char *)NULL)) {
-      mode_t mode = strtol(dir_mode.c_str(), NULL, 8);
+      mode_t mode;
+      try {
+        mode = std::stol(dir_mode, nullptr, 8);
+      } catch (std::logic_error&) {
+        *err_msg << "ceph-dokan: invalid directory access mode: " << dir_mode;
+        return -EINVAL;
+      }
       if (!std::regex_match(dir_mode, std::regex("^[0-7]{3}$"))
           || mode < 01 || mode > 0777) {
-        *err_msg << "ceph-dokan: invalid directory access mode";
+        *err_msg << "ceph-dokan: invalid directory access mode: " << dir_mode;
         return -EINVAL;
       }
       cfg->dir_mode = mode;


### PR DESCRIPTION
We're using std::stoul to parse cli args, however we aren't catching the exceptions.

This change will handle the exceptions and log the according error message. For consistency, we'll use the std conversion functions throughout ceph-dokan.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
