### PR TITLE
cephadm: Adding support to configure public_network cfg section

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5631,8 +5631,10 @@ def finish_bootstrap_config(
         cli(['config', 'set', 'global', 'container_image', f'{ctx.image}'])
 
     if mon_network:
-        logger.info(f'Setting mon public_network to {mon_network}')
-        cli(['config', 'set', 'mon', 'public_network', mon_network])
+        cp = read_config(ctx.config)
+        cfg_section = 'global' if cp.has_option('global', 'public_network') else 'mon'
+        logger.info(f'Setting public_network to {mon_network} in {cfg_section} config section')
+        cli(['config', 'set', cfg_section, 'public_network', mon_network])
 
     if cluster_network:
         logger.info(f'Setting cluster_network to {cluster_network}')


### PR DESCRIPTION
So far cephadm always set the `public_network` as part of the `mon` configuration section during a cluster bootsratp without providing any configuration option to alter this behavior (so user can configure `public_network` as `global` i.e). With this fix the idea is to use the ceph configuration file to specify in which section the user want to put `public_network` parameter.

**Testing:** 

**Use case 1:**
Bootstrap a cluster providing configuration file  where `public_network` is defined in `global` section.

```
[root@ceph-node-0 ~]# cat ceph.conf 
[global]
public_network = 192.168.100.0/24

[root@ceph-node-0 ~]# cephadm --image quay.ceph.io/ceph-ci/ceph:main bootstrap --mon-ip 192.168.100.100 --initial-dashboard-password admin --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/home/redo/workspaces/ceph -c ceph.conf 
Verifying podman|docker is present...
Verifying lvm2 is present...
Verifying time synchronization is in place...
Unit chronyd.service is enabled and running
...
...
[root@ceph-node-0 ~]# cephadm shell
Inferring fsid 27317454-f87e-11ed-896e-5254002b853a
Inferring config /var/lib/ceph/27317454-f87e-11ed-896e-5254002b853a/mon.ceph-node-0/config
Using ceph image with id 'd2ff4754afde' and tag 'main' created on 2023-05-21 21:46:27 +0000 UTC
quay.ceph.io/ceph-ci/ceph@sha256:8cef21adb9e7e803e44ebba93d5a6cd7b0be71de74412f6123e77a509e851944
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph config dump | grep -i public_network
global        advanced  public_network                         192.168.100.0/24         

```



**Use case 2:**
Bootstrap a cluster without providing any configuration file and make sure legacy behavior is still the same: `public_network` is defined as part of `mon` section

```
[root@ceph-node-0 ~]# cephadm --image quay.ceph.io/ceph-ci/ceph:main bootstrap --mon-ip 192.168.100.100 --initial-dashboard-password admin --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/home/redo/workspaces/ceph
Verifying podman|docker is present...
Verifying lvm2 is present...
...
...
[root@ceph-node-0 ~]# cephadm shell
Inferring fsid 98422ff8-f87e-11ed-a96a-5254002b853a
Inferring config /var/lib/ceph/98422ff8-f87e-11ed-a96a-5254002b853a/mon.ceph-node-0/config
Using ceph image with id 'd2ff4754afde' and tag 'main' created on 2023-05-21 21:46:27 +0000 UTC
quay.ceph.io/ceph-ci/ceph@sha256:8cef21adb9e7e803e44ebba93d5a6cd7b0be71de74412f6123e77a509e851944
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph config dump | grep -i public_network
mon           advanced  public_network                         192.168.100.0/24  

```

Fixes: https://tracker.ceph.com/issues/61330





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
