### PR TITLE
reef: crimson/os/seastore: avoid segment nonce collision

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1301,6 +1301,7 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
         if (tail.segment_nonce != header.segment_nonce) {
           return scan_no_tail_segment(header, segment_id);
         }
+        ceph_assert(header.get_type() == tail.get_type());
 
         sea_time_point modify_time = mod_to_timepoint(tail.modify_time);
         std::size_t num_extents = tail.num_extents;


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50840

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh