### PR TITLE
reef: crimson/os/seastore/epm: also do prepare_write for rbm

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -593,6 +593,7 @@ RandomBlockOolWriter::do_write(
     stats.extents.bytes += ex->get_length();
     stats.num_records += 1;
 
+    ex->prepare_write();
     return rbm->write(paddr,
       ex->get_bptr()
     ).handle_error(


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50317

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh