### PR TITLE
[WIP]crimson/osd/osd_operations/pg_advance: make PGAdvanceMap a pg_operation

### DIFF
--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -72,7 +72,7 @@ struct EventBackendRegistry {
   template <typename...> static constexpr bool always_false = false;
 
   static std::tuple<> get_backends() {
-    static_assert(always_false<T>, "Registry specialization not found");
+    //static_assert(always_false<T>, "Registry specialization not found");
     return {};
   }
 };

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -88,6 +88,12 @@ class OSD final : public crimson::net::Dispatcher,
   //< since when there is no more pending pg creates from mon
   epoch_t last_pg_create_epoch = 0;
 
+  interval_set<epoch_t> handled_epochs;
+
+  interval_set<epoch_t> calc_new_osd_maps(
+    epoch_t origin_first,
+    epoch_t origin_last);
+
   ceph::mono_time startup_time;
 
   OSDSuperblock superblock;
@@ -166,8 +172,12 @@ private:
 
   bool require_mon_peer(crimson::net::Connection *conn, Ref<Message> m);
 
-  seastar::future<> handle_osd_map(crimson::net::ConnectionRef conn,
-                                   Ref<MOSDMap> m);
+  seastar::future<> maybe_handle_osd_maps(crimson::net::ConnectionRef conn,
+                                         Ref<MOSDMap> m);
+  seastar::future<> _handle_osd_map(crimson::net::ConnectionRef conn,
+                                   Ref<MOSDMap> m,
+                                   epoch_t first,
+                                   epoch_t last);
   seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
 				     Ref<MOSDPGCreate2> m);
   seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -185,7 +185,8 @@ private:
   seastar::future<> handle_mark_me_down(crimson::net::ConnectionRef conn,
 					Ref<MOSDMarkMeDown> m);
 
-  seastar::future<> committed_osd_maps(version_t first,
+  seastar::future<> committed_osd_maps(crimson::net::ConnectionRef conn,
+                                       version_t first,
                                        version_t last,
                                        Ref<MOSDMap> m);
 

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -30,8 +30,8 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
                     osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
     read_errorator::all_same_way([e] {
-      throw std::runtime_error(fmt::format("read gave enoent on {}",
-                                           osdmap_oid(e)));
+      ceph_abort_msg(fmt::format("{} read gave enoent on {}",
+                                 __func__, osdmap_oid(e)));
     }));
 }
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -73,6 +73,7 @@ seastar::future<> PGAdvanceMap::start()
       });
     }
     return fut.then([this] {
+      ceph_assert(std::cmp_less_equal(*from, to));
       return seastar::do_for_each(
 	boost::make_counting_iterator(*from + 1),
 	boost::make_counting_iterator(to + 1),

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -24,7 +24,10 @@ PGAdvanceMap::PGAdvanceMap(
   ShardServices &shard_services, Ref<PG> pg, epoch_t to,
   PeeringCtx &&rctx, bool do_init)
   : shard_services(shard_services), pg(pg), to(to),
-    rctx(std::move(rctx)), do_init(do_init) {}
+    rctx(std::move(rctx)), do_init(do_init)
+  {
+    logger().debug("{}: created", *this);
+  }
 
 PGAdvanceMap::~PGAdvanceMap() {}
 
@@ -75,6 +78,8 @@ seastar::future<> PGAdvanceMap::start()
 	boost::make_counting_iterator(*from + 1),
 	boost::make_counting_iterator(to + 1),
 	[this](epoch_t next_epoch) {
+	  logger().debug("{}: start: getting map {}",
+	                 *this, next_epoch);
 	  return shard_services.get_map(next_epoch).then(
 	    [this] (cached_map_t&& next_map) {
 	      logger().debug("{}: advancing map to {}",

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -35,7 +35,7 @@ void PGAdvanceMap::print(std::ostream &lhs) const
 {
   lhs << "PGAdvanceMap("
       << "pg=" << pg->get_pgid()
-      << " from=" << (from ? *from : -1)
+      << " from=" << from
       << " to=" << to;
   if (do_init) {
     lhs << " do_init";
@@ -47,9 +47,7 @@ void PGAdvanceMap::dump_detail(Formatter *f) const
 {
   f->open_object_section("PGAdvanceMap");
   f->dump_stream("pgid") << pg->get_pgid();
-  if (from) {
-    f->dump_int("from", *from);
-  }
+  f->dump_int("from", from);
   f->dump_int("to", to);
   f->dump_bool("do_init", do_init);
   f->close_section();
@@ -73,9 +71,9 @@ seastar::future<> PGAdvanceMap::start()
       });
     }
     return fut.then([this] {
-      ceph_assert(std::cmp_less_equal(*from, to));
+      ceph_assert(std::cmp_less_equal(from, to));
       return seastar::do_for_each(
-	boost::make_counting_iterator(*from + 1),
+	boost::make_counting_iterator(from + 1),
 	boost::make_counting_iterator(to + 1),
 	[this](epoch_t next_epoch) {
 	  logger().debug("{}: start: getting map {}",

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -20,10 +20,10 @@ namespace {
 
 namespace crimson::osd {
 
-PGAdvanceMap::PGAdvanceMap(
-  ShardServices &shard_services, Ref<PG> pg, epoch_t to,
+PGAdvanceMap::PGAdvanceMap(crimson::net::ConnectionRef conn,
+  ShardServices &shard_services, Ref<PG> pg, epoch_t from, epoch_t to,
   PeeringCtx &&rctx, bool do_init)
-  : shard_services(shard_services), pg(pg), to(to),
+  : conn(conn), shard_services(shard_services), pg(pg), from(from) ,to(to),
     rctx(std::move(rctx)), do_init(do_init)
   {
     logger().debug("{}: created", *this);
@@ -65,7 +65,6 @@ seastar::future<> PGAdvanceMap::start()
   return enter_stage<>(
     pg->peering_request_pg_pipeline.process
   ).then([this] {
-    from = pg->get_osdmap_epoch();
     auto fut = seastar::now();
     if (do_init) {
       fut = pg->handle_initialize(rctx

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -6,10 +6,13 @@
 #include <iostream>
 #include <seastar/core/future.hh>
 
+#include "crimson/net/Connection.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "osd/osd_types.h"
 #include "crimson/common/type_helpers.h"
+#include "crimson/osd/osd_connection_priv.h"
+#include "crimson/osd/pg.h"
 
 namespace ceph {
   class Formatter;
@@ -23,12 +26,41 @@ class PG;
 class PGAdvanceMap : public PhasedOperationT<PGAdvanceMap> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::pg_advance_map;
+  static constexpr bool can_create() { return false; }
+  spg_t get_pgid() const {
+    return pg->get_pgid();
+  }
+  ConnectionPipeline &get_connection_pipeline() {
+    return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
+  }
+
+  seastar::future<> with_pg(ShardServices &shard_services, Ref<PG> pg)
+  {
+    return start();
+  }
+
+  std::tuple<
+    StartEvent,
+    ConnectionPipeline::AwaitActive::BlockingEvent,
+    ConnectionPipeline::AwaitMap::BlockingEvent,
+    ConnectionPipeline::GetPG::BlockingEvent,
+    PGMap::PGCreationBlockingEvent,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    PGPeeringPipeline::Process::BlockingEvent
+  > tracking_events;
+
 
 protected:
+  ClientRequest::PGPipeline &pp(PG &pg) {
+    return pg.request_pg_pipeline;
+  }
+  crimson::net::ConnectionRef conn;
+
   ShardServices &shard_services;
   Ref<PG> pg;
   PipelineHandle handle;
 
+  // todo: no longer optional
   std::optional<epoch_t> from;
   epoch_t to;
 
@@ -36,8 +68,8 @@ protected:
   const bool do_init;
 
 public:
-  PGAdvanceMap(
-    ShardServices &shard_services, Ref<PG> pg, epoch_t to,
+  PGAdvanceMap(crimson::net::ConnectionRef conn,
+    ShardServices &shard_services, Ref<PG> pg, epoch_t from, epoch_t to,
     PeeringCtx &&rctx, bool do_init);
   ~PGAdvanceMap();
 
@@ -45,10 +77,21 @@ public:
   void dump_detail(ceph::Formatter *f) const final;
   seastar::future<> start();
   PipelineHandle &get_handle() { return handle; }
+  epoch_t get_epoch() const { return *from; }
 
-  std::tuple<
-    PGPeeringPipeline::Process::BlockingEvent
-  > tracking_events;
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 };
 
 }

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -60,9 +60,7 @@ protected:
   Ref<PG> pg;
   PipelineHandle handle;
 
-  // todo: no longer optional
-  std::optional<epoch_t> from;
-  epoch_t to;
+  const epoch_t from, to;
 
   PeeringCtx rctx;
   const bool do_init;
@@ -77,7 +75,7 @@ public:
   void dump_detail(ceph::Formatter *f) const final;
   seastar::future<> start();
   PipelineHandle &get_handle() { return handle; }
-  epoch_t get_epoch() const { return *from; }
+  epoch_t get_epoch() const { return from; }
 
   seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
     assert(conn);

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -54,6 +54,9 @@ seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
 
 template <OSDMapGateType OSDMapGateTypeV>
 void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
+  if (current >= epoch) {
+    return;
+  }
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -535,7 +535,7 @@ void PG::on_active_advmap(const OSDMapRef &osdmap)
     }
     logger().info("{}: {} new removed snaps {}, snap_trimq now{}",
                   *this, __func__, it->second, snap_trimq);
-    assert(!bad || local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
+    assert(!bad || !local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
   }
 }
 

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -337,9 +337,20 @@ public:
   }
 
   template <typename T, typename... Args>
+  auto start_pg_operation_with_state(PerShardState& _state, Args&&... args) {
+    ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
+    return _start_pg_operation<T>(_state, std::forward<Args>(args)...);
+  }
+
+  template <typename T, typename... Args>
   auto start_pg_operation(Args&&... args) {
     ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
-    auto op = get_local_state().registry.create_operation<T>(
+    return _start_pg_operation<T>(get_local_state(), std::forward<Args>(args)...);
+  }
+
+  template <typename T, typename... Args>
+  auto _start_pg_operation(PerShardState& state, Args&&... args) {
+    auto op = state.registry.create_operation<T>(
       std::forward<Args>(args)...);
     auto &logger = crimson::get_logger(ceph_subsys_osd);
     logger.debug("{}: starting {}", *op, __func__);

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -212,7 +212,7 @@ public:
 	      auto &&trigger) {
 	    return shard_services.get_or_create_pg(
 	      std::move(trigger),
-	      opref.get_pgid(), opref.get_epoch(),
+	      opref.get_pgid(),
 	      std::move(opref.get_create_info())
 	    );
 	  }).safe_then([&logger, &shard_services, &opref](Ref<PG> pgref) {

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -9,6 +9,7 @@
 
 #include "crimson/osd/shard_services.h"
 #include "crimson/osd/pg_map.h"
+#include "crimson/net/Connection.h"
 
 namespace crimson::os {
   class FuturizedStore;
@@ -321,7 +322,7 @@ public:
     return get_osd_singleton_state().pg_to_shard_mapping.get_num_pgs();
   }
 
-  seastar::future<> broadcast_map_to_pgs(epoch_t epoch);
+  seastar::future<> broadcast_map_to_pgs(crimson::net::ConnectionRef conn, epoch_t advance_from, epoch_t advance_to);
 
   template <typename F>
   auto with_pg(spg_t pgid, F &&f) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -405,14 +405,14 @@ seastar::future<std::map<epoch_t, bufferlist>> OSDSingletonState::load_map_bls(
 seastar::future<std::unique_ptr<OSDMap>> OSDSingletonState::load_map(epoch_t e)
 {
   auto o = std::make_unique<OSDMap>();
-  if (e > 0) {
-    return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
-      o->decode(bl);
-      return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
-    });
-  } else {
+  logger().info("{} osdmap.{}", __func__, e);
+  if (e == 0) {
     return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
   }
+  return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
+    o->decode(bl);
+    return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
+  });
 }
 
 seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -349,8 +349,10 @@ OSDSingletonState::get_local_map(epoch_t e)
 {
   // TODO: use LRU cache for managing osdmap, fallback to disk if we have to
   if (auto found = osdmaps.find(e); found) {
+    logger().debug("{} osdmap.{} found in cache", __func__, e);
     return seastar::make_ready_future<local_cached_map_t>(std::move(found));
   } else {
+    logger().debug("{} loading osdmap.{} from disk", __func__, e);
     return load_map(e).then([e, this](std::unique_ptr<OSDMap> osdmap) {
       return seastar::make_ready_future<local_cached_map_t>(
 	osdmaps.insert(e, std::move(osdmap)));
@@ -370,8 +372,10 @@ seastar::future<bufferlist> OSDSingletonState::load_map_bl(
   epoch_t e)
 {
   if (std::optional<bufferlist> found = map_bl_cache.find(e); found) {
+    logger().debug("{} osdmap.{} found in cache", __func__, e);
     return seastar::make_ready_future<bufferlist>(*found);
   } else {
+    logger().debug("{} loading osdmap.{} from disk", __func__, e);
     return meta_coll->load_map(e);
   }
 }
@@ -421,12 +425,15 @@ seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
       if (auto p = m->maps.find(e); p != m->maps.end()) {
 	auto o = std::make_unique<OSDMap>();
 	o->decode(p->second);
-	logger().info("store_maps osdmap.{}", e);
+	logger().info("store_maps storing osdmap.{}", e);
 	store_map_bl(t, e, std::move(std::move(p->second)));
 	osdmaps.insert(e, std::move(o));
 	return seastar::now();
       } else if (auto p = m->incremental_maps.find(e);
 		 p != m->incremental_maps.end()) {
+	ceph_assert (std::cmp_greater(e, 0u));
+	logger().info("store_maps found osdmap.{} incremental map, "
+	              "loading osdmap.{}", e, e - 1);
 	return load_map(e - 1).then([e, bl=p->second, &t, this](auto o) {
 	  OSDMap::Incremental inc;
 	  auto i = bl.cbegin();
@@ -434,6 +441,7 @@ seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
 	  o->apply_incremental(inc);
 	  bufferlist fbl;
 	  o->encode(fbl, inc.encode_features | CEPH_FEATURE_RESERVED);
+	  logger().info("store_maps storing osdmap.{}", o->get_epoch());
 	  store_map_bl(t, e, std::move(fbl));
 	  osdmaps.insert(e, std::move(o));
 	  return seastar::now();
@@ -700,6 +708,9 @@ seastar::future<> OSDSingletonState::send_incremental_map(
   crimson::net::Connection &conn,
   epoch_t first)
 {
+  logger().info("{}: first osdmap: {} "
+                "superblock's oldest map: {}",
+                __func__, first, superblock.oldest_map);
   if (first >= superblock.oldest_map) {
     return load_map_bls(
       first, superblock.newest_map

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -82,22 +82,6 @@ std::map<pg_t, pg_stat_t> PerShardState::get_pg_stats() const
   return ret;
 }
 
-seastar::future<> PerShardState::broadcast_map_to_pgs(
-  ShardServices &shard_services,
-  epoch_t epoch)
-{
-  assert_core();
-  auto &pgs = pg_map.get_pgs();
-  return seastar::parallel_for_each(
-    pgs.begin(), pgs.end(),
-    [=, &shard_services](auto& pg) {
-      return shard_services.start_operation<PGAdvanceMap>(
-	shard_services,
-	pg.second, epoch,
-	PeeringCtx{}, false).second;
-    });
-}
-
 Ref<PG> PerShardState::get_pg(spg_t pgid)
 {
   assert_core();

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -595,7 +595,6 @@ ShardServices::get_or_create_pg_ret
 ShardServices::get_or_create_pg(
   PGMap::PGCreationBlockingEvent::TriggerI&& trigger,
   spg_t pgid,
-  epoch_t epoch,
   std::unique_ptr<PGCreateInfo> info)
 {
   if (info) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -597,8 +597,8 @@ seastar::future<Ref<PG>> ShardServices::handle_pg_create_info(
 	    info->past_intervals,
 	    rctx.transaction);
 
-	  return start_operation<PGAdvanceMap>(
-	    *this, pg, get_map()->get_epoch(), std::move(rctx), true
+	  return start_operation<PGAdvanceMap>(nullptr,
+	    *this, pg, pg->get_osdmap_epoch(), get_map()->get_epoch(), std::move(rctx), true
 	  ).second.then([pg=pg] {
 	    return seastar::make_ready_future<Ref<PG>>(pg);
 	  });

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -400,11 +400,11 @@ seastar::future<std::unique_ptr<OSDMap>> OSDSingletonState::load_map(epoch_t e)
 }
 
 seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
-                                  epoch_t start, Ref<MOSDMap> m)
+                                  epoch_t start, epoch_t last, Ref<MOSDMap> m)
 {
   return seastar::do_for_each(
     boost::make_counting_iterator(start),
-    boost::make_counting_iterator(m->get_last() + 1),
+    boost::make_counting_iterator(last + 1),
     [&t, m, this](epoch_t e) {
       if (auto p = m->maps.find(e); p != m->maps.end()) {
 	auto o = std::make_unique<OSDMap>();

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -424,7 +424,6 @@ public:
   get_or_create_pg_ret get_or_create_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&,
     spg_t pgid,
-    epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
 
   using wait_for_pg_ertr = PGMap::wait_for_pg_ertr;

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -111,10 +111,6 @@ class PerShardState {
 
   seastar::future<> stop_pgs();
   std::map<pg_t, pg_stat_t> get_pg_stats() const;
-  seastar::future<> broadcast_map_to_pgs(
-    ShardServices &shard_services,
-    epoch_t epoch);
-
   Ref<PG> get_pg(spg_t pgid);
   template <typename F>
   void for_each_pg(F &&f) const {

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -310,7 +310,7 @@ private:
   void store_map_bl(ceph::os::Transaction& t,
                     epoch_t e, bufferlist&& bl);
   seastar::future<> store_maps(ceph::os::Transaction& t,
-                               epoch_t start, Ref<MOSDMap> m);
+                               epoch_t start, epoch_t last, Ref<MOSDMap> m);
 };
 
 /**


### PR DESCRIPTION
[eb27130aa424e65738342b3baf26d52e21241ab2] Fixes the following case:
```
DEBUG 2023-05-09 13:27:22,883 [shard 0] osd - pg_advance_map(id=13033, detail=PGAdvanceMap(pg=10.16 from=76 to=77)): complete
DEBUG 2023-05-09 13:27:22,883 [shard 0] osd - pg_advance_map(id=13152, detail=PGAdvanceMap(pg=15.11 from=76 to=77)): sending pg temp
DEBUG 2023-05-09 13:27:22,883 [shard 0] osd - pg_advance_map(id=12506, detail=PGAdvanceMap(pg=3.1b from=77 to=76)): start: getting map 78
DEBUG 2023-05-09 13:27:22,883 [shard 0] osd - get_local_map loading osdmap.78 from disk
INFO  2023-05-09 13:27:22,883 [shard 0] osd - load_map osdmap.78
DEBUG 2023-05-09 13:27:22,883 [shard 0] osd - load_map_bl loading osdmap.78 from disk
DEBUG 2023-05-09 13:27:22,883 [shard 0] alienstore - read
...
DEBUG 2023-05-09 13:27:22,957 [shard 0] osd - pg_advance_map(id=13074, detail=PGAdvanceMap(pg=12.d from=76 to=77)): complete
DEBUG 2023-05-09 13:27:22,957 [shard 0] osd - pg_advance_map(id=12975, detail=PGAdvanceMap(pg=8.b from=76 to=77)): sending pg temp
DEBUG 2023-05-09 13:27:22,957 [shard 0] osd - pg_advance_map(id=13144, detail=PGAdvanceMap(pg=15.7 from=76 to=77)): complete
DEBUG 2023-05-09 13:27:22,957 [shard 0] osd - pg_advance_map(id=12833, detail=PGAdvanceMap(pg=2.2 from=76 to=77)): sending pg temp
DEBUG 2023-05-09 13:27:22,957 [shard 0] osd - OSDMeta::load_map: start read gave enoent on 78
ERROR 2023-05-09 13:27:22,957 [shard 0] none - ../src/crimson/osd/osd_meta.cc:40 : In function 'OSDMeta::load_map(epoch_t)::<lambda()>', abort(%s)
abort() called
```
```
// See PGAdvanceMap(pg=3.1b from=77 to=76)
// from is set via `pg->get_osdmap_epoch()`
// 'from' is already newer than 'to'
// we start iterating from 77+1 (osdmap.78 does not exist)
```

Drafted for discussion - comments left in commit. The fix assumes that if the pg was already advanced to a later osdmap than `to` - we can skip the `PGAdvanceMap` operation.
 
https://gist.github.com/Matan-B/67a6c2a9b9c581600799c2c37704e913 

Fixes: https://tracker.ceph.com/issues/59165


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
