### PR TITLE
quincy: mgr/dashboard: fix regression caused by cephPgImabalance alert

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -66,11 +66,7 @@ class PrometheusRESTController(RESTController):
             alerts_info = []
             if 'data' in content:
                 if balancer_status['active'] and balancer_status['no_optimization_needed'] and path == '/alerts':  # noqa E501  #pylint: disable=line-too-long
-                    for alert in content['data']:
-                        for k, v in alert.items():
-                            if k == 'labels':
-                                alerts_info.append(v)
-                    alerts_info = [i for i in alerts_info if i['alertname'] != 'CephPGImbalance']
+                    alerts_info = [alert for alert in content['data'] if alert['labels']['alertname'] != 'CephPGImbalance']  # noqa E501  #pylint: disable=line-too-long
                     return alerts_info
                 return content['data']
             return content


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61179

---

backport of https://github.com/ceph/ceph/pull/51385
parent tracker: https://tracker.ceph.com/issues/59666

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh