### PR TITLE
pacific: mgr/cephadm: don't try to write client/os tuning profiles to known offline hosts

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1065,6 +1065,8 @@ class CephadmServe:
                             client_files: Dict[str, Dict[str, Tuple[int, int, int, bytes, str]]],
                             host: str) -> None:
         updated_files = False
+        if host in self.mgr.offline_hosts:
+            return
         old_files = self.mgr.cache.get_host_client_files(host).copy()
         for path, m in client_files.get(host, {}).items():
             mode, uid, gid, content, digest = m


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59649

---

backport of https://github.com/ceph/ceph/pull/47666
parent tracker: https://tracker.ceph.com/issues/57175

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh