### PR TITLE
reef: rbd-wnbd: improve image map error message

### DIFF
--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -313,8 +313,11 @@ int send_map_request(std::string arguments) {
     return -EINVAL;
   }
   if (reply.status) {
-    derr << "The ceph service failed to map the image. Error: "
-         << reply.status << dendl;
+    derr << "The ceph service failed to map the image. "
+         << "Check the log file or pass '-f' (foreground mode) "
+         << "for additional information. "
+         << "Error: " << cpp_strerror(reply.status)
+         << dendl;
   }
 
   return reply.status;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61365

---

backport of https://github.com/ceph/ceph/pull/51665
parent tracker: https://tracker.ceph.com/issues/61364

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh