### PR TITLE
librados: aio operate functions can set mtimes

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3227,6 +3227,22 @@ CEPH_RADOS_API int rados_aio_write_op_operate(rados_write_op_t write_op,
 			                      int flags);
 
 /**
+ * Perform a write operation asynchronously
+ * @param write_op operation to perform
+ * @param io the ioctx that the object is in
+ * @param completion what to do when operation has been attempted
+ * @param oid the object id
+ * @param mtime the time to set the mtime to, NULL for the current time
+ * @param flags flags to apply to the entire operation (LIBRADOS_OPERATION_*)
+ */
+CEPH_RADOS_API int rados_aio_write_op_operate2(rados_write_op_t write_op,
+                                               rados_ioctx_t io,
+                                               rados_completion_t completion,
+                                               const char *oid,
+                                               struct timespec *mtime,
+                                               int flags);
+
+/**
  * Create a new rados_read_op_t read operation. This will store all
  * actions to be performed atomically. You must call
  * rados_release_read_op when you are finished with it (after it

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -751,12 +751,13 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 
 int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
-				     const SnapContext& snap_context, int flags,
+				     const SnapContext& snap_context,
+				     const ceph::real_time *pmtime, int flags,
                                      const blkin_trace_info *trace_info)
 {
   FUNCTRACE(client->cct);
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_WRITE_OP_BEGIN");
-  auto ut = ceph::real_clock::now();
+  const ceph::real_time ut = (pmtime ? *pmtime : ceph::real_clock::now());
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
@@ -1137,7 +1138,7 @@ int librados::IoCtxImpl::aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.rmxattr(name);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
@@ -1146,7 +1147,7 @@ int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.setxattr(name, bl);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 namespace {

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -158,7 +158,8 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags, const blkin_trace_info *trace_info = nullptr);
+		  const ceph::real_time *pmtime, int flags,
+		  const blkin_trace_info *trace_info = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 

--- a/src/librados/ObjectOperationImpl.h
+++ b/src/librados/ObjectOperationImpl.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "common/ceph_time.h"
+#include "osdc/Objecter.h"
+
+namespace librados {
+
+// Wraps Objecter's ObjectOperation with storage for an optional mtime argument.
+struct ObjectOperationImpl {
+  ::ObjectOperation o;
+  ceph::real_time rt;
+  ceph::real_time *prt = nullptr;
+};
+
+} // namespace librados

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -4048,7 +4048,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
   ::ObjectOperation *oo = (::ObjectOperation *) write_op;
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
-  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, translate_flags(flags));
+  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, nullptr, translate_flags(flags));
   tracepoint(librados, rados_aio_write_op_operate_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -19,6 +19,7 @@
 #include "librados/librados_c.h"
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
@@ -3600,7 +3601,7 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_break_lock);
 extern "C" rados_write_op_t LIBRADOS_C_API_DEFAULT_F(rados_create_write_op)()
 {
   tracepoint(librados, rados_create_write_op_enter);
-  rados_write_op_t retval = new (std::nothrow)::ObjectOperation;
+  rados_write_op_t retval = new (std::nothrow) librados::ObjectOperationImpl;
   tracepoint(librados, rados_create_write_op_exit, retval);
   return retval;
 }
@@ -3610,17 +3611,22 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_release_write_op)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_release_write_op_enter, write_op);
-  delete (::ObjectOperation*)write_op;
+  delete static_cast<librados::ObjectOperationImpl*>(write_op);
   tracepoint(librados, rados_release_write_op_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_release_write_op);
+
+static ::ObjectOperation* to_object_operation(rados_write_op_t write_op)
+{
+  return &static_cast<librados::ObjectOperationImpl*>(write_op)->o;
+}
 
 extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_flags)(
   rados_write_op_t write_op,
   int flags)
 {
   tracepoint(librados, rados_write_op_set_flags_enter, write_op, flags);
-  ((::ObjectOperation *)write_op)->set_last_op_flags(get_op_flags(flags));
+  to_object_operation(write_op)->set_last_op_flags(get_op_flags(flags));
   tracepoint(librados, rados_write_op_set_flags_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_flags);
@@ -3630,7 +3636,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_version)(
   uint64_t ver)
 {
   tracepoint(librados, rados_write_op_assert_version_enter, write_op, ver);
-  ((::ObjectOperation *)write_op)->assert_version(ver);
+  to_object_operation(write_op)->assert_version(ver);
   tracepoint(librados, rados_write_op_assert_version_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_version);
@@ -3639,7 +3645,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_exists)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_assert_exists_enter, write_op);
-  ((::ObjectOperation *)write_op)->stat(nullptr, nullptr, nullptr);
+  to_object_operation(write_op)->stat(nullptr, nullptr, nullptr);
   tracepoint(librados, rados_write_op_assert_exists_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_exists);
@@ -3653,7 +3659,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpext)(
 {
   tracepoint(librados, rados_write_op_cmpext_enter, write_op, cmp_buf,
 	     cmp_len, off, prval);
-  ((::ObjectOperation *)write_op)->cmpext(off, cmp_len, cmp_buf, prval);
+  to_object_operation(write_op)->cmpext(off, cmp_len, cmp_buf, prval);
   tracepoint(librados, rados_write_op_cmpext_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpext);
@@ -3668,10 +3674,10 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpxattr)(
   tracepoint(librados, rados_write_op_cmpxattr_enter, write_op, name, comparison_operator, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->cmpxattr(name,
-					    comparison_operator,
-					    CEPH_OSD_CMPXATTR_MODE_STRING,
-					    bl);
+  to_object_operation(write_op)->cmpxattr(name,
+					  comparison_operator,
+					  CEPH_OSD_CMPXATTR_MODE_STRING,
+					  bl);
   tracepoint(librados, rados_write_op_cmpxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpxattr);
@@ -3702,7 +3708,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp)(
   int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, strlen(key), val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
@@ -3718,7 +3724,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp2)(
   int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, key_len, val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
@@ -3733,7 +3739,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_setxattr)(
   tracepoint(librados, rados_write_op_setxattr_enter, write_op, name, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->setxattr(name, bl);
+  to_object_operation(write_op)->setxattr(name, bl);
   tracepoint(librados, rados_write_op_setxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_setxattr);
@@ -3743,7 +3749,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_rmxattr)(
   const char *name)
 {
   tracepoint(librados, rados_write_op_rmxattr_enter, write_op, name);
-  ((::ObjectOperation *)write_op)->rmxattr(name);
+  to_object_operation(write_op)->rmxattr(name);
   tracepoint(librados, rados_write_op_rmxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_rmxattr);
@@ -3754,8 +3760,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_create)(
   const char* category) // unused
 {
   tracepoint(librados, rados_write_op_create_enter, write_op, exclusive);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
-  oo->create(!!exclusive);
+  to_object_operation(write_op)->create(!!exclusive);
   tracepoint(librados, rados_write_op_create_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_create);
@@ -3769,7 +3774,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write)(
   tracepoint(librados, rados_write_op_write_enter, write_op, buffer, len, offset);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write(offset, bl);
+  to_object_operation(write_op)->write(offset, bl);
   tracepoint(librados, rados_write_op_write_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write);
@@ -3782,7 +3787,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write_full)(
   tracepoint(librados, rados_write_op_write_full_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write_full(bl);
+  to_object_operation(write_op)->write_full(bl);
   tracepoint(librados, rados_write_op_write_full_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write_full);
@@ -3797,7 +3802,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_writesame)(
   tracepoint(librados, rados_write_op_writesame_enter, write_op, buffer, data_len, write_len, offset);
   bufferlist bl;
   bl.append(buffer, data_len);
-  ((::ObjectOperation *)write_op)->writesame(offset, write_len, bl);
+  to_object_operation(write_op)->writesame(offset, write_len, bl);
   tracepoint(librados, rados_write_op_writesame_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_writesame);
@@ -3810,7 +3815,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_append)(
   tracepoint(librados, rados_write_op_append_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->append(bl);
+  to_object_operation(write_op)->append(bl);
   tracepoint(librados, rados_write_op_append_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_append);
@@ -3819,7 +3824,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_remove)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_remove_enter, write_op);
-  ((::ObjectOperation *)write_op)->remove();
+  to_object_operation(write_op)->remove();
   tracepoint(librados, rados_write_op_remove_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_remove);
@@ -3829,7 +3834,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_truncate)(
   uint64_t offset)
 {
   tracepoint(librados, rados_write_op_truncate_enter, write_op, offset);
-  ((::ObjectOperation *)write_op)->truncate(offset);
+  to_object_operation(write_op)->truncate(offset);
   tracepoint(librados, rados_write_op_truncate_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_truncate);
@@ -3840,7 +3845,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_zero)(
   uint64_t len)
 {
   tracepoint(librados, rados_write_op_zero_enter, write_op, offset, len);
-  ((::ObjectOperation *)write_op)->zero(offset, len);
+  to_object_operation(write_op)->zero(offset, len);
   tracepoint(librados, rados_write_op_zero_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_zero);
@@ -3856,7 +3861,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_exec)(
   tracepoint(librados, rados_write_op_exec_enter, write_op, cls, method, in_buf, in_len, prval);
   bufferlist inbl;
   inbl.append(in_buf, in_len);
-  ((::ObjectOperation *)write_op)->call(cls, method, inbl, NULL, NULL, prval);
+  to_object_operation(write_op)->call(cls, method, inbl, NULL, NULL, prval);
   tracepoint(librados, rados_write_op_exec_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_exec);
@@ -3876,7 +3881,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set)(
     bl.append(vals[i], lens[i]);
     entries[keys[i]] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set);
@@ -3897,7 +3902,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set2)(
     string key(keys[i], key_lens[i]);
     entries[key] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set2);
@@ -3912,7 +3917,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys)(
     tracepoint(librados, rados_write_op_omap_rm_keys_entry, keys[i]);
   }
   std::set<std::string> to_remove(keys, keys + keys_len);
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys);
@@ -3928,7 +3933,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys2)(
   for(size_t i = 0; i < keys_len; i++) {
     to_remove.emplace(keys[i], key_lens[i]);
   }
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys2);
@@ -3942,8 +3947,8 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_range2)(
 {
   tracepoint(librados, rados_write_op_omap_rm_range_enter,
              write_op, key_begin, key_end);
-  ((::ObjectOperation *)write_op)->omap_rm_range({key_begin, key_begin_len},
-                                                 {key_end, key_end_len});
+  to_object_operation(write_op)->omap_rm_range({key_begin, key_begin_len},
+                                               {key_end, key_end_len});
   tracepoint(librados, rados_write_op_omap_rm_range_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_range2);
@@ -3952,7 +3957,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_clear)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_omap_clear_enter, write_op);
-  ((::ObjectOperation *)write_op)->omap_clear();
+  to_object_operation(write_op)->omap_clear();
   tracepoint(librados, rados_write_op_omap_clear_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_clear);
@@ -3963,8 +3968,8 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint)(
   uint64_t expected_write_size)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint_enter, write_op, expected_object_size, expected_write_size);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size, 0);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size, 0);
   tracepoint(librados, rados_write_op_set_alloc_hint_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint);
@@ -3976,9 +3981,9 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint2)(
   uint32_t flags)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint2_enter, write_op, expected_object_size, expected_write_size, flags);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size,
-						  flags);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size,
+						flags);
   tracepoint(librados, rados_write_op_set_alloc_hint2_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint2);
@@ -3992,7 +3997,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate)(
 {
   tracepoint(librados, rados_write_op_operate_enter, write_op, io, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   ceph::real_time *prt = NULL;
@@ -4018,7 +4023,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate2)(
 {
   tracepoint(librados, rados_write_op_operate2_enter, write_op, io, oid, ts, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   ceph::real_time *prt = NULL;
@@ -4045,7 +4050,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
 {
   tracepoint(librados, rados_aio_write_op_operate_enter, write_op, io, completion, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
   int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, nullptr, translate_flags(flags));

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -3997,18 +3997,15 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate)(
 {
   tracepoint(librados, rados_write_op_operate_enter, write_op, io, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = to_object_operation(write_op);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (mtime) {
-    rt = ceph::real_clock::from_time_t(*mtime);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_time_t(*mtime);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }
@@ -4023,18 +4020,15 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate2)(
 {
   tracepoint(librados, rados_write_op_operate2_enter, write_op, io, oid, ts, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = to_object_operation(write_op);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (ts) {
-    rt = ceph::real_clock::from_timespec(*ts);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_timespec(*ts);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -4059,6 +4059,31 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_op_operate);
 
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate2)(
+  rados_write_op_t write_op,
+  rados_ioctx_t io,
+  rados_completion_t completion,
+  const char *oid,
+  struct timespec *mtime,
+  int flags)
+{
+  tracepoint(librados, rados_aio_write_op_operate2_enter, write_op, io, completion, oid, mtime, flags);
+  object_t obj(oid);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
+
+  if (mtime) {
+    oimpl->rt = ceph::real_clock::from_timespec(*mtime);
+    oimpl->prt = &oimpl->rt;
+  }
+
+  int retval = ctx->aio_operate(obj, &oimpl->o, c, ctx->snapc, oimpl->prt, translate_flags(flags));
+  tracepoint(librados, rados_aio_write_op_operate_exit, retval);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_write_op_operate2);
+
 extern "C" rados_read_op_t LIBRADOS_C_API_DEFAULT_F(rados_create_read_op)()
 {
   tracepoint(librados, rados_create_read_op_enter);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1559,7 +1559,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc, 0);
+				  io_ctx_impl->snapc, o->impl->prt, 0);
 }
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 ObjectWriteOperation *o, int flags)
@@ -1568,7 +1568,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc,
+				  io_ctx_impl->snapc, o->impl->prt,
 				  translate_flags(flags));
 }
 
@@ -1585,7 +1585,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  snapc, 0);
+				  snapc, o->impl->prt, 0);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1602,7 +1602,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-          snapc, 0, trace_info);
+          snapc, o->impl->prt, 0, trace_info);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1618,7 +1618,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   for (size_t i = 0; i < snaps.size(); ++i)
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
-  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc,
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc, o->impl->prt,
                                   translate_flags(flags), trace_info);
 }
 

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -29,6 +29,7 @@
 
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
@@ -87,18 +88,6 @@ static TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tra
  * |          RadosClient                 |
  * +--------------------------------------+
  */
-
-namespace librados {
-
-struct ObjectOperationImpl {
-  ::ObjectOperation o;
-  real_time rt;
-  real_time *prt;
-
-  ObjectOperationImpl() : prt(NULL) {}
-};
-
-}
 
 size_t librados::ObjectOperation::size()
 {

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -776,6 +776,68 @@ TEST(LibRadosAio, SimpleStat) {
   rados_aio_release(my_completion2);
 }
 
+TEST(LibRadosAio, OperateMtime)
+{
+  AioTestData test_data;
+  ASSERT_EQ("", test_data.init());
+
+  time_t set_mtime = 1457129052;
+  {
+    rados_write_op_t op = rados_create_write_op();
+    rados_write_op_create(op, LIBRADOS_CREATE_IDEMPOTENT, nullptr);
+    rados_completion_t completion;
+    ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &completion));
+    ASSERT_EQ(0, rados_aio_write_op_operate(op, test_data.m_ioctx, completion,
+                                            "foo", &set_mtime, 0));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
+    }
+    ASSERT_EQ(0, rados_aio_get_return_value(completion));
+    rados_aio_release(completion);
+    rados_release_write_op(op);
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, rados_stat2(test_data.m_ioctx, "foo", &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime, mtime.tv_sec);
+    EXPECT_EQ(0, mtime.tv_nsec);
+  }
+}
+
+TEST(LibRadosAio, Operate2Mtime)
+{
+  AioTestData test_data;
+  ASSERT_EQ("", test_data.init());
+
+  timespec set_mtime{1457129052, 123456789};
+  {
+    rados_write_op_t op = rados_create_write_op();
+    rados_write_op_create(op, LIBRADOS_CREATE_IDEMPOTENT, nullptr);
+    rados_completion_t completion;
+    ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &completion));
+    ASSERT_EQ(0, rados_aio_write_op_operate2(op, test_data.m_ioctx, completion,
+                                             "foo", &set_mtime, 0));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
+    }
+    ASSERT_EQ(0, rados_aio_get_return_value(completion));
+    rados_aio_release(completion);
+    rados_release_write_op(op);
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, rados_stat2(test_data.m_ioctx, "foo", &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime.tv_sec, mtime.tv_sec);
+    EXPECT_EQ(set_mtime.tv_nsec, mtime.tv_nsec);
+  }
+}
+
 TEST(LibRadosAio, SimpleStatNS) {
   AioTestData test_data;
   rados_completion_t my_completion;

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -931,6 +931,62 @@ TEST(LibRadosAio, SimpleStatPP) {
   ASSERT_EQ(sizeof(buf), psize);
 }
 
+TEST(LibRadosAio, OperateMtime)
+{
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+
+  time_t set_mtime = 1457129052;
+  {
+    auto c = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+    librados::ObjectWriteOperation op;
+    op.mtime(&set_mtime);
+    op.create(false);
+    ASSERT_EQ(0, test_data.m_ioctx.aio_operate(test_data.m_oid, c.get(), &op));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, c->wait_for_complete());
+    }
+    ASSERT_EQ(0, c->get_return_value());
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, test_data.m_ioctx.stat2(test_data.m_oid, &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime, mtime.tv_sec);
+    EXPECT_EQ(0, mtime.tv_nsec);
+  }
+}
+
+TEST(LibRadosAio, OperateMtime2)
+{
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+
+  timespec set_mtime{1457129052, 123456789};
+  {
+    auto c = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+    librados::ObjectWriteOperation op;
+    op.mtime2(&set_mtime);
+    op.create(false);
+    ASSERT_EQ(0, test_data.m_ioctx.aio_operate(test_data.m_oid, c.get(), &op));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, c->wait_for_complete());
+    }
+    ASSERT_EQ(0, c->get_return_value());
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, test_data.m_ioctx.stat2(test_data.m_oid, &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime.tv_sec, mtime.tv_sec);
+    EXPECT_EQ(set_mtime.tv_nsec, mtime.tv_nsec);
+  }
+}
+
 TEST(LibRadosAio, StatRemovePP) {
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -446,7 +446,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
-  return ctx->aio_operate(oid, *ops, c->pc, NULL, 0);
+  return ctx->aio_operate(oid, *ops, c->pc, nullptr, nullptr, 0);
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -462,7 +462,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(seq, snv);
 
-  return ctx->aio_operate(oid, *ops, c->pc, &snapc, flags);
+  return ctx->aio_operate(oid, *ops, c->pc, &snapc, nullptr, flags);
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -44,11 +44,13 @@ public:
     return TestMemIoCtxImpl::aio_notify(o, c, bl, timeout_ms, pbl);
   }
 
-  MOCK_METHOD5(aio_operate, int(const std::string&, TestObjectOperationImpl&,
-                                AioCompletionImpl*, SnapContext*, int));
+  MOCK_METHOD6(aio_operate, int(const std::string&, TestObjectOperationImpl&,
+                                AioCompletionImpl*, SnapContext*,
+                                const ceph::real_time*, int));
   int do_aio_operate(const std::string& o, TestObjectOperationImpl& ops,
-                     AioCompletionImpl* c, SnapContext* snapc, int flags) {
-    return TestMemIoCtxImpl::aio_operate(o, ops, c, snapc, flags);
+                     AioCompletionImpl* c, SnapContext* snapc,
+                     const ceph::real_time* pmtime, int flags) {
+    return TestMemIoCtxImpl::aio_operate(o, ops, c, snapc, pmtime, flags);
   }
 
   MOCK_METHOD4(aio_watch, int(const std::string& o, AioCompletionImpl *c,
@@ -214,7 +216,7 @@ public:
 
     ON_CALL(*this, clone()).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_clone));
     ON_CALL(*this, aio_notify(_, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_notify));
-    ON_CALL(*this, aio_operate(_, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_operate));
+    ON_CALL(*this, aio_operate(_, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_operate));
     ON_CALL(*this, aio_watch(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_watch));
     ON_CALL(*this, aio_unwatch(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_unwatch));
     ON_CALL(*this, assert_exists(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_assert_exists));

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -550,7 +550,7 @@ void RADOS::execute(const Object& o, const IOContext& ioc, WriteOp&& op,
   }
 
   auto completion = create_aio_completion(std::move(c));
-  auto r = io_ctx->aio_operate(std::string{o}, *ops, completion, &snapc, 0U);
+  auto r = io_ctx->aio_operate(std::string{o}, *ops, completion, &snapc, nullptr, 0U);
   ceph_assert(r == 0);
 }
 

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -107,7 +107,7 @@ void TestIoCtxImpl::aio_notify(const std::string& oid, AioCompletionImpl *c,
 
 int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, SnapContext *snap_context,
-                               int flags) {
+                               const ceph::real_time *pmtime, int flags) {
   // TODO flags for now
   ops.get();
   m_pending_ops++;

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -88,7 +88,7 @@ public:
                           bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl);
   virtual int aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                           AioCompletionImpl *c, SnapContext *snap_context,
-                          int flags);
+                          const ceph::real_time *pmtime, int flags);
   virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, int flags,
                                bufferlist *pbl, uint64_t snap_id,

--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -169,7 +169,7 @@ public:
   void expect_mirror_status_update(
       const MirrorImageSiteStatuses& mirror_image_site_statuses,
       const std::string& mirror_uuid, int r) {
-    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
       .WillOnce(Invoke([this](auto&&... args) {
           int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
           m_mock_local_io_ctx->aio_flush();
@@ -203,7 +203,7 @@ public:
 
   void expect_mirror_status_removes(const std::set<std::string>& mirror_images,
                                     int r) {
-    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
       .WillOnce(Invoke([this](auto&&... args) {
           int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
           m_mock_local_io_ctx->aio_flush();
@@ -439,7 +439,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveStatus) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond remove_flush_ctx;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke([this, &remove_flush_ctx](auto&&... args) {
         int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
         m_mock_local_io_ctx->aio_flush();
@@ -506,7 +506,7 @@ TEST_F(TestMockMirrorStatusUpdater, OverwriteStatusInFlight) {
   Context* update_task = nullptr;
   fire_timer_event(&timer_event, &update_task);
 
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke([this, &mock_mirror_status_updater](auto&&... args) {
         mock_mirror_status_updater.set_mirror_image_status(
           "1", {"", cls::rbd::MIRROR_IMAGE_STATUS_STATE_REPLAYING,
@@ -617,7 +617,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveRefreshInFlightStatus) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond on_removed;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke(
       [this, &mock_mirror_status_updater, &on_removed](auto&&... args) {
         mock_mirror_status_updater.remove_refresh_mirror_image_status(
@@ -652,7 +652,7 @@ TEST_F(TestMockMirrorStatusUpdater, ShutDownWhileUpdating) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond on_shutdown;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke(
       [this, &mock_mirror_status_updater, &on_shutdown](auto&&... args) {
         mock_mirror_status_updater.shut_down(&on_shutdown);

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -3597,6 +3597,24 @@ TRACEPOINT_EVENT(librados, rados_aio_write_op_operate_enter,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_aio_write_op_operate2_enter,
+    TP_ARGS(
+        rados_write_op_t, op,
+        rados_ioctx_t, ioctx,
+        rados_completion_t, completion,
+        const char*, oid,
+        struct timespec*, ts,
+        int, flags),
+    TP_FIELDS(
+        ctf_integer_hex(rados_write_op_t, op, op)
+        ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
+        ctf_integer_hex(rados_completion_t, completion, completion)
+        ctf_string(oid, oid)
+        ceph_ctf_timespecp(ts, ts)
+        ctf_integer_hex(int, flags, flags)
+    )
+)
+
 TRACEPOINT_EVENT(librados, rados_aio_write_op_operate_exit,
     TP_ARGS(
         int, retval),


### PR DESCRIPTION
copy the optional mtime logic from `operate()`, so that mtimes set on the `ObjectOperation` are propagated through `aio_operate()` as well

also fixes the c `rados_aio_write_op_operate()` to propagate its `time_t *mtime` argument, and adds a `rados_aio_write_op_operate2()` that takes `timespec *mtime` instead (this matches the non-aio interfaces `rados_write_op_operate()` and `rados_write_op_operate2()`)

adds new c and c++ test cases that use each overload to set the mtime and read it back

Fixes: https://tracker.ceph.com/issues/61349

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
