### PR TITLE
rgw - jumbo consolidated etag trailing nul make-it-bullet-proof bug fix commit series.

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1845,6 +1845,8 @@ int RGWRados::Bucket::List::list_objects_ordered(
       rgw_obj_index_key index_key = entry.key;
       rgw_obj_key obj(index_key);
 
+      rgw_fix_etag(cct, entry.meta.etag);
+
       ldpp_dout(dpp, 20) << __func__ <<
 	": considering entry " << entry.key << dendl;
 
@@ -7855,6 +7857,7 @@ int RGWRados::raw_obj_stat(const DoutPrefixProvider *dpp,
     *pmtime = ceph::real_clock::from_timespec(mtime_ts);
   if (attrs) {
     rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
+    rgw_fix_etag(cct, attrs);
   }
 
   return 0;
@@ -8296,6 +8299,7 @@ int RGWRados::bi_get_instance(const DoutPrefixProvider *dpp, const RGWBucketInfo
     ldpp_dout(dpp, 0) << "ERROR: failed to decode bi_entry()" << dendl;
     return -EIO;
   }
+  rgw_fix_etag(cct, dirent->meta.etag);
 
   return 0;
 }
@@ -9099,6 +9103,9 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 
       bool force_check = force_check_filter &&
 	force_check_filter(dirent.key.name);
+
+      rgw_fix_etag(cct, dirent.meta.etag);
+
       if ((!dirent.exists && !dirent.is_delete_marker()) ||
 	  !dirent.pending_map.empty() ||
 	  force_check) {

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -88,6 +88,10 @@ const char *rgw_find_mime_by_ext(std::string& ext);
 void rgw_filter_attrset(std::map<std::string, bufferlist>& unfiltered_attrset, const std::string& check_prefix,
                         std::map<std::string, bufferlist> *attrset);
 
+void rgw_fix_etag(CephContext *, std::map<std::string, bufferlist> *);
+void rgw_fix_etag(CephContext *cct, bufferlist& etagbl);
+void rgw_fix_etag(CephContext *cct, std::string& etag);
+
 /// indicates whether the current thread is in boost::asio::io_context::run(),
 /// used to log warnings if synchronous librados calls are made
 extern thread_local bool is_asio_thread;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7719,7 +7719,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   std::map<std::string, ceph::bufferlist> attrs;
   std::string etag = calc_md5;
   ceph::bufferlist etag_bl;
-  etag_bl.append(etag.c_str(), etag.size() + 1);
+  etag_bl.append(etag.c_str(), etag.size());
   attrs.emplace(RGW_ATTR_ETAG, std::move(etag_bl));
 
   /* Create metadata: ACLs. */


### PR DESCRIPTION

This is the jumbo consolidated etag trailing nul make-it-bullet-proof bug fix commit series.

2 commits:
adf8329d4c3 rgw: etag handling - do not append nul here.
d500a2b8df3 rgw: jumbo etag fix-em-up logic

Older ceph (up to luminous) appended nuls to rados objects including etags.  Ceph from nautilus on is not supposed to.  The first commit here fixes one last case where it still writes out a nul.  The 2nd commit handles the various cases of weird tags resulting including a nasty one that could create trailing \016 bytes on etag values.
