### PR TITLE
crimson/osd/objclass: Fix compilation warning

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -276,7 +276,7 @@ int cls_cxx_setxattr(cls_method_context_t hctx,
 
 int cls_cxx_snap_revert(cls_method_context_t hctx, snapid_t snapid)
 {
-  OSDOp op{op = CEPH_OSD_OP_ROLLBACK};
+  OSDOp op{CEPH_OSD_OP_ROLLBACK};
   op.op.snap.snapid = snapid;
   return execute_osd_op(hctx, op);
 }


### PR DESCRIPTION
```
In copy constructor ‘ceph::buffer::v15_2_0::list::list(const ceph::buffer::v15_2_0::list&)’,
    inlined from ‘OSDOp::OSDOp(const OSDOp&)’ at ../src/osd/osd_types.h:4081:8,
    inlined from ‘int cls_cxx_snap_revert(cls_method_context_t, snapid_t)’ at ../src/crimson/osd/objclass.cc:279:37:
../src/include/buffer.h:945:20: warning: ‘op.OSDOp::indata.ceph::buffer::v15_2_0::list::_len’ is used uninitialized [-Wuninitialized]
  945 |         _len(other._len),
      |              ~~~~~~^~~~
../src/crimson/osd/objclass.cc: In function ‘int cls_cxx_snap_revert(cls_method_context_t, snapid_t)’:
../src/crimson/osd/objclass.cc:279:9: note: ‘op’ declared here
  279 |   OSDOp op{op = CEPH_OSD_OP_ROLLBACK};
      |
```

Build looks good: https://shaman.ceph.com/builds/ceph/wip-matanb-crimson-only-testing-3.5/12877b4e4694861aa1f9ae444a0b4532908f015a/crimson/341550/

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
