### PR TITLE
bluestore: Move most of configuration from DB to superblock

### DIFF
--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -47,17 +47,10 @@ class BitmapFreelistManager : public FreelistManager {
   int _read_cfg(
     std::function<int(const std::string&, std::string*)> cfg_reader);
 
-  int _expand(uint64_t new_size, KeyValueDB* db);
-
   uint64_t size_2_block_count(uint64_t target_size) const;
 
-  int read_size_meta_from_db(KeyValueDB* kvdb, uint64_t* res);
-  void _sync(KeyValueDB* kvdb, bool read_only);
-
-  void _load_from_db(KeyValueDB* kvdb);
-
 public:
-  BitmapFreelistManager(CephContext* cct, std::string meta_prefix,
+  BitmapFreelistManager(ObjectStore* store, std::string meta_prefix,
 			std::string bitmap_prefix);
 
   static void setup_merge_operator(KeyValueDB *db, std::string prefix);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5628,7 +5628,7 @@ int BlueStore::_open_fm(KeyValueDB::Transaction t,
     freelist_type = "null";
     need_to_destage_allocation_file = true;
   }
-  fm = FreelistManager::create(cct, freelist_type, PREFIX_ALLOC);
+  fm = FreelistManager::create(this, freelist_type, PREFIX_ALLOC);
   ceph_assert(fm);
   if (t) {
     // create mode. initialize freespace

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2688,8 +2688,13 @@ private:
 			       bool create);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
 
-  int _open_super_meta();
-
+  int _open_superblock_meta();
+  int _relocate_db_settings_to_super_meta();
+  int _read_superblock_meta();
+  int _read_meta(const std::string& name, uint64_t* val);
+  int _read_meta_from_db();
+  int _read_db_dynamic_values();
+  int _setup_settings();
   void _open_statfs();
   void _get_statfs_overall(struct store_statfs_t *buf);
 
@@ -2838,16 +2843,18 @@ private:
 
   // -- ondisk version ---
 public:
-  const int32_t latest_ondisk_format = 4;        ///< our version
+  const int32_t latest_ondisk_format = 5;        ///< our version
   const int32_t min_readable_ondisk_format = 1;  ///< what we can read
-  const int32_t min_compat_ondisk_format = 3;    ///< who can read us
+  const int32_t min_compat_ondisk_format = 5;    ///< who can read us
 
 private:
   int32_t ondisk_format = 0;  ///< value detected on mount
   bool    m_fast_shutdown = false;
-  int _upgrade_super();  ///< upgrade (called during open_super)
+  int _upgrade_super_db();  ///< upgrade (called during open_super)
+  int _upgrade_superblock_meta();
+  int _init_superblock_meta();
   uint64_t _get_ondisk_reserved() const;
-  void _prepare_ondisk_format_super(KeyValueDB::Transaction& t);
+  void _prepare_ondisk_format_db(KeyValueDB::Transaction& t);
 
   // --- public interface ---
 public:

--- a/src/os/bluestore/FreelistManager.cc
+++ b/src/os/bluestore/FreelistManager.cc
@@ -8,7 +8,7 @@
 #endif
 
 FreelistManager *FreelistManager::create(
-  CephContext* cct,
+  ObjectStore* store,
   std::string type,
   std::string prefix)
 {
@@ -18,11 +18,11 @@ FreelistManager *FreelistManager::create(
   // freelist type until after we open the db.
   ceph_assert(prefix == "B");
   if (type == "bitmap") {
-    return new BitmapFreelistManager(cct, "B", "b");
+    return new BitmapFreelistManager(store, "B", "b");
   }
   if (type == "null") {
     // use BitmapFreelistManager with the null option to stop allocations from going to RocksDB
-    auto *fm = new BitmapFreelistManager(cct, "B", "b");
+    auto *fm = new BitmapFreelistManager(store, "B", "b");
     fm->set_null_manager();
     return fm;
   }
@@ -35,7 +35,7 @@ FreelistManager *FreelistManager::create(
   // passed to create and use the prefixes defined for zoned devices at the top
   // of BlueStore.cc.
   if (type == "zoned")
-    return new ZonedFreelistManager(cct, "Z", "z");
+    return new ZonedFreelistManager(store, "Z", "z");
 #endif
 
   return NULL;

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -10,16 +10,20 @@
 #include <ostream>
 #include "kv/KeyValueDB.h"
 #include "bluestore_types.h"
+#include "os/ObjectStore.h"
 
 class FreelistManager {
   bool         null_manager = false;
-public:
+protected:
+  ObjectStore* store; //this is always BlueStore
   CephContext* cct;
-  explicit FreelistManager(CephContext* cct) : cct(cct) {}
+public:
+  explicit FreelistManager(ObjectStore* store)
+    : store(store), cct(store->cct) {}
   virtual ~FreelistManager() {}
 
   static FreelistManager *create(
-    CephContext* cct,
+    ObjectStore* store,
     std::string type,
     std::string prefix);
 

--- a/src/os/bluestore/ZonedFreelistManager.cc
+++ b/src/os/bluestore/ZonedFreelistManager.cc
@@ -86,10 +86,10 @@ void ZonedFreelistManager::setup_merge_operator(KeyValueDB *db, string prefix)
 }
 
 ZonedFreelistManager::ZonedFreelistManager(
-  CephContext* cct,
+  ObjectStore* store,
   string meta_prefix,
   string info_prefix)
-  : FreelistManager(cct),
+  : FreelistManager(store),
     meta_prefix(meta_prefix),
     info_prefix(info_prefix),
     enumerate_zone_num(~0UL)
@@ -118,32 +118,12 @@ int ZonedFreelistManager::create(
 	  << " zone size 0x " << zone_size
 	  << " num_zones 0x" << num_zones
 	  << " starting_zone 0x" << starting_zone_num << dendl;
-  {
-    bufferlist bl;
-    encode(size, bl);
-    txn->set(meta_prefix, "size", bl);
-  }
-  {
-    bufferlist bl;
-    encode(bytes_per_block, bl);
-    txn->set(meta_prefix, "bytes_per_block", bl);
-  }
-  {
-    bufferlist bl;
-    encode(zone_size, bl);
-    txn->set(meta_prefix, "zone_size", bl);
-  }
-  {
-    bufferlist bl;
-    encode(num_zones, bl);
-    txn->set(meta_prefix, "num_zones", bl);
-  }
-  {
-    bufferlist bl;
-    encode(starting_zone_num, bl);
-    txn->set(meta_prefix, "starting_zone_num", bl);
-  }
 
+  store->write_meta("zfm_size", stringify(size));
+  store->write_meta("zfm_bytes_per_block", stringify(bytes_per_block));
+  store->write_meta("zfm_zone_size", stringify(zone_size));
+  store->write_meta("zfm_num_zones", stringify(num_zones));
+  store->write_meta("zfm_starting_zone_num", stringify(starting_zone_num));
   init_zone_states(txn);
 
   return 0;

--- a/src/os/bluestore/ZonedFreelistManager.h
+++ b/src/os/bluestore/ZonedFreelistManager.h
@@ -56,7 +56,7 @@ class ZonedFreelistManager : public FreelistManager {
   int _read_cfg(cfg_reader_t cfg_reader);
 
 public:
-  ZonedFreelistManager(CephContext* cct,
+  ZonedFreelistManager(ObjectStore* store,
 		       std::string meta_prefix,
 		       std::string info_prefix);
 


### PR DESCRIPTION
Some configuration elements are stored in DB.
It requires deep db open to access then, and even deeper (db read/write) to modify.
It makes impossible:
- early detection null freelist / bitmap freelist
- main block device expand that works in every condition
- cleanup of NCB code to separate file & separate freelist (detach it from being parasitic to bitmap)
- cleanup of open hierarchy of bdev / bluefs / alloc / freelist / db / mount


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
