### PR TITLE
pacific: mgr/dashboard: fix the rbd mirroring configure check

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -614,7 +614,7 @@ class RbdMirroringStatus(BaseController):
         # using dashboard.
         if not orch_status['available']:
             return status
-        if not CephService.get_service_list('rbd-mirror') or not CephService.get_pool_list('rbd'):
+        if not CephService.get_service_list('rbd-mirror') and not CephService.get_pool_list('rbd'):
             status['available'] = False
             status['message'] = 'RBD mirroring is not configured'  # type: ignore
         return status


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59622

---

backport of https://github.com/ceph/ceph/pull/51255
parent tracker: https://tracker.ceph.com/issues/59573

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh