### PR TITLE
cephadm: call compile_dir to byte compile zipapp py files

### DIFF
--- a/src/cephadm/build.py
+++ b/src/cephadm/build.py
@@ -6,6 +6,7 @@
 # of python to build with? Even with the intermediate cmake layer?
 
 import argparse
+import compileall
 import logging
 import os
 import pathlib
@@ -67,6 +68,14 @@ def _build(dest, src):
 
 def _compile(dest, tempdir):
     """Compile the zipapp."""
+    log.info("Byte-compiling py to pyc")
+    compileall.compile_dir(
+        tempdir,
+        maxlevels=16,
+        legacy=True,
+        quiet=1,
+        workers=0,
+    )
     # TODO we could explicitly pass a python version here
     log.info("Constructing the zipapp file")
     try:


### PR DESCRIPTION
Python provides the compileall module to explicitly create pyc files from py files. If we byte-compile the content of the cephadm zipapp we get a small speed boost when running the application.

In a not-very-scientific benchmark I found that running with pyc files almost halved the time to run the help command 50 times.

```
$ time for _ in {0..50}; do  /tmp/cephadm-nobc -h >/dev/null; done

real    0m9.486s
user    0m8.547s
sys     0m0.893s

$ time for _ in {0..50}; do  /tmp/cephadm-bc -h >/dev/null; done

real    0m4.634s
user    0m3.992s
sys     0m0.618s
```

I ran the above a few times on my laptop and the numbers are pretty consistent.

One thing to note is that zipapp doesn't seem to understand the current `__pycache__` approach to storing the bytecode files so we have to set the `legacy` argument for compileall.compile_dir to true. Since __pycache__ dirs mostly exist to allow multiple bytecode files for different python versions to coexist, and a zipapp is read-only this should not be a major issue. Tangentially related, we lose out on the speedup if you run the zipapp with a version of python other than the one the zipapp was built with but it continues to function.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), but it's build stuff and I am too lazy to open a tracker for this sort of thing
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] It's a build time thing. If it don't run the build was bad, ideally no one notices this change

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
