### PR TITLE
rgw: disable RGWDataChangesLog::add_entry() when log_data is off

### DIFF
--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -640,6 +640,10 @@ int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp,
 				 const rgw::bucket_log_layout_generation& gen,
 				 int shard_id, optional_yield y)
 {
+  if (!zone->log_data) {
+    return 0;
+  }
+
   auto& bucket = bucket_info.bucket;
 
   if (!filter_bucket(dpp, bucket, y)) {


### PR DESCRIPTION
this re-cherry-picks the commit from https://github.com/ceph/ceph/pull/45357 which fixed https://tracker.ceph.com/issues/54531

that change was reverted during the multisite reshard project in https://github.com/ceph/ceph/commit/6f83f07d7f1d5301b9bb99e557565087b4ccf1a3

Fixes: https://tracker.ceph.com/issues/61300

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
