### PR TITLE
reef: crimson/osd/objclass: Fix compilation warning

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -276,7 +276,7 @@ int cls_cxx_setxattr(cls_method_context_t hctx,
 
 int cls_cxx_snap_revert(cls_method_context_t hctx, snapid_t snapid)
 {
-  OSDOp op{op = CEPH_OSD_OP_ROLLBACK};
+  OSDOp op{CEPH_OSD_OP_ROLLBACK};
   op.op.snap.snapid = snapid;
   return execute_osd_op(hctx, op);
 }


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51333

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh