### PR TITLE
reef: crimson/osd/heartbeat: share osdmap to peers when necessary

### DIFF
--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -124,7 +124,7 @@ void Heartbeat::add_peer(osd_id_t _peer, epoch_t epoch)
   assert(whoami != _peer);
   auto [iter, added] = peers.try_emplace(_peer, *this, _peer);
   auto& peer = iter->second;
-  peer.set_epoch(epoch);
+  peer.set_epoch_added(epoch);
 }
 
 Heartbeat::osds_t Heartbeat::remove_down_peers()
@@ -136,7 +136,7 @@ Heartbeat::osds_t Heartbeat::remove_down_peers()
     if (!osdmap->is_up(osd)) {
       i = peers.erase(i);
     } else {
-      if (peer.get_epoch() < osdmap->get_epoch()) {
+      if (peer.get_epoch_added() < osdmap->get_epoch()) {
         old_osds.push_back(osd);
       }
       ++i;

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -274,8 +274,8 @@ class Heartbeat::Session {
  public:
   Session(osd_id_t peer) : peer{peer} {}
 
-  void set_epoch(epoch_t epoch_) { epoch = epoch_; }
-  epoch_t get_epoch() const { return epoch; }
+  void set_epoch_added(epoch_t epoch_) { epoch = epoch_; }
+  epoch_t get_epoch_added() const { return epoch; }
   bool is_started() const { return connected; }
   bool pinged() const {
     if (clock::is_zero(first_tx)) {
@@ -404,8 +404,9 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   Peer& operator=(Peer&&) = delete;
   Peer& operator=(const Peer&) = delete;
 
-  void set_epoch(epoch_t epoch) { session.set_epoch(epoch); }
-  epoch_t get_epoch() const { return session.get_epoch(); }
+  // set/get the epoch at which the peer was added
+  void set_epoch_added(epoch_t epoch) { session.set_epoch_added(epoch); }
+  epoch_t get_epoch_added() const { return session.get_epoch_added(); }
 
   // if failure, return time_point since last active
   // else, return clock::zero()

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -384,7 +384,7 @@ class Heartbeat::Session {
   // last time we got a ping reply on the back side
   clock::time_point last_rx_back;
   // most recent epoch we wanted this peer
-  epoch_t epoch;
+  epoch_t epoch; // rename me to epoch_added
 
   struct reply_t {
     clock::time_point deadline;

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -276,6 +276,10 @@ class Heartbeat::Session {
 
   void set_epoch_added(epoch_t epoch_) { epoch = epoch_; }
   epoch_t get_epoch_added() const { return epoch; }
+
+  void set_last_epoch_sent(epoch_t epoch_) { last_sent_epoch = epoch_; }
+  epoch_t get_last_epoch_sent() const { return last_sent_epoch; }
+
   bool is_started() const { return connected; }
   bool pinged() const {
     if (clock::is_zero(first_tx)) {
@@ -385,6 +389,8 @@ class Heartbeat::Session {
   clock::time_point last_rx_back;
   // most recent epoch we wanted this peer
   epoch_t epoch; // rename me to epoch_added
+  // last epoch sent
+  epoch_t last_sent_epoch = 0;
 
   struct reply_t {
     clock::time_point deadline;
@@ -407,6 +413,9 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   // set/get the epoch at which the peer was added
   void set_epoch_added(epoch_t epoch) { session.set_epoch_added(epoch); }
   epoch_t get_epoch_added() const { return session.get_epoch_added(); }
+
+  void set_last_epoch_sent(epoch_t epoch) { session.set_last_epoch_sent(epoch); }
+  epoch_t get_last_epoch_sent() const { return session.get_last_epoch_sent(); }
 
   // if failure, return time_point since last active
   // else, return clock::zero()

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -27,7 +27,7 @@ public:
   using osd_id_t = int;
 
   Heartbeat(osd_id_t whoami,
-            const crimson::osd::ShardServices& service,
+	    crimson::osd::ShardServices& service,
 	    crimson::mon::Client& monc,
 	    crimson::net::Messenger &front_msgr,
 	    crimson::net::Messenger &back_msgr);
@@ -73,9 +73,11 @@ private:
 
   seastar::future<> start_messenger(crimson::net::Messenger& msgr,
 				    const entity_addrvec_t& addrs);
+  seastar::future<> maybe_share_osdmap(crimson::net::ConnectionRef,
+                                       Ref<MOSDPing> m);
 private:
   const osd_id_t whoami;
-  const crimson::osd::ShardServices& service;
+  crimson::osd::ShardServices& service;
   crimson::mon::Client& monc;
   crimson::net::Messenger &front_msgr;
   crimson::net::Messenger &back_msgr;

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -730,6 +730,18 @@ seastar::future<> OSDSingletonState::send_incremental_map(
   }
 }
 
-
+seastar::future<> OSDSingletonState::send_incremental_map_to_osd(
+  int osd,
+  epoch_t first)
+{
+  if (osdmap->is_down(osd)) {
+    logger().info("{}: osd.{} is_down", __func__, osd);
+    return seastar::now();
+  } else {
+    auto conn = cluster_msgr.connect(
+      osdmap->get_cluster_addrs(osd).front(), CEPH_ENTITY_TYPE_OSD);
+    return send_incremental_map(*conn, first);
+  }
+}
 
 };

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -380,6 +380,8 @@ seastar::future<std::map<epoch_t, bufferlist>> OSDSingletonState::load_map_bls(
   epoch_t first,
   epoch_t last)
 {
+  logger().debug("{} loading maps [{},{}]",
+                 __func__, first, last);
   ceph_assert(first <= last);
   return seastar::map_reduce(boost::make_counting_iterator<epoch_t>(first),
 			     boost::make_counting_iterator<epoch_t>(last + 1),

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -235,6 +235,8 @@ private:
     crimson::net::Connection &conn,
     epoch_t first);
 
+  seastar::future<> send_incremental_map_to_osd(int osd, epoch_t first);
+
   auto get_pool_info(int64_t poolid) {
     return get_meta_coll().load_final_pool_info(poolid);
   }
@@ -451,6 +453,7 @@ public:
   FORWARD(with_throttle_while, with_throttle_while, local_state.throttler)
 
   FORWARD_TO_OSD_SINGLETON(send_incremental_map)
+  FORWARD_TO_OSD_SINGLETON(send_incremental_map_to_osd)
 
   FORWARD_TO_OSD_SINGLETON(osdmap_subscribe)
   FORWARD_TO_OSD_SINGLETON(queue_want_pg_temp)


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50227

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh