### PR TITLE
reef: qa/tasks: Changing default mClock profile to high_recovery_ops

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -47,6 +47,7 @@
 
         osd scrub load threshold = 5.0
 	osd scrub max interval = 600
+        osd mclock profile = high_recovery_ops
 
 	osd recover clone overlap = true
 	osd recovery max chunk = 1048576

--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -39,6 +39,7 @@ mon allow pool delete = true
 [osd]
 osd scrub load threshold = 5.0
 osd scrub max interval = 600
+osd mclock profile = high_recovery_ops
 
 osd recover clone overlap = true
 osd recovery max chunk = 1048576


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61232

---

backport of https://github.com/ceph/ceph/pull/51449
parent tracker: https://tracker.ceph.com/issues/61228

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh