### PR TITLE
quincy: rgw/rados: check_quota() uses real bucket owner

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -735,7 +735,7 @@ int RadosBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 int RadosBucket::check_quota(const DoutPrefixProvider *dpp, RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
 				optional_yield y, bool check_size_only)
 {
-    return store->getRados()->check_quota(dpp, owner->get_id(), get_key(),
+    return store->getRados()->check_quota(dpp, info.owner, get_key(),
 					  user_quota, bucket_quota, obj_size, y, check_size_only);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59618

---

backport of https://github.com/ceph/ceph/pull/50925
parent tracker: https://tracker.ceph.com/issues/58725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh