### PR TITLE
pacific: rgw/rados: check_quota() uses real bucket owner

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -317,7 +317,7 @@ int RGWRadosBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
 int RGWRadosBucket::check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
 				optional_yield y, bool check_size_only)
 {
-    return store->getRados()->check_quota(owner->get_user(), get_key(),
+    return store->getRados()->check_quota(info.owner, get_key(),
 					  user_quota, bucket_quota, obj_size, y, check_size_only);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59616

---

backport of https://github.com/ceph/ceph/pull/50925
parent tracker: https://tracker.ceph.com/issues/58725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh