### PR TITLE
rgw: improved admin token diagnostics.

### DIFF
--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -34,6 +34,13 @@ enum class ApiVersion {
   VER_3
 };
 
+inline std::ostream& operator<<(std::ostream& out, const ApiVersion &o) {
+  switch(o) {
+  case ApiVersion::VER_2: return out << '2';
+  case ApiVersion::VER_3: return out << '3';
+  }
+  return out << '?';
+}
 
 class Config {
 protected:
@@ -119,6 +126,7 @@ public:
   typedef RGWKeystoneHTTPTransceiver RGWValidateKeystoneToken;
   typedef RGWKeystoneHTTPTransceiver RGWGetKeystoneAdminToken;
 
+  static int validate_admin_token(TokenEnvelope& t);
   static int get_admin_token(const DoutPrefixProvider *dpp,
                              CephContext* const cct,
                              TokenCache& token_cache,
@@ -155,6 +163,7 @@ public:
     Token() : expires(0) { }
     std::string id;
     time_t expires;
+    time_t issued;
     Project tenant_v2;
     void decode_json(JSONObj *obj);
   };
@@ -198,6 +207,7 @@ public:
 
   void set_expires(time_t expires) { token.expires = expires; }
   time_t get_expires() const { return token.expires; }
+  time_t get_issued() const { return token.issued; }
   const std::string& get_domain_id() const {return project.domain.id;};
   const std::string& get_domain_name() const {return project.domain.name;};
   const std::string& get_project_id() const {return project.id;};


### PR DESCRIPTION
As a result of assorted bugs, various versions of radosgw have been caught trying to use a defective cached admin token.  The resulting behavior is wrong and the log messages are not very clueful.  This fix includes logic to prevent this; if a token is bad, it should not be cached, and should generate a more obvious error message.

This fix:
/1/ be way pickier about incoming admin tokens.
/2/ try to produce more useful error messaging upon misbehavior or misconfiguration.

Fixes: https://tracker.ceph.com/issues/61258





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
