### PR TITLE
osd/scrub: increasing max_osd_scrubs to 3

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -182,7 +182,7 @@ options:
   desc: Maximum concurrent scrubs on a single OSD
   fmt_desc: The maximum number of simultaneous scrub operations for
     a Ceph OSD Daemon.
-  default: 1
+  default: 3
   with_legacy: true
 - name: osd_scrub_during_recovery
   type: bool


### PR DESCRIPTION
Bug reports seem to hint that the current default value of '1' is too low: the cluster is susceptible to scrub scheduling delays and issues stemming from local software/networking/hardware problems, even if affecting a very small number of OSDs.

Squid will include a major overhaul of the way scrubs are counted in the cluster, providing a better solution to the problem. For now - modifying the default is an effective stop-gap measure.
