### PR TITLE
reef: crimson/os/seastore: don't set INVALID extents to CLEAN when reading extents

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1311,11 +1311,15 @@ private:
     ).safe_then(
       [extent=std::move(extent)]() mutable {
         LOG_PREFIX(Cache::read_extent);
-        extent->state = CachedExtent::extent_state_t::CLEAN;
-        /* TODO: crc should be checked against LBA manager */
-        extent->last_committed_crc = extent->get_crc32c();
+	if (likely(extent->state == CachedExtent::extent_state_t::CLEAN_PENDING)) {
+	  extent->state = CachedExtent::extent_state_t::CLEAN;
+	  /* TODO: crc should be checked against LBA manager */
+	  extent->last_committed_crc = extent->get_crc32c();
 
-        extent->on_clean_read();
+	  extent->on_clean_read();
+	} else {
+	  ceph_assert(!extent->is_valid());
+	}
         extent->complete_io();
         SUBDEBUG(seastore_cache, "read extent done -- {}", *extent);
         return get_extent_ertr::make_ready_future<TCachedExtentRef<T>>(


### PR DESCRIPTION


---

backport of https://github.com/ceph/ceph/pull/50602

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh