### PR TITLE
pybind/ceph_argparse: Fix error message for ceph tell command

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -522,6 +522,11 @@ class TestMisc(CephFSTestCase):
     def test_client_ls(self):
         self._session_client_ls(['client', 'ls'])
 
+    def test_ceph_tell_for_unknown_cephname_type(self):
+        with self.assertRaises(CommandFailedError) as ce:
+            self.run_ceph_cmd('tell', 'cephfs.c', 'something')
+        self.assertEqual(ce.exception.exitstatus, 1)
+
 
 @classhook('_add_session_client_evictions')
 class TestSessionClientEvict(CephFSTestCase):
@@ -599,7 +604,7 @@ class TestSessionClientEvict(CephFSTestCase):
             setattr(cls, 'test_session' + t, create_test(t, ['session']))
             setattr(cls, 'test_client' + t, create_test(t, ['client']))
 
-        
+
 class TestCacheDrop(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -502,13 +502,13 @@ class CephPgid(CephArgtype):
         try:
             poolid = int(poolid_s)
         except ValueError:
-            raise ArgumentFormat('pool {0} not integer'.format(poolid))
+            raise ArgumentFormat('pool {0} not integer'.format(poolid_s))
         if poolid < 0:
             raise ArgumentFormat('pool {0} < 0'.format(poolid))
         try:
             pgnum = int(pgnum_s, 16)
         except ValueError:
-            raise ArgumentFormat('pgnum {0} not hex integer'.format(pgnum))
+            raise ArgumentFormat('pgnum {0} not hex integer'.format(pgnum_s))
         self.val = s
 
     def __str__(self):


### PR DESCRIPTION
$ceph tell cephfs_1.magna023.yvyxvl client ls
error handling command target: local variable 'poolid' referenced before assignment

The error message `local variable 'poolid' referenced before assignment` looks not  descriptive. The exception was not getting raised by the usage of `ArgumentValid` which was getting bypassed and hence code asks for poolid when no type has been provided in tell commands.

Now after this fix, we are getting the proper error message as type is unknown for above example. 

Fixes: https://tracker.ceph.com/issues/59624
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
