### PR TITLE
cmake: cls_rgw and cls_fifo depend on fmt

### DIFF
--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -201,7 +201,7 @@ if (WITH_RADOSGW)
     rgw/cls_rgw_types.cc
     ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
   add_library(cls_rgw SHARED ${cls_rgw_srcs})
-  target_link_libraries(cls_rgw json_spirit)
+  target_link_libraries(cls_rgw fmt json_spirit)
   target_include_directories(cls_rgw
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
@@ -359,6 +359,7 @@ set_target_properties(cls_fifo PROPERTIES
   SOVERSION "1"
   INSTALL_RPATH ""
   CXX_VISIBILITY_PRESET hidden)
+target_link_libraries(cls_fifo fmt)
 install(TARGETS cls_fifo DESTINATION ${cls_dir})
 
 # cls_test_remote_reads


### PR DESCRIPTION
followup fix for https://tracker.ceph.com/issues/58953 on centos9. the osds fail to load the object classes for rgw and fifo with errors like this:

> 2023-05-23T02:20:52.611+0000 7f03f890f500  0 _load_class could not open class /usr/lib64/rados-classes/libcls_fifo.so (dlopen failed): /usr/lib64/rados-classes/libcls_fifo.so: undefined symbol: _ZN3fmt2v87vformatB5cxx11ENS0_17basic_string_viewIcEENS0_17basic_format_argsINS0_20basic_format_contextINS0_8appenderEcEEEE

see example [teuthology.log](http://qa-proxy.ceph.com/teuthology/cbodley-2023-05-23_01:42:51-rgw-wip-58953-distro-default-smithi/7283188/teuthology.log) from centos 9, which was scheduled against https://github.com/ceph/ceph/pull/50441

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
