### PR TITLE
doc: explain cephfs mirroring `peer_add` step in detail

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -98,19 +98,32 @@ To disable mirroring for a given file system::
   $ ceph fs snapshot mirror disable <fs_name>
 
 Once mirroring is enabled, add a peer to which directory snapshots are to be mirrored.
-Peers are specified by `<client>@<cluster>` and are assigned a unique-id (UUID)
-when added. See `Creating Users` section on how to create Ceph users for mirroring.
+Peers are specified by `<client>@<cluster>` format which is also termed as `remote_cluster_spec`
+(further in this document) and are assigned a unique-id (UUID) when added. See `Creating Users`
+section on how to create Ceph users for mirroring.
 
 To add a peer use::
 
   $ ceph fs snapshot mirror peer_add <fs_name> <remote_cluster_spec> [<remote_fs_name>] [<remote_mon_host>] [<cephx_key>]
 
+`<remote_cluster_spec>` is of format `client.<id>@<cluster_name>`.
 `<remote_fs_name>` is optional, and defaults to `<fs_name>` (on the remote cluster).
 
 This requires the remote cluster ceph configuration and user keyring to be available in
-the primary cluster. See `Bootstrap Peers` section to avoid this. `peer_add` additionally
-supports passing the remote cluster monitor address and the user key. However, bootstrapping
-a peer is the recommended way to add a peer.
+the primary cluster.  E.g.: Say, user `client_mirror` is created on the remote cluster which
+has `rwps` permissions for the remote file system `remote_fs` (Refer `Creating Users`) and the
+remote cluster is named `remote_ceph` (i.e., the remote cluster configuration file is named
+`remote_ceph.conf` on the primary cluster), use the following command to add the remote filesystem
+as a peer to the primary filesystem `primary_fs`::
+
+  $ ceph fs snapshot mirror peer_add primary_fs client.mirror_remote@remote_ceph remote_fs
+
+To avoid maintaining remote cluster configuration file and remote ceph user keyring in the primary
+cluster, users can bootstrap a peer (which stores the relevant remote cluster details in the monitor
+config store on the parimary cluster). See `Bootstrap Peers` section.
+
+Note that, `peer_add` additionally supports passing the remote cluster monitor address and the user key.
+However, bootstrapping a peer is the recommended way to add a peer.
 
 .. note:: Only a single peer is currently supported.
 


### PR DESCRIPTION
@zdover23 reached out regarding missing explanation for `peer_add` step in cephfs mirroring documentation. Add some explanation and and example to make the step clear.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
