### PR TITLE
Revert "common/tracer: fix decoding when jaeger tracing is disabled"

### DIFF
--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -100,21 +100,8 @@ struct Tracer {
   jspan add_span(std::string_view span_name, const jspan_context& parent_ctx) { return {}; }
   void init(std::string_view service_name) {}
 };
-
-inline void encode(const jspan_context& span_ctx, bufferlist& bl, uint64_t f = 0) {
-  ENCODE_START(1, 1, bl);
-  // jaeger is missing, set "is_valid" to false.
-  bool is_valid = false;
-  encode(is_valid, bl);
-  ENCODE_FINISH(bl);
+  inline void encode(const jspan_context& span, bufferlist& bl, uint64_t f=0) {}
+  inline void decode(jspan_context& span_ctx, ceph::buffer::list::const_iterator& bl) {}
 }
-
-inline void decode(jspan_context& span_ctx, bufferlist::const_iterator& bl) {
-  DECODE_START(254, bl);
-  // jaeger is missing, consume the buffer but do not decode it.
-  DECODE_FINISH(bl);
-}
-
-} // namespace tracing
 
 #endif // !HAVE_JAEGER


### PR DESCRIPTION
This reverts commit 3701ffa6733b001d4278a0b68395c5efe2382f25.

--------

This commit currently breaks all centos8 builds (with `!HAVE_JAEGER`).
```
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-3687-g9dd84573/rpm/el8/BUILD/ceph-18.0.0-3687-g9dd84573/src/common/tracer.h: In function ‘void tracing::encode(const jspan_context&, ceph::bufferlist&, uint64_t)’:
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-3687-g9dd84573/rpm/el8/BUILD/ceph-18.0.0-3687-g9dd84573/src/common/tracer.h:105:3: error: ‘ENCODE_START’ was not declared in this scope
  105 |   ENCODE_START(1, 1, bl);
      |   ^~~~~~~~~~~~
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/18.0.0-3687-g9dd84573/rpm/el8/BUILD/ceph-18.0.0-3687-g9dd84573/src/common/tracer.h:108:10: error: invalid initialization of reference of type ‘const jspan_context&’ from expression of type ‘bool’
  108 |   encode(is_valid, bl);
      |          ^~~~~~~~
```
https://shaman.ceph.com/builds/ceph/wip-adk-testing-2023-05-02-1727/24d8b207c00b7180a761adae28d1821aba627d6e/crimson/341501/

--------

#51043 was introduced because of:
```
message decoding failures after a recent change [1]
[1] https://github.com/ceph/ceph/pull/47457
```
#47457 was reverted here #51293 so we can also revert #51043.

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
