### PR TITLE
qa/rgw: add POOL_APP_NOT_ENABLED to log-ignorelist

### DIFF
--- a/qa/rgw/ignore-pg-availability.yaml
+++ b/qa/rgw/ignore-pg-availability.yaml
@@ -1,7 +1,9 @@
 # https://tracker.ceph.com/issues/45802
 # https://tracker.ceph.com/issues/51282
+# https://tracker.ceph.com/issues/61168
 overrides:
   ceph:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
+    - \(POOL_APP_NOT_ENABLED\)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61168

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
