### PR TITLE
quincy: RGW: Solving the issue of not populating etag in Multipart upload result

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6464,6 +6464,9 @@ void RGWCompleteMultipart::complete()
       ldpp_dout(this, 0) << "WARNING: failed to unlock " << serializer->oid << dendl;
     }
   }
+
+  etag = s->object->get_attrs()[RGW_ATTR_ETAG].to_str();
+
   send_response();
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59730

---

backport of https://github.com/ceph/ceph/pull/50627
parent tracker: https://tracker.ceph.com/issues/58879

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh