### PR TITLE
reef: qa/rgw: add POOL_APP_NOT_ENABLED to log-ignorelist

### DIFF
--- a/qa/rgw/ignore-pg-availability.yaml
+++ b/qa/rgw/ignore-pg-availability.yaml
@@ -1,7 +1,9 @@
 # https://tracker.ceph.com/issues/45802
 # https://tracker.ceph.com/issues/51282
+# https://tracker.ceph.com/issues/61168
 overrides:
   ceph:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
+    - \(POOL_APP_NOT_ENABLED\)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61298

---

backport of https://github.com/ceph/ceph/pull/51494
parent tracker: https://tracker.ceph.com/issues/61168

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh