### PR TITLE
reef: cephadm: require --image is passed to inspect-image

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -19,7 +19,7 @@ Synopsis
 
 | **cephadm** **pull**
 
-| **cephadm** **inspect-image**
+| **cephadm** --image IMAGE_NAME **inspect-image**
 
 | **cephadm** **ls** [-h] [--no-detail] [--legacy-dir LEGACY_DIR]
 
@@ -334,7 +334,10 @@ Positional arguments:
 inspect-image
 -------------
 
-inspect local ceph container image.
+Inspect local Ceph container image. From Reef onward, requires specifying
+the image to inspect with ``--image``::
+
+    cephadm --image IMAGE_NAME inspect-image
 
 list-networks
 -------------

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2243,6 +2243,19 @@ def infer_image(func: FuncT) -> FuncT:
     return cast(FuncT, _infer_image)
 
 
+def require_image(func: FuncT) -> FuncT:
+    """
+    Require the global --image flag to be set
+    """
+    @wraps(func)
+    def _require_image(ctx: CephadmContext) -> Any:
+        if not ctx.image:
+            raise Error('This command requires the global --image option to be set')
+        return func(ctx)
+
+    return cast(FuncT, _require_image)
+
+
 def default_image(func: FuncT) -> FuncT:
     @wraps(func)
     def _default_image(ctx: CephadmContext) -> Any:
@@ -4882,6 +4895,7 @@ def _pull_image(ctx, image, insecure=False):
 ##################################
 
 
+@require_image
 @infer_image
 def command_inspect_image(ctx):
     # type: (CephadmContext) -> int

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -152,6 +152,18 @@ class TestCephAdm(object):
         args = _cephadm._parse_args(['--image', 'foo', 'version'])
         assert args.image == 'foo'
 
+    def test_check_required_global_args(self):
+        ctx = _cephadm.CephadmContext()
+        mock_fn = mock.Mock()
+        mock_fn.return_value = 0
+        require_image = _cephadm.require_image(mock_fn)
+
+        with pytest.raises(_cephadm.Error, match='This command requires the global --image option to be set'):
+            require_image(ctx)
+
+        ctx.image = 'sample-image'
+        require_image(ctx)
+
     @mock.patch('cephadm.logger')
     def test_parse_mem_usage(self, _logger):
         len, summary = _cephadm._parse_mem_usage(0, 'c6290e3f1489,-- / --')


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/51172

The selection of an image by default was likely unused and has always been a bit of a flaky thing, especially if multiple clusters are making use of the host where this is run. It seems preferable to just require this argument. Additionally, the command without the image specified is currently untested and prone to being broken. All uses of inspect-image done through the cephadm mgr module specify the image.

Signed-off-by: Adam King <adking@redhat.com>
(cherry picked from commit 110fcb04adf31881f2f41bd0c27f7ce25438f3b9)

