### PR TITLE
rgw: Add coverity annotations to ignore warnings about 32 bit time

### DIFF
--- a/src/rgw/driver/rados/rgw_trim_datalog.cc
+++ b/src/rgw/driver/rados/rgw_trim_datalog.cc
@@ -223,6 +223,9 @@ int DataLogTrimPollCR::operate(const DoutPrefixProvider *dpp)
       // request a 'data_trim' lock that covers the entire wait interval to
       // prevent other gateways from attempting to trim for the duration
       set_status("acquiring trim lock");
+
+      // interval is a small number and unlikely to overflow
+      // coverity[Y2K38_SAFETY:FALSE]
       yield call(new RGWSimpleRadosLockCR(store->svc()->rados->get_async_processor(), store,
                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, lock_oid),
                                           "data_trim", lock_cookie,

--- a/src/rgw/driver/rados/rgw_trim_mdlog.cc
+++ b/src/rgw/driver/rados/rgw_trim_mdlog.cc
@@ -668,6 +668,9 @@ int MetaTrimPollCR::operate(const DoutPrefixProvider *dpp)
 
       // prevent others from trimming for our entire wait interval
       set_status("acquiring trim lock");
+
+      // interval is a small number and unlikely to overflow
+      // coverity[Y2K38_SAFETY:FALSE]
       yield call(new RGWSimpleRadosLockCR(store->svc()->rados->get_async_processor(), store,
                                           obj, name, cookie, interval.sec()));
       if (retcode < 0) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3036,6 +3036,9 @@ static int scan_totp(CephContext *cct, ceph::real_time& now, rados::cls::otp::ot
                              nullptr,
                              pins[0].c_str());
     if (rc != OATH_INVALID_OTP) {
+      // oath_totp_validate2 is an external library function, cannot fix internally
+      // Further, step_size is a small number and unlikely to overflow
+      // coverity[Y2K38_SAFETY:FALSE]
       rc = oath_totp_validate2(totp.seed_bin.c_str(), totp.seed_bin.length(),
                                start_time, 
                                step_size,
@@ -10371,6 +10374,8 @@ next:
       return -ret;
     }
 
+    // time offset is a small number and unlikely to overflow
+    // coverity[Y2K38_SAFETY:FALSE]
     config.time_ofs = time_ofs;
 
     /* now update the backend */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1292,6 +1292,8 @@ struct RGWBucketEnt {
   void encode(bufferlist& bl) const {
     ENCODE_START(7, 5, bl);
     uint64_t s = size;
+    // issue tracked here: https://tracker.ceph.com/issues/61160
+    // coverity[Y2K38_SAFETY]
     __u32 mt = ceph::real_clock::to_time_t(creation_time);
     std::string empty_str;  // originally had the bucket name here, but we encode bucket later
     encode(empty_str, bl);

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -169,6 +169,8 @@ bufferlist RGWPutObj_Torrent::bencode_torrent(std::string_view filename) const
 
   // Only encode create_date and sha1 info. Other fields will be added during
   // GetObjectTorrent by rgw_read_torrent_file()
+  // issue tracked here: https://tracker.ceph.com/issues/61160
+  // coverity[Y2K38_SAFETY]
   bencode(CREATION_DATE, std::time(nullptr), bl);
 
   bencode_key(INFO_PIECES, bl);


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
