### PR TITLE
reef: osd/scheduler: Reset ephemeral changes to mClock built-in profile

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -173,6 +173,11 @@ in order to ensure mClock scheduler is able to provide predictable QoS.
 
 mClock Config Options
 ---------------------
+.. important:: These defaults cannot be changed using any of the config
+   subsytem commands like *config set* or via the *config daemon* or *config
+   tell* interfaces. Although the above command(s) report success, the mclock
+   QoS parameters are reverted to their respective built-in profile defaults.
+
 When a built-in profile is enabled, the mClock scheduler calculates the low
 level mclock parameters [*reservation*, *weight*, *limit*] based on the profile
 enabled for each client type. The mclock parameters are calculated based on

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1432,6 +1432,12 @@ def exec_test():
     remote.run(args=[CEPH_CMD, "tell", "osd.*", "injectargs", "--osd-mon-report-interval", "5"])
     ceph_cluster.set_ceph_conf("osd", "osd_mon_report_interval", "5")
 
+    # Enable override of recovery options if mClock scheduler is active. This is to allow
+    # current and future tests to modify recovery related limits. This is because by default,
+    # with mclock enabled, a subset of recovery options are not allowed to be modified.
+    remote.run(args=[CEPH_CMD, "tell", "osd.*", "injectargs", "--osd-mclock-override-recovery-settings", "true"])
+    ceph_cluster.set_ceph_conf("osd", "osd_mclock_override_recovery_settings", "true")
+
     # Vstart defaults to two segments, which very easily gets a "behind on trimming" health warning
     # from normal IO latency.  Increase it for running teests.
     ceph_cluster.set_ceph_conf("mds", "mds log max segments", "10")

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -186,6 +186,11 @@ void MonCapGrant::expand_profile(const EntityName& name) const
     StringConstraint constraint(StringConstraint::MATCH_TYPE_REGEX,
                                 string("osd_mclock_max_capacity_iops_(hdd|ssd)"));
     profile_grants.push_back(MonCapGrant("config set", "name", constraint));
+    constraint = StringConstraint(StringConstraint::MATCH_TYPE_REGEX,
+                                  string("^(osd_max_backfills|") +
+                                  string("osd_recovery_max_active(.*)|") +
+                                  string("osd_mclock_scheduler_(.*))"));
+    profile_grants.push_back(MonCapGrant("config rm", "name", constraint));
   }
   if (profile == "mds") {
     profile_grants.push_back(MonCapGrant("mds", MON_CAP_ALL));

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -583,6 +583,12 @@ void mClockScheduler::handle_conf_change(
         }
       }
     }
+    // Alternatively, the QoS parameter, if set ephemerally for this OSD via
+    // the 'daemon' or 'tell' interfaces must be removed.
+    if (!cct->_conf.rm_val(*key)) {
+      dout(10) << __func__ << " Restored " << *key << " to default" << dendl;
+      cct->_conf.apply_changes(nullptr);
+    }
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61336

---

backport of https://github.com/ceph/ceph/pull/51480
parent tracker: https://tracker.ceph.com/issues/61155

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh