### PR TITLE
reef: doc/cephfs: fix prompts in fs-volumes.rst

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -42,7 +42,7 @@ Requirements
 FS Volumes
 ----------
 
-Create a volume using::
+Create a volume using:
 
     $ ceph fs volume create <vol_name> [<placement>]
 
@@ -68,18 +68,18 @@ nodes ``host1`` and ``host2`` (for a total of four MDS daemons in the cluster):
 For more details on placement specification refer to the :ref:`orchestrator-cli-service-spec`,
 but keep in mind that specifying placement via a YAML file is not supported.
 
-To remove a volume, run the following command::
+To remove a volume, run the following command:
 
     $ ceph fs volume rm <vol_name> [--yes-i-really-mean-it]
 
 This removes a file system and its data and metadata pools. It also tries to
 remove MDS daemons using the enabled ceph-mgr orchestrator module.
 
-List volumes using::
+List volumes using:
 
     $ ceph fs volume ls
 
-Rename a volume using::
+Rename a volume using:
 
     $ ceph fs volume rename <vol_name> <new_vol_name> [--yes-i-really-mean-it]
 
@@ -97,7 +97,7 @@ The CephX IDs authorized for <vol_name> need to be reauthorized for <new_vol_nam
 on-going operations of the clients using these IDs may be disrupted. Mirroring is
 expected to be disabled on the volume.
 
-To fetch the information of a CephFS volume, run::
+To fetch the information of a CephFS volume, run:
 
     $ ceph fs volume info vol_name [--human_readable]
 
@@ -173,8 +173,8 @@ List subvolume groups using::
 
     $ ceph fs subvolumegroup ls <vol_name>
 
-.. note:: Subvolume group snapshot feature is no longer supported in mainline CephFS (existing group
-          snapshots can still be listed and deleted)
+.. note:: Subvolume group snapshot feature is no longer supported in mainline
+   CephFS (existing group snapshots can still be listed and deleted)
 
 Fetch the metadata of a subvolume group using::
 
@@ -199,7 +199,7 @@ Check the presence of any subvolume group using::
 
     $ ceph fs subvolumegroup exist <vol_name>
 
-The 'exist' command outputs:
+The 'exist' command outputs::
 
 * "subvolumegroup exists": if any subvolumegroup is present
 * "no subvolumegroup exists": if no subvolumegroup is present
@@ -384,7 +384,6 @@ Create a snapshot of a subvolume using::
 
     $ ceph fs subvolume snapshot create <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>]
 
-
 Remove a snapshot of a subvolume using::
 
     $ ceph fs subvolume snapshot rm <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>] [--force]
@@ -479,9 +478,12 @@ Protecting snapshots prior to cloning was a prerequisite in the Nautilus release
 snapshots were introduced for this purpose. This prerequisite, and hence the commands to protect/unprotect, is being
 deprecated and may be removed from a future release.
 
-The commands being deprecated are::
-  $ ceph fs subvolume snapshot protect <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>]
-  $ ceph fs subvolume snapshot unprotect <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>]
+The commands being deprecated are:
+
+.. prompt:: bash #
+
+   ceph fs subvolume snapshot protect <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>]
+   ceph fs subvolume snapshot unprotect <vol_name> <subvol_name> <snap_name> [--group_name <subvol_group_name>]
 
 .. note:: Using the above commands will not result in an error, but they have no useful purpose.
 
@@ -611,7 +613,6 @@ On successful cancellation, the cloned subvolume is moved to the ``canceled`` st
 
 Pinning Subvolumes and Subvolume Groups
 ---------------------------------------
-
 
 Subvolumes and subvolume groups may be automatically pinned to ranks according
 to policies. This can distribute load across MDS ranks in predictable and


### PR DESCRIPTION
Fixed a regression introduced in
e5355e3d66e1438d51de6b57eae79fab47cd0184 that broke the unselectable prompts in the RST.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit e019948783adf41207d70e8cd2540d335e07b80b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
