### PR TITLE
doc/rados/configuration: correct space amp in bluestore-config-ref.rst

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -431,7 +431,7 @@ GateWay (RGW) deployments that host large numbers of small files
 For example, when an RGW client stores a 1KB S3 object, it is written to a
 single RADOS object.  With the default :confval:`min_alloc_size` value, 4KB of
 underlying drive space is allocated.  This means that roughly
-(4KB - 1KB) == 3KB is allocated but never used, which corresponds to 300%
+(4KB - 1KB) == 3KB of that RADOS object's allocated space is never used, which corresponds to 300%
 overhead or 25% efficiency. Similarly, a 5KB user object will be stored
 as one 4KB and one 1KB RADOS object, again stranding 4KB of device capacity,
 though in this case the overhead is a much smaller percentage.  Think of this
@@ -440,8 +440,8 @@ thus decreases rapidly as user object size increases.
 
 An easily missed additional subtlety is that this
 takes place for *each* replica.  So when using the default three copies of
-data (3R), a 1KB S3 object actually consumes roughly 9KB of storage device
-capacity.  If erasure coding (EC) is used instead of replication, the
+data (3R), a 1KB S3 object actually consumes 12KB of storage device
+capacity, with 11KB of overhead.  If erasure coding (EC) is used instead of replication, the
 amplification may be even higher: for a ``k=4,m=2`` pool, our 1KB S3 object
 will allocate (6 * 4KB) = 24KB of device capacity.
 


### PR DESCRIPTION
doc/rados/configuration: correct space amp in bluestore-config-ref.rst

Thanks to [Igor Podlesny](https://github.com/poige) for pointing out this error.

Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
