### PR TITLE
reef: crimson/os: support multicore seastore

### DIFF
--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -20,7 +20,8 @@ class Transaction;
 
 namespace crimson::os {
 using coll_core_t = FuturizedStore::coll_core_t;
-class AlienStore final : public FuturizedStore {
+class AlienStore final : public FuturizedStore,
+                         public FuturizedStore::Shard {
 public:
   AlienStore(const std::string& type,
              const std::string& path,
@@ -98,6 +99,10 @@ public:
     const ghobject_t&,
     uint64_t off,
     uint64_t len) final;
+
+  FuturizedStore::Shard& get_sharded_store() final {
+    return *this;
+  }
 
 private:
   template <class... Args>

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -53,16 +53,12 @@ private:
   };
 };
 
-seastar::future<> CyanStore::start()
-{
-  return shard_stores.start(path);
-}
-
 seastar::future<store_statfs_t> CyanStore::stat() const
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   logger().debug("{}", __func__);
   return shard_stores.map_reduce0(
-    [](const CyanStore::ShardStores &local_store) {
+    [](const CyanStore::Shard &local_store) {
       return local_store.get_used_bytes();
     },
     (uint64_t)0,
@@ -78,6 +74,7 @@ seastar::future<store_statfs_t> CyanStore::stat() const
 
 CyanStore::mkfs_ertr::future<> CyanStore::mkfs(uuid_d new_osd_fsid)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   static const char read_meta_errmsg[]{"read_meta"};
   static const char parse_fsid_errmsg[]{"failed to parse fsid"};
   static const char match_ofsid_errmsg[]{"unmatched osd_fsid"};
@@ -113,7 +110,7 @@ CyanStore::mkfs_ertr::future<> CyanStore::mkfs(uuid_d new_osd_fsid)
   });
 }
 
-seastar::future<> CyanStore::ShardStores::mkfs()
+seastar::future<> CyanStore::Shard::mkfs()
 {
   std::string fn =
     path + "/collections" + std::to_string(seastar::this_shard_id());
@@ -123,9 +120,11 @@ seastar::future<> CyanStore::ShardStores::mkfs()
   return crimson::write_file(std::move(bl), fn);
 }
 
+using coll_core_t = FuturizedStore::coll_core_t;
 seastar::future<std::vector<coll_core_t>>
 CyanStore::list_collections()
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   return seastar::do_with(std::vector<coll_core_t>{}, [this](auto &collections) {
     return shard_stores.map([](auto &local_store) {
       return local_store.list_collections();
@@ -139,7 +138,7 @@ CyanStore::list_collections()
   });
 }
 
-CyanStore::mount_ertr::future<> CyanStore::ShardStores::mount()
+CyanStore::mount_ertr::future<> CyanStore::Shard::mount()
 {
   static const char read_file_errmsg[]{"read_file"};
   ceph::bufferlist bl;
@@ -170,7 +169,7 @@ CyanStore::mount_ertr::future<> CyanStore::ShardStores::mount()
   return mount_ertr::now();
 }
 
-seastar::future<> CyanStore::ShardStores::umount()
+seastar::future<> CyanStore::Shard::umount()
 {
   return seastar::do_with(std::set<coll_t>{}, [this](auto& collections) {
     return seastar::do_for_each(coll_map, [&collections, this](auto& coll) {
@@ -193,7 +192,7 @@ seastar::future<> CyanStore::ShardStores::umount()
 }
 
 seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
-CyanStore::ShardStores::list_objects(
+CyanStore::Shard::list_objects(
   CollectionRef ch,
   const ghobject_t& start,
   const ghobject_t& end,
@@ -220,7 +219,7 @@ CyanStore::ShardStores::list_objects(
 }
 
 seastar::future<CollectionRef>
-CyanStore::ShardStores::create_new_collection(const coll_t& cid)
+CyanStore::Shard::create_new_collection(const coll_t& cid)
 {
   auto c = new Collection{cid};
   new_coll_map[cid] = c;
@@ -228,13 +227,13 @@ CyanStore::ShardStores::create_new_collection(const coll_t& cid)
 }
 
 seastar::future<CollectionRef>
-CyanStore::ShardStores::open_collection(const coll_t& cid)
+CyanStore::Shard::open_collection(const coll_t& cid)
 {
   return seastar::make_ready_future<CollectionRef>(_get_collection(cid));
 }
 
 seastar::future<std::vector<coll_core_t>>
-CyanStore::ShardStores::list_collections()
+CyanStore::Shard::list_collections()
 {
   std::vector<coll_core_t> collections;
   for (auto& coll : coll_map) {
@@ -243,8 +242,8 @@ CyanStore::ShardStores::list_collections()
   return seastar::make_ready_future<std::vector<coll_core_t>>(std::move(collections));
 }
 
-CyanStore::read_errorator::future<ceph::bufferlist>
-CyanStore::ShardStores::read(
+CyanStore::Shard::read_errorator::future<ceph::bufferlist>
+CyanStore::Shard::read(
   CollectionRef ch,
   const ghobject_t& oid,
   uint64_t offset,
@@ -271,8 +270,8 @@ CyanStore::ShardStores::read(
   return read_errorator::make_ready_future<ceph::bufferlist>(o->read(offset, l));
 }
 
-CyanStore::read_errorator::future<ceph::bufferlist>
-CyanStore::ShardStores::readv(
+CyanStore::Shard::read_errorator::future<ceph::bufferlist>
+CyanStore::Shard::readv(
   CollectionRef ch,
   const ghobject_t& oid,
   interval_set<uint64_t>& m,
@@ -292,8 +291,8 @@ CyanStore::ShardStores::readv(
   });
 }
 
-CyanStore::get_attr_errorator::future<ceph::bufferlist>
-CyanStore::ShardStores::get_attr(
+CyanStore::Shard::get_attr_errorator::future<ceph::bufferlist>
+CyanStore::Shard::get_attr(
   CollectionRef ch,
   const ghobject_t& oid,
   std::string_view name) const
@@ -312,8 +311,8 @@ CyanStore::ShardStores::get_attr(
   }
 }
 
-CyanStore::get_attrs_ertr::future<CyanStore::attrs_t>
-CyanStore::ShardStores::get_attrs(
+CyanStore::Shard::get_attrs_ertr::future<CyanStore::Shard::attrs_t>
+CyanStore::Shard::get_attrs(
   CollectionRef ch,
   const ghobject_t& oid)
 {
@@ -327,7 +326,7 @@ CyanStore::ShardStores::get_attrs(
   return get_attrs_ertr::make_ready_future<attrs_t>(o->xattr);
 }
 
-auto CyanStore::ShardStores::omap_get_values(
+auto CyanStore::Shard::omap_get_values(
   CollectionRef ch,
   const ghobject_t& oid,
   const omap_keys_t& keys)
@@ -348,11 +347,11 @@ auto CyanStore::ShardStores::omap_get_values(
   return seastar::make_ready_future<omap_values_t>(std::move(values));
 }
 
-auto CyanStore::ShardStores::omap_get_values(
+auto CyanStore::Shard::omap_get_values(
   CollectionRef ch,
   const ghobject_t &oid,
   const std::optional<string> &start)
-  -> read_errorator::future<std::tuple<bool, omap_values_t>>
+  -> CyanStore::Shard::read_errorator::future<std::tuple<bool, omap_values_t>>
 {
   auto c = static_cast<Collection*>(ch.get());
   logger().debug("{} {} {}", __func__, c->get_cid(), oid);
@@ -370,10 +369,10 @@ auto CyanStore::ShardStores::omap_get_values(
     std::make_tuple(true, std::move(values)));
 }
 
-auto CyanStore::ShardStores::omap_get_header(
+auto CyanStore::Shard::omap_get_header(
   CollectionRef ch,
   const ghobject_t& oid)
-  -> get_attr_errorator::future<ceph::bufferlist>
+  -> CyanStore::Shard::get_attr_errorator::future<ceph::bufferlist>
 {
   auto c = static_cast<Collection*>(ch.get());
   auto o = c->get_object(oid);
@@ -385,7 +384,7 @@ auto CyanStore::ShardStores::omap_get_header(
     o->omap_header);
 }
 
-seastar::future<> CyanStore::ShardStores::do_transaction_no_callbacks(
+seastar::future<> CyanStore::Shard::do_transaction_no_callbacks(
   CollectionRef ch,
   ceph::os::Transaction&& t)
 {
@@ -577,7 +576,7 @@ seastar::future<> CyanStore::ShardStores::do_transaction_no_callbacks(
   return seastar::now();
 }
 
-int CyanStore::ShardStores::_remove(const coll_t& cid, const ghobject_t& oid)
+int CyanStore::Shard::_remove(const coll_t& cid, const ghobject_t& oid)
 {
   logger().debug("{} cid={} oid={}",
                 __func__, cid, oid);
@@ -594,7 +593,7 @@ int CyanStore::ShardStores::_remove(const coll_t& cid, const ghobject_t& oid)
   return 0;
 }
 
-int CyanStore::ShardStores::_touch(const coll_t& cid, const ghobject_t& oid)
+int CyanStore::Shard::_touch(const coll_t& cid, const ghobject_t& oid)
 {
   logger().debug("{} cid={} oid={}",
                 __func__, cid, oid);
@@ -606,7 +605,7 @@ int CyanStore::ShardStores::_touch(const coll_t& cid, const ghobject_t& oid)
   return 0;
 }
 
-int CyanStore::ShardStores::_write(
+int CyanStore::Shard::_write(
   const coll_t& cid,
   const ghobject_t& oid,
   uint64_t offset,
@@ -632,7 +631,7 @@ int CyanStore::ShardStores::_write(
   return 0;
 }
 
-int CyanStore::ShardStores::_zero(
+int CyanStore::Shard::_zero(
   const coll_t& cid,
   const ghobject_t& oid,
   uint64_t offset,
@@ -646,7 +645,7 @@ int CyanStore::ShardStores::_zero(
   return _write(cid, oid, offset, len, bl, 0);
 }
 
-int CyanStore::ShardStores::_omap_clear(
+int CyanStore::Shard::_omap_clear(
   const coll_t& cid,
   const ghobject_t& oid)
 {
@@ -665,7 +664,7 @@ int CyanStore::ShardStores::_omap_clear(
   return 0;
 }
 
-int CyanStore::ShardStores::_omap_set_values(
+int CyanStore::Shard::_omap_set_values(
   const coll_t& cid,
   const ghobject_t& oid,
   std::map<std::string, ceph::bufferlist> &&aset)
@@ -685,7 +684,7 @@ int CyanStore::ShardStores::_omap_set_values(
   return 0;
 }
 
-int CyanStore::ShardStores::_omap_set_header(
+int CyanStore::Shard::_omap_set_header(
   const coll_t& cid,
   const ghobject_t& oid,
   const ceph::bufferlist &header)
@@ -703,7 +702,7 @@ int CyanStore::ShardStores::_omap_set_header(
   return 0;
 }
 
-int CyanStore::ShardStores::_omap_rmkeys(
+int CyanStore::Shard::_omap_rmkeys(
   const coll_t& cid,
   const ghobject_t& oid,
   const omap_keys_t& aset)
@@ -723,7 +722,7 @@ int CyanStore::ShardStores::_omap_rmkeys(
   return 0;
 }
 
-int CyanStore::ShardStores::_omap_rmkeyrange(
+int CyanStore::Shard::_omap_rmkeyrange(
   const coll_t& cid,
   const ghobject_t& oid,
   const std::string &first,
@@ -744,7 +743,7 @@ int CyanStore::ShardStores::_omap_rmkeyrange(
   return 0;
 }
 
-int CyanStore::ShardStores::_truncate(
+int CyanStore::Shard::_truncate(
   const coll_t& cid,
   const ghobject_t& oid,
   uint64_t size)
@@ -766,7 +765,7 @@ int CyanStore::ShardStores::_truncate(
   return r;
 }
 
-int CyanStore::ShardStores::_clone(
+int CyanStore::Shard::_clone(
   const coll_t& cid,
   const ghobject_t& oid,
   const ghobject_t& noid)
@@ -792,7 +791,7 @@ int CyanStore::ShardStores::_clone(
   return 0;
 }
 
-int CyanStore::ShardStores::_setattrs(
+int CyanStore::Shard::_setattrs(
   const coll_t& cid,
   const ghobject_t& oid,
   std::map<std::string,bufferlist>&& aset)
@@ -812,7 +811,7 @@ int CyanStore::ShardStores::_setattrs(
   return 0;
 }
 
-int CyanStore::ShardStores::_rm_attr(
+int CyanStore::Shard::_rm_attr(
   const coll_t& cid,
   const ghobject_t& oid,
   std::string_view name)
@@ -834,7 +833,7 @@ int CyanStore::ShardStores::_rm_attr(
   return 0;
 }
 
-int CyanStore::ShardStores::_rm_attrs(
+int CyanStore::Shard::_rm_attrs(
   const coll_t& cid,
   const ghobject_t& oid)
 {
@@ -851,7 +850,7 @@ int CyanStore::ShardStores::_rm_attrs(
   return 0;
 }
 
-int CyanStore::ShardStores::_create_collection(const coll_t& cid, int bits)
+int CyanStore::Shard::_create_collection(const coll_t& cid, int bits)
 {
   auto result = coll_map.try_emplace(cid);
   if (!result.second)
@@ -865,7 +864,7 @@ int CyanStore::ShardStores::_create_collection(const coll_t& cid, int bits)
 }
 
 boost::intrusive_ptr<Collection>
-CyanStore::ShardStores::_get_collection(const coll_t& cid)
+CyanStore::Shard::_get_collection(const coll_t& cid)
 {
   auto cp = coll_map.find(cid);
   if (cp == coll_map.end())
@@ -877,6 +876,7 @@ seastar::future<> CyanStore::write_meta(
   const std::string& key,
   const std::string& value)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   std::string v = value;
   v += "\n";
   if (int r = safe_write_file(path.c_str(), key.c_str(),
@@ -890,6 +890,7 @@ seastar::future<> CyanStore::write_meta(
 seastar::future<std::tuple<int, std::string>>
 CyanStore::read_meta(const std::string& key)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   std::string fsid(4096, '\0');
   int r = safe_read_file(path.c_str(), key.c_str(), fsid.data(), fsid.size());
   if (r > 0) {
@@ -906,17 +907,18 @@ CyanStore::read_meta(const std::string& key)
 
 uuid_d CyanStore::get_fsid() const
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   return osd_fsid;
 }
 
-unsigned CyanStore::get_max_attr_name_length() const
+unsigned CyanStore::Shard::get_max_attr_name_length() const
 {
   // arbitrary limitation exactly like in the case of MemStore.
   return 256;
 }
 
-CyanStore::read_errorator::future<std::map<uint64_t, uint64_t>>
-CyanStore::ShardStores::fiemap(
+CyanStore::Shard::read_errorator::future<std::map<uint64_t, uint64_t>>
+CyanStore::Shard::fiemap(
   CollectionRef ch,
   const ghobject_t& oid,
   uint64_t off,
@@ -933,7 +935,7 @@ CyanStore::ShardStores::fiemap(
 }
 
 seastar::future<struct stat>
-CyanStore::ShardStores::stat(
+CyanStore::Shard::stat(
   CollectionRef ch,
   const ghobject_t& oid)
 {

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -25,13 +25,79 @@ class Transaction;
 }
 
 namespace crimson::os {
-using coll_core_t = FuturizedStore::coll_core_t;
 class CyanStore final : public FuturizedStore {
-  class ShardStores {
+  class Shard : public FuturizedStore::Shard {
   public:
-    ShardStores(std::string path)
+    Shard(std::string path)
       :path(path){}
 
+    seastar::future<struct stat> stat(
+      CollectionRef c,
+      const ghobject_t& oid) final;
+
+    read_errorator::future<ceph::bufferlist> read(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint64_t offset,
+      size_t len,
+      uint32_t op_flags = 0) final;
+
+    read_errorator::future<ceph::bufferlist> readv(
+      CollectionRef c,
+      const ghobject_t& oid,
+      interval_set<uint64_t>& m,
+      uint32_t op_flags = 0) final;
+
+    get_attr_errorator::future<ceph::bufferlist> get_attr(
+      CollectionRef c,
+      const ghobject_t& oid,
+      std::string_view name) const final;
+
+    get_attrs_ertr::future<attrs_t> get_attrs(
+      CollectionRef c,
+      const ghobject_t& oid) final;
+
+    read_errorator::future<omap_values_t> omap_get_values(
+      CollectionRef c,
+      const ghobject_t& oid,
+      const omap_keys_t& keys) final;
+
+    read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
+      CollectionRef c,           ///< [in] collection
+      const ghobject_t &oid,     ///< [in] oid
+      const std::optional<std::string> &start ///< [in] start, empty for begin
+      ) final;
+
+    get_attr_errorator::future<ceph::bufferlist> omap_get_header(
+      CollectionRef c,
+      const ghobject_t& oid) final;
+
+    seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
+    list_objects(
+      CollectionRef c,
+      const ghobject_t& start,
+      const ghobject_t& end,
+      uint64_t limit) const final;
+
+    seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
+
+    seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
+
+    seastar::future<> do_transaction_no_callbacks(
+      CollectionRef ch,
+      ceph::os::Transaction&& txn) final;
+
+    read_errorator::future<std::map<uint64_t, uint64_t>>
+    fiemap(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint64_t off,
+      uint64_t len) final;
+
+    unsigned get_max_attr_name_length() const final;
+
+  public:
+    // only exposed to CyanStore
     mount_ertr::future<> mount();
 
     seastar::future<> umount();
@@ -40,70 +106,8 @@ class CyanStore final : public FuturizedStore {
 
     mkfs_ertr::future<> mkcoll(uuid_d new_osd_fsid);
 
-    seastar::future<struct stat> stat(
-      CollectionRef c,
-      const ghobject_t& oid);
-
-    read_errorator::future<ceph::bufferlist> read(
-      CollectionRef c,
-      const ghobject_t& oid,
-      uint64_t offset,
-      size_t len,
-      uint32_t op_flags = 0);
-
-    read_errorator::future<ceph::bufferlist> readv(
-      CollectionRef c,
-      const ghobject_t& oid,
-      interval_set<uint64_t>& m,
-      uint32_t op_flags = 0);
-
-    get_attr_errorator::future<ceph::bufferlist> get_attr(
-      CollectionRef c,
-      const ghobject_t& oid,
-      std::string_view name) const;
-
-    get_attrs_ertr::future<attrs_t> get_attrs(
-      CollectionRef c,
-      const ghobject_t& oid);
-
-    read_errorator::future<omap_values_t> omap_get_values(
-      CollectionRef c,
-      const ghobject_t& oid,
-      const omap_keys_t& keys);
-
-    read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
-      CollectionRef c,           ///< [in] collection
-      const ghobject_t &oid,     ///< [in] oid
-      const std::optional<std::string> &start ///< [in] start, empty for begin
-      );
-
-    seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
-    list_objects(
-      CollectionRef c,
-      const ghobject_t& start,
-      const ghobject_t& end,
-      uint64_t limit) const;
-
-    get_attr_errorator::future<ceph::bufferlist> omap_get_header(
-      CollectionRef c,
-      const ghobject_t& oid);
-
-    seastar::future<CollectionRef> create_new_collection(const coll_t& cid);
-
-    seastar::future<CollectionRef> open_collection(const coll_t& cid);
-
+    using coll_core_t = FuturizedStore::coll_core_t;
     seastar::future<std::vector<coll_core_t>> list_collections();
-
-    seastar::future<> do_transaction_no_callbacks(
-      CollectionRef ch,
-      ceph::os::Transaction&& txn);
-
-    read_errorator::future<std::map<uint64_t, uint64_t>>
-    fiemap(
-      CollectionRef c,
-      const ghobject_t& oid,
-      uint64_t off,
-      uint64_t len);
 
     uint64_t get_used_bytes() const { return used_bytes; }
 
@@ -137,11 +141,11 @@ class CyanStore final : public FuturizedStore {
       const std::string &last);
     int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
     int _clone(const coll_t& cid, const ghobject_t& oid,
-               const ghobject_t& noid);
+	       const ghobject_t& noid);
     int _setattrs(const coll_t& cid, const ghobject_t& oid,
-                  std::map<std::string,bufferlist>&& aset);
+		  std::map<std::string,bufferlist>&& aset);
     int _rm_attr(const coll_t& cid, const ghobject_t& oid,
-                 std::string_view name);
+		 std::string_view name);
     int _rm_attrs(const coll_t& cid, const ghobject_t& oid);
     int _create_collection(const coll_t& cid, int bits);
     boost::intrusive_ptr<Collection> _get_collection(const coll_t& cid);
@@ -153,29 +157,22 @@ class CyanStore final : public FuturizedStore {
     std::map<coll_t, boost::intrusive_ptr<Collection>> new_coll_map;
   };
 
-// public interfaces called by main OSD
 public:
   CyanStore(const std::string& path);
   ~CyanStore() final;
 
+  seastar::future<> start() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.start(path);
+  }
+
   seastar::future<> stop() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
     return shard_stores.stop();
   }
-  seastar::future<> start() final;
-
-  mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
-
-  seastar::future<store_statfs_t> stat() const final;
-
-  seastar::future<> write_meta(const std::string& key,
-		  const std::string& value) final;
-
-  seastar::future<std::tuple<int, std::string>>
-  read_meta(const std::string& key) final;
-
-  uuid_d get_fsid() const final;
 
   mount_ertr::future<> mount() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
     return shard_stores.invoke_on_all(
       [](auto &local_store) {
       return local_store.mount().handle_error(
@@ -189,123 +186,34 @@ public:
   }
 
   seastar::future<> umount() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
     return shard_stores.invoke_on_all(
       [](auto &local_store) {
       return local_store.umount();
     });
   }
 
+  mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
+
+  seastar::future<store_statfs_t> stat() const final;
+
+  uuid_d get_fsid() const final;
+
+  seastar::future<> write_meta(const std::string& key,
+		  const std::string& value) final;
+
+  FuturizedStore::Shard& get_sharded_store() final{
+    return shard_stores.local();
+  }
+
+  seastar::future<std::tuple<int, std::string>>
+  read_meta(const std::string& key) final;
+
   seastar::future<std::vector<coll_core_t>> list_collections() final;
 
-// public interfaces called by each shard osd
-public:
-  unsigned get_max_attr_name_length() const final;
-
-  seastar::future<struct stat> stat(
-    CollectionRef c,
-    const ghobject_t& oid) final {
-    return shard_stores.local().stat(
-      c, oid);
-  }
-
-  read_errorator::future<ceph::bufferlist> read(
-    CollectionRef c,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    uint32_t op_flags = 0) final {
-    return shard_stores.local().read(
-      c, oid, offset, len, op_flags);
-  }
-
-  read_errorator::future<ceph::bufferlist> readv(
-    CollectionRef c,
-    const ghobject_t& oid,
-    interval_set<uint64_t>& m,
-    uint32_t op_flags = 0) final {
-    return shard_stores.local().readv(
-      c, oid, m, op_flags);
-  }
-
-  get_attr_errorator::future<ceph::bufferlist> get_attr(
-    CollectionRef c,
-    const ghobject_t& oid,
-    std::string_view name) const final {
-    return shard_stores.local().get_attr(
-      c, oid, name);
-  }
-
-  get_attrs_ertr::future<attrs_t> get_attrs(
-    CollectionRef c,
-    const ghobject_t& oid) final {
-    return shard_stores.local().get_attrs(
-      c, oid);
-  }
-
-  read_errorator::future<omap_values_t> omap_get_values(
-    CollectionRef c,
-    const ghobject_t& oid,
-    const omap_keys_t& keys) final {
-    return shard_stores.local().omap_get_values(
-      c, oid, keys);
-  }
-
-  /// Retrieves paged set of values > start (if present)
-  read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) final {
-    return shard_stores.local().omap_get_values(
-      c, oid, start);
-  }
-
-  seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
-  list_objects(
-    CollectionRef c,
-    const ghobject_t& start,
-    const ghobject_t& end,
-    uint64_t limit) const final {
-    return shard_stores.local().list_objects(
-      c, start, end, limit);
-  }
-
-  get_attr_errorator::future<ceph::bufferlist> omap_get_header(
-    CollectionRef c,
-    const ghobject_t& oid) final {
-    return shard_stores.local().omap_get_header(
-      c, oid);
-  }
-
-  seastar::future<CollectionRef>
-  create_new_collection(const coll_t& cid) final {
-    return shard_stores.local().create_new_collection(cid);
-  }
-
-  seastar::future<CollectionRef>
-  open_collection(const coll_t& cid) final {
-    return shard_stores.local().open_collection(cid);
-  }
-
-  seastar::future<> do_transaction_no_callbacks(
-    CollectionRef ch,
-    ceph::os::Transaction&& txn) final {
-    return shard_stores.local().do_transaction_no_callbacks(
-      ch, std::move(txn));
-  }
-
-  read_errorator::future<std::map<uint64_t, uint64_t>>
-  fiemap(CollectionRef c,
-         const ghobject_t& oid,
-         uint64_t off,
-         uint64_t len) final {
-    return shard_stores.local().fiemap(
-      c, oid, off, len);
-  }
-
 private:
+  seastar::sharded<CyanStore::Shard> shard_stores;
   const std::string path;
   uuid_d osd_fsid;
-  seastar::sharded<ShardStores> shard_stores;
 };
 }

--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -10,29 +10,22 @@
 
 namespace crimson::os {
 
-seastar::future<std::unique_ptr<FuturizedStore>>
+std::unique_ptr<FuturizedStore>
 FuturizedStore::create(const std::string& type,
                        const std::string& data,
                        const ConfigValues& values)
 {
   if (type == "cyanstore") {
     using crimson::os::CyanStore;
-    return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(
-      std::make_unique<CyanStore>(data));
+    return std::make_unique<CyanStore>(data);
   } else if (type == "seastore") {
     return crimson::os::seastore::make_seastore(
-      data, values
-    ).then([] (auto seastore) {
-      return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(
-	std::make_unique<ShardedStoreProxy<seastore::SeaStore>>(
-	  seastore.release()));
-    });
+      data);
   } else {
     using crimson::os::AlienStore;
 #ifdef WITH_BLUESTORE
     // use AlienStore as a fallback. It adapts e.g. BlueStore.
-    return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(
-      std::make_unique<AlienStore>(type, data, values));
+    return std::make_unique<AlienStore>(type, data, values);
 #else
     ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
     return {};

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -25,322 +25,173 @@ class Transaction;
 namespace crimson::os {
 class FuturizedCollection;
 
+constexpr core_id_t PRIMARY_CORE = 0;
+
 class FuturizedStore {
+public:
+  class Shard {
+  public:
+    Shard() = default;
+    virtual ~Shard() = default;
+    // no copying
+    explicit Shard(const Shard& o) = delete;
+    const Shard& operator=(const Shard& o) = delete;
+
+    using CollectionRef = boost::intrusive_ptr<FuturizedCollection>;
+    using read_errorator = crimson::errorator<crimson::ct_error::enoent,
+					      crimson::ct_error::input_output_error>;
+    virtual read_errorator::future<ceph::bufferlist> read(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint64_t offset,
+      size_t len,
+      uint32_t op_flags = 0) = 0;
+
+    virtual read_errorator::future<ceph::bufferlist> readv(
+      CollectionRef c,
+      const ghobject_t& oid,
+      interval_set<uint64_t>& m,
+      uint32_t op_flags = 0) = 0;
+
+    using get_attr_errorator = crimson::errorator<
+      crimson::ct_error::enoent,
+      crimson::ct_error::enodata>;
+    virtual get_attr_errorator::future<ceph::bufferlist> get_attr(
+      CollectionRef c,
+      const ghobject_t& oid,
+      std::string_view name) const = 0;
+
+    using get_attrs_ertr = crimson::errorator<
+      crimson::ct_error::enoent>;
+    using attrs_t = std::map<std::string, ceph::bufferlist, std::less<>>;
+    virtual get_attrs_ertr::future<attrs_t> get_attrs(
+      CollectionRef c,
+      const ghobject_t& oid) = 0;
+
+    virtual seastar::future<struct stat> stat(
+      CollectionRef c,
+      const ghobject_t& oid) = 0;
+
+    using omap_values_t = std::map<std::string, ceph::bufferlist, std::less<>>;
+    using omap_keys_t = std::set<std::string>;
+    virtual read_errorator::future<omap_values_t> omap_get_values(
+      CollectionRef c,
+      const ghobject_t& oid,
+      const omap_keys_t& keys) = 0;
+
+    virtual read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
+      CollectionRef c,           ///< [in] collection
+      const ghobject_t &oid,     ///< [in] oid
+      const std::optional<std::string> &start ///< [in] start, empty for begin
+      ) = 0; ///< @return <done, values> values.empty() only if done
+
+    virtual get_attr_errorator::future<bufferlist> omap_get_header(
+      CollectionRef c,
+      const ghobject_t& oid) = 0;
+
+    virtual seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
+      CollectionRef c,
+      const ghobject_t& start,
+      const ghobject_t& end,
+      uint64_t limit) const = 0;
+
+    virtual seastar::future<CollectionRef> create_new_collection(const coll_t& cid) = 0;
+
+    virtual seastar::future<CollectionRef> open_collection(const coll_t& cid) = 0;
+
+  protected:
+    virtual seastar::future<> do_transaction_no_callbacks(
+      CollectionRef ch,
+      ceph::os::Transaction&& txn) = 0;
+
+  public:
+    seastar::future<> do_transaction(
+      CollectionRef ch,
+      ceph::os::Transaction&& txn) {
+      std::unique_ptr<Context> on_commit(
+	ceph::os::Transaction::collect_all_contexts(txn));
+      return do_transaction_no_callbacks(
+	std::move(ch), std::move(txn)
+      ).then([on_commit=std::move(on_commit)]() mutable {
+	auto c = on_commit.release();
+	if (c) c->complete(0);
+	return seastar::now();
+      });
+    }
+
+
+    /**
+     * flush
+     *
+     * Flushes outstanding transactions on ch, returned future resolves
+     * after any previously submitted transactions on ch have committed.
+     *
+     * @param ch [in] collection on which to flush
+     */
+    virtual seastar::future<> flush(CollectionRef ch) {
+      return do_transaction(ch, ceph::os::Transaction{});
+    }
+
+    // error injection
+    virtual seastar::future<> inject_data_error(const ghobject_t& o) {
+      return seastar::now();
+    }
+
+    virtual seastar::future<> inject_mdata_error(const ghobject_t& o) {
+      return seastar::now();
+    }
+
+    virtual read_errorator::future<std::map<uint64_t, uint64_t>> fiemap(
+      CollectionRef ch,
+      const ghobject_t& oid,
+      uint64_t off,
+      uint64_t len) = 0;
+
+    virtual unsigned get_max_attr_name_length() const = 0;
+  };
 
 public:
-  static seastar::future<std::unique_ptr<FuturizedStore>> create(const std::string& type,
+  static std::unique_ptr<FuturizedStore> create(const std::string& type,
                                                 const std::string& data,
                                                 const ConfigValues& values);
-  FuturizedStore() = default;
+  FuturizedStore()
+  : primary_core(seastar::this_shard_id())
+  {}
+
   virtual ~FuturizedStore() = default;
 
   // no copying
   explicit FuturizedStore(const FuturizedStore& o) = delete;
   const FuturizedStore& operator=(const FuturizedStore& o) = delete;
 
-  virtual seastar::future<> start() {
-    return seastar::now();
-  }
+  virtual seastar::future<> start() = 0;
+
   virtual seastar::future<> stop() = 0;
 
   using mount_ertr = crimson::errorator<crimson::stateful_ec>;
   virtual mount_ertr::future<> mount() = 0;
+
   virtual seastar::future<> umount() = 0;
 
   using mkfs_ertr = crimson::errorator<crimson::stateful_ec>;
   virtual mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) = 0;
+
   virtual seastar::future<store_statfs_t> stat() const = 0;
 
-  using CollectionRef = boost::intrusive_ptr<FuturizedCollection>;
-  using read_errorator = crimson::errorator<crimson::ct_error::enoent,
-                                            crimson::ct_error::input_output_error>;
-  virtual read_errorator::future<ceph::bufferlist> read(
-    CollectionRef c,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    uint32_t op_flags = 0) = 0;
-  virtual read_errorator::future<ceph::bufferlist> readv(
-    CollectionRef c,
-    const ghobject_t& oid,
-    interval_set<uint64_t>& m,
-    uint32_t op_flags = 0) = 0;
+  virtual uuid_d get_fsid() const  = 0;
 
-  using get_attr_errorator = crimson::errorator<
-    crimson::ct_error::enoent,
-    crimson::ct_error::enodata>;
-  virtual get_attr_errorator::future<ceph::bufferlist> get_attr(
-    CollectionRef c,
-    const ghobject_t& oid,
-    std::string_view name) const = 0;
+  virtual seastar::future<> write_meta(const std::string& key,
+				       const std::string& value) = 0;
+  // called on the shard and get this FuturizedStore::shard;
+  virtual Shard& get_sharded_store() = 0;
 
-  using get_attrs_ertr = crimson::errorator<
-    crimson::ct_error::enoent>;
-  using attrs_t = std::map<std::string, ceph::bufferlist, std::less<>>;
-  virtual get_attrs_ertr::future<attrs_t> get_attrs(
-    CollectionRef c,
-    const ghobject_t& oid) = 0;
-  virtual seastar::future<struct stat> stat(
-    CollectionRef c,
-    const ghobject_t& oid) = 0;
+  virtual seastar::future<std::tuple<int, std::string>> read_meta(
+    const std::string& key) = 0;
 
-  using omap_values_t = std::map<std::string, ceph::bufferlist, std::less<>>;
-  using omap_keys_t = std::set<std::string>;
-  virtual read_errorator::future<omap_values_t> omap_get_values(
-    CollectionRef c,
-    const ghobject_t& oid,
-    const omap_keys_t& keys) = 0;
-  virtual seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
-    CollectionRef c,
-    const ghobject_t& start,
-    const ghobject_t& end,
-    uint64_t limit) const = 0;
-  virtual read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) = 0; ///< @return <done, values> values.empty() only if done
-
-  virtual get_attr_errorator::future<bufferlist> omap_get_header(
-    CollectionRef c,
-    const ghobject_t& oid) = 0;
-
-  virtual seastar::future<CollectionRef> create_new_collection(const coll_t& cid) = 0;
-  virtual seastar::future<CollectionRef> open_collection(const coll_t& cid) = 0;
   using coll_core_t = std::pair<coll_t, core_id_t>;
   virtual seastar::future<std::vector<coll_core_t>> list_collections() = 0;
 
 protected:
-  virtual seastar::future<> do_transaction_no_callbacks(
-    CollectionRef ch,
-    ceph::os::Transaction&& txn) = 0;
-
-public:
-  seastar::future<> do_transaction(
-    CollectionRef ch,
-    ceph::os::Transaction&& txn) {
-    std::unique_ptr<Context> on_commit(
-      ceph::os::Transaction::collect_all_contexts(txn));
-    return do_transaction_no_callbacks(
-      std::move(ch), std::move(txn)
-    ).then([on_commit=std::move(on_commit)]() mutable {
-      auto c = on_commit.release();
-      if (c) c->complete(0);
-      return seastar::now();
-    });
-  }
-
-
-  /**
-   * flush
-   *
-   * Flushes outstanding transactions on ch, returned future resolves
-   * after any previously submitted transactions on ch have committed.
-   *
-   * @param ch [in] collection on which to flush
-   */
-  virtual seastar::future<> flush(CollectionRef ch) {
-    return do_transaction(ch, ceph::os::Transaction{});
-  }
-
-  // error injection
-  virtual seastar::future<> inject_data_error(const ghobject_t& o) {
-    return seastar::now();
-  }
-  virtual seastar::future<> inject_mdata_error(const ghobject_t& o) {
-    return seastar::now();
-  }
-
-  virtual read_errorator::future<std::map<uint64_t, uint64_t>> fiemap(
-    CollectionRef ch,
-    const ghobject_t& oid,
-    uint64_t off,
-    uint64_t len) = 0;
-
-  virtual seastar::future<> write_meta(const std::string& key,
-				       const std::string& value) = 0;
-  virtual seastar::future<std::tuple<int, std::string>> read_meta(
-    const std::string& key) = 0;
-  virtual uuid_d get_fsid() const  = 0;
-  virtual unsigned get_max_attr_name_length() const = 0;
+  const core_id_t primary_core;
 };
-
-/**
- * ShardedStoreProxy
- *
- * Simple helper to proxy FuturizedStore operations to the core on which
- * the store was initialized for implementations without support for multiple
- * reactors.
- */
-template <typename T>
-class ShardedStoreProxy : public FuturizedStore {
-  const core_id_t core;
-  std::unique_ptr<T> impl;
-  uuid_d fsid;
-  unsigned max_attr = 0;
-
-  template <typename Method, typename... Args>
-  decltype(auto) proxy(Method method, Args&&... args) const {
-    return proxy_method_on_core(
-      core, *impl, method, std::forward<Args>(args)...);
-  }
-
-  template <typename Method, typename... Args>
-  decltype(auto) proxy(Method method, Args&&... args) {
-    return proxy_method_on_core(
-      core, *impl, method, std::forward<Args>(args)...);
-  }
-
-public:
-  ShardedStoreProxy(T *t)
-    : core(seastar::this_shard_id()),
-      impl(t) {}
-  template <typename... Args>
-  ShardedStoreProxy(Args&&... args)
-    : core(seastar::this_shard_id()),
-      impl(std::make_unique<T>(std::forward<Args>(args)...)) {}
-  ~ShardedStoreProxy() = default;
-
-  // no copying
-  explicit ShardedStoreProxy(const ShardedStoreProxy &o) = delete;
-  const ShardedStoreProxy &operator=(const ShardedStoreProxy &o) = delete;
-
-  seastar::future<> start() final { return proxy(&T::start); }
-  seastar::future<> stop() final { return proxy(&T::stop); }
-  mount_ertr::future<> mount() final {
-    auto ret = seastar::smp::submit_to(
-      core,
-      [this] {
-	auto ret = impl->mount(
-	).safe_then([this] {
-	  fsid = impl->get_fsid();
-	  max_attr = impl->get_max_attr_name_length();
-	  return seastar::now();
-	});
-	return std::move(ret).to_base();
-      });
-    return mount_ertr::future<>(std::move(ret));
-  }
-  seastar::future<> umount() final { return proxy(&T::umount); }
-  mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final {
-    return proxy(&T::mkfs, new_osd_fsid);
-  }
-  seastar::future<store_statfs_t> stat() const final {
-    return crimson::submit_to(core, [this] { return impl->stat(); });
-  }
-  read_errorator::future<ceph::bufferlist> read(
-    CollectionRef c,
-    const ghobject_t &oid,
-    uint64_t offset,
-    size_t len,
-    uint32_t op_flags = 0) final {
-    return proxy(&T::read, std::move(c), oid, offset, len, op_flags);
-  }
-  read_errorator::future<ceph::bufferlist> readv(
-    CollectionRef c,
-    const ghobject_t &oid,
-    interval_set<uint64_t> &m,
-    uint32_t op_flags = 0) final {
-    return crimson::submit_to(core, [this, c, oid, m, op_flags]() mutable {
-      return impl->readv(c, oid, m, op_flags);
-    });
-  }
-  get_attr_errorator::future<ceph::bufferlist> get_attr(
-    CollectionRef c,
-    const ghobject_t &oid,
-    std::string_view name) const final {
-    return proxy(&T::get_attr, std::move(c), oid, std::string(name));
-  }
-  get_attrs_ertr::future<attrs_t> get_attrs(
-    CollectionRef c,
-    const ghobject_t &oid) final {
-    return proxy(&T::get_attrs, std::move(c), oid);
-  }
-  seastar::future<struct stat> stat(
-    CollectionRef c,
-    const ghobject_t &oid) final {
-    return crimson::submit_to(
-      core,
-      [this, c, oid] {
-	return impl->stat(c, oid);
-      });
-  }
-  read_errorator::future<omap_values_t> omap_get_values(
-    CollectionRef c,
-    const ghobject_t &oid,
-    const omap_keys_t &keys) final {
-    return crimson::submit_to(core, [this, c, oid, keys] {
-      return impl->omap_get_values(c, oid, keys);
-    });
-  }
-  seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
-  list_objects(
-    CollectionRef c,
-    const ghobject_t &start,
-    const ghobject_t &end,
-    uint64_t limit) const final {
-    return proxy(&T::list_objects, std::move(c), start, end, limit);
-  }
-  read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,
-    const ghobject_t &oid,
-    const std::optional<std::string> &start) final {
-    return crimson::submit_to(core, [this, c, oid, start] {
-      return impl->omap_get_values(c, oid, start);
-    });
-  }
-  get_attr_errorator::future<bufferlist> omap_get_header(
-    CollectionRef c,
-    const ghobject_t &oid) final {
-    return proxy(&T::omap_get_header, std::move(c), oid);
-  }
-  seastar::future<CollectionRef> create_new_collection(const coll_t &cid) final {
-    return proxy(&T::create_new_collection, cid);
-  }
-  seastar::future<CollectionRef> open_collection(const coll_t &cid) final {
-    return proxy(&T::open_collection, cid);
-  }
-  seastar::future<std::vector<coll_core_t>> list_collections() final {
-    return proxy(&T::list_collections);
-  }
-  seastar::future<> do_transaction_no_callbacks(
-    CollectionRef ch,
-    ceph::os::Transaction &&txn) final {
-    return proxy(&T::do_transaction_no_callbacks, std::move(ch), std::move(txn));
-  }
-  seastar::future<> flush(CollectionRef ch) final {
-    return proxy(&T::flush, std::move(ch));
-  }
-  seastar::future<> inject_data_error(const ghobject_t &o) final {
-    return proxy(&T::inject_data_error, o);
-  }
-  seastar::future<> inject_mdata_error(const ghobject_t &o) final {
-    return proxy(&T::inject_mdata_error, o);
-  }
-
-  read_errorator::future<std::map<uint64_t, uint64_t>> fiemap(
-    CollectionRef ch,
-    const ghobject_t &oid,
-    uint64_t off,
-    uint64_t len) final {
-    return proxy(&T::fiemap, std::move(ch), oid, off, len);
-  }
-
-  seastar::future<> write_meta(
-    const std::string &key,
-    const std::string &value) final {
-    return proxy(&T::write_meta, key, value);
-  }
-  seastar::future<std::tuple<int, std::string>> read_meta(
-    const std::string &key) final {
-    return proxy(&T::read_meta, key);
-  }
-  uuid_d get_fsid() const final {
-    return fsid;
-  }
-  unsigned get_max_attr_name_length() const final {
-    return max_attr;
-  }
-};
-
 }

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -45,6 +45,34 @@ struct device_config_t {
     denc(v.secondary_devices, p);
     DENC_FINISH(p);
   }
+  static device_config_t create_primary(
+    uuid_d new_osd_fsid,
+    device_id_t id,
+    device_type_t d_type,
+    secondary_device_set_t sds) {
+    return device_config_t{
+             true,
+             device_spec_t{
+               (magic_t)std::rand(),
+		d_type,
+		id},
+             seastore_meta_t{new_osd_fsid},
+             sds};
+   }
+  static device_config_t create_secondary(
+    uuid_d new_osd_fsid,
+    device_id_t id,
+    device_type_t d_type,
+    magic_t magic) {
+    return device_config_t{
+             false,
+             device_spec_t{
+               magic,
+               d_type,
+               id},
+             seastore_meta_t{new_osd_fsid},
+             secondary_device_set_t()};
+  }
 };
 
 std::ostream& operator<<(std::ostream&, const device_config_t&);
@@ -58,9 +86,41 @@ using DeviceRef = std::unique_ptr<Device>;
  * Represents a general device regardless of the underlying medium.
  */
 class Device {
+// interfaces used by device
 public:
   virtual ~Device() {}
 
+  virtual seastar::future<> start() {
+    return seastar::now();
+  }
+
+  virtual seastar::future<> stop() {
+    return seastar::now();
+  }
+  // called on the shard to get this shard device;
+  virtual Device& get_sharded_device() {
+    return *this;
+  }
+
+  using access_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error,
+    crimson::ct_error::permission_denied,
+    crimson::ct_error::enoent>;
+
+  using mkfs_ertr = access_ertr;
+  using mkfs_ret = mkfs_ertr::future<>;
+  virtual mkfs_ret mkfs(device_config_t) = 0;
+
+  using mount_ertr = access_ertr;
+  using mount_ret = access_ertr::future<>;
+  virtual mount_ret mount() = 0;
+
+  static seastar::future<DeviceRef> make_device(
+    const std::string &device,
+    device_type_t dtype);
+
+// interfaces used by each device shard
+public:
   virtual device_id_t get_device_id() const = 0;
 
   virtual magic_t get_magic() const = 0;
@@ -76,19 +136,6 @@ public:
   virtual std::size_t get_available_size() const = 0;
 
   virtual secondary_device_set_t& get_secondary_devices() = 0;
-
-  using access_ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::permission_denied,
-    crimson::ct_error::enoent>;
-
-  using mkfs_ertr = access_ertr;
-  using mkfs_ret = mkfs_ertr::future<>;
-  virtual mkfs_ret mkfs(device_config_t) = 0;
-
-  using mount_ertr = access_ertr;
-  using mount_ret = access_ertr::future<>;
-  virtual mount_ret mount() = 0;
 
   using close_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
@@ -115,10 +162,6 @@ public:
       return read_ertr::make_ready_future<bufferptr>(std::move(*ptrref));
     });
   }
-
-  static seastar::future<DeviceRef> make_device(
-    const std::string &device,
-    device_type_t dtype);
 };
 
 }

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -171,4 +171,5 @@ WRITE_CLASS_DENC(crimson::os::seastore::device_config_t)
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::os::seastore::device_config_t> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::device_spec_t> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -152,7 +152,7 @@ class tree_cursor_t final
   eagain_ifuture<> trim_value(context_t, value_size_t);
 
   static Ref<tree_cursor_t> get_invalid() {
-    static Ref<tree_cursor_t> INVALID = new tree_cursor_t();
+    Ref<tree_cursor_t> INVALID = new tree_cursor_t();
     return INVALID;
   }
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -34,9 +34,9 @@
 using std::string;
 using crimson::common::local_conf;
 
-template <> struct fmt::formatter<crimson::os::seastore::SeaStore::op_type_t>
+template <> struct fmt::formatter<crimson::os::seastore::op_type_t>
   : fmt::formatter<std::string_view> {
-  using op_type_t =  crimson::os::seastore::SeaStore::op_type_t;
+  using op_type_t =  crimson::os::seastore::op_type_t;
   // parse is inherited from formatter<string_view>.
   template <typename FormatContext>
   auto format(op_type_t op, FormatContext& ctx) {
@@ -113,29 +113,35 @@ public:
 
 using crimson::common::get_conf;
 
-SeaStore::SeaStore(
-  const std::string& root,
-  MDStoreRef mdstore,
-  DeviceRef dev,
+SeaStore::Shard::Shard(
+  std::string root,
+  Device* dev,
   bool is_test)
-  : root(root),
-    mdstore(std::move(mdstore)),
-    device(std::move(dev)),
-    max_object_size(
-      get_conf<uint64_t>("seastore_default_max_object_size")),
-    is_test(is_test),
-    throttler(
+  :root(root),
+   max_object_size(
+     get_conf<uint64_t>("seastore_default_max_object_size")),
+   is_test(is_test),
+   throttler(
       get_conf<uint64_t>("seastore_max_concurrent_transactions"))
 {
+  device.reset(dev);
   register_metrics();
+}
+
+SeaStore::SeaStore(
+  const std::string& root,
+  MDStoreRef mdstore)
+  : root(root),
+    mdstore(std::move(mdstore))
+{
 }
 
 SeaStore::~SeaStore() = default;
 
-void SeaStore::register_metrics()
+void SeaStore::Shard::register_metrics()
 {
   namespace sm = seastar::metrics;
-  using op_type_t = SeaStore::op_type_t;
+  using op_type_t = crimson::os::seastore::op_type_t;
   std::pair<op_type_t, sm::label_instance> labels_by_op_type[] = {
     {op_type_t::TRANSACTION,     sm::label_instance("latency", "TRANSACTION")},
     {op_type_t::READ,            sm::label_instance("latency", "READ")},
@@ -186,23 +192,71 @@ void SeaStore::register_metrics()
   );
 }
 
+seastar::future<> SeaStore::start()
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+#ifndef NDEBUG
+  bool is_test = true;
+#else
+  bool is_test = false;
+#endif
+  return shard_stores.start(root, nullptr, is_test)
+    .then([this] {
+    return shard_stores.invoke_on_all([](auto& local_store) {
+      return local_store.make_shard_stores();
+    });
+  });
+}
+
+seastar::future<> SeaStore::test_start(DeviceRef device)
+{
+  if (device) {
+    ceph_assert(root == "");
+    return shard_stores.start_single(root, device.release(), true);
+  } else {
+    ceph_assert(0 == "impossible no device");
+  }
+}
+
+
 seastar::future<> SeaStore::stop()
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  return shard_stores.stop();
+}
+
+seastar::future<> SeaStore::Shard::make_shard_stores()
+{
+  if (root != "") {
+    using crimson::common::get_conf;
+    std::string type = get_conf<std::string>("seastore_main_device_type");
+    device_type_t d_type = string_to_device_type(type);
+    assert(d_type == device_type_t::SSD ||
+         d_type == device_type_t::RANDOM_BLOCK_SSD);
+
+    return Device::make_device(
+      root, d_type
+    ).then([this](DeviceRef device_obj) {
+      device = std::move(device_obj);
+    });
+  }
   return seastar::now();
 }
 
 SeaStore::mount_ertr::future<> SeaStore::test_mount()
 {
-  init_managers();
-  return transaction_manager->mount(
-  ).handle_error(
-    crimson::ct_error::assert_all{
-      "Invalid error in SeaStore::test_mount"
-    }
-  );
+
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  shard_stores.local().init_managers();
+    return shard_stores.local().get_transaction_manager()->mount(
+    ).handle_error(
+      crimson::ct_error::assert_all{
+        "Invalid error in SeaStore::test_mount"
+      }
+    );
 }
 
-SeaStore::mount_ertr::future<> SeaStore::mount()
+SeaStore::mount_ertr::future<> SeaStore::Shard::mount()
 {
   return device->mount(
   ).safe_then([this] {
@@ -211,9 +265,9 @@ SeaStore::mount_ertr::future<> SeaStore::mount()
       device_id_t id = device_entry.first;
       magic_t magic = device_entry.second.magic;
       device_type_t dtype = device_entry.second.dtype;
-      std::ostringstream oss;
-      oss << root << "/block." << dtype << "." << std::to_string(id);
-      return Device::make_device(oss.str(), dtype
+      std::string path =
+        fmt::format("{}/block.{}.{}", root, dtype, std::to_string(id));
+      return Device::make_device(path, dtype
       ).then([this, magic](DeviceRef sec_dev) {
         return sec_dev->mount(
         ).safe_then([this, sec_dev=std::move(sec_dev), magic]() mutable {
@@ -228,12 +282,12 @@ SeaStore::mount_ertr::future<> SeaStore::mount()
     return transaction_manager->mount();
   }).handle_error(
     crimson::ct_error::assert_all{
-      "Invalid error in SeaStore::mount"
+      "Invalid error in Shard::mount"
     }
   );
 }
 
-seastar::future<> SeaStore::umount()
+seastar::future<> SeaStore::Shard::umount()
 {
   return [this] {
     if (transaction_manager) {
@@ -264,6 +318,7 @@ seastar::future<> SeaStore::umount()
 
 seastar::future<> SeaStore::write_fsid(uuid_d new_osd_fsid)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   LOG_PREFIX(SeaStore::write_fsid);
   return read_meta("fsid").then([this, FNAME, new_osd_fsid] (auto tuple) {
     auto [ret, fsid] = tuple;
@@ -280,7 +335,8 @@ seastar::future<> SeaStore::write_fsid(uuid_d new_osd_fsid)
    });
 }
 
-seastar::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
+seastar::future<>
+SeaStore::Shard::mkfs_managers()
 {
   init_managers();
   return transaction_manager->mkfs(
@@ -304,33 +360,88 @@ seastar::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
 	});
       });
     });
-  }).safe_then([this, new_osd_fsid] {
-    return write_fsid(new_osd_fsid);
-  }).safe_then([this] {
-    return read_meta("type").then([this] (auto tuple) {
-      auto [ret, type] = tuple;
-      if (ret == 0 && type == "seastore") {
-	return seastar::now();
-      } else if (ret == 0 && type != "seastore") {
-	LOG_PREFIX(SeaStore::mkfs);
-	ERROR("expected seastore, but type is {}", type);
-	throw std::runtime_error("store type error");
-      } else {
-	return write_meta("type", "seastore");
-      }
-    });
-  }).safe_then([this] {
-    return write_meta("mkfs_done", "yes");
   }).handle_error(
     crimson::ct_error::assert_all{
-      "Invalid error in SeaStore::_mkfs"
+      "Invalid error in Shard::mkfs_managers"
     }
   );
 }
 
+seastar::future<>
+SeaStore::Shard::mkfs(
+  secondary_device_set_t &sds,
+  uuid_d new_osd_fsid)
+{
+  device_type_t d_type = device->get_device_type();
+  device_id_t id = (d_type == device_type_t::RANDOM_BLOCK_SSD) ?
+    static_cast<device_id_t>(DEVICE_ID_RANDOM_BLOCK_MIN) : 0;
+
+  return device->mkfs(
+    device_config_t{
+      true,
+      device_spec_t{
+        (magic_t)std::rand(),
+        d_type,
+        id},
+      seastore_meta_t{new_osd_fsid},
+      sds}
+  ).safe_then([this] {
+    return crimson::do_for_each(secondaries, [](auto& sec_dev) {
+      return sec_dev->mount();
+    });
+  }).safe_then([this] {
+    return device->mount();
+  }).safe_then([this] {
+    return mkfs_managers();
+  }).handle_error(
+    crimson::ct_error::assert_all{
+      "Invalid error in SeaStore::Shard::mkfs"
+    }
+  );
+}
+
+seastar::future<> SeaStore::Shard::sec_mkfs(
+  const std::string path,
+  device_type_t dtype,
+  device_id_t id,
+  secondary_device_set_t &sds,
+  uuid_d new_osd_fsid)
+{
+  return Device::make_device(path, dtype
+  ).then([this, &sds, id, dtype, new_osd_fsid](DeviceRef sec_dev) {
+    magic_t magic = (magic_t)std::rand();
+    sds.emplace(
+      (device_id_t)id,
+      device_spec_t{magic, dtype, (device_id_t)id});
+    return sec_dev->mkfs(
+      device_config_t{
+        false,
+        device_spec_t{
+          magic,
+          dtype,
+          (device_id_t)id},
+        seastore_meta_t{new_osd_fsid},
+        secondary_device_set_t()}
+    ).safe_then([this, sec_dev=std::move(sec_dev), id]() mutable {
+      LOG_PREFIX(SeaStore::Shard::sec_mkfs);
+      DEBUG("mkfs: finished for device {}", id);
+      secondaries.emplace_back(std::move(sec_dev));
+    }).handle_error(crimson::ct_error::assert_all{"not possible"});
+  });
+}
+
+seastar::future<> SeaStore::_mkfs(uuid_d new_osd_fsid)
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  return shard_stores.local().mkfs_managers(
+  ).then([this, new_osd_fsid] {
+    return prepare_meta(new_osd_fsid);
+  });
+}
+
 SeaStore::mkfs_ertr::future<> SeaStore::test_mkfs(uuid_d new_osd_fsid)
 {
-
+  ceph_assert(seastar::this_shard_id() == primary_core);
   return read_meta("mkfs_done").then([this, new_osd_fsid] (auto tuple) {
     auto [done, value] = tuple;
     if (done == 0) {
@@ -340,16 +451,39 @@ SeaStore::mkfs_ertr::future<> SeaStore::test_mkfs(uuid_d new_osd_fsid)
   });
 }
 
+seastar::future<> SeaStore::prepare_meta(uuid_d new_osd_fsid)
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  return write_fsid(new_osd_fsid).then([this] {
+    return read_meta("type").then([this] (auto tuple) {
+      auto [ret, type] = tuple;
+      if (ret == 0 && type == "seastore") {
+	return seastar::now();
+      } else if (ret == 0 && type != "seastore") {
+	LOG_PREFIX(SeaStore::prepare_meta);
+	ERROR("expected seastore, but type is {}", type);
+	throw std::runtime_error("store type error");
+      } else {
+	return write_meta("type", "seastore");
+      }
+    });
+  }).then([this] {
+    return write_meta("mkfs_done", "yes");
+  });
+}
+
 SeaStore::mkfs_ertr::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   return read_meta("mkfs_done").then([this, new_osd_fsid] (auto tuple) {
     auto [done, value] = tuple;
     if (done == 0) {
       return seastar::now();
     } else {
       return seastar::do_with(
-        secondary_device_set_t(),
+        std::vector<secondary_device_set_t>(),
         [this, new_osd_fsid](auto& sds) {
+        sds.resize(seastar::smp::count);
         auto fut = seastar::now();
         LOG_PREFIX(SeaStore::mkfs);
         DEBUG("root: {}", root);
@@ -375,27 +509,16 @@ SeaStore::mkfs_ertr::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
                   return seastar::now();
                 }
                 auto id = std::stoi(entry_name.substr(dtype_end + 1));
-                std::ostringstream oss;
-                oss << root << "/" << entry_name;
-                return Device::make_device(oss.str(), dtype
-                ).then([this, &sds, id, dtype, new_osd_fsid](DeviceRef sec_dev) {
-                  magic_t magic = (magic_t)std::rand();
-                  sds.emplace(
-                    (device_id_t)id,
-                    device_spec_t{magic, dtype, (device_id_t)id});
-                  return sec_dev->mkfs(device_config_t{
-                      false,
-                      device_spec_t{
-                        magic,
-                        dtype,
-                        (device_id_t)id},
-                      seastore_meta_t{new_osd_fsid},
-                      secondary_device_set_t()}
-                  ).safe_then([this, sec_dev=std::move(sec_dev), id]() mutable {
-                    LOG_PREFIX(SeaStore::mkfs);
-                    DEBUG("mkfs: finished for device {}", id);
-                    secondaries.emplace_back(std::move(sec_dev));
-                  }).handle_error(crimson::ct_error::assert_all{"not possible"});
+                std::string path = fmt::format("{}/{}", root, entry_name);
+                return shard_stores.invoke_on_all(
+                  [&sds, id, path, dtype, new_osd_fsid]
+                  (auto &local_store) {
+                  return local_store.sec_mkfs(
+                    path,
+                    dtype,
+                    id,
+                    sds[seastar::this_shard_id()],
+                    new_osd_fsid);
                 });
               }
               return seastar::now();
@@ -404,55 +527,64 @@ SeaStore::mkfs_ertr::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
           });
         }
         return fut.then([this, &sds, new_osd_fsid] {
-	  device_id_t id = 0;
-	  device_type_t d_type = device->get_device_type();
-	  assert(d_type == device_type_t::SSD ||
-		 d_type == device_type_t::RANDOM_BLOCK_SSD);
-	  if (d_type == device_type_t::RANDOM_BLOCK_SSD) {
-	    id = static_cast<device_id_t>(DEVICE_ID_RANDOM_BLOCK_MIN);
-	  } 
-
-          return device->mkfs(
-            device_config_t{
-              true,
-              device_spec_t{
-                (magic_t)std::rand(),
-		d_type,
-		id},
-              seastore_meta_t{new_osd_fsid},
-              sds}
-          );
-        }).safe_then([this] {
-          return crimson::do_for_each(secondaries, [](auto& sec_dev) {
-            return sec_dev->mount();
+          return shard_stores.invoke_on_all(
+            [&sds, new_osd_fsid](auto &local_store) {
+            return local_store.mkfs(
+              sds[seastar::this_shard_id()], new_osd_fsid);
           });
         });
-      }).safe_then([this] {
-        return device->mount();
-      }).safe_then([this, new_osd_fsid] {
-	return _mkfs(new_osd_fsid);
-      }).safe_then([this] {
+      }).then([this, new_osd_fsid] {
+        return prepare_meta(new_osd_fsid);
+      }).then([this] {
 	return umount();
-      }).handle_error(
-        crimson::ct_error::assert_all{
-          "Invalid error in SeaStore::mkfs"
-        }
-      );
+      });
     }
   });
 }
 
+using coll_core_t = FuturizedStore::coll_core_t;
+seastar::future<std::vector<coll_core_t>>
+SeaStore::list_collections()
+{
+  ceph_assert(seastar::this_shard_id() == primary_core);
+  return shard_stores.map([](auto &local_store) {
+    return local_store.list_collections();
+  }).then([](std::vector<std::vector<coll_core_t>> results) {
+    std::vector<coll_core_t> collections;
+    for (auto& colls : results) {
+      collections.insert(collections.end(), colls.begin(), colls.end());
+    }
+    return seastar::make_ready_future<std::vector<coll_core_t>>(
+      std::move(collections));
+  });
+}
+
+store_statfs_t SeaStore::Shard::stat() const
+{
+  return transaction_manager->store_stat();
+}
+
 seastar::future<store_statfs_t> SeaStore::stat() const
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   LOG_PREFIX(SeaStore::stat);
   DEBUG("");
-  return seastar::make_ready_future<store_statfs_t>(
-    transaction_manager->store_stat()
-  );
+  return shard_stores.map_reduce0(
+    [](const SeaStore::Shard &local_store) {
+      return local_store.stat();
+    },
+    store_statfs_t(),
+    [](auto &&ss, auto &&ret) {
+      ss.add(ret);
+      return std::move(ss);
+    }
+  ).then([](store_statfs_t ss) {
+    return seastar::make_ready_future<store_statfs_t>(std::move(ss));
+  });
 }
 
 TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
-SeaStore::get_coll_bits(CollectionRef ch, Transaction &t) const
+SeaStore::Shard::get_coll_bits(CollectionRef ch, Transaction &t) const
 {
   return transaction_manager->read_collection_root(t)
     .si_then([this, ch, &t](auto coll_root) {
@@ -545,7 +677,7 @@ get_ranges(CollectionRef ch,
 }
 
 seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>>
-SeaStore::list_objects(CollectionRef ch,
+SeaStore::Shard::list_objects(CollectionRef ch,
                        const ghobject_t& start,
                        const ghobject_t& end,
                        uint64_t limit) const
@@ -573,7 +705,7 @@ SeaStore::list_objects(CollectionRef ch,
 		  std::vector<ghobject_t>(),
 		  ghobject_t::get_max()));
           } else {
-            auto filter = get_objs_range(ch, *bits);
+            auto filter = SeaStore::get_objs_range(ch, *bits);
 	    using list_iertr = OnodeManager::list_onodes_iertr;
 	    using repeat_ret = list_iertr::future<seastar::stop_iteration>;
             return trans_intr::repeat(
@@ -627,20 +759,23 @@ SeaStore::list_objects(CollectionRef ch,
   });
 }
 
-seastar::future<CollectionRef> SeaStore::create_new_collection(const coll_t& cid)
+seastar::future<CollectionRef>
+SeaStore::Shard::create_new_collection(const coll_t& cid)
 {
   LOG_PREFIX(SeaStore::create_new_collection);
   DEBUG("{}", cid);
   return seastar::make_ready_future<CollectionRef>(_get_collection(cid));
 }
 
-seastar::future<CollectionRef> SeaStore::open_collection(const coll_t& cid)
+seastar::future<CollectionRef>
+SeaStore::Shard::open_collection(const coll_t& cid)
 {
   LOG_PREFIX(SeaStore::open_collection);
   DEBUG("{}", cid);
   return list_collections().then([cid, this] (auto colls_cores) {
-    if (auto found = std::find(colls_cores.begin(), colls_cores.end(),
-        std::make_pair(cid, NULL_CORE));
+    if (auto found = std::find(colls_cores.begin(),
+                               colls_cores.end(),
+                               std::make_pair(cid, seastar::this_shard_id()));
       found != colls_cores.end()) {
       return seastar::make_ready_future<CollectionRef>(_get_collection(cid));
     } else {
@@ -649,7 +784,8 @@ seastar::future<CollectionRef> SeaStore::open_collection(const coll_t& cid)
   });
 }
 
-seastar::future<std::vector<coll_core_t>> SeaStore::list_collections()
+seastar::future<std::vector<coll_core_t>>
+SeaStore::Shard::list_collections()
 {
   return seastar::do_with(
     std::vector<coll_core_t>(),
@@ -667,7 +803,9 @@ seastar::future<std::vector<coll_core_t>> SeaStore::list_collections()
             ret.resize(colls.size());
             std::transform(
               colls.begin(), colls.end(), ret.begin(),
-              [](auto p) { return std::make_pair(p.first, NULL_CORE); });
+              [](auto p) {
+              return std::make_pair(p.first, seastar::this_shard_id());
+            });
           });
         });
       }).safe_then([&ret] {
@@ -681,7 +819,8 @@ seastar::future<std::vector<coll_core_t>> SeaStore::list_collections()
   );
 }
 
-SeaStore::read_errorator::future<ceph::bufferlist> SeaStore::read(
+SeaStore::Shard::read_errorator::future<ceph::bufferlist>
+SeaStore::Shard::read(
   CollectionRef ch,
   const ghobject_t& oid,
   uint64_t offset,
@@ -718,7 +857,8 @@ SeaStore::read_errorator::future<ceph::bufferlist> SeaStore::read(
     });
 }
 
-SeaStore::read_errorator::future<ceph::bufferlist> SeaStore::readv(
+SeaStore::Shard::read_errorator::future<ceph::bufferlist>
+SeaStore::Shard::readv(
   CollectionRef ch,
   const ghobject_t& _oid,
   interval_set<uint64_t>& m,
@@ -746,7 +886,8 @@ SeaStore::read_errorator::future<ceph::bufferlist> SeaStore::readv(
 
 using crimson::os::seastore::omap_manager::BtreeOMapManager;
 
-SeaStore::get_attr_errorator::future<ceph::bufferlist> SeaStore::get_attr(
+SeaStore::Shard::get_attr_errorator::future<ceph::bufferlist>
+SeaStore::Shard::get_attr(
   CollectionRef ch,
   const ghobject_t& oid,
   std::string_view name) const
@@ -784,7 +925,8 @@ SeaStore::get_attr_errorator::future<ceph::bufferlist> SeaStore::get_attr(
   }), crimson::ct_error::pass_further_all{});
 }
 
-SeaStore::get_attrs_ertr::future<SeaStore::attrs_t> SeaStore::get_attrs(
+SeaStore::Shard::get_attrs_ertr::future<SeaStore::Shard::attrs_t>
+SeaStore::Shard::get_attrs(
   CollectionRef ch,
   const ghobject_t& oid)
 {
@@ -822,7 +964,7 @@ SeaStore::get_attrs_ertr::future<SeaStore::attrs_t> SeaStore::get_attrs(
   }), crimson::ct_error::pass_further_all{});
 }
 
-seastar::future<struct stat> SeaStore::stat(
+seastar::future<struct stat> SeaStore::Shard::stat(
   CollectionRef c,
   const ghobject_t& oid)
 {
@@ -850,16 +992,16 @@ seastar::future<struct stat> SeaStore::stat(
   );
 }
 
-SeaStore::get_attr_errorator::future<ceph::bufferlist>
-SeaStore::omap_get_header(
+SeaStore::Shard::get_attr_errorator::future<ceph::bufferlist>
+SeaStore::Shard::omap_get_header(
   CollectionRef ch,
   const ghobject_t& oid)
 {
   return get_attr(ch, oid, OMAP_HEADER_XATTR_KEY);
 }
 
-SeaStore::read_errorator::future<SeaStore::omap_values_t>
-SeaStore::omap_get_values(
+SeaStore::Shard::read_errorator::future<SeaStore::Shard::omap_values_t>
+SeaStore::Shard::omap_get_values(
   CollectionRef ch,
   const ghobject_t &oid,
   const omap_keys_t &keys)
@@ -881,7 +1023,8 @@ SeaStore::omap_get_values(
     });
 }
 
-SeaStore::_omap_get_value_ret SeaStore::_omap_get_value(
+SeaStore::Shard::_omap_get_value_ret
+SeaStore::Shard::_omap_get_value(
   Transaction &t,
   omap_root_t &&root,
   std::string_view key) const
@@ -905,7 +1048,8 @@ SeaStore::_omap_get_value_ret SeaStore::_omap_get_value(
   );
 }
 
-SeaStore::_omap_get_values_ret SeaStore::_omap_get_values(
+SeaStore::Shard::_omap_get_values_ret
+SeaStore::Shard::_omap_get_values(
   Transaction &t,
   omap_root_t &&omap_root,
   const omap_keys_t &keys) const
@@ -944,7 +1088,8 @@ SeaStore::_omap_get_values_ret SeaStore::_omap_get_values(
   );
 }
 
-SeaStore::omap_list_ret SeaStore::omap_list(
+SeaStore::Shard::omap_list_ret
+SeaStore::Shard::omap_list(
   Onode &onode,
   const omap_root_le_t& omap_root,
   Transaction& t,
@@ -968,7 +1113,8 @@ SeaStore::omap_list_ret SeaStore::omap_list(
   });
 }
 
-SeaStore::omap_get_values_ret_t SeaStore::omap_get_values(
+SeaStore::Shard::omap_get_values_ret_t
+SeaStore::Shard::omap_get_values(
   CollectionRef ch,
   const ghobject_t &oid,
   const std::optional<string> &start)
@@ -976,7 +1122,7 @@ SeaStore::omap_get_values_ret_t SeaStore::omap_get_values(
   auto c = static_cast<SeastoreCollection*>(ch.get());
   LOG_PREFIX(SeaStore::omap_get_values);
   DEBUG("{} {}", c->get_cid(), oid);
-  using ret_bare_t = std::tuple<bool, SeaStore::omap_values_t>;
+  using ret_bare_t = std::tuple<bool, SeaStore::Shard::omap_values_t>;
   return repeat_with_onode<ret_bare_t>(
     c,
     oid,
@@ -993,7 +1139,7 @@ SeaStore::omap_get_values_ret_t SeaStore::omap_get_values(
   });
 }
 
-SeaStore::_fiemap_ret SeaStore::_fiemap(
+SeaStore::Shard::_fiemap_ret SeaStore::Shard::_fiemap(
   Transaction &t,
   Onode &onode,
   uint64_t off,
@@ -1013,7 +1159,8 @@ SeaStore::_fiemap_ret SeaStore::_fiemap(
   });
 }
 
-SeaStore::read_errorator::future<std::map<uint64_t, uint64_t>> SeaStore::fiemap(
+SeaStore::Shard::read_errorator::future<std::map<uint64_t, uint64_t>>
+SeaStore::Shard::fiemap(
   CollectionRef ch,
   const ghobject_t& oid,
   uint64_t off,
@@ -1040,7 +1187,7 @@ SeaStore::read_errorator::future<std::map<uint64_t, uint64_t>> SeaStore::fiemap(
   });
 }
 
-void SeaStore::on_error(ceph::os::Transaction &t) {
+void SeaStore::Shard::on_error(ceph::os::Transaction &t) {
   LOG_PREFIX(SeaStore::on_error);
   ERROR(" transaction dump:\n");
   JSONFormatter f(true);
@@ -1053,7 +1200,7 @@ void SeaStore::on_error(ceph::os::Transaction &t) {
   abort();
 }
 
-seastar::future<> SeaStore::do_transaction_no_callbacks(
+seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
   CollectionRef _ch,
   ceph::os::Transaction&& _t)
 {
@@ -1095,7 +1242,7 @@ seastar::future<> SeaStore::do_transaction_no_callbacks(
 }
 
 
-seastar::future<> SeaStore::flush(CollectionRef ch)
+seastar::future<> SeaStore::Shard::flush(CollectionRef ch)
 {
   return seastar::do_with(
     get_dummy_ordering_handle(),
@@ -1108,7 +1255,8 @@ seastar::future<> SeaStore::flush(CollectionRef ch)
     });
 }
 
-SeaStore::tm_ret SeaStore::_do_transaction_step(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_do_transaction_step(
   internal_context_t &ctx,
   CollectionRef &col,
   std::vector<OnodeRef> &onodes,
@@ -1292,7 +1440,8 @@ SeaStore::tm_ret SeaStore::_do_transaction_step(
   );
 }
 
-SeaStore::tm_ret SeaStore::_remove(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_remove(
   internal_context_t &ctx,
   OnodeRef &onode)
 {
@@ -1334,7 +1483,8 @@ SeaStore::tm_ret SeaStore::_remove(
   );
 }
 
-SeaStore::tm_ret SeaStore::_touch(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_touch(
   internal_context_t &ctx,
   OnodeRef &onode)
 {
@@ -1343,7 +1493,8 @@ SeaStore::tm_ret SeaStore::_touch(
   return tm_iertr::now();
 }
 
-SeaStore::tm_ret SeaStore::_write(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_write(
   internal_context_t &ctx,
   OnodeRef &onode,
   uint64_t offset, size_t len,
@@ -1373,7 +1524,8 @@ SeaStore::tm_ret SeaStore::_write(
     });
 }
 
-SeaStore::tm_ret SeaStore::_zero(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_zero(
   internal_context_t &ctx,
   OnodeRef &onode,
   objaddr_t offset,
@@ -1400,8 +1552,8 @@ SeaStore::tm_ret SeaStore::_zero(
   });
 }
 
-SeaStore::omap_set_kvs_ret
-SeaStore::_omap_set_kvs(
+SeaStore::Shard::omap_set_kvs_ret
+SeaStore::Shard::_omap_set_kvs(
   OnodeRef &onode,
   const omap_root_le_t& omap_root,
   Transaction& t,
@@ -1434,7 +1586,8 @@ SeaStore::_omap_set_kvs(
   );
 }
 
-SeaStore::tm_ret SeaStore::_omap_set_values(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_omap_set_values(
   internal_context_t &ctx,
   OnodeRef &onode,
   std::map<std::string, ceph::bufferlist> &&aset)
@@ -1449,7 +1602,8 @@ SeaStore::tm_ret SeaStore::_omap_set_values(
     std::move(aset));
 }
 
-SeaStore::tm_ret SeaStore::_omap_set_header(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_omap_set_header(
   internal_context_t &ctx,
   OnodeRef &onode,
   ceph::bufferlist &&header)
@@ -1461,7 +1615,8 @@ SeaStore::tm_ret SeaStore::_omap_set_header(
   return _setattrs(ctx, onode,std::move(to_set));
 }
 
-SeaStore::tm_ret SeaStore::_omap_clear(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_omap_clear(
   internal_context_t &ctx,
   OnodeRef &onode)
 {
@@ -1495,7 +1650,8 @@ SeaStore::tm_ret SeaStore::_omap_clear(
   });
 }
 
-SeaStore::tm_ret SeaStore::_omap_rmkeys(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_omap_rmkeys(
   internal_context_t &ctx,
   OnodeRef &onode,
   omap_keys_t &&keys)
@@ -1536,7 +1692,8 @@ SeaStore::tm_ret SeaStore::_omap_rmkeys(
   }
 }
 
-SeaStore::tm_ret SeaStore::_omap_rmkeyrange(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_omap_rmkeyrange(
   internal_context_t &ctx,
   OnodeRef &onode,
   std::string first,
@@ -1583,7 +1740,8 @@ SeaStore::tm_ret SeaStore::_omap_rmkeyrange(
   }
 }
 
-SeaStore::tm_ret SeaStore::_truncate(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_truncate(
   internal_context_t &ctx,
   OnodeRef &onode,
   uint64_t size)
@@ -1604,7 +1762,8 @@ SeaStore::tm_ret SeaStore::_truncate(
   });
 }
 
-SeaStore::tm_ret SeaStore::_setattrs(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_setattrs(
   internal_context_t &ctx,
   OnodeRef &onode,
   std::map<std::string, bufferlist>&& aset)
@@ -1671,7 +1830,8 @@ SeaStore::tm_ret SeaStore::_setattrs(
   });
 }
 
-SeaStore::tm_ret SeaStore::_rmattr(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_rmattr(
   internal_context_t &ctx,
   OnodeRef &onode,
   std::string name)
@@ -1695,7 +1855,8 @@ SeaStore::tm_ret SeaStore::_rmattr(
   }
 }
 
-SeaStore::tm_ret SeaStore::_xattr_rmattr(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_xattr_rmattr(
   internal_context_t &ctx,
   OnodeRef &onode,
   std::string &&name)
@@ -1724,7 +1885,8 @@ SeaStore::tm_ret SeaStore::_xattr_rmattr(
   }
 }
 
-SeaStore::tm_ret SeaStore::_rmattrs(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_rmattrs(
   internal_context_t &ctx,
   OnodeRef &onode)
 {
@@ -1738,7 +1900,8 @@ SeaStore::tm_ret SeaStore::_rmattrs(
   return _xattr_clear(ctx, onode);
 }
 
-SeaStore::tm_ret SeaStore::_xattr_clear(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_xattr_clear(
   internal_context_t &ctx,
   OnodeRef &onode)
 {
@@ -1765,7 +1928,8 @@ SeaStore::tm_ret SeaStore::_xattr_clear(
   }
 }
 
-SeaStore::tm_ret SeaStore::_create_collection(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_create_collection(
   internal_context_t &ctx,
   const coll_t& cid, int bits)
 {
@@ -1797,7 +1961,8 @@ SeaStore::tm_ret SeaStore::_create_collection(
   );
 }
 
-SeaStore::tm_ret SeaStore::_remove_collection(
+SeaStore::Shard::tm_ret
+SeaStore::Shard::_remove_collection(
   internal_context_t &ctx,
   const coll_t& cid)
 {
@@ -1828,13 +1993,15 @@ SeaStore::tm_ret SeaStore::_remove_collection(
   );
 }
 
-boost::intrusive_ptr<SeastoreCollection> SeaStore::_get_collection(const coll_t& cid)
+boost::intrusive_ptr<SeastoreCollection>
+SeaStore::Shard::_get_collection(const coll_t& cid)
 {
   return new SeastoreCollection{cid};
 }
 
-seastar::future<> SeaStore::write_meta(const std::string& key,
-					const std::string& value)
+seastar::future<> SeaStore::Shard::write_meta(
+  const std::string& key,
+  const std::string& value)
 {
   LOG_PREFIX(SeaStore::write_meta);
   DEBUG("key: {}; value: {}", key, value);
@@ -1854,16 +2021,16 @@ seastar::future<> SeaStore::write_meta(const std::string& key,
               return transaction_manager->submit_transaction(t);
             });
           });
-	}).safe_then([this, &key, &value] {
-	  return mdstore->write_meta(key, value);
 	});
       }).handle_error(
 	crimson::ct_error::assert_all{"Invalid error in SeaStore::write_meta"}
       );
 }
 
-seastar::future<std::tuple<int, std::string>> SeaStore::read_meta(const std::string& key)
+seastar::future<std::tuple<int, std::string>>
+SeaStore::read_meta(const std::string& key)
 {
+  ceph_assert(seastar::this_shard_id() == primary_core);
   LOG_PREFIX(SeaStore::read_meta);
   DEBUG("key: {}", key);
   return mdstore->read_meta(key).safe_then([](auto v) {
@@ -1879,12 +2046,12 @@ seastar::future<std::tuple<int, std::string>> SeaStore::read_meta(const std::str
   );
 }
 
-uuid_d SeaStore::get_fsid() const
+uuid_d SeaStore::Shard::get_fsid() const
 {
   return device->get_meta().seastore_id;
 }
 
-void SeaStore::init_managers()
+void SeaStore::Shard::init_managers()
 {
   transaction_manager.reset();
   collection_manager.reset();
@@ -1902,42 +2069,21 @@ void SeaStore::init_managers()
       *transaction_manager);
 }
 
-seastar::future<std::unique_ptr<SeaStore>> make_seastore(
-  const std::string &device,
-  const ConfigValues &config)
+std::unique_ptr<SeaStore> make_seastore(
+  const std::string &device)
 {
-  using crimson::common::get_conf;
-  std::string type = get_conf<std::string>("seastore_main_device_type");
-  device_type_t d_type = string_to_device_type(type);
-  assert(d_type == device_type_t::SSD ||
-	 d_type == device_type_t::RANDOM_BLOCK_SSD);
-
-  return Device::make_device(
-    device, d_type
-  ).then([&device](DeviceRef device_obj) {
-#ifndef NDEBUG
-    bool is_test = true;
-#else
-    bool is_test = false;
-#endif
-    auto mdstore = std::make_unique<FileMDStore>(device);
-    return std::make_unique<SeaStore>(
-      device,
-      std::move(mdstore),
-      std::move(device_obj),
-      is_test);
-  });
+  auto mdstore = std::make_unique<FileMDStore>(device);
+  return std::make_unique<SeaStore>(
+    device,
+    std::move(mdstore));
 }
 
 std::unique_ptr<SeaStore> make_test_seastore(
-  DeviceRef device,
   SeaStore::MDStoreRef mdstore)
 {
   return std::make_unique<SeaStore>(
     "",
-    std::move(mdstore),
-    std::move(device),
-    true);
+    std::move(mdstore));
 }
 
 }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -33,6 +33,18 @@ class Onode;
 using OnodeRef = boost::intrusive_ptr<Onode>;
 class TransactionManager;
 
+enum class op_type_t : uint8_t {
+    TRANSACTION = 0,
+    READ,
+    WRITE,
+    GET_ATTR,
+    GET_ATTRS,
+    STAT,
+    OMAP_GET_VALUES,
+    OMAP_LIST,
+    MAX
+};
+
 class SeastoreCollection final : public FuturizedCollection {
 public:
   template <typename... T>
@@ -56,7 +68,6 @@ struct col_obj_ranges_t {
   ghobject_t obj_end;
 };
 
-using coll_core_t = FuturizedStore::coll_core_t;
 class SeaStore final : public FuturizedStore {
 public:
   class MDStore {
@@ -80,159 +91,170 @@ public:
   };
   using MDStoreRef = std::unique_ptr<MDStore>;
 
-  SeaStore(
-    const std::string& root,
-    MDStoreRef mdstore,
-    DeviceRef device,
-    bool is_test);
-  ~SeaStore();
-    
-  seastar::future<> stop() final;
-  mount_ertr::future<> mount() final;
-  seastar::future<> umount() final;
+  class Shard : public FuturizedStore::Shard {
+  public:
+    Shard(
+      std::string root,
+      Device* device,
+      bool is_test);
+    ~Shard() = default;
 
-  mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
-  seastar::future<store_statfs_t> stat() const final;
+    seastar::future<struct stat> stat(
+      CollectionRef c,
+      const ghobject_t& oid) final;
 
-  read_errorator::future<ceph::bufferlist> read(
-    CollectionRef c,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    uint32_t op_flags = 0) final;
-  read_errorator::future<ceph::bufferlist> readv(
-    CollectionRef c,
-    const ghobject_t& oid,
-    interval_set<uint64_t>& m,
-    uint32_t op_flags = 0) final;
-  get_attr_errorator::future<ceph::bufferlist> get_attr(
-    CollectionRef c,
-    const ghobject_t& oid,
-    std::string_view name) const final;
-  get_attrs_ertr::future<attrs_t> get_attrs(
-    CollectionRef c,
-    const ghobject_t& oid) final;
+    read_errorator::future<ceph::bufferlist> read(
+      CollectionRef c,
+      const ghobject_t& oid,
+      uint64_t offset,
+      size_t len,
+      uint32_t op_flags = 0) final;
 
-  seastar::future<struct stat> stat(
-    CollectionRef c,
-    const ghobject_t& oid) final;
+    read_errorator::future<ceph::bufferlist> readv(
+      CollectionRef c,
+      const ghobject_t& oid,
+      interval_set<uint64_t>& m,
+      uint32_t op_flags = 0) final;
 
-  read_errorator::future<omap_values_t> omap_get_values(
-    CollectionRef c,
-    const ghobject_t& oid,
-    const omap_keys_t& keys) final;
+    get_attr_errorator::future<ceph::bufferlist> get_attr(
+      CollectionRef c,
+      const ghobject_t& oid,
+      std::string_view name) const final;
 
-  /// Retrieves paged set of values > start (if present)
-  using omap_get_values_ret_bare_t = std::tuple<bool, omap_values_t>;
-  using omap_get_values_ret_t = read_errorator::future<
-    omap_get_values_ret_bare_t>;
-  omap_get_values_ret_t omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) final; ///< @return <done, values> values.empty() iff done
+    get_attrs_ertr::future<attrs_t> get_attrs(
+      CollectionRef c,
+      const ghobject_t& oid) final;
 
-  get_attr_errorator::future<bufferlist> omap_get_header(
-    CollectionRef c,
-    const ghobject_t& oid) final;
+    read_errorator::future<omap_values_t> omap_get_values(
+      CollectionRef c,
+      const ghobject_t& oid,
+      const omap_keys_t& keys) final;
 
-  static col_obj_ranges_t
-  get_objs_range(CollectionRef ch, unsigned bits);
+    /// Retrieves paged set of values > start (if present)
+    using omap_get_values_ret_bare_t = std::tuple<bool, omap_values_t>;
+    using omap_get_values_ret_t = read_errorator::future<
+      omap_get_values_ret_bare_t>;
+    omap_get_values_ret_t omap_get_values(
+      CollectionRef c,           ///< [in] collection
+      const ghobject_t &oid,     ///< [in] oid
+      const std::optional<std::string> &start ///< [in] start, empty for begin
+      ) final; ///< @return <done, values> values.empty() iff done
 
-  seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
-    CollectionRef c,
-    const ghobject_t& start,
-    const ghobject_t& end,
-    uint64_t limit) const final;
+    get_attr_errorator::future<bufferlist> omap_get_header(
+      CollectionRef c,
+      const ghobject_t& oid) final;
 
-  seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
-  seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
-  seastar::future<std::vector<coll_core_t>> list_collections() final;
+    seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
+      CollectionRef c,
+      const ghobject_t& start,
+      const ghobject_t& end,
+      uint64_t limit) const final;
 
-  seastar::future<> do_transaction_no_callbacks(
-    CollectionRef ch,
-    ceph::os::Transaction&& txn) final;
+    seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
+    seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
 
-  /* Note, flush() machinery must go through the same pipeline
-   * stages and locks as do_transaction. */
-  seastar::future<> flush(CollectionRef ch) final;
-
-  read_errorator::future<std::map<uint64_t, uint64_t>> fiemap(
-    CollectionRef ch,
-    const ghobject_t& oid,
-    uint64_t off,
-    uint64_t len) final;
-
-  seastar::future<> write_meta(const std::string& key,
-		  const std::string& value) final;
-  seastar::future<std::tuple<int, std::string>> read_meta(const std::string& key) final;
-  uuid_d get_fsid() const final;
-
-  unsigned get_max_attr_name_length() const final {
-    return 256;
-  }
-  enum class op_type_t : uint8_t {
-    TRANSACTION = 0,
-    READ,
-    WRITE,
-    GET_ATTR,
-    GET_ATTRS,
-    STAT,
-    OMAP_GET_VALUES,
-    OMAP_LIST,
-    MAX
-  };
-
-  // for test
-  mount_ertr::future<> test_mount();
-  mkfs_ertr::future<> test_mkfs(uuid_d new_osd_fsid);
-  DeviceRef get_primary_device_ref() {
-    return std::move(device);
-  }
-
-private:
-  struct internal_context_t {
-    CollectionRef ch;
-    ceph::os::Transaction ext_transaction;
-
-    internal_context_t(
+    seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
-      ceph::os::Transaction &&_ext_transaction,
-      TransactionRef &&transaction)
-      : ch(ch), ext_transaction(std::move(_ext_transaction)),
-	transaction(std::move(transaction)),
-	iter(ext_transaction.begin()) {}
+      ceph::os::Transaction&& txn) final;
 
-    TransactionRef transaction;
+    /* Note, flush() machinery must go through the same pipeline
+     * stages and locks as do_transaction. */
+    seastar::future<> flush(CollectionRef ch) final;
 
-    ceph::os::Transaction::iterator iter;
-    std::chrono::steady_clock::time_point begin_timestamp = std::chrono::steady_clock::now();
+    read_errorator::future<std::map<uint64_t, uint64_t>> fiemap(
+      CollectionRef ch,
+      const ghobject_t& oid,
+      uint64_t off,
+      uint64_t len) final;
 
-    void reset_preserve_handle(TransactionManager &tm) {
-      tm.reset_transaction_preserve_handle(*transaction);
-      iter = ext_transaction.begin();
+    unsigned get_max_attr_name_length() const final {
+      return 256;
     }
-  };
 
-  TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
-  get_coll_bits(CollectionRef ch, Transaction &t) const;
+  // only exposed to SeaStore
+  public:
+    mount_ertr::future<> mount();
 
-  static void on_error(ceph::os::Transaction &t);
+    seastar::future<> umount();
 
-  template <typename F>
-  auto repeat_with_internal_context(
-    CollectionRef ch,
-    ceph::os::Transaction &&t,
-    Transaction::src_t src,
-    const char* tname,
-    op_type_t op_type,
-    F &&f) {
-    return seastar::do_with(
+    seastar::future<> mkfs(
+      secondary_device_set_t &sds,
+      uuid_d new_osd_fsid);
+
+    using coll_core_t = FuturizedStore::coll_core_t;
+    seastar::future<std::vector<coll_core_t>> list_collections();
+
+    seastar::future<> write_meta(const std::string& key,
+                                 const std::string& value);
+
+    store_statfs_t stat() const;
+
+    uuid_d get_fsid() const;
+    // for each shard store make device
+    seastar::future<> make_shard_stores();
+
+    seastar::future<> mkfs_managers();
+
+    void init_managers();
+
+    TransactionManagerRef& get_transaction_manager() {
+      return transaction_manager;
+    }
+    // for secondaries device mkfs
+    seastar::future<> sec_mkfs(
+      const std::string path,
+      device_type_t dtype,
+      device_id_t id,
+      secondary_device_set_t &sds,
+      uuid_d new_osd_fsid);
+
+    DeviceRef get_primary_device_ref() {
+      return std::move(device);
+    }
+
+  private:
+    struct internal_context_t {
+      CollectionRef ch;
+      ceph::os::Transaction ext_transaction;
+
       internal_context_t(
-	ch, std::move(t),
-	transaction_manager->create_transaction(src, tname)),
-      std::forward<F>(f),
-      [this, op_type](auto &ctx, auto &f) {
+        CollectionRef ch,
+        ceph::os::Transaction &&_ext_transaction,
+        TransactionRef &&transaction)
+        : ch(ch), ext_transaction(std::move(_ext_transaction)),
+          transaction(std::move(transaction)),
+          iter(ext_transaction.begin()) {}
+
+      TransactionRef transaction;
+
+      ceph::os::Transaction::iterator iter;
+      std::chrono::steady_clock::time_point begin_timestamp = std::chrono::steady_clock::now();
+
+      void reset_preserve_handle(TransactionManager &tm) {
+        tm.reset_transaction_preserve_handle(*transaction);
+        iter = ext_transaction.begin();
+      }
+    };
+
+    TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
+    get_coll_bits(CollectionRef ch, Transaction &t) const;
+
+    static void on_error(ceph::os::Transaction &t);
+
+    template <typename F>
+    auto repeat_with_internal_context(
+      CollectionRef ch,
+      ceph::os::Transaction &&t,
+      Transaction::src_t src,
+      const char* tname,
+      op_type_t op_type,
+      F &&f) {
+      return seastar::do_with(
+        internal_context_t(
+          ch, std::move(t),
+          transaction_manager->create_transaction(src, tname)),
+        std::forward<F>(f),
+        [this, op_type](auto &ctx, auto &f) {
 	return ctx.transaction->get_handle().take_collection_lock(
 	  static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
 	).then([this] {
@@ -253,206 +275,285 @@ private:
 	}).finally([this] {
 	  throttler.put();
 	});
-      }
-    );
-  }
+      });
+    }
 
-  template <typename Ret, typename F>
-  auto repeat_with_onode(
-    CollectionRef ch,
-    const ghobject_t &oid,
-    Transaction::src_t src,
-    const char* tname,
-    op_type_t op_type,
-    F &&f) const {
-    auto begin_time = std::chrono::steady_clock::now();
-    return seastar::do_with(
-      oid, Ret{}, std::forward<F>(f),
-      [this, src, op_type, begin_time, tname
-      ](auto &oid, auto &ret, auto &f)
-    {
-      return repeat_eagain([&, this, src, tname] {
-        return transaction_manager->with_transaction_intr(
-          src,
-          tname,
-          [&, this](auto& t)
-        {
-          return onode_manager->get_onode(t, oid
-          ).si_then([&](auto onode) {
-            return seastar::do_with(std::move(onode), [&](auto& onode) {
-              return f(t, *onode);
+    template <typename Ret, typename F>
+    auto repeat_with_onode(
+      CollectionRef ch,
+      const ghobject_t &oid,
+      Transaction::src_t src,
+      const char* tname,
+      op_type_t op_type,
+      F &&f) const {
+      auto begin_time = std::chrono::steady_clock::now();
+      return seastar::do_with(
+        oid, Ret{}, std::forward<F>(f),
+        [this, src, op_type, begin_time, tname
+        ](auto &oid, auto &ret, auto &f)
+      {
+        return repeat_eagain([&, this, src, tname] {
+          return transaction_manager->with_transaction_intr(
+            src,
+            tname,
+            [&, this](auto& t)
+          {
+            return onode_manager->get_onode(t, oid
+            ).si_then([&](auto onode) {
+              return seastar::do_with(std::move(onode), [&](auto& onode) {
+                return f(t, *onode);
+              });
+            }).si_then([&ret](auto _ret) {
+              ret = _ret;
             });
-          }).si_then([&ret](auto _ret) {
-            ret = _ret;
           });
+        }).safe_then([&ret, op_type, begin_time, this] {
+          const_cast<Shard*>(this)->add_latency_sample(op_type,
+                     std::chrono::steady_clock::now() - begin_time);
+          return seastar::make_ready_future<Ret>(ret);
         });
-      }).safe_then([&ret, op_type, begin_time, this] {
-        const_cast<SeaStore*>(this)->add_latency_sample(op_type,
-                   std::chrono::steady_clock::now() - begin_time);
-        return seastar::make_ready_future<Ret>(ret);
+      });
+    }
+
+    using _fiemap_ret = ObjectDataHandler::fiemap_ret;
+    _fiemap_ret _fiemap(
+      Transaction &t,
+      Onode &onode,
+      uint64_t off,
+      uint64_t len) const;
+
+    using _omap_get_value_iertr = OMapManager::base_iertr::extend<
+      crimson::ct_error::enodata
+      >;
+    using _omap_get_value_ret = _omap_get_value_iertr::future<ceph::bufferlist>;
+    _omap_get_value_ret _omap_get_value(
+      Transaction &t,
+      omap_root_t &&root,
+      std::string_view key) const;
+
+    using _omap_get_values_iertr = OMapManager::base_iertr;
+    using _omap_get_values_ret = _omap_get_values_iertr::future<omap_values_t>;
+    _omap_get_values_ret _omap_get_values(
+      Transaction &t,
+      omap_root_t &&root,
+      const omap_keys_t &keys) const;
+
+    friend class SeaStoreOmapIterator;
+
+    using omap_list_bare_ret = OMapManager::omap_list_bare_ret;
+    using omap_list_ret = OMapManager::omap_list_ret;
+    omap_list_ret omap_list(
+      Onode &onode,
+      const omap_root_le_t& omap_root,
+      Transaction& t,
+      const std::optional<std::string>& start,
+      OMapManager::omap_list_config_t config) const;
+
+    using tm_iertr = TransactionManager::base_iertr;
+    using tm_ret = tm_iertr::future<>;
+    tm_ret _do_transaction_step(
+      internal_context_t &ctx,
+      CollectionRef &col,
+      std::vector<OnodeRef> &onodes,
+      std::vector<OnodeRef> &d_onodes,
+      ceph::os::Transaction::iterator &i);
+
+    tm_ret _remove(
+      internal_context_t &ctx,
+      OnodeRef &onode);
+    tm_ret _touch(
+      internal_context_t &ctx,
+      OnodeRef &onode);
+    tm_ret _write(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      uint64_t offset, size_t len,
+      ceph::bufferlist &&bl,
+      uint32_t fadvise_flags);
+    tm_ret _zero(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      objaddr_t offset, extent_len_t len);
+    tm_ret _omap_set_values(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      std::map<std::string, ceph::bufferlist> &&aset);
+    tm_ret _omap_set_header(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      ceph::bufferlist &&header);
+    tm_ret _omap_clear(
+      internal_context_t &ctx,
+      OnodeRef &onode);
+    tm_ret _omap_rmkeys(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      omap_keys_t &&aset);
+    tm_ret _omap_rmkeyrange(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      std::string first,
+      std::string last);
+    tm_ret _truncate(
+      internal_context_t &ctx,
+      OnodeRef &onode, uint64_t size);
+    tm_ret _setattrs(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      std::map<std::string,bufferlist>&& aset);
+    tm_ret _rmattr(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      std::string name);
+    tm_ret _rmattrs(
+      internal_context_t &ctx,
+      OnodeRef &onode);
+    tm_ret _xattr_rmattr(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      std::string &&name);
+    tm_ret _xattr_clear(
+      internal_context_t &ctx,
+      OnodeRef &onode);
+    tm_ret _create_collection(
+      internal_context_t &ctx,
+      const coll_t& cid, int bits);
+    tm_ret _remove_collection(
+      internal_context_t &ctx,
+      const coll_t& cid);
+    using omap_set_kvs_ret = tm_iertr::future<>;
+    omap_set_kvs_ret _omap_set_kvs(
+      OnodeRef &onode,
+      const omap_root_le_t& omap_root,
+      Transaction& t,
+      omap_root_le_t& mutable_omap_root,
+      std::map<std::string, ceph::bufferlist>&& kvs);
+
+    boost::intrusive_ptr<SeastoreCollection> _get_collection(const coll_t& cid);
+
+    static constexpr auto LAT_MAX = static_cast<std::size_t>(op_type_t::MAX);
+
+    struct {
+      std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
+    } stats;
+
+    seastar::metrics::histogram& get_latency(
+      op_type_t op_type) {
+      assert(static_cast<std::size_t>(op_type) < stats.op_lat.size());
+      return stats.op_lat[static_cast<std::size_t>(op_type)];
+    }
+
+    void add_latency_sample(op_type_t op_type,
+        std::chrono::steady_clock::duration dur) {
+      seastar::metrics::histogram& lat = get_latency(op_type);
+      lat.sample_count++;
+      lat.sample_sum += std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+     }
+
+  private:
+    std::string root;
+    DeviceRef device;
+    const uint32_t max_object_size;
+    bool is_test;
+
+    std::vector<DeviceRef> secondaries;
+    TransactionManagerRef transaction_manager;
+    CollectionManagerRef collection_manager;
+    OnodeManagerRef onode_manager;
+
+    common::Throttle throttler;
+
+    seastar::metrics::metric_group metrics;
+    void register_metrics();
+  };
+
+public:
+  SeaStore(
+    const std::string& root,
+    MDStoreRef mdstore);
+  ~SeaStore();
+
+  seastar::future<> start() final;
+  seastar::future<> stop() final;
+
+  mount_ertr::future<> mount() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.invoke_on_all(
+      [](auto &local_store) {
+      return local_store.mount().handle_error(
+        crimson::ct_error::assert_all{
+        "Invalid error in SeaStore::mount"
       });
     });
   }
 
-  using _fiemap_ret = ObjectDataHandler::fiemap_ret;
-  _fiemap_ret _fiemap(
-    Transaction &t,
-    Onode &onode,
-    uint64_t off,
-    uint64_t len) const;
+  seastar::future<> umount() final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.invoke_on_all(
+      [](auto &local_store) {
+      return local_store.umount();
+    });
+  }
 
-  using _omap_get_value_iertr = OMapManager::base_iertr::extend<
-    crimson::ct_error::enodata
-    >;
-  using _omap_get_value_ret = _omap_get_value_iertr::future<ceph::bufferlist>;
-  _omap_get_value_ret _omap_get_value(
-    Transaction &t,
-    omap_root_t &&root,
-    std::string_view key) const;
+  mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
+  seastar::future<store_statfs_t> stat() const final;
 
-  using _omap_get_values_iertr = OMapManager::base_iertr;
-  using _omap_get_values_ret = _omap_get_values_iertr::future<omap_values_t>;
-  _omap_get_values_ret _omap_get_values(
-    Transaction &t,
-    omap_root_t &&root,
-    const omap_keys_t &keys) const;
+  uuid_d get_fsid() const final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.local().get_fsid();
+  }
 
-  friend class SeaStoreOmapIterator;
+  seastar::future<> write_meta(
+    const std::string& key,
+    const std::string& value) final {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.local().write_meta(
+      key, value).then([this, key, value] {
+      return mdstore->write_meta(key, value);
+    }).handle_error(
+      crimson::ct_error::assert_all{"Invalid error in SeaStore::write_meta"}
+    );
+  }
 
-  using omap_list_bare_ret = OMapManager::omap_list_bare_ret;
-  using omap_list_ret = OMapManager::omap_list_ret;
-  omap_list_ret omap_list(
-    Onode &onode,
-    const omap_root_le_t& omap_root,
-    Transaction& t,
-    const std::optional<std::string>& start,
-    OMapManager::omap_list_config_t config) const;
+  seastar::future<std::tuple<int, std::string>> read_meta(const std::string& key) final;
 
-  void init_managers();
+  seastar::future<std::vector<coll_core_t>> list_collections() final;
 
+  FuturizedStore::Shard& get_sharded_store() final {
+    return shard_stores.local();
+  }
+
+  static col_obj_ranges_t
+  get_objs_range(CollectionRef ch, unsigned bits);
+
+// for test
+public:
+  mount_ertr::future<> test_mount();
+  mkfs_ertr::future<> test_mkfs(uuid_d new_osd_fsid);
+
+  DeviceRef get_primary_device_ref() {
+    ceph_assert(seastar::this_shard_id() == primary_core);
+    return shard_stores.local().get_primary_device_ref();
+  }
+
+  seastar::future<> test_start(DeviceRef dev);
+
+private:
+  seastar::future<> write_fsid(uuid_d new_osd_fsid);
+
+  seastar::future<> prepare_meta(uuid_d new_osd_fsid);
+
+  seastar::future<> _mkfs(uuid_d new_osd_fsid);
+
+private:
   std::string root;
   MDStoreRef mdstore;
-  DeviceRef device;
-  const uint32_t max_object_size = 0;
-  bool is_test;
-
-  std::vector<DeviceRef> secondaries;
-  TransactionManagerRef transaction_manager;
-  CollectionManagerRef collection_manager;
-  OnodeManagerRef onode_manager;
-
-  common::Throttle throttler;
-
-  using tm_iertr = TransactionManager::base_iertr;
-  using tm_ret = tm_iertr::future<>;
-  tm_ret _do_transaction_step(
-    internal_context_t &ctx,
-    CollectionRef &col,
-    std::vector<OnodeRef> &onodes,
-    std::vector<OnodeRef> &d_onodes,
-    ceph::os::Transaction::iterator &i);
-
-  tm_ret _remove(
-    internal_context_t &ctx,
-    OnodeRef &onode);
-  tm_ret _touch(
-    internal_context_t &ctx,
-    OnodeRef &onode);
-  tm_ret _write(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    uint64_t offset, size_t len,
-    ceph::bufferlist &&bl,
-    uint32_t fadvise_flags);
-  tm_ret _zero(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    objaddr_t offset, extent_len_t len);
-  tm_ret _omap_set_values(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    std::map<std::string, ceph::bufferlist> &&aset);
-  tm_ret _omap_set_header(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    ceph::bufferlist &&header);
-  tm_ret _omap_clear(
-    internal_context_t &ctx,
-    OnodeRef &onode);
-  tm_ret _omap_rmkeys(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    omap_keys_t &&aset);
-  tm_ret _omap_rmkeyrange(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    std::string first,
-    std::string last);
-  tm_ret _truncate(
-    internal_context_t &ctx,
-    OnodeRef &onode, uint64_t size);
-  tm_ret _setattrs(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    std::map<std::string,bufferlist>&& aset);
-  tm_ret _rmattr(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    std::string name);
-  tm_ret _rmattrs(
-    internal_context_t &ctx,
-    OnodeRef &onode);
-  tm_ret _xattr_rmattr(
-    internal_context_t &ctx,
-    OnodeRef &onode,
-    std::string &&name);
-  tm_ret _xattr_clear(
-    internal_context_t &ctx,
-    OnodeRef &onode);
-  tm_ret _create_collection(
-    internal_context_t &ctx,
-    const coll_t& cid, int bits);
-  tm_ret _remove_collection(
-    internal_context_t &ctx,
-    const coll_t& cid);
-  using omap_set_kvs_ret = tm_iertr::future<>;
-  omap_set_kvs_ret _omap_set_kvs(
-    OnodeRef &onode,
-    const omap_root_le_t& omap_root,
-    Transaction& t,
-    omap_root_le_t& mutable_omap_root,
-    std::map<std::string, ceph::bufferlist>&& kvs);
-
-  boost::intrusive_ptr<SeastoreCollection> _get_collection(const coll_t& cid);
-
-  static constexpr auto LAT_MAX = static_cast<std::size_t>(op_type_t::MAX);
-  struct {
-    std::array<seastar::metrics::histogram, LAT_MAX> op_lat;
-  } stats;
-
-  seastar::metrics::histogram& get_latency(
-      op_type_t op_type) {
-    assert(static_cast<std::size_t>(op_type) < stats.op_lat.size());
-    return stats.op_lat[static_cast<std::size_t>(op_type)];
-  }
-
-  void add_latency_sample(op_type_t op_type,
-       std::chrono::steady_clock::duration dur) {
-    seastar::metrics::histogram& lat = get_latency(op_type);
-    lat.sample_count++;
-    lat.sample_sum += std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-  }
-  seastar::metrics::metric_group metrics;
-  void register_metrics();
-  seastar::future<> write_fsid(uuid_d new_osd_fsid);
-  seastar::future<> _mkfs(uuid_d new_osd_fsid);
+  seastar::sharded<SeaStore::Shard> shard_stores;
 };
 
-seastar::future<std::unique_ptr<SeaStore>> make_seastore(
-  const std::string &device,
-  const ConfigValues &config);
+std::unique_ptr<SeaStore> make_seastore(
+  const std::string &device);
 
 std::unique_ptr<SeaStore> make_test_seastore(
-  DeviceRef device,
   SeaStore::MDStoreRef mdstore);
 }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2121,6 +2121,7 @@ template <> struct fmt::formatter<crimson::os::seastore::omap_root_t> : fmt::ost
 template <> struct fmt::formatter<crimson::os::seastore::paddr_list_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::paddr_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::placement_hint_t> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::device_type_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::record_group_header_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::record_group_size_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::record_header_t> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -52,7 +52,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
     static_cast<size_t>(0),
     [&](auto &nr_zones) {
       return seastar::open_file_dma(
-	device + "/block",
+	device + "/block" + std::to_string(seastar::this_shard_id()),
 	seastar::open_flags::rw
       ).then([&](auto file) {
 	return seastar::do_with(
@@ -67,11 +67,11 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
 	if (nr_zones != 0) {
 	  return std::make_unique<
 	    segment_manager::zns::ZNSSegmentManager
-	    >(device + "/block");
+	    >(device + "/block" + std::to_string(seastar::this_shard_id()));
 	} else {
 	  return std::make_unique<
 	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block", dtype);
+	    >(device + "/block" + std::to_string(seastar::this_shard_id()), dtype);
 	}
       });
     });
@@ -79,7 +79,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
-    >(device + "/block", dtype));
+    >(device + "/block" + std::to_string(seastar::this_shard_id()), dtype));
 #endif
 }
 

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -13,16 +13,29 @@ SET_SUBSYS(seastore_device);
 
 namespace crimson::os::seastore {
 
+std::ostream& operator<<(std::ostream& out, const block_shard_info_t& sf)
+{
+  out << "("
+      << "size=" << sf.size
+      << ", segments=" <<sf.segments
+      << ", tracker_offset=" <<sf.tracker_offset
+      << ", first_segment_offset=" <<sf.first_segment_offset
+      <<")";
+  return out;
+}
+
 std::ostream& operator<<(std::ostream& out, const block_sm_superblock_t& sb)
 {
   out << "superblock("
-      << "size=" << sb.size
+      << "shard_num=" << sb.shard_num
       << ", segment_size=" << sb.segment_size
       << ", block_size=" << sb.block_size
-      << ", segments=" << sb.segments
-      << ", tracker_offset=" << sb.tracker_offset
-      << ", first_segment_offset=" << sb.first_segment_offset
-      << ", config=" << sb.config
+      << ", shard_info:";
+  for (auto &sf : sb.shard_infos) {
+    out << sf
+        << ",";
+  }
+  out << "config=" << sb.config
       << ")";
   return out;
 }
@@ -52,7 +65,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
     static_cast<size_t>(0),
     [&](auto &nr_zones) {
       return seastar::open_file_dma(
-	device + "/block" + std::to_string(seastar::this_shard_id()),
+	device + "/block",
 	seastar::open_flags::rw
       ).then([&](auto file) {
 	return seastar::do_with(
@@ -67,11 +80,11 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
 	if (nr_zones != 0) {
 	  return std::make_unique<
 	    segment_manager::zns::ZNSSegmentManager
-	    >(device + "/block" + std::to_string(seastar::this_shard_id()));
+	    >(device + "/block");
 	} else {
 	  return std::make_unique<
 	    segment_manager::block::BlockSegmentManager
-	    >(device + "/block" + std::to_string(seastar::this_shard_id()), dtype);
+	    >(device + "/block", dtype);
 	}
       });
     });
@@ -79,7 +92,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::make_ready_future<crimson::os::seastore::SegmentManagerRef>(
     std::make_unique<
       segment_manager::block::BlockSegmentManager
-    >(device + "/block" + std::to_string(seastar::this_shard_id()), dtype));
+    >(device + "/block", dtype));
 #endif
 }
 

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -20,43 +20,59 @@
 
 namespace crimson::os::seastore {
 
+using std::vector;
+struct block_shard_info_t {
+  std::size_t size;
+  std::size_t segments;
+  uint64_t tracker_offset;
+  uint64_t first_segment_offset;
+
+  DENC(block_shard_info_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.size, p);
+    denc(v.segments, p);
+    denc(v.tracker_offset, p);
+    denc(v.first_segment_offset, p);
+    DENC_FINISH(p);
+  }
+};
+
 struct block_sm_superblock_t {
-  size_t size = 0;
+  unsigned int shard_num = 0;
   size_t segment_size = 0;
   size_t block_size = 0;
 
-  size_t segments = 0;
-  uint64_t tracker_offset = 0;
-  uint64_t first_segment_offset = 0;
+  std::vector<block_shard_info_t> shard_infos;
 
   device_config_t config;
 
   DENC(block_sm_superblock_t, v, p) {
     DENC_START(1, 1, p);
-    denc(v.size, p);
+    denc(v.shard_num, p);
     denc(v.segment_size, p);
     denc(v.block_size, p);
-    denc(v.segments, p);
-    denc(v.tracker_offset, p);
-    denc(v.first_segment_offset, p);
+    denc(v.shard_infos, p);
     denc(v.config, p);
     DENC_FINISH(p);
   }
 
   void validate() const {
+    ceph_assert(shard_num == seastar::smp::count);
     ceph_assert(block_size > 0);
     ceph_assert(segment_size > 0 &&
                 segment_size % block_size == 0);
     ceph_assert_always(segment_size <= SEGMENT_OFF_MAX);
-    ceph_assert(size > segment_size &&
-                size % block_size == 0);
-    ceph_assert_always(size <= DEVICE_OFF_MAX);
-    ceph_assert(segments > 0);
-    ceph_assert_always(segments <= DEVICE_SEGMENT_ID_MAX);
-    ceph_assert(tracker_offset > 0 &&
-                tracker_offset % block_size == 0);
-    ceph_assert(first_segment_offset > tracker_offset &&
-                first_segment_offset % block_size == 0);
+    for (unsigned int i = 0; i < seastar::smp::count; i ++) {
+      ceph_assert(shard_infos[i].size > segment_size &&
+                  shard_infos[i].size % block_size == 0);
+      ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
+      ceph_assert(shard_infos[i].segments > 0);
+      ceph_assert_always(shard_infos[i].segments <= DEVICE_SEGMENT_ID_MAX);
+      ceph_assert(shard_infos[i].tracker_offset > 0 &&
+                  shard_infos[i].tracker_offset % block_size == 0);
+      ceph_assert(shard_infos[i].first_segment_offset > shard_infos[i].tracker_offset &&
+                  shard_infos[i].first_segment_offset % block_size == 0);
+    }
     ceph_assert(config.spec.magic != 0);
     ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
 		backend_type_t::SEGMENTED);
@@ -75,6 +91,7 @@ struct block_sm_superblock_t {
   }
 };
 
+std::ostream& operator<<(std::ostream&, const block_shard_info_t&);
 std::ostream& operator<<(std::ostream&, const block_sm_superblock_t&);
 
 class Segment : public boost::intrusive_ref_counter<
@@ -187,9 +204,13 @@ public:
 }
 
 WRITE_CLASS_DENC(
+  crimson::os::seastore::block_shard_info_t
+)
+WRITE_CLASS_DENC(
   crimson::os::seastore::block_sm_superblock_t
 )
 
 #if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::block_shard_info_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::block_sm_superblock_t> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -206,7 +206,7 @@ block_sm_superblock_t make_superblock(
   using crimson::common::get_conf;
 
   auto config_size = get_conf<Option::size_t>(
-    "seastore_device_size");
+    "seastore_device_size")/seastar::smp::count;
 
   size_t size = (data.size == 0) ? config_size : data.size;
 
@@ -530,7 +530,8 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
     check_create_device_ret maybe_create = check_create_device_ertr::now();
     using crimson::common::get_conf;
     if (get_conf<bool>("seastore_block_create")) {
-      auto size = get_conf<Option::size_t>("seastore_device_size");
+      auto size =
+        get_conf<Option::size_t>("seastore_device_size")/seastar::smp::count;
       maybe_create = check_create_device(device_path, size);
     }
 

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -233,7 +233,7 @@ block_sm_superblock_t make_superblock(
   INFO("{} disk_size={}, segment_size={}, block_size={}",
        device_id_printer_t{device_id},
        size,
-       config_segment_size,
+       uint64_t(config_segment_size),
        data.block_size);
   for (unsigned int i = 0; i < seastar::smp::count; i++) {
     INFO("shard {} infos:", i, shard_infos[i]);

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -195,7 +195,7 @@ SegmentStateTracker::read_in(
     bptr.length(),
     bptr);
 }
-
+using std::vector;
 static
 block_sm_superblock_t make_superblock(
   device_id_t device_id,
@@ -206,39 +206,44 @@ block_sm_superblock_t make_superblock(
   using crimson::common::get_conf;
 
   auto config_size = get_conf<Option::size_t>(
-    "seastore_device_size")/seastar::smp::count;
+    "seastore_device_size");
 
   size_t size = (data.size == 0) ? config_size : data.size;
 
   auto config_segment_size = get_conf<Option::size_t>(
     "seastore_segment_size");
   size_t raw_segments = size / config_segment_size;
-  size_t tracker_size = SegmentStateTracker::get_raw_size(
-    raw_segments,
+  size_t shard_tracker_size = SegmentStateTracker::get_raw_size(
+    raw_segments / seastar::smp::count,
     data.block_size);
-  size_t tracker_off = data.block_size;
-  size_t first_seg_off = tracker_size + tracker_off;
-  size_t segments = (size - first_seg_off) / config_segment_size;
-  size_t available_size = segments * config_segment_size;
+  size_t total_tracker_size = shard_tracker_size * seastar::smp::count;
+  size_t tracker_off = data.block_size;   //superblock
+  size_t segments = (size - tracker_off - total_tracker_size) / config_segment_size;
+  size_t segments_per_shard = segments / seastar::smp::count;
 
-  INFO("{} disk_size={}, available_size={}, segment_size={}, segments={}, "
-       "block_size={}, tracker_off={}, first_seg_off={}",
+  vector<block_shard_info_t> shard_infos(seastar::smp::count);
+  for (unsigned int i = 0; i < seastar::smp::count; i++) {
+    shard_infos[i].size = segments_per_shard * config_segment_size;
+    shard_infos[i].segments = segments_per_shard;
+    shard_infos[i].tracker_offset = tracker_off + i * shard_tracker_size;
+    shard_infos[i].first_segment_offset = tracker_off + total_tracker_size
+                             + i * segments_per_shard * config_segment_size;
+  }
+
+  INFO("{} disk_size={}, segment_size={}, block_size={}",
        device_id_printer_t{device_id},
        size,
-       available_size,
        config_segment_size,
-       segments,
-       data.block_size,
-       tracker_off,
-       first_seg_off);
+       data.block_size);
+  for (unsigned int i = 0; i < seastar::smp::count; i++) {
+    INFO("shard {} infos:", i, shard_infos[i]);
+  }
 
   return block_sm_superblock_t{
-    available_size,
+    seastar::smp::count,
     config_segment_size,
     data.block_size,
-    segments,
-    tracker_off,
-    first_seg_off,
+    shard_infos,
     std::move(sm_config)
   };
 }
@@ -449,7 +454,8 @@ Segment::close_ertr::future<> BlockSegmentManager::segment_close(
   stats.closed_segments_unused_bytes += unused_bytes;
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device, superblock.tracker_offset);
+      get_device_id(), device,
+      shard_info.tracker_offset);
 }
 
 Segment::write_ertr::future<> BlockSegmentManager::segment_write(
@@ -474,7 +480,18 @@ BlockSegmentManager::~BlockSegmentManager()
 
 BlockSegmentManager::mount_ret BlockSegmentManager::mount()
 {
-  LOG_PREFIX(BlockSegmentManager::mount);
+  return shard_devices.invoke_on_all([](auto &local_device) {
+    return local_device.shard_mount(
+    ).handle_error(
+      crimson::ct_error::assert_all{
+        "Invalid error in BlockSegmentManager::mount"
+    });
+  });
+}
+
+BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
+{
+  LOG_PREFIX(BlockSegmentManager::shard_mount);
   return open_device(
     device_path
   ).safe_then([=, this](auto p) {
@@ -483,19 +500,20 @@ BlockSegmentManager::mount_ret BlockSegmentManager::mount()
     return read_superblock(device, sd);
   }).safe_then([=, this](auto sb) {
     set_device_id(sb.config.spec.id);
-    INFO("{} read {}", device_id_printer_t{get_device_id()}, sb);
+    shard_info = sb.shard_infos[seastar::this_shard_id()];
+    INFO("{} read {}", device_id_printer_t{get_device_id()}, shard_info);
     sb.validate();
     superblock = sb;
     stats.data_read.increment(
         ceph::encoded_sizeof<block_sm_superblock_t>(superblock));
     tracker = std::make_unique<SegmentStateTracker>(
-      superblock.segments,
+      shard_info.segments,
       superblock.block_size);
     stats.data_read.increment(tracker->get_size());
     return tracker->read_in(
       get_device_id(),
       device,
-      superblock.tracker_offset
+      shard_info.tracker_offset
     ).safe_then([this] {
       for (device_segment_id_t i = 0; i < tracker->get_capacity(); ++i) {
 	if (tracker->get(i) == segment_state_t::OPEN) {
@@ -504,7 +522,8 @@ BlockSegmentManager::mount_ret BlockSegmentManager::mount()
       }
       stats.metadata_write.increment(tracker->get_size());
       return tracker->write_out(
-          get_device_id(), device, superblock.tracker_offset);
+          get_device_id(), device,
+          shard_info.tracker_offset);
     });
   }).safe_then([this, FNAME] {
     INFO("{} complete", device_id_printer_t{get_device_id()});
@@ -515,7 +534,22 @@ BlockSegmentManager::mount_ret BlockSegmentManager::mount()
 BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
   device_config_t sm_config)
 {
-  LOG_PREFIX(BlockSegmentManager::mkfs);
+  return shard_devices.local().primary_mkfs(sm_config
+  ).safe_then([this] {
+    return shard_devices.invoke_on_all([](auto &local_device) {
+      return local_device.shard_mkfs(
+      ).handle_error(
+        crimson::ct_error::assert_all{
+          "Invalid error in BlockSegmentManager::mkfs"
+      });
+    });
+  });
+}
+
+BlockSegmentManager::mkfs_ret BlockSegmentManager::primary_mkfs(
+  device_config_t sm_config)
+{
+  LOG_PREFIX(BlockSegmentManager::primary_mkfs);
   ceph_assert(sm_config.spec.dtype == superblock.config.spec.dtype);
   set_device_id(sm_config.spec.id);
   INFO("{} path={}, {}",
@@ -530,8 +564,7 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
     check_create_device_ret maybe_create = check_create_device_ertr::now();
     using crimson::common::get_conf;
     if (get_conf<bool>("seastore_block_create")) {
-      auto size =
-        get_conf<Option::size_t>("seastore_device_size")/seastar::smp::count;
+      auto size = get_conf<Option::size_t>("seastore_device_size");
       maybe_create = check_create_device(device_path, size);
     }
 
@@ -544,18 +577,40 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::mkfs(
       stats.metadata_write.increment(
           ceph::encoded_sizeof<block_sm_superblock_t>(sb));
       return write_superblock(get_device_id(), device, sb);
-    }).safe_then([&, FNAME, this] {
-      DEBUG("{} superblock written", device_id_printer_t{get_device_id()});
-      tracker.reset(new SegmentStateTracker(sb.segments, sb.block_size));
-      stats.metadata_write.increment(tracker->get_size());
-      return tracker->write_out(
-          get_device_id(), device, sb.tracker_offset);
     }).finally([&] {
       return device.close();
     }).safe_then([FNAME, this] {
       INFO("{} complete", device_id_printer_t{get_device_id()});
       return mkfs_ertr::now();
     });
+  });
+}
+
+BlockSegmentManager::mkfs_ret BlockSegmentManager::shard_mkfs()
+{
+  LOG_PREFIX(BlockSegmentManager::shard_mkfs);
+  return open_device(
+    device_path
+  ).safe_then([this](auto p) {
+    device = std::move(p.first);
+    auto sd = p.second;
+    return read_superblock(device, sd);
+  }).safe_then([this, FNAME](auto sb) {
+    set_device_id(sb.config.spec.id);
+    shard_info = sb.shard_infos[seastar::this_shard_id()];
+    INFO("{} read {}", device_id_printer_t{get_device_id()}, shard_info);
+    sb.validate();
+    tracker.reset(new SegmentStateTracker(
+      shard_info.segments, sb.block_size));
+    stats.metadata_write.increment(tracker->get_size());
+    return tracker->write_out(
+      get_device_id(), device,
+      shard_info.tracker_offset);
+  }).finally([this] {
+    return device.close();
+  }).safe_then([FNAME, this] {
+    INFO("{} complete", device_id_printer_t{get_device_id()});
+    return mkfs_ertr::now();
   });
 }
 
@@ -589,7 +644,8 @@ SegmentManager::open_ertr::future<SegmentRef> BlockSegmentManager::open(
   tracker->set(s_id, segment_state_t::OPEN);
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device, superblock.tracker_offset
+      get_device_id(), device,
+      shard_info.tracker_offset
   ).safe_then([this, id, FNAME] {
     ++stats.opened_segments;
     DEBUG("{} done", id);
@@ -622,7 +678,8 @@ SegmentManager::release_ertr::future<> BlockSegmentManager::release(
   ++stats.released_segments;
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device, superblock.tracker_offset);
+      get_device_id(), device,
+      shard_info.tracker_offset);
 }
 
 SegmentManager::read_ertr::future<> BlockSegmentManager::read(

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -19,16 +19,30 @@
 
 namespace crimson::os::seastore::segment_manager::zns {
 
-  struct zns_sm_metadata_t {
+  struct zns_shard_info_t {
     size_t size = 0;
+    size_t segments = 0;
+    size_t first_segment_offset = 0;
+
+    DENC(zns_shard_info_t, v, p) {
+      DENC_START(1, 1, p);
+      denc(v.size, p);
+      denc(v.segments, p);
+      denc(v.first_segment_offset, p);
+      DENC_FINISH(p);
+    }
+  };
+
+  struct zns_sm_metadata_t {
+    unsigned int shard_num = 0;
     size_t segment_size = 0;
     size_t segment_capacity = 0;
     size_t zones_per_segment = 0;
     size_t zone_capacity = 0;
     size_t block_size = 0;
-    size_t segments = 0;
     size_t zone_size = 0;
-    size_t first_segment_offset = 0;
+
+    std::vector<zns_shard_info_t> shard_infos;
 
     seastore_meta_t meta;
     
@@ -40,15 +54,14 @@ namespace crimson::os::seastore::segment_manager::zns {
 
     DENC(zns_sm_metadata_t, v, p) {
       DENC_START(1, 1, p);
-      denc(v.size, p);
+      denc(v.shard_num, p);
       denc(v.segment_size, p);
       denc(v.segment_capacity, p);
       denc(v.zones_per_segment, p);
       denc(v.zone_capacity, p);
       denc(v.block_size, p);
-      denc(v.segments, p);
       denc(v.zone_size, p);
-      denc(v.first_segment_offset, p);
+      denc(v.shard_infos, p);
       denc(v.meta, p);
       denc(v.magic, p);
       denc(v.dtype, p);
@@ -60,12 +73,15 @@ namespace crimson::os::seastore::segment_manager::zns {
     }
 
     void validate() const {
-      ceph_assert_always(size > 0);
-      ceph_assert_always(size <= DEVICE_OFF_MAX);
+      ceph_assert_always(shard_num == seastar::smp::count);
+      for (unsigned int i = 0; i < seastar::smp::count; i++) {
+        ceph_assert_always(shard_infos[i].size > 0);
+        ceph_assert_always(shard_infos[i].size <= DEVICE_OFF_MAX);
+        ceph_assert_always(shard_infos[i].segments > 0);
+        ceph_assert_always(shard_infos[i].segments <= DEVICE_SEGMENT_ID_MAX);
+      }
       ceph_assert_always(segment_capacity > 0);
       ceph_assert_always(segment_capacity <= SEGMENT_OFF_MAX);
-      ceph_assert_always(segments > 0);
-      ceph_assert_always(segments <= DEVICE_SEGMENT_ID_MAX);
     }
   };
 
@@ -102,9 +118,29 @@ namespace crimson::os::seastore::segment_manager::zns {
   };
 
   class ZNSSegmentManager final : public SegmentManager{
+  // interfaces used by Device
   public:
+    seastar::future<> start() {
+      return shard_devices.start(device_path);
+    }
+
+    seastar::future<> stop() {
+      return shard_devices.stop();
+    }
+
+    Device& get_sharded_device() final {
+      return shard_devices.local();
+    }
+
     mount_ret mount() final;
     mkfs_ret mkfs(device_config_t meta) final;
+
+    ZNSSegmentManager(const std::string &path) : device_path(path) {}
+
+    ~ZNSSegmentManager() final = default;
+
+  //interfaces used by each shard device
+  public:
     open_ertr::future<SegmentRef> open(segment_id_t id) final;
     close_ertr::future<> close() final;
 
@@ -120,7 +156,7 @@ namespace crimson::os::seastore::segment_manager::zns {
     }
 
     size_t get_available_size() const final {
-      return metadata.size;
+      return shard_info.size;
     };
 
     extent_len_t get_block_size() const final {
@@ -141,10 +177,6 @@ namespace crimson::os::seastore::segment_manager::zns {
 
     magic_t get_magic() const final;
 
-    ZNSSegmentManager(const std::string &path) : device_path(path) {}
-
-    ~ZNSSegmentManager() final = default;
-
     Segment::write_ertr::future<> segment_write(
     paddr_t addr,
     ceph::bufferlist bl,
@@ -153,6 +185,7 @@ namespace crimson::os::seastore::segment_manager::zns {
   private:
     friend class ZNSSegment;
     std::string device_path;
+    zns_shard_info_t shard_info;
     zns_sm_metadata_t metadata;
     seastar::file device;
     uint32_t nr_zones;
@@ -188,14 +221,26 @@ namespace crimson::os::seastore::segment_manager::zns {
 
     uint64_t get_offset(paddr_t addr) {
       auto& seg_addr = addr.as_seg_paddr();
-      return (metadata.first_segment_offset +
+      return (shard_info.first_segment_offset +
 	      (seg_addr.get_segment_id().device_segment_id() * 
 	       metadata.segment_size)) + seg_addr.get_segment_off();
     }
+  private:
+    // shard 0 mkfs
+    mkfs_ret primary_mkfs(device_config_t meta);
+    // all shards mkfs
+    mkfs_ret shard_mkfs();
+
+    mount_ret shard_mount();
+
+    seastar::sharded<ZNSSegmentManager> shard_devices;
   };
 
 }
 
+WRITE_CLASS_DENC_BOUNDED(
+  crimson::os::seastore::segment_manager::zns::zns_shard_info_t
+)
 WRITE_CLASS_DENC_BOUNDED(
   crimson::os::seastore::segment_manager::zns::zns_sm_metadata_t
 )

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -33,7 +33,7 @@ private:
 		      epoch_t min_epoch, epoch_t max_epoch,
 		      std::vector<pg_log_entry_t>&& log_entries) final;
   CollectionRef coll;
-  crimson::os::FuturizedStore* store;
+  crimson::os::FuturizedStore::Shard* store;
   seastar::future<> request_committed(const osd_reqid_t& reqid,
 				       const eversion_t& version) final {
     return seastar::now();

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -197,7 +197,7 @@ int main(int argc, const char* argv[])
           auto store = crimson::os::FuturizedStore::create(
             local_conf().get_val<std::string>("osd_objectstore"),
             local_conf().get_val<std::string>("osd_data"),
-            local_conf().get_config_values()).get();
+            local_conf().get_config_values());
 
           crimson::osd::OSD osd(
             whoami, nonce, std::ref(should_stop.abort_source()),

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -11,7 +11,7 @@
 #include "os/Transaction.h"
 
 using std::string;
-using read_errorator = crimson::os::FuturizedStore::read_errorator;
+using read_errorator = crimson::os::FuturizedStore::Shard::read_errorator;
 
 void OSDMeta::create(ceph::os::Transaction& t)
 {

--- a/src/crimson/osd/osd_meta.h
+++ b/src/crimson/osd/osd_meta.h
@@ -24,12 +24,12 @@ namespace crimson::os {
 class OSDMeta {
   template<typename T> using Ref = boost::intrusive_ptr<T>;
 
-  crimson::os::FuturizedStore& store;
+  crimson::os::FuturizedStore::Shard& store;
   Ref<crimson::os::FuturizedCollection> coll;
 
 public:
   OSDMeta(Ref<crimson::os::FuturizedCollection> coll,
-          crimson::os::FuturizedStore& store)
+          crimson::os::FuturizedStore::Shard& store)
     : store{store}, coll{coll}
   {}
 
@@ -45,7 +45,7 @@ public:
   void store_superblock(ceph::os::Transaction& t,
                         const OSDSuperblock& sb);
 
-  using load_superblock_ertr = crimson::os::FuturizedStore::read_errorator;
+  using load_superblock_ertr = crimson::os::FuturizedStore::Shard::read_errorator;
   using load_superblock_ret = load_superblock_ertr::future<OSDSuperblock>;
   load_superblock_ret load_superblock();
 

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -612,7 +612,7 @@ void PG::init(
     new_acting_primary, history, pi, t);
 }
 
-seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
+seastar::future<> PG::read_state(crimson::os::FuturizedStore::Shard* store)
 {
   if (__builtin_expect(stopping, false)) {
     return seastar::make_exception_future<>(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -491,7 +491,7 @@ public:
     const PastIntervals& pim,
     ceph::os::Transaction &t);
 
-  seastar::future<> read_state(crimson::os::FuturizedStore* store);
+  seastar::future<> read_state(crimson::os::FuturizedStore::Shard* store);
 
   interruptible_future<> do_peering_event(
     PGPeeringEvent& evt, PeeringCtx &rctx);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1280,7 +1280,7 @@ void PGBackend::clone(
 }
 
 using get_omap_ertr =
-  crimson::os::FuturizedStore::read_errorator::extend<
+  crimson::os::FuturizedStore::Shard::read_errorator::extend<
     crimson::ct_error::enodata>;
 using get_omap_iertr =
   ::crimson::interruptible::interruptible_errorator<
@@ -1288,9 +1288,9 @@ using get_omap_iertr =
     get_omap_ertr>;
 static
 get_omap_iertr::future<
-  crimson::os::FuturizedStore::omap_values_t>
+  crimson::os::FuturizedStore::Shard::omap_values_t>
 maybe_get_omap_vals_by_keys(
-  crimson::os::FuturizedStore* store,
+  crimson::os::FuturizedStore::Shard* store,
   const crimson::os::CollectionRef& coll,
   const object_info_t& oi,
   const std::set<std::string>& keys_to_get)
@@ -1304,9 +1304,9 @@ maybe_get_omap_vals_by_keys(
 
 static
 get_omap_iertr::future<
-  std::tuple<bool, crimson::os::FuturizedStore::omap_values_t>>
+  std::tuple<bool, crimson::os::FuturizedStore::Shard::omap_values_t>>
 maybe_get_omap_vals(
-  crimson::os::FuturizedStore* store,
+  crimson::os::FuturizedStore::Shard* store,
   const crimson::os::CollectionRef& coll,
   const object_info_t& oi,
   const std::string& start_after)
@@ -1557,7 +1557,7 @@ PGBackend::omap_get_vals_by_keys(
   delta_stats.num_rd++;
   return maybe_get_omap_vals_by_keys(store, coll, os.oi, keys_to_get)
   .safe_then_interruptible(
-    [&osd_op] (crimson::os::FuturizedStore::omap_values_t&& vals) {
+    [&osd_op] (crimson::os::FuturizedStore::Shard::omap_values_t&& vals) {
       encode(vals, osd_op.outdata);
       return ll_read_errorator::now();
     }).handle_error_interruptible(

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -40,7 +40,7 @@ protected:
   using CollectionRef = crimson::os::CollectionRef;
   using ec_profile_t = std::map<std::string, std::string>;
   // low-level read errorator
-  using ll_read_errorator = crimson::os::FuturizedStore::read_errorator;
+  using ll_read_errorator = crimson::os::FuturizedStore::Shard::read_errorator;
   using ll_read_ierrorator =
     ::crimson::interruptible::interruptible_errorator<
       ::crimson::osd::IOInterruptCondition,
@@ -238,7 +238,7 @@ public:
     const OSDOp& osd_op,
     ceph::os::Transaction& trans,
     object_stat_sum_t& delta_stats);
-  using get_attr_errorator = crimson::os::FuturizedStore::get_attr_errorator;
+  using get_attr_errorator = crimson::os::FuturizedStore::Shard::get_attr_errorator;
   using get_attr_ierrorator =
     ::crimson::interruptible::interruptible_errorator<
       ::crimson::osd::IOInterruptCondition,
@@ -322,7 +322,7 @@ public:
     OSDOp& osd_op,
     object_stat_sum_t& delta_stats) const;
   using omap_cmp_ertr =
-    crimson::os::FuturizedStore::read_errorator::extend<
+    crimson::os::FuturizedStore::Shard::read_errorator::extend<
       crimson::ct_error::ecanceled,
       crimson::ct_error::invarg>;
   using omap_cmp_iertr =
@@ -389,7 +389,7 @@ protected:
   CollectionRef coll;
   crimson::osd::ShardServices &shard_services;
   DoutPrefixProvider &dpp; ///< provides log prefix context
-  crimson::os::FuturizedStore* store;
+  crimson::os::FuturizedStore::Shard* store;
   virtual seastar::future<> request_committed(
     const osd_reqid_t& reqid,
     const eversion_t& at_version) = 0;

--- a/src/crimson/osd/pg_meta.cc
+++ b/src/crimson/osd/pg_meta.cc
@@ -14,14 +14,14 @@ using std::string_view;
 // easily skip them
 using crimson::os::FuturizedStore;
 
-PGMeta::PGMeta(FuturizedStore& store, spg_t pgid)
+PGMeta::PGMeta(FuturizedStore::Shard& store, spg_t pgid)
   : store{store},
     pgid{pgid}
 {}
 
 namespace {
   template<typename T>
-  std::optional<T> find_value(const FuturizedStore::omap_values_t& values,
+  std::optional<T> find_value(const FuturizedStore::Shard::omap_values_t& values,
                               string_view key)
   {
     auto found = values.find(key);
@@ -57,7 +57,7 @@ seastar::future<epoch_t> PGMeta::get_epoch()
         return seastar::make_ready_future<epoch_t>(*epoch);
       }
     },
-    FuturizedStore::read_errorator::assert_all{
+    FuturizedStore::Shard::read_errorator::assert_all{
       "PGMeta::get_epoch: unable to read pgmeta"
     });
   });
@@ -104,7 +104,7 @@ seastar::future<std::tuple<pg_info_t, PastIntervals>> PGMeta::load()
     return seastar::make_ready_future<std::tuple<pg_info_t, PastIntervals>>(
       std::make_tuple(std::move(info), std::move(past_intervals)));
   },
-  FuturizedStore::read_errorator::assert_all{
+  FuturizedStore::Shard::read_errorator::assert_all{
     "PGMeta::load: unable to read pgmeta"
   });
 }

--- a/src/crimson/osd/pg_meta.h
+++ b/src/crimson/osd/pg_meta.h
@@ -6,18 +6,15 @@
 #include <tuple>
 #include <seastar/core/future.hh>
 #include "osd/osd_types.h"
-
-namespace crimson::os {
-  class FuturizedStore;
-}
+#include "crimson/os/futurized_store.h"
 
 /// PG related metadata
 class PGMeta
 {
-  crimson::os::FuturizedStore& store;
+  crimson::os::FuturizedStore::Shard& store;
   const spg_t pgid;
 public:
-  PGMeta(crimson::os::FuturizedStore& store, spg_t pgid);
+  PGMeta(crimson::os::FuturizedStore::Shard& store, spg_t pgid);
   seastar::future<epoch_t> get_epoch();
   seastar::future<std::tuple<pg_info_t, PastIntervals>> load();
 };

--- a/src/crimson/osd/pg_shard_manager.cc
+++ b/src/crimson/osd/pg_shard_manager.cc
@@ -45,10 +45,10 @@ seastar::future<> PGShardManager::stop()
   });
 }
 
-seastar::future<> PGShardManager::load_pgs()
+seastar::future<> PGShardManager::load_pgs(crimson::os::FuturizedStore& store)
 {
   ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
-  return get_local_state().store.list_collections(
+  return store.list_collections(
   ).then([this](auto colls_cores) {
     return seastar::parallel_for_each(
       colls_cores,

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -10,8 +10,11 @@
 #include "crimson/osd/shard_services.h"
 #include "crimson/osd/pg_map.h"
 
-namespace crimson::osd {
+namespace crimson::os {
+  class FuturizedStore;
+}
 
+namespace crimson::osd {
 /**
  * PGShardManager
  *
@@ -233,7 +236,7 @@ public:
       });
   }
 
-  seastar::future<> load_pgs();
+  seastar::future<> load_pgs(crimson::os::FuturizedStore& store);
   seastar::future<> stop_pgs();
 
   seastar::future<std::map<pg_t, pg_stat_t>> get_pg_stats() const;

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -95,7 +95,7 @@ public:
 protected:
   crimson::osd::PG& pg;
   crimson::osd::ShardServices& shard_services;
-  crimson::os::FuturizedStore* store;
+  crimson::os::FuturizedStore::Shard* store;
   crimson::os::CollectionRef coll;
   PGBackend* backend;
 

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -455,17 +455,17 @@ ReplicatedRecoveryBackend::read_metadata_for_push_op(
   }
   return interruptor::make_interruptible(interruptor::when_all_succeed(
       backend->omap_get_header(coll, ghobject_t(oid)).handle_error_interruptible<false>(
-	crimson::os::FuturizedStore::read_errorator::all_same_way(
+	crimson::os::FuturizedStore::Shard::read_errorator::all_same_way(
 	  [oid] (const std::error_code& e) {
 	  logger().debug("read_metadata_for_push_op, error {} when getting omap header: {}", e, oid);
 	  return seastar::make_ready_future<bufferlist>();
 	})),
       interruptor::make_interruptible(store->get_attrs(coll, ghobject_t(oid)))
       .handle_error_interruptible<false>(
-	crimson::os::FuturizedStore::get_attrs_ertr::all_same_way(
+	crimson::os::FuturizedStore::Shard::get_attrs_ertr::all_same_way(
 	  [oid] (const std::error_code& e) {
 	  logger().debug("read_metadata_for_push_op, error {} when getting attrs: {}", e, oid);
-	  return seastar::make_ready_future<crimson::os::FuturizedStore::attrs_t>();
+	  return seastar::make_ready_future<crimson::os::FuturizedStore::Shard::attrs_t>();
 	}))
   )).then_unpack_interruptible([&new_progress, push_op](auto bl, auto attrs) {
     if (bl.length() == 0) {
@@ -593,7 +593,7 @@ ReplicatedRecoveryBackend::read_omap_for_push_op(
       return seastar::make_ready_future<seastar::stop_iteration>(
         stop ? seastar::stop_iteration::yes : seastar::stop_iteration::no
       );
-    }, crimson::os::FuturizedStore::read_errorator::assert_all{});
+    }, crimson::os::FuturizedStore::Shard::read_errorator::assert_all{});
   });
 }
 

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -40,7 +40,7 @@ PerShardState::PerShardState(
   PerfCounters *recoverystate_perf,
   crimson::os::FuturizedStore &store)
   : whoami(whoami),
-    store(store),
+    store(store.get_sharded_store()),
     perf(perf), recoverystate_perf(recoverystate_perf),
     throttler(crimson::common::local_conf()),
     next_tid(

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -65,7 +65,7 @@ class PerShardState {
 #define assert_core() ceph_assert(seastar::this_shard_id() == core);
 
   const int whoami;
-  crimson::os::FuturizedStore &store;
+  crimson::os::FuturizedStore::Shard &store;
   crimson::common::CephContext cct;
 
   PerfCounters *perf = nullptr;
@@ -374,7 +374,7 @@ public:
 
   FORWARD_TO_OSD_SINGLETON(send_to_osd)
 
-  crimson::os::FuturizedStore &get_store() {
+  crimson::os::FuturizedStore::Shard &get_store() {
     return local_state.store;
   }
 

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -145,7 +145,7 @@ seastar::future<> FSDriver::write(
       config.log_size);
   }
 
-  return fs->do_transaction(
+  return sharded_fs->do_transaction(
     mapping.pg.collection,
     std::move(t));
 }
@@ -156,7 +156,7 @@ seastar::future<bufferlist> FSDriver::read(
 {
   auto mapping = map_offset(offset);
   ceph_assert((mapping.offset + size) <= config.object_size);
-  return fs->read(
+  return sharded_fs->read(
     mapping.pg.collection,
     mapping.object,
     mapping.offset,
@@ -179,11 +179,9 @@ seastar::future<bufferlist> FSDriver::read(
 
 seastar::future<> FSDriver::mkfs()
 {
-  return init(    
+  return init(
   ).then([this] {
     assert(fs);
-    return fs->start();
-  }).then([this] {
     uuid_d uuid;
     uuid.generate_random();
     return fs->mkfs(uuid).handle_error(
@@ -197,9 +195,7 @@ seastar::future<> FSDriver::mkfs()
   }).then([this] {
     return fs->stop();
   }).then([this] {
-    return init().then([this] {
-      return fs->start();
-    });
+    return init();
   }).then([this] {
     return fs->mount(
     ).handle_error(
@@ -218,11 +214,11 @@ seastar::future<> FSDriver::mkfs()
       boost::counting_iterator<unsigned>(0),
       boost::counting_iterator<unsigned>(config.num_pgs),
       [this](auto i) {
-	return fs->create_new_collection(get_coll(i)
+	return sharded_fs->create_new_collection(get_coll(i)
 	).then([this, i](auto coll) {
 	  ceph::os::Transaction t;
 	  t.create_collection(get_coll(i), 0);
-	  return fs->do_transaction(coll, std::move(t));
+	  return sharded_fs->do_transaction(coll, std::move(t));
 	});
       });
   }).then([this] {
@@ -241,9 +237,7 @@ seastar::future<> FSDriver::mount()
   return (
     config.mkfs ? mkfs() : seastar::now()
   ).then([this] {
-    return init().then([this] {
-      return fs->start();
-    });
+    return init();
   }).then([this] {
     return fs->mount(
     ).handle_error(
@@ -262,7 +256,7 @@ seastar::future<> FSDriver::mount()
       boost::counting_iterator<unsigned>(0),
       boost::counting_iterator<unsigned>(config.num_pgs),
       [this](auto i) {
-	return fs->open_collection(get_coll(i)
+	return sharded_fs->open_collection(get_coll(i)
 	).then([this, i](auto ref) {
 	  collections[i].collection = ref;
 	  collections[i].log_object = get_log_object(i);
@@ -275,7 +269,7 @@ seastar::future<> FSDriver::mount()
 		config.log_entry_size,
 		config.log_size);
 	    }
-	    return fs->do_transaction(
+	    return sharded_fs->do_transaction(
 	      collections[i].collection,
 	      std::move(t));
 	  } else {
@@ -305,12 +299,12 @@ seastar::future<> FSDriver::close()
 seastar::future<> FSDriver::init()
 {
   fs.reset();
-  return FuturizedStore::create(
+  fs = FuturizedStore::create(
     config.get_fs_type(),
     *config.path,
     crimson::common::local_conf().get_config_values()
-  ).then([this] (auto store_ptr) {
-      fs = std::move(store_ptr);
-      return seastar::now();
+  );
+  return fs->start().then([this] {
+    sharded_fs = &(fs->get_sharded_store());
   });
 }

--- a/src/crimson/tools/store_nbd/fs_driver.h
+++ b/src/crimson/tools/store_nbd/fs_driver.h
@@ -37,6 +37,7 @@ private:
   size_t size = 0;
   const config_t config;
   std::unique_ptr<crimson::os::FuturizedStore> fs;
+  crimson::os::FuturizedStore::Shard* sharded_fs;
 
   struct pg_analogue_t {
     crimson::os::CollectionRef collection;

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -1074,8 +1074,8 @@ void PGLog::rebuild_missing_set_with_deletes(
 #ifdef WITH_SEASTAR
 
 namespace {
-  struct FuturizedStoreLogReader {
-    crimson::os::FuturizedStore &store;
+  struct FuturizedShardStoreLogReader {
+    crimson::os::FuturizedStore::Shard &store;
     const pg_info_t &info;
     PGLog::IndexedLog &log;
     std::set<std::string>* log_keys_debug = NULL;
@@ -1165,7 +1165,7 @@ namespace {
               return seastar::make_ready_future<seastar::stop_iteration>(
                 done ? seastar::stop_iteration::yes : seastar::stop_iteration::no
               );
-            }, crimson::os::FuturizedStore::read_errorator::assert_all{});
+            }, crimson::os::FuturizedStore::Shard::read_errorator::assert_all{});
           }).then([this] {
             if (info.pgid.is_no_shard()) {
               // replicated pool pg does not persist this key
@@ -1186,7 +1186,7 @@ namespace {
 }
 
 seastar::future<> PGLog::read_log_and_missing_crimson(
-  crimson::os::FuturizedStore &store,
+  crimson::os::FuturizedStore::Shard &store,
   crimson::os::CollectionRef ch,
   const pg_info_t &info,
   IndexedLog &log,
@@ -1198,16 +1198,16 @@ seastar::future<> PGLog::read_log_and_missing_crimson(
   ldpp_dout(dpp, 20) << "read_log_and_missing coll "
                      << ch->get_cid()
                      << " " << pgmeta_oid << dendl;
-  return seastar::do_with(FuturizedStoreLogReader{
+  return seastar::do_with(FuturizedShardStoreLogReader{
       store, info, log, log_keys_debug,
       missing, dpp},
-    [ch, pgmeta_oid](FuturizedStoreLogReader& reader) {
+    [ch, pgmeta_oid](FuturizedShardStoreLogReader& reader) {
     return reader.read(ch, pgmeta_oid);
   });
 }
 
 seastar::future<> PGLog::rebuild_missing_set_with_deletes_crimson(
-  crimson::os::FuturizedStore &store,
+  crimson::os::FuturizedStore::Shard &store,
   crimson::os::CollectionRef ch,
   const pg_info_t &info)
 {

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -945,7 +945,7 @@ public:
 
 #ifdef WITH_SEASTAR
   seastar::future<> rebuild_missing_set_with_deletes_crimson(
-    crimson::os::FuturizedStore &store,
+    crimson::os::FuturizedStore::Shard &store,
     crimson::os::CollectionRef ch,
     const pg_info_t &info);
 #endif
@@ -1683,7 +1683,7 @@ public:
 
 #ifdef WITH_SEASTAR
   seastar::future<> read_log_and_missing_crimson(
-    crimson::os::FuturizedStore &store,
+    crimson::os::FuturizedStore::Shard &store,
     crimson::os::CollectionRef ch,
     const pg_info_t &info,
     ghobject_t pgmeta_oid
@@ -1695,7 +1695,7 @@ public:
   }
 
   static seastar::future<> read_log_and_missing_crimson(
-    crimson::os::FuturizedStore &store,
+    crimson::os::FuturizedStore::Shard &store,
     crimson::os::CollectionRef ch,
     const pg_info_t &info,
     IndexedLog &log,

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -35,7 +35,7 @@
 
 class OSDriver : public MapCacher::StoreDriver<std::string, ceph::buffer::list> {
 #ifdef WITH_SEASTAR
-  using ObjectStoreT = crimson::os::FuturizedStore;
+  using ObjectStoreT = crimson::os::FuturizedStore::Shard;
   using CollectionHandleT = ObjectStoreT::CollectionRef;
 #else
   using ObjectStoreT = ObjectStore;

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -70,15 +70,15 @@ struct fltree_onode_manager_test_t
     return tm_teardown();
   }
 
-
-  virtual void _init() final {
-    TMTestState::_init();
-    manager.reset(new FLTreeOnodeManager(*tm));
+  virtual seastar::future<> _init() final {
+    return TMTestState::_init().then([this] {
+      manager.reset(new FLTreeOnodeManager(*tm));
+    });
   }
 
-  virtual void _destroy() final {
+  virtual seastar::future<> _destroy() final {
     manager.reset();
-    TMTestState::_destroy();
+    return TMTestState::_destroy();
   }
 
   virtual FuturizedStore::mkfs_ertr::future<> _mkfs() final {

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -16,6 +16,7 @@
 using namespace crimson;
 using namespace crimson::os;
 using namespace crimson::os::seastore;
+using SeaStoreShard = FuturizedStore::Shard;
 using CTransaction = ceph::os::Transaction;
 using namespace std;
 
@@ -75,12 +76,12 @@ struct seastore_test_t :
     }
     return tm_setup(journal
     ).then([this] {
-      return seastore->create_new_collection(coll_name);
+      return sharded_seastore->create_new_collection(coll_name);
     }).then([this](auto coll_ref) {
       coll = coll_ref;
       CTransaction t;
       t.create_collection(coll_name, 0);
-      return seastore->do_transaction(
+      return sharded_seastore->do_transaction(
 	coll,
 	std::move(t));
     });
@@ -92,7 +93,7 @@ struct seastore_test_t :
   }
 
   void do_transaction(CTransaction &&t) {
-    return seastore->do_transaction(
+    return sharded_seastore->do_transaction(
       coll,
       std::move(t)).get0();
   }
@@ -122,10 +123,10 @@ struct seastore_test_t :
     }
 
     void touch(
-      SeaStore &seastore) {
+      SeaStoreShard &sharded_seastore) {
       CTransaction t;
       touch(t);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
@@ -137,26 +138,26 @@ struct seastore_test_t :
     }
 
     void truncate(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t off) {
       CTransaction t;
       truncate(t, off);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
     std::map<uint64_t, uint64_t> fiemap(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t off,
       uint64_t len) {
-      return seastore.fiemap(coll, oid, off, len).unsafe_get0();
+      return sharded_seastore.fiemap(coll, oid, off, len).unsafe_get0();
     }
 
     bufferlist readv(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       interval_set<uint64_t>&m) {
-      return seastore.readv(coll, oid, m).unsafe_get0();
+      return sharded_seastore.readv(coll, oid, m).unsafe_get0();
     }
 
     void remove(
@@ -166,10 +167,10 @@ struct seastore_test_t :
     }
 
     void remove(
-      SeaStore &seastore) {
+      SeaStoreShard &sharded_seastore) {
       CTransaction t;
       remove(t);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
@@ -188,18 +189,18 @@ struct seastore_test_t :
     }
 
     void set_omap(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       const string &key,
       const bufferlist &val) {
       CTransaction t;
       set_omap(t, key, val);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
 	coll,
 	std::move(t)).get0();
     }
 
     void write(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       CTransaction &t,
       uint64_t offset,
       bufferlist bl)  {
@@ -234,17 +235,17 @@ struct seastore_test_t :
     }
 
     void write(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t offset,
       bufferlist bl)  {
       CTransaction t;
-      write(seastore, t, offset, bl);
-      seastore.do_transaction(
+      write(sharded_seastore, t, offset, bl);
+      sharded_seastore.do_transaction(
 	coll,
 	std::move(t)).get0();
     }
     void write(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t offset,
       size_t len,
       char fill)  {
@@ -252,11 +253,11 @@ struct seastore_test_t :
       ::memset(buffer.c_str(), fill, len);
       bufferlist bl;
       bl.append(buffer);
-      write(seastore, offset, bl);
+      write(sharded_seastore, offset, bl);
     }
 
     void zero(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       CTransaction &t,
       uint64_t offset,
       size_t len) {
@@ -292,18 +293,18 @@ struct seastore_test_t :
     }
 
     void zero(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t offset,
       size_t len) {
       CTransaction t;
-      zero(seastore, t, offset, len);
-      seastore.do_transaction(
+      zero(sharded_seastore, t, offset, len);
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
     void read(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       uint64_t offset,
       uint64_t len) {
       bufferlist to_check;
@@ -311,7 +312,7 @@ struct seastore_test_t :
 	contents,
 	offset,
 	len);
-      auto ret = seastore.read(
+      auto ret = sharded_seastore.read(
 	coll,
 	oid,
 	offset,
@@ -320,65 +321,65 @@ struct seastore_test_t :
       EXPECT_EQ(ret, to_check);
     }
 
-    void check_size(SeaStore &seastore) {
-      auto st = seastore.stat(
+    void check_size(SeaStoreShard &sharded_seastore) {
+      auto st = sharded_seastore.stat(
 	coll,
 	oid).get0();
       EXPECT_EQ(contents.length(), st.st_size);
     }
 
     void set_attr(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       std::string key,
       bufferlist& val) {
       CTransaction t;
       t.setattr(cid, oid, key, val);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
     void rm_attr(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       std::string key) {
       CTransaction t;
       t.rmattr(cid, oid, key);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
     void rm_attrs(
-      SeaStore &seastore) {
+      SeaStoreShard &sharded_seastore) {
       CTransaction t;
       t.rmattrs(cid, oid);
-      seastore.do_transaction(
+      sharded_seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
-    SeaStore::attrs_t get_attrs(
-      SeaStore &seastore) {
-      return seastore.get_attrs(coll, oid)
-		     .handle_error(SeaStore::get_attrs_ertr::discard_all{})
+    SeaStoreShard::attrs_t get_attrs(
+      SeaStoreShard &sharded_seastore) {
+      return sharded_seastore.get_attrs(coll, oid)
+		     .handle_error(SeaStoreShard::get_attrs_ertr::discard_all{})
 		     .get();
     }
 
     ceph::bufferlist get_attr(
-      SeaStore& seastore,
+      SeaStoreShard& sharded_seastore,
       std::string_view name) {
-      return seastore.get_attr(coll, oid, name)
+      return sharded_seastore.get_attr(coll, oid, name)
 		      .handle_error(
-			SeaStore::get_attr_errorator::discard_all{})
+			SeaStoreShard::get_attr_errorator::discard_all{})
 		      .get();
     }
 
     void check_omap_key(
-      SeaStore &seastore,
+      SeaStoreShard &sharded_seastore,
       const string &key) {
       std::set<string> to_check;
       to_check.insert(key);
-      auto result = seastore.omap_get_values(
+      auto result = sharded_seastore.omap_get_values(
 	coll,
 	oid,
 	to_check).unsafe_get0();
@@ -394,11 +395,11 @@ struct seastore_test_t :
       }
     }
 
-    void check_omap(SeaStore &seastore) {
+    void check_omap(SeaStoreShard &sharded_seastore) {
       auto refiter = omap.begin();
       std::optional<std::string> start;
       while(true) {
-        auto [done, kvs] = seastore.omap_get_values(
+        auto [done, kvs] = sharded_seastore.omap_get_values(
           coll,
           oid,
           start).unsafe_get0();
@@ -446,7 +447,7 @@ struct seastore_test_t :
   void remove_object(
     object_state_t &sobj) {
 
-    sobj.remove(*seastore);
+    sobj.remove(*sharded_seastore);
     auto erased = test_objects.erase(sobj.oid);
     ceph_assert(erased == 1);
   }
@@ -456,7 +457,7 @@ struct seastore_test_t :
     for (auto& [oid, obj] : test_objects) {
       oids.emplace_back(oid);
     }
-    auto ret = seastore->list_objects(
+    auto ret = sharded_seastore->list_objects(
         coll,
         ghobject_t(),
         ghobject_t::get_max(),
@@ -529,8 +530,8 @@ struct seastore_test_t :
     auto create = [this, &objs](ghobject_t hoid) {
       objs.emplace_back(std::move(hoid));
       auto &obj = get_object(objs.back());
-      obj.touch(*seastore);
-      obj.check_size(*seastore);
+      obj.touch(*sharded_seastore);
+      obj.check_size(*sharded_seastore);
     };
     for (unsigned i = 0; i < temp_to_create; ++i) {
       create(make_temp_oid(i));
@@ -545,7 +546,7 @@ struct seastore_test_t :
       auto right_bound = in_right_bound.get_oid(*seastore, coll);
 
       // get results from seastore
-      auto [listed, next] = seastore->list_objects(
+      auto [listed, next] = sharded_seastore->list_objects(
 	coll, left_bound, right_bound, limit).get0();
 
       // compute correct answer
@@ -593,7 +594,7 @@ struct seastore_test_t :
     }
 
     // teardown
-    for (auto &&hoid : objs) { get_object(hoid).remove(*seastore); }
+    for (auto &&hoid : objs) { get_object(hoid).remove(*sharded_seastore); }
   }
 };
 
@@ -610,7 +611,7 @@ TEST_P(seastore_test_t, collection_create_list_remove)
   run_async([this] {
     coll_t test_coll{spg_t{pg_t{1, 0}}};
     {
-      seastore->create_new_collection(test_coll).get0();
+      sharded_seastore->create_new_collection(test_coll).get0();
       {
 	CTransaction t;
 	t.create_collection(test_coll, 4);
@@ -663,8 +664,8 @@ TEST_P(seastore_test_t, touch_stat_list_remove)
 {
   run_async([this] {
     auto &test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
-    test_obj.check_size(*seastore);
+    test_obj.touch(*sharded_seastore);
+    test_obj.check_size(*sharded_seastore);
     validate_objects();
 
     remove_object(test_obj);
@@ -755,13 +756,13 @@ TEST_P(seastore_test_t, omap_test_simple)
 {
   run_async([this] {
     auto &test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
     test_obj.set_omap(
-      *seastore,
+      *sharded_seastore,
       "asdf",
       make_bufferlist(128));
     test_obj.check_omap_key(
-      *seastore,
+      *sharded_seastore,
       "asdf");
   });
 }
@@ -770,24 +771,24 @@ TEST_P(seastore_test_t, attr)
 {
   run_async([this] {
     auto& test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
   {
     std::string oi("asdfasdfasdf");
     bufferlist bl;
     encode(oi, bl);
-    test_obj.set_attr(*seastore, OI_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, OI_ATTR, bl);
 
     std::string ss("fdsfdsfs");
     bl.clear();
     encode(ss, bl);
-    test_obj.set_attr(*seastore, SS_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, SS_ATTR, bl);
 
     std::string test_val("ssssssssssss");
     bl.clear();
     encode(test_val, bl);
-    test_obj.set_attr(*seastore, "test_key", bl);
+    test_obj.set_attr(*sharded_seastore, "test_key", bl);
 
-    auto attrs = test_obj.get_attrs(*seastore);
+    auto attrs = test_obj.get_attrs(*sharded_seastore);
     std::string oi2;
     bufferlist bl2 = attrs[OI_ATTR];
     decode(oi2, bl2);
@@ -804,13 +805,13 @@ TEST_P(seastore_test_t, attr)
     EXPECT_EQ(test_val, test_val2);
 
     bl2.clear();
-    bl2 = test_obj.get_attr(*seastore, "test_key");
+    bl2 = test_obj.get_attr(*sharded_seastore, "test_key");
     test_val2.clear();
     decode(test_val2, bl2);
     EXPECT_EQ(test_val, test_val2);
     //test rm_attrs
-    test_obj.rm_attrs(*seastore);
-    attrs = test_obj.get_attrs(*seastore);
+    test_obj.rm_attrs(*sharded_seastore);
+    attrs = test_obj.get_attrs(*sharded_seastore);
     EXPECT_EQ(attrs.find(OI_ATTR), attrs.end());
     EXPECT_EQ(attrs.find(SS_ATTR), attrs.end());
     EXPECT_EQ(attrs.find("test_key"), attrs.end());
@@ -822,15 +823,15 @@ TEST_P(seastore_test_t, attr)
     std::string oi_str(&oi_array[0], sizeof(oi_array));
     bl.clear();
     encode(oi_str, bl);
-    test_obj.set_attr(*seastore, OI_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, OI_ATTR, bl);
 
     char ss_array[onode_layout_t::MAX_SS_LENGTH + 1] = {'b'};
     std::string ss_str(&ss_array[0], sizeof(ss_array));
     bl.clear();
     encode(ss_str, bl);
-    test_obj.set_attr(*seastore, SS_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, SS_ATTR, bl);
 
-    attrs = test_obj.get_attrs(*seastore);
+    attrs = test_obj.get_attrs(*sharded_seastore);
     bl2.clear();
     bl2 = attrs[OI_ATTR];
     std::string oi_str2;
@@ -845,20 +846,20 @@ TEST_P(seastore_test_t, attr)
 
     bl2.clear();
     ss_str2.clear();
-    bl2 = test_obj.get_attr(*seastore, SS_ATTR);
+    bl2 = test_obj.get_attr(*sharded_seastore, SS_ATTR);
     decode(ss_str2, bl2);
     EXPECT_EQ(ss_str, ss_str2);
 
     bl2.clear();
     oi_str2.clear();
-    bl2 = test_obj.get_attr(*seastore, OI_ATTR);
+    bl2 = test_obj.get_attr(*sharded_seastore, OI_ATTR);
     decode(oi_str2, bl2);
     EXPECT_EQ(oi_str, oi_str2);
 
-    test_obj.rm_attr(*seastore, OI_ATTR);
-    test_obj.rm_attr(*seastore, SS_ATTR);
+    test_obj.rm_attr(*sharded_seastore, OI_ATTR);
+    test_obj.rm_attr(*sharded_seastore, SS_ATTR);
 
-    attrs = test_obj.get_attrs(*seastore);
+    attrs = test_obj.get_attrs(*sharded_seastore);
     EXPECT_EQ(attrs.find(OI_ATTR), attrs.end());
     EXPECT_EQ(attrs.find(SS_ATTR), attrs.end());
   }
@@ -868,19 +869,19 @@ TEST_P(seastore_test_t, attr)
     std::string oi("asdfasdfasdf");
     bufferlist bl;
     encode(oi, bl);
-    test_obj.set_attr(*seastore, OI_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, OI_ATTR, bl);
 
     std::string ss("f");
     bl.clear();
     encode(ss, bl);
-    test_obj.set_attr(*seastore, SS_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, SS_ATTR, bl);
 
     std::string test_val("ssssssssssss");
     bl.clear();
     encode(test_val, bl);
-    test_obj.set_attr(*seastore, "test_key", bl);
+    test_obj.set_attr(*sharded_seastore, "test_key", bl);
 
-    auto attrs = test_obj.get_attrs(*seastore);
+    auto attrs = test_obj.get_attrs(*sharded_seastore);
     std::string oi2;
     bufferlist bl2 = attrs[OI_ATTR];
     decode(oi2, bl2);
@@ -896,11 +897,11 @@ TEST_P(seastore_test_t, attr)
     EXPECT_EQ(oi, oi2);
     EXPECT_EQ(test_val, test_val2);
 
-    test_obj.rm_attr(*seastore, OI_ATTR);
-    test_obj.rm_attr(*seastore, SS_ATTR);
-    test_obj.rm_attr(*seastore, "test_key");
+    test_obj.rm_attr(*sharded_seastore, OI_ATTR);
+    test_obj.rm_attr(*sharded_seastore, SS_ATTR);
+    test_obj.rm_attr(*sharded_seastore, "test_key");
 
-    attrs = test_obj.get_attrs(*seastore);
+    attrs = test_obj.get_attrs(*sharded_seastore);
     EXPECT_EQ(attrs.find(OI_ATTR), attrs.end());
     EXPECT_EQ(attrs.find(SS_ATTR), attrs.end());
     EXPECT_EQ(attrs.find("test_key"), attrs.end());
@@ -914,25 +915,25 @@ TEST_P(seastore_test_t, attr)
     std::string oi(&oi_array[0], sizeof(oi_array));
     bufferlist bl;
     encode(oi, bl);
-    test_obj.set_attr(*seastore, OI_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, OI_ATTR, bl);
 
     oi = "asdfasdfasdf";
     bl.clear();
     encode(oi, bl);
-    test_obj.set_attr(*seastore, OI_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, OI_ATTR, bl);
 
     char ss_array[onode_layout_t::MAX_SS_LENGTH + 1] = {'b'};
     std::string ss(&ss_array[0], sizeof(ss_array));
     bl.clear();
     encode(ss, bl);
-    test_obj.set_attr(*seastore, SS_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, SS_ATTR, bl);
 
     ss = "f";
     bl.clear();
     encode(ss, bl);
-    test_obj.set_attr(*seastore, SS_ATTR, bl);
+    test_obj.set_attr(*sharded_seastore, SS_ATTR, bl);
 
-    auto attrs = test_obj.get_attrs(*seastore);
+    auto attrs = test_obj.get_attrs(*sharded_seastore);
     std::string oi2, ss2;
     bufferlist bl2 = attrs[OI_ATTR];
     decode(oi2, bl2);
@@ -954,14 +955,14 @@ TEST_P(seastore_test_t, omap_test_iterator)
       return ss.str();
     };
     auto &test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
     for (unsigned i = 0; i < 20; ++i) {
       test_obj.set_omap(
-	*seastore,
+	*sharded_seastore,
 	make_key(i),
 	make_bufferlist(128));
     }
-    test_obj.check_omap(*seastore);
+    test_obj.check_omap(*sharded_seastore);
   });
 }
 
@@ -974,23 +975,23 @@ TEST_P(seastore_test_t, object_data_omap_remove)
       return ss.str();
     };
     auto &test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
     for (unsigned i = 0; i < 1024; ++i) {
       test_obj.set_omap(
-	*seastore,
+	*sharded_seastore,
 	make_key(i),
 	make_bufferlist(128));
     }
-    test_obj.check_omap(*seastore);
+    test_obj.check_omap(*sharded_seastore);
 
     for (uint64_t i = 0; i < 16; i++) {
       test_obj.write(
-	*seastore,
+	*sharded_seastore,
 	4096 * i,
 	4096,
 	'a');
     }
-    test_obj.remove(*seastore);
+    test_obj.remove(*sharded_seastore);
   });
 }
 
@@ -1000,15 +1001,15 @@ TEST_P(seastore_test_t, simple_extent_test)
   run_async([this] {
     auto &test_obj = get_object(make_oid(0));
     test_obj.write(
-      *seastore,
+      *sharded_seastore,
       1024,
       1024,
       'a');
     test_obj.read(
-      *seastore,
+      *sharded_seastore,
       1024,
       1024);
-    test_obj.check_size(*seastore);
+    test_obj.check_size(*sharded_seastore);
   });
 }
 
@@ -1016,14 +1017,14 @@ TEST_P(seastore_test_t, fiemap_empty)
 {
   run_async([this] {
     auto &test_obj = get_object(make_oid(0));
-    test_obj.touch(*seastore);
-    test_obj.truncate(*seastore, 100000);
+    test_obj.touch(*sharded_seastore);
+    test_obj.truncate(*sharded_seastore, 100000);
 
     std::map<uint64_t, uint64_t> m;
-    m = test_obj.fiemap(*seastore, 0, 100000);
+    m = test_obj.fiemap(*sharded_seastore, 0, 100000);
     EXPECT_TRUE(m.empty());
 
-    test_obj.remove(*seastore);
+    test_obj.remove(*sharded_seastore);
   });
 }
 
@@ -1038,14 +1039,14 @@ TEST_P(seastore_test_t, fiemap_holes)
     bufferlist bl;
     bl.append("foo");
 
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
     for (uint64_t i = 0; i < MAX_EXTENTS; i++) {
-      test_obj.write(*seastore, SKIP_STEP * i, bl);
+      test_obj.write(*sharded_seastore, SKIP_STEP * i, bl);
     }
 
     { // fiemap test from 0 to SKIP_STEP * (MAX_EXTENTS - 1) + 3
       auto m = test_obj.fiemap(
-	*seastore, 0, SKIP_STEP * (MAX_EXTENTS - 1) + 3);
+	*sharded_seastore, 0, SKIP_STEP * (MAX_EXTENTS - 1) + 3);
       ASSERT_EQ(m.size(), MAX_EXTENTS);
       for (uint64_t i = 0; i < MAX_EXTENTS; i++) {
 	ASSERT_TRUE(m.count(SKIP_STEP * i));
@@ -1055,7 +1056,7 @@ TEST_P(seastore_test_t, fiemap_holes)
 
     { // fiemap test from SKIP_STEP to SKIP_STEP * (MAX_EXTENTS - 2) + 3
       auto m = test_obj.fiemap(
-	*seastore, SKIP_STEP, SKIP_STEP * (MAX_EXTENTS - 3) + 3);
+	*sharded_seastore, SKIP_STEP, SKIP_STEP * (MAX_EXTENTS - 3) + 3);
       ASSERT_EQ(m.size(), MAX_EXTENTS - 2);
       for (uint64_t i = 1; i < MAX_EXTENTS - 1; i++) {
 	ASSERT_TRUE(m.count(SKIP_STEP * i));
@@ -1065,7 +1066,7 @@ TEST_P(seastore_test_t, fiemap_holes)
 
     { // fiemap test SKIP_STEP + 1 to 2 * SKIP_STEP + 1 (partial overlap)
       auto m = test_obj.fiemap(
-	*seastore, SKIP_STEP + 1, SKIP_STEP + 1);
+	*sharded_seastore, SKIP_STEP + 1, SKIP_STEP + 1);
       ASSERT_EQ(m.size(), 2);
       ASSERT_EQ(m.begin()->first, SKIP_STEP + 1);
       ASSERT_GE(m.begin()->second, bl.length());
@@ -1073,7 +1074,7 @@ TEST_P(seastore_test_t, fiemap_holes)
       ASSERT_EQ(m.rbegin()->first + m.rbegin()->second, 2 * SKIP_STEP + 2);
     }
 
-    test_obj.remove(*seastore);
+    test_obj.remove(*sharded_seastore);
   });
 }
 
@@ -1086,16 +1087,16 @@ TEST_P(seastore_test_t, sparse_read)
     bufferlist wbl;
     wbl.append("foo");
 
-    test_obj.touch(*seastore);
+    test_obj.touch(*sharded_seastore);
     for (uint64_t i = 0; i < MAX_EXTENTS; i++) {
-      test_obj.write(*seastore, SKIP_STEP * i, wbl);
+      test_obj.write(*sharded_seastore, SKIP_STEP * i, wbl);
     }
     interval_set<uint64_t> m;
     m = interval_set<uint64_t>(
-	test_obj.fiemap(*seastore, 0, SKIP_STEP * (MAX_EXTENTS - 1) + 3));
+	test_obj.fiemap(*sharded_seastore, 0, SKIP_STEP * (MAX_EXTENTS - 1) + 3));
     ASSERT_TRUE(!m.empty());
     uint64_t off = 0;
-    auto rbl = test_obj.readv(*seastore, m);
+    auto rbl = test_obj.readv(*sharded_seastore, m);
 
     for (auto &&miter : m) {
       bufferlist subl;
@@ -1103,7 +1104,7 @@ TEST_P(seastore_test_t, sparse_read)
       ASSERT_TRUE(subl.contents_equal(wbl));
       off += miter.second;
     }
-    test_obj.remove(*seastore);
+    test_obj.remove(*sharded_seastore);
   });
 }
 
@@ -1120,21 +1121,21 @@ TEST_P(seastore_test_t, zero)
       uint64_t size = 0;
       for (auto &[off, len, repeat]: writes) {
 	for (decltype(repeat) i = 0; i < repeat; ++i) {
-	  test_obj.write(*seastore, off + (len * repeat), len, 'a');
+	  test_obj.write(*sharded_seastore, off + (len * repeat), len, 'a');
 	}
 	size = off + (len * (repeat + 1));
       }
       test_obj.read(
-	*seastore,
+	*sharded_seastore,
 	0,
 	size);
-      test_obj.check_size(*seastore);
-      test_obj.zero(*seastore, zero_off, zero_len);
+      test_obj.check_size(*sharded_seastore);
+      test_obj.zero(*sharded_seastore, zero_off, zero_len);
       test_obj.read(
-	*seastore,
+	*sharded_seastore,
 	0,
 	size);
-      test_obj.check_size(*seastore);
+      test_obj.check_size(*sharded_seastore);
       remove_object(test_obj);
     };
 

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -181,11 +181,11 @@ protected:
 
   virtual seastar::future<> _init() = 0;
 
-  virtual void _destroy() = 0;
+  virtual seastar::future<> _destroy() = 0;
   virtual seastar::future<> _teardown() = 0;
   seastar::future<> teardown() {
     return _teardown().then([this] {
-      _destroy();
+      return _destroy();
     });
   }
 
@@ -226,7 +226,7 @@ protected:
     }
     SUBINFO(test, "begin with {} devices ...", devices->get_num_devices());
     return devices->setup(
-    ).then([this]() {
+    ).then([this] {
       return _init();
     }).then([this, FNAME] {
         return _mkfs(
@@ -273,18 +273,16 @@ protected:
     return seastar::now();
   }
 
-  virtual void _destroy() override {
+  virtual seastar::future<> _destroy() override {
     epm = nullptr;
     lba_manager = nullptr;
     cache = nullptr;
     tm.reset();
+    return seastar::now();
   }
 
   virtual seastar::future<> _teardown() {
-    return tm->close().safe_then([this] {
-      _destroy();
-      return seastar::now();
-    }).handle_error(
+    return tm->close().handle_error(
       crimson::ct_error::assert_all{"Error in teardown"}
     );
   }
@@ -407,18 +405,24 @@ class SeaStoreTestState : public EphemeralTestState {
 
 protected:
   std::unique_ptr<SeaStore> seastore;
+  FuturizedStore::Shard *sharded_seastore;
 
   SeaStoreTestState() : EphemeralTestState(1, 0) {}
 
   virtual seastar::future<> _init() final {
     seastore = make_test_seastore(
       std::make_unique<TestMDStoreState::Store>(mdstore_state.get_mdstore()));
-    return seastore->test_start(devices->get_primary_device_ref());
+    return seastore->test_start(devices->get_primary_device_ref()
+    ).then([this] {
+      sharded_seastore = &(seastore->get_sharded_store());
+    });
   }
 
-  virtual void _destroy() final {
+  virtual seastar::future<> _destroy() final {
     devices->set_primary_device_ref(seastore->get_primary_device_ref());
-    seastore.reset();
+    return seastore->stop().then([this] {
+      seastore.reset();
+    });
   }
 
   virtual seastar::future<> _teardown() final {


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/48717

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh