### PR TITLE
reef: crimson/osd: Support librados::OPERATION_ORDERSNAP

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -291,6 +291,15 @@ ClientRequest::do_process(
 
   SnapContext snapc = get_snapc(pg,obc);
 
+  if ((m->has_flag(CEPH_OSD_FLAG_ORDERSNAP)) &&
+       snapc.seq < obc->ssc->snapset.seq) {
+        logger().debug("{} ORDERSNAP flag set and snapc seq {}",
+                       " < snapset seq {} on {}",
+                       __func__, snapc.seq, obc->ssc->snapset.seq,
+                       obc->obs.oi.soid);
+     return reply_op_error(pg, -EOLDSNAPC);
+  }
+
   if (!pg->is_primary()) {
     // primary can handle both normal ops and balanced reads
     if (is_misdirected(*pg)) {

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -242,6 +242,10 @@ private:
 
   bool is_misdirected(const PG& pg) const;
 
+  const SnapContext get_snapc(
+    Ref<PG>& pg,
+    crimson::osd::ObjectContextRef obc) const;
+
 public:
 
   friend class LttngBackend;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -952,27 +952,11 @@ PG::do_osd_ops_iertr::future<PG::pg_rep_op_fut_t<MURef<MOSDOpReply>>>
 PG::do_osd_ops(
   Ref<MOSDOp> m,
   ObjectContextRef obc,
-  const OpInfo &op_info)
+  const OpInfo &op_info,
+  const SnapContext& snapc)
 {
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
-  }
-  SnapContext snapc;
-  if (op_info.may_write() || op_info.may_cache()) {
-    // snap
-    if (get_pgpool().info.is_pool_snaps_mode()) {
-      // use pool's snapc
-      snapc = get_pgpool().snapc;
-      logger().debug("{} using pool's snapc snaps={}",
-                     __func__, snapc.snaps);
-
-    } else {
-      // client specified snapc
-      snapc.seq = m->get_snap_seq();
-      snapc.snaps = m->get_snaps();
-      logger().debug("{} client specified snapc seq={} snaps={}",
-                     __func__, snapc.seq, snapc.snaps);
-    }
   }
   return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -565,7 +565,8 @@ private:
   do_osd_ops_iertr::future<pg_rep_op_fut_t<MURef<MOSDOpReply>>> do_osd_ops(
     Ref<MOSDOp> m,
     ObjectContextRef obc,
-    const OpInfo &op_info);
+    const OpInfo &op_info,
+    const SnapContext& snapc);
   using do_osd_ops_success_func_t =
     std::function<do_osd_ops_iertr::future<>()>;
   using do_osd_ops_failure_func_t =

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -409,7 +409,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, Bug11677) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, OrderSnap) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   char buf[bufsize];
   memset(buf, 0xcc, sizeof(buf));


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50546

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh