### PR TITLE
mgr/dashboard: add 'omit_usage' query param to dashboard api 'get rbd' endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -122,8 +122,18 @@ class Rbd(RESTController):
 
     @handle_rbd_error()
     @handle_rados_error('pool')
-    def get(self, image_spec):
-        return RbdService.get_image(image_spec)
+    @EndpointDoc("Get Rbd Image Info",
+                 parameters={
+                     'image_spec': (str, 'URL-encoded "pool/rbd_name". e.g. "rbd%2Ffoo"'),
+                     'omit_usage': (bool, 'When true, usage information is not returned'),
+                 },
+                 responses={200: RBD_SCHEMA})
+    def get(self, image_spec, omit_usage=False):
+        try:
+            omit_usage_bool = str_to_bool(omit_usage)
+        except ValueError:
+            omit_usage_bool = False
+        return RbdService.get_image(image_spec, omit_usage_bool)
 
     @RbdTask('create',
              {'pool_name': '{pool_name}', 'namespace': '{namespace}', 'image_name': '{name}'}, 2.0)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -526,16 +526,38 @@ paths:
       - Rbd
     get:
       parameters:
-      - in: path
+      - description: URL-encoded "pool/rbd_name". e.g. "rbd%2Ffoo"
+        in: path
         name: image_spec
         required: true
         schema:
           type: string
+      - default: false
+        description: When true, usage information is not returned
+        in: query
+        name: omit_usage
+        schema:
+          type: boolean
       responses:
         '200':
           content:
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                items:
+                  properties:
+                    pool_name:
+                      description: pool name
+                      type: string
+                    value:
+                      description: ''
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                required:
+                - value
+                - pool_name
+                type: array
           description: OK
         '400':
           description: Operation exception. Please check the response body for details.
@@ -548,6 +570,7 @@ paths:
             trace.
       security:
       - jwt: []
+      summary: Get Rbd Image Info
       tags:
       - Rbd
     put:

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -269,7 +269,8 @@ class RbdService(object):
         return total_used_size, snap_map
 
     @classmethod
-    def _rbd_image(cls, ioctx, pool_name, namespace, image_name):  # pylint: disable=R0912
+    def _rbd_image(cls, ioctx, pool_name, namespace, image_name,  # pylint: disable=R0912
+                   omit_usage=False):
         with rbd.Image(ioctx, image_name) as img:
             stat = img.stat()
             mirror_info = img.mirror_image_get_info()
@@ -353,7 +354,7 @@ class RbdService(object):
 
             # disk usage
             img_flags = img.flags()
-            if 'fast-diff' in stat['features_name'] and \
+            if not omit_usage and 'fast-diff' in stat['features_name'] and \
                     not rbd.RBD_FLAG_FAST_DIFF_INVALID & img_flags and \
                     mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
                 snaps = [(s['id'], s['size'], s['name'])
@@ -481,13 +482,13 @@ class RbdService(object):
         return result, paginator.get_count()
 
     @classmethod
-    def get_image(cls, image_spec):
+    def get_image(cls, image_spec, omit_usage=False):
         pool_name, namespace, image_name = parse_image_spec(image_spec)
         ioctx = mgr.rados.open_ioctx(pool_name)
         if namespace:
             ioctx.set_namespace(namespace)
         try:
-            return cls._rbd_image(ioctx, pool_name, namespace, image_name)
+            return cls._rbd_image(ioctx, pool_name, namespace, image_name, omit_usage)
         except rbd.ImageNotFound:
             raise cherrypy.HTTPError(404, 'Image not found')
 


### PR DESCRIPTION
Allows RBD info to be retrieved without getting associated usage info. This can be useful for large RBDs where the process of gathering such usage info is sometimes very slow.

Fixes: https://tracker.ceph.com/issues/59588

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
