### PR TITLE
crimson/os/seastore: fix ceph_assert in segment_manager.h

### DIFF
--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -63,18 +63,26 @@ SegmentManager::get_segment_manager(
 LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::do_with(
     static_cast<size_t>(0),
-    [&](auto &nr_zones) {
+    [FNAME,
+     dtype,
+     device](auto &nr_zones) {
       return seastar::open_file_dma(
 	device + "/block",
 	seastar::open_flags::rw
-      ).then([&](auto file) {
+      ).then([FNAME,
+	      dtype,
+	      device,
+	      &nr_zones](auto file) {
 	return seastar::do_with(
 	  file,
-	  [=, &nr_zones](auto &f) -> seastar::future<int> {
+	  [&nr_zones](auto &f) -> seastar::future<int> {
 	    ceph_assert(f);
 	    return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
 	  });
-      }).then([&](auto ret) -> crimson::os::seastore::SegmentManagerRef {
+      }).then([FNAME,
+	       dtype,
+	       device,
+	       &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
 	crimson::os::seastore::SegmentManagerRef sm;
 	INFO("Found {} zones.", nr_zones);
 	if (nr_zones != 0) {


### PR DESCRIPTION
Assert is seen when crimson-osd is compiled with -DWITH_ZNS=ON and crimson-osd is started with a regular SSD.

ceph/src/crimson/os/seastore/segment_manager.h:77 : In function 'void crimson::os::seastore::block_sm_superblock_t::validate() const', ceph_assert(%s) get_default_backend_of_device(config.spec.dtype) == backend_type_t::SEGMENTED

The device type "dtype" is not getting propogated properly to BlockSegmentManager instantiation causing the assert at a later point.
Most likely due to commit: 1e515e8561519ded43b1046942057d705441ee22




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
