### PR TITLE
reef: crimson/os/seastore: evict cold data to slower devices

### DIFF
--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -151,10 +151,10 @@ vstart.sh
 The following options aree handy when using ``vstart.sh``,
 
 ``--crimson``
-    start ``crimson-osd`` instead of ``ceph-osd``
+    Start ``crimson-osd`` instead of ``ceph-osd``.
 
 ``--nodaemon``
-    do not daemonize the service
+    Do not daemonize the service.
 
 ``--redirect-output``
     Redirect the ``stdout`` and ``stderr`` to ``out/$type.$num.stdout``.
@@ -170,7 +170,7 @@ The following options aree handy when using ``vstart.sh``,
     for additional Seastar-specific command line options.
 
 ``--cyanstore``
-    use CyanStore as the object store backend.
+    Use CyanStore as the object store backend.
 
 ``--bluestore``
     Use the alienized BlueStore as the object store backend. This is the default.

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -102,3 +102,18 @@ options:
   level: dev
   desc: Total size to use for CircularBoundedJournal if created, it is valid only if seastore_main_device_type is RANDOM_BLOCK
   default: 5_G
+- name: seastore_multiple_tiers_stop_evict_ratio
+  type: float
+  level: advanced
+  desc: When the used ratio of main tier is less than this value, then stop evict cold data to the cold tier.
+  default: 0.5
+- name: seastore_multiple_tiers_default_evict_ratio
+  type: float
+  level: advanced
+  desc: Begin evicting cold data to the cold tier when the used ratio of the main tier reaches this value.
+  default: 0.6
+- name: seastore_multiple_tiers_fast_evict_ratio
+  type: float
+  level: advanced
+  desc: Begin fast eviction when the used ratio of the main tier reaches this value.
+  default: 0.7

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -830,13 +830,13 @@ SegmentCleaner::SegmentCleaner(
   config_t config,
   SegmentManagerGroupRef&& sm_group,
   BackrefManager &backref_manager,
+  SegmentSeqAllocator &segment_seq_allocator,
   bool detailed)
   : detailed(detailed),
     config(config),
     sm_group(std::move(sm_group)),
     backref_manager(backref_manager),
-    ool_segment_seq_allocator(
-      new SegmentSeqAllocator(segment_type_t::OOL))
+    ool_segment_seq_allocator(segment_seq_allocator)
 {
   config.validate();
 }

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -831,8 +831,10 @@ SegmentCleaner::SegmentCleaner(
   SegmentManagerGroupRef&& sm_group,
   BackrefManager &backref_manager,
   SegmentSeqAllocator &segment_seq_allocator,
-  bool detailed)
+  bool detailed,
+  bool is_cold)
   : detailed(detailed),
+    is_cold(is_cold),
     config(config),
     sm_group(std::move(sm_group)),
     backref_manager(backref_manager),
@@ -854,7 +856,13 @@ void SegmentCleaner::register_metrics()
   i = get_bucket_index(UTIL_STATE_EMPTY);
   stats.segment_util.buckets[i].count = segments.get_num_segments();
 
-  metrics.add_group("segment_cleaner", {
+  std::string prefix;
+  if (is_cold) {
+    prefix.append("cold_");
+  }
+  prefix.append("segment_cleaner");
+
+  metrics.add_group(prefix, {
     sm::make_counter("segments_number",
 		     [this] { return segments.get_num_segments(); },
 		     sm::description("the number of segments")),

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1149,6 +1149,7 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
 {
   LOG_PREFIX(SegmentCleaner::clean_space);
   assert(background_callback->is_ready());
+  ceph_assert(can_clean_space());
   if (!reclaim_state) {
     segment_id_t seg_id = get_next_reclaim_segment();
     auto &segment_info = segments[seg_id];

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1061,8 +1061,12 @@ SegmentCleaner::do_reclaim_space(
                         &pin_list, &reclaimed, &runs] {
     reclaimed = 0;
     runs++;
+    auto src = Transaction::src_t::CLEANER_MAIN;
+    if (is_cold) {
+      src = Transaction::src_t::CLEANER_COLD;
+    }
     return extent_callback->with_transaction_intr(
-      Transaction::src_t::CLEANER,
+      src,
       "clean_reclaim_space",
       [this, &backref_extents, &pin_list, &reclaimed](auto &t)
     {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1211,7 +1211,8 @@ public:
     SegmentManagerGroupRef&& sm_group,
     BackrefManager &backref_manager,
     SegmentSeqAllocator &segment_seq_allocator,
-    bool detailed);
+    bool detailed,
+    bool is_cold);
 
   void set_journal_trimmer(JournalTrimmer &_trimmer) {
     trimmer = &_trimmer;
@@ -1222,9 +1223,11 @@ public:
       SegmentManagerGroupRef&& sm_group,
       BackrefManager &backref_manager,
       SegmentSeqAllocator &ool_seq_allocator,
-      bool detailed) {
+      bool detailed,
+      bool is_cold = false) {
     return std::make_unique<SegmentCleaner>(
-        config, std::move(sm_group), backref_manager, ool_seq_allocator, detailed);
+        config, std::move(sm_group), backref_manager,
+        ool_seq_allocator, detailed, is_cold);
   }
 
   /*
@@ -1524,6 +1527,7 @@ private:
   }
 
   const bool detailed;
+  const bool is_cold;
   const config_t config;
 
   SegmentManagerGroupRef sm_group;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1210,11 +1210,8 @@ public:
     config_t config,
     SegmentManagerGroupRef&& sm_group,
     BackrefManager &backref_manager,
+    SegmentSeqAllocator &segment_seq_allocator,
     bool detailed);
-
-  SegmentSeqAllocator& get_ool_segment_seq_allocator() {
-    return *ool_segment_seq_allocator;
-  }
 
   void set_journal_trimmer(JournalTrimmer &_trimmer) {
     trimmer = &_trimmer;
@@ -1224,9 +1221,10 @@ public:
       config_t config,
       SegmentManagerGroupRef&& sm_group,
       BackrefManager &backref_manager,
+      SegmentSeqAllocator &ool_seq_allocator,
       bool detailed) {
     return std::make_unique<SegmentCleaner>(
-        config, std::move(sm_group), backref_manager, detailed);
+        config, std::move(sm_group), backref_manager, ool_seq_allocator, detailed);
   }
 
   /*
@@ -1521,7 +1519,7 @@ private:
     auto new_usage = calc_utilization(segment);
     adjust_segment_util(old_usage, new_usage);
     if (s_type == segment_type_t::OOL) {
-      ool_segment_seq_allocator->set_next_segment_seq(seq);
+      ool_segment_seq_allocator.set_next_segment_seq(seq);
     }
   }
 
@@ -1574,7 +1572,7 @@ private:
   BackgroundListener *background_callback = nullptr;
 
   // TODO: drop once paddr->journal_seq_t is introduced
-  SegmentSeqAllocatorRef ool_segment_seq_allocator;
+  SegmentSeqAllocator &ool_segment_seq_allocator;
 };
 
 class RBMCleaner;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1150,6 +1150,8 @@ public:
   using clean_space_ret = clean_space_ertr::future<>;
   virtual clean_space_ret clean_space() = 0;
 
+  virtual const std::set<device_id_t>& get_device_ids() const = 0;
+
   // test only
   virtual bool check_usage() = 0;
 
@@ -1328,6 +1330,10 @@ public:
   }
 
   clean_space_ret clean_space() final;
+
+  const std::set<device_id_t>& get_device_ids() const final {
+    return sm_group->get_device_ids();
+  }
 
   // Testing interfaces
 
@@ -1645,6 +1651,10 @@ public:
   }
 
   clean_space_ret clean_space() final;
+
+  const std::set<device_id_t>& get_device_ids() const final {
+    return rb_group->get_device_ids();
+  }
 
   RandomBlockManager* get_rbm(paddr_t paddr) {
     auto rbs = rb_group->get_rb_managers();

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -544,14 +544,6 @@ public:
     journal_alloc_tail = JOURNAL_SEQ_NULL;
   }
 
-  bool should_trim_dirty() const {
-    return get_dirty_tail_target() > journal_dirty_tail;
-  }
-
-  bool should_trim_alloc() const {
-    return get_alloc_tail_target() > journal_alloc_tail;
-  }
-
   bool should_trim() const {
     return should_trim_alloc() || should_trim_dirty();
   }
@@ -596,6 +588,14 @@ public:
   friend std::ostream &operator<<(std::ostream &, const stat_printer_t &);
 
 private:
+  bool should_trim_dirty() const {
+    return get_dirty_tail_target() > journal_dirty_tail;
+  }
+
+  bool should_trim_alloc() const {
+    return get_alloc_tail_target() > journal_alloc_tail;
+  }
+
   using trim_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
   trim_ertr::future<> trim_dirty();
@@ -1152,6 +1152,8 @@ public:
 
   virtual const std::set<device_id_t>& get_device_ids() const = 0;
 
+  virtual std::size_t get_reclaim_size_per_cycle() const = 0;
+
   // test only
   virtual bool check_usage() = 0;
 
@@ -1333,6 +1335,10 @@ public:
 
   const std::set<device_id_t>& get_device_ids() const final {
     return sm_group->get_device_ids();
+  }
+
+  std::size_t get_reclaim_size_per_cycle() const final {
+    return config.reclaim_bytes_per_cycle;
   }
 
   // Testing interfaces
@@ -1654,6 +1660,10 @@ public:
 
   const std::set<device_id_t>& get_device_ids() const final {
     return rb_group->get_device_ids();
+  }
+
+  std::size_t get_reclaim_size_per_cycle() const final {
+    return 0;
   }
 
   RandomBlockManager* get_rbm(paddr_t paddr) {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1144,6 +1144,8 @@ public:
 
   virtual bool should_block_io_on_clean() const = 0;
 
+  virtual bool can_clean_space() const = 0;
+
   virtual bool should_clean_space() const = 0;
 
   using clean_space_ertr = base_ertr;
@@ -1315,6 +1317,11 @@ public:
     }
     auto aratio = get_projected_available_ratio();
     return aratio < config.available_ratio_hard_limit;
+  }
+
+  bool can_clean_space() const final {
+    assert(background_callback->is_ready());
+    return get_segments_reclaimable() > 0;
   }
 
   bool should_clean_space() const final {
@@ -1649,6 +1656,10 @@ public:
   void release_projected_usage(size_t) final;
 
   bool should_block_io_on_clean() const final {
+    return false;
+  }
+
+  bool can_clean_space() const final {
     return false;
   }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -135,7 +135,8 @@ void Cache::register_metrics()
     {src_t::READ, sm::label_instance("src", "READ")},
     {src_t::TRIM_DIRTY, sm::label_instance("src", "TRIM_DIRTY")},
     {src_t::TRIM_ALLOC, sm::label_instance("src", "TRIM_ALLOC")},
-    {src_t::CLEANER, sm::label_instance("src", "CLEANER")},
+    {src_t::CLEANER_MAIN, sm::label_instance("src", "CLEANER_MAIN")},
+    {src_t::CLEANER_COLD, sm::label_instance("src", "CLEANER_COLD")},
   };
   assert(labels_by_src.size() == (std::size_t)src_t::MAX);
 
@@ -624,8 +625,10 @@ void Cache::register_metrics()
            src2 == Transaction::src_t::READ) ||
           (src1 == Transaction::src_t::TRIM_DIRTY &&
            src2 == Transaction::src_t::TRIM_DIRTY) ||
-          (src1 == Transaction::src_t::CLEANER &&
-           src2 == Transaction::src_t::CLEANER) ||
+          (src1 == Transaction::src_t::CLEANER_MAIN &&
+           src2 == Transaction::src_t::CLEANER_MAIN) ||
+          (src1 == Transaction::src_t::CLEANER_COLD &&
+           src2 == Transaction::src_t::CLEANER_COLD) ||
           (src1 == Transaction::src_t::TRIM_ALLOC &&
            src2 == Transaction::src_t::TRIM_ALLOC)) {
         continue;
@@ -1389,7 +1392,8 @@ record_t Cache::prepare_record(
   auto &rewrite_version_stats = t.get_rewrite_version_stats();
   if (trans_src == Transaction::src_t::TRIM_DIRTY) {
     stats.committed_dirty_version.increment_stat(rewrite_version_stats);
-  } else if (trans_src == Transaction::src_t::CLEANER) {
+  } else if (trans_src == Transaction::src_t::CLEANER_MAIN ||
+             trans_src == Transaction::src_t::CLEANER_COLD) {
     stats.committed_reclaim_version.increment_stat(rewrite_version_stats);
   } else {
     assert(rewrite_version_stats.is_clear());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1225,8 +1225,10 @@ private:
              src2 == Transaction::src_t::READ));
     assert(!(src1 == Transaction::src_t::TRIM_DIRTY &&
              src2 == Transaction::src_t::TRIM_DIRTY));
-    assert(!(src1 == Transaction::src_t::CLEANER &&
-             src2 == Transaction::src_t::CLEANER));
+    assert(!(src1 == Transaction::src_t::CLEANER_MAIN &&
+	     src2 == Transaction::src_t::CLEANER_MAIN));
+    assert(!(src1 == Transaction::src_t::CLEANER_COLD &&
+	     src2 == Transaction::src_t::CLEANER_COLD));
     assert(!(src1 == Transaction::src_t::TRIM_ALLOC &&
              src2 == Transaction::src_t::TRIM_ALLOC));
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -567,6 +567,15 @@ private:
     return backref_entryrefs_by_seq;
   }
 
+  const segment_info_t* get_segment_info(segment_id_t sid) {
+    auto provider = segment_providers_by_device_id[sid.device_id()];
+    if (provider) {
+      return &provider->get_seg_info(sid);
+    } else {
+      return nullptr;
+    }
+  }
+
 public:
   /**
    * get_extent_by_type
@@ -685,9 +694,8 @@ public:
    *
    * FIXME: This is specific to the segmented implementation
    */
-  void set_segment_provider(SegmentProvider &sp) {
-    assert(segment_provider == nullptr);
-    segment_provider = &sp;
+  void set_segment_providers(std::vector<SegmentProvider*> &&providers) {
+    segment_providers_by_device_id = std::move(providers);
   }
 
   /**
@@ -980,7 +988,7 @@ private:
   journal_seq_t last_commit = JOURNAL_SEQ_MIN;
 
   // FIXME: This is specific to the segmented implementation
-  SegmentProvider *segment_provider = nullptr;
+  std::vector<SegmentProvider*> segment_providers_by_device_id;
 
   /**
    * dirty

--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -36,7 +36,7 @@ seastar::future<DeviceRef>
 Device::make_device(const std::string& device, device_type_t dtype)
 {
   if (get_default_backend_of_device(dtype) == backend_type_t::SEGMENTED) {
-    return SegmentManager::get_segment_manager(device
+    return SegmentManager::get_segment_manager(device, dtype
     ).then([](DeviceRef ret) {
       return ret;
     });

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -680,7 +680,7 @@ ExtentPlacementManager::BackgroundProcess::do_background_cycle()
     });
   } else {
     bool should_clean_main =
-      main_cleaner->should_clean_space() ||
+      main_cleaner_should_run() ||
       // make sure cleaner will start
       // when the trimmer should run but
       // failed to reserve space.

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -190,7 +190,7 @@ void ExtentPlacementManager::init(
     for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::DATA, gen, *segment_cleaner,
-	    segment_cleaner->get_ool_segment_seq_allocator()));
+            *ool_segment_seq_allocator));
       data_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
     }
 
@@ -198,7 +198,7 @@ void ExtentPlacementManager::init(
     for (rewrite_gen_t gen = OOL_GENERATION; gen < REWRITE_GENERATIONS; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::METADATA, gen, *segment_cleaner,
-	    segment_cleaner->get_ool_segment_seq_allocator()));
+            *ool_segment_seq_allocator));
       md_writers_by_gen[generation_to_writer(gen)] = writer_refs.back().get();
     }
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -13,6 +13,8 @@
 #include "crimson/os/seastore/random_block_manager/block_rb_manager.h"
 #include "crimson/os/seastore/randomblock_manager_group.h"
 
+class transaction_manager_test_t;
+
 namespace crimson::os::seastore {
 
 /**
@@ -870,6 +872,8 @@ private:
     bool is_running_until_halt = false;
     state_t state = state_t::STOP;
     eviction_state_t eviction_state;
+
+    friend class ::transaction_manager_test_t;
   };
 
   std::vector<ExtentOolWriterRef> writer_refs;
@@ -881,10 +885,12 @@ private:
   Device* primary_device = nullptr;
   std::size_t num_devices = 0;
 
-  rewrite_gen_t dynamic_max_rewrite_generation;
+  rewrite_gen_t dynamic_max_rewrite_generation = REWRITE_GENERATIONS;
   BackgroundProcess background_process;
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;
+
+  friend class ::transaction_manager_test_t;
 };
 
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -173,11 +173,18 @@ struct reserve_io_result_t {
 
 class ExtentPlacementManager {
 public:
-  ExtentPlacementManager() {
+  ExtentPlacementManager()
+    : ool_segment_seq_allocator(
+          std::make_unique<SegmentSeqAllocator>(segment_type_t::OOL))
+  {
     devices_by_id.resize(DEVICE_ID_MAX, nullptr);
   }
 
   void init(JournalTrimmerImplRef &&, AsyncCleanerRef &&);
+
+  SegmentSeqAllocator &get_ool_segment_seq_allocator() const {
+    return *ool_segment_seq_allocator;
+  }
 
   void set_primary_device(Device *device);
 
@@ -645,6 +652,8 @@ private:
   std::size_t num_devices = 0;
 
   BackgroundProcess background_process;
+  // TODO: drop once paddr->journal_seq_t is introduced
+  SegmentSeqAllocatorRef ool_segment_seq_allocator;
 };
 
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -399,8 +399,10 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
     return os << "TRIM_DIRTY";
   case transaction_type_t::TRIM_ALLOC:
     return os << "TRIM_ALLOC";
-  case transaction_type_t::CLEANER:
-    return os << "CLEANER";
+  case transaction_type_t::CLEANER_MAIN:
+    return os << "CLEANER_MAIN";
+  case transaction_type_t::CLEANER_COLD:
+    return os << "CLEANER_COLD";
   case transaction_type_t::MAX:
     return os << "TRANS_TYPE_NULL";
   default:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -797,8 +797,10 @@ std::ostream& operator<<(std::ostream& out, device_type_t t)
     return out << "SSD";
   case device_type_t::ZNS:
     return out << "ZNS";
-  case device_type_t::SEGMENTED_EPHEMERAL:
-    return out << "SEGMENTED_EPHEMERAL";
+  case device_type_t::EPHEMERAL_COLD:
+    return out << "EPHEMERAL_COLD";
+  case device_type_t::EPHEMERAL_MAIN:
+    return out << "EPHEMERAL_MAIN";
   case device_type_t::RANDOM_BLOCK_SSD:
     return out << "RANDOM_BLOCK_SSD";
   case device_type_t::RANDOM_BLOCK_EPHEMERAL:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1190,7 +1190,8 @@ enum class data_category_t : uint8_t {
 std::ostream &operator<<(std::ostream &out, data_category_t c);
 
 constexpr data_category_t get_extent_category(extent_types_t type) {
-  if (type == extent_types_t::OBJECT_DATA_BLOCK) {
+  if (type == extent_types_t::OBJECT_DATA_BLOCK ||
+      type == extent_types_t::TEST_BLOCK) {
     return data_category_t::DATA;
   } else {
     return data_category_t::METADATA;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -876,7 +876,8 @@ enum class device_type_t : uint8_t {
   HDD,
   SSD,
   ZNS,
-  SEGMENTED_EPHEMERAL,
+  EPHEMERAL_COLD,
+  EPHEMERAL_MAIN,
   RANDOM_BLOCK_SSD,
   RANDOM_BLOCK_EPHEMERAL,
   NUM_TYPES
@@ -899,7 +900,7 @@ constexpr backend_type_t get_default_backend_of_device(device_type_t dtype) {
   assert(dtype != device_type_t::NONE &&
 	 dtype != device_type_t::NUM_TYPES);
   if (dtype >= device_type_t::HDD &&
-      dtype <= device_type_t::SEGMENTED_EPHEMERAL) {
+      dtype <= device_type_t::EPHEMERAL_MAIN) {
     return backend_type_t::SEGMENTED;
   } else {
     return backend_type_t::RANDOM_BLOCK;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1189,8 +1189,7 @@ enum class data_category_t : uint8_t {
 std::ostream &operator<<(std::ostream &out, data_category_t c);
 
 constexpr data_category_t get_extent_category(extent_types_t type) {
-  if (type == extent_types_t::OBJECT_DATA_BLOCK ||
-      type == extent_types_t::COLL_BLOCK) {
+  if (type == extent_types_t::OBJECT_DATA_BLOCK) {
     return data_category_t::DATA;
   } else {
     return data_category_t::METADATA;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1746,7 +1746,8 @@ enum class transaction_type_t : uint8_t {
   READ, // including weak and non-weak read transactions
   TRIM_DIRTY,
   TRIM_ALLOC,
-  CLEANER,
+  CLEANER_MAIN,
+  CLEANER_COLD,
   MAX
 };
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1149,14 +1149,9 @@ constexpr rewrite_gen_t OOL_GENERATION = 2;
 
 // All the rewritten extents start with MIN_REWRITE_GENERATION
 constexpr rewrite_gen_t MIN_REWRITE_GENERATION = 3;
-constexpr rewrite_gen_t MAX_REWRITE_GENERATION = 4;
-
-/**
- * TODO:
- * For tiering, might introduce 5 and 6 for the cold tier, and 1 ~ 4 for the
- * hot tier.
- */
-
+// without cold tier, the largest generation is less than MIN_COLD_GENERATION
+constexpr rewrite_gen_t MIN_COLD_GENERATION = 5;
+constexpr rewrite_gen_t MAX_REWRITE_GENERATION = 7;
 constexpr rewrite_gen_t REWRITE_GENERATIONS = MAX_REWRITE_GENERATION + 1;
 constexpr rewrite_gen_t NULL_GENERATION =
   std::numeric_limits<rewrite_gen_t>::max();

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -44,7 +44,7 @@ std::ostream& operator<<(std::ostream &out, Segment::segment_state_t s)
 
 seastar::future<crimson::os::seastore::SegmentManagerRef>
 SegmentManager::get_segment_manager(
-  const std::string &device)
+  const std::string &device, device_type_t dtype)
 {
 #ifdef HAVE_ZNS
 LOG_PREFIX(SegmentManager::get_segment_manager);
@@ -71,7 +71,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
 	} else {
 	  return std::make_unique<
 	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block");
+	    >(device + "/block", dtype);
 	}
       });
     });
@@ -79,7 +79,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
-    >(device + "/block"));
+    >(device + "/block", dtype));
 #endif
 }
 

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -180,7 +180,8 @@ public:
 
   virtual ~SegmentManager() {}
 
-  static seastar::future<SegmentManagerRef> get_segment_manager(const std::string &device);
+  static seastar::future<SegmentManagerRef>
+  get_segment_manager(const std::string &device, device_type_t dtype);
 };
 
 }

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -58,7 +58,8 @@ struct block_sm_superblock_t {
     ceph_assert(first_segment_offset > tracker_offset &&
                 first_segment_offset % block_size == 0);
     ceph_assert(config.spec.magic != 0);
-    ceph_assert(config.spec.dtype == device_type_t::SSD);
+    ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
+		backend_type_t::SEGMENTED);
     ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
     if (!config.major_dev) {
       ceph_assert(config.secondary_devices.size() == 0);
@@ -154,10 +155,6 @@ using SegmentManagerRef = std::unique_ptr<SegmentManager>;
 
 class SegmentManager : public Device {
 public:
-  device_type_t get_device_type() const final {
-    return device_type_t::SSD;
-  }
-
   backend_type_t get_backend_type() const final {
     return backend_type_t::SEGMENTED;
   }

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -516,6 +516,7 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
   device_config_t sm_config)
 {
   LOG_PREFIX(BlockSegmentManager::mkfs);
+  ceph_assert(sm_config.spec.dtype == superblock.config.spec.dtype);
   set_device_id(sm_config.spec.id);
   INFO("{} path={}, {}",
        device_id_printer_t{get_device_id()}, device_path, sm_config);

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -118,8 +118,12 @@ public:
   close_ertr::future<> close();
 
   BlockSegmentManager(
-    const std::string &path)
-  : device_path(path) {}
+    const std::string &path,
+    device_type_t dtype)
+  : device_path(path) {
+    ceph_assert(get_device_type() == device_type_t::NONE);
+    superblock.config.spec.dtype = dtype;
+  }
 
   ~BlockSegmentManager();
 

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -132,6 +132,9 @@ public:
     size_t len,
     ceph::bufferptr &out) final;
 
+  device_type_t get_device_type() const final {
+    return superblock.config.spec.dtype;
+  }
   size_t get_available_size() const final {
     return superblock.size;
   }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -69,6 +69,10 @@ class EphemeralSegmentManager final : public SegmentManager {
   const ephemeral_config_t config;
   std::optional<device_config_t> device_config;
 
+  device_type_t get_device_type() const final {
+    return device_type_t::SEGMENTED_EPHEMERAL;
+  }
+
   size_t get_offset(paddr_t addr) {
     auto& seg_addr = addr.as_seg_paddr();
     return (seg_addr.get_segment_id().device_segment_id() * config.segment_size) +

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -42,7 +42,9 @@ std::ostream &operator<<(std::ostream &, const ephemeral_config_t &);
 EphemeralSegmentManagerRef create_test_ephemeral();
 
 device_config_t get_ephemeral_device_config(
-    std::size_t index, std::size_t num_devices);
+    std::size_t index,
+    std::size_t num_main_devices,
+    std::size_t num_cold_devices);
 
 class EphemeralSegment final : public Segment {
   friend class EphemeralSegmentManager;
@@ -70,7 +72,8 @@ class EphemeralSegmentManager final : public SegmentManager {
   std::optional<device_config_t> device_config;
 
   device_type_t get_device_type() const final {
-    return device_type_t::SEGMENTED_EPHEMERAL;
+    assert(device_config);
+    return device_config->spec.dtype;
   }
 
   size_t get_offset(paddr_t addr) {

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -115,6 +115,10 @@ namespace crimson::os::seastore::segment_manager::zns {
       size_t len, 
       ceph::bufferptr &out) final;
 
+    device_type_t get_device_type() const final {
+      return device_type_t::ZNS;
+    }
+
     size_t get_available_size() const final {
       return metadata.size;
     };

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -35,6 +35,11 @@ public:
   void add_segment_manager(SegmentManager* segment_manager) {
     auto device_id = segment_manager->get_device_id();
     ceph_assert(!has_device(device_id));
+    if (!device_ids.empty()) {
+      auto existing_id = *device_ids.begin();
+      ceph_assert(segment_managers[existing_id]->get_device_type()
+                  == segment_manager->get_device_type());
+    }
     segment_managers[device_id] = segment_manager;
     device_ids.insert(device_id);
   }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -709,6 +709,7 @@ TransactionManagerRef make_transaction_manager(
       cleaner_config,
       std::move(sms),
       *backref_manager,
+      epm->get_ool_segment_seq_allocator(),
       cleaner_is_detailed);
     auto segment_cleaner = static_cast<SegmentCleaner*>(cleaner.get());
     cache->set_segment_provider(*segment_cleaner);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -648,6 +648,9 @@ TransactionManagerRef make_transaction_manager(
   auto p_backend_type = primary_device->get_backend_type();
 
   if (p_backend_type == backend_type_t::SEGMENTED) {
+    auto dtype = primary_device->get_device_type();
+    ceph_assert(dtype != device_type_t::HDD &&
+		dtype != device_type_t::EPHEMERAL_COLD);
     sms->add_segment_manager(static_cast<SegmentManager*>(primary_device));
   } else {
     auto rbm = std::make_unique<BlockRBManager>(

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -122,7 +122,7 @@ struct btree_test_base :
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       sms.reset(new SegmentManagerGroup());
       journal = journal::make_segmented(*this, *this);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -86,7 +86,7 @@ struct cache_test_t : public seastar_test_suite_t {
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       epm.reset(new ExtentPlacementManager());
       cache.reset(new Cache(*epm));

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -146,7 +146,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
     return segment_manager->init(
     ).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, 1));
+        segment_manager::get_ephemeral_device_config(0, 1, 0));
     }).safe_then([this] {
       block_size = segment_manager->get_block_size();
       sms.reset(new SegmentManagerGroup());

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -63,7 +63,7 @@ public:
       });
     }).safe_then([this] {
       return segment_manager->mkfs(
-        segment_manager::get_ephemeral_device_config(0, get_num_devices()));
+        segment_manager::get_ephemeral_device_config(0, get_num_devices(), 0));
     }).safe_then([this] {
       return seastar::do_with(std::size_t(0), [this](auto &cnt) {
         return crimson::do_for_each(
@@ -73,7 +73,7 @@ public:
         {
           ++cnt;
           return sec_sm->mkfs(
-            segment_manager::get_ephemeral_device_config(cnt, get_num_devices()));
+            segment_manager::get_ephemeral_device_config(cnt, get_num_devices(), 0));
         });
       });
     }).handle_error(


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/47974

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh