### PR TITLE
mgr/cephadm: lower log level when logging about related services

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1113,14 +1113,14 @@ class HostCache():
         if service_spec.service_type == 'ingress':
             dds = list(dd for dd in self._get_daemons() if dd.service_name() == cast(IngressSpec, service_spec).backend_service)
             dds += list(dd for dd in self._get_tmp_daemons() if dd.service_name() == cast(IngressSpec, service_spec).backend_service)
-            logger.info(f'Found related daemons {dds} for service {service_spec.service_name()}')
+            logger.debug(f'Found related daemons {dds} for service {service_spec.service_name()}')
             return dds
         else:
             for ingress_spec in [cast(IngressSpec, s) for s in self.mgr.spec_store.active_specs.values() if s.service_type == 'ingress']:
                 if ingress_spec.backend_service == service_spec.service_name():
                     dds = list(dd for dd in self._get_daemons() if dd.service_name() == ingress_spec.service_name())
                     dds += list(dd for dd in self._get_tmp_daemons() if dd.service_name() == ingress_spec.service_name())
-                    logger.info(f'Found related daemons {dds} for service {service_spec.service_name()}')
+                    logger.debug(f'Found related daemons {dds} for service {service_spec.service_name()}')
                     return dds
         return None
 

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -258,11 +258,6 @@ class HostAssignment(object):
 
         self.validate()
 
-        if self.related_service_daemons:
-            logger.info(f'Service {self.service_name} has related daemons already placed: {self.related_service_daemons}')
-        else:
-            logger.info(f'Service {self.service_name} has no related daemon already placed.')
-
         count = self.spec.placement.count
 
         # get candidate hosts based on [hosts, label, host_pattern]
@@ -362,7 +357,7 @@ class HostAssignment(object):
                     if need <= 0:
                         break
                     if dp.hostname in related_service_hosts and dp.hostname not in [h.hostname for h in self.unreachable_hosts]:
-                        logger.info(f'Preferring {dp.hostname} for service {self.service_name} as related daemons have been placed there')
+                        logger.debug(f'Preferring {dp.hostname} for service {self.service_name} as related daemons have been placed there')
                         to_add.append(dp)
                         need -= 1  # this is last use of need so it can work as a counter
                 # at this point, we've either met our placement quota entirely using hosts with related


### PR DESCRIPTION
This was recently added in https://github.com/ceph/ceph/commit/088d2c4205c599a7d4f2ce4de8e2af8e129adac8 and seems to work fine, but logging these things at info level spams the log as every single service every serve loop iteration is reporting on whether it has related daemons. This changes it to only log when it finds related daemons or when it prefers a host due to those related daemons, and do both of those at only debug level.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
