### PR TITLE
ceph.spec.in: enable build on riscv64 for openSUSE Factory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -189,7 +189,7 @@ URL:		http://ceph.com/
 Source0:	%{?_remote_tarball_prefix}@TARBALL_BASENAME@.tar.bz2
 %if 0%{?suse_version}
 # _insert_obs_source_lines_here
-ExclusiveArch:  x86_64 aarch64 ppc64le s390x
+ExclusiveArch:  x86_64 aarch64 ppc64le s390x riscv64
 %endif
 #################################################################################
 # dependencies that apply across all distro families


### PR DESCRIPTION
Signed-off-by: Andreas Schwab <schwab@suse.de>
