### PR TITLE
[WIP] librbd: fix busy looping caused by remote request ETIMEDOUT handling logic

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -792,27 +792,27 @@ template <typename I>
 int ImageWatcher<I>::prepare_async_request(const AsyncRequestId& async_request_id,
                                            bool* new_request, Context** ctx,
                                            ProgressContext** prog_ctx) {
+  int r = 0;
   if (async_request_id.client_id == get_client_id()) {
-    return -ERESTART;
+    r = -ERESTART;
   } else {
     std::unique_lock l{m_async_request_lock};
     if (is_new_request(async_request_id)) {
       m_async_pending.insert(async_request_id);
       *new_request = true;
-      *prog_ctx = new RemoteProgressContext(*this, async_request_id);
-      *ctx = new RemoteContext(*this, async_request_id, *prog_ctx);
     } else {
       *new_request = false;
       auto it = m_async_complete.find(async_request_id);
       if (it != m_async_complete.end()) {
-        int r = it->second;
+        r = it->second;
         // reset complete request expiration time
         mark_async_request_complete(async_request_id, r);
-        return r;
       }
     }
+    *prog_ctx = new RemoteProgressContext(*this, async_request_id);
+    *ctx = new RemoteContext(*this, async_request_id, *prog_ctx);
   }
-  return 0;
+  return r;
 }
 
 template <typename I>
@@ -922,47 +922,51 @@ bool ImageWatcher<I>::handle_operation_request(
     C_NotifyAck *ack_ctx) {
   std::shared_lock owner_locker{m_image_ctx.owner_lock};
 
+  bool complete = true;
   if (m_image_ctx.exclusive_lock != nullptr) {
     int r = 0;
     if (m_image_ctx.exclusive_lock->accept_request(request_type, &r)) {
       bool new_request;
       Context *ctx;
       ProgressContext *prog_ctx;
-      bool complete;
       if (async_request_id) {
         r = prepare_async_request(async_request_id, &new_request, &ctx,
                                   &prog_ctx);
-        encode(ResponseMessage(r), ack_ctx->out);
-        complete = true;
+	if (!new_request) {
+          ldout(m_image_ctx.cct, 20) << this << " " << __func__ << ": op: "
+                                     << operation << " whose async request id: "
+                                     << async_request_id
+                                     << " has a previous return value r=" << r
+                                     << dendl;
+          // reset previous return value as we are about to retry the operation
+          r = 0;
+	}
       } else {
         new_request = true;
         ctx = new C_ResponseMessage(ack_ctx);
         prog_ctx = &m_no_op_prog_ctx;
         complete = false;
       }
-      if (r == 0 && new_request) {
-        ctx = new LambdaContext(
-          [this, operation, ctx](int r) {
-            m_image_ctx.operations->finish_op(operation, r);
+      ctx = new LambdaContext(
+        [this, operation, ctx](int r) {
+          m_image_ctx.operations->finish_op(operation, r);
+          ctx->complete(r);
+        });
+      ctx = new LambdaContext(
+        [this, execute, prog_ctx, ctx](int r) {
+          if (r < 0) {
             ctx->complete(r);
-          });
-        ctx = new LambdaContext(
-          [this, execute, prog_ctx, ctx](int r) {
-            if (r < 0) {
-              ctx->complete(r);
-              return;
-            }
-            std::shared_lock l{m_image_ctx.owner_lock};
-            execute(*prog_ctx, ctx);
-          });
-        m_image_ctx.operations->start_op(operation, ctx);
-      }
-      return complete;
+            return;
+          }
+          std::shared_lock l{m_image_ctx.owner_lock};
+          execute(*prog_ctx, ctx);
+        });
+      m_image_ctx.operations->start_op(operation, ctx);
     } else if (r < 0) {
       encode(ResponseMessage(r), ack_ctx->out);
     }
   }
-  return true;
+  return complete;
 }
 
 template <typename I>

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -331,6 +331,10 @@ struct C_InvokeAsyncRequest : public Context {
       send_refresh_image();
       return;
     } else if (r != -ETIMEDOUT && r != -ERESTART) {
+      // Except for ETIMEDOUT, ERESTART  all remote requests should be made to
+      // behave exactly the same as a local requests as far as error
+      // propagation goes; operation proxying must be completely transparent
+      // to the user.
       image_ctx.state->handle_update_notification();
 
       complete(r);

--- a/src/librbd/watcher/Notifier.cc
+++ b/src/librbd/watcher/Notifier.cc
@@ -23,8 +23,13 @@ Notifier::C_AioNotify::C_AioNotify(Notifier *notifier, NotifyResponse *response,
 }
 
 void Notifier::C_AioNotify::finish(int r) {
+  // convert ETIMEOUT errors to EBUSY to distinguish the notifier errors
+  // from real RPC timeout errors
+  if (r == -ETIMEDOUT) {
+    r = -EBUSY;
+  }
   if (response != nullptr) {
-    if (r == 0 || r == -ETIMEDOUT) {
+    if (r == 0 || r == -EBUSY) {
       try {
         auto it = out_bl.cbegin();
         decode(*response, it);


### PR DESCRIPTION
* librbd: notifier convert ETIMEOUT errors to EBUSY
    
Currently the local client gets ETIMEOUT errors from both notifier and
RPC, so its not possible to distinguish the notifier errors from real RPC
timeout errors and take appropriate actions in both the cases. Hence its
better to return a different error from notifier so that the local client
can now differentiate between the cause and can take necessary action.

* librbd: retry the operation which was not marked complete previously

In case if the previous operation returned a failure and is not marked
complete (i.e if error is ETIMEDOUT or ERESTART) then rather than just
retuning the previous error code again and again in a loop, retry the
operation each time.




Fixes: https://tracker.ceph.com/issues/59563
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
