### PR TITLE
reef: crimson/qa: make crimson run multicore in teuthology test

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -5,6 +5,8 @@ overrides:
         enable experimental unrecoverable data corrupting features: crimson
       mon:
         osd pool default crimson: true
+      osd:
+        crimson seastar smp: 3
     flavor: crimson
   workunit:
     env:


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51167

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh