### PR TITLE
reef: qa/suites/crimson-rados/rbd: Add new rbd image format api tests

### DIFF
--- a/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
@@ -1,0 +1,21 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - overall HEALTH_
+      - \(CACHE_POOL_NO_HIT_SET\)
+      - \(POOL_APP_NOT_ENABLED\)
+      - is full \(reached quota
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(POOL_FULL\)
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/crimson/test_crimson_librbd.sh
+    env:
+      RBD_FEATURES: "61"
+

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
+#include "test/librados/crimson_utils.h"
 
 #include <errno.h>
 #include <string>
@@ -1797,6 +1798,7 @@ TEST_F(TestClsRbd, mirror_image) {
 }
 
 TEST_F(TestClsRbd, mirror_image_status) {
+  SKIP_IF_CRIMSON();
   struct WatchCtx : public librados::WatchCtx2 {
     librados::IoCtx *m_ioctx;
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
+#include "test/librados/crimson_utils.h"
 #include "include/rbd/librbd.h"
 #include "include/rbd/librbd.hpp"
 #include "test/librados/test.h"
@@ -219,6 +220,7 @@ TEST_F(TestGroup, add_imagePP)
 
 TEST_F(TestGroup, add_snapshot)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   rados_ioctx_t ioctx;
@@ -365,6 +367,7 @@ TEST_F(TestGroup, add_snapshot)
 
 TEST_F(TestGroup, add_snapshotPP)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   librados::IoCtx ioctx;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -29,6 +29,7 @@
 #include <boost/assign/list_of.hpp>
 #include <utility>
 #include <vector>
+#include "test/librados/crimson_utils.h"
 
 using namespace std;
 
@@ -267,6 +268,7 @@ TEST_F(TestInternal, SnapCreateFailsToLockImage) {
 }
 
 TEST_F(TestInternal, SnapRollbackLocksImage) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   ASSERT_EQ(0, create_snapshot("snap1", false));
@@ -378,6 +380,7 @@ TEST_F(TestInternal, FlattenFailsToLockImage) {
 }
 
 TEST_F(TestInternal, WriteFailsToLockImageBlocklisted) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::Rados blocklist_rados;
@@ -411,6 +414,7 @@ TEST_F(TestInternal, WriteFailsToLockImageBlocklisted) {
 }
 
 TEST_F(TestInternal, WriteFailsToLockImageBlocklistedWatch) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::Rados blocklist_rados;
@@ -654,6 +658,9 @@ TEST_F(TestInternal, MetadataConfApply) {
 
 TEST_F(TestInternal, SnapshotCopyup)
 {
+  //https://tracker.ceph.com/issues/58263
+  // Clone overlap is WIP
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1175,6 +1182,7 @@ TEST_F(TestInternal, ImageOptions) {
 }
 
 TEST_F(TestInternal, WriteFullCopyup) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1729,6 +1737,7 @@ TEST_F(TestInternal, Sparsify) {
 
 
 TEST_F(TestInternal, SparsifyClone) {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -21,6 +21,7 @@
 #include "include/err.h"
 #include "common/ceph_mutex.h"
 #include "json_spirit/json_spirit.h"
+#include "test/librados/crimson_utils.h"
 
 #include "gtest/gtest.h"
 
@@ -6924,6 +6925,7 @@ TEST_F(TestLibRBD, ListChildren)
 
 TEST_F(TestLibRBD, ListChildrenTiered)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::RBD rbd;
@@ -8527,6 +8529,7 @@ TEST_F(TestLibRBD, SnapshotLimitPP)
 
 TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
 
   librados::IoCtx ioctx;
@@ -8579,6 +8582,7 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8619,6 +8623,7 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
 
 TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8663,6 +8668,7 @@ TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 
 TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   librados::IoCtx ioctx;
@@ -8703,7 +8709,7 @@ TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 }
 
 TEST_F(TestLibRBD, UpdateFeaturesViaLockOwner) {
-
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8954,6 +8960,7 @@ TEST_F(TestLibRBD, SnapUnprotectViaLockOwner)
 
 TEST_F(TestLibRBD, FlattenViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9002,6 +9009,7 @@ TEST_F(TestLibRBD, FlattenViaLockOwner)
 
 TEST_F(TestLibRBD, ResizeViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9038,6 +9046,7 @@ TEST_F(TestLibRBD, ResizeViaLockOwner)
 
 TEST_F(TestLibRBD, SparsifyViaLockOwner)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9742,6 +9751,7 @@ TEST_F(TestLibRBD, BlockingAIO)
 
 TEST_F(TestLibRBD, ExclusiveLockTransition)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -10415,6 +10425,7 @@ TEST_F(TestLibRBD, FlushCacheWithCopyupOnExternalSnapshot) {
 
 TEST_F(TestLibRBD, ExclusiveLock)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   static char buf[10];
@@ -10558,6 +10569,7 @@ TEST_F(TestLibRBD, ExclusiveLock)
 
 TEST_F(TestLibRBD, BreakLock)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
   REQUIRE(!is_rbd_pwl_enabled((CephContext *)_rados.cct()));
 
@@ -11949,6 +11961,7 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
 
 TEST_F(TestLibRBD, QuiesceWatch)
 {
+  SKIP_IF_CRIMSON();
   rados_ioctx_t ioctx;
   rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
 
@@ -12040,6 +12053,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
 
 TEST_F(TestLibRBD, QuiesceWatchPP)
 {
+  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -12119,6 +12133,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
 
 TEST_F(TestLibRBD, QuiesceWatchError)
 {
+  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -12477,6 +12492,7 @@ TEST_F(TestLibRBD, WriteZeroesThickProvision) {
 
 TEST_F(TestLibRBD, ConcurentOperations)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::RBD rbd;

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -13,6 +13,7 @@
  */
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
+#include "test/librados/crimson_utils.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
@@ -1223,6 +1224,7 @@ TEST_F(TestMirroring, SnapshotRemoveOnDisable)
 
 TEST_F(TestMirroring, SnapshotUnlinkPeer)
 {
+  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50457

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh