### PR TITLE
reef: crimson/os/seastore: ensure transaction commit order

### DIFF
--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -233,10 +233,10 @@ private:
 	transaction_manager->create_transaction(src, tname)),
       std::forward<F>(f),
       [this, op_type](auto &ctx, auto &f) {
-	return throttler.get(1).then([&ctx] {
-	  return ctx.transaction->get_handle().take_collection_lock(
-	    static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
-	  );
+	return ctx.transaction->get_handle().take_collection_lock(
+	  static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
+	).then([this] {
+	  return throttler.get(1);
 	}).then([&, this] {
 	  return repeat_eagain([&, this] {
 	    ctx.reset_preserve_handle(*transaction_manager);


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50839

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh