### PR TITLE
quincy: OSD: Fix check_past_interval_bounds()

### DIFF
--- a/doc/dev/osd_internals/past_intervals.rst
+++ b/doc/dev/osd_internals/past_intervals.rst
@@ -81,12 +81,13 @@ trimmed up to epoch ``e``, we know that the PG must have been clean at some epoc
 
 This dependency also pops up in PeeringState::check_past_interval_bounds().
 PeeringState::get_required_past_interval_bounds takes as a parameter
-oldest_epoch, which comes from OSDSuperblock::max_oldest_map. We use
-max_oldest_map rather than a specific osd's oldest_map because we don't
-necessarily trim all MOSDMap::oldest_map. In order to avoid doing too much
-work at once we limit the amount of osdmaps trimmed using
+oldest_epoch, which comes from OSDSuperblock::cluster_osdmap_trim_lower_bound.
+We use cluster_osdmap_trim_lower_bound rather than a specific osd's oldest_map
+because we don't necessarily trim all MOSDMap::oldest_map. In order to avoid
+doing too much work at once we limit the amount of osdmaps trimmed using
 ``osd_target_transaction_size`` in OSD::trim_maps().
-For this reason, a specific OSD's oldest_map can lag OSDSuperblock::max_oldest_map
+For this reason, a specific OSD's oldest_map can lag behind
+OSDSuperblock::cluster_osdmap_trim_lower_bound
 for a while.
 
 See https://tracker.ceph.com/issues/49689 for an example.

--- a/doc/dev/osd_internals/past_intervals.rst
+++ b/doc/dev/osd_internals/past_intervals.rst
@@ -83,9 +83,9 @@ This dependency also pops up in PeeringState::check_past_interval_bounds().
 PeeringState::get_required_past_interval_bounds takes as a parameter
 oldest_epoch, which comes from OSDSuperblock::cluster_osdmap_trim_lower_bound.
 We use cluster_osdmap_trim_lower_bound rather than a specific osd's oldest_map
-because we don't necessarily trim all MOSDMap::oldest_map. In order to avoid
-doing too much work at once we limit the amount of osdmaps trimmed using
-``osd_target_transaction_size`` in OSD::trim_maps().
+because we don't necessarily trim all MOSDMap::cluster_osdmap_trim_lower_bound.
+In order to avoid doing too much work at once we limit the amount of osdmaps
+trimmed using ``osd_target_transaction_size`` in OSD::trim_maps().
 For this reason, a specific OSD's oldest_map can lag behind
 OSDSuperblock::cluster_osdmap_trim_lower_bound
 for a while.

--- a/doc/dev/osd_internals/past_intervals.rst
+++ b/doc/dev/osd_internals/past_intervals.rst
@@ -1,0 +1,92 @@
+=============
+PastIntervals
+=============
+
+Purpose
+-------
+
+There are two situations where we need to consider the set of all acting-set
+OSDs for a PG back to some epoch ``e``:
+
+ * During peering, we need to consider the acting set for every epoch back to
+   ``last_epoch_started``, the last epoch in which the PG completed peering and
+   became active.
+   (see :doc:`/dev/osd_internals/last_epoch_started` for a detailed explanation)
+ * During recovery, we need to consider the acting set for every epoch back to
+   ``last_epoch_clean``, the last epoch at which all of the OSDs in the acting
+   set were fully recovered, and the acting set was full.
+
+For either of these purposes, we could build such a set by iterating backwards
+from the current OSDMap to the relevant epoch.  Instead, we maintain a structure
+PastIntervals for each PG.
+
+An ``interval`` is a contiguous sequence of OSDMap epochs where the PG mapping
+didn't change.  This includes changes to the acting set, the up set, the
+primary, and several other parameters fully spelled out in
+PastIntervals::check_new_interval.
+
+Maintenance and Trimming
+------------------------
+
+The PastIntervals structure stores a record for each ``interval`` back to
+last_epoch_clean.  On each new ``interval`` (See AdvMap reactions,
+PeeringState::should_restart_peering, and PeeringState::start_peering_interval)
+each OSD with the PG will add the new ``interval`` to its local PastIntervals.
+Activation messages to OSDs which do not already have the PG contain the
+sender's PastIntervals so that the recipient needn't rebuild it.  (See
+PeeringState::activate needs_past_intervals).
+
+PastIntervals are trimmed in two places.  First, when the primary marks the
+PG clean, it clears its past_intervals instance
+(PeeringState::try_mark_clean()).  The replicas will do the same thing when
+they receive the info (See PeeringState::update_history).
+
+The second, more complex, case is in PeeringState::start_peering_interval.  In
+the event of a "map gap", we assume that the PG actually has gone clean, but we
+haven't received a pg_info_t with the updated ``last_epoch_clean`` value yet.
+To explain this behavior, we need to discuss OSDMap trimming.
+
+OSDMap Trimming
+---------------
+
+OSDMaps are created by the Monitor quorum and gossiped out to the OSDs.  The
+Monitor cluster also determines when OSDs (and the Monitors) are allowed to
+trim old OSDMap epochs.  For the reasons explained above in this document, the
+primary constraint is that we must retain all OSDMaps back to some epoch such
+that all PGs have been clean at that or a later epoch (min_last_epoch_clean).
+(See OSDMonitor::get_trim_to).
+
+The Monitor quorum determines min_last_epoch_clean through MOSDBeacon messages
+sent periodically by each OSDs.  Each message contains a set of PGs for which
+the OSD is primary at that moment as well as the min_last_epoch_clean across
+that set.  The Monitors track these values in OSDMonitor::last_epoch_clean.
+
+There is a subtlety in the min_last_epoch_clean value used by the OSD to
+populate the MOSDBeacon.  OSD::collect_pg_stats invokes PG::with_pg_stats to
+obtain the lec value, which actually uses
+pg_stat_t::get_effective_last_epoch_clean() rather than
+info.history.last_epoch_clean.  If the PG is currently clean,
+pg_stat_t::get_effective_last_epoch_clean() is the current epoch rather than
+last_epoch_clean -- this works because the PG is clean at that epoch and it
+allows OSDMaps to be trimmed during periods where OSDMaps are being created
+(due to snapshot activity, perhaps), but no PGs are undergoing ``interval``
+changes.
+
+Back to PastIntervals
+---------------------
+
+We can now understand our second trimming case above.  If OSDMaps have been
+trimmed up to epoch ``e``, we know that the PG must have been clean at some epoch
+>= ``e`` (indeed, **all** PGs must have been), so we can drop our PastIntevals.
+
+This dependency also pops up in PeeringState::check_past_interval_bounds().
+PeeringState::get_required_past_interval_bounds takes as a parameter
+oldest_epoch, which comes from OSDSuperblock::max_oldest_map. We use
+max_oldest_map rather than a specific osd's oldest_map because we don't
+necessarily trim all MOSDMap::oldest_map. In order to avoid doing too much
+work at once we limit the amount of osdmaps trimmed using
+``osd_target_transaction_size`` in OSD::trim_maps().
+For this reason, a specific OSD's oldest_map can lag OSDSuperblock::max_oldest_map
+for a while.
+
+See https://tracker.ceph.com/issues/49689 for an example.

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -616,7 +616,9 @@ void OSD::print(std::ostream& out) const
 {
   out << "{osd." << superblock.whoami << " "
     << superblock.osd_fsid << " [" << superblock.oldest_map
-    << "," << superblock.newest_map << "] " << pg_map.get_pgs().size()
+    << "," << superblock.newest_map << "] "
+    << "tlb:" << superblock.cluster_osdmap_trim_lower_bound
+    << " " << pg_map.get_pgs().size()
     << " pgs}";
 }
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -594,6 +594,8 @@ void OSD::dump_status(Formatter* f) const
   f->dump_unsigned("whoami", superblock.whoami);
   f->dump_string("state", state.to_string());
   f->dump_unsigned("oldest_map", superblock.oldest_map);
+  f->dump_unsigned("cluster_osdmap_trim_lower_bound",
+                   superblock.cluster_osdmap_trim_lower_bound);
   f->dump_unsigned("newest_map", superblock.newest_map);
   f->dump_unsigned("num_pgs", pg_map.get_pgs().size());
 }
@@ -1066,7 +1068,8 @@ seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
   const auto first = m->get_first();
   const auto last = m->get_last();
   logger().info("handle_osd_map epochs [{}..{}], i have {}, src has [{}..{}]",
-                first, last, superblock.newest_map, m->oldest_map, m->newest_map);
+                first, last, superblock.newest_map,
+                m->cluster_osdmap_trim_lower_bound, m->newest_map);
   // make sure there is something new, here, before we bother flushing
   // the queues and such
   if (last <= superblock.newest_map) {
@@ -1078,15 +1081,16 @@ seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
   if (first > start) {
     logger().info("handle_osd_map message skips epochs {}..{}",
                   start, first - 1);
-    if (m->oldest_map <= start) {
+    if (m->cluster_osdmap_trim_lower_bound <= start) {
       return shard_services.osdmap_subscribe(start, false);
     }
     // always try to get the full range of maps--as many as we can.  this
     //  1- is good to have
     //  2- is at present the only way to ensure that we get a *full* map as
     //     the first map!
-    if (m->oldest_map < first) {
-      return shard_services.osdmap_subscribe(m->oldest_map - 1, true);
+    if (m->cluster_osdmap_trim_lower_bound < first) {
+      return shard_services.osdmap_subscribe(
+        m->cluster_osdmap_trim_lower_bound - 1, true);
     }
     skip_maps = true;
     start = first;
@@ -1180,7 +1184,8 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
       logger().info("osd.{}: now preboot", whoami);
 
       if (m->get_source().is_mon()) {
-        return _preboot(m->oldest_map, m->newest_map);
+        return _preboot(
+          m->cluster_osdmap_trim_lower_bound, m->newest_map);
       } else {
         logger().info("osd.{}: start_boot", whoami);
         return start_boot();
@@ -1211,7 +1216,7 @@ seastar::future<> OSD::send_incremental_map(crimson::net::ConnectionRef conn,
     .then([this, conn, first](auto&& bls) {
       auto m = crimson::make_message<MOSDMap>(monc->get_fsid(),
 	  osdmap->get_encoding_features());
-      m->oldest_map = first;
+      m->cluster_osdmap_trim_lower_bound = first;
       m->newest_map = superblock.newest_map;
       m->maps = std::move(bls);
       return conn->send(std::move(m));
@@ -1221,7 +1226,7 @@ seastar::future<> OSD::send_incremental_map(crimson::net::ConnectionRef conn,
     .then([this, conn](auto&& bl) mutable {
       auto m = crimson::make_message<MOSDMap>(monc->get_fsid(),
 	  osdmap->get_encoding_features());
-      m->oldest_map = superblock.oldest_map;
+      m->cluster_osdmap_trim_lower_bound = superblock.oldest_map;
       m->newest_map = superblock.newest_map;
       m->maps.emplace(osdmap->get_epoch(), std::move(bl));
       return conn->send(std::move(m));

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -351,6 +351,11 @@ public:
     return 0;
   }
 
+  epoch_t max_oldest_stored_osdmap() final {
+    // TODO
+    return 0;
+  }
+
   void on_backfill_reserved() final {
     recovery_handler->on_backfill_reserved();
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -347,7 +347,7 @@ public:
     // Not needed yet
   }
 
-  epoch_t max_oldest_stored_osdmap() final {
+  epoch_t cluster_osdmap_trim_lower_bound() final {
     // TODO
     return 0;
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -346,10 +346,6 @@ public:
   void on_active_advmap(const OSDMapRef &osdmap) final {
     // Not needed yet
   }
-  epoch_t oldest_stored_osdmap() final {
-    // TODO
-    return 0;
-  }
 
   epoch_t max_oldest_stored_osdmap() final {
     // TODO

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -68,13 +68,6 @@ public:
         (e == 0 || i->first > e)) e = i->first;
     return e;
   }
-  epoch_t get_oldest() {
-    return cluster_osdmap_trim_lower_bound;
-  }
-  epoch_t get_newest() {
-    return newest_map;
-  }
-
 
   MOSDMap() : Message{CEPH_MSG_OSD_MAP, HEAD_VERSION, COMPAT_VERSION} { }
   MOSDMap(const uuid_d &f, const uint64_t features)

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -30,7 +30,25 @@ public:
   uint64_t encode_features = 0;
   std::map<epoch_t, ceph::buffer::list> maps;
   std::map<epoch_t, ceph::buffer::list> incremental_maps;
-  epoch_t oldest_map =0, newest_map = 0;
+  /**
+   * cluster_osdmap_trim_lower_bound
+   *
+   * Encodes a lower bound on the monitor's osdmap trim bound.  Recipients
+   * can safely trim up to this bound.  The sender stores maps back to
+   * cluster_osdmap_trim_lower_bound.
+   *
+   * This field was formerly named oldest_map and encoded the oldest map
+   * stored by the sender.  The primary usage of this field, however, was to
+   * allow the recipient to trim.  The secondary usage was to inform the
+   * recipient of how many maps the sender stored in case it needed to request
+   * more.  For both purposes, it should be safe for an older OSD to interpret
+   * this field as oldest_map, and it should be safe for a new osd to interpret
+   * the oldest_map field sent by an older osd as
+   * cluster_osdmap_trim_lower_bound.
+   * See bug https://tracker.ceph.com/issues/49689
+   */
+  epoch_t cluster_osdmap_trim_lower_bound = 0;
+  epoch_t newest_map = 0;
 
   epoch_t get_first() const {
     epoch_t e = 0;
@@ -51,7 +69,7 @@ public:
     return e;
   }
   epoch_t get_oldest() {
-    return oldest_map;
+    return cluster_osdmap_trim_lower_bound;
   }
   epoch_t get_newest() {
     return newest_map;
@@ -62,7 +80,7 @@ public:
   MOSDMap(const uuid_d &f, const uint64_t features)
     : Message{CEPH_MSG_OSD_MAP, HEAD_VERSION, COMPAT_VERSION},
       fsid(f), encode_features(features),
-      oldest_map(0), newest_map(0) { }
+      cluster_osdmap_trim_lower_bound(0), newest_map(0) { }
 private:
   ~MOSDMap() final {}
 public:
@@ -74,10 +92,10 @@ public:
     decode(incremental_maps, p);
     decode(maps, p);
     if (header.version >= 2) {
-      decode(oldest_map, p);
+      decode(cluster_osdmap_trim_lower_bound, p);
       decode(newest_map, p);
     } else {
-      oldest_map = 0;
+      cluster_osdmap_trim_lower_bound = 0;
       newest_map = 0;
     }
     if (header.version >= 4) {
@@ -143,7 +161,7 @@ public:
     encode(incremental_maps, payload);
     encode(maps, payload);
     if (header.version >= 2) {
-      encode(oldest_map, payload);
+      encode(cluster_osdmap_trim_lower_bound, payload);
       encode(newest_map, payload);
     }
     if (header.version >= 4) {
@@ -154,8 +172,9 @@ public:
   std::string_view get_type_name() const override { return "osdmap"; }
   void print(std::ostream& out) const override {
     out << "osd_map(" << get_first() << ".." << get_last();
-    if (oldest_map || newest_map)
-      out << " src has " << oldest_map << ".." << newest_map;
+    if (cluster_osdmap_trim_lower_bound || newest_map)
+      out << " src has " << cluster_osdmap_trim_lower_bound
+          << ".." << newest_map;
     out << ")";
   }
 private:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2878,7 +2878,7 @@ bool OSDMonitor::preprocess_get_osdmap(MonOpRequestRef op)
     ceph_assert(r >= 0);
     max_bytes -= bl.length();
   }
-  reply->oldest_map = first;
+  reply->cluster_osdmap_trim_lower_bound = first;
   reply->newest_map = last;
   mon.send_reply(op, reply);
   return true;
@@ -4455,7 +4455,7 @@ MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
 {
   MOSDMap *r = new MOSDMap(mon.monmap->fsid, features);
   get_version_full(osdmap.get_epoch(), features, r->maps[osdmap.get_epoch()]);
-  r->oldest_map = get_first_committed();
+  r->cluster_osdmap_trim_lower_bound = get_first_committed();
   r->newest_map = osdmap.get_epoch();
   return r;
 }
@@ -4465,7 +4465,7 @@ MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to, uint64_t featur
   dout(10) << "build_incremental [" << from << ".." << to << "] with features "
 	   << std::hex << features << std::dec << dendl;
   MOSDMap *m = new MOSDMap(mon.monmap->fsid, features);
-  m->oldest_map = get_first_committed();
+  m->cluster_osdmap_trim_lower_bound = get_first_committed();
   m->newest_map = osdmap.get_epoch();
 
   for (epoch_t e = to; e >= from && e > 0; e--) {
@@ -4543,7 +4543,7 @@ void OSDMonitor::send_incremental(epoch_t first,
 
   if (first < get_first_committed()) {
     MOSDMap *m = new MOSDMap(osdmap.get_fsid(), features);
-    m->oldest_map = get_first_committed();
+    m->cluster_osdmap_trim_lower_bound = get_first_committed();
     m->newest_map = osdmap.get_epoch();
 
     first = get_first_committed();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1336,13 +1336,13 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
 {
   MOSDMap *m = new MOSDMap(monc->get_fsid(),
 			   osdmap->get_encoding_features());
-  m->oldest_map = sblock.cluster_osdmap_trim_lower_bound;
+  m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
   m->newest_map = sblock.newest_map;
 
   int max = cct->_conf->osd_map_message_max;
   ssize_t max_bytes = cct->_conf->osd_map_message_max_bytes;
 
-  if (since < m->oldest_map) {
+  if (since < m->cluster_osdmap_trim_lower_bound) {
     // we don't have the next map the target wants, so start with a
     // full map.
     bufferlist bl;
@@ -1350,7 +1350,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
              << sblock.cluster_osdmap_trim_lower_bound
              << " > since " << since << ", starting with full map"
              << dendl;
-    since = m->oldest_map;
+    since = m->cluster_osdmap_trim_lower_bound;
     if (!get_map_bl(since, bl)) {
       derr << __func__ << " missing full map " << since << dendl;
       goto panic;
@@ -1420,7 +1420,7 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
       // just send latest full map
       MOSDMap *m = new MOSDMap(monc->get_fsid(),
 			       osdmap->get_encoding_features());
-      m->oldest_map = sblock.cluster_osdmap_trim_lower_bound;
+      m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
       m->newest_map = sblock.newest_map;
       get_map_bl(to, m->maps[to]);
       send_map(m, con);
@@ -8071,7 +8071,8 @@ void OSD::handle_osd_map(MOSDMap *m)
   epoch_t last = m->get_last();
   dout(3) << "handle_osd_map epochs [" << first << "," << last << "], i have "
 	  << superblock.newest_map
-	  << ", src has [" << m->oldest_map << "," << m->newest_map << "]"
+	  << ", src has [" << m->cluster_osdmap_trim_lower_bound
+          << "," << m->newest_map << "]"
 	  << dendl;
 
   logger->inc(l_osd_map);
@@ -8079,8 +8080,10 @@ void OSD::handle_osd_map(MOSDMap *m)
   if (first <= superblock.newest_map)
     logger->inc(l_osd_mape_dup, superblock.newest_map - first + 1);
 
-  if (superblock.cluster_osdmap_trim_lower_bound < m->oldest_map) {
-    superblock.cluster_osdmap_trim_lower_bound = m->oldest_map;
+  if (superblock.cluster_osdmap_trim_lower_bound <
+      m->cluster_osdmap_trim_lower_bound) {
+    superblock.cluster_osdmap_trim_lower_bound =
+      m->cluster_osdmap_trim_lower_bound;
     dout(10) << " superblock cluster_osdmap_trim_lower_bound new epoch is: "
              << superblock.cluster_osdmap_trim_lower_bound << dendl;
     ceph_assert(
@@ -8100,7 +8103,7 @@ void OSD::handle_osd_map(MOSDMap *m)
   if (first > superblock.newest_map + 1) {
     dout(10) << "handle_osd_map message skips epochs "
 	     << superblock.newest_map + 1 << ".." << (first-1) << dendl;
-    if (m->oldest_map <= superblock.newest_map + 1) {
+    if (m->cluster_osdmap_trim_lower_bound <= superblock.newest_map + 1) {
       osdmap_subscribe(superblock.newest_map + 1, false);
       m->put();
       return;
@@ -8109,8 +8112,8 @@ void OSD::handle_osd_map(MOSDMap *m)
     //  1- is good to have
     //  2- is at present the only way to ensure that we get a *full* map as
     //     the first map!
-    if (m->oldest_map < first) {
-      osdmap_subscribe(m->oldest_map - 1, true);
+    if (m->cluster_osdmap_trim_lower_bound < first) {
+      osdmap_subscribe(m->cluster_osdmap_trim_lower_bound - 1, true);
       m->put();
       return;
     }
@@ -8231,7 +8234,8 @@ void OSD::handle_osd_map(MOSDMap *m)
 
   if (superblock.oldest_map) {
     // make sure we at least keep pace with incoming maps
-    trim_maps(m->oldest_map, last - first + 1, skip_maps);
+    trim_maps(m->cluster_osdmap_trim_lower_bound,
+              last - first + 1, skip_maps);
     pg_num_history.prune(superblock.oldest_map);
   }
 
@@ -8573,7 +8577,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
   }
   else if (is_preboot()) {
     if (m->get_source().is_mon())
-      _preboot(m->oldest_map, m->newest_map);
+      _preboot(m->cluster_osdmap_trim_lower_bound, m->newest_map);
     else
       start_boot();
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2640,6 +2640,8 @@ void OSD::asok_command(
     f->dump_unsigned("whoami", superblock.whoami);
     f->dump_string("state", get_state_name(get_state()));
     f->dump_unsigned("oldest_map", superblock.oldest_map);
+    f->dump_unsigned("cluster_osdmap_trim_lower_bound",
+                     superblock.cluster_osdmap_trim_lower_bound);
     f->dump_unsigned("newest_map", superblock.newest_map);
     f->dump_unsigned("num_pgs", num_pgs);
     f->close_section();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -149,7 +149,6 @@ public:
 
   int get_nodeid() const { return whoami; }
 
-  std::atomic<epoch_t> max_oldest_map;
 private:
   OSDMapRef osdmap;
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1625,8 +1625,8 @@ void PG::on_new_interval()
   m_scrubber->on_maybe_registration_change(m_planned_scrub);
 }
 
-epoch_t PG::max_oldest_stored_osdmap() {
-  return osd->get_superblock().max_oldest_map;
+epoch_t PG::cluster_osdmap_trim_lower_bound() {
+  return osd->get_superblock().cluster_osdmap_trim_lower_bound;
 }
 
 OstreamTemp PG::get_clog_info() {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1629,6 +1629,10 @@ epoch_t PG::oldest_stored_osdmap() {
   return osd->get_superblock().oldest_map;
 }
 
+epoch_t PG::max_oldest_stored_osdmap() {
+  return osd->get_superblock().max_oldest_map;
+}
+
 OstreamTemp PG::get_clog_info() {
   return osd->clog->info();
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1625,10 +1625,6 @@ void PG::on_new_interval()
   m_scrubber->on_maybe_registration_change(m_planned_scrub);
 }
 
-epoch_t PG::oldest_stored_osdmap() {
-  return osd->get_superblock().oldest_map;
-}
-
 epoch_t PG::max_oldest_stored_osdmap() {
   return osd->get_superblock().max_oldest_map;
 }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -591,6 +591,7 @@ public:
   void clear_primary_state() override;
 
   epoch_t oldest_stored_osdmap() override;
+  epoch_t max_oldest_stored_osdmap() override;
   OstreamTemp get_clog_error() override;
   OstreamTemp get_clog_info() override;
   OstreamTemp get_clog_debug() override;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -590,7 +590,7 @@ public:
   void clear_publish_stats() override;
   void clear_primary_state() override;
 
-  epoch_t max_oldest_stored_osdmap() override;
+  epoch_t cluster_osdmap_trim_lower_bound() override;
   OstreamTemp get_clog_error() override;
   OstreamTemp get_clog_info() override;
   OstreamTemp get_clog_debug() override;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -590,7 +590,6 @@ public:
   void clear_publish_stats() override;
   void clear_primary_state() override;
 
-  epoch_t oldest_stored_osdmap() override;
   epoch_t max_oldest_stored_osdmap() override;
   OstreamTemp get_clog_error() override;
   OstreamTemp get_clog_info() override;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -636,7 +636,7 @@ void PeeringState::start_peering_interval(
     psdout(10) << __func__ << ": check_new_interval output: "
 	       << debug.str() << dendl;
     if (new_interval) {
-      if (osdmap->get_epoch() == pl->oldest_stored_osdmap() &&
+      if (osdmap->get_epoch() == pl->max_oldest_stored_osdmap() &&
 	  info.history.last_epoch_clean < osdmap->get_epoch()) {
 	psdout(10) << " map gap, clearing past_intervals and faking" << dendl;
 	// our information is incomplete and useless; someone else was clean

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -930,7 +930,9 @@ static pair<epoch_t, epoch_t> get_required_past_interval_bounds(
 
 void PeeringState::check_past_interval_bounds() const
 {
-  auto oldest_epoch = pl->oldest_stored_osdmap();
+  // a specific OSD's oldest_map can lag for a while, therfore
+  // use the maximum MOSDMap.oldest_map received with peers.
+  auto oldest_epoch = pl->max_oldest_stored_osdmap();
   auto rpib = get_required_past_interval_bounds(
     info,
     oldest_epoch);

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -636,7 +636,7 @@ void PeeringState::start_peering_interval(
     psdout(10) << __func__ << ": check_new_interval output: "
 	       << debug.str() << dendl;
     if (new_interval) {
-      if (osdmap->get_epoch() == pl->max_oldest_stored_osdmap() &&
+      if (osdmap->get_epoch() == pl->cluster_osdmap_trim_lower_bound() &&
 	  info.history.last_epoch_clean < osdmap->get_epoch()) {
 	psdout(10) << " map gap, clearing past_intervals and faking" << dendl;
 	// our information is incomplete and useless; someone else was clean
@@ -930,9 +930,9 @@ static pair<epoch_t, epoch_t> get_required_past_interval_bounds(
 
 void PeeringState::check_past_interval_bounds() const
 {
-  // a specific OSD's oldest_map can lag for a while, therfore
-  // use the maximum MOSDMap.oldest_map received with peers.
-  auto oldest_epoch = pl->max_oldest_stored_osdmap();
+  // cluster_osdmap_trim_lower_bound gives us a bound on needed
+  // intervals, see doc/dev/osd_internals/past_intervals.rst
+  auto oldest_epoch = pl->cluster_osdmap_trim_lower_bound();
   auto rpib = get_required_past_interval_bounds(
     info,
     oldest_epoch);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -404,7 +404,6 @@ public:
     // ==================== Std::map notifications ===================
     virtual void on_active_actmap() = 0;
     virtual void on_active_advmap(const OSDMapRef &osdmap) = 0;
-    virtual epoch_t oldest_stored_osdmap() = 0;
     virtual epoch_t max_oldest_stored_osdmap() = 0;
 
     // ============ recovery reservation notifications ==========

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -405,6 +405,7 @@ public:
     virtual void on_active_actmap() = 0;
     virtual void on_active_advmap(const OSDMapRef &osdmap) = 0;
     virtual epoch_t oldest_stored_osdmap() = 0;
+    virtual epoch_t max_oldest_stored_osdmap() = 0;
 
     // ============ recovery reservation notifications ==========
     virtual void on_backfill_reserved() = 0;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -404,7 +404,7 @@ public:
     // ==================== Std::map notifications ===================
     virtual void on_active_actmap() = 0;
     virtual void on_active_advmap(const OSDMapRef &osdmap) = 0;
-    virtual epoch_t max_oldest_stored_osdmap() = 0;
+    virtual epoch_t cluster_osdmap_trim_lower_bound() = 0;
 
     // ============ recovery reservation notifications ==========
     virtual void on_backfill_reserved() = 0;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5677,7 +5677,7 @@ void OSDSuperblock::encode(ceph::buffer::list &bl) const
   encode((uint32_t)0, bl);  // map<int64_t,epoch_t> pool_last_epoch_marked_full
   encode(purged_snaps_last, bl);
   encode(last_purged_snaps_scrub, bl);
-  encode(max_oldest_map, bl);
+  encode(cluster_osdmap_trim_lower_bound, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -5718,9 +5718,9 @@ void OSDSuperblock::decode(ceph::buffer::list::const_iterator &bl)
     purged_snaps_last = 0;
   }
   if (struct_v >= 10) {
-    decode(max_oldest_map, bl);
+    decode(cluster_osdmap_trim_lower_bound, bl);
   } else {
-    max_oldest_map = 0;
+    cluster_osdmap_trim_lower_bound = 0;
   }
   DECODE_FINISH(bl);
 }
@@ -5741,7 +5741,8 @@ void OSDSuperblock::dump(Formatter *f) const
   f->dump_int("last_epoch_mounted", mounted);
   f->dump_unsigned("purged_snaps_last", purged_snaps_last);
   f->dump_stream("last_purged_snaps_scrub") << last_purged_snaps_scrub;
-  f->dump_int("max_oldest_map", max_oldest_map);
+  f->dump_int("cluster_osdmap_trim_lower_bound",
+              cluster_osdmap_trim_lower_bound);
 }
 
 void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5662,7 +5662,7 @@ void pg_hit_set_history_t::generate_test_instances(list<pg_hit_set_history_t*>& 
 
 void OSDSuperblock::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(9, 5, bl);
+  ENCODE_START(10, 5, bl);
   encode(cluster_fsid, bl);
   encode(whoami, bl);
   encode(current_epoch, bl);
@@ -5677,12 +5677,13 @@ void OSDSuperblock::encode(ceph::buffer::list &bl) const
   encode((uint32_t)0, bl);  // map<int64_t,epoch_t> pool_last_epoch_marked_full
   encode(purged_snaps_last, bl);
   encode(last_purged_snaps_scrub, bl);
+  encode(max_oldest_map, bl);
   ENCODE_FINISH(bl);
 }
 
 void OSDSuperblock::decode(ceph::buffer::list::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(9, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(10, 5, 5, bl);
   if (struct_v < 3) {
     string magic;
     decode(magic, bl);
@@ -5716,6 +5717,11 @@ void OSDSuperblock::decode(ceph::buffer::list::const_iterator &bl)
   } else {
     purged_snaps_last = 0;
   }
+  if (struct_v >= 10) {
+    decode(max_oldest_map, bl);
+  } else {
+    max_oldest_map = 0;
+  }
   DECODE_FINISH(bl);
 }
 
@@ -5735,6 +5741,7 @@ void OSDSuperblock::dump(Formatter *f) const
   f->dump_int("last_epoch_mounted", mounted);
   f->dump_unsigned("purged_snaps_last", purged_snaps_last);
   f->dump_stream("last_purged_snaps_scrub") << last_purged_snaps_scrub;
+  f->dump_int("max_oldest_map", max_oldest_map);
 }
 
 void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5480,6 +5480,8 @@ public:
   epoch_t purged_snaps_last = 0;
   utime_t last_purged_snaps_scrub;
 
+  epoch_t max_oldest_map = 0;  // maximum oldest map we have.
+
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
@@ -5495,7 +5497,7 @@ inline std::ostream& operator<<(std::ostream& out, const OSDSuperblock& sb)
              << " e" << sb.current_epoch
              << " [" << sb.oldest_map << "," << sb.newest_map << "]"
 	     << " lci=[" << sb.mounted << "," << sb.clean_thru << "]"
-             << ")";
+             << " max oldest=" << sb.max_oldest_map << ")";
 }
 
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5480,7 +5480,7 @@ public:
   epoch_t purged_snaps_last = 0;
   utime_t last_purged_snaps_scrub;
 
-  epoch_t max_oldest_map = 0;  // maximum oldest map we have.
+  epoch_t cluster_osdmap_trim_lower_bound = 0;
 
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
@@ -5497,7 +5497,8 @@ inline std::ostream& operator<<(std::ostream& out, const OSDSuperblock& sb)
              << " e" << sb.current_epoch
              << " [" << sb.oldest_map << "," << sb.newest_map << "]"
 	     << " lci=[" << sb.mounted << "," << sb.clean_thru << "]"
-             << " max oldest=" << sb.max_oldest_map << ")";
+             << " tlb=" << sb.cluster_osdmap_trim_lower_bound
+             << ")";
 }
 
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1220,7 +1220,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
 	  logger->inc(l_osdc_map_full);
 	}
 	else {
-	  if (e >= m->get_oldest()) {
+	  if (e >= m->cluster_osdmap_trim_lower_bound) {
 	    ldout(cct, 3) << "handle_osd_map requesting missing epoch "
 			  << osdmap->get_epoch()+1 << dendl;
 	    _maybe_request_map();
@@ -1228,8 +1228,9 @@ void Objecter::handle_osd_map(MOSDMap *m)
 	  }
 	  ldout(cct, 3) << "handle_osd_map missing epoch "
 			<< osdmap->get_epoch()+1
-			<< ", jumping to " << m->get_oldest() << dendl;
-	  e = m->get_oldest() - 1;
+			<< ", jumping to "
+			<< m->cluster_osdmap_trim_lower_bound << dendl;
+	  e = m->cluster_osdmap_trim_lower_bound - 1;
 	  skipped_map = true;
 	  continue;
 	}

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -798,8 +798,10 @@ class OSDStub : public TestStub
     if (first > osdmap.get_epoch() + 1) {
       dout(5) << __func__
 	      << osdmap.get_epoch() + 1 << ".." << (first-1) << dendl;
-      if ((m->oldest_map < first && osdmap.get_epoch() == 0) ||
-	  m->oldest_map <= osdmap.get_epoch()) {
+      if ((m->cluster_osdmap_trim_lower_bound <
+           first && osdmap.get_epoch() == 0) ||
+	  m->cluster_osdmap_trim_lower_bound <=
+          osdmap.get_epoch()) {
 	monc.sub_want("osdmap", osdmap.get_epoch()+1,
 		       CEPH_SUBSCRIBE_ONETIME);
 	monc.renew_subs();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61150

---

#### Manually fixed cherry-picks:
bdf318fd95da78396c6889d5cc161244813f62fe - Change in existing OSD members from original commit

####  Crimson Manually fixed cherry-picks: 
Note: These shouldn't matter since we are not maintaining Crimson backports to Q):
ac4b0d9aeabb21b25c852598214d4c2b56c9b538
327ec45a30b97314500ce0296d8154ab8068c935

---

backport of https://github.com/ceph/ceph/pull/48706
parent tracker: https://tracker.ceph.com/issues/49689

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh