### PR TITLE
reef: crimson/osd/scheduler/mclock_scheduler: Fix OSD unable to start

### DIFF
--- a/src/crimson/osd/scheduler/mclock_scheduler.cc
+++ b/src/crimson/osd/scheduler/mclock_scheduler.cc
@@ -45,21 +45,21 @@ mClockScheduler::mClockScheduler(ConfigProxy &conf) :
 void mClockScheduler::ClientRegistry::update_from_config(const ConfigProxy &conf)
 {
   default_external_client_info.update(
-    conf.get_val<uint64_t>("osd_mclock_scheduler_client_res"),
+    conf.get_val<double>("osd_mclock_scheduler_client_res"),
     conf.get_val<uint64_t>("osd_mclock_scheduler_client_wgt"),
-    conf.get_val<uint64_t>("osd_mclock_scheduler_client_lim"));
+    conf.get_val<double>("osd_mclock_scheduler_client_lim"));
 
   internal_client_infos[
     static_cast<size_t>(scheduler_class_t::background_recovery)].update(
-    conf.get_val<uint64_t>("osd_mclock_scheduler_background_recovery_res"),
+    conf.get_val<double>("osd_mclock_scheduler_background_recovery_res"),
     conf.get_val<uint64_t>("osd_mclock_scheduler_background_recovery_wgt"),
-    conf.get_val<uint64_t>("osd_mclock_scheduler_background_recovery_lim"));
+    conf.get_val<double>("osd_mclock_scheduler_background_recovery_lim"));
 
   internal_client_infos[
     static_cast<size_t>(scheduler_class_t::background_best_effort)].update(
-    conf.get_val<uint64_t>("osd_mclock_scheduler_background_best_effort_res"),
+    conf.get_val<double>("osd_mclock_scheduler_background_best_effort_res"),
     conf.get_val<uint64_t>("osd_mclock_scheduler_background_best_effort_wgt"),
-    conf.get_val<uint64_t>("osd_mclock_scheduler_background_best_effort_lim"));
+    conf.get_val<double>("osd_mclock_scheduler_background_best_effort_lim"));
 }
 
 const dmc::ClientInfo *mClockScheduler::ClientRegistry::get_external_client(


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51448

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh