### PR TITLE
mds: enqueue ~mdsdir at the time of enqueing root

### DIFF
--- a/doc/cephfs/scrub.rst
+++ b/doc/cephfs/scrub.rst
@@ -151,6 +151,6 @@ Evaluate strays using recursive scrub
     ceph tell mds.<fsname>:0 scrub start ~mdsdir recursive
 
 - ``~mdsdir`` is not enqueued by default when scrubbing at the CephFS root. In order to perform stray evaluation
-  at root, run scrub with flag ``scrub_mdsdir``::
+  at root, run scrub with flags ``scrub_mdsdir`` and ``recursive``::
 
-    ceph tell mds.<fsname>:0 scrub start / scrub_mdsdir
+    ceph tell mds.<fsname>:0 scrub start / recursive,scrub_mdsdir

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -374,7 +374,7 @@ class TestScrubChecks(CephFSTestCase):
         test flag scrub_mdsdir
         """
         self.scrub_with_stray_evaluation(self.fs, self.mount_a, "/",
-                                         "scrub_mdsdir")
+                                         "recursive,scrub_mdsdir")
 
     @staticmethod
     def json_validator(json_out, rc, element, expected_value):

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13015,19 +13015,14 @@ void MDCache::enqueue_scrub(
 
   bool is_internal = false;
   std::string tag_str(tag);
-  C_MDS_EnqueueScrub *cs;
-  if ((path == "~mdsdir" && scrub_mdsdir)) {
+  if (tag_str.empty()) {
+    uuid_d uuid_gen;
+    uuid_gen.generate_random();
+    tag_str = uuid_gen.to_string();
     is_internal = true;
-    cs = new C_MDS_EnqueueScrub(tag_str, f, fin, false);
-  } else {
-    if (tag_str.empty()) {
-      uuid_d uuid_gen;
-      uuid_gen.generate_random();
-      tag_str = uuid_gen.to_string();
-      is_internal = true;
-    }
-    cs = new C_MDS_EnqueueScrub(tag_str, f, fin);
   }
+
+  C_MDS_EnqueueScrub *cs = new C_MDS_EnqueueScrub(tag_str, f, fin);
   cs->header = std::make_shared<ScrubHeader>(tag_str, is_internal, force,
                                              recursive, repair, scrub_mdsdir);
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12960,24 +12960,19 @@ class C_MDS_EnqueueScrub : public Context
   std::string tag;
   Formatter *formatter;
   Context *on_finish;
-  bool dump_values;
 public:
   ScrubHeaderRef header;
-  C_MDS_EnqueueScrub(std::string_view tag, Formatter *f, Context *fin,
-                     bool dump_values = true) :
-    tag(tag), formatter(f), on_finish(fin), dump_values(dump_values),
-    header(nullptr) {}
+  C_MDS_EnqueueScrub(std::string_view tag, Formatter *f, Context *fin) :
+    tag(tag), formatter(f), on_finish(fin), header(nullptr) {}
 
   void finish(int r) override {
-    if (dump_values) {
-      formatter->open_object_section("results");
-      formatter->dump_int("return_code", r);
-      if (r == 0) {
-        formatter->dump_string("scrub_tag", tag);
-        formatter->dump_string("mode", "asynchronous");
-      }
-      formatter->close_section();
+    formatter->open_object_section("results");
+    formatter->dump_int("return_code", r);
+    if (r == 0) {
+      formatter->dump_string("scrub_tag", tag);
+      formatter->dump_string("mode", "asynchronous");
     }
+    formatter->close_section();
 
     r = 0;
     if (on_finish)

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2986,13 +2986,6 @@ void MDSRank::command_scrub_start(Formatter *f,
   }
 
   std::lock_guard l(mds_lock);
-  if (scrub_mdsdir) {
-    MDSGatherBuilder gather(g_ceph_context);
-    mdcache->enqueue_scrub("~mdsdir", "", false, true, false, scrub_mdsdir,
-                           f, gather.new_sub());
-    gather.set_finisher(new C_MDSInternalNoop);
-    gather.activate();
-  }
   mdcache->enqueue_scrub(path, tag, force, recursive, repair, scrub_mdsdir,
                          f, on_finish);
   // scrub_dentry() finishers will dump the data for us; we're done!

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -668,11 +668,6 @@ void ScrubStack::scrub_status(Formatter *f) {
     have_more = false;
     auto& header = p.second;
 
-    if (mdcache->get_inode(header->get_origin())->is_mdsdir() 
-    && header->get_scrub_mdsdir() && header->get_tag().empty()) {
-      continue;
-    }
-
     std::string tag(header->get_tag());
     f->open_object_section(tag.c_str()); // scrub id
 

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -119,7 +119,20 @@ int ScrubStack::enqueue(CInode *in, ScrubHeaderRef& header, bool top)
 	     << ", conflicting tag " << header->get_tag() << dendl;
     return -CEPHFS_EEXIST;
   }
-
+  if (header->get_scrub_mdsdir()) {
+    filepath fp;
+    mds_rank_t rank;
+    rank = mdcache->mds->get_nodeid();
+    if(rank >= 0 && rank < MAX_MDS) {
+      fp.set_path("", MDS_INO_MDSDIR(rank));
+    }
+    int r = _enqueue(mdcache->get_inode(fp.get_ino()), header, true);
+    if (r < 0) {
+      return r;
+    }
+    //to make sure mdsdir is always on the top
+    top = false;
+  }
   int r = _enqueue(in, header, top);
   if (r < 0)
     return r;


### PR DESCRIPTION
This would avoid the need to run individual scrubs for
~mdsdir and root, i.e. run both the scrubs under the
same header, this also helps to avoid edge case where
in case ~mdsdir is huge and it's taking time to scrub it,
the scrub status would report something like this until
root inodes kick in:

```
{
    "status": "scrub active (757 inodes in the stack)",
    "scrubs": {}
}
```

Fixes: https://tracker.ceph.com/issues/59350

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
