### PR TITLE
mount: support arbitrary order of command line arguments

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -703,15 +703,15 @@ static void modprobe(void)
 
 static void usage(const char *prog_name)
 {
-	printf("usage: %s [src] [mount-point] [-n] [-v] [-o ceph-options]\n",
-		prog_name);
+	printf("usage: %s [options] <source> <directory>\n\n", prog_name);
+	printf("Mount a CephFS filesystem.\n\n");
 	printf("options:\n");
-	printf("\t-h, --help\tPrint this help\n");
-	printf("\t-n, --no-mtab\tDo not update /etc/mtab\n");
-	printf("\t-v, --verbose\tVerbose\n");
-	printf("\t-f, --fake\tFake mount, do not actually mount\n");
-	printf("ceph-options: refer to mount.ceph(8)\n");
-	printf("\n");
+	printf("    -h, --help            Print this help\n");
+	printf("    -n, --no-mtab         Do not update /etc/mtab\n");
+	printf("    -v, --verbose         Verbose output\n");
+	printf("    -f, --fake            Fake mount, do not actually mount\n");
+	printf("    -o, --options <list>  Comma-separated list of mount options\n\n");
+	printf("For more details see mount.ceph(8).\n");
 }
 
 /*

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -655,16 +655,6 @@ static int parse_arguments(int argc, char *const *const argv,
 		// There were no arguments. Just show the usage.
 		return 1;
 	}
-	if ((!strcmp(argv[1], "-h")) || (!strcmp(argv[1], "--help"))) {
-		// The user asked for help.
-		return 1;
-	}
-
-	// The first two arguments are positional
-	if (argc < 3)
-		return -EINVAL;
-	*src = argv[1];
-	*node = argv[2];
 
 	// Parse the remaining options
 	*opts = EMPTY_STRING;
@@ -689,6 +679,14 @@ static int parse_arguments(int argc, char *const *const argv,
 				return -EINVAL;
 		}
 	}
+
+	if (optind + 2 != argc) {
+		return -EINVAL;
+	}
+
+	*src = argv[optind];
+	*node = argv[optind + 1];
+
 	return 0;
 }
 


### PR DESCRIPTION
Allow positional args to go after other args, just like mount program, instead of printing confusing "error parsing device string" message.

Also update the help message.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
