### PR TITLE
reef: crimson/osd/ops_executer: Fix usage of Message's connection

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -796,6 +796,11 @@ struct PG::do_osd_ops_params_t {
     return false;
   }
 
+  // Only used by ExecutableMessagePimpl
+  entity_name_t get_source() const {
+    return orig_source_inst.name;
+  }
+
   crimson::net::ConnectionRef &conn;
   osd_reqid_t reqid;
   utime_t mtime;


### PR DESCRIPTION
This PR is part of Crimson Reef backport batch, See: https://gist.github.com/Matan-B/0e076b8c55545c631012bb22a996b6e6

---

backport of https://github.com/ceph/ceph/pull/51312

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh