### PR TITLE
reef: qa/suites/crimson: Enhance rbd api testing 

### DIFF
--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
@@ -1,0 +1,12 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(SLOW_OPS\)
+      - slow request
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'
+    env:
+      RBD_FEATURES: "61"

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
@@ -7,4 +7,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rbd/test_librbd_python.sh
+        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'

--- a/qa/workunits/rbd/test_librbd_python.sh
+++ b/qa/workunits/rbd/test_librbd_python.sh
@@ -5,8 +5,8 @@ relpath=$(dirname $0)/../../../src/test/pybind
 if [ -n "${VALGRIND}" ]; then
   valgrind ${VALGRIND} --suppressions=${TESTDIR}/valgrind.supp \
     --errors-for-leak-kinds=definite --error-exitcode=1 \
-    python3 -m nose -v $relpath/test_rbd.py
+    python3 -m nose -v $relpath/test_rbd.py "$@"
 else
-    python3 -m nose -v $relpath/test_rbd.py
+    python3 -m nose -v $relpath/test_rbd.py "$@"
 fi
 exit 0

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -20,7 +20,6 @@
 
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
-#include "test/librados/crimson_utils.h"
 
 #include <errno.h>
 #include <string>
@@ -1798,7 +1797,6 @@ TEST_F(TestClsRbd, mirror_image) {
 }
 
 TEST_F(TestClsRbd, mirror_image_status) {
-  SKIP_IF_CRIMSON();
   struct WatchCtx : public librados::WatchCtx2 {
     librados::IoCtx *m_ioctx;
 

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -3,7 +3,6 @@
 
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
-#include "test/librados/crimson_utils.h"
 #include "include/rbd/librbd.h"
 #include "include/rbd/librbd.hpp"
 #include "test/librados/test.h"
@@ -220,7 +219,6 @@ TEST_F(TestGroup, add_imagePP)
 
 TEST_F(TestGroup, add_snapshot)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   rados_ioctx_t ioctx;
@@ -367,7 +365,6 @@ TEST_F(TestGroup, add_snapshot)
 
 TEST_F(TestGroup, add_snapshotPP)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   librados::IoCtx ioctx;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -268,7 +268,6 @@ TEST_F(TestInternal, SnapCreateFailsToLockImage) {
 }
 
 TEST_F(TestInternal, SnapRollbackLocksImage) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   ASSERT_EQ(0, create_snapshot("snap1", false));
@@ -1182,7 +1181,6 @@ TEST_F(TestInternal, ImageOptions) {
 }
 
 TEST_F(TestInternal, WriteFullCopyup) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;
@@ -1737,7 +1735,6 @@ TEST_F(TestInternal, Sparsify) {
 
 
 TEST_F(TestInternal, SparsifyClone) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
   librbd::ImageCtx *ictx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8529,7 +8529,6 @@ TEST_F(TestLibRBD, SnapshotLimitPP)
 
 TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_OBJECT_MAP);
 
   librados::IoCtx ioctx;
@@ -8582,7 +8581,6 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8623,7 +8621,6 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
 
 TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8668,7 +8665,6 @@ TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 
 TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   librados::IoCtx ioctx;
@@ -8709,7 +8705,6 @@ TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 }
 
 TEST_F(TestLibRBD, UpdateFeaturesViaLockOwner) {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -8960,7 +8955,6 @@ TEST_F(TestLibRBD, SnapUnprotectViaLockOwner)
 
 TEST_F(TestLibRBD, FlattenViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9009,7 +9003,6 @@ TEST_F(TestLibRBD, FlattenViaLockOwner)
 
 TEST_F(TestLibRBD, ResizeViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9046,7 +9039,6 @@ TEST_F(TestLibRBD, ResizeViaLockOwner)
 
 TEST_F(TestLibRBD, SparsifyViaLockOwner)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -9751,7 +9743,6 @@ TEST_F(TestLibRBD, BlockingAIO)
 
 TEST_F(TestLibRBD, ExclusiveLockTransition)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
@@ -10425,7 +10416,6 @@ TEST_F(TestLibRBD, FlushCacheWithCopyupOnExternalSnapshot) {
 
 TEST_F(TestLibRBD, ExclusiveLock)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   static char buf[10];
@@ -11961,7 +11951,6 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
 
 TEST_F(TestLibRBD, QuiesceWatch)
 {
-  SKIP_IF_CRIMSON();
   rados_ioctx_t ioctx;
   rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
 
@@ -12053,7 +12042,6 @@ TEST_F(TestLibRBD, QuiesceWatch)
 
 TEST_F(TestLibRBD, QuiesceWatchPP)
 {
-  SKIP_IF_CRIMSON();
   librbd::RBD rbd;
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -13,7 +13,6 @@
  */
 #include "test/librbd/test_fixture.h"
 #include "test/librbd/test_support.h"
-#include "test/librados/crimson_utils.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageState.h"
 #include "librbd/ImageWatcher.h"
@@ -1224,7 +1223,6 @@ TEST_F(TestMirroring, SnapshotRemoveOnDisable)
 
 TEST_F(TestMirroring, SnapshotUnlinkPeer)
 {
-  SKIP_IF_CRIMSON();
   REQUIRE_FORMAT_V2();
 
   ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -12,6 +12,7 @@ import sys
 
 from datetime import datetime, timedelta
 from nose import with_setup, SkipTest
+from nose.plugins.attrib import attr
 from nose.tools import eq_ as eq, assert_raises, assert_not_equal
 from rados import (Rados,
                    LIBRADOS_OP_FLAG_FADVISE_DONTNEED,
@@ -777,6 +778,7 @@ class TestImage(object):
         self._test_copy(features, self.image.stat()['order'],
                         self.image.stripe_unit(), self.image.stripe_count())
 
+    @attr('SKIP_IF_CRIMSON')
     def test_deep_copy(self):
         global ioctx
         global features
@@ -2029,6 +2031,7 @@ class TestExclusiveLock(object):
             image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE)
             image.lock_release()
 
+    @attr('SKIP_IF_CRIMSON')
     def test_break_lock(self):
         blocklist_rados = Rados(conffile='')
         blocklist_rados.connect()


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51388

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh