### PR TITLE
osd/scrub: use one single queue priority for all transactions

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -454,7 +454,7 @@ void PG::queue_scrub_after_repair()
   m_scrubber->set_op_parameters(m_planned_scrub);
   dout(15) << __func__ << ": queueing" << dendl;
 
-  osd->queue_scrub_after_repair(this, Scrub::scrub_prio_t::high_priority);
+  osd->queue_scrub_after_repair(this, Scrub::scrub_prio_t::low_priority);
 }
 
 unsigned PG::get_scrub_priority()

--- a/src/osd/scrubber/PrimaryLogScrub.h
+++ b/src/osd/scrubber/PrimaryLogScrub.h
@@ -38,7 +38,9 @@ class PrimaryLogScrub : public PgScrubber {
 
   void add_to_stats(const object_stat_sum_t& stat) final;
 
-  void submit_digest_fixes(const digests_fixes_t& fixes) final;
+  void submit_digest_fixes(
+      const digests_fixes_t& fixes,
+      Scrub::scrub_prio_t queue_prio) final;
 
  private:
   // we know our PG is actually a PrimaryLogPG. Let's alias the pointer to that

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -614,7 +614,9 @@ class PgScrubber : public ScrubPgIF,
     ceph_assert(0 && "expecting a PrimaryLogScrub object");
   }
 
-  void submit_digest_fixes(const digests_fixes_t& fixes) override
+  void submit_digest_fixes(
+      const digests_fixes_t& fixes,
+      Scrub::scrub_prio_t queue_prio) override
   {
     ceph_assert(0 && "expecting a PrimaryLogScrub object");
   }

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -135,11 +135,13 @@ class TestScrubber : public ScrubBeListener, public Scrub::SnapMapReaderI {
   // submit_digest_fixes() mock can be set to expect a specific set of
   // fixes to perform.
   /// \todo implement the mock.
-  void submit_digest_fixes(const digests_fixes_t& fixes) final
+  void submit_digest_fixes(
+      const digests_fixes_t& fixes,
+      Scrub::scrub_prio_t queue_prio) final
   {
-    std::cout << fmt::format("{} submit_digest_fixes({})",
-			     __func__,
-			     fmt::join(fixes, ","))
+    std::cout << fmt::format(
+		     "{} submit_digest_fixes({})", __func__,
+		     fmt::join(fixes, ","))
 	      << std::endl;
   }
 
@@ -572,9 +574,10 @@ TEST_F(TestTScrubberBe_data_1, smaps_creation_1)
   ASSERT_EQ(sbe->get_omap_stats().omap_bytes, 0);
 
   // for test data 'minimal_snaps_configuration':
-  // scrub_compare_maps() should not emmit any error, nor
+  // scrub_compare_maps() should not emit any error, nor
   // return any snap-mapper fix
-  auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
+  auto [incons, fix_list] = sbe->scrub_compare_maps(
+      true, *test_scrubber, Scrub::scrub_prio_t::low_priority);
 
   EXPECT_EQ(fix_list.size(), 0);  // snap-mapper fix should be empty
 
@@ -605,7 +608,8 @@ TEST_F(TestTScrubberBe_data_1, snapmapper_1)
   bogus_30[hobj_ms1_snp30_inpool] = {0x333, 0x666};
 
   test_scrubber->set_snaps(bogus_30);
-  auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
+  auto [incons, fix_list] = sbe->scrub_compare_maps(
+      true, *test_scrubber, Scrub::scrub_prio_t::high_priority);
 
   EXPECT_EQ(fix_list.size(), 1);
 
@@ -657,7 +661,8 @@ TEST_F(TestTScrubberBe_data_2, smaps_clone_size)
   ASSERT_TRUE(sbe);
   EXPECT_EQ(sbe->get_omap_stats().omap_bytes, 0);
   logger.set_expected_err_count(1);
-  auto [incons, fix_list] = sbe->scrub_compare_maps(true, *test_scrubber);
+  auto [incons, fix_list] = sbe->scrub_compare_maps(
+      true, *test_scrubber, Scrub::scrub_prio_t::low_priority);
 
   EXPECT_EQ(fix_list.size(), 0);  // snap-mapper fix should be empty
 


### PR DESCRIPTION
initiated by scrub_compare_maps()

* using a single queue priority hint for all transactions initiated within scrub_compare_maps();
* low priority for queue_scrub_after_repair()

A follow-up PR will introduce more changes to scrub events queue priorities. This change is a minimal & back-portable bug fix.

Fixes: https://tracker.ceph.com/issues/59049
