### PR TITLE
quincy: rgw: set keys from from master zone on admin api user create

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -206,9 +206,6 @@ void RGWOp_User_Create::execute(optional_yield y)
   if (s->info.args.exists("exclusive"))
     op_state.set_exclusive(exclusive);
 
-  if (gen_key)
-    op_state.set_generate_key();
-
   if (!default_placement_str.empty()) {
     rgw_placement_rule target_rule;
     target_rule.from_str(default_placement_str);
@@ -226,12 +223,27 @@ void RGWOp_User_Create::execute(optional_yield y)
     op_state.set_placement_tags(placement_tags_list);
   }
 
-  bufferlist data;
-  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
-  if (op_ret < 0) {
-    ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
-    return;
+  if(!(store->is_meta_master())) {
+    bufferlist data;
+    JSONParser jp;
+    RGWUserInfo ui;
+    op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, &jp, s->info, y);
+    if (op_ret < 0) {
+      ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
+      return;
+    }
+    ui.decode_json(&jp);
+    std::map<std::string, RGWAccessKey> keys = ui.access_keys;
+    auto keys_itr = keys.begin();
+    RGWAccessKey first_key = keys_itr->second;
+    op_state.id = first_key.id;
+    op_state.key = first_key.key;
   }
+
+  if (gen_key) {
+    op_state.set_generate_key();
+  }
+
   op_ret = RGWUserAdminOp_User::create(s, store, op_state, flusher, y);
 }
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1551,6 +1551,12 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
     return -EINVAL;
   }
 
+  // if op_state.op_access_keys is not empty most recent keys have been fetched from master zone
+  if(!op_state.op_access_keys.empty()) {
+    auto user_access_keys = op_state.get_access_keys();
+    *(user_access_keys) = op_state.op_access_keys;
+  }
+
   RGWUserInfo *pold_info = (is_populated() ? &old_info : nullptr);
 
   ret = user->store_user(dpp, y, false, pold_info);

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -128,6 +128,8 @@ struct RGWUserAdminOpState {
   // key_attributes
   std::string id; // access key
   std::string key; // secret key
+  // access keys fetched for a user in the middle of an op
+  std::map<std::string, RGWAccessKey> op_access_keys;
   int32_t key_type{-1};
   bool access_key_exist = false;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58583

---

backport of https://github.com/ceph/ceph/pull/48731
parent tracker: https://tracker.ceph.com/issues/57724

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh