### PR TITLE
librbd/managed_lock/GetLockerRequest: Fix no valid lockers case

### DIFF
--- a/src/librbd/managed_lock/GetLockerRequest.cc
+++ b/src/librbd/managed_lock/GetLockerRequest.cc
@@ -103,14 +103,14 @@ void GetLockerRequest<I>::handle_get_lockers(int r) {
     return;
   }
 
+  if (iter->second.addr.is_blank_ip()) {
+    ldout(m_cct, 5) << "locker has a blank address" << dendl;
+    finish(-EBUSY);
+    return;
+  }
   m_locker->entity = iter->first.locker;
   m_locker->cookie = iter->first.cookie;
   m_locker->address = iter->second.addr.get_legacy_str();
-  if (m_locker->cookie.empty() || m_locker->address.empty()) {
-    ldout(m_cct, 20) << "no valid lockers detected" << dendl;
-    finish(-ENOENT);
-    return;
-  }
 
   ldout(m_cct, 10) << "retrieved exclusive locker: "
                  << m_locker->entity << "@" << m_locker->address << dendl;


### PR DESCRIPTION
See:
`m_locker->address = iter->second.addr.get_legacy_str();`

In the case where `iter->second.addr` is an empty address, `m_locker->address` string is assigned with "0)/0" and therfore will never result in an empty string.

Use `is_blank_ip()` before `get_legacy_str()` instead.

Fixes: https://tracker.ceph.com/issues/59641

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
