### PR TITLE
rgw: Do not forward functor objects in rgw_iam_policy.h

### DIFF
--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -404,7 +404,7 @@ struct Condition {
     for (auto itr = it.first; itr != it.second; itr++) {
       bool matched = false;
       for (const auto& d : v) {
-        if (std::forward<F>(f)(itr->second, d)) {
+        if (f(itr->second, d)) {
 	        matched = true;
       }
      }
@@ -419,7 +419,7 @@ struct Condition {
 		      const std::vector<std::string>& v) {
     for (auto itr = it.first; itr != it.second; itr++) {
       for (const auto& d : v) {
-        if (std::forward<F>(f)(itr->second, d)) {
+        if (f(itr->second, d)) {
 	        return true;
       }
      }
@@ -436,13 +436,13 @@ struct Condition {
     }
 
     for (const auto& d : v) {
-      auto xd = std::forward<X>(x)(d);
+      auto xd = x(d);
       if (!xd) {
-	continue;
+        continue;
       }
 
-      if (std::forward<F>(f)(*xc, *xd)) {
-	return true;
+      if (f(*xc, *xd)) {
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
rgw_iam_policy.h implements the andible, orrible, and shortible methods which called forward on functor objects called in a loop. This does not have any effect currently since the callers do not pass stateful functors. However, in case a stateful functor that is also an rvalue is used, the forward would cause it to lose its state.

Fixes coverity defects 1510264, 1511592, 1511865
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
