### PR TITLE
crimson: Avoid any Message's connection usage

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -20,6 +20,7 @@
 #include "messages/MCommandReply.h"
 #include "crimson/common/log.h"
 #include "crimson/net/Socket.h"
+#include "crimson/net/Connection.h"
 
 using namespace crimson::common;
 using namespace std::literals;

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -22,6 +22,7 @@
 #include "crimson/osd/pg_map.h"
 #include "crimson/osd/state.h"
 #include "common/AsyncReserver.h"
+#include "crimson/net/Connection.h"
 
 namespace crimson::net {
   class Messenger;

--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -48,9 +48,13 @@ public:
     tid(t), client_caps(caps), msg(NULL) {
     client_type = m->get_source().type();
     client_addrs = m->get_source_addrs();
+#ifdef WITH_SEASTAR
+    ceph_abort("In crimson, conn is independently maintained outside Message");
+#else
     if (auto &con = m->get_connection()) {
       client_socket_addr = con->get_peer_socket_addr();
     }
+#endif
     con_features = feat;
     msg = (PaxosServiceMessage*)m->get();
   }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -167,10 +167,10 @@ public:
     if (features)
       return features;
 #ifdef WITH_SEASTAR
-    // In crimson, conn is independently maintained outside Message.
-    ceph_abort();
-#endif
+    ceph_abort("In crimson, conn is independently maintained outside Message");
+#else
     return get_connection()->get_features();
+#endif
   }
 
   MOSDOp()

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -326,7 +326,10 @@ Message *decode_message(CephContext *cct,
     if (front_crc != footer.front_crc) {
       if (cct) {
 	ldout(cct, 0) << "bad crc in front " << front_crc << " != exp " << footer.front_crc
-		      << " from " << conn->get_peer_addr() << dendl;
+#ifndef WITH_SEASTAR
+	              << " from " << conn->get_peer_addr()
+#endif
+	              << dendl;
 	ldout(cct, 20) << " ";
 	front.hexdump(*_dout);
 	*_dout << dendl;
@@ -336,7 +339,10 @@ Message *decode_message(CephContext *cct,
     if (middle_crc != footer.middle_crc) {
       if (cct) {
 	ldout(cct, 0) << "bad crc in middle " << middle_crc << " != exp " << footer.middle_crc
-		      << " from " << conn->get_peer_addr() << dendl;
+#ifndef WITH_SEASTAR
+	              << " from " << conn->get_peer_addr()
+#endif
+	              << dendl;
 	ldout(cct, 20) << " ";
 	middle.hexdump(*_dout);
 	*_dout << dendl;
@@ -350,7 +356,10 @@ Message *decode_message(CephContext *cct,
       if (data_crc != footer.data_crc) {
 	if (cct) {
 	  ldout(cct, 0) << "bad crc in data " << data_crc << " != exp " << footer.data_crc
-			<< " from " << conn->get_peer_addr() << dendl;
+#ifndef WITH_SEASTAR
+	                << " from " << conn->get_peer_addr()
+#endif
+	                << dendl;
 	  ldout(cct, 20) << " ";
 	  data.hexdump(*_dout);
 	  *_dout << dendl;

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -54,7 +54,11 @@ public:
   void _dump(ceph::Formatter *f) const override;
 
   bool has_feature(uint64_t f) const {
+#ifdef WITH_SEASTAR
+    ceph_abort("In crimson, conn is independently maintained outside Message");
+#else
     return request->get_connection()->has_feature(f);
+#endif
   }
 
 private:


### PR DESCRIPTION
In continuation to: https://github.com/ceph/ceph/pull/50835
Do not include Crimson's SocketConnection in Message header.

This change will allow us to avoid issues similar to: https://github.com/ceph/ceph/pull/51312

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
