### PR TITLE
rgw: Use a unique_ptr when creating a D3nCacheAioWriteRequest instance

### DIFF
--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -41,20 +41,19 @@ struct D3nChunkDataInfo : public LRUObject {
 
 struct D3nCacheAioWriteRequest {
 	std::string oid;
-	void *data;
-	int fd;
-	struct aiocb *cb;
-	D3nDataCache *priv_data;
-	CephContext *cct;
+	void *data = nullptr;
+	int fd = -1;
+	struct aiocb *cb = nullptr;
+	D3nDataCache *priv_data = nullptr;
+	CephContext *cct = nullptr;
 
 	D3nCacheAioWriteRequest(CephContext *_cct) : cct(_cct) {}
 	int d3n_prepare_libaio_write_op(bufferlist& bl, unsigned int len, std::string oid, std::string cache_location);
 
   ~D3nCacheAioWriteRequest() {
     ::close(fd);
-		cb->aio_buf = nullptr;
-		free(data);
-		data = nullptr;
+    free(data);
+    cb->aio_buf = nullptr;
 		delete(cb);
   }
 };


### PR DESCRIPTION
There were quite a few places inside rgw_d3n_datacache.cc where we should delete the D3nCacheAioWriteRequest object upon error. However, it was possible that someone might forget to delete the allocated object and memory might leak. This commit changes this behaviour by using a unique_ptr for the write request object. If any error occurs during submission or object creation, the unique_ptr goes out of scope and deletes the object.

Fixes coverity defect ID 1510555





## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
