### PR TITLE
mds: wait migrate to finish when linking

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -108,6 +108,8 @@ ostream& operator<<(ostream& out, const CDentry& dn)
   out << " state=" << dn.get_state();
   if (dn.is_new()) out << "|new";
   if (dn.state_test(CDentry::STATE_BOTTOMLRU)) out << "|bottomlru";
+  if (dn.state_test(CDentry::STATE_UNLINKING)) out << "|unlinking";
+  if (dn.state_test(CDentry::STATE_REINTEGRATING)) out << "|reintegrating";
 
   if (dn.get_num_ref()) {
     out << " |";

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -87,6 +87,7 @@ public:
   static const int STATE_PURGINGPINNED =  (1<<5);
   static const int STATE_BOTTOMLRU =    (1<<6);
   static const int STATE_UNLINKING =    (1<<7);
+  static const int STATE_REINTEGRATING = (1<<8);
   // stray dentry needs notification of releasing reference
   static const int STATE_STRAY =	STATE_NOTIFYREF;
   static const int MASK_STATE_IMPORT_KEPT = STATE_BOTTOMLRU;
@@ -100,8 +101,9 @@ public:
 
   static const unsigned EXPORT_NONCE = 1;
 
-  const static uint64_t WAIT_UNLINK_STATE  = (1<<0);
-  const static uint64_t WAIT_UNLINK_FINISH = (1<<1);
+  const static uint64_t WAIT_UNLINK_STATE       = (1<<0);
+  const static uint64_t WAIT_UNLINK_FINISH      = (1<<1);
+  const static uint64_t WAIT_REINTEGRATE_FINISH = (1<<2);
   uint32_t replica_unlinking_ref = 0;
 
   CDentry(std::string_view n, __u32 h,

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11326,6 +11326,11 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
       }
       ceph_assert(dnl->is_null());
       dn->state_clear(CDentry::STATE_UNLINKING);
+
+      MDSContext::vec finished;
+      dn->take_waiting(CDentry::WAIT_UNLINK_FINISH, finished);
+      mds->queue_waiters(finished);
+
     }
   }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8499,6 +8499,10 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
         if (in) {
 	  dout(7) << "linking in remote in " << *in << dendl;
 	  dn->link_remote(dnl, in);
+	  if (mds->server->is_reintegrate_pending(dn)) {
+	    mds->server->wait_for_pending_reintegrate(dn, mdr);
+	    return 1;
+	  }
 	} else {
           dout(7) << "remote link to " << dnl->get_remote_ino() << ", which i don't have" << dendl;
 	  ceph_assert(mdr);  // we shouldn't hit non-primary dentries doing a non-mdr traversal!

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6895,6 +6895,7 @@ void Server::wait_for_pending_reintegrate(CDentry *dn, MDRequestRef& mdr)
 {
   dout(20) << __func__ << " dn " << *dn << dendl;
   mds->locker->drop_locks(mdr.get());
+  mdr->drop_local_auth_pins();
   auto fin = new C_MDS_RetryRequest(mdcache, mdr);
   dn->get(CDentry::PIN_PURGING);
   dn->add_waiter(CDentry::WAIT_REINTEGRATE_FINISH, new C_WaitReintegrateToFinish(mdcache, dn, fin));

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -159,6 +159,7 @@ public:
 
   // -- requests --
   void handle_client_request(const cref_t<MClientRequest> &m);
+  void handle_client_reply(const cref_t<MClientReply> &m);
 
   void journal_and_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn,
 			 LogEvent *le, MDSLogContextBase *fin);
@@ -237,6 +238,9 @@ public:
 
   bool is_unlink_pending(CDentry *dn);
   void wait_for_pending_unlink(CDentry *dn, MDRequestRef& mdr);
+
+  bool is_reintegrate_pending(CDentry *dn);
+  void wait_for_pending_reintegrate(CDentry *dn, MDRequestRef& mdr);
 
   // open
   void handle_client_open(MDRequestRef& mdr);

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -687,19 +687,27 @@ void StrayManager::reintegrate_stray(CDentry *straydn, CDentry *rdn)
   dout(10) << __func__ << " " << *straydn << " to " << *rdn << dendl;
 
   logger->inc(l_mdc_strays_reintegrated);
-  
+
   // rename it to remote linkage .
   filepath src(straydn->get_name(), straydn->get_dir()->ino());
   filepath dst(rdn->get_name(), rdn->get_dir()->ino());
 
+  ceph_tid_t tid = mds->issue_tid();
+
   auto req = make_message<MClientRequest>(CEPH_MDS_OP_RENAME);
   req->set_filepath(dst);
   req->set_filepath2(src);
-  req->set_tid(mds->issue_tid());
+  req->set_tid(tid);
+
+  rdn->state_set(CDentry::STATE_REINTEGRATING);
+  MDSMetaRequest *r = new MDSMetaRequest(CEPH_MDS_OP_RENAME);
+  r->set_dentry(rdn);
+  r->set_tid(tid);
+  mds->internal_client_requests[tid] = r;
 
   mds->send_message_mds(req, rdn->authority().first);
 }
- 
+
 void StrayManager::migrate_stray(CDentry *dn, mds_rank_t to)
 {
   dout(10) << __func__ << " " << *dn << " to mds." << to << dendl;
@@ -713,10 +721,17 @@ void StrayManager::migrate_stray(CDentry *dn, mds_rank_t to)
   filepath src(dn->get_name(), dirino);
   filepath dst(dn->get_name(), MDS_INO_STRAY(to, MDS_INO_STRAY_INDEX(dirino)));
 
+  ceph_tid_t tid = mds->issue_tid();
+
   auto req = make_message<MClientRequest>(CEPH_MDS_OP_RENAME);
   req->set_filepath(dst);
   req->set_filepath2(src);
-  req->set_tid(mds->issue_tid());
+  req->set_tid(tid);
+
+  MDSMetaRequest *r = new MDSMetaRequest(CEPH_MDS_OP_RENAME);
+  r->set_dentry(dn);
+  r->set_tid(tid);
+  mds->internal_client_requests[tid] = r;
 
   mds->send_message_mds(req, to);
 }

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -79,7 +79,7 @@ public:
    * on completion of mv (i.e. inode put), resulting in a subsequent
    * reintegration.
    */
-  void migrate_stray(CDentry *dn, mds_rank_t dest);
+  void migrate_stray(CDentry *dn, mds_rank_t dest, CDentry *rdn=nullptr);
 
   /**
    * Update stats to reflect a newly created stray dentry. Needed


### PR DESCRIPTION
If the inode have 2 hard links and in two different MDSs. If the
local dentry was unlinked and a new link request, which is trying
to link a new dentry to this inode, comes, it will try to trigger
to migrate the local stray denty to the remote MDS.

This will cause deadlock because the link request will authpin
the inode and keep waiting the migrating, which will also try to
autopin the inode too, to finish.

Fixes: https://tracker.ceph.com/issues/59657
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
