### PR TITLE
rgw: use string_view to parse Accept header

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1727,17 +1727,15 @@ int RGWHandler_REST::allocate_formatter(req_state *s,
     } else {
       const char *accept = s->info.env->get("HTTP_ACCEPT");
       if (accept) {
-        char format_buf[64];
-        unsigned int i = 0;
-        for (; i < sizeof(format_buf) - 1 && accept[i] && accept[i] != ';'; ++i) {
-          format_buf[i] = accept[i];
-        }
-        format_buf[i] = 0;
-        if ((strcmp(format_buf, "text/xml") == 0) || (strcmp(format_buf, "application/xml") == 0)) {
+        // trim at first ;
+        std::string_view format = accept;
+        format = format.substr(0, format.find(';'));
+
+        if (format == "text/xml" || format == "application/xml") {
           type = RGWFormat::XML;
-        } else if (strcmp(format_buf, "application/json") == 0) {
+        } else if (format == "application/json") {
           type = RGWFormat::JSON;
-        } else if (strcmp(format_buf, "text/html") == 0) {
+        } else if (format == "text/html") {
           type = RGWFormat::HTML;
         }
       }


### PR DESCRIPTION
avoid copying the header into a separate buffer to do comparisons

Fixes: https://tracker.ceph.com/issues/59490

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
