### PR TITLE
reef: crimson/net: change ConnectionRef to be a local_shared_foreign_ptr

### DIFF
--- a/src/crimson/common/local_shared_foreign_ptr.h
+++ b/src/crimson/common/local_shared_foreign_ptr.h
@@ -34,7 +34,9 @@ class local_shared_foreign_ptr {
 
   /// Wraps a pointer object and remembers the current core.
   local_shared_foreign_ptr(seastar::foreign_ptr<PtrType> &&fptr)
-    : ptr(seastar::make_lw_shared(std::move(fptr))) {}
+    : ptr(fptr ? seastar::make_lw_shared(std::move(fptr)) : nullptr) {
+    assert(!ptr || (ptr && *ptr));
+  }
 
   template <typename T>
   friend local_shared_foreign_ptr<T> make_local_shared_foreign(
@@ -57,8 +59,10 @@ public:
   ~local_shared_foreign_ptr() = default;
 
   /// Creates a copy of this foreign ptr. Only works if the stored ptr is copyable.
-  seastar::future<seastar::foreign_ptr<PtrType>> get_foreign() {
-    return ptr->copy();
+  seastar::future<seastar::foreign_ptr<PtrType>> get_foreign() const noexcept {
+    assert(!ptr || (ptr && *ptr));
+    return ptr ? ptr->copy() :
+           seastar::make_ready_future<seastar::foreign_ptr<PtrType>>(nullptr);
   }
 
   /// Accesses the wrapped object.
@@ -80,8 +84,8 @@ public:
 
   /// Return the owner-shard of the contained foreign_ptr.
   unsigned get_owner_shard() const noexcept {
-    assert(ptr && *ptr);
-    return ptr->get_owner_shard();
+    assert(!ptr || (ptr && *ptr));
+    return ptr ? ptr->get_owner_shard() : seastar::this_shard_id();
   }
 
   /// Checks whether the wrapped pointer is non-null.
@@ -94,6 +98,18 @@ public:
   local_shared_foreign_ptr& operator=(local_shared_foreign_ptr&& other) noexcept {
     ptr = std::move(other.ptr);
     return *this;
+  }
+
+  /// Copy-assigns a \c local_shared_foreign_ptr<>.
+  local_shared_foreign_ptr& operator=(const local_shared_foreign_ptr& other) noexcept {
+    ptr = other.ptr;
+    return *this;
+  }
+
+  /// Reset the containing ptr
+  void reset() noexcept {
+    assert(!ptr || (ptr && *ptr));
+    ptr = nullptr;
   }
 };
 
@@ -108,8 +124,116 @@ local_shared_foreign_ptr<T> make_local_shared_foreign(
 template <typename T>
 local_shared_foreign_ptr<T> make_local_shared_foreign(T &&ptr) {
   return make_local_shared_foreign<T>(
-    seastar::make_foreign(std::forward<T>(ptr)));
+    ptr ? seastar::make_foreign(std::forward<T>(ptr)) : nullptr);
 }
+
+template <typename T, typename U>
+inline bool operator==(const local_shared_foreign_ptr<T> &x,
+                       const local_shared_foreign_ptr<U> &y) {
+  return x.get() == y.get();
+}
+
+template <typename T>
+inline bool operator==(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() == nullptr;
+}
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr == y.get();
+}
+
+template <typename T, typename U>
+inline bool operator!=(const local_shared_foreign_ptr<T> &x,
+                       const local_shared_foreign_ptr<U> &y) {
+  return x.get() != y.get();
+}
+
+template <typename T>
+inline bool operator!=(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() != nullptr;
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr != y.get();
+}
+
+template <typename T, typename U>
+inline bool operator<(const local_shared_foreign_ptr<T> &x,
+                      const local_shared_foreign_ptr<U> &y) {
+  return x.get() < y.get();
+}
+
+template <typename T>
+inline bool operator<(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() < nullptr;
+}
+
+template <typename T>
+inline bool operator<(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr < y.get();
+}
+
+template <typename T, typename U>
+inline bool operator<=(const local_shared_foreign_ptr<T> &x,
+                       const local_shared_foreign_ptr<U> &y) {
+  return x.get() <= y.get();
+}
+
+template <typename T>
+inline bool operator<=(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() <= nullptr;
+}
+
+template <typename T>
+inline bool operator<=(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr <= y.get();
+}
+
+template <typename T, typename U>
+inline bool operator>(const local_shared_foreign_ptr<T> &x,
+                      const local_shared_foreign_ptr<U> &y) {
+  return x.get() > y.get();
+}
+
+template <typename T>
+inline bool operator>(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() > nullptr;
+}
+
+template <typename T>
+inline bool operator>(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr > y.get();
+}
+
+template <typename T, typename U>
+inline bool operator>=(const local_shared_foreign_ptr<T> &x,
+                       const local_shared_foreign_ptr<U> &y) {
+  return x.get() >= y.get();
+}
+
+template <typename T>
+inline bool operator>=(const local_shared_foreign_ptr<T> &x, std::nullptr_t) {
+  return x.get() >= nullptr;
+}
+
+template <typename T>
+inline bool operator>=(std::nullptr_t, const local_shared_foreign_ptr<T>& y) {
+  return nullptr >= y.get();
+}
+
+}
+
+namespace std {
+
+template <typename T>
+struct hash<crimson::local_shared_foreign_ptr<T>>
+    : private hash<typename std::pointer_traits<T>::element_type *> {
+  size_t operator()(const crimson::local_shared_foreign_ptr<T>& p) const {
+    return hash<typename std::pointer_traits<T>::element_type *>::operator()(p.get());
+  }
+};
 
 }
 

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -25,6 +25,7 @@
 #include "msg/msg_types.h"
 
 #include "crimson/common/errorator.h"
+#include "crimson/common/local_shared_foreign_ptr.h"
 
 class AuthConnectionMeta;
 
@@ -34,8 +35,11 @@ using msgr_tag_t = uint8_t;
 using stop_t = seastar::stop_iteration;
 
 class Connection;
-using ConnectionRef = seastar::shared_ptr<Connection>;
-using ConnectionFRef = seastar::foreign_ptr<ConnectionRef>;
+using ConnectionLRef = seastar::shared_ptr<Connection>;
+using ConnectionFRef = seastar::foreign_ptr<ConnectionLRef>;
+using ConnectionRef = ::crimson::local_shared_foreign_ptr<ConnectionLRef>;
+
+class SocketConnection;
 
 class Dispatcher;
 class ChainedDispatchers;

--- a/src/crimson/net/Interceptor.h
+++ b/src/crimson/net/Interceptor.h
@@ -116,11 +116,11 @@ struct Breakpoint {
 struct Interceptor {
   socket_blocker blocker;
   virtual ~Interceptor() {}
-  virtual void register_conn(Connection& conn) = 0;
-  virtual void register_conn_ready(Connection& conn) = 0;
-  virtual void register_conn_closed(Connection& conn) = 0;
-  virtual void register_conn_replaced(Connection& conn) = 0;
-  virtual bp_action_t intercept(Connection& conn, Breakpoint bp) = 0;
+  virtual void register_conn(SocketConnection& conn) = 0;
+  virtual void register_conn_ready(SocketConnection& conn) = 0;
+  virtual void register_conn_closed(SocketConnection& conn) = 0;
+  virtual void register_conn_replaced(SocketConnection& conn) = 0;
+  virtual bp_action_t intercept(SocketConnection& conn, Breakpoint bp) = 0;
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -107,7 +107,7 @@ namespace crimson::net {
 // should be consistent to intercept_frame() in FrameAssemblerV2.cc
 void intercept(Breakpoint bp,
                bp_type_t type,
-               Connection& conn,
+               SocketConnection& conn,
                Interceptor *interceptor,
                SocketRef& socket) {
   if (interceptor) {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -22,8 +22,9 @@
 #endif
 
 using std::ostream;
-using namespace crimson::net;
 using crimson::common::local_conf;
+
+namespace crimson::net {
 
 SocketConnection::SocketConnection(SocketMessenger& messenger,
                                    ChainedDispatchers& dispatchers)
@@ -137,6 +138,14 @@ seastar::socket_address SocketConnection::get_local_address() const {
   return socket->get_local_address();
 }
 
+ConnectionRef
+SocketConnection::get_local_shared_foreign_from_this()
+{
+  assert(seastar::this_shard_id() == shard_id());
+  return make_local_shared_foreign(
+      seastar::make_foreign(shared_from_this()));
+}
+
 void SocketConnection::print(ostream& out) const {
     out << (void*)this << " ";
     messenger.print(out);
@@ -150,3 +159,5 @@ void SocketConnection::print(ostream& out) const {
           << " >> " << get_peer_name() << " " << peer_addr;
     }
 }
+
+} // namespace crimson::net

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -25,7 +25,6 @@ namespace crimson::net {
 
 class ProtocolV2;
 class SocketMessenger;
-class SocketConnection;
 using SocketConnectionRef = seastar::shared_ptr<SocketConnection>;
 
 #ifdef UNIT_TESTS_BUILT
@@ -165,6 +164,8 @@ class SocketConnection : public Connection {
   SocketMessenger &get_messenger() const {
     return messenger;
   }
+
+  ConnectionRef get_local_shared_foreign_from_this();
 
 private:
   seastar::shard_id shard_id() const;

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -239,12 +239,12 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_name_t& pe
 
   if (auto found = lookup_conn(peer_addr); found) {
     logger().debug("{} connect to existing", *found);
-    return found->shared_from_this();
+    return found->get_local_shared_foreign_from_this();
   }
   SocketConnectionRef conn =
     seastar::make_shared<SocketConnection>(*this, dispatchers);
   conn->start_connect(peer_addr, peer_name);
-  return conn->shared_from_this();
+  return conn->get_local_shared_foreign_from_this();
 }
 
 seastar::future<> SocketMessenger::shutdown()

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -107,6 +107,10 @@ public:
     if (is_dispatch_reset) {
       dispatch_reset(is_replace);
     }
+
+    ceph_assert_always(conn_ref);
+    conn_ref.reset();
+
     assert(!gate.is_closed());
     return gate.close();
   }
@@ -182,6 +186,9 @@ private:
   ChainedDispatchers &dispatchers;
 
   SocketConnection &conn;
+
+  // core local reference for dispatching, valid until reset/close
+  ConnectionRef conn_ref;
 
   HandshakeListener *handshake_listener = nullptr;
 

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -138,7 +138,8 @@ OpsExecuter::call_ierrorator::future<> OpsExecuter::do_op_call(OSDOp& osd_op)
 }
 
 static watch_info_t create_watch_info(const OSDOp& osd_op,
-                                      const OpsExecuter::ExecutableMessage& msg)
+                                      const OpsExecuter::ExecutableMessage& msg,
+                                      entity_addr_t peer_addr)
 {
   using crimson::common::local_conf;
   const uint32_t timeout =
@@ -147,7 +148,7 @@ static watch_info_t create_watch_info(const OSDOp& osd_op,
   return {
     osd_op.op.watch.cookie,
     timeout,
-    msg.get_connection()->get_peer_addr()
+    peer_addr
   };
 }
 
@@ -159,48 +160,47 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
   logger().debug("{}", __func__);
   struct connect_ctx_t {
     ObjectContext::watch_key_t key;
-    crimson::net::ConnectionFRef conn;
+    crimson::net::ConnectionRef conn;
     watch_info_t info;
 
     connect_ctx_t(
       const OSDOp& osd_op,
       const ExecutableMessage& msg,
-      crimson::net::ConnectionFRef conn)
+      crimson::net::ConnectionRef conn)
       : key(osd_op.op.watch.cookie, msg.get_reqid().name),
-        conn(std::move(conn)),
-        info(create_watch_info(osd_op, msg)) {
+        conn(conn),
+        info(create_watch_info(osd_op, msg, conn->get_peer_addr())) {
     }
   };
-  return get_message().get_connection().copy(
-  ).then([&, this](auto &&conn) {
-    return with_effect_on_obc(
-      connect_ctx_t{ osd_op, get_message(), std::move(conn) },
-      [&] (auto& ctx) {
-	const auto& entity = ctx.key.second;
-	auto [it, emplaced] =
-	  os.oi.watchers.try_emplace(ctx.key, std::move(ctx.info));
-	if (emplaced) {
-	  logger().info("registered new watch {} by {}", it->second, entity);
-	  txn.nop();
-	} else {
-	  logger().info("found existing watch {} by {}", it->second, entity);
-	}
-	return seastar::now();
-      },
-      [] (auto&& ctx, ObjectContextRef obc, Ref<PG> pg) {
-	assert(pg);
-	auto [it, emplaced] = obc->watchers.try_emplace(ctx.key, nullptr);
-	if (emplaced) {
-	  const auto& [cookie, entity] = ctx.key;
-	  it->second = crimson::osd::Watch::create(
-	    obc, ctx.info, entity, std::move(pg));
-	  logger().info("op_effect: added new watcher: {}", ctx.key);
-	} else {
-	  logger().info("op_effect: found existing watcher: {}", ctx.key);
-	}
-	return it->second->connect(std::move(ctx.conn), true /* will_ping */);
-      });
-  });
+
+  return with_effect_on_obc(
+    connect_ctx_t{ osd_op, get_message(), conn },
+    [&](auto& ctx) {
+      const auto& entity = ctx.key.second;
+      auto [it, emplaced] =
+        os.oi.watchers.try_emplace(ctx.key, std::move(ctx.info));
+      if (emplaced) {
+        logger().info("registered new watch {} by {}", it->second, entity);
+        txn.nop();
+      } else {
+        logger().info("found existing watch {} by {}", it->second, entity);
+      }
+      return seastar::now();
+    },
+    [](auto&& ctx, ObjectContextRef obc, Ref<PG> pg) {
+      assert(pg);
+      auto [it, emplaced] = obc->watchers.try_emplace(ctx.key, nullptr);
+      if (emplaced) {
+        const auto& [cookie, entity] = ctx.key;
+        it->second = crimson::osd::Watch::create(
+          obc, ctx.info, entity, std::move(pg));
+        logger().info("op_effect: added new watcher: {}", ctx.key);
+      } else {
+        logger().info("op_effect: found existing watcher: {}", ctx.key);
+      }
+      return it->second->connect(std::move(ctx.conn), true /* will_ping */);
+    }
+  );
 }
 
 OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_reconnect(
@@ -323,57 +323,56 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_notify(
     return crimson::ct_error::enoent::make();
   }
   struct notify_ctx_t {
-    crimson::net::ConnectionFRef conn;
+    crimson::net::ConnectionRef conn;
     notify_info_t ninfo;
     const uint64_t client_gid;
     const epoch_t epoch;
 
-    notify_ctx_t(const ExecutableMessage& msg, crimson::net::ConnectionFRef conn)
-      : conn(std::move(conn)),
+    notify_ctx_t(const ExecutableMessage& msg,
+                 crimson::net::ConnectionRef conn)
+      : conn(conn),
         client_gid(msg.get_reqid().name.num()),
         epoch(msg.get_map_epoch()) {
     }
   };
-  return get_message().get_connection().copy(
-  ).then([&, this](auto &&conn) {
-    return with_effect_on_obc(
-      notify_ctx_t{ get_message(), std::move(conn) },
-      [&] (auto& ctx) {
-	try {
-	  auto bp = osd_op.indata.cbegin();
-	  uint32_t ver; // obsolete
-	  ceph::decode(ver, bp);
-	  ceph::decode(ctx.ninfo.timeout, bp);
-	  ceph::decode(ctx.ninfo.bl, bp);
-	} catch (const buffer::error&) {
-	  ctx.ninfo.timeout = 0;
-	}
-	if (!ctx.ninfo.timeout) {
-	  using crimson::common::local_conf;
-	  ctx.ninfo.timeout = local_conf()->osd_default_notify_timeout;
-	}
-	ctx.ninfo.notify_id = get_next_notify_id(ctx.epoch);
-	ctx.ninfo.cookie = osd_op.op.notify.cookie;
-	// return our unique notify id to the client
-	ceph::encode(ctx.ninfo.notify_id, osd_op.outdata);
-	return seastar::now();
-      },
-      [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
-	auto alive_watchers = obc->watchers | boost::adaptors::map_values
-	  | boost::adaptors::filtered(
-	    [] (const auto& w) {
-	      // FIXME: filter as for the `is_ping` in `Watch::start_notify`
-	      return w->is_alive();
-	    });
-	return crimson::osd::Notify::create_n_propagate(
-	  std::begin(alive_watchers),
-	  std::end(alive_watchers),
-	  std::move(ctx.conn),
-	  ctx.ninfo,
-	  ctx.client_gid,
-	  obc->obs.oi.user_version);
-      });
-  });
+  return with_effect_on_obc(
+    notify_ctx_t{ get_message(), conn },
+    [&](auto& ctx) {
+      try {
+        auto bp = osd_op.indata.cbegin();
+        uint32_t ver; // obsolete
+        ceph::decode(ver, bp);
+        ceph::decode(ctx.ninfo.timeout, bp);
+        ceph::decode(ctx.ninfo.bl, bp);
+      } catch (const buffer::error&) {
+        ctx.ninfo.timeout = 0;
+      }
+      if (!ctx.ninfo.timeout) {
+        using crimson::common::local_conf;
+        ctx.ninfo.timeout = local_conf()->osd_default_notify_timeout;
+      }
+      ctx.ninfo.notify_id = get_next_notify_id(ctx.epoch);
+      ctx.ninfo.cookie = osd_op.op.notify.cookie;
+      // return our unique notify id to the client
+      ceph::encode(ctx.ninfo.notify_id, osd_op.outdata);
+      return seastar::now();
+    },
+    [](auto&& ctx, ObjectContextRef obc, Ref<PG>) {
+      auto alive_watchers = obc->watchers | boost::adaptors::map_values
+        | boost::adaptors::filtered(
+          [] (const auto& w) {
+            // FIXME: filter as for the `is_ping` in `Watch::start_notify`
+            return w->is_alive();
+          });
+      return crimson::osd::Notify::create_n_propagate(
+        std::begin(alive_watchers),
+        std::end(alive_watchers),
+        std::move(ctx.conn),
+        ctx.ninfo,
+        ctx.client_gid,
+        obc->obs.oi.user_version);
+    }
+  );
 }
 
 OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_list_watchers(
@@ -1046,11 +1045,13 @@ OpsExecuter::OpsExecuter(Ref<PG> pg,
                          ObjectContextRef _obc,
                          const OpInfo& op_info,
                          abstracted_msg_t&& msg,
+                         crimson::net::ConnectionRef conn,
                          const SnapContext& _snapc)
   : pg(std::move(pg)),
     obc(std::move(_obc)),
     op_info(op_info),
     msg(std::move(msg)),
+    conn(conn),
     snapc(_snapc)
 {
   if (op_info.may_write() && should_clone(*obc, snapc)) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1226,6 +1226,7 @@ seastar::future<> OSD::handle_peering_op(
 {
   const int from = m->get_source().num();
   logger().debug("handle_peering_op on {} from {}", m->get_spg(), from);
+  m->set_features(conn->get_features());
   std::unique_ptr<PGPeeringEvent> evt(m->get_event());
   (void) pg_shard_manager.start_pg_operation<RemotePeeringEvent>(
     conn,

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -80,20 +80,9 @@ ConnectionPipeline &ClientRequest::get_connection_pipeline()
   return get_osd_priv(conn.get()).client_request_conn_pipeline;
 }
 
-ConnectionPipeline &ClientRequest::cp()
-{
-  return get_osd_priv(conn.get()).client_request_conn_pipeline;
-}
-
 ClientRequest::PGPipeline &ClientRequest::pp(PG &pg)
 {
   return pg.request_pg_pipeline;
-}
-
-bool ClientRequest::same_session_and_pg(const ClientRequest& other_op) const
-{
-  return &get_osd_priv(conn.get()) == &get_osd_priv(other_op.conn.get()) &&
-         m->get_spg() == other_op.m->get_spg();
 }
 
 bool ClientRequest::is_pg_op() const

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -308,7 +308,7 @@ ClientRequest::do_process(
                      __func__, m->get_hobj());
     }
   }
-  return pg->do_osd_ops(m, obc, op_info, snapc).safe_then_unpack_interruptible(
+  return pg->do_osd_ops(m, conn, obc, op_info, snapc).safe_then_unpack_interruptible(
     [this, pg, &ihref](auto submitted, auto all_completed) mutable {
       return submitted.then_interruptible([this, pg, &ihref] {
 	return ihref.enter_stage<interruptor>(pp(*pg).wait_repop, *this);

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -208,11 +208,11 @@ public:
 
   seastar::future<> with_pg_int(
     ShardServices &shard_services, Ref<PG> pg);
-public:
-  bool same_session_and_pg(const ClientRequest& other_op) const;
 
+public:
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pgref);
+
 private:
   template <typename FuncT>
   interruptible_future<> with_sequencer(FuncT&& func);
@@ -231,7 +231,6 @@ private:
       Ref<PG> &pg);
   bool is_pg_op() const;
 
-  ConnectionPipeline &cp();
   PGPipeline &pp(PG &pg);
 
   template <typename Errorator>

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -61,7 +61,7 @@ seastar::future<> LogMissingRequest::with_pg(
 
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
-    return pg->do_update_log_missing(req);
+    return pg->do_update_log_missing(req, conn);
   }, [ref](std::exception_ptr) { return seastar::now(); }, pg);
 }
 

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -34,9 +34,22 @@ public:
   spg_t get_pgid() const {
     return req->get_spg();
   }
-  ConnectionPipeline &get_connection_pipeline();
   PipelineHandle &get_handle() { return handle; }
   epoch_t get_epoch() const { return req->get_min_epoch(); }
+
+  ConnectionPipeline &get_connection_pipeline();
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
@@ -53,7 +66,7 @@ public:
 private:
   ClientRequest::PGPipeline &pp(PG &pg);
 
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive
   PipelineHandle handle;
   Ref<MOSDPGUpdateLogMissing> req;

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.h
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.h
@@ -34,9 +34,22 @@ public:
   spg_t get_pgid() const {
     return req->get_spg();
   }
-  ConnectionPipeline &get_connection_pipeline();
   PipelineHandle &get_handle() { return handle; }
   epoch_t get_epoch() const { return req->get_min_epoch(); }
+
+  ConnectionPipeline &get_connection_pipeline();
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
@@ -53,7 +66,7 @@ public:
 private:
   ClientRequest::PGPipeline &pp(PG &pg);
 
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive
   PipelineHandle handle;
   Ref<MOSDPGUpdateLogMissingReply> req;

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -107,7 +107,7 @@ public:
 
 class RemotePeeringEvent : public PeeringEvent<RemotePeeringEvent> {
 protected:
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   // must be after conn due to ConnectionPipeline's life-time
   PipelineHandle handle;
 
@@ -153,9 +153,22 @@ public:
   spg_t get_pgid() const {
     return pgid;
   }
-  ConnectionPipeline &get_connection_pipeline();
   PipelineHandle &get_handle() { return handle; }
   epoch_t get_epoch() const { return evt.get_epoch_sent(); }
+
+  ConnectionPipeline &get_connection_pipeline();
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 };
 
 class LocalPeeringEvent final : public PeeringEvent<LocalPeeringEvent> {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -30,7 +30,7 @@ seastar::future<> RecoverySubRequest::with_pg(
   track_event<StartEvent>();
   IRef opref = this;
   return interruptor::with_interruption([this, pgref] {
-    return pgref->get_recovery_backend()->handle_recovery_op(m);
+    return pgref->get_recovery_backend()->handle_recovery_op(m, conn);
   }, [](std::exception_ptr) {
     return seastar::now();
   }, pgref).finally([this, opref, pgref] {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.h
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.h
@@ -37,9 +37,22 @@ public:
   spg_t get_pgid() const {
     return m->get_spg();
   }
-  ConnectionPipeline &get_connection_pipeline();
   PipelineHandle &get_handle() { return handle; }
   epoch_t get_epoch() const { return m->get_min_epoch(); }
+
+  ConnectionPipeline &get_connection_pipeline();
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
@@ -55,7 +68,7 @@ public:
   > tracking_events;
 
 private:
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive
   PipelineHandle handle;
   Ref<MOSDFastDispatchOp> m;

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -34,9 +34,22 @@ public:
   spg_t get_pgid() const {
     return req->get_spg();
   }
-  ConnectionPipeline &get_connection_pipeline();
   PipelineHandle &get_handle() { return handle; }
   epoch_t get_epoch() const { return req->get_min_epoch(); }
+
+  ConnectionPipeline &get_connection_pipeline();
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
 
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
@@ -55,7 +68,7 @@ public:
 private:
   ClientRequest::PGPipeline &pp(PG &pg);
 
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   PipelineHandle handle;
   Ref<MOSDRepOp> req;
 };

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -972,6 +972,7 @@ seastar::future<> PG::submit_error_log(
 PG::do_osd_ops_iertr::future<PG::pg_rep_op_fut_t<MURef<MOSDOpReply>>>
 PG::do_osd_ops(
   Ref<MOSDOp> m,
+  crimson::net::ConnectionRef conn,
   ObjectContextRef obc,
   const OpInfo &op_info,
   const SnapContext& snapc)
@@ -981,7 +982,7 @@ PG::do_osd_ops(
   }
   return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(
-      Ref<PG>{this}, obc, op_info, *m, snapc),
+      Ref<PG>{this}, obc, op_info, *m, conn, snapc),
     m->ops,
     [this, m, obc, may_write = op_info.may_write(),
      may_read = op_info.may_read(), rvec = op_info.allows_returnvec()] {
@@ -1103,7 +1104,13 @@ PG::do_osd_ops(
     [=, this, &ops, &op_info](auto &msg_params) {
     return do_osd_ops_execute<void>(
       seastar::make_lw_shared<OpsExecuter>(
-        Ref<PG>{this}, std::move(obc), op_info, msg_params, SnapContext{}),
+        Ref<PG>{this},
+        std::move(obc),
+        op_info,
+        msg_params,
+        msg_params.get_connection(),
+        SnapContext{}
+      ),
       ops,
       std::move(success_func),
       std::move(failure_func));
@@ -1300,7 +1307,8 @@ void PG::handle_rep_op_reply(const MOSDRepOpReply& m)
 }
 
 PG::interruptible_future<> PG::do_update_log_missing(
-  Ref<MOSDPGUpdateLogMissing> m)
+  Ref<MOSDPGUpdateLogMissing> m,
+  crimson::net::ConnectionRef conn)
 {
   if (__builtin_expect(stopping, false)) {
     return seastar::make_exception_future<>(
@@ -1322,7 +1330,7 @@ PG::interruptible_future<> PG::do_update_log_missing(
 
   return interruptor::make_interruptible(shard_services.get_store().do_transaction(
     coll_ref, std::move(t))).then_interruptible(
-    [m, lcod=peering_state.get_info().last_complete, this] {
+    [m, conn, lcod=peering_state.get_info().last_complete, this] {
     if (!peering_state.pg_has_reset_since(m->get_epoch())) {
       peering_state.update_last_complete_ondisk(lcod);
       auto reply =
@@ -1334,7 +1342,7 @@ PG::interruptible_future<> PG::do_update_log_missing(
           m->get_tid(),
           lcod);
       reply->set_priority(CEPH_MSG_PRIO_HIGH);
-      return m->get_connection()->send(std::move(reply));
+      return conn->send(std::move(reply));
     }
     return seastar::now();
   });

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -534,7 +534,9 @@ public:
   void replica_clear_repop_obc(
     const std::vector<pg_log_entry_t> &logv);
   void handle_rep_op_reply(const MOSDRepOpReply& m);
-  interruptible_future<> do_update_log_missing(Ref<MOSDPGUpdateLogMissing> m);
+  interruptible_future<> do_update_log_missing(
+    Ref<MOSDPGUpdateLogMissing> m,
+    crimson::net::ConnectionRef conn);
   interruptible_future<> do_update_log_missing_reply(
                          Ref<MOSDPGUpdateLogMissingReply> m);
 
@@ -562,6 +564,7 @@ private:
                do_osd_ops_iertr::future<Ret>>;
   do_osd_ops_iertr::future<pg_rep_op_fut_t<MURef<MOSDOpReply>>> do_osd_ops(
     Ref<MOSDOp> m,
+    crimson::net::ConnectionRef conn,
     ObjectContextRef obc,
     const OpInfo &op_info,
     const SnapContext& snapc);
@@ -770,7 +773,7 @@ private:
 };
 
 struct PG::do_osd_ops_params_t {
-  crimson::net::ConnectionFRef &get_connection() const {
+  crimson::net::ConnectionRef &get_connection() const {
     return conn;
   }
   osd_reqid_t get_reqid() const {
@@ -791,8 +794,9 @@ struct PG::do_osd_ops_params_t {
   // Only used by InternalClientRequest, no op flags
   bool has_flag(uint32_t flag) const {
     return false;
- }
-  crimson::net::ConnectionFRef &conn;
+  }
+
+  crimson::net::ConnectionRef &conn;
   osd_reqid_t reqid;
   utime_t mtime;
   epoch_t map_epoch;

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -148,6 +148,37 @@ public:
       });
   }
 
+  template <typename T, typename F>
+  auto with_remote_shard_state_and_op(
+      core_id_t core,
+      typename T::IRef &&op,
+      F &&f) {
+    ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
+    if (seastar::this_shard_id() == core) {
+      auto &target_shard_services = shard_services.local();
+      return std::invoke(
+        std::move(f),
+        target_shard_services.local_state,
+        target_shard_services,
+        std::move(op));
+    }
+    return op->prepare_remote_submission(
+    ).then([op=std::move(op), f=std::move(f), this, core
+           ](auto f_conn) mutable {
+      return shard_services.invoke_on(
+        core,
+        [f=std::move(f), op=std::move(op), f_conn=std::move(f_conn)
+        ](auto &target_shard_services) mutable {
+        op->finish_remote_submission(std::move(f_conn));
+        return std::invoke(
+          std::move(f),
+          target_shard_services.local_state,
+          target_shard_services,
+          std::move(op));
+      });
+    });
+  }
+
   /// Runs opref on the appropriate core, creating the pg as necessary.
   template <typename T>
   seastar::future<> run_with_pg_maybe_create(
@@ -163,11 +194,11 @@ public:
       op->get_pgid());
 
     get_local_state().registry.remove_from_registry(*op);
-    return with_remote_shard_state(
-      core,
-      [op=std::move(op)](
-	PerShardState &per_shard_state,
-	ShardServices &shard_services) mutable {
+    return with_remote_shard_state_and_op<T>(
+      core, std::move(op),
+      [](PerShardState &per_shard_state,
+         ShardServices &shard_services,
+         typename T::IRef op) {
 	per_shard_state.registry.add_to_registry(*op);
 	auto &logger = crimson::get_logger(ceph_subsys_osd);
 	auto &opref = *op;
@@ -207,11 +238,11 @@ public:
       op->get_pgid());
 
     get_local_state().registry.remove_from_registry(*op);
-    return with_remote_shard_state(
-      core,
-      [op=std::move(op)](
-	PerShardState &per_shard_state,
-	ShardServices &shard_services) mutable {
+    return with_remote_shard_state_and_op<T>(
+      core, std::move(op),
+      [](PerShardState &per_shard_state,
+         ShardServices &shard_services,
+         typename T::IRef op) {
 	per_shard_state.registry.add_to_registry(*op);
 	auto &logger = crimson::get_logger(ceph_subsys_osd);
 	auto &opref = *op;

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -69,7 +69,8 @@ void RecoveryBackend::WaitForObjectRecovery::stop() {
 }
 
 void RecoveryBackend::handle_backfill_finish(
-  MOSDPGBackfill& m)
+  MOSDPGBackfill& m,
+  crimson::net::ConnectionRef conn)
 {
   logger().debug("{}", __func__);
   ceph_assert(!pg.is_primary());
@@ -80,7 +81,7 @@ void RecoveryBackend::handle_backfill_finish(
     m.query_epoch,
     spg_t(pg.get_pgid().pgid, pg.get_primary().shard));
   reply->set_priority(pg.get_recovery_op_priority());
-  std::ignore = m.get_connection()->send(std::move(reply));
+  std::ignore = conn->send(std::move(reply));
   shard_services.start_operation<crimson::osd::LocalPeeringEvent>(
     static_cast<crimson::osd::PG*>(&pg),
     pg.get_pg_whoami(),
@@ -123,7 +124,8 @@ RecoveryBackend::handle_backfill_finish_ack(
 
 RecoveryBackend::interruptible_future<>
 RecoveryBackend::handle_backfill(
-  MOSDPGBackfill& m)
+  MOSDPGBackfill& m,
+  crimson::net::ConnectionRef conn)
 {
   logger().debug("{}", __func__);
   if (pg.old_peering_msg(m.map_epoch, m.query_epoch)) {
@@ -132,7 +134,7 @@ RecoveryBackend::handle_backfill(
   }
   switch (m.op) {
     case MOSDPGBackfill::OP_BACKFILL_FINISH:
-      handle_backfill_finish(m);
+      handle_backfill_finish(m, conn);
       [[fallthrough]];
     case MOSDPGBackfill::OP_BACKFILL_PROGRESS:
       return handle_backfill_progress(m);
@@ -224,7 +226,8 @@ RecoveryBackend::scan_for_backfill(
 
 RecoveryBackend::interruptible_future<>
 RecoveryBackend::handle_scan_get_digest(
-  MOSDPGScan& m)
+  MOSDPGScan& m,
+  crimson::net::ConnectionRef conn)
 {
   logger().debug("{}", __func__);
   if (false /* FIXME: check for backfill too full */) {
@@ -243,7 +246,7 @@ RecoveryBackend::handle_scan_get_digest(
     crimson::common::local_conf().get_val<std::int64_t>("osd_backfill_scan_min"),
     crimson::common::local_conf().get_val<std::int64_t>("osd_backfill_scan_max")
   ).then_interruptible(
-    [this, query_epoch=m.query_epoch, &conn=*(m.get_connection())
+    [this, query_epoch=m.query_epoch, conn
     ](auto backfill_interval) {
       auto reply = crimson::make_message<MOSDPGScan>(
 	MOSDPGScan::OP_SCAN_DIGEST,
@@ -254,7 +257,7 @@ RecoveryBackend::handle_scan_get_digest(
 	backfill_interval.begin,
 	backfill_interval.end);
       encode(backfill_interval.objects, reply->get_data());
-      return conn.send(std::move(reply));
+      return conn->send(std::move(reply));
     });
 }
 
@@ -285,7 +288,8 @@ RecoveryBackend::handle_scan_digest(
 
 RecoveryBackend::interruptible_future<>
 RecoveryBackend::handle_scan(
-  MOSDPGScan& m)
+  MOSDPGScan& m,
+  crimson::net::ConnectionRef conn)
 {
   logger().debug("{}", __func__);
   if (pg.old_peering_msg(m.map_epoch, m.query_epoch)) {
@@ -294,7 +298,7 @@ RecoveryBackend::handle_scan(
   }
   switch (m.op) {
     case MOSDPGScan::OP_SCAN_GET_DIGEST:
-      return handle_scan_get_digest(m);
+      return handle_scan_get_digest(m, conn);
     case MOSDPGScan::OP_SCAN_DIGEST:
       return handle_scan_digest(m);
     default:
@@ -306,15 +310,16 @@ RecoveryBackend::handle_scan(
 
 RecoveryBackend::interruptible_future<>
 RecoveryBackend::handle_recovery_op(
-  Ref<MOSDFastDispatchOp> m)
+  Ref<MOSDFastDispatchOp> m,
+  crimson::net::ConnectionRef conn)
 {
   switch (m->get_header().type) {
   case MSG_OSD_PG_BACKFILL:
-    return handle_backfill(*boost::static_pointer_cast<MOSDPGBackfill>(m));
+    return handle_backfill(*boost::static_pointer_cast<MOSDPGBackfill>(m), conn);
   case MSG_OSD_PG_BACKFILL_REMOVE:
     return handle_backfill_remove(*boost::static_pointer_cast<MOSDPGBackfillRemove>(m));
   case MSG_OSD_PG_SCAN:
-    return handle_scan(*boost::static_pointer_cast<MOSDPGScan>(m));
+    return handle_scan(*boost::static_pointer_cast<MOSDPGScan>(m), conn);
   default:
     return seastar::make_exception_future<>(
 	std::invalid_argument(fmt::format("invalid request type: {}",

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -65,7 +65,8 @@ public:
   }
 
   virtual interruptible_future<> handle_recovery_op(
-    Ref<MOSDFastDispatchOp> m);
+    Ref<MOSDFastDispatchOp> m,
+    crimson::net::ConnectionRef conn);
 
   virtual interruptible_future<> recover_object(
     const hobject_t& soid,
@@ -210,18 +211,23 @@ protected:
   virtual seastar::future<> on_stop() = 0;
 private:
   void handle_backfill_finish(
-    MOSDPGBackfill& m);
+    MOSDPGBackfill& m,
+    crimson::net::ConnectionRef conn);
   interruptible_future<> handle_backfill_progress(
     MOSDPGBackfill& m);
   interruptible_future<> handle_backfill_finish_ack(
     MOSDPGBackfill& m);
-  interruptible_future<> handle_backfill(MOSDPGBackfill& m);
+  interruptible_future<> handle_backfill(
+    MOSDPGBackfill& m,
+    crimson::net::ConnectionRef conn);
 
   interruptible_future<> handle_scan_get_digest(
-    MOSDPGScan& m);
+    MOSDPGScan& m,
+    crimson::net::ConnectionRef conn);
   interruptible_future<> handle_scan_digest(
     MOSDPGScan& m);
   interruptible_future<> handle_scan(
-    MOSDPGScan& m);
+    MOSDPGScan& m,
+    crimson::net::ConnectionRef conn);
   interruptible_future<> handle_backfill_remove(MOSDPGBackfillRemove& m);
 };

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -1156,7 +1156,9 @@ ReplicatedRecoveryBackend::handle_recovery_delete_reply(
 }
 
 RecoveryBackend::interruptible_future<>
-ReplicatedRecoveryBackend::handle_recovery_op(Ref<MOSDFastDispatchOp> m)
+ReplicatedRecoveryBackend::handle_recovery_op(
+  Ref<MOSDFastDispatchOp> m,
+  crimson::net::ConnectionRef conn)
 {
   switch (m->get_header().type) {
   case MSG_OSD_PG_PULL:
@@ -1174,7 +1176,7 @@ ReplicatedRecoveryBackend::handle_recovery_op(Ref<MOSDFastDispatchOp> m)
 	boost::static_pointer_cast<MOSDPGRecoveryDeleteReply>(m));
   default:
     // delegate to parent class for handling backend-agnostic recovery ops.
-    return RecoveryBackend::handle_recovery_op(std::move(m));
+    return RecoveryBackend::handle_recovery_op(std::move(m), conn);
   }
 }
 

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -23,7 +23,8 @@ public:
     : RecoveryBackend(pg, shard_services, coll, backend)
   {}
   interruptible_future<> handle_recovery_op(
-    Ref<MOSDFastDispatchOp> m) final;
+    Ref<MOSDFastDispatchOp> m,
+    crimson::net::ConnectionRef conn) final;
 
   interruptible_future<> recover_object(
     const hobject_t& soid,

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -78,7 +78,7 @@ Watch::~Watch()
   logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
 }
 
-seastar::future<> Watch::connect(crimson::net::ConnectionFRef conn, bool)
+seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
 {
   if (this->conn == conn) {
     logger().debug("conn={} already connected", conn);
@@ -218,7 +218,7 @@ std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs)
   return out;
 }
 
-Notify::Notify(crimson::net::ConnectionFRef conn,
+Notify::Notify(crimson::net::ConnectionRef conn,
                const notify_info_t& ninfo,
                const uint64_t client_gid,
                const uint64_t user_version)

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -34,7 +34,7 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   struct private_ctag_t{};
 
   std::set<NotifyRef, std::less<>> in_progress_notifies;
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   crimson::osd::ObjectContextRef obc;
 
   watch_info_t winfo;
@@ -67,7 +67,7 @@ public:
   }
   ~Watch();
 
-  seastar::future<> connect(crimson::net::ConnectionFRef, bool);
+  seastar::future<> connect(crimson::net::ConnectionRef, bool);
   void disconnect();
   bool is_alive() const {
     return true;
@@ -131,7 +131,7 @@ std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs);
 class Notify : public seastar::enable_shared_from_this<Notify> {
   std::set<WatchRef> watchers;
   const notify_info_t ninfo;
-  crimson::net::ConnectionFRef conn;
+  crimson::net::ConnectionRef conn;
   const uint64_t client_gid;
   const uint64_t user_version;
   bool complete{false};
@@ -152,14 +152,14 @@ class Notify : public seastar::enable_shared_from_this<Notify> {
   /// Called on Notify timeout
   void do_notify_timeout();
 
-  Notify(crimson::net::ConnectionFRef conn,
+  Notify(crimson::net::ConnectionRef conn,
          const notify_info_t& ninfo,
          const uint64_t client_gid,
          const uint64_t user_version);
   template <class WatchIteratorT>
   Notify(WatchIteratorT begin,
          WatchIteratorT end,
-         crimson::net::ConnectionFRef conn,
+         crimson::net::ConnectionRef conn,
          const notify_info_t& ninfo,
          const uint64_t client_gid,
          const uint64_t user_version);
@@ -205,7 +205,7 @@ public:
 template <class WatchIteratorT>
 Notify::Notify(WatchIteratorT begin,
                WatchIteratorT end,
-               crimson::net::ConnectionFRef conn,
+               crimson::net::ConnectionRef conn,
                const notify_info_t& ninfo,
                const uint64_t client_gid,
                const uint64_t user_version)

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -166,6 +166,10 @@ public:
   uint64_t get_features() const {
     if (features)
       return features;
+#ifdef WITH_SEASTAR
+    // In crimson, conn is independently maintained outside Message.
+    ceph_abort();
+#endif
     return get_connection()->get_features();
   }
 

--- a/src/messages/MOSDPGNotify2.h
+++ b/src/messages/MOSDPGNotify2.h
@@ -33,7 +33,12 @@ public:
 	spgid,
 	pg_shard_t(get_source().num(), notify.from),
 	notify,
-	get_connection()->get_features()),
+#ifdef WITH_SEASTAR
+	features
+#else
+	get_connection()->get_features()
+#endif
+      ),
       true,
       new PGCreateInfo(
 	spgid,

--- a/src/messages/MOSDPeeringOp.h
+++ b/src/messages/MOSDPeeringOp.h
@@ -25,4 +25,16 @@ public:
   virtual epoch_t get_min_epoch() const = 0;
   virtual PGPeeringEvent *get_event() = 0;
   virtual void inner_print(std::ostream& out) const = 0;
+
+#ifdef WITH_SEASTAR
+  // In crimson, conn is independently maintained outside Message.
+  // Instead of get features from the connection later, set features at
+  // the start of the operation.
+  void set_features(uint64_t _features) {
+    features = _features;
+  }
+
+protected:
+  uint64_t features;
+#endif
 };

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -314,6 +314,10 @@ Message *decode_message(CephContext *cct,
                         ceph::bufferlist& data,
                         Message::ConnectionRef conn)
 {
+#ifdef WITH_SEASTAR
+  // In crimson, conn is independently maintained outside Message.
+  ceph_assert(conn == nullptr);
+#endif
   // verify crc
   if (crcflags & MSG_CRC_HEADER) {
     __u32 front_crc = front.crc32c(0);

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -252,10 +252,8 @@ class Message : public RefCountedObject {
 public:
 #ifdef WITH_SEASTAR
   using ConnectionRef = crimson::net::ConnectionRef;
-  using ConnectionFRef = crimson::net::ConnectionFRef;
 #else
   using ConnectionRef = ::ConnectionRef;
-  using ConnectionFRef = ::ConnectionRef;
 #endif // WITH_SEASTAR
 
 protected:
@@ -276,7 +274,7 @@ protected:
   /* time at which message was fully read */
   utime_t recv_complete_stamp;
 
-  ConnectionFRef connection;
+  ConnectionRef connection;
 
   uint32_t magic = 0;
 
@@ -351,8 +349,18 @@ protected:
       completion_hook->complete(0);
   }
 public:
-  const ConnectionFRef& get_connection() const { return connection; }
+  const ConnectionRef& get_connection() const {
+#ifdef WITH_SEASTAR
+    // In crimson, conn is independently maintained outside Message.
+    ceph_abort();
+#endif
+    return connection;
+  }
   void set_connection(ConnectionRef c) {
+#ifdef WITH_SEASTAR
+    // In crimson, conn is independently maintained outside Message.
+    ceph_assert(c == nullptr);
+#endif
     connection = std::move(c);
   }
   CompletionHook* get_completion_hook() { return completion_hook; }

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -118,17 +118,15 @@ class SyntheticDispatcher final
     auto p = m->get_data().cbegin();
     decode(pl, p);
     if (pl.who == Payload::PING) {
-      logger().info(" {} conn= {} {}", __func__,
-        *m->get_connection(), pl);
-      return reply_message(m, pl);
+      logger().info(" {} conn= {} {}", __func__, *con, pl);
+      return reply_message(m, con, pl);
     } else {
       ceph_assert(pl.who == Payload::PONG);
       if (sent.count(pl.seq)) {
-        logger().info(" {} conn= {} {}", __func__,
-          m->get_connection(), pl);
-        ceph_assert(conn_sent[&*m->get_connection()].front() == pl.seq);
+        logger().info(" {} conn= {} {}", __func__, *con, pl);
+        ceph_assert(conn_sent[&*con].front() == pl.seq);
         ceph_assert(pl.data.contents_equal(sent[pl.seq]));
-        conn_sent[&*m->get_connection()].pop_front();
+        conn_sent[&*con].pop_front();
         sent.erase(pl.seq);
       }
 
@@ -150,7 +148,10 @@ class SyntheticDispatcher final
     clear_pending(con);
   }
 
-  std::optional<seastar::future<>> reply_message(const MessageRef m, Payload& pl) {
+  std::optional<seastar::future<>> reply_message(
+      const MessageRef m,
+      crimson::net::ConnectionRef con,
+      Payload& pl) {
     pl.who = Payload::PONG;
     bufferlist bl;
     encode(pl, bl);
@@ -158,9 +159,9 @@ class SyntheticDispatcher final
     rm->set_data(bl);
     if (verbose) {
       logger().info("{} conn= {} reply i= {}",
-        __func__, m->get_connection(), pl.seq);
+        __func__, *con, pl.seq);
     }
-    return m->get_connection()->send(std::move(rm));
+    return con->send(std::move(rm));
   }
 
   seastar::future<> send_message_wrap(crimson::net::ConnectionRef con,

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -200,8 +200,10 @@ class SyntheticDispatcher final
 };
 
 class SyntheticWorkload {
+  // messengers must be freed after its connections
   std::set<crimson::net::MessengerRef> available_servers;
   std::set<crimson::net::MessengerRef> available_clients;
+
   crimson::net::SocketPolicy server_policy;
   crimson::net::SocketPolicy client_policy;
   std::map<crimson::net::ConnectionRef,
@@ -453,8 +455,6 @@ class SyntheticWorkload {
          return server->shutdown();
        });
      }).then([this] {
-       available_servers.clear();
-     }).then([this] {
        return seastar::do_for_each(available_clients, [] (auto client) {
 	 if (verbose) {
            logger().info("client {} shutdown" , client->get_myaddrs());
@@ -462,8 +462,6 @@ class SyntheticWorkload {
          client->stop();
          return client->shutdown();
        });
-     }).then([this] {
-       available_clients.clear();
      });
    }
 


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/50835

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh