### PR TITLE
ceph-volume: fix a bug in `get_lvm_fast_allocs()` (batch)

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -171,7 +171,7 @@ def group_devices_by_vg(devices):
 def get_lvm_fast_allocs(lvs):
     return [("{}/{}".format(d.vg_name, d.lv_name), 100.0,
              disk.Size(b=int(d.lvs[0].lv_size)), 1) for d in lvs if not
-            d.used_by_ceph]
+            d.journal_used_by_ceph]
 
 
 class Batch(object):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -529,6 +529,15 @@ class Device(object):
         return any(osd_ids)
 
     @property
+    def journal_used_by_ceph(self):
+        # similar to used_by_ceph() above. This is for 'journal' devices (db/wal/..)
+        # needed by get_lvm_fast_allocs() in devices/lvm/batch.py
+        # see https://tracker.ceph.com/issues/59640
+        osd_ids = [lv.tags.get("ceph.osd_id") is not None for lv in self.lvs
+                   if lv.tags.get("ceph.type") in ["db", "wal"]]
+        return any(osd_ids)
+
+    @property
     def vg_free_percent(self):
         if self.vgs:
             return [vg.free_percent for vg in self.vgs]


### PR DESCRIPTION
`get_lvm_fast_allocs()` in `devices/lvm/batch.py` calls the property `Device.used_by_ceph` in order to filter out devices that are already used by ceph. The issue is that `Device.used_by_ceph()` itself filters out journal devices (db/wal) given that a db/wal device can be shared between multiple OSDs. The consequence is that `Device.used_by_ceph()` always returns False for a db/wal device (even if it is actually already used by ceph) so `get_lvm_fast_allocs()` always returns the full list of the passed db/wal devices on the `lvm batch` CLI command. Finally, the logic in `devices.lvm.batch.get_deployment_layout()` checks whether the length of the list returned by `get_lvm_fast_allocs()` is equal to `num_osds` (the number of OSD being created), if not it fails.

Fixes: https://tracker.ceph.com/issues/59640
