### PR TITLE
reef: crimson/osd: Handle rollback to head obejct

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -788,6 +788,13 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
     head, target_coid,
     [this, &os, &txn, &delta_stats, &osd_op_params]
     (auto clone_obc) {
+    if (clone_obc->obs.oi.soid.is_head()) {
+      // no-op: The resolved oid returned the head object.
+      logger().debug("PGBackend::rollback: loaded head_obc: {}"
+                     " do nothing",
+                     clone_obc->obs.oi.soid);
+      return rollback_iertr::now();
+    }
     logger().debug("PGBackend::rollback: loaded clone_obc: {}",
                    clone_obc->obs.oi.soid);
     // 1) Delete current head

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -784,7 +784,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
                   __func__, os.oi.soid ,snapid);
   hobject_t target_coid = os.oi.soid;
   target_coid.snap = snapid;
-  return obc_loader.with_clone_obc_only<RWState::RWREAD>(
+  return obc_loader.with_clone_obc_only<RWState::RWWRITE>(
     head, target_coid,
     [this, &os, &txn, &delta_stats, &osd_op_params]
     (auto clone_obc) {

--- a/src/test/librados/snapshots.cc
+++ b/src/test/librados/snapshots.cc
@@ -127,7 +127,6 @@ TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   my_snaps.push_back(-2);
   ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
@@ -137,6 +136,7 @@ TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
   ::std::reverse(my_snaps.begin(), my_snaps.end());
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));
+  // First write
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
 
   my_snaps.push_back(-2);
@@ -147,7 +147,9 @@ TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
   ::std::reverse(my_snaps.begin(), my_snaps.end());
   char buf2[sizeof(buf)];
   memset(buf2, 0xdd, sizeof(buf2));
+  // Second write
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf2, sizeof(buf2), 0));
+  // Rollback to my_snaps[1] - Object is expeceted to conatin the first write
   rados_ioctx_selfmanaged_snap_rollback(ioctx, "foo", my_snaps[1]);
   char buf3[sizeof(buf)];
   ASSERT_EQ((int)sizeof(buf3), rados_read(ioctx, "foo", buf3, sizeof(buf3), 0));
@@ -159,6 +161,51 @@ TEST_F(LibRadosSnapshotsSelfManaged, Rollback) {
   my_snaps.pop_back();
   ASSERT_EQ(0, rados_remove(ioctx, "foo"));
 }
+
+TEST_F(LibRadosSnapshotsSelfManaged, FutureSnapRollback) {
+  std::vector<uint64_t> my_snaps;
+  // Snapshot 1
+  my_snaps.push_back(-2);
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
+  ::std::reverse(my_snaps.begin(), my_snaps.end());
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_set_write_ctx(ioctx, my_snaps[0],
+					&my_snaps[0], my_snaps.size()));
+  ::std::reverse(my_snaps.begin(), my_snaps.end());
+  char buf[bufsize];
+  memset(buf, 0xcc, sizeof(buf));
+  // First write
+  ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
+
+  // Snapshot 2
+  my_snaps.push_back(-2);
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
+  ::std::reverse(my_snaps.begin(), my_snaps.end());
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_set_write_ctx(ioctx, my_snaps[0],
+					&my_snaps[0], my_snaps.size()));
+  ::std::reverse(my_snaps.begin(), my_snaps.end());
+  char buf2[sizeof(buf)];
+  memset(buf2, 0xdd, sizeof(buf2));
+  // Second write
+  ASSERT_EQ(0, rados_write(ioctx, "foo", buf2, sizeof(buf2), 0));
+  // Snapshot 3
+  my_snaps.push_back(-2);
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back()));
+
+  // Rollback to the last snap id - Object is expected to conatin
+  // latest write (head object)
+  rados_ioctx_selfmanaged_snap_rollback(ioctx, "foo", my_snaps[2]);
+  char buf3[sizeof(buf)];
+  ASSERT_EQ((int)sizeof(buf3), rados_read(ioctx, "foo", buf3, sizeof(buf3), 0));
+  ASSERT_EQ(0, memcmp(buf3, buf2, sizeof(buf)));
+
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_remove(ioctx, my_snaps.back()));
+  my_snaps.pop_back();
+  ASSERT_EQ(0, rados_ioctx_selfmanaged_snap_remove(ioctx, my_snaps.back()));
+  my_snaps.pop_back();
+  ASSERT_EQ(0, rados_remove(ioctx, "foo"));
+}
+
+
 
 // EC testing
 TEST_F(LibRadosSnapshotsEC, SnapList) {

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -465,6 +465,53 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, OrderSnap) {
   comp4->release();
 }
 
+TEST_F(LibRadosSnapshotsSelfManagedPP, WriteRollback) {
+  // https://tracker.ceph.com/issues/59114
+  GTEST_SKIP();
+  uint64_t snapid = 5;
+
+  // buf1
+  char buf[bufsize];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  // buf2
+  char buf2[sizeof(buf)];
+  memset(buf2, 0xdd, sizeof(buf2));
+  bufferlist bl2;
+  bl2.append(buf2, sizeof(buf2));
+
+  // First write
+  ObjectWriteOperation op_write1;
+  op_write1.write(0, bl);
+  // Operate
+  librados::AioCompletion *comp_write = cluster.aio_create_completion();
+  ASSERT_EQ(0, ioctx.aio_operate("foo", comp_write, &op_write1, 0));
+  ASSERT_EQ(0, comp_write->wait_for_complete());
+  ASSERT_EQ(0, comp_write->get_return_value());
+  comp_write->release();
+
+  // Take Snapshot
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&snapid));
+
+  // Rollback + Second write in the same op
+  ObjectWriteOperation op_write2_snap_rollback;
+  op_write2_snap_rollback.write(0, bl2);
+  op_write2_snap_rollback.selfmanaged_snap_rollback(snapid);
+  // Operate
+  librados::AioCompletion *comp_write2 = cluster.aio_create_completion();
+  ASSERT_EQ(0, ioctx.aio_operate("foo", comp_write2, &op_write2_snap_rollback, 0));
+  ASSERT_EQ(0, comp_write2->wait_for_complete());
+  ASSERT_EQ(0, comp_write2->get_return_value());
+  comp_write2->release();
+
+  // Resolved should be first write
+  bufferlist bl3;
+  EXPECT_EQ((int)sizeof(buf), ioctx.read("foo", bl3, sizeof(buf), 0));
+  EXPECT_EQ(0, memcmp(buf, bl3.c_str(), sizeof(buf)));
+}
+
 TEST_F(LibRadosSnapshotsSelfManagedPP, ReusePurgedSnap) {
   SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50530

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh