### PR TITLE
librbd: remove unused enum WriteOpType

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -87,11 +87,6 @@ private:
    * @endverbatim
    */
 
-  enum WriteOpType {
-    WRITE_OP_TYPE_WRITE,
-    WRITE_OP_TYPE_ZERO
-  };
-
   struct ReadOp {
     interval_set<uint64_t> image_interval;
     io::Extents image_extent_map;


### PR DESCRIPTION
This removes the unused enum WriteOpType from
the librbd deep_copy code.
