### PR TITLE
rbd_mirror: introduce a timeout for remote cluster OSD operations

### DIFF
--- a/src/common/options/rbd-mirror.yaml.in
+++ b/src/common/options/rbd-mirror.yaml.in
@@ -2,6 +2,13 @@
 ---
 
 options:
+- name: rbd_mirror_remote_osd_op_timeout
+  type: secs
+  level: advanced
+  desc: timeout for OSD operations against the remote cluster (0 is unlimited)
+  default: 300
+  services:
+  - rbd-mirror
 - name: rbd_mirror_journal_commit_age
   type: float
   level: advanced

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -554,6 +554,18 @@ int PoolReplayer<I>::init_rados(const std::string &cluster_name,
     }
   }
 
+  if (is_remote) {
+    auto seconds = cct->_conf.get_val<std::chrono::seconds>(
+        "rbd_mirror_remote_osd_op_timeout").count();
+    r = cct->_conf.set_val("rados_osd_op_timeout", std::to_string(seconds));
+    if (r < 0) {
+      derr << "failed to set rados_osd_op_timeout: " << seconds
+           << ", r=" << r << dendl;
+      return r;
+    }
+    dout(10) << "setting rados_osd_op_timeout: " << seconds << dendl;
+  }
+
   // disable unnecessary librbd cache
   cct->_conf.set_val_or_die("rbd_cache", "false");
   cct->_conf.apply_changes(nullptr);


### PR DESCRIPTION
Currently `rbd mirror image status` reports "up+stopping_replay" upon a force promote at secondary, after a disaster on primary.

This is because the `StateBuilder<I>::close_remote_image()` eventually endup calling `void Watcher::unregister_watch()` which will call `m_ioctx.aio_unwatch()` but fails to receive a callback.

This commit introduce `rbd_mirror_remote_osd_op_timeout` which is a timeout for remote operations handled by osds such as write (0 is unlimited, default is 5)


Fixes: https://tracker.ceph.com/issues/59685
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
