### PR TITLE
reef: crimson/osd/snaptrim_event: Handle missing clone obc case

### DIFF
--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -528,9 +528,10 @@ SnapTrimObjSubEvent::with_pg(
           });
         });
       });
-    }).handle_error_interruptible(PG::load_obc_ertr::all_same_way([] {
-      return seastar::now();
-    }));
+    }).handle_error_interruptible(
+      remove_or_update_iertr::pass_further{},
+      crimson::ct_error::assert_all{"unexpected error in SnapTrimObjSubEvent"}
+    );
   });
 }
 

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -139,6 +139,7 @@ SnapTrimEvent::with_pg(
       }).then_interruptible([&shard_services, this] (const auto& to_trim) {
         if (to_trim.empty()) {
           // the legit ENOENT -> done
+          logger().debug("{}: to_trim is empty! Stopping iteration", *this);
           return snap_trim_iertr::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         }
@@ -502,12 +503,12 @@ SnapTrimObjSubEvent::with_pg(
     return pg->obc_loader.with_head_and_clone_obc<RWState::RWWRITE>(
       coid,
       [this](auto head_obc, auto clone_obc) {
-      logger().debug("{}: got clone_obc={}", *this, fmt::ptr(clone_obc.get()));
+      logger().debug("{}: got clone_obc={}", *this, clone_obc->get_oid());
       return enter_stage<interruptor>(
         pp().process
       ).then_interruptible(
         [this,clone_obc=std::move(clone_obc), head_obc=std::move(head_obc)]() mutable {
-        logger().debug("{}: processing clone_obc={}", *this, fmt::ptr(clone_obc.get()));
+        logger().debug("{}: processing clone_obc={}", *this, clone_obc->get_oid());
         return remove_or_update(
           clone_obc, head_obc
         ).safe_then_unpack_interruptible([clone_obc, this]

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -489,7 +489,10 @@ void PG::on_active_actmap()
         logger().debug("{}: trimmed snap={}", *this, trimmed);
       });
     }).finally([this] {
+      logger().debug("{}: PG::on_active_actmap() finished trimming",
+                     *this);
       peering_state.state_clear(PG_STATE_SNAPTRIM);
+      peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
       publish_stats_to_osd();
     });
 }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -453,9 +453,10 @@ void PG::on_active_actmap()
 {
   logger().debug("{}: {} snap_trimq={}", *this, __func__, snap_trimq);
   peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
+  // loops until snap_trimq is empty or SNAPTRIM_ERROR.
   std::ignore = seastar::do_until(
     [this] { return snap_trimq.empty()
-                    && !peering_state.state_test(PG_STATE_SNAPTRIM_ERROR);
+                    || peering_state.state_test(PG_STATE_SNAPTRIM_ERROR);
     },
     [this] {
       peering_state.state_set(PG_STATE_SNAPTRIM);


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51198

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh