### PR TITLE
cephadm: create a new version of the deploy command

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -260,10 +260,13 @@ $CEPHADM ls | jq '.[]' | jq 'select(.name == "mon.a").version' | grep -q \\.
 # add mon.b
 cp $CONFIG $MONCONFIG
 echo "public addrv = [v2:$IP:3301,v1:$IP:6790]" >> $MONCONFIG
-$CEPHADM deploy --name mon.b \
-      --fsid $FSID \
-      --keyring /var/lib/ceph/$FSID/mon.a/keyring \
-      --config $MONCONFIG
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name mon.b \
+    --arg keyring /var/lib/ceph/$FSID/mon.a/keyring \
+    --arg config "$MONCONFIG" \
+    '{"fsid": $fsid, "name": $name, "params":{"keyring": $keyring, "config": $config}}' | \
+    $CEPHADM _orch deploy
 for u in ceph-$FSID@mon.b; do
     systemctl is-enabled $u
     systemctl is-active $u
@@ -278,10 +281,13 @@ $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
       mon 'allow profile mgr' \
       osd 'allow *' \
       mds 'allow *' > $TMPDIR/keyring.mgr.y
-$CEPHADM deploy --name mgr.y \
-      --fsid $FSID \
-      --keyring $TMPDIR/keyring.mgr.y \
-      --config $CONFIG
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name mgr.y \
+    --arg keyring $TMPDIR/keyring.mgr.y \
+    --arg config "$CONFIG" \
+    '{"fsid": $fsid, "name": $name, "params":{"keyring": $keyring, "config": $config}}' | \
+    $CEPHADM _orch deploy
 for u in ceph-$FSID@mgr.y; do
     systemctl is-enabled $u
     systemctl is-active $u
@@ -331,30 +337,42 @@ for id in `seq 0 $((--OSD_TO_CREATE))`; do
     osd_fsid=$($SUDO cat $TMPDIR/osd.map | jq -cr '.. | ."ceph.osd_fsid"? | select(.)')
 
     # deploy the osd
-    $CEPHADM deploy --name osd.$osd_id \
-          --fsid $FSID \
-          --keyring $TMPDIR/keyring.bootstrap.osd \
-          --config $CONFIG \
-          --osd-fsid $osd_fsid
+    jq --null-input \
+        --arg fsid $FSID \
+        --arg name osd.$osd_id \
+        --arg keyring $TMPDIR/keyring.bootstrap.osd \
+        --arg config "$CONFIG" \
+        --arg osd_fsid $osd_fsid \
+        '{"fsid": $fsid, "name": $name, "params":{"keyring": $keyring, "config": $config, "osd_fsid": $osd_fsid}}' | \
+        $CEPHADM _orch deploy
 done
 
 # add node-exporter
-${CEPHADM//--image $IMAGE_DEFAULT/} deploy \
-    --name node-exporter.a --fsid $FSID
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name node-exporter.a \
+    '{"fsid": $fsid, "name": $name}' | \
+    ${CEPHADM//--image $IMAGE_DEFAULT/} _orch deploy
 cond="curl 'http://localhost:9100' | grep -q 'Node Exporter'"
 is_available "node-exporter" "$cond" 10
 
 # add prometheus
-cat ${CEPHADM_SAMPLES_DIR}/prometheus.json | \
-        ${CEPHADM//--image $IMAGE_DEFAULT/} deploy \
-	    --name prometheus.a --fsid $FSID --config-json -
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name prometheus.a \
+    --argjson config_blobs "$(cat ${CEPHADM_SAMPLES_DIR}/prometheus.json)" \
+    '{"fsid": $fsid, "name": $name, "config_blobs": $config_blobs}' | \
+    ${CEPHADM//--image $IMAGE_DEFAULT/} _orch deploy
 cond="curl 'localhost:9095/api/v1/query?query=up'"
 is_available "prometheus" "$cond" 10
 
 # add grafana
-cat ${CEPHADM_SAMPLES_DIR}/grafana.json | \
-        ${CEPHADM//--image $IMAGE_DEFAULT/} deploy \
-            --name grafana.a --fsid $FSID --config-json -
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name grafana.a \
+    --argjson config_blobs "$(cat ${CEPHADM_SAMPLES_DIR}/grafana.json)" \
+    '{"fsid": $fsid, "name": $name, "config_blobs": $config_blobs}' | \
+    ${CEPHADM//--image $IMAGE_DEFAULT/} _orch deploy
 cond="curl --insecure 'https://localhost:3000' | grep -q 'grafana'"
 is_available "grafana" "$cond" 50
 
@@ -367,11 +385,14 @@ $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
         rados --pool nfs-ganesha --namespace nfs-ns create conf-nfs.a
 $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
 	 ceph orch pause
-$CEPHADM deploy --name nfs.a \
-      --fsid $FSID \
-      --keyring $KEYRING \
-      --config $CONFIG \
-      --config-json ${CEPHADM_SAMPLES_DIR}/nfs.json
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name nfs.a \
+    --arg keyring "$KEYRING" \
+    --arg config "$CONFIG" \
+    --argjson config_blobs "$(cat ${CEPHADM_SAMPLES_DIR}/nfs.json)" \
+    '{"fsid": $fsid, "name": $name, "params": {"keyring": $keyring, "config": $config}, "config_blobs": $config_blobs}' | \
+    ${CEPHADM} _orch deploy
 cond="$SUDO ss -tlnp '( sport = :nfs )' | grep 'ganesha.nfsd'"
 is_available "nfs" "$cond" 10
 $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
@@ -379,15 +400,17 @@ $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
 
 # add alertmanager via custom container
 alertmanager_image=$(cat ${CEPHADM_SAMPLES_DIR}/custom_container.json | jq -r '.image')
-tcp_ports=$(cat ${CEPHADM_SAMPLES_DIR}/custom_container.json | jq -r '.ports | map_values(.|tostring) | join(" ")')
-cat ${CEPHADM_SAMPLES_DIR}/custom_container.json | \
-      ${CEPHADM//--image $IMAGE_DEFAULT/} \
-      --image $alertmanager_image \
-      deploy \
-      --tcp-ports "$tcp_ports" \
-      --name container.alertmanager.a \
-      --fsid $FSID \
-      --config-json -
+tcp_ports=$(jq .ports ${CEPHADM_SAMPLES_DIR}/custom_container.json)
+jq --null-input \
+    --arg fsid $FSID \
+    --arg name container.alertmanager.a \
+    --arg keyring $TMPDIR/keyring.bootstrap.osd \
+    --arg config "$CONFIG" \
+    --arg image "$alertmanager_image" \
+    --argjson tcp_ports "${tcp_ports}" \
+    --argjson config_blobs "$(cat ${CEPHADM_SAMPLES_DIR}/custom_container.json)" \
+    '{"fsid": $fsid, "name": $name, "image": $image, "params": {"keyring": $keyring, "config": $config, "tcp_ports": $tcp_ports}, "config_blobs": $config_blobs}' | \
+    ${CEPHADM//--image $IMAGE_DEFAULT/} _orch deploy
 cond="$CEPHADM enter --fsid $FSID --name container.alertmanager.a -- test -f \
       /etc/alertmanager/alertmanager.yml"
 is_available "alertmanager.yml" "$cond" 10

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -6273,8 +6273,9 @@ def apply_deploy_config_to_ctx(
     similar to how cli options on `deploy` are bound to the context.
     """
     ctx.name = config_data['name']
-    if 'image' in config_data:
-        ctx.image = config_data['image']
+    image = config_data.get('image', '')
+    if image:
+        ctx.image = image
     if 'fsid' in config_data:
         ctx.fsid = config_data['fsid']
     if 'meta' in config_data:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -9397,6 +9397,68 @@ def command_maintenance(ctx: CephadmContext) -> str:
 ##################################
 
 
+def _add_deploy_parser_args(parser_deploy: argparse.ArgumentParser) -> None:
+    parser_deploy.add_argument(
+        '--config', '-c',
+        help='config file for new daemon')
+    parser_deploy.add_argument(
+        '--config-json',
+        help='Additional configuration information in JSON format')
+    parser_deploy.add_argument(
+        '--keyring',
+        help='keyring for new daemon')
+    parser_deploy.add_argument(
+        '--key',
+        help='key for new daemon')
+    parser_deploy.add_argument(
+        '--osd-fsid',
+        help='OSD uuid, if creating an OSD container')
+    parser_deploy.add_argument(
+        '--skip-firewalld',
+        action='store_true',
+        help='Do not configure firewalld')
+    parser_deploy.add_argument(
+        '--tcp-ports',
+        help='List of tcp ports to open in the host firewall')
+    parser_deploy.add_argument(
+        '--reconfig',
+        action='store_true',
+        help='Reconfigure a previously deployed daemon')
+    parser_deploy.add_argument(
+        '--allow-ptrace',
+        action='store_true',
+        help='Allow SYS_PTRACE on daemon container')
+    parser_deploy.add_argument(
+        '--container-init',
+        action='store_true',
+        default=CONTAINER_INIT,
+        help=argparse.SUPPRESS)
+    parser_deploy.add_argument(
+        '--memory-request',
+        help='Container memory request/target'
+    )
+    parser_deploy.add_argument(
+        '--memory-limit',
+        help='Container memory hard limit'
+    )
+    parser_deploy.add_argument(
+        '--meta-json',
+        help='JSON dict of additional metadata'
+    )
+    parser_deploy.add_argument(
+        '--extra-container-args',
+        action='append',
+        default=[],
+        help='Additional container arguments to apply to daemon'
+    )
+    parser_deploy.add_argument(
+        '--extra-entrypoint-args',
+        action='append',
+        default=[],
+        help='Additional entrypoint arguments to apply to deamon'
+    )
+
+
 def _get_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
@@ -9899,65 +9961,7 @@ def _get_parser():
         '--fsid',
         required=True,
         help='cluster FSID')
-    parser_deploy.add_argument(
-        '--config', '-c',
-        help='config file for new daemon')
-    parser_deploy.add_argument(
-        '--config-json',
-        help='Additional configuration information in JSON format')
-    parser_deploy.add_argument(
-        '--keyring',
-        help='keyring for new daemon')
-    parser_deploy.add_argument(
-        '--key',
-        help='key for new daemon')
-    parser_deploy.add_argument(
-        '--osd-fsid',
-        help='OSD uuid, if creating an OSD container')
-    parser_deploy.add_argument(
-        '--skip-firewalld',
-        action='store_true',
-        help='Do not configure firewalld')
-    parser_deploy.add_argument(
-        '--tcp-ports',
-        help='List of tcp ports to open in the host firewall')
-    parser_deploy.add_argument(
-        '--reconfig',
-        action='store_true',
-        help='Reconfigure a previously deployed daemon')
-    parser_deploy.add_argument(
-        '--allow-ptrace',
-        action='store_true',
-        help='Allow SYS_PTRACE on daemon container')
-    parser_deploy.add_argument(
-        '--container-init',
-        action='store_true',
-        default=CONTAINER_INIT,
-        help=argparse.SUPPRESS)
-    parser_deploy.add_argument(
-        '--memory-request',
-        help='Container memory request/target'
-    )
-    parser_deploy.add_argument(
-        '--memory-limit',
-        help='Container memory hard limit'
-    )
-    parser_deploy.add_argument(
-        '--meta-json',
-        help='JSON dict of additional metadata'
-    )
-    parser_deploy.add_argument(
-        '--extra-container-args',
-        action='append',
-        default=[],
-        help='Additional container arguments to apply to daemon'
-    )
-    parser_deploy.add_argument(
-        '--extra-entrypoint-args',
-        action='append',
-        default=[],
-        help='Additional entrypoint arguments to apply to deamon'
-    )
+    _add_deploy_parser_args(parser_deploy)
 
     parser_check_host = subparsers.add_parser(
         'check-host', help='check host configuration')

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3064,6 +3064,23 @@ def fetch_configs(ctx: CephadmContext) -> Dict[str, str]:
     return {}
 
 
+def fetch_custom_config_files(ctx: CephadmContext) -> List[Dict[str, Any]]:
+    """Return a list containing dicts that can be used to populate
+    custom configuration files for containers.
+    """
+    # NOTE: this function works like the opposite of fetch_configs.
+    # instead of filtering out custom_config_files, it returns only
+    # the content in that key.
+    cfg_blobs = getattr(ctx, 'config_blobs', None)
+    if cfg_blobs:
+        return cfg_blobs.get('custom_config_files', [])
+    cfg_json = getattr(ctx, 'config_json', None)
+    if cfg_json:
+        jdata = _get_config_json(cfg_json)
+        return jdata.get('custom_config_files', [])
+    return []
+
+
 def fetch_tcp_ports(ctx: CephadmContext) -> List[int]:
     """Return a list of tcp ports, as integers, stored on the given ctx.
     """

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1409,7 +1409,7 @@ def dict_get(d: Dict, key: str, default: Any = None, require: bool = False) -> A
 ##################################
 
 
-def dict_get_join(d: Dict, key: str) -> Any:
+def dict_get_join(d: Dict[str, Any], key: str) -> Any:
     """
     Helper function to get the value of a given key from a dictionary.
     `List` values will be converted to a string by joining them with a

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3057,14 +3057,21 @@ def fetch_configs(ctx: CephadmContext) -> Dict[str, str]:
     must not be part of a deployment's configuration key-value pairs.
     To access custom configuration file data, use `fetch_custom_config_files`.
     """
+    # ctx.config_blobs is *always* a dict. it is created once when
+    # a command is parsed/processed and stored "forever"
     cfg_blobs = getattr(ctx, 'config_blobs', None)
     if cfg_blobs:
         cfg_blobs = dict(cfg_blobs)
         cfg_blobs.pop('custom_config_files', None)
         return cfg_blobs
+    # ctx.config_json is the legacy equivalent of config_blobs. it is a
+    # string that either contains json or refers to a file name where
+    # the file contains json.
     cfg_json = getattr(ctx, 'config_json', None)
     if cfg_json:
-        return get_parm(cfg_json) or {}
+        jdata = _get_config_json(cfg_json) or {}
+        jdata.pop('custom_config_files', None)
+        return jdata
     return {}
 
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -444,9 +444,9 @@ class SNMPGateway:
     @classmethod
     def init(cls, ctx: CephadmContext, fsid: str,
              daemon_id: Union[int, str]) -> 'SNMPGateway':
-        assert ctx.config_json
-        return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
+        cfgs = fetch_configs(ctx)
+        assert cfgs  # assert some config data was found
+        return cls(ctx, fsid, daemon_id, cfgs, ctx.image)
 
     @staticmethod
     def get_version(ctx: CephadmContext, fsid: str, daemon_id: str) -> Optional[str]:
@@ -755,7 +755,7 @@ class NFSGanesha(object):
     @classmethod
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> NFSGanesha
-        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json), ctx.image)
+        return cls(ctx, fsid, daemon_id, fetch_configs(ctx), ctx.image)
 
     def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
@@ -883,7 +883,7 @@ class CephIscsi(object):
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> CephIscsi
         return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
+                   fetch_configs(ctx), ctx.image)
 
     @staticmethod
     def get_container_mounts(data_dir, log_dir):
@@ -1019,7 +1019,7 @@ class CephExporter(object):
     def init(cls, ctx: CephadmContext, fsid: str,
              daemon_id: Union[int, str]) -> 'CephExporter':
         return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
+                   fetch_configs(ctx), ctx.image)
 
     @staticmethod
     def get_container_mounts() -> Dict[str, str]:
@@ -1068,7 +1068,7 @@ class HAproxy(object):
     @classmethod
     def init(cls, ctx: CephadmContext,
              fsid: str, daemon_id: Union[int, str]) -> 'HAproxy':
-        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json),
+        return cls(ctx, fsid, daemon_id, fetch_configs(ctx),
                    ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
@@ -1157,7 +1157,7 @@ class Keepalived(object):
     def init(cls, ctx: CephadmContext, fsid: str,
              daemon_id: Union[int, str]) -> 'Keepalived':
         return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
+                   fetch_configs(ctx), ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -1293,7 +1293,7 @@ class CustomContainer(object):
     def init(cls, ctx: CephadmContext,
              fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
         return cls(fsid, daemon_id,
-                   get_parm(ctx.config_json), ctx.image)
+                   fetch_configs(ctx), ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """
@@ -2800,7 +2800,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
                     port = meta['ports'][0]
             r += [f'--web.listen-address={ip}:{port}']
             if daemon_type == 'prometheus':
-                config = get_parm(ctx.config_json)
+                config = fetch_configs(ctx)
                 retention_time = config.get('retention_time', '15d')
                 retention_size = config.get('retention_size', '0')  # default to disabled
                 r += [f'--storage.tsdb.retention.time={retention_time}']
@@ -2816,7 +2816,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
                     host = wrap_ipv6(addr) if addr else host
                 r += [f'--web.external-url={scheme}://{host}:{port}']
         if daemon_type == 'alertmanager':
-            config = get_parm(ctx.config_json)
+            config = fetch_configs(ctx)
             peers = config.get('peers', list())  # type: ignore
             for peer in peers:
                 r += ['--cluster.peer={}'.format(peer)]
@@ -2829,13 +2829,13 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
         if daemon_type == 'promtail':
             r += ['--config.expand-env']
         if daemon_type == 'prometheus':
-            config = get_parm(ctx.config_json)
+            config = fetch_configs(ctx)
             try:
                 r += [f'--web.config.file={config["web_config"]}']
             except KeyError:
                 pass
         if daemon_type == 'node-exporter':
-            config = get_parm(ctx.config_json)
+            config = fetch_configs(ctx)
             try:
                 r += [f'--web.config={config["web_config"]}']
             except KeyError:
@@ -2883,9 +2883,7 @@ def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
             f.write(keyring)
 
     if daemon_type in Monitoring.components.keys():
-        config_json: Dict[str, Any] = dict()
-        if 'config_json' in ctx:
-            config_json = get_parm(ctx.config_json)
+        config_json = fetch_configs(ctx)
 
         # Set up directories specific to the monitoring component
         config_dir = ''
@@ -2936,7 +2934,10 @@ def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
         # populate the config directory for the component from the config-json
         if 'files' in config_json:
             for fname in config_json['files']:
-                content = dict_get_join(config_json['files'], fname)
+                # work around mypy wierdness where it thinks `str`s aren't Anys
+                # when used for dictionary values! feels like possibly a mypy bug?!
+                cfg = cast(Dict[str, Any], config_json['files'])
+                content = dict_get_join(cfg, fname)
                 if os.path.isabs(fname):
                     fpath = os.path.join(data_dir_root, fname.lstrip(os.path.sep))
                 else:
@@ -3071,8 +3072,8 @@ def get_config_and_keyring(ctx):
     config = None
     keyring = None
 
-    if 'config_json' in ctx and ctx.config_json:
-        d = get_parm(ctx.config_json)
+    d = fetch_configs(ctx)
+    if d:
         config = d.get('config')
         keyring = d.get('keyring')
         if config and keyring:
@@ -3332,7 +3333,7 @@ def get_container(ctx: CephadmContext,
     elif daemon_type in Tracing.components:
         entrypoint = ''
         name = '%s.%s' % (daemon_type, daemon_id)
-        config = get_parm(ctx.config_json)
+        config = fetch_configs(ctx)
         Tracing.set_configuration(config, daemon_type)
         envs.extend(Tracing.components[daemon_type].get('envs', []))
     elif daemon_type == NFSGanesha.daemon_type:
@@ -3527,10 +3528,7 @@ def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
     # with systemd if this is not a reconfig
     if deployment_type != DeploymentType.RECONFIG:
         if daemon_type == CephadmAgent.daemon_type:
-            if ctx.config_json == '-':
-                config_js = get_parm('-')
-            else:
-                config_js = get_parm(ctx.config_json)
+            config_js = fetch_configs(ctx)
             assert isinstance(config_js, dict)
 
             cephadm_agent = CephadmAgent(ctx, fsid, daemon_id)
@@ -6237,9 +6235,7 @@ def command_deploy(ctx):
         uid, gid = extract_uid_gid(ctx)
         make_var_run(ctx, ctx.fsid, uid, gid)
 
-        config_json: Optional[Dict[str, str]] = None
-        if 'config_json' in ctx and ctx.config_json:
-            config_json = get_parm(ctx.config_json)
+        config_json = fetch_configs(ctx)
 
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id,
                                      ptrace=ctx.allow_ptrace)
@@ -6262,7 +6258,7 @@ def command_deploy(ctx):
         # monitoring daemon - prometheus, grafana, alertmanager, node-exporter
         # Default Checks
         # make sure provided config-json is sufficient
-        config = get_parm(ctx.config_json)  # type: ignore
+        config = fetch_configs(ctx)  # type: ignore
         required_files = Monitoring.components[daemon_type].get('config-json-files', list())
         required_args = Monitoring.components[daemon_type].get('config-json-args', list())
         if required_files:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -6259,10 +6259,8 @@ def command_deploy(ctx):
     _common_deploy(ctx, daemon_type, daemon_id, daemon_ports, deployment_type)
 
 
-def command_deploy_from(ctx: CephadmContext) -> None:
-    """The deploy-from command is similar to deploy but sources nearly all
-    configuration parameters from an input JSON configuration file.
-    """
+def read_configuration_source(ctx: CephadmContext) -> Dict[str, Any]:
+    """Read a JSON configuration based on the `ctx.source` value."""
     source = '-'
     if 'source' in ctx and ctx.source:
         source = ctx.source
@@ -6272,9 +6270,16 @@ def command_deploy_from(ctx: CephadmContext) -> None:
         with open(source, 'rb') as fh:
             config_data = json.load(fh)
     logger.debug('Loaded deploy configuration: %r', config_data)
+    return config_data
 
-    # Bind properties taken from the json to our ctx, similar to how
-    # cli options on `deploy` are bound to the context.
+
+def apply_deploy_config_to_ctx(
+    config_data: Dict[str, Any],
+    ctx: CephadmContext,
+) -> None:
+    """Bind properties taken from the config_data dictionary to our ctx,
+    similar to how cli options on `deploy` are bound to the context.
+    """
     ctx.name = config_data['name']
     if 'image' in config_data:
         ctx.image = config_data['image']
@@ -6305,6 +6310,14 @@ def command_deploy_from(ctx: CephadmContext) -> None:
         setattr(ctx, key, value)
     update_default_image(ctx)
     logger.debug('Determined image: %r', ctx.image)
+
+
+def command_deploy_from(ctx: CephadmContext) -> None:
+    """The deploy-from command is similar to deploy but sources nearly all
+    configuration parameters from an input JSON configuration file.
+    """
+    config_data = read_configuration_source(ctx)
+    apply_deploy_config_to_ctx(config_data, ctx)
 
     daemon_type, daemon_id = ctx.name.split('.', 1)
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3049,6 +3049,23 @@ def fetch_meta(ctx: CephadmContext) -> Dict[str, Any]:
     return {}
 
 
+def fetch_configs(ctx: CephadmContext) -> Dict[str, str]:
+    """Return a dict containing arbitrary configuration parameters.
+    This function filters out the key 'custom_config_files' which
+    must not be part of a deployment's configuration key-value pairs.
+    To access custom configuration file data, use `fetch_custom_config_files`.
+    """
+    cfg_blobs = getattr(ctx, 'config_blobs', None)
+    if cfg_blobs:
+        cfg_blobs = dict(cfg_blobs)
+        cfg_blobs.pop('custom_config_files', None)
+        return cfg_blobs
+    cfg_json = getattr(ctx, 'config_json', None)
+    if cfg_json:
+        return get_parm(cfg_json) or {}
+    return {}
+
+
 def get_config_and_keyring(ctx):
     # type: (CephadmContext) -> Tuple[Optional[str], Optional[str]]
     config = None

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -6241,22 +6241,7 @@ def get_deployment_type(ctx: CephadmContext, daemon_type: str, daemon_id: str) -
 @deprecated_command
 def command_deploy(ctx):
     # type: (CephadmContext) -> None
-    daemon_type, daemon_id = ctx.name.split('.', 1)
-
-    lock = FileLock(ctx, ctx.fsid)
-    lock.acquire()
-
-    if daemon_type not in get_supported_daemons():
-        raise Error('daemon type %s not recognized' % daemon_type)
-
-    deployment_type: DeploymentType = get_deployment_type(ctx, daemon_type, daemon_id)
-
-    # Migrate sysctl conf files from /usr/lib to /etc
-    migrate_sysctl_dir(ctx, ctx.fsid)
-
-    # Get and check ports explicitly required to be opened
-    daemon_ports = fetch_tcp_ports(ctx)
-    _common_deploy(ctx, daemon_type, daemon_id, daemon_ports, deployment_type)
+    _common_deploy(ctx)
 
 
 def read_configuration_source(ctx: CephadmContext) -> Dict[str, Any]:
@@ -6311,14 +6296,16 @@ def command_deploy_from(ctx: CephadmContext) -> None:
     """
     config_data = read_configuration_source(ctx)
     apply_deploy_config_to_ctx(config_data, ctx)
+    _common_deploy(ctx)
 
+
+def _common_deploy(ctx: CephadmContext) -> None:
     daemon_type, daemon_id = ctx.name.split('.', 1)
+    if daemon_type not in get_supported_daemons():
+        raise Error('daemon type %s not recognized' % daemon_type)
 
     lock = FileLock(ctx, ctx.fsid)
     lock.acquire()
-
-    if daemon_type not in get_supported_daemons():
-        raise Error('daemon type %s not recognized' % daemon_type)
 
     deployment_type = get_deployment_type(ctx, daemon_type, daemon_id)
 
@@ -6327,10 +6314,10 @@ def command_deploy_from(ctx: CephadmContext) -> None:
 
     # Get and check ports explicitly required to be opened
     daemon_ports = fetch_tcp_ports(ctx)
-    _common_deploy(ctx, daemon_type, daemon_id, daemon_ports, deployment_type)
+    _dispatch_deploy(ctx, daemon_type, daemon_id, daemon_ports, deployment_type)
 
 
-def _common_deploy(
+def _dispatch_deploy(
     ctx: CephadmContext,
     daemon_type: str,
     daemon_id: str,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2304,27 +2304,33 @@ def require_image(func: FuncT) -> FuncT:
 def default_image(func: FuncT) -> FuncT:
     @wraps(func)
     def _default_image(ctx: CephadmContext) -> Any:
-        if not ctx.image:
-            if 'name' in ctx and ctx.name:
-                type_ = ctx.name.split('.', 1)[0]
-                if type_ in Monitoring.components:
-                    ctx.image = Monitoring.components[type_]['image']
-                if type_ == 'haproxy':
-                    ctx.image = HAproxy.default_image
-                if type_ == 'keepalived':
-                    ctx.image = Keepalived.default_image
-                if type_ == SNMPGateway.daemon_type:
-                    ctx.image = SNMPGateway.default_image
-                if type_ in Tracing.components:
-                    ctx.image = Tracing.components[type_]['image']
-            if not ctx.image:
-                ctx.image = os.environ.get('CEPHADM_IMAGE')
-            if not ctx.image:
-                ctx.image = _get_default_image(ctx)
-
+        update_default_image(ctx)
         return func(ctx)
 
     return cast(FuncT, _default_image)
+
+
+def update_default_image(ctx: CephadmContext) -> None:
+    if getattr(ctx, 'image', None):
+        return
+    ctx.image = None  # ensure ctx.image exists to avoid repeated `getattr`s
+    name = getattr(ctx, 'name', None)
+    if name:
+        type_ = name.split('.', 1)[0]
+        if type_ in Monitoring.components:
+            ctx.image = Monitoring.components[type_]['image']
+        if type_ == 'haproxy':
+            ctx.image = HAproxy.default_image
+        if type_ == 'keepalived':
+            ctx.image = Keepalived.default_image
+        if type_ == SNMPGateway.daemon_type:
+            ctx.image = SNMPGateway.default_image
+        if type_ in Tracing.components:
+            ctx.image = Tracing.components[type_]['image']
+    if not ctx.image:
+        ctx.image = os.environ.get('CEPHADM_IMAGE')
+    if not ctx.image:
+        ctx.image = _get_default_image(ctx)
 
 
 def executes_early(func: FuncT) -> FuncT:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -89,6 +89,7 @@ DEFAULT_TIMEOUT = None  # in seconds
 DEFAULT_RETRY = 15
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 QUIET_LOG_LEVEL = 9  # DEBUG is 10, so using 9 to be lower level than DEBUG
+NO_DEPRECATED = False
 
 logger: logging.Logger = None  # type: ignore
 
@@ -2338,6 +2339,17 @@ def executes_early(func: FuncT) -> FuncT:
     """
     cast(Any, func)._execute_early = True
     return func
+
+
+def deprecated_command(func: FuncT) -> FuncT:
+    @wraps(func)
+    def _deprecated_command(ctx: CephadmContext) -> Any:
+        logger.warning(f'Deprecated command used: {func}')
+        if NO_DEPRECATED:
+            raise Error('running deprecated commands disabled')
+        return func(ctx)
+
+    return cast(FuncT, _deprecated_command)
 
 
 def get_container_info(ctx: CephadmContext, daemon_filter: str, by_name: bool) -> Optional[ContainerInfo]:
@@ -6226,6 +6238,7 @@ def get_deployment_type(ctx: CephadmContext, daemon_type: str, daemon_id: str) -
 
 
 @default_image
+@deprecated_command
 def command_deploy(ctx):
     # type: (CephadmContext) -> None
     daemon_type, daemon_id = ctx.name.split('.', 1)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -6289,24 +6289,17 @@ def apply_deploy_config_to_ctx(
         ctx.meta_properties = config_data['meta']
     if 'config_blobs' in config_data:
         ctx.config_blobs = config_data['config_blobs']
-    # this is quite the hack!  this is a workaround for the fact that
-    # cephadm orch module knows about "args" not what they represent
-    # and so this lets us (try to) smooth the transition. Ideally, these
-    # would be set using key-value pairs in 'params' below.
-    parser = argparse.ArgumentParser(add_help=False)
-    _add_deploy_parser_args(parser)
-    try:
-        parsed_args = parser.parse_args(
-            config_data.get('deploy_arguments', []),
-        )
-    except SystemExit:
-        # exit_on_error arg for ArgumentParser is not present on py 3.6.
-        # we need to catch the exception until we can drop this code
-        raise Error('invalid argument encountered')
-    for key, value in vars(parsed_args).items():
-        setattr(ctx, key, value)
-    # prefer to get the values directly from the params JSON object.
+
+    # many functions don't check that an attribute is set on the ctx
+    # (with getattr or the '__contains__' func on ctx).
+    # This reuses the defaults from the CLI options so we don't
+    # have to repeat things and they can stay in sync.
+    facade = ArgumentFacade()
+    _add_deploy_parser_args(facade)
+    facade.apply(ctx)
     for key, value in config_data.get('params', {}).items():
+        if key not in facade.defaults:
+            logger.warning('unexpected parameter: %r=%r', key, value)
         setattr(ctx, key, value)
     update_default_image(ctx)
     logger.debug('Determined image: %r', ctx.image)
@@ -9511,7 +9504,28 @@ def command_maintenance(ctx: CephadmContext) -> str:
 ##################################
 
 
-def _add_deploy_parser_args(parser_deploy: argparse.ArgumentParser) -> None:
+class ArgumentFacade:
+    def __init__(self) -> None:
+        self.defaults: Dict[str, Any] = {}
+
+    def add_argument(self, *args: Any, **kwargs: Any) -> None:
+        if not args:
+            raise ValueError('expected at least one argument')
+        name = args[0]
+        if not name.startswith('--'):
+            raise ValueError(f'expected long option, got: {name!r}')
+        name = name[2:].replace('-', '_')
+        value = kwargs.pop('default', None)
+        self.defaults[name] = value
+
+    def apply(self, ctx: CephadmContext) -> None:
+        for key, value in self.defaults.items():
+            setattr(ctx, key, value)
+
+
+def _add_deploy_parser_args(
+    parser_deploy: Union[argparse.ArgumentParser, ArgumentFacade],
+) -> None:
     parser_deploy.add_argument(
         '--config', '-c',
         help='config file for new daemon')

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3035,6 +3035,20 @@ def _get_config_json(option: str) -> Dict[str, Any]:
         return js
 
 
+def fetch_meta(ctx: CephadmContext) -> Dict[str, Any]:
+    """Return a dict containing metadata about a deployment.
+    """
+    meta = getattr(ctx, 'meta_properties', None)
+    if meta is not None:
+        return meta
+    mjson = getattr(ctx, 'meta_json', None)
+    if mjson is not None:
+        meta = json.loads(mjson) or {}
+        ctx.meta_properties = meta
+        return meta
+    return {}
+
+
 def get_config_and_keyring(ctx):
     # type: (CephadmContext) -> Tuple[Optional[str], Optional[str]]
     config = None

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2792,8 +2792,8 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
         if daemon_type not in ['grafana', 'loki', 'promtail']:
             ip = ''
             port = Monitoring.port_map[daemon_type][0]
-            if 'meta_json' in ctx and ctx.meta_json:
-                meta = json.loads(ctx.meta_json) or {}
+            meta = fetch_meta(ctx)
+            if meta:
                 if 'ip' in meta and meta['ip']:
                     ip = meta['ip']
                 if 'ports' in meta and meta['ports']:
@@ -3693,9 +3693,7 @@ def deploy_daemon_units(
         _write_container_cmd_to_bash(ctx, f, c, '%s.%s' % (daemon_type, str(daemon_id)))
 
         # some metadata about the deploy
-        meta: Dict[str, Any] = {}
-        if 'meta_json' in ctx and ctx.meta_json:
-            meta = json.loads(ctx.meta_json) or {}
+        meta: Dict[str, Any] = fetch_meta(ctx)
         meta.update({
             'memory_request': int(ctx.memory_request) if ctx.memory_request else None,
             'memory_limit': int(ctx.memory_limit) if ctx.memory_limit else None,
@@ -4504,10 +4502,8 @@ class CephadmAgent():
         with write_new(unit_run_path) as f:
             f.write(self.unit_run())
 
-        meta: Dict[str, Any] = {}
+        meta: Dict[str, Any] = fetch_meta(self.ctx)
         meta_file_path = os.path.join(self.daemon_dir, 'unit.meta')
-        if 'meta_json' in self.ctx and self.ctx.meta_json:
-            meta = json.loads(self.ctx.meta_json) or {}
         with write_new(meta_file_path) as f:
             f.write(json.dumps(meta, indent=4) + '\n')
 
@@ -5381,7 +5377,7 @@ def create_mon(
     fsid: str, mon_id: str
 ) -> None:
     mon_c = get_container(ctx, fsid, 'mon', mon_id)
-    ctx.meta_json = json.dumps({'service_name': 'mon'})
+    ctx.meta_properties = {'service_name': 'mon'}
     deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
                   config=None, keyring=None)
 
@@ -5428,7 +5424,7 @@ def create_mgr(
     mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
     mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
     # Note:the default port used by the Prometheus node exporter is opened in fw
-    ctx.meta_json = json.dumps({'service_name': 'mgr'})
+    ctx.meta_properties = {'service_name': 'mgr'}
     ports = [9283, 8765]
     if not ctx.skip_monitoring_stack:
         ports.append(8443)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3067,6 +3067,17 @@ def fetch_configs(ctx: CephadmContext) -> Dict[str, str]:
     return {}
 
 
+def fetch_tcp_ports(ctx: CephadmContext) -> List[int]:
+    """Return a list of tcp ports, as integers, stored on the given ctx.
+    """
+    ports = getattr(ctx, 'tcp_ports', None)
+    if ports is None:
+        return []
+    if isinstance(ports, str):
+        return list(map(int, ports.split()))
+    return ports
+
+
 def get_config_and_keyring(ctx):
     # type: (CephadmContext) -> Tuple[Optional[str], Optional[str]]
     config = None

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -1,4 +1,3 @@
-from importlib.resources import contents
 import mock
 import os
 import pytest

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -313,6 +313,8 @@ class TestCephAdm(object):
     @mock.patch('cephadm.get_unit_name', lambda *args, **kwargs: 'mon-unit-name')
     @mock.patch('cephadm.extract_uid_gid', lambda *args, **kwargs: (0, 0))
     @mock.patch('cephadm.get_deployment_container')
+    @mock.patch('cephadm.read_configuration_source', lambda c: {})
+    @mock.patch('cephadm.apply_deploy_config_to_ctx', lambda d, c: None)
     def test_mon_crush_location(self, _get_deployment_container, _migrate_sysctl, _make_var_run, _get_parm, _deploy_daemon, _file_lock, _logger):
         """
         test that crush location for mon is set if it is included in config_json
@@ -354,7 +356,7 @@ class TestCephAdm(object):
         _deploy_daemon.side_effect = _crush_location_checker
 
         with pytest.raises(Exception, match='--set-crush-location database=a'):
-            _cephadm.command_deploy(ctx)
+            _cephadm.command_deploy_from(ctx)
 
     @mock.patch('cephadm.logger')
     @mock.patch('cephadm.fetch_custom_config_files')

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -258,7 +258,7 @@ class TestCephAdm(object):
             _cephadm.prepare_dashboard(ctx, 0, 0, lambda _, extra_mounts=None, ___=None : '5', lambda : None)
 
     @mock.patch('cephadm.logger')
-    @mock.patch('cephadm.get_custom_config_files')
+    @mock.patch('cephadm.fetch_custom_config_files')
     @mock.patch('cephadm.get_container')
     def test_get_deployment_container(self, _get_container, _get_config, _logger):
         """
@@ -272,12 +272,12 @@ class TestCephAdm(object):
             '--something',
         ]
         ctx.data_dir = 'data'
-        _get_config.return_value = {'custom_config_files': [
+        _get_config.return_value = [
             {
                 'mount_path': '/etc/testing.str',
                 'content': 'this\nis\na\nstring',
             }
-        ]}
+        ]
         _get_container.return_value = _cephadm.CephContainer.for_daemon(
             ctx,
             fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
@@ -357,7 +357,7 @@ class TestCephAdm(object):
             _cephadm.command_deploy(ctx)
 
     @mock.patch('cephadm.logger')
-    @mock.patch('cephadm.get_custom_config_files')
+    @mock.patch('cephadm.fetch_custom_config_files')
     def test_write_custom_conf_files(self, _get_config, _logger, cephadm_fs):
         """
         test _write_custom_conf_files writes the conf files correctly
@@ -366,7 +366,7 @@ class TestCephAdm(object):
         ctx = _cephadm.CephadmContext()
         ctx.config_json = '-'
         ctx.data_dir = _cephadm.DATA_DIR
-        _get_config.return_value = {'custom_config_files': [
+        _get_config.return_value = [
             {
                 'mount_path': '/etc/testing.str',
                 'content': 'this\nis\na\nstring',
@@ -378,7 +378,7 @@ class TestCephAdm(object):
             {
                 'mount_path': '/etc/no-content.conf',
             },
-        ]}
+        ]
         _cephadm._write_custom_conf_files(ctx, 'mon', 'host1', 'fsid', 0, 0)
         with open(os.path.join(_cephadm.DATA_DIR, 'fsid', 'custom_config_files', 'mon.host1', 'testing.str'), 'r') as f:
             assert 'this\nis\na\nstring' == f.read()

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -306,7 +306,7 @@ class TestCephAdm(object):
     @mock.patch('cephadm.logger')
     @mock.patch('cephadm.FileLock')
     @mock.patch('cephadm.deploy_daemon')
-    @mock.patch('cephadm.get_parm')
+    @mock.patch('cephadm.fetch_configs')
     @mock.patch('cephadm.make_var_run')
     @mock.patch('cephadm.migrate_sysctl_dir')
     @mock.patch('cephadm.check_unit', lambda *args, **kwargs: (None, 'running', None))
@@ -315,7 +315,7 @@ class TestCephAdm(object):
     @mock.patch('cephadm.get_deployment_container')
     @mock.patch('cephadm.read_configuration_source', lambda c: {})
     @mock.patch('cephadm.apply_deploy_config_to_ctx', lambda d, c: None)
-    def test_mon_crush_location(self, _get_deployment_container, _migrate_sysctl, _make_var_run, _get_parm, _deploy_daemon, _file_lock, _logger):
+    def test_mon_crush_location(self, _get_deployment_container, _migrate_sysctl, _make_var_run, _fetch_configs, _deploy_daemon, _file_lock, _logger):
         """
         test that crush location for mon is set if it is included in config_json
         """
@@ -329,7 +329,7 @@ class TestCephAdm(object):
         ctx.config_json = '-'
         ctx.osd_fsid = '0'
         ctx.tcp_ports = '3300 6789'
-        _get_parm.return_value = {
+        _fetch_configs.return_value = {
             'crush_location': 'database=a'
         }
 

--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -94,7 +94,7 @@ class TestCopyTree:
             self._copy_tree([src1], dst, uid=0, gid=0)
             assert len(_chown.mock_calls) >= 2
             for c in _chown.mock_calls:
-                assert c.args[1:] == (0, 0)
+                assert c == mock.call(mock.ANY, 0, 0)
         assert (dst / "foo.txt").exists()
 
 
@@ -187,7 +187,7 @@ class TestCopyFiles:
             self._copy_files([file1], dst, uid=0, gid=0)
             assert len(_chown.mock_calls) >= 1
             for c in _chown.mock_calls:
-                assert c.args[1:] == (0, 0)
+                assert c == mock.call(mock.ANY, 0, 0)
         assert (dst / "f1.txt").exists()
 
 
@@ -270,7 +270,7 @@ class TestMoveFiles:
             self._move_files([file1], dst, uid=0, gid=0)
             assert len(_chown.mock_calls) >= 1
             for c in _chown.mock_calls:
-                assert c.args[1:] == (0, 0)
+                assert c == mock.call(mock.ANY, 0, 0)
         assert dst.is_file()
         assert not file1.exists()
 
@@ -288,9 +288,9 @@ def test_recursive_chown(tmp_path):
         _chown.return_value = None
         _cephadm.recursive_chown(str(d1), uid=500, gid=500)
     assert len(_chown.mock_calls) == 3
-    assert _chown.mock_calls[0].args == (str(d1), 500, 500)
-    assert _chown.mock_calls[1].args == (str(d2), 500, 500)
-    assert _chown.mock_calls[2].args == (str(f1), 500, 500)
+    assert _chown.mock_calls[0] == mock.call(str(d1), 500, 500)
+    assert _chown.mock_calls[1] == mock.call(str(d2), 500, 500)
+    assert _chown.mock_calls[2] == mock.call(str(f1), 500, 500)
 
 
 class TestFindExecutable:

--- a/src/cephadm/tests/test_util_funcs.py
+++ b/src/cephadm/tests/test_util_funcs.py
@@ -726,3 +726,83 @@ class TestWriteNew:
         assert not dest.exists()
         assert not dest.with_name(dest.name+".new").exists()
         assert list(dest.parent.iterdir()) == []
+
+
+class CompareContext1:
+    cfg_data = {
+        "name": "mane",
+        "fsid": "foobar",
+        "image": "fake.io/noway/nohow:gndn",
+        "meta": {
+            "fruit": "banana",
+            "vegetable": "carrot",
+        },
+        "params": {
+            "osd_fsid": "robble",
+            "tcp_ports": [404, 9999],
+        },
+        "config_blobs": {
+            "alpha": {"sloop": "John B"},
+            "beta": {"forest": "birch"},
+            "gamma": {"forest": "pine"},
+        },
+    }
+
+    def check(self, ctx):
+        assert ctx.name == 'mane'
+        assert ctx.fsid == 'foobar'
+        assert ctx.image == 'fake.io/noway/nohow:gndn'
+        assert ctx.meta_properties == {"fruit": "banana", "vegetable": "carrot"}
+        assert ctx.config_blobs == {
+            "alpha": {"sloop": "John B"},
+            "beta": {"forest": "birch"},
+            "gamma": {"forest": "pine"},
+        }
+        assert ctx.osd_fsid == "robble"
+        assert ctx.tcp_ports == [404, 9999]
+
+
+class CompareContext2:
+    cfg_data = {
+        "name": "cc2",
+        "fsid": "foobar",
+        "meta": {
+            "fruit": "banana",
+            "vegetable": "carrot",
+        },
+        "params": {},
+        "config_blobs": {
+            "alpha": {"sloop": "John B"},
+            "beta": {"forest": "birch"},
+            "gamma": {"forest": "pine"},
+        },
+    }
+
+    def check(self, ctx):
+        assert ctx.name == 'cc2'
+        assert ctx.fsid == 'foobar'
+        assert ctx.image == 'quay.ceph.io/ceph-ci/ceph:main'
+        assert ctx.meta_properties == {"fruit": "banana", "vegetable": "carrot"}
+        assert ctx.config_blobs == {
+            "alpha": {"sloop": "John B"},
+            "beta": {"forest": "birch"},
+            "gamma": {"forest": "pine"},
+        }
+        assert ctx.osd_fsid is None
+        assert ctx.tcp_ports is None
+
+
+@pytest.mark.parametrize(
+    "cc",
+    [
+        CompareContext1(),
+        CompareContext2(),
+    ],
+)
+def test_apply_deploy_config_to_ctx(cc, monkeypatch):
+    import logging
+
+    monkeypatch.setattr("cephadm.logger", logging.getLogger())
+    ctx = FakeContext()
+    _cephadm.apply_deploy_config_to_ctx(cc.cfg_data, ctx)
+    cc.check(ctx)

--- a/src/pybind/mgr/cephadm/exchange.py
+++ b/src/pybind/mgr/cephadm/exchange.py
@@ -1,0 +1,164 @@
+# Data exchange formats for communicating more
+# complex data structures between the cephadm binary
+# an the mgr module.
+
+import json
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
+
+
+FuncT = TypeVar("FuncT", bound=Callable)
+
+
+class _DataField:
+    """A descriptor to map object fields into a data dictionary."""
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        field_type: Optional[FuncT] = None,
+    ):
+        self.name = name
+        self.field_type = field_type
+
+    def __set_name__(self, _: str, name: str) -> None:
+        if not self.name:
+            self.name = name
+
+    def __get__(self, obj: Any, objtype: Any = None) -> Any:
+        return obj.data[self.name]
+
+    def __set__(self, obj: Any, value: Any) -> None:
+        if self.field_type is not None:
+            obj.data[self.name] = self.field_type(value)
+        else:
+            obj.data[self.name] = value
+
+
+def _get_data(obj: Any) -> Any:
+    """Wrapper to get underlying data dicts from objects that
+    advertise having them.
+    """
+    _gd = getattr(obj, "get_data", None)
+    if _gd:
+        return _gd()
+    return obj
+
+
+def _or_none(field_type: FuncT) -> FuncT:
+    def _field_type_or_none(value: Any) -> Any:
+        if value is None:
+            return None
+        return field_type(value)
+
+    return cast(FuncT, _field_type_or_none)
+
+
+class DeployMeta:
+    """Deployment metadata. Child of Deploy. Used by cephadm to
+    determine when certain changes have been made.
+    """
+
+    service_name = _DataField(field_type=str)
+    ports = _DataField(field_type=list)
+    ip = _DataField(field_type=_or_none(str))
+    deployed_by = _DataField(field_type=_or_none(list))
+    rank = _DataField(field_type=_or_none(int))
+    rank_generation = _DataField(field_type=_or_none(int))
+    extra_container_args = _DataField(field_type=_or_none(list))
+    extra_entrypoint_args = _DataField(field_type=_or_none(list))
+
+    def __init__(
+        self,
+        init_data: Optional[Dict[str, Any]] = None,
+        *,
+        service_name: str = "",
+        ports: Optional[List[int]] = None,
+        ip: Optional[str] = None,
+        deployed_by: Optional[List[str]] = None,
+        rank: Optional[int] = None,
+        rank_generation: Optional[int] = None,
+        extra_container_args: Optional[List[str]] = None,
+        extra_entrypoint_args: Optional[List[str]] = None,
+    ):
+        self.data = dict(init_data or {})
+        # set fields
+        self.service_name = service_name
+        self.ports = ports or []
+        self.ip = ip
+        self.deployed_by = deployed_by
+        self.rank = rank
+        self.rank_generation = rank_generation
+        self.extra_container_args = extra_container_args
+        self.extra_entrypoint_args = extra_entrypoint_args
+
+    def get_data(self) -> Dict[str, Any]:
+        return self.data
+
+    to_simplified = get_data
+
+    @classmethod
+    def convert(
+        cls,
+        value: Union[Dict[str, Any], "DeployMeta", None],
+    ) -> "DeployMeta":
+        if not isinstance(value, DeployMeta):
+            return cls(value)
+        return value
+
+
+class Deploy:
+    """Set of fields that instructs cephadm to deploy a
+    service/daemon.
+    """
+
+    fsid = _DataField(field_type=str)
+    name = _DataField(field_type=str)
+    image = _DataField(field_type=str)
+    deploy_arguments = _DataField(field_type=list)
+    params = _DataField(field_type=dict)
+    meta = _DataField(field_type=DeployMeta.convert)
+    config_blobs = _DataField(field_type=dict)
+
+    def __init__(
+        self,
+        init_data: Optional[Dict[str, Any]] = None,
+        *,
+        fsid: str = "",
+        name: str = "",
+        image: str = "",
+        deploy_arguments: Optional[List[str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        meta: Optional[DeployMeta] = None,
+        config_blobs: Optional[Dict[str, Any]] = None,
+    ):
+        self.data = dict(init_data or {})
+        # set fields
+        self.fsid = fsid
+        self.name = name
+        self.image = image
+        self.deploy_arguments = deploy_arguments or []
+        self.params = params or {}
+        self.meta = DeployMeta.convert(meta)
+        self.config_blobs = config_blobs or {}
+
+    def get_data(self) -> Dict[str, Any]:
+        """Return the underlying data dict."""
+        return self.data
+
+    def to_simplified(self) -> Dict[str, Any]:
+        """Return a simplified serializable version of the object."""
+        return {k: _get_data(v) for k, v in self.get_data().items()}
+
+    def dump_json_str(self) -> str:
+        """Return the object's JSON string representation."""
+        return json.dumps(self.to_simplified())

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1268,10 +1268,16 @@ class CephadmServe:
                     daemon_spec.name(), daemon_spec.host))
 
                 out, err, code = await self._run_cephadm(
-                    daemon_spec.host, daemon_spec.name(), 'deploy',
-                    [
-                        '--name', daemon_spec.name(),
-                        '--meta-json', json.dumps({
+                    daemon_spec.host,
+                    daemon_spec.name(),
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": self.mgr._cluster_fsid,
+                        "name": daemon_spec.name(),
+                        "image": image,
+                        "deploy_arguments": daemon_spec.extra_args,
+                        "meta": {
                             'service_name': daemon_spec.service_name,
                             'ports': daemon_spec.ports,
                             'ip': daemon_spec.ip,
@@ -1280,11 +1286,9 @@ class CephadmServe:
                             'rank_generation': daemon_spec.rank_generation,
                             'extra_container_args': extra_container_args,
                             'extra_entrypoint_args': extra_entrypoint_args
-                        }),
-                        '--config-json', '-',
-                    ] + daemon_spec.extra_args,
-                    stdin=json.dumps(daemon_spec.final_config),
-                    image=image,
+                        },
+                        "config_blobs": daemon_spec.final_config,
+                    }),
                 )
 
                 if daemon_spec.daemon_type == 'agent':

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1431,7 +1431,7 @@ class CephadmServe:
     async def _run_cephadm(self,
                            host: str,
                            entity: Union[CephadmNoImage, str],
-                           command: str,
+                           command: Union[str, List[str]],
                            args: List[str],
                            addr: Optional[str] = "",
                            stdin: Optional[str] = "",
@@ -1496,7 +1496,10 @@ class CephadmServe:
         final_args += ['--timeout', str(timeout)]
 
         # subcommand
-        final_args.append(command)
+        if isinstance(command, list):
+            final_args.extend([str(v) for v in command])
+        else:
+            final_args.append(command)
 
         # subcommand args
         if not no_fsid:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -80,8 +80,10 @@ class CephadmDaemonDeploySpec:
         # for run_cephadm.
         self.keyring: Optional[str] = keyring
 
+        # FIXME: finish removing this
         # For run_cephadm. Would be great to have more expressive names.
-        self.extra_args: List[str] = extra_args or []
+        # self.extra_args: List[str] = extra_args or []
+        assert not extra_args
 
         self.ceph_conf = ceph_conf
         self.extra_files = extra_files or {}
@@ -147,6 +149,10 @@ class CephadmDaemonDeploySpec:
             extra_container_args=self.extra_container_args,
             extra_entrypoint_args=self.extra_entrypoint_args,
         )
+
+    @property
+    def extra_args(self) -> List[str]:
+        return []
 
 
 class CephadmService(metaclass=ABCMeta):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -119,10 +119,7 @@ def with_osd_daemon(cephadm_module: CephadmOrchestrator, _run_cephadm, host: str
     assert _run_cephadm.mock_calls == [
         mock.call(host, 'osd', 'ceph-volume',
                   ['--', 'lvm', 'list', '--format', 'json'], no_fsid=False, error_ok=False, image='', log_output=True),
-        mock.call(host, f'osd.{osd_id}', 'deploy',
-                  ['--name', f'osd.{osd_id}', '--meta-json', mock.ANY,
-                   '--config-json', '-', '--osd-fsid', 'uuid'],
-                  stdin=mock.ANY, image=''),
+        mock.call(host, f'osd.{osd_id}', ['_orch', 'deploy'], [], stdin=mock.ANY),
         mock.call(host, 'osd', 'ceph-volume',
                   ['--', 'raw', 'list', '--format', 'json'], no_fsid=False, error_ok=False, image='', log_output=True),
     ]
@@ -452,16 +449,37 @@ class TestCephadm(object):
                 CephadmServe(cephadm_module)._check_daemons()
 
                 _run_cephadm.assert_called_with(
-                    'test', 'mon.test', 'deploy', [
-                        '--name', 'mon.test',
-                        '--meta-json', ('{"service_name": "mon", "ports": [], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--reconfig',
-                    ],
-                    stdin='{"config": "[mon]\\nk=v\\n[mon.test]\\npublic network = 127.0.0.0/8\\n", '
-                    + '"keyring": "", "files": {"config": "[mon.test]\\npublic network = 127.0.0.0/8\\n"}}',
-                    image='')
+                    'test',
+                    'mon.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "mon.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'reconfig': True,
+                        },
+                        "meta": {
+                            'service_name': 'mon',
+                            'ports': [],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "[mon]\nk=v\n[mon.test]\npublic network = 127.0.0.0/8\n",
+                            "keyring": "",
+                            "files": {
+                                "config": "[mon.test]\npublic network = 127.0.0.0/8\n"
+                            },
+                        },
+                    }),
+                )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_mon_crush_location_deployment(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
@@ -486,14 +504,35 @@ class TestCephadm(object):
 
             with with_service(cephadm_module, ServiceSpec(service_type='mon', crush_locations={'test': ['datacenter=a', 'rack=2']}), CephadmOrchestrator.apply_mon, 'test'):
                 _run_cephadm.assert_called_with(
-                    'test', 'mon.test', 'deploy', [
-                        '--name', 'mon.test',
-                        '--meta-json', '{"service_name": "mon", "ports": [], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}',
-                        '--config-json', '-',
-                    ],
-                    stdin=('{"config": "[mon.test]\\npublic network = 127.0.0.0/8\\n", "keyring": "", '
-                           '"files": {"config": "[mon.test]\\npublic network = 127.0.0.0/8\\n"}, "crush_location": "datacenter=a"}'),
-                    image='',
+                    'test',
+                    'mon.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "mon.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {},
+                        "meta": {
+                            'service_name': 'mon',
+                            'ports': [],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "[mon.test]\npublic network = 127.0.0.0/8\n",
+                            "keyring": "",
+                            "files": {
+                                "config": "[mon.test]\npublic network = 127.0.0.0/8\n",
+                            },
+                            "crush_location": "datacenter=a",
+                        },
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -502,16 +541,39 @@ class TestCephadm(object):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, ServiceSpec(service_type='crash', extra_container_args=['--cpus=2', '--quiet']), CephadmOrchestrator.apply_crash):
                 _run_cephadm.assert_called_with(
-                    'test', 'crash.test', 'deploy', [
-                        '--name', 'crash.test',
-                        '--meta-json', ('{"service_name": "crash", "ports": [], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": ["--cpus=2", "--quiet"], "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--extra-container-args=--cpus=2',
-                        '--extra-container-args=--quiet'
-                    ],
-                    stdin='{"config": "", "keyring": "[client.crash.test]\\nkey = None\\n"}',
-                    image='',
+                    'test',
+                    'crash.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "crash.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'extra_container_args': [
+                                "--cpus=2",
+                                "--quiet",
+                            ],
+                        },
+                        "meta": {
+                            'service_name': 'crash',
+                            'ports': [],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': [
+                                "--cpus=2",
+                                "--quiet",
+                            ],
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": "[client.crash.test]\nkey = None\n",
+                        },
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -522,19 +584,37 @@ class TestCephadm(object):
                               extra_entrypoint_args=['--collector.textfile.directory=/var/lib/node_exporter/textfile_collector', '--some-other-arg']),
                               CephadmOrchestrator.apply_node_exporter):
                 _run_cephadm.assert_called_with(
-                    'test', 'node-exporter.test', 'deploy', [
-                        '--name', 'node-exporter.test',
-                        '--meta-json', ('{"service_name": "node-exporter", "ports": [9100], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": '
-                                        '["--collector.textfile.directory=/var/lib/node_exporter/textfile_collector", '
-                                        '"--some-other-arg"]}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9100',
-                        '--extra-entrypoint-args=--collector.textfile.directory=/var/lib/node_exporter/textfile_collector',
-                        '--extra-entrypoint-args=--some-other-arg'
-                    ],
-                    stdin='{}',
-                    image='',
+                    'test',
+                    'node-exporter.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "node-exporter.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9100],
+                            'extra_entrypoint_args': [
+                                "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector",
+                                "--some-other-arg",
+                            ],
+                        },
+                        "meta": {
+                            'service_name': 'node-exporter',
+                            'ports': [9100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': [
+                                "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector",
+                                "--some-other-arg",
+                            ],
+                        },
+                        "config_blobs": {},
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -546,21 +626,44 @@ class TestCephadm(object):
                               extra_container_args=['--cpus=2', '--quiet']),
                               CephadmOrchestrator.apply_node_exporter):
                 _run_cephadm.assert_called_with(
-                    'test', 'node-exporter.test', 'deploy', [
-                        '--name', 'node-exporter.test',
-                        '--meta-json', ('{"service_name": "node-exporter", "ports": [9100], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": ["--cpus=2", "--quiet"], "extra_entrypoint_args": '
-                                        '["--collector.textfile.directory=/var/lib/node_exporter/textfile_collector", '
-                                        '"--some-other-arg"]}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9100',
-                        '--extra-container-args=--cpus=2',
-                        '--extra-container-args=--quiet',
-                        '--extra-entrypoint-args=--collector.textfile.directory=/var/lib/node_exporter/textfile_collector',
-                        '--extra-entrypoint-args=--some-other-arg'
-                    ],
-                    stdin='{}',
-                    image='',
+                    'test',
+                    'node-exporter.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "node-exporter.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9100],
+                            'extra_container_args': [
+                                "--cpus=2",
+                                "--quiet",
+                            ],
+                            'extra_entrypoint_args': [
+                                "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector",
+                                "--some-other-arg",
+                            ],
+                        },
+                        "meta": {
+                            'service_name': 'node-exporter',
+                            'ports': [9100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': [
+                                "--cpus=2",
+                                "--quiet",
+                            ],
+                            'extra_entrypoint_args': [
+                                "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector",
+                                "--some-other-arg",
+                            ],
+                        },
+                        "config_blobs": {},
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -572,24 +675,48 @@ class TestCephadm(object):
                               extra_container_args=['--cpus    2', '--container-arg-with-value value']),
                               CephadmOrchestrator.apply_node_exporter):
                 _run_cephadm.assert_called_with(
-                    'test', 'node-exporter.test', 'deploy', [
-                        '--name', 'node-exporter.test',
-                        '--meta-json', ('{"service_name": "node-exporter", "ports": [9100], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": ["--cpus    2", "--container-arg-with-value value"], '
-                                        '"extra_entrypoint_args": ["--entrypoint-arg-with-value value", "--some-other-arg   3"]}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9100',
-                        '--extra-container-args=--cpus',
-                        '--extra-container-args=2',
-                        '--extra-container-args=--container-arg-with-value',
-                        '--extra-container-args=value',
-                        '--extra-entrypoint-args=--entrypoint-arg-with-value',
-                        '--extra-entrypoint-args=value',
-                        '--extra-entrypoint-args=--some-other-arg',
-                        '--extra-entrypoint-args=3'
-                    ],
-                    stdin='{}',
-                    image='',
+                    'test',
+                    'node-exporter.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "node-exporter.test",
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9100],
+                            'extra_container_args': [
+                                "--cpus",
+                                "2",
+                                "--container-arg-with-value",
+                                "value",
+                            ],
+                            'extra_entrypoint_args': [
+                                "--entrypoint-arg-with-value",
+                                "value",
+                                "--some-other-arg",
+                                "3",
+                            ],
+                        },
+                        "meta": {
+                            'service_name': 'node-exporter',
+                            'ports': [9100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': [
+                                "--cpus    2",
+                                "--container-arg-with-value value",
+                            ],
+                            'extra_entrypoint_args': [
+                                "--entrypoint-arg-with-value value",
+                                "--some-other-arg   3",
+                            ],
+                        },
+                        "config_blobs": {},
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -608,20 +735,45 @@ class TestCephadm(object):
                          mount_path='/etc/test.conf'),
             CustomConfig(content='\n'.join(test_cert), mount_path='/usr/share/grafana/thing.crt')
         ]
-        conf_outs = [json.dumps(c.to_json()) for c in configs]
-        stdin_str = '{' + \
-            f'"config": "", "keyring": "[client.crash.test]\\nkey = None\\n", "custom_config_files": [{conf_outs[0]}, {conf_outs[1]}]' + '}'
+        tc_joined = '\n'.join(test_cert)
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, ServiceSpec(service_type='crash', custom_configs=configs), CephadmOrchestrator.apply_crash):
-                _run_cephadm.assert_called_with(
-                    'test', 'crash.test', 'deploy', [
-                        '--name', 'crash.test',
-                        '--meta-json', ('{"service_name": "crash", "ports": [], "ip": null, "deployed_by": [], "rank": null, '
-                                        '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                    ],
-                    stdin=stdin_str,
-                    image='',
+                _run_cephadm(
+                    'test',
+                    'crash.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "crash.test",
+                        "image": "",
+                        "deploy_arguments": [],
+                        "params": {},
+                        "meta": {
+                            "service_name": "crash",
+                            "ports": [],
+                            "ip": None,
+                            "deployed_by": [],
+                            "rank": None,
+                            "rank_generation": None,
+                            "extra_container_args": None,
+                            "extra_entrypoint_args": None,
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": "[client.crash.test]\nkey = None\n",
+                            "custom_config_files": [
+                                {
+                                    "content": "something something something",
+                                    "mount_path": "/etc/test.conf",
+                                },
+                                {
+                                    "content": tc_joined,
+                                    "mount_path": "/usr/share/grafana/thing.crt",
+                                },
+                            ]
+                        }
+                    }),
                 )
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -2086,7 +2238,7 @@ Traceback (most recent call last):
                 if 'ceph-volume' in args:
                     return (json.dumps(ceph_volume_lvm_list), '', 0)
                 else:
-                    assert 'deploy' in args
+                    assert ['_orch', 'deploy'] in args
                     raise OrchestratorError("let's fail somehow")
             _run_cephadm.side_effect = _r_c
             assert cephadm_module._osd_activate(

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -299,14 +299,35 @@ log_to_file = False"""
                 _run_cephadm.assert_called_with(
                     'test',
                     f'iscsi.{iscsi_daemon_id}',
-                    'deploy',
-                    [
-                        '--name', f'iscsi.{iscsi_daemon_id}',
-                        '--meta-json', f'{"{"}"service_name": "iscsi.{pool}", "ports": [{api_port}], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null{"}"}',
-                        '--config-json', '-', '--tcp-ports', '3456'
-                    ],
-                    stdin=json.dumps({"config": "", "keyring": f"[client.iscsi.{iscsi_daemon_id}]\nkey = None\n", "files": {"iscsi-gateway.cfg": iscsi_gateway_conf}}),
-                    image='')
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": f'iscsi.{iscsi_daemon_id}',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [api_port],
+                        },
+                        "meta": {
+                            'service_name': f'iscsi.{pool}',
+                            'ports': [api_port],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": f"[client.iscsi.{iscsi_daemon_id}]\nkey = None\n",
+                            "files": {
+                                "iscsi-gateway.cfg": iscsi_gateway_conf,
+                            },
+                        }
+                    }),
+                )
 
 
 class TestMonitoring:
@@ -386,24 +407,35 @@ class TestMonitoring:
             with with_service(cephadm_module, AlertManagerSpec()):
                 y = dedent(self._get_config(expected_yaml_url)).lstrip()
                 _run_cephadm.assert_called_with(
-                    "test",
+                    'test',
                     "alertmanager.test",
-                    "deploy",
-                    [
-                        "--name",
-                        "alertmanager.test",
-                        "--meta-json",
-                        ('{"service_name": "alertmanager", "ports": [9093, 9094], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        "--config-json",
-                        "-",
-                        "--tcp-ports",
-                        "9093 9094",
-                    ],
-                    stdin=json.dumps(
-                        {"files": {"alertmanager.yml": y}, "peers": []}
-                    ),
-                    image="",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
+                        },
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                            },
+                            "peers": [],
+                        }
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -466,25 +498,40 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'alertmanager.test',
-                    'deploy',
-                    [
-                        '--name', 'alertmanager.test',
-                        '--meta-json', '{"service_name": "alertmanager", "ports": [9093, 9094], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}',
-                        '--config-json', '-', '--tcp-ports', '9093 9094'
-                    ],
+                    "alertmanager.test",
+                    ['_orch', 'deploy'],
+                    [],
                     stdin=json.dumps({
-                        "files": {
-                            "alertmanager.yml": y,
-                            'alertmanager.crt': 'mycert',
-                            'alertmanager.key': 'mykey',
-                            'web.yml': web_config,
-                            'root_cert.pem': 'my_root_cert'
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
                         },
-                        'peers': [],
-                        'web_config': '/etc/alertmanager/web.yml'
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                                'alertmanager.crt': 'mycert',
+                                'alertmanager.key': 'mykey',
+                                'web.yml': web_config,
+                                'root_cert.pem': 'my_root_cert'
+                            },
+                            'peers': [],
+                            'web_config': '/etc/alertmanager/web.yml',
+                        }
                     }),
-                    image='')
+                )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
@@ -542,21 +589,37 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'prometheus.test',
-                    'deploy',
-                    [
-                        '--name', 'prometheus.test',
-                        '--meta-json',
-                        ('{"service_name": "prometheus", "ports": [9095], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9095'
-                    ],
-                    stdin=json.dumps({"files": {"prometheus.yml": y,
-                                                "/etc/prometheus/alerting/custom_alerts.yml": ""},
-                                      'retention_time': '15d',
-                                      'retention_size': '0'}),
-                    image='')
+                    "prometheus.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'prometheus.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9095],
+                        },
+                        "meta": {
+                            'service_name': 'prometheus',
+                            'ports': [9095],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "prometheus.yml": y,
+                                "/etc/prometheus/alerting/custom_alerts.yml": "",
+                            },
+                            'retention_time': '15d',
+                            'retention_size': '0',
+                        },
+                    }),
+                )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
@@ -672,29 +735,42 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'prometheus.test',
-                    'deploy',
-                    [
-                        '--name', 'prometheus.test',
-                        '--meta-json',
-                        '{"service_name": "prometheus", "ports": [9095], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}',
-                        '--config-json', '-',
-                        '--tcp-ports', '9095'
-                    ],
+                    "prometheus.test",
+                    ['_orch', 'deploy'],
+                    [],
                     stdin=json.dumps({
-                        'files': {
-                            'prometheus.yml': y,
-                            'root_cert.pem': '',
-                            'mgr_prometheus_cert.pem': '',
-                            'web.yml': web_config,
-                            'prometheus.crt': 'mycert',
-                            'prometheus.key': 'mykey',
-                            "/etc/prometheus/alerting/custom_alerts.yml": "",
+                        "fsid": "fsid",
+                        "name": 'prometheus.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9095],
                         },
-                        'retention_time': '15d',
-                        'retention_size': '0',
-                        'web_config': '/etc/prometheus/web.yml'}),
-                    image=''
+                        "meta": {
+                            'service_name': 'prometheus',
+                            'ports': [9095],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            'files': {
+                                'prometheus.yml': y,
+                                'root_cert.pem': '',
+                                'mgr_prometheus_cert.pem': '',
+                                'web.yml': web_config,
+                                'prometheus.crt': 'mycert',
+                                'prometheus.key': 'mykey',
+                                "/etc/prometheus/alerting/custom_alerts.yml": "",
+                            },
+                            'retention_time': '15d',
+                            'retention_size': '0',
+                            'web_config': '/etc/prometheus/web.yml',
+                        },
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -736,18 +812,34 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'loki.test',
-                    'deploy',
-                    [
-                        '--name', 'loki.test',
-                        '--meta-json',
-                        ('{"service_name": "loki", "ports": [3100], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '3100'
-                    ],
-                    stdin=json.dumps({"files": {"loki.yml": y}}),
-                    image='')
+                    "loki.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'loki.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3100],
+                        },
+                        "meta": {
+                            'service_name': 'loki',
+                            'ports': [3100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "loki.yml": y
+                            },
+                        },
+                    }),
+                )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_promtail_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
@@ -778,18 +870,34 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'promtail.test',
-                    'deploy',
-                    [
-                        '--name', 'promtail.test',
-                        '--meta-json',
-                        ('{"service_name": "promtail", "ports": [9080], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9080'
-                    ],
-                    stdin=json.dumps({"files": {"promtail.yml": y}}),
-                    image='')
+                    "promtail.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'promtail.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9080],
+                        },
+                        "meta": {
+                            'service_name': 'promtail',
+                            'ports': [9080],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "promtail.yml": y
+                            },
+                        },
+                    }),
+                )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
@@ -861,16 +969,32 @@ class TestMonitoring:
 
                 _run_cephadm.assert_called_with(
                     'test',
-                    'grafana.test',
-                    'deploy',
-                    [
-                        '--name', 'grafana.test',
-                        '--meta-json',
-                        ('{"service_name": "grafana", "ports": [3000], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-', '--tcp-ports', '3000'],
-                    stdin=json.dumps({"files": files}),
-                    image='')
+                    "grafana.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'grafana.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3000],
+                        },
+                        "meta": {
+                            'service_name': 'grafana',
+                            'ports': [3000],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": files,
+                        },
+                    }),
+                )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_grafana_initial_admin_pw(self, cephadm_module: CephadmOrchestrator):
@@ -991,16 +1115,32 @@ spec:
                     CephadmServe(cephadm_module)._check_daemons()
 
                     _run_cephadm.assert_called_with(
-                        'test', 'alertmanager.test', 'deploy', [
-                            '--name', 'alertmanager.test',
-                            '--meta-json', ('{"service_name": "alertmanager", "ports": [4200, 9094], "ip": null, "deployed_by": [], "rank": null, '
-                                            '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                            '--config-json', '-',
-                            '--tcp-ports', '4200 9094',
-                            '--reconfig'
-                        ],
-                        stdin='{}',
-                        image='')
+                        'test',
+                        "alertmanager.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'alertmanager.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [4200, 9094],
+                                'reconfig': True,
+                            },
+                            "meta": {
+                                'service_name': 'alertmanager',
+                                'ports': [4200, 9094],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": {},
+                        }),
+                    )
 
 
 class TestRGWService:
@@ -1083,18 +1223,29 @@ class TestSNMPGateway:
             with with_service(cephadm_module, spec):
                 _run_cephadm.assert_called_with(
                     'test',
-                    'snmp-gateway.test',
-                    'deploy',
-                    [
-                        '--name', 'snmp-gateway.test',
-                        '--meta-json',
-                        ('{"service_name": "snmp-gateway", "ports": [9464], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9464'
-                    ],
-                    stdin=json.dumps(config),
-                    image=''
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -1119,18 +1270,29 @@ class TestSNMPGateway:
             with with_service(cephadm_module, spec):
                 _run_cephadm.assert_called_with(
                     'test',
-                    'snmp-gateway.test',
-                    'deploy',
-                    [
-                        '--name', 'snmp-gateway.test',
-                        '--meta-json',
-                        ('{"service_name": "snmp-gateway", "ports": [9465], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9465'
-                    ],
-                    stdin=json.dumps(config),
-                    image=''
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9465],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9465],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -1159,18 +1321,29 @@ class TestSNMPGateway:
             with with_service(cephadm_module, spec):
                 _run_cephadm.assert_called_with(
                     'test',
-                    'snmp-gateway.test',
-                    'deploy',
-                    [
-                        '--name', 'snmp-gateway.test',
-                        '--meta-json',
-                        ('{"service_name": "snmp-gateway", "ports": [9464], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9464'
-                    ],
-                    stdin=json.dumps(config),
-                    image=''
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -1204,18 +1377,29 @@ class TestSNMPGateway:
             with with_service(cephadm_module, spec):
                 _run_cephadm.assert_called_with(
                     'test',
-                    'snmp-gateway.test',
-                    'deploy',
-                    [
-                        '--name', 'snmp-gateway.test',
-                        '--meta-json',
-                        ('{"service_name": "snmp-gateway", "ports": [9464], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9464'
-                    ],
-                    stdin=json.dumps(config),
-                    image=''
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
                 )
 
 
@@ -2039,19 +2223,29 @@ class TestJaeger:
             with with_service(cephadm_module, spec):
                 _run_cephadm.assert_called_with(
                     'test',
-                    'jaeger-query.test',
-                    'deploy',
-                    [
-                        '--name', 'jaeger-query.test',
-                        '--meta-json',
-                        ('{"service_name": "jaeger-query", "ports": [16686], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '16686'
-
-                    ],
-                    stdin=json.dumps(config),
-                    image=''
+                    "jaeger-query.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'jaeger-query.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [16686],
+                        },
+                        "meta": {
+                            'service_name': 'jaeger-query',
+                            'ports': [16686],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
                 )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -2067,37 +2261,57 @@ class TestJaeger:
                 "elasticsearch_nodes": f'http://{build_url(host=cephadm_module.inventory.get_addr("test"), port=9200).lstrip("/")}'}
             with with_service(cephadm_module, es_spec):
                 _run_cephadm.assert_called_with(
-                    'test',
-                    'elasticsearch.test',
-                    'deploy',
-                    [
-                        '--name', 'elasticsearch.test',
-                        '--meta-json',
-                        ('{"service_name": "elasticsearch", "ports": [9200], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '9200'
-
-                    ],
-                    stdin=json.dumps(es_config),
-                    image=''
+                    "test",
+                    "elasticsearch.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'elasticsearch.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9200],
+                        },
+                        "meta": {
+                            'service_name': 'elasticsearch',
+                            'ports': [9200],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": es_config,
+                    }),
                 )
                 with with_service(cephadm_module, collector_spec):
                     _run_cephadm.assert_called_with(
-                        'test',
-                        'jaeger-collector.test',
-                        'deploy',
-                        [
-                            '--name', 'jaeger-collector.test',
-                            '--meta-json',
-                            ('{"service_name": "jaeger-collector", "ports": [14250], "ip": null, "deployed_by": [], "rank": null, '
-                             '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                            '--config-json', '-',
-                            '--tcp-ports', '14250'
-
-                        ],
-                        stdin=json.dumps(collector_config),
-                        image=''
+                        "test",
+                        "jaeger-collector.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'jaeger-collector.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [14250],
+                            },
+                            "meta": {
+                                'service_name': 'jaeger-collector',
+                                'ports': [14250],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": collector_config,
+                        }),
                     )
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -2113,35 +2327,55 @@ class TestJaeger:
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, collector_spec):
                 _run_cephadm.assert_called_with(
-                    'test',
-                    'jaeger-collector.test',
-                    'deploy',
-                    [
-                        '--name', 'jaeger-collector.test',
-                        '--meta-json',
-                        ('{"service_name": "jaeger-collector", "ports": [14250], "ip": null, "deployed_by": [], "rank": null, '
-                         '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                        '--config-json', '-',
-                        '--tcp-ports', '14250'
-
-                    ],
-                    stdin=json.dumps(collector_config),
-                    image=''
+                    "test",
+                    "jaeger-collector.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'jaeger-collector.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [14250],
+                        },
+                        "meta": {
+                            'service_name': 'jaeger-collector',
+                            'ports': [14250],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": collector_config,
+                    }),
                 )
                 with with_service(cephadm_module, agent_spec):
                     _run_cephadm.assert_called_with(
-                        'test',
-                        'jaeger-agent.test',
-                        'deploy',
-                        [
-                            '--name', 'jaeger-agent.test',
-                            '--meta-json',
-                            ('{"service_name": "jaeger-agent", "ports": [6799], "ip": null, "deployed_by": [], "rank": null, '
-                             '"rank_generation": null, "extra_container_args": null, "extra_entrypoint_args": null}'),
-                            '--config-json', '-',
-                            '--tcp-ports', '6799'
-
-                        ],
-                        stdin=json.dumps(agent_config),
-                        image=''
+                        "test",
+                        "jaeger-agent.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'jaeger-agent.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [6799],
+                            },
+                            "meta": {
+                                'service_name': 'jaeger-agent',
+                                'ports': [6799],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": agent_config,
+                        }),
                     )


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61408

Previously, the `cephadm deploy` command  used a mix of various command line arguments that take single input values, command line arguments that take JSON-encoded strings, and json-encoded input on stdin.

This mish-mash of inputs makes fixes and extensions to cephadm more difficult. In addition, the current method of passing extra CLI options for entrypoint arguments and container engine arguments will fail if the argument should have spaces in it. The plan is to add a new `cephadm _orch deploy` command that takes the vast majority of configuration parameters as a single JSON encoded object on the stdin (or as a specific input file).

The `_orch` term is a new special "namespace" in cephadm that serves as a boundary between commands that can / should be run by users directly and commands that are meant primarily to be called by the orchestrator module and use by humans/scripts should be very rare. These commands are permitted to be tightly coupled with the needs of the orchestrator module.

This series currently has a few experimental patches that could probably be dropped if this PR seems to be doing too much at once. Also the commit starting with `xxx` indicates that this should not be part of the final mergable version but I want it present during initial testing for both CI and, at some point, in teuthology.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Updates tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
