### PR TITLE
mgr/dashboard: default encryption type to sse-s3 in rgw

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.e2e-spec.ts
@@ -32,6 +32,11 @@ describe('RGW buckets page', () => {
       buckets.delete(bucket_name);
     });
 
+    it('should check default encryption is SSE-S3', () => {
+      buckets.navigateTo('create');
+      buckets.checkForDefaultEncryption();
+    });
+
     it('should create bucket with object locking enabled', () => {
       buckets.navigateTo('create');
       buckets.create(bucket_name, BucketsPageHelper.USERS[0], 'default-placement', true);

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
@@ -52,6 +52,15 @@ export class BucketsPageHelper extends PageHelper {
     this.getFirstTableCell(name).should('exist');
   }
 
+  @PageHelper.restrictTo(pages.create.url)
+  checkForDefaultEncryption() {
+    cy.get("cd-helper[aria-label='toggle encryption helper']").click();
+    cy.get("a[aria-label='click here']").click();
+    cy.get('cd-modal').within(() => {
+      cy.get('input[id=s3Enabled]').should('be.checked');
+    });
+  }
+
   @PageHelper.restrictTo(pages.index.url)
   edit(name: string, new_owner: string, isLocking = false) {
     this.navigateEdit(name);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -294,11 +294,12 @@
                 <label class="form-check-label"
                        for="encryption_enabled"
                        i18n>Encryption</label>
-                <cd-helper>
+                <cd-helper aria-label="toggle encryption helper">
                   <span i18n>Enables encryption for the objects in the bucket.
                      To enable encryption on a bucket you need to set the configuration values for SSE-S3 or SSE-KMS.
                      To set the configuration values <a href="#/rgw/bucket/create"
-                                                        (click)="openConfigModal()">Click here</a></span>
+                                                        (click)="openConfigModal()"
+                                                        aria-label="click here">Click here</a></span>
                 </cd-helper>
               </div>
             </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -335,6 +335,6 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     const modalRef = this.modalService.show(RgwConfigModalComponent, null, { size: 'lg' });
     modalRef.componentInstance.configForm
       .get('encryptionType')
-      .setValue(this.bucketForm.getValue('encryption_type'));
+      .setValue(this.bucketForm.getValue('encryption_type') || 'AES256');
   }
 }


### PR DESCRIPTION
by default the form doesn't select any values, so i am defaulting it to sse-s3


https://github.com/ceph/ceph/assets/71764184/5a3ffc05-5482-43a2-8783-f1b77446188f


Fixes: https://tracker.ceph.com/issues/61211
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
