### PR TITLE
mon/ConnectionTracker: Fix connection score weirdness + Enhance check for clean score

### DIFF
--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -121,12 +121,16 @@ class ConnectionTracker {
   void get_total_connection_score(int peer_rank, double *rating,
 				  int *live_count) const;
   /**
-  * Check if our ranks are clean and make
-  * sure there are no extra peer_report lingering.
-  * In the future we also want to check the reports
-  * current and history of each peer_report.
+  * By using monmap_size and quorum size as reference,
+  * we expect connection score to hold such conditions:
+  * 1. peer_reports and monmap should have the same size.
+  * 2. Sizes of current_report and history_report should be
+  *  equal or less than monmap_size (in the case where there
+  *  are dead monitors).
+  * 3. Peers that are alive according to current_report should
+  * contain exactly the same ranks as of those in the quorum set.
   */
-  bool is_clean(int mon_rank, int monmap_size);
+  bool is_clean(int mon_rank, unsigned monmap_size, std::set<int> quorum);
   /**
    * Encode this ConnectionTracker. Useful both for storing on disk
    * and for sending off to peers for decoding and import

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -459,8 +459,20 @@ void Elector::begin_peer_ping(int peer)
     return;
   }
 
-  if (!mon->get_quorum_mon_features().contains_all(
-				      ceph::features::mon::FEATURE_PINGING)) {
+  if (mon->get_quorum_mon_features().empty()) {
+    // quorum_mon_features has not been assigned yet.
+    // Sometimes at bootup we haven't finish our first election yet.
+    // Lets check if our feature supports FEATURE_PINGING.
+    mon_feature_t mon_supported = ceph::features::mon::get_supported();
+    if (!mon_supported.contains_all(ceph::features::mon::FEATURE_PINGING)) {
+      dout(10) << "We currently do not support FEATURE_PINGING"
+        << " please upgrade! ... return" << dendl;
+      return;
+    }
+  } else if (!mon->get_quorum_mon_features().contains_all(
+                                      ceph::features::mon::FEATURE_PINGING)) {
+    dout(10) << "Not all monitors support FEATURE_PINGING,"
+      << " please upgrade! ... return" << dendl;
     return;
   }
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -719,7 +719,7 @@ void Elector::start_participating()
 
 bool Elector::peer_tracker_is_clean()
 {
-  return peer_tracker.is_clean(mon->rank, paxos_size());
+  return peer_tracker.is_clean(mon->rank, paxos_size(), mon->get_quorum());
 }
 
 void Elector::notify_clear_peer_state()

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -740,6 +740,10 @@ bool HealthMonitor::check_leader_health()
   if (g_conf().get_val<bool>("mon_warn_on_msgr2_not_enabled")) {
     check_if_msgr2_enabled(&next);
   }
+  // Connection Score
+  if (mon.monmap->strategy == 3) {
+    check_connection_score(&next);
+  }
 
   if (next != leader_checks) {
     changed = true;
@@ -820,6 +824,16 @@ void HealthMonitor::check_for_mon_down(health_check_map_t *checks)
 	d.detail.push_back(ss.str());
       }
     }
+  }
+}
+
+void HealthMonitor::check_connection_score(health_check_map_t *checks) {
+  if (!mon.is_peer_tracker_clean()) {
+    ostringstream ss;
+    ss << "mon " << mon.name << " has inconsistent connectivity score; this may cause"
+      << " issues during election.";
+    auto& d = checks->add("CONNECTIVITY_SCORE_INCONSISTENT", HEALTH_WARN, ss.str(), 0);
+    d.detail.push_back(ss.str());
   }
 }
 

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -65,6 +65,7 @@ private:
   bool prepare_health_checks(MonOpRequestRef op);
   void check_for_older_version(health_check_map_t *checks);
   void check_for_mon_down(health_check_map_t *checks);
+  void check_connection_score(health_check_map_t *checks);
   void check_for_clock_skew(health_check_map_t *checks);
   void check_if_msgr2_enabled(health_check_map_t *checks);
   bool check_leader_health();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -946,7 +946,7 @@ int Monitor::init()
 
   bootstrap();
 
-  if (!elector.peer_tracker_is_clean()){
+  if (!is_peer_tracker_clean()){
     dout(10) << "peer_tracker looks inconsistent"
       << " previous bad logic, clearing ..." << dendl;
     elector.notify_clear_peer_state();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -279,6 +279,7 @@ public:
   bool is_stretch_mode() { return stretch_mode_engaged; }
   bool is_degraded_stretch_mode() { return degraded_stretch_mode; }
   bool is_recovering_stretch_mode() { return recovering_stretch_mode; }
+  bool is_peer_tracker_clean() { return elector.peer_tracker_is_clean(); }
 
   /**
    * This set of functions maintains the in-memory stretch state


### PR DESCRIPTION
Problem:

Connection scores not populated properly on monitors at boot up time,
this leads to missing peer_score for some monitors. Also, there are instances
where peer_scores contain a rank of -1. This happens usually when new
monitor is added to the cluster and are trying to probe for other monitors so
that it can join the quorum.

Solution:

**To fix missing peer_score at boot up time:**
In `begin_peer_ping`, when we are at bootup time, `quorum_mon_features` 
is not yet assigned any values because an election have not yet taken place.
To prevent the monitor from rejecting pings at bootup time, we modify
the condition to see if we ourself (MON) supports
`FEAUTURE_PINGING`, if we do then we continue with
`begin_peer_ping` process. If we don't then
we just exit the function.

**To fix the -1 rank in peer score:**
We basically check the rank of the
monitor that is trying to send us message
to see if it is -1. If so, we just don't add
their score to ours (including creating a new
key/value for them).

Moreover, we also enhance the checking mechanism
for a clean connection score by using `monmap size`
and `quorum size` as reference,
we expect connection score to hold such conditions:

1. peer_reports and monmap should have the same size.
2. Sizes of current_report and history_report should be
equal or less than monmap_size (in the case where there
are dead monitors).
3. Peers that are alive according to current_report should
contain exactly the same ranks as of those in the quorum set.

Lastly, we have added a `HealthMonitor` for connection score,
utilizing the enhanced checking mechanism for a clean connection
score. This will warn the user if the connection score for a particular
monitor is not consistent with what is reported to monmap and quorum.

Fixes: https://tracker.ceph.com/issues/59564

Signed-off-by: Kamoltat <ksirivad@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
