### PR TITLE
reef: crimson/osd/pg: make clone object's version consistent with pglog

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -951,7 +951,7 @@ std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
   cloning_ctx->log_entry = {
     pg_log_entry_t::CLONE,
     coid,
-    osd_op_params->at_version,
+    snap_oi.version,
     initial_obs.oi.version,
     initial_obs.oi.user_version,
     osd_reqid_t(),
@@ -965,12 +965,10 @@ std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
 }
 
 void OpsExecuter::CloningContext::apply_to(
-  const eversion_t& at_version,
   std::vector<pg_log_entry_t>& log_entries,
   ObjectContext& processed_obc) &&
 {
   log_entry.mtime = processed_obc.obs.oi.mtime;
-  log_entry.version = at_version;
   log_entries.emplace_back(std::move(log_entry));
   processed_obc.ssc->snapset = std::move(new_snapset);
 }
@@ -985,11 +983,7 @@ OpsExecuter::flush_clone_metadata(
   assert(!txn.empty());
   auto maybe_snap_mapped = interruptor::now();
   if (cloning_ctx) {
-    osd_op_params->at_version = pg->next_version();
-    std::move(*cloning_ctx).apply_to(
-      osd_op_params->at_version,
-      log_entries,
-      *obc);
+    std::move(*cloning_ctx).apply_to(log_entries, *obc);
     const auto& coid = log_entries.back().soid;
     const auto& cloned_snaps = obc->ssc->snapset.clone_snaps[coid.snap];
     maybe_snap_mapped = snap_map_clone(
@@ -1019,7 +1013,7 @@ std::pair<object_info_t, ObjectContextRef> OpsExecuter::prepare_clone(
   const hobject_t& coid)
 {
   object_info_t static_snap_oi(coid);
-  static_snap_oi.version = osd_op_params->at_version;
+  static_snap_oi.version = pg->next_version();
   static_snap_oi.prior_version = obc->obs.oi.version;
   static_snap_oi.copy_user_bits(obc->obs.oi);
   if (static_snap_oi.is_whiteout()) {

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -190,7 +190,6 @@ private:
     pg_log_entry_t log_entry;
 
     void apply_to(
-      const eversion_t& at_version,
       std::vector<pg_log_entry_t>& log_entries,
       ObjectContext& processed_obc) &&;
   };


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51202

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh