### PR TITLE
reef: crimson/os/seastore: implement get_stat() for RBM

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1615,6 +1615,7 @@ void RBMCleaner::mark_space_used(
     if (addr.get_device_id() == rbm->get_device_id()) {
       if (rbm->get_start() <= addr) {
 	INFO("allocate addr: {} len: {}", addr, len);
+	stats.used_bytes += len;
 	rbm->mark_space_used(addr, len);
       }
       return;
@@ -1633,6 +1634,8 @@ void RBMCleaner::mark_space_free(
     if (addr.get_device_id() == rbm->get_device_id()) {
       if (rbm->get_start() <= addr) {
 	INFO("free addr: {} len: {}", addr, len);
+	ceph_assert(stats.used_bytes >= len);
+	stats.used_bytes -= len;
 	rbm->mark_space_free(addr, len);
       }
       return;
@@ -1677,6 +1680,7 @@ RBMCleaner::clean_space_ret RBMCleaner::clean_space()
 RBMCleaner::mount_ret RBMCleaner::mount()
 {
   stats = {};
+  register_metrics();
   return seastar::do_with(
     rb_group->get_rb_managers(),
     [](auto &rbs) {
@@ -1768,6 +1772,22 @@ bool RBMCleaner::equals(const RBMSpaceTracker &_other) const
     }
   }
   return all_match;
+}
+
+void RBMCleaner::register_metrics()
+{
+  namespace sm = seastar::metrics;
+
+  metrics.add_group("rbm_cleaner", {
+    sm::make_counter("total_bytes",
+		     [this] { return get_total_bytes(); },
+		     sm::description("the size of the space")),
+    sm::make_counter("available_bytes",
+		     [this] { return get_total_bytes() - get_journal_bytes() - stats.used_bytes; },
+		     sm::description("the size of the space is available")),
+    sm::make_counter("used_bytes", stats.used_bytes,
+		     sm::description("the size of the space occupied by live extents")),
+  });
 }
 
 }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1613,7 +1613,10 @@ public:
 
   store_statfs_t get_stat() const final {
     store_statfs_t st;
-    // TODO 
+    st.total = get_total_bytes();
+    st.available = get_total_bytes() - get_journal_bytes() - stats.used_bytes;
+    st.allocated = get_journal_bytes() + stats.used_bytes;
+    st.data_stored = get_journal_bytes() + stats.used_bytes;
     return st;
   }
 
@@ -1654,7 +1657,27 @@ public:
   paddr_t alloc_paddr(extent_len_t length) {
     // TODO: implement allocation strategy (dirty metadata and multiple devices)
     auto rbs = rb_group->get_rb_managers();
-    return rbs[0]->alloc_extent(length);
+    auto paddr = rbs[0]->alloc_extent(length);
+    stats.used_bytes += length;
+    return paddr;
+  }
+
+  size_t get_total_bytes() const {
+    auto rbs = rb_group->get_rb_managers();
+    size_t total = 0;
+    for (auto p : rbs) {
+      total += p->get_device()->get_available_size();
+    }
+    return total;
+  }
+
+  size_t get_journal_bytes() const {
+    auto rbs = rb_group->get_rb_managers();
+    size_t total = 0;
+    for (auto p : rbs) {
+      total += p->get_journal_size();
+    }
+    return total;
   }
 
   // Testing interfaces
@@ -1689,6 +1712,8 @@ private:
      */
     uint64_t projected_used_bytes = 0;
   } stats;
+  seastar::metrics::metric_group metrics;
+  void register_metrics();
 
   ExtentCallbackInterface *extent_callback = nullptr;
   BackgroundListener *background_callback = nullptr;

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -105,6 +105,7 @@ public:
   virtual Device* get_device() = 0;
   virtual paddr_t get_start() = 0;
   virtual rbm_extent_state_t get_extent_state(paddr_t addr, size_t size) = 0;
+  virtual size_t get_journal_size() const = 0;
   virtual ~RandomBlockManager() {}
 };
 using RandomBlockManagerRef = std::unique_ptr<RandomBlockManager>;

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -123,6 +123,10 @@ public:
     return allocator->get_extent_state(addr, size);
   }
 
+  size_t get_journal_size() const final {
+    return device->get_journal_size();
+  }
+
 private:
   /*
    * this contains the number of bitmap blocks, free blocks and


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50555

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh