### PR TITLE
pacific: rgw: set keys from from master zone on admin api user create

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -17,6 +17,21 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+int fetch_access_keys_from_master(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore* store, RGWUserAdminOpState &op_state, req_state *s, optional_yield y) {
+    bufferlist data;
+    JSONParser jp;
+    RGWUserInfo ui;
+    int op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, &jp, s->info, y);
+    if (op_ret < 0) {
+      ldpp_dout(dpp, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
+      return op_ret;
+    }
+    ui.decode_json(&jp);
+    op_state.op_access_keys = std::move(ui.access_keys);
+
+    return 0;
+}
+
 class RGWOp_User_List : public RGWRESTOp {
 
 public:
@@ -222,20 +237,14 @@ void RGWOp_User_Create::execute(optional_yield y)
   }
 
   if(!(store->is_meta_master())) {
-    bufferlist data;
-    JSONParser jp;
-    RGWUserInfo ui;
-    op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, &jp, s->info, y);
-    if (op_ret < 0) {
-      ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
+    op_ret = fetch_access_keys_from_master(this, store, op_state, s, y);
+
+    if(op_ret < 0) {
       return;
+    } else {
+      // set_generate_key() is not set if keys have already been fetched from master zone
+      gen_key = false;
     }
-    ui.decode_json(&jp);
-    std::map<std::string, RGWAccessKey> keys = ui.access_keys;
-    auto keys_itr = keys.begin();
-    RGWAccessKey first_key = keys_itr->second;
-    op_state.id = first_key.id;
-    op_state.key = first_key.key;
   }
 
   if (gen_key) {
@@ -321,8 +330,6 @@ void RGWOp_User_Modify::execute(optional_yield y)
     }
     op_state.set_max_buckets(max_buckets);
   }
-  if (gen_key)
-    op_state.set_generate_key();
 
   if (!key_type_str.empty()) {
     int32_t key_type = KEY_TYPE_UNDEFINED;
@@ -378,12 +385,21 @@ void RGWOp_User_Modify::execute(optional_yield y)
     op_state.set_placement_tags(placement_tags_list);
   }
   
-  bufferlist data;
-  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
-  if (op_ret < 0) {
-    ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
-    return;
+  if(!(store->is_meta_master())) {
+    op_ret = fetch_access_keys_from_master(this, store, op_state, s, y);
+
+    if(op_ret < 0) {
+      return;
+    } else {
+      // set_generate_key() is not set if keys have already been fetched from master zone
+      gen_key = false;
+    }
   }
+
+  if (gen_key) {
+    op_state.set_generate_key();
+  }
+
   op_ret = RGWUserAdminOp_User::modify(s, store, op_state, flusher, y);
 }
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1596,6 +1596,12 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
     return -EINVAL;
   }
 
+  // if op_state.op_access_keys is not empty most recent keys have been fetched from master zone
+  if(!op_state.op_access_keys.empty()) {
+    auto user_access_keys = op_state.get_access_keys();
+    *(user_access_keys) = op_state.op_access_keys;
+  }
+
   RGWUserInfo *pold_info = (is_populated() ? &old_info : nullptr);
 
   ret = rgw_store_user_info(dpp, user_ctl, user_info, pold_info, &op_state.objv,

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -181,6 +181,8 @@ struct RGWUserAdminOpState {
   // key_attributes
   std::string id; // access key
   std::string key; // secret key
+  // access keys fetched for a user in the middle of an op
+  std::map<std::string, RGWAccessKey> op_access_keys;
   int32_t key_type;
 
   std::set<string> mfa_ids;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58584

---

backport of https://github.com/ceph/ceph/pull/48731
parent tracker: https://tracker.ceph.com/issues/57724

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh