### PR TITLE
reef: test/librados/snapshots*: Enable Crimson supported tests

### DIFF
--- a/src/test/librados/snapshots.cc
+++ b/src/test/librados/snapshots.cc
@@ -18,7 +18,6 @@ typedef RadosTestEC LibRadosSnapshotsSelfManagedEC;
 const int bufsize = 128;
 
 TEST_F(LibRadosSnapshots, SnapList) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -33,7 +32,6 @@ TEST_F(LibRadosSnapshots, SnapList) {
 }
 
 TEST_F(LibRadosSnapshots, SnapRemove) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -46,7 +44,6 @@ TEST_F(LibRadosSnapshots, SnapRemove) {
 }
 
 TEST_F(LibRadosSnapshots, Rollback) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -62,7 +59,6 @@ TEST_F(LibRadosSnapshots, Rollback) {
 }
 
 TEST_F(LibRadosSnapshots, SnapGetName) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -80,7 +76,6 @@ TEST_F(LibRadosSnapshots, SnapGetName) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
@@ -127,7 +122,6 @@ TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -20,7 +20,6 @@ typedef RadosTestECPP LibRadosSnapshotsSelfManagedECPP;
 const int bufsize = 128;
 
 TEST_F(LibRadosSnapshotsPP, SnapListPP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -40,7 +39,6 @@ TEST_F(LibRadosSnapshotsPP, SnapListPP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapRemovePP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -54,7 +52,6 @@ TEST_F(LibRadosSnapshotsPP, SnapRemovePP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, RollbackPP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -74,7 +71,6 @@ TEST_F(LibRadosSnapshotsPP, RollbackPP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapGetNamePP) {
-  SKIP_IF_CRIMSON();
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -93,7 +89,6 @@ TEST_F(LibRadosSnapshotsPP, SnapGetNamePP) {
 }
 
 TEST_F(LibRadosSnapshotsPP, SnapCreateRemovePP) {
-  SKIP_IF_CRIMSON();
   // reproduces http://tracker.ceph.com/issues/10262
   bufferlist bl;
   bl.append("foo");
@@ -112,7 +107,6 @@ TEST_F(LibRadosSnapshotsPP, SnapCreateRemovePP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, SnapPP) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_FALSE(cluster.get_pool_is_selfmanaged_snaps_mode(pool_name));
@@ -244,6 +238,7 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, RollbackPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, SnapOverlapPP) {
+  // WIP https://tracker.ceph.com/issues/58263
   SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   IoCtx readioctx;
@@ -374,7 +369,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, SnapOverlapPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, Bug11677) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps.back()));
@@ -466,7 +460,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, OrderSnap) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, ReusePurgedSnap) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps.back()));


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50491

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh