### PR TITLE
qa/suites/crimson: Enhance rbd api testing 

### DIFF
--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
@@ -1,0 +1,12 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(SLOW_OPS\)
+      - slow request
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'
+    env:
+      RBD_FEATURES: "61"

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
@@ -7,4 +7,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rbd/test_librbd_python.sh
+        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'

--- a/qa/workunits/rbd/test_librbd_python.sh
+++ b/qa/workunits/rbd/test_librbd_python.sh
@@ -5,8 +5,8 @@ relpath=$(dirname $0)/../../../src/test/pybind
 if [ -n "${VALGRIND}" ]; then
   valgrind ${VALGRIND} --suppressions=${TESTDIR}/valgrind.supp \
     --errors-for-leak-kinds=definite --error-exitcode=1 \
-    python3 -m nose -v $relpath/test_rbd.py
+    python3 -m nose -v $relpath/test_rbd.py "$@"
 else
-    python3 -m nose -v $relpath/test_rbd.py
+    python3 -m nose -v $relpath/test_rbd.py "$@"
 fi
 exit 0

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -20,7 +20,6 @@
 
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
-#include "test/librados/crimson_utils.h"
 
 #include <errno.h>
 #include <string>
@@ -1798,7 +1797,6 @@ TEST_F(TestClsRbd, mirror_image) {
 }
 
 TEST_F(TestClsRbd, mirror_image_status) {
-  SKIP_IF_CRIMSON();
   struct WatchCtx : public librados::WatchCtx2 {
     librados::IoCtx *m_ioctx;
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -3,7 +3,6 @@
 
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
-#include "test/librados/crimson_utils.h"
 #include "include/rbd/librbd.h"
 #include "include/rbd/librbd.hpp"
 #include "test/librados/test.h"
@@ -220,7 +219,6 @@ TEST_F(TestGroup, add_imagePP)
 
 TEST_F(TestGroup, add_snapshot)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   rados_ioctx_t ioctx;
@@ -367,7 +365,6 @@ TEST_F(TestGroup, add_snapshot)
 
 TEST_F(TestGroup, add_snapshotPP)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   librados::IoCtx ioctx;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -268,7 +268,6 @@ TEST_F(TestInternal, SnapCreateFailsToLockImage) {
 }
 
 TEST_F(TestInternal, SnapRollbackLocksImage) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   ASSERT_EQ(0, create_snapshot("snap1", false));
@@ -1182,7 +1181,6 @@ TEST_F(TestInternal, ImageOptions) {
 }
 
 TEST_F(TestInternal, WriteFullCopyup) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1737,7 +1735,6 @@ TEST_F(TestInternal, Sparsify) {
 
 
 TEST_F(TestInternal, SparsifyClone) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8529,7 +8529,6 @@ TEST_F(TestLibRBD, SnapshotLimitPP)
 
 TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
 
   librados::IoCtx ioctx;
@@ -8582,7 +8581,6 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8623,7 +8621,6 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
 
 TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8668,7 +8665,6 @@ TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 
 TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   librados::IoCtx ioctx;
@@ -8709,7 +8705,6 @@ TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 }
 
 TEST_F(TestLibRBD, UpdateFeaturesViaLockOwner) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8960,7 +8955,6 @@ TEST_F(TestLibRBD, SnapUnprotectViaLockOwner)
 
 TEST_F(TestLibRBD, FlattenViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9009,7 +9003,6 @@ TEST_F(TestLibRBD, FlattenViaLockOwner)
 
 TEST_F(TestLibRBD, ResizeViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9046,7 +9039,6 @@ TEST_F(TestLibRBD, ResizeViaLockOwner)
 
 TEST_F(TestLibRBD, SparsifyViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9751,7 +9743,6 @@ TEST_F(TestLibRBD, BlockingAIO)
 
 TEST_F(TestLibRBD, ExclusiveLockTransition)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -10425,7 +10416,6 @@ TEST_F(TestLibRBD, FlushCacheWithCopyupOnExternalSnapshot) {
 
 TEST_F(TestLibRBD, ExclusiveLock)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   static char buf[10];
@@ -11961,7 +11951,6 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
 
 TEST_F(TestLibRBD, QuiesceWatch)
 {
-  SKIP_IF_CRIMSON();
   rados_ioctx_t ioctx;
   rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
 
@@ -12053,7 +12042,6 @@ TEST_F(TestLibRBD, QuiesceWatch)
 
 TEST_F(TestLibRBD, QuiesceWatchPP)
 {
-  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -13,7 +13,6 @@
  */
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
-#include "test/librados/crimson_utils.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
@@ -1224,7 +1223,6 @@ TEST_F(TestMirroring, SnapshotRemoveOnDisable)
 
 TEST_F(TestMirroring, SnapshotUnlinkPeer)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -12,6 +12,7 @@ import sys
 
 from datetime import datetime, timedelta
 from nose import with_setup, SkipTest
+from nose.plugins.attrib import attr
 from nose.tools import eq_ as eq, assert_raises, assert_not_equal
 from rados import (Rados,
                    LIBRADOS_OP_FLAG_FADVISE_DONTNEED,
@@ -777,6 +778,7 @@ class TestImage(object):
         self._test_copy(features, self.image.stat()['order'],
                         self.image.stripe_unit(), self.image.stripe_count())
 
+    @attr('SKIP_IF_CRIMSON')
     def test_deep_copy(self):
         global ioctx
         global features
@@ -2029,6 +2031,7 @@ class TestExclusiveLock(object):
             image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE)
             image.lock_release()
 
+    @attr('SKIP_IF_CRIMSON')
     def test_break_lock(self):
         blocklist_rados = Rados(conffile='')
         blocklist_rados.connect()


### PR DESCRIPTION
* 6895fb33e8308d8bfabe14d92e156b02044b9c8e Enable supported (`rbd_api_tests`) tests.
* 5823c04542c2a6870cb038da752e752ea2a3cf9a Skip 2 unsupported (`rbd_python_api` ) tests. This will make the py api tests to pass in suite runs and help with identifying regressions when gating PRs.
* 01958e648ef6ea0689e30e946be71b28a641303c Enable `rbd_python_api` with **new** rbd image format.

-------

This PR can be merged based on:

https://pulpito.ceph.com/matan-2023-05-08_14:59:25-crimson-rados-wip-matanb-crimson-only-testing-8.5-distro-crimson-smithi/

`rbd_api_tests` - ok
`rbd_api_tests_old_format` - ok
`rbd_python` - ok
`rbd_python_api_tests_old_format` - ok 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
