### PR TITLE
reef: mClockScheduler: Set priority cutoff in the mClock Scheduler

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -386,12 +386,11 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
 {
   auto id = get_scheduler_id(item);
   unsigned priority = item.get_priority();
-  unsigned cutoff = get_io_prio_cut(cct);
   
   // TODO: move this check into OpSchedulerItem, handle backwards compat
   if (op_scheduler_class::immediate == id.class_id) {
     enqueue_high(immediate_class_priority, std::move(item));
-  } else if (priority >= cutoff) {
+  } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item));
   } else {
     auto cost = calc_scaled_cost(item.get_cost());
@@ -424,12 +423,11 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
 void mClockScheduler::enqueue_front(OpSchedulerItem&& item)
 {
   unsigned priority = item.get_priority();
-  unsigned cutoff = get_io_prio_cut(cct);
   auto id = get_scheduler_id(item);
 
   if (op_scheduler_class::immediate == id.class_id) {
     enqueue_high(immediate_class_priority, std::move(item), true);
-  } else if (priority >= cutoff) {
+  } else if (priority >= cutoff_priority) {
     enqueue_high(priority, std::move(item), true);
   } else {
     // mClock does not support enqueue at front, so we use

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -197,6 +197,8 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     }
   }
 
+  unsigned cutoff_priority = get_io_prio_cut(cct);
+
   /**
    * set_osd_capacity_params_from_config
    *
@@ -214,7 +216,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   // Set the mclock related config params based on the profile
   void set_config_defaults_from_profile();
 
-public:
+public: 
   mClockScheduler(CephContext *cct, int whoami, uint32_t num_shards,
     int shard_id, bool is_rotational, MonClient *monc);
   ~mClockScheduler() override;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61303

---

backport of https://github.com/ceph/ceph/pull/50691
parent tracker: https://tracker.ceph.com/issues/58940

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh