### PR TITLE
reef: crimson/osd/osd_operations/client_request: Fix client blocklisting

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -283,8 +283,8 @@ ClientRequest::do_process(
     return reply_op_error(pg, -ENAMETOOLONG);
   } else if (m->get_hobj().oid.name.empty()) {
     return reply_op_error(pg, -EINVAL);
-  } else if (pg->get_osdmap()->is_blocklisted(m->get_source_addr())) {
-    logger().info("{} is blocklisted", m->get_source_addr());
+  } else if (pg->get_osdmap()->is_blocklisted(conn->get_peer_addr())) {
+    logger().info("{} is blocklisted", conn->get_peer_addr());
     return reply_op_error(pg, -EBLOCKLISTED);
   }
 


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51381

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh