### PR TITLE
reef: mgr: add urllib3==1.26.15 to mgr/requirements.txt

### DIFF
--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,3 +1,4 @@
 -rrequirements-required.txt
 asyncssh==2.9
 kubernetes==11.0.0
+urllib3==1.26.15


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59600

---

backport of https://github.com/ceph/ceph/pull/51298
parent tracker: https://tracker.ceph.com/issues/59591

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh