### PR TITLE
mgr/dashboard: add helpers for compression in pool form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -421,9 +421,10 @@
 
           <!-- Compression Mode -->
           <div class="form-group row">
-            <label i18n
-                   class="cd-col-form-label"
-                   for="mode">Mode</label>
+            <label class="cd-col-form-label"
+                   for="mode"
+                   i18n>Mode
+            </label>
             <div class="cd-col-form-input">
               <select class="form-select"
                       id="mode"
@@ -434,14 +435,16 @@
                   {{ mode }}
                 </option>
               </select>
+              <cd-help-text>Policy used for compression algorithm</cd-help-text>
             </div>
           </div>
           <div *ngIf="hasCompressionEnabled()">
             <!-- Compression algorithm selection -->
             <div class="form-group row">
-              <label i18n
-                     class="cd-col-form-label"
-                     for="algorithm">Algorithm</label>
+              <label class="cd-col-form-label"
+                     for="algorithm">
+                <ng-container i18n>Algorithm</ng-container>
+              </label>
               <div class="cd-col-form-input">
                 <select class="form-select"
                         id="algorithm"
@@ -458,14 +461,18 @@
                     {{ algorithm }}
                   </option>
                 </select>
+                <cd-help-text>
+                  <span i18n>Compression algorithm used</span>
+                </cd-help-text>
               </div>
             </div>
 
             <!-- Compression min blob size -->
             <div class="form-group row">
-              <label i18n
-                     class="cd-col-form-label"
-                     for="minBlobSize">Minimum blob size</label>
+              <label class="cd-col-form-label"
+                     for="minBlobSize">
+                <ng-container i18n>Minimum blob size</ng-container>
+              </label>
               <div class="cd-col-form-input">
                 <input id="minBlobSize"
                        name="minBlobSize"
@@ -477,6 +484,9 @@
                        placeholder="e.g., 128KiB"
                        defaultUnit="KiB"
                        cdDimlessBinary>
+                <cd-help-text>
+                  <span i18n>Chunks smaller than Minimum blob size are never compressed</span>
+                </cd-help-text>
                 <span class="invalid-feedback"
                       *ngIf="form.showError('minBlobSize', formDir, 'min')"
                       i18n>Value should be greater than 0</span>
@@ -491,9 +501,10 @@
 
             <!-- Compression max blob size -->
             <div class="form-group row">
-              <label i18n
-                     class="cd-col-form-label"
-                     for="maxBlobSize">Maximum blob size</label>
+              <label class="cd-col-form-label"
+                     for="maxBlobSize">
+                <ng-container i18n>Maximum blob size</ng-container>
+              </label>
               <div class="cd-col-form-input">
                 <input id="maxBlobSize"
                        type="text"
@@ -504,6 +515,9 @@
                        placeholder="e.g., 512KiB"
                        defaultUnit="KiB"
                        cdDimlessBinary>
+                <cd-help-text>
+                  <span i18n>Chunks larger than `Maximum Blob Size` are broken into smaller blobs of size mentioned before being compressed.</span>
+                </cd-help-text>
                 <span class="invalid-feedback"
                       *ngIf="form.showError('maxBlobSize', formDir, 'min')"
                       i18n>Value should be greater than 0</span>
@@ -518,9 +532,10 @@
 
             <!-- Compression ratio -->
             <div class="form-group row">
-              <label i18n
-                     class="cd-col-form-label"
-                     for="ratio">Ratio</label>
+              <label class="cd-col-form-label"
+                     for="ratio">
+                <ng-container i18n>Ratio</ng-container>
+              </label>
               <div class="cd-col-form-input">
                 <input id="ratio"
                        name="ratio"
@@ -529,9 +544,10 @@
                        min="0"
                        max="1"
                        step="0.1"
-                       class="form-control"
-                       i18n-placeholder
-                       placeholder="Compression ratio">
+                       class="form-control">
+                <cd-help-text>
+                  <span i18n>The ratio of the size of the data chunk after compression relative to the original size must be at least this small in order to store the compressed version</span>
+                </cd-help-text>
                 <span class="invalid-feedback"
                       *ngIf="form.showError('ratio', formDir, 'min') || form.showError('ratio', formDir, 'max')"
                       i18n>Value should be between 0.0 and 1.0</span>
@@ -550,11 +566,6 @@
             <label class="cd-col-form-label"
                    for="max_bytes">
               <ng-container i18n>Max bytes</ng-container>
-              <cd-helper>
-                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
-                <br>
-                <span i18n>A valid quota should be greater than 0.</span>
-              </cd-helper>
             </label>
             <div class="cd-col-form-input">
               <input class="form-control"
@@ -566,6 +577,11 @@
                      placeholder="e.g., 10GiB"
                      defaultUnit="GiB"
                      cdDimlessBinary>
+              <cd-help-text>
+                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
+                <br>
+                <span i18n>A valid quota should be greater than 0.</span>
+              </cd-help-text>
               <span *ngIf="form.showError('max_bytes', formDir, 'pattern')"
                     class="invalid-feedback"
                     i18n>Size must be a number or in a valid format. eg: 5 GiB</span>
@@ -577,11 +593,6 @@
             <label class="cd-col-form-label"
                    for="max_objects">
               <ng-container i18n>Max objects</ng-container>
-              <cd-helper>
-                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
-                <br>
-                <span i18n>A valid quota should be greater than 0.</span>
-              </cd-helper>
             </label>
             <div class="cd-col-form-input">
               <input class="form-control"
@@ -590,6 +601,11 @@
                      name="max_objects"
                      type="number"
                      formControlName="max_objects">
+              <cd-help-text>
+                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
+                <br>
+                <span i18n>A valid quota should be greater than 0.</span>
+              </cd-help-text>
               <span class="invalid-feedback"
                     *ngIf="form.showError('max_objects', formDir, 'min')"
                     i18n>The value should be greater or equal to 0</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -83,6 +83,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
   crushUsage: string[] = undefined; // Will only be set if a rule is used by some pool
   ecpUsage: string[] = undefined; // Will only be set if a rule is used by some pool
   crushRuleMaxSize = 10;
+  DEFAULT_RATIO = 0.875;
 
   private modalSubscription: Subscription;
 
@@ -128,7 +129,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       maxBlobSize: new UntypedFormControl('', {
         updateOn: 'blur'
       }),
-      ratio: new UntypedFormControl('', {
+      ratio: new UntypedFormControl(this.DEFAULT_RATIO, {
         updateOn: 'blur'
       })
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -121,7 +121,7 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
       {
         prop: 'pool_name',
         name: $localize`Name`,
-        flexGrow: 4,
+        flexGrow: 2,
         cellTransformation: CellTemplate.executing
       },
       {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61297
Signed-off-by: avanthakkar <avanjohn@gmail.com>

Adding helpers for compression mode, algorithm, min/max blob size and compression ratio which is set to 0.875 as default. Also reduced size of pool name column. 
![Screenshot from 2024-05-27 15-42-53](https://github.com/ceph/ceph/assets/23611106/6400551d-d66a-4765-94e7-26eae7518f68)







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
