### PR TITLE
rgw: fix http client relevant headers behavior

### DIFF
--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -223,6 +223,17 @@ private:
   std::map<header_name_t, header_value_t, ltstr_nocase> found_headers;
 };
 
+static inline std::ostream& operator<<(std::ostream& out,
+    const RGWHTTPHeadersCollector::header_spec_t &o) {
+  bool first = true;
+  for (auto &x: o) {
+    if (!first) out << "|";
+    out << x;
+    first = false;
+  }
+  return out;
+}
+
 
 class RGWHTTPTransceiver : public RGWHTTPHeadersCollector {
   bufferlist * const read_bl;


### PR DESCRIPTION
In a containerized install with keystone; radosgw was caught redhanded in the act of attempting to validate a uesr supplied token with an empty admin token.  The problem turned out to be a bug that was never present upstream - but the problem was masked by debug behavior which considered all headers to be relevant causing the bug to go away.  This is classic noxious heisenbug behavior.

This fix:
/1/ debug behavior does not alter what are "relevant headers". /2/ debug behavior produces useful diagnostics for uninteresting headers. /3/ refactor some of the other logic in receive_headers, which was
    previously recalculating val_loc_s and val_loc_e twice.

Fixes: https://tracker.ceph.com/issues/61259





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
