### PR TITLE
reef: rgw/rados: remove sal handles from RGWRados::Object ops

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -736,8 +736,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
   rgw::sal::Attrs attrs;
 
-  rgw::sal::RadosBucket bucket(store, src_bucket);
-  rgw::sal::RadosObject src_obj(store, key, &bucket);
+  rgw_obj src_obj(src_bucket, key);
+
   rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
   rgw::sal::RadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
     
@@ -748,9 +748,9 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
                        user_id.value_or(rgw_user()),
                        NULL, /* req_info */
                        source_zone,
-                       &dest_obj,
-                       &src_obj,
-                       &dest_bucket, /* dest */
+                       dest_obj.get_obj(),
+                       src_obj,
+                       dest_bucket_info, /* dest */
                        nullptr, /* source */
                        dest_placement_rule,
                        nullptr, /* real_time* src_mtime, */
@@ -839,15 +839,15 @@ int RGWAsyncStatRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   char buf[16];
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
 
-  rgw::sal::RadosBucket bucket(store, src_bucket);
-  rgw::sal::RadosObject src_obj(store, key, &bucket);
+
+  rgw_obj src_obj(src_bucket, key);
 
   int r = store->getRados()->stat_remote_obj(dpp,
                        obj_ctx,
                        rgw_user(user_id),
                        nullptr, /* req_info */
                        source_zone,
-                       &src_obj,
+                       src_obj,
                        nullptr, /* source */
                        pmtime, /* real_time* src_mtime, */
                        psize, /* uint64_t * */

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -6428,14 +6428,14 @@ string RGWBucketPipeSyncStatusManager::inc_status_oid(const rgw_zone_id& source_
 
 string RGWBucketPipeSyncStatusManager::obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
                                                       const rgw_zone_id& source_zone,
-                                                      const rgw::sal::Object* obj)
+                                                      const rgw_obj& obj)
 {
-  string prefix = object_status_oid_prefix + "." + source_zone.id + ":" + obj->get_bucket()->get_key().get_key();
+  string prefix = object_status_oid_prefix + "." + source_zone.id + ":" + obj.bucket.get_key();
   if (sync_pipe.source_bucket_info.bucket !=
       sync_pipe.dest_bucket_info.bucket) {
     prefix += string("/") + sync_pipe.dest_bucket_info.bucket.get_key();
   }
-  return prefix + ":" + obj->get_name() + ":" + obj->get_instance();
+  return prefix + ":" + obj.key.name + ":" + obj.key.instance;
 }
 
 int rgw_read_remote_bilog_info(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -823,8 +823,8 @@ public:
 				    uint64_t gen);
   // specific source obj sync status, can be used by sync modules
   static std::string obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
-				    const rgw_zone_id& source_zone, const rgw::sal::Object* obj); /* specific source obj sync status,
-										       can be used by sync modules */
+				    const rgw_zone_id& source_zone,
+				    const rgw_obj& obj);
 
   // implements DoutPrefixProvider
   CephContext *get_cct() const override;

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -237,35 +237,24 @@ static void init_headers(map<string, bufferlist>& attrs,
 static int cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
                          std::map<std::string, std::string>& headers) {
   RGWRESTConn::get_obj_params req_params;
-  RGWBucketInfo b;
   std::string target_obj_name;
   int ret = 0;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
         tier_ctx.target_storage_class);
   std::string etag;
   RGWRESTStreamRWRequest *in_req;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
                     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , reterr = " << ret << dendl;
-    return ret;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
   /* init input connection */
   req_params.get_op = !head;
   req_params.prepend_metadata = true;
@@ -273,7 +262,7 @@ static int cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
   req_params.sync_manifest = true;
   req_params.skip_decrypt = true;
 
-  ret = tier_ctx.conn.get_obj(tier_ctx.dpp, dest_obj.get(), req_params, true /* send */, &in_req);
+  ret = tier_ctx.conn.get_obj(tier_ctx.dpp, dest_obj, req_params, true /* send */, &in_req);
   if (ret < 0) {
     ldpp_dout(tier_ctx.dpp, 0) << "ERROR: " << __func__ << "(): conn.get_obj() returned ret=" << ret << dendl;
     return ret;
@@ -360,7 +349,7 @@ class RGWLCCloudStreamPut
   const DoutPrefixProvider *dpp;
   rgw_lc_obj_properties obj_properties;
   RGWRESTConn& conn;
-  rgw::sal::Object *dest_obj;
+  const rgw_obj& dest_obj;
   std::string etag;
   RGWRESTStreamS3PutObj *out_req{nullptr};
 
@@ -377,7 +366,7 @@ class RGWLCCloudStreamPut
   RGWLCCloudStreamPut(const DoutPrefixProvider *_dpp,
       const rgw_lc_obj_properties&  _obj_properties,
       RGWRESTConn& _conn,
-      rgw::sal::Object *_dest_obj) :
+      const rgw_obj& _dest_obj) :
     dpp(_dpp), obj_properties(_obj_properties), conn(_conn), dest_obj(_dest_obj) {
     }
   int init();
@@ -763,33 +752,22 @@ static int cloud_tier_transfer_object(const DoutPrefixProvider* dpp,
 
 static int cloud_tier_plain_transfer(RGWLCCloudTierCtx& tier_ctx) {
   int ret;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
 
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
                         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
                         tier_ctx.target_storage_class);
-  RGWBucketInfo b;
   std::string target_obj_name;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
+
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , ret = " << ret << dendl;
-    return ret;
-  }
-
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
   tier_ctx.obj->set_atomic();
 
@@ -804,7 +782,7 @@ static int cloud_tier_plain_transfer(RGWLCCloudTierCtx& tier_ctx) {
 
   std::shared_ptr<RGWLCCloudStreamPut> writef;
   writef.reset(new RGWLCCloudStreamPut(tier_ctx.dpp, obj_properties, tier_ctx.conn,
-               dest_obj.get()));
+               dest_obj));
 
   /* actual Read & Write */
   ret = cloud_tier_transfer_object(tier_ctx.dpp, readf.get(), writef.get());
@@ -817,34 +795,23 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
                                 const rgw_lc_multipart_part_info& part_info,
                                 std::string *petag) {
   int ret;
-  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-  std::unique_ptr<rgw::sal::Object> dest_obj;
 
   rgw_lc_obj_properties obj_properties(tier_ctx.o.meta.mtime, tier_ctx.o.meta.etag,
                         tier_ctx.o.versioned_epoch, tier_ctx.acl_mappings,
                         tier_ctx.target_storage_class);
-  RGWBucketInfo b;
   std::string target_obj_name;
   off_t end;
 
-  b.bucket.name = tier_ctx.target_bucket_name;
+  rgw_bucket dest_bucket;
+  dest_bucket.name = tier_ctx.target_bucket_name;
+
   target_obj_name = tier_ctx.bucket_info.bucket.name + "/" +
     tier_ctx.obj->get_name();
   if (!tier_ctx.o.is_current()) {
     target_obj_name += get_key_instance(tier_ctx.obj->get_key());
   }
 
-  ret = tier_ctx.driver->get_bucket(nullptr, b, &dest_bucket);
-  if (ret < 0) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_bucket - " << tier_ctx.target_bucket_name << " , ret = " << ret << dendl;
-    return ret;
-  }
-
-  dest_obj = dest_bucket->get_object(rgw_obj_key(target_obj_name));
-  if (!dest_obj) {
-    ldpp_dout(tier_ctx.dpp, 0) << "ERROR: failed to initialize dest_object path - " << target_obj_name << dendl;
-    return -1;
-  }
+  rgw_obj dest_obj(dest_bucket, rgw_obj_key(target_obj_name));
 
   tier_ctx.obj->set_atomic();
 
@@ -857,7 +824,7 @@ static int cloud_tier_send_multipart_part(RGWLCCloudTierCtx& tier_ctx,
 
   std::shared_ptr<RGWLCCloudStreamPut> writef;
   writef.reset(new RGWLCCloudStreamPut(tier_ctx.dpp, obj_properties, tier_ctx.conn,
-               dest_obj.get()));
+               dest_obj));
 
   /* Prepare Read from source */
   end = part_info.ofs + part_info.size - 1;

--- a/src/rgw/driver/rados/rgw_obj_manifest.h
+++ b/src/rgw/driver/rados/rgw_obj_manifest.h
@@ -58,7 +58,7 @@ public:
   }
 
   rgw_raw_obj get_raw_obj(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params) const;
-  rgw_raw_obj get_raw_obj(rgw::sal::RadosStore* store) const;
+  rgw_raw_obj get_raw_obj(RGWRados* store) const;
 
   rgw_obj_select& operator=(const rgw_obj& rhs) {
     obj = rhs;
@@ -607,7 +607,7 @@ public:
     int create_next(uint64_t ofs);
 
     rgw_raw_obj get_cur_obj(RGWZoneGroup& zonegroup, RGWZoneParams& zone_params) { return cur_obj.get_raw_obj(zonegroup, zone_params); }
-    rgw_raw_obj get_cur_obj(rgw::sal::RadosStore* store) const { return cur_obj.get_raw_obj(store); }
+    rgw_raw_obj get_cur_obj(RGWRados* store) const { return cur_obj.get_raw_obj(store); }
 
     /* total max size of current stripe (including head obj) */
     uint64_t cur_stripe_max_size() const {

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -114,8 +114,7 @@ static int process_completed(const AioResultList& completed, RawObjSet *written)
 }
 
 void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
-  const rgw_obj obj = head_obj->get_obj();
-  const RGWObjStateManifest *sm = obj_ctx.get_state(obj);
+  const RGWObjStateManifest *sm = obj_ctx.get_state(head_obj);
   const bool compressed = sm->state.compressed;
   uint32_t alloc_hint_flags = 0;
   if (compressed) {
@@ -127,7 +126,7 @@ void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
 
 int RadosWriter::set_stripe_obj(const rgw_raw_obj& raw_obj)
 {
-  stripe_obj = store->svc()->rados->obj(raw_obj);
+  stripe_obj = store->svc.rados->obj(raw_obj);
   return stripe_obj.open(dpp);
 }
 
@@ -178,10 +177,9 @@ RadosWriter::~RadosWriter()
 
   bool need_to_remove_head = false;
   std::optional<rgw_raw_obj> raw_head;
-  if (!rgw::sal::Object::empty(head_obj.get())) {
+  if (!head_obj.empty()) {
     raw_head.emplace();
-    rgw::sal::RadosObject* obj = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get());
-    obj->get_raw_obj(&*raw_head);
+    store->obj_to_raw(bucket_info.placement_rule, head_obj, &*raw_head);
   }
 
   /**
@@ -212,7 +210,7 @@ RadosWriter::~RadosWriter()
   if (need_to_remove_head) {
     std::string version_id;
     ldpp_dout(dpp, 5) << "NOTE: we are going to process the head obj (" << *raw_head << ")" << dendl;
-    int r = head_obj->delete_object(dpp, null_yield);
+    int r = store->delete_obj(dpp, obj_ctx, bucket_info, head_obj, 0, 0);
     if (r < 0 && r != -ENOENT) {
       ldpp_dout(dpp, 0) << "WARNING: failed to remove obj (" << *raw_head << "), leaked" << dendl;
     }
@@ -232,7 +230,7 @@ int ManifestObjectProcessor::next(uint64_t offset, uint64_t *pstripe_size)
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
 
   uint64_t chunk_size = 0;
-  r = store->get_raw_chunk_size(dpp, stripe_obj, &chunk_size);
+  r = store->get_max_chunk_size(stripe_obj.pool, &chunk_size, dpp);
   if (r < 0) {
     return r;
   }
@@ -262,29 +260,39 @@ int AtomicObjectProcessor::prepare(optional_yield y)
   uint64_t head_max_size;
   uint64_t chunk_size = 0;
   uint64_t alignment;
+  rgw_pool head_pool;
 
-  int r = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_chunk_size(
-				       dpp, head_obj->get_bucket()->get_placement_rule(),
-				       &max_head_chunk_size, &alignment);
+  if (!store->get_obj_data_pool(bucket_info.placement_rule, head_obj, &head_pool)) {
+    return -EIO;
+  }
+
+  int r = store->get_max_chunk_size(head_pool, &max_head_chunk_size, dpp, &alignment);
   if (r < 0) {
     return r;
   }
 
   bool same_pool = true;
-  if (head_obj->get_bucket()->get_placement_rule() != tail_placement_rule) {
-    if (!head_obj->placement_rules_match(head_obj->get_bucket()->get_placement_rule(), tail_placement_rule)) {
+  if (bucket_info.placement_rule != tail_placement_rule) {
+    rgw_pool tail_pool;
+    if (!store->get_obj_data_pool(tail_placement_rule, head_obj, &tail_pool)) {
+      return -EIO;
+    }
+
+    if (tail_pool != head_pool) {
       same_pool = false;
-      r = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_chunk_size(dpp, tail_placement_rule, &chunk_size);
+
+      r = store->get_max_chunk_size(tail_pool, &chunk_size, dpp);
       if (r < 0) {
         return r;
       }
+
       head_max_size = 0;
     }
   }
 
   if (same_pool) {
     RGWZonePlacementInfo placement_info;
-    if (!store->svc()->zone->get_zone_params().get_placement(head_obj->get_bucket()->get_placement_rule().name, &placement_info) || placement_info.inline_data) {
+    if (!store->svc.zone->get_zone_params().get_placement(bucket_info.placement_rule.name, &placement_info) || placement_info.inline_data) {
       head_max_size = max_head_chunk_size;
     } else {
       head_max_size = 0;
@@ -295,17 +303,14 @@ int AtomicObjectProcessor::prepare(optional_yield y)
   uint64_t stripe_size;
   const uint64_t default_stripe_size = store->ctx()->_conf->rgw_obj_stripe_size;
 
-  dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_max_aligned_size(
-					default_stripe_size, alignment, &stripe_size);
+  store->get_max_aligned_size(default_stripe_size, alignment, &stripe_size);
 
   manifest.set_trivial_rule(head_max_size, stripe_size);
 
-  rgw_obj obj = head_obj->get_obj();
-
   r = manifest_gen.create_begin(store->ctx(), &manifest,
-                                head_obj->get_bucket()->get_placement_rule(),
+                                bucket_info.placement_rule,
                                 &tail_placement_rule,
-                                obj.bucket, obj);
+                                head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
   }
@@ -346,15 +351,14 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  head_obj->set_atomic();
+  obj_ctx.set_atomic(head_obj);
 
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
 
   /* some object types shouldn't be versioned, e.g., multipart parts */
-  op_target.set_versioning_disabled(!head_obj->get_bucket()->versioning_enabled());
+  op_target.set_versioning_disabled(!bucket_info.versioning_enabled());
+
+  RGWRados::Object::Write obj_op(&op_target);
   obj_op.meta.data = &first_chunk;
   obj_op.meta.manifest = &manifest;
   obj_op.meta.ptag = &unique_tag; /* use req_id as operation tag */
@@ -402,8 +406,8 @@ int MultipartObjectProcessor::process_first_chunk(bufferlist&& data,
     // randomize the oid prefix and reprepare the head/manifest
     std::string oid_rand = gen_rand_alphanumeric(store->ctx(), 32);
 
-    mp.init(target_obj->get_name(), upload_id, oid_rand);
-    manifest.set_prefix(target_obj->get_name() + "." + oid_rand);
+    mp.init(target_obj.key.name, upload_id, oid_rand);
+    manifest.set_prefix(target_obj.key.name + "." + oid_rand);
 
     r = prepare_head();
     if (r < 0) {
@@ -426,29 +430,26 @@ int MultipartObjectProcessor::prepare_head()
   uint64_t stripe_size;
   uint64_t alignment;
 
-  int r = dynamic_cast<rgw::sal::RadosObject*>(target_obj.get())->get_max_chunk_size(dpp,
-					  tail_placement_rule, &chunk_size, &alignment);
+  int r = store->get_max_chunk_size(tail_placement_rule, target_obj, &chunk_size, dpp, &alignment);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: unexpected: get_max_chunk_size(): placement_rule=" << tail_placement_rule.to_str() << " obj=" << target_obj << " returned r=" << r << dendl;
     return r;
   }
-  dynamic_cast<rgw::sal::RadosObject*>(target_obj.get())->get_max_aligned_size(
-					default_stripe_size, alignment, &stripe_size);
+  store->get_max_aligned_size(default_stripe_size, alignment, &stripe_size);
 
   manifest.set_multipart_part_rule(stripe_size, part_num);
 
   r = manifest_gen.create_begin(store->ctx(), &manifest,
-				head_obj->get_bucket()->get_placement_rule(),
+				bucket_info.placement_rule,
 				&tail_placement_rule,
-				target_obj->get_bucket()->get_key(),
-				target_obj->get_obj());
+				target_obj.bucket, target_obj);
   if (r < 0) {
     return r;
   }
 
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
-  dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->raw_obj_to_obj(stripe_obj);
-  head_obj->set_hash_source(target_obj->get_name());
+  RGWSI_Tier_RADOS::raw_obj_to_obj(head_obj.bucket, stripe_obj, &head_obj);
+  head_obj.index_hash_source = target_obj.key.name;
 
   r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {
@@ -464,7 +465,7 @@ int MultipartObjectProcessor::prepare_head()
 
 int MultipartObjectProcessor::prepare(optional_yield y)
 {
-  manifest.set_prefix(target_obj->get_name() + "." + upload_id);
+  manifest.set_prefix(target_obj.key.name + "." + upload_id);
 
   return prepare_head();
 }
@@ -491,13 +492,11 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
-
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
   op_target.set_versioning_disabled(true);
   op_target.set_meta_placement_rule(&tail_placement_rule);
+
+  RGWRados::Object::Write obj_op(&op_target);
   obj_op.meta.set_mtime = set_mtime;
   obj_op.meta.mtime = mtime;
   obj_op.meta.owner = owner;
@@ -534,16 +533,15 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  std::unique_ptr<rgw::sal::Object> meta_obj =
-    head_obj->get_bucket()->get_object(rgw_obj_key(mp.get_meta(), std::string(), RGW_OBJ_NS_MULTIPART));
-  meta_obj->set_in_extra_data(true);
+  rgw_obj meta_obj;
+  meta_obj.init_ns(bucket_info.bucket, mp.get_meta(), RGW_OBJ_NS_MULTIPART);
+  meta_obj.set_in_extra_data(true);
 
   rgw_raw_obj meta_raw_obj;
-  store->getRados()->obj_to_raw(meta_obj->get_bucket()->get_placement_rule(), 
-                                meta_obj->get_obj(),
-                                &meta_raw_obj);
+  store->obj_to_raw(bucket_info.placement_rule, meta_obj, &meta_raw_obj); 
+
   rgw_rados_ref meta_obj_ref;
-  r = store->getRados()->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
+  r = store->get_raw_obj_ref(dpp, meta_raw_obj, &meta_obj_ref);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed to get obj ref of meta obj with ret=" << r << dendl;
     return r;
@@ -558,7 +556,14 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     // New CLS call to update part info is not yet supported. Fall back to the old handling.
     bufferlist bl;
     encode(info, bl);
-    r = meta_obj->omap_set_val_by_key(dpp, p, bl, true, null_yield);
+
+    map<string, bufferlist> m;
+    m[p] = bl;
+
+    op = librados::ObjectWriteOperation{};
+    op.assert_exists(); // detect races with abort
+    op.omap_set(m);
+    r = rgw_rados_operate(dpp, meta_obj_ref.pool.ioctx(), meta_obj_ref.obj.oid, &op, y);
   }
   if (r < 0) {
     return r == -ENOENT ? -ERR_NO_SUCH_UPLOAD : r;
@@ -587,7 +592,8 @@ int AppendObjectProcessor::process_first_chunk(bufferlist &&data, rgw::sal::Data
 int AppendObjectProcessor::prepare(optional_yield y)
 {
   RGWObjState *astate;
-  int r = head_obj->get_obj_state(dpp, &astate, y);
+  int r = store->get_obj_state(dpp, &obj_ctx, bucket_info, head_obj,
+                               &astate, &cur_manifest, y);
   if (r < 0) {
     return r;
   }
@@ -602,7 +608,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
       //set the prefix
       char buf[33];
       gen_rand_alphanumeric(store->ctx(), buf, sizeof(buf) - 1);
-      string oid_prefix = head_obj->get_name();
+      string oid_prefix = head_obj.key.name;
       oid_prefix.append(".");
       oid_prefix.append(buf);
       oid_prefix.append("_");
@@ -641,22 +647,19 @@ int AppendObjectProcessor::prepare(optional_yield y)
     } else {
       tail_placement_rule.storage_class = RGW_STORAGE_CLASS_STANDARD;
     }
-    cur_manifest = dynamic_cast<rgw::sal::RadosObject*>(head_obj.get())->get_manifest();
     manifest.set_prefix(cur_manifest->get_prefix());
     astate->keep_tail = true;
   }
   manifest.set_multipart_part_rule(store->ctx()->_conf->rgw_obj_stripe_size, cur_part_num);
 
-  rgw_obj obj = head_obj->get_obj();
-
-  r = manifest_gen.create_begin(store->ctx(), &manifest, head_obj->get_bucket()->get_placement_rule(), &tail_placement_rule, obj.bucket, obj);
+  r = manifest_gen.create_begin(store->ctx(), &manifest, bucket_info.placement_rule, &tail_placement_rule, head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
   }
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
 
   uint64_t chunk_size = 0;
-  r = store->get_raw_chunk_size(dpp, stripe_obj, &chunk_size);
+  r = store->get_max_chunk_size(stripe_obj.pool, &chunk_size, dpp);
   if (r < 0) {
     return r;
   }
@@ -691,15 +694,13 @@ int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, c
   if (r < 0) {
     return r;
   }
-  head_obj->set_atomic();
-  RGWRados::Object op_target(store->getRados(),
-		  head_obj->get_bucket(),
-		  obj_ctx, head_obj.get());
-  RGWRados::Object::Write obj_op(&op_target);
+  obj_ctx.set_atomic(head_obj);
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, head_obj);
   //For Append obj, disable versioning
   op_target.set_versioning_disabled(true);
+  RGWRados::Object::Write obj_op(&op_target);
   if (cur_manifest) {
-    cur_manifest->append(dpp, manifest, store->svc()->zone->get_zonegroup(), store->svc()->zone->get_zone_params());
+    cur_manifest->append(dpp, manifest, store->svc.zone->get_zonegroup(), store->svc.zone->get_zone_params());
     obj_op.meta.manifest = cur_manifest;
   } else {
     obj_op.meta.manifest = &manifest;

--- a/src/rgw/driver/rados/rgw_putobj_processor.h
+++ b/src/rgw/driver/rados/rgw_putobj_processor.h
@@ -66,26 +66,23 @@ using RawObjSet = std::set<rgw_raw_obj>;
 // a data sink that writes to rados objects and deletes them on cancelation
 class RadosWriter : public rgw::sal::DataProcessor {
   Aio *const aio;
-  rgw::sal::RadosStore *const store;
+  RGWRados *const store;
+  const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  const rgw_obj head_obj;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
   const DoutPrefixProvider *dpp;
   optional_yield y;
 
  public:
-  RadosWriter(Aio *aio, rgw::sal::RadosStore *store,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
+  RadosWriter(Aio *aio, RGWRados *store,
+              const RGWBucketInfo& bucket_info,
+              RGWObjectCtx& obj_ctx, const rgw_obj& _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
-    : aio(aio), store(store),
-      obj_ctx(obj_ctx), head_obj(std::move(_head_obj)), dpp(dpp), y(y)
+    : aio(aio), store(store), bucket_info(bucket_info),
+      obj_ctx(obj_ctx), head_obj(_head_obj), dpp(dpp), y(y)
   {}
-  RadosWriter(RadosWriter&& r)
-    : aio(r.aio), store(r.store),
-      obj_ctx(r.obj_ctx), head_obj(std::move(r.head_obj)), dpp(r.dpp), y(r.y)
-  {}
-
   ~RadosWriter();
 
   // add alloc hint to osd
@@ -113,11 +110,12 @@ class RadosWriter : public rgw::sal::DataProcessor {
 class ManifestObjectProcessor : public HeadObjectProcessor,
                                 public StripeGenerator {
  protected:
-  rgw::sal::RadosStore* const store;
+  RGWRados* const store;
+  RGWBucketInfo& bucket_info;
   rgw_placement_rule tail_placement_rule;
   rgw_user owner;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  rgw_obj head_obj;
 
   RadosWriter writer;
   RGWObjManifest manifest;
@@ -130,16 +128,17 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   int next(uint64_t offset, uint64_t *stripe_size) override;
 
  public:
-  ManifestObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  ManifestObjectProcessor(Aio *aio, RGWRados* store,
+                          RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& _obj_ctx,
-                          std::unique_ptr<rgw::sal::Object> _head_obj,
+                          const rgw_obj& _head_obj,
                           const DoutPrefixProvider* dpp, optional_yield y)
     : HeadObjectProcessor(0),
-      store(store),
+      store(store), bucket_info(bucket_info),
       owner(owner),
-      obj_ctx(_obj_ctx), head_obj(std::move(_head_obj)),
-      writer(aio, store, obj_ctx, head_obj->clone(), dpp, y),
+      obj_ctx(_obj_ctx), head_obj(_head_obj),
+      writer(aio, store, bucket_info, obj_ctx, head_obj, dpp, y),
       chunk(&writer, 0), stripe(&chunk, this, 0), dpp(dpp) {
         if (ptail_placement_rule) {
           tail_placement_rule = *ptail_placement_rule;
@@ -169,16 +168,16 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 
   int process_first_chunk(bufferlist&& data, rgw::sal::DataProcessor **processor) override;
  public:
-  AtomicObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  AtomicObjectProcessor(Aio *aio, RGWRados* store,
+                        RGWBucketInfo& bucket_info,
                         const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
-                        RGWObjectCtx& obj_ctx,
-			std::unique_ptr<rgw::sal::Object> _head_obj,
+                        RGWObjectCtx& obj_ctx, const rgw_obj& _head_obj,
                         std::optional<uint64_t> olh_epoch,
                         const std::string& unique_tag,
                         const DoutPrefixProvider *dpp, optional_yield y)
-    : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                              owner, obj_ctx, std::move(_head_obj), dpp, y),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, _head_obj, dpp, y),
       olh_epoch(olh_epoch), unique_tag(unique_tag)
   {}
 
@@ -201,7 +200,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 // part's head is written with an exclusive create to detect racing uploads of
 // the same part/upload id, which are restarted with a random oid prefix
 class MultipartObjectProcessor : public ManifestObjectProcessor {
-  std::unique_ptr<rgw::sal::Object> target_obj; // target multipart object
+  const rgw_obj target_obj; // target multipart object
   const std::string upload_id;
   const int part_num;
   const std::string part_num_str;
@@ -213,18 +212,19 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   // prepare the head stripe and manifest
   int prepare_head();
  public:
-  MultipartObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+  MultipartObjectProcessor(Aio *aio, RGWRados* store,
+                           RGWBucketInfo& bucket_info,
                            const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
-                           std::unique_ptr<rgw::sal::Object> _head_obj,
+                           const rgw_obj& _head_obj,
                            const std::string& upload_id, uint64_t part_num,
                            const std::string& part_num_str,
                            const DoutPrefixProvider *dpp, optional_yield y)
-    : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                              owner, obj_ctx, std::move(_head_obj), dpp, y),
-      target_obj(head_obj->clone()), upload_id(upload_id),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, _head_obj, dpp, y),
+      target_obj(head_obj), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
-      mp(head_obj->get_name(), upload_id)
+      mp(head_obj.key.name, upload_id)
   {}
 
   // prepare a multipart manifest
@@ -255,15 +255,16 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int process_first_chunk(bufferlist&& data, rgw::sal::DataProcessor **processor) override;
 
   public:
-    AppendObjectProcessor(Aio *aio, rgw::sal::RadosStore* store,
+    AppendObjectProcessor(Aio *aio, RGWRados* store,
+                          RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+                          const rgw_obj& _head_obj,
                           const std::string& unique_tag, uint64_t position,
                           uint64_t *cur_accounted_size,
                           const DoutPrefixProvider *dpp, optional_yield y)
-            : ManifestObjectProcessor(aio, store, ptail_placement_rule,
-                                      owner, obj_ctx, std::move(_head_obj), dpp, y),
+            : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                                      owner, obj_ctx, _head_obj, dpp, y),
               position(position), cur_size(0), cur_accounted_size(cur_accounted_size),
               unique_tag(unique_tag), cur_manifest(nullptr)
     {}

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -121,7 +121,7 @@ static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int RadosCompletions::drain()
+static int drain_aio(std::list<librados::AioCompletion*>& handles)
 {
   int ret = 0;
   while (!handles.empty()) {
@@ -135,6 +135,11 @@ int RadosCompletions::drain()
     }
   }
   return ret;
+}
+
+int RadosCompletions::drain()
+{
+  return drain_aio(handles);
 }
 
 int RadosUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& marker,
@@ -532,7 +537,7 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
   params.list_versions = true;
   params.allow_unordered = true;
 
-  std::unique_ptr<rgw::sal::Completions> handles = store->get_completions();
+  std::list<librados::AioCompletion*> handles;
 
   int max_aio = concurrent_max;
   results.is_truncated = true;
@@ -546,10 +551,10 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
     for (; it != results.objs.end(); ++it) {
       RGWObjState *astate = NULL;
       RGWObjManifest *amanifest = nullptr;
-      std::unique_ptr<rgw::sal::Object> obj = get_object((*it).key);
+      rgw_obj obj{get_key(), it->key};
 
-      ret = store->getRados()->get_obj_state(dpp, &obj_ctx, obj->get_bucket()->get_info(),
-					     obj.get(), &astate, &amanifest,
+      ret = store->getRados()->get_obj_state(dpp, &obj_ctx, get_info(),
+					     obj, &astate, &amanifest,
 					     false, y);
       if (ret == -ENOENT) {
         ldpp_dout(dpp, 1) << "WARNING: cannot find obj state for obj " << obj << dendl;
@@ -563,13 +568,13 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
       if (amanifest) {
         RGWObjManifest& manifest = *amanifest;
         RGWObjManifest::obj_iterator miter = manifest.obj_begin(dpp);
-	std::unique_ptr<rgw::sal::Object> head_obj = get_object(manifest.get_obj().key);
+        const rgw_obj head_obj = manifest.get_obj();
         rgw_raw_obj raw_head_obj;
-	dynamic_cast<RadosObject*>(head_obj.get())->get_raw_obj(&raw_head_obj);
+        store->get_raw_obj(manifest.get_head_placement_rule(), head_obj, &raw_head_obj);
 
         for (; miter != manifest.obj_end(dpp) && max_aio--; ++miter) {
           if (!max_aio) {
-            ret = handles->drain();
+            ret = drain_aio(handles);
             if (ret < 0) {
               ldpp_dout(dpp, -1) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
               return ret;
@@ -577,20 +582,21 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
             max_aio = concurrent_max;
           }
 
-          rgw_raw_obj last_obj = miter.get_location().get_raw_obj(store);
+          rgw_raw_obj last_obj = miter.get_location().get_raw_obj(store->getRados());
           if (last_obj == raw_head_obj) {
             // have the head obj deleted at the end
             continue;
           }
 
-          ret = store->delete_raw_obj_aio(dpp, last_obj, handles.get());
+          ret = store->getRados()->delete_raw_obj_aio(dpp, last_obj, handles);
           if (ret < 0) {
             ldpp_dout(dpp, -1) << "ERROR: delete obj aio failed with " << ret << dendl;
             return ret;
           }
         } // for all shadow objs
 
-	ret = head_obj->delete_obj_aio(dpp, astate, handles.get(), keep_index_consistent, y);
+        ret = store->getRados()->delete_obj_aio(dpp, head_obj, get_info(), astate,
+                                                handles, keep_index_consistent, y);
         if (ret < 0) {
           ldpp_dout(dpp, -1) << "ERROR: delete obj aio failed with " << ret << dendl;
           return ret;
@@ -598,18 +604,18 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
       }
 
       if (!max_aio) {
-        ret = handles->drain();
+        ret = drain_aio(handles);
         if (ret < 0) {
           ldpp_dout(dpp, -1) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
           return ret;
         }
         max_aio = concurrent_max;
       }
-      obj_ctx.invalidate(obj->get_obj());
+      obj_ctx.invalidate(obj);
     } // for all RGW objects in results
   } // while is_truncated
 
-  ret = handles->drain();
+  ret = drain_aio(handles);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
     return ret;
@@ -1676,16 +1682,18 @@ int RadosStore::get_oidc_providers(const DoutPrefixProvider *dpp,
 
 std::unique_ptr<Writer> RadosStore::get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
 				  uint64_t position,
 				  uint64_t *cur_accounted_size)
 {
+  RGWBucketInfo& bucket_info = obj->get_bucket()->get_info();
+  RGWObjectCtx& obj_ctx = static_cast<RadosObject*>(obj)->get_ctx();
   auto aio = rgw::make_throttle(ctx()->_conf->rgw_put_obj_min_window_size, y);
   return std::make_unique<RadosAppendWriter>(dpp, y,
-				 std::move(_head_obj),
+				 bucket_info, obj_ctx, obj->get_obj(),
 				 this, std::move(aio), owner,
 				 ptail_placement_rule,
 				 unique_tag, position,
@@ -1694,15 +1702,17 @@ std::unique_ptr<Writer> RadosStore::get_append_writer(const DoutPrefixProvider *
 
 std::unique_ptr<Writer> RadosStore::get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag)
 {
+  RGWBucketInfo& bucket_info = obj->get_bucket()->get_info();
+  RGWObjectCtx& obj_ctx = static_cast<RadosObject*>(obj)->get_ctx();
   auto aio = rgw::make_throttle(ctx()->_conf->rgw_put_obj_min_window_size, y);
   return std::make_unique<RadosAtomicWriter>(dpp, y,
-				 std::move(_head_obj),
+				 bucket_info, obj_ctx, obj->get_obj(),
 				 this, std::move(aio), owner,
 				 ptail_placement_rule,
 				 olh_epoch, unique_tag);
@@ -1731,7 +1741,7 @@ RadosObject::~RadosObject()
 
 int RadosObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjState **pstate, optional_yield y, bool follow_olh)
 {
-  int ret = store->getRados()->get_obj_state(dpp, rados_ctx, bucket->get_info(), this, pstate, &manifest, follow_olh, y);
+  int ret = store->getRados()->get_obj_state(dpp, rados_ctx, bucket->get_info(), get_obj(), pstate, &manifest, follow_olh, y);
   if (ret < 0) {
     return ret;
   }
@@ -1764,7 +1774,7 @@ int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, A
   Attrs empty;
   return store->getRados()->set_attrs(dpp, rados_ctx,
 			bucket->get_info(),
-			this,
+			get_obj(),
 			setattrs ? *setattrs : empty,
 			delattrs ? delattrs : nullptr,
 			y);
@@ -1772,7 +1782,7 @@ int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, A
 
 int RadosObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj)
 {
-  RGWRados::Object op_target(store->getRados(), bucket, *rados_ctx, this);
+  RGWRados::Object op_target(store->getRados(), bucket->get_info(), *rados_ctx, get_obj());
   RGWRados::Object::Read read_op(&op_target);
 
   return read_attrs(dpp, read_op, y, target_obj);
@@ -1964,7 +1974,7 @@ int RadosObject::transition(Bucket* bucket,
 			    const DoutPrefixProvider* dpp,
 			    optional_yield y)
 {
-  return store->getRados()->transition_obj(*rados_ctx, bucket, *this, placement_rule, mtime, olh_epoch, dpp, y);
+  return store->getRados()->transition_obj(*rados_ctx, bucket->get_info(), get_obj(), placement_rule, mtime, olh_epoch, dpp, y);
 }
 
 int RadosObject::transition_to_cloud(Bucket* bucket,
@@ -2054,7 +2064,7 @@ int RadosObject::write_cloud_tier(const DoutPrefixProvider* dpp,
 {
   rgw::sal::RadosPlacementTier* rtier = static_cast<rgw::sal::RadosPlacementTier*>(tier);
   map<string, bufferlist> attrs = get_attrs();
-  RGWRados::Object op_target(store->getRados(), bucket, *rados_ctx, this);
+  RGWRados::Object op_target(store->getRados(), bucket->get_info(), *rados_ctx, get_obj());
   RGWRados::Object::Write obj_op(&op_target);
 
   obj_op.meta.modify_tail = true;
@@ -2136,7 +2146,7 @@ int RadosObject::dump_obj_layout(const DoutPrefixProvider *dpp, optional_yield y
   RGWObjManifest *amanifest{nullptr};
   rgw_raw_obj head_obj;
 
-  RGWRados::Object op_target(store->getRados(), get_bucket(), *rados_ctx, this);
+  RGWRados::Object op_target(store->getRados(), bucket->get_info(), *rados_ctx, get_obj());
   RGWRados::Object::Read parent_op(&op_target);
   uint64_t obj_size;
 
@@ -2160,7 +2170,7 @@ int RadosObject::dump_obj_layout(const DoutPrefixProvider *dpp, optional_yield y
   f->open_array_section("data_location");
   for (auto miter = amanifest->obj_begin(dpp); miter != amanifest->obj_end(dpp); ++miter) {
     f->open_object_section("obj");
-    rgw_raw_obj raw_loc = miter.get_location().get_raw_obj(store);
+    rgw_raw_obj raw_loc = miter.get_location().get_raw_obj(store->getRados());
     uint64_t ofs = miter.get_ofs();
     uint64_t left = amanifest->get_obj_size() - ofs;
     ::encode_json("ofs", miter.get_ofs(), f);
@@ -2187,9 +2197,9 @@ RadosObject::RadosReadOp::RadosReadOp(RadosObject *_source, RGWObjectCtx *_rctx)
 	source(_source),
 	rctx(_rctx),
 	op_target(_source->store->getRados(),
-		  _source->get_bucket(),
+		  _source->get_bucket()->get_info(),
 		  *static_cast<RGWObjectCtx *>(rctx),
-		  _source),
+		  _source->get_obj()),
 	parent_op(&op_target)
 { }
 
@@ -2237,9 +2247,9 @@ std::unique_ptr<Object::DeleteOp> RadosObject::get_delete_op()
 RadosObject::RadosDeleteOp::RadosDeleteOp(RadosObject *_source) :
 	source(_source),
 	op_target(_source->store->getRados(),
-		  _source->get_bucket(),
+		  _source->get_bucket()->get_info(),
 		  _source->get_ctx(),
-		  _source),
+		  _source->get_obj()),
 	parent_op(&op_target)
 { }
 
@@ -2274,7 +2284,7 @@ int RadosObject::delete_object(const DoutPrefixProvider* dpp,
 			       optional_yield y,
 			       bool prevent_versioning)
 {
-  RGWRados::Object del_target(store->getRados(), bucket, *rados_ctx, this);
+  RGWRados::Object del_target(store->getRados(), bucket->get_info(), *rados_ctx, get_obj());
   RGWRados::Object::Delete del_op(&del_target);
 
   del_op.params.bucket_owner = bucket->get_info().owner;
@@ -2325,10 +2335,10 @@ int RadosObject::copy_object(User* user,
 				     user->get_id(),
 				     info,
 				     source_zone,
-				     dest_object,
-				     this,
-				     dest_bucket,
-				     src_bucket,
+				     dest_object->get_obj(),
+				     get_obj(),
+				     dest_bucket->get_info(),
+				     src_bucket->get_info(),
 				     dest_placement,
 				     src_mtime,
 				     mtime,
@@ -2360,10 +2370,11 @@ int RadosObject::RadosReadOp::iterate(const DoutPrefixProvider* dpp, int64_t ofs
 int RadosObject::swift_versioning_restore(bool& restored,
 					  const DoutPrefixProvider* dpp)
 {
+  rgw_obj obj = get_obj();
   return store->getRados()->swift_versioning_restore(*rados_ctx,
 						     bucket->get_owner()->get_id(),
-						     bucket,
-						     this,
+						     bucket->get_info(),
+						     obj,
 						     restored,
 						     dpp);
 }
@@ -2372,8 +2383,8 @@ int RadosObject::swift_versioning_copy(const DoutPrefixProvider* dpp, optional_y
 {
   return store->getRados()->swift_versioning_copy(*rados_ctx,
                                         bucket->get_info().owner,
-                                        bucket,
-                                        this,
+                                        bucket->get_info(),
+                                        get_obj(),
                                         dpp,
                                         y);
 }
@@ -2396,7 +2407,7 @@ int RadosMultipartUpload::cleanup_part_history(const DoutPrefixProvider* dpp,
     manifest.set_prefix(ppfx);
     RGWObjManifest::obj_iterator miter = manifest.obj_begin(dpp);
     for (; miter != manifest.obj_end(dpp); ++miter) {
-      rgw_raw_obj raw_part_obj = miter.get_location().get_raw_obj(store);
+      rgw_raw_obj raw_part_obj = miter.get_location().get_raw_obj(store->getRados());
       cls_rgw_obj_key part_key(raw_part_obj.oid);
       chain.push_obj(raw_part_obj.pool.to_str(), part_key, raw_part_obj.loc);
     }
@@ -2457,7 +2468,7 @@ int RadosMultipartUpload::abort(const DoutPrefixProvider *dpp, CephContext *cct)
         RGWObjManifest::obj_iterator oiter = obj_part->info.manifest.obj_begin(dpp);
         if (oiter != obj_part->info.manifest.obj_end(dpp)) {
 	  std::unique_ptr<rgw::sal::Object> head = bucket->get_object(rgw_obj_key());
-          rgw_raw_obj raw_head = oiter.get_location().get_raw_obj(store);
+          rgw_raw_obj raw_head = oiter.get_location().get_raw_obj(store->getRados());
 	  dynamic_cast<rgw::sal::RadosObject*>(head.get())->raw_obj_to_obj(raw_head);
 
           rgw_obj_index_key key;
@@ -2534,8 +2545,8 @@ int RadosMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y, 
     obj->set_hash_source(oid);
 
     RGWRados::Object op_target(store->getRados(),
-			       obj->get_bucket(),
-			       obj_ctx, obj.get());
+			       obj->get_bucket()->get_info(),
+			       obj_ctx, obj->get_obj());
     RGWRados::Object::Write obj_op(&op_target);
 
     op_target.set_versioning_disabled(true); /* no versioning for multipart meta */
@@ -2815,9 +2826,9 @@ int RadosMultipartUpload::complete(const DoutPrefixProvider *dpp,
   target_obj->set_atomic();
 
   RGWRados::Object op_target(store->getRados(),
-			     target_obj->get_bucket(),
+			     target_obj->get_bucket()->get_info(),
 			     dynamic_cast<RadosObject*>(target_obj)->get_ctx(),
-			     target_obj);
+			     target_obj->get_obj());
   RGWRados::Object::Write obj_op(&op_target);
 
   obj_op.meta.manifest = &manifest;
@@ -2916,15 +2927,18 @@ int RadosMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield
 std::unique_ptr<Writer> RadosMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
+  RGWBucketInfo& bucket_info = obj->get_bucket()->get_info();
+  RGWObjectCtx& obj_ctx = static_cast<RadosObject*>(obj)->get_ctx();
   auto aio = rgw::make_throttle(store->ctx()->_conf->rgw_put_obj_min_window_size, y);
-  return std::make_unique<RadosMultipartWriter>(dpp, y, this,
-				 std::move(_head_obj), store, std::move(aio), owner,
+  return std::make_unique<RadosMultipartWriter>(dpp, y, get_upload_id(),
+				 bucket_info, obj_ctx,
+				 obj->get_obj(), store, std::move(aio), owner,
 				 ptail_placement_rule, part_num, part_num_str);
 }
 

--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -37,12 +37,9 @@ static string get_key_oid(const rgw_obj_key& key)
   return oid;
 }
 
-static string obj_to_aws_path(rgw::sal::Object* obj)
+static string obj_to_aws_path(const rgw_obj& obj)
 {
-  string path = obj->get_bucket()->get_name() + "/" + get_key_oid(obj->get_key());
-
-
-  return path;
+  return obj.bucket.name + "/" + get_key_oid(obj.key);
 }
 
 /*
@@ -730,7 +727,7 @@ class RGWRESTStreamGetCRF : public RGWStreamReadHTTPResourceCRF
 {
   RGWDataSyncCtx *sc;
   RGWRESTConn *conn;
-  rgw::sal::Object* src_obj;
+  const rgw_obj& src_obj;
   RGWRESTConn::get_obj_params req_params;
 
   rgw_sync_aws_src_obj_properties src_properties;
@@ -740,9 +737,9 @@ public:
                                RGWCoroutine *_caller,
                                RGWDataSyncCtx *_sc,
                                RGWRESTConn *_conn,
-                               rgw::sal::Object* _src_obj,
+                               const rgw_obj& _src_obj,
                                const rgw_sync_aws_src_obj_properties& _src_properties) : RGWStreamReadHTTPResourceCRF(_cct, _env, _caller,
-                                                                                                                      _sc->env->http_manager, _src_obj->get_key()),
+                                                                                                                      _sc->env->http_manager, _src_obj.key),
                                                                                  sc(_sc), conn(_conn), src_obj(_src_obj),
                                                                                  src_properties(_src_properties) {
   }
@@ -809,7 +806,7 @@ class RGWAWSStreamPutCRF : public RGWStreamWriteHTTPResourceCRF
   RGWDataSyncCtx *sc;
   rgw_sync_aws_src_obj_properties src_properties;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
   string etag;
 public:
   RGWAWSStreamPutCRF(CephContext *_cct,
@@ -818,7 +815,7 @@ public:
                                RGWDataSyncCtx *_sc,
                                const rgw_sync_aws_src_obj_properties&  _src_properties,
                                std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                               rgw::sal::Object* _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
+                               const rgw_obj& _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
                                                      sc(_sc), src_properties(_src_properties), target(_target), dest_obj(_dest_obj) {
   }
 
@@ -1007,8 +1004,8 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1018,10 +1015,10 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudPlainCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 std::shared_ptr<AWSSyncConfig_Profile> _target,
-                                rgw::sal::Object* _dest_obj) : RGWCoroutine(_sc->cct),
+                                const rgw_obj& _dest_obj) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    source_conn(_source_conn),
                                                    target(_target),
@@ -1056,8 +1053,8 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1073,9 +1070,9 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudMultipartPartCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const string& _upload_id,
                                 const rgw_sync_aws_multipart_part_info& _part_info,
@@ -1125,14 +1122,14 @@ public:
 class RGWAWSAbortMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   string upload_id;
 
 public:
   RGWAWSAbortMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         const string& _upload_id) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    dest_conn(_dest_conn),
@@ -1164,7 +1161,7 @@ public:
 class RGWAWSInitMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   uint64_t obj_size;
   map<string, string> attrs;
@@ -1188,7 +1185,7 @@ class RGWAWSInitMultipartCR : public RGWCoroutine {
 public:
   RGWAWSInitMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         uint64_t _obj_size,
                         const map<string, string>& _attrs,
                         string *_upload_id) : RGWCoroutine(_sc->cct),
@@ -1254,7 +1251,7 @@ public:
 class RGWAWSCompleteMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
 
   bufferlist out_bl;
 
@@ -1292,7 +1289,7 @@ class RGWAWSCompleteMultipartCR : public RGWCoroutine {
 public:
   RGWAWSCompleteMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::Object* _dest_obj,
+                        const rgw_obj& _dest_obj,
                         string _upload_id,
                         const map<int, rgw_sync_aws_multipart_part_info>& _parts) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
@@ -1364,7 +1361,7 @@ public:
 class RGWAWSStreamAbortMultipartUploadCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& dest_obj;
   const rgw_raw_obj status_obj;
 
   string upload_id;
@@ -1373,7 +1370,7 @@ public:
 
   RGWAWSStreamAbortMultipartUploadCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_dest_conn,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 const rgw_raw_obj& _status_obj,
                                 const string& _upload_id) : RGWCoroutine(_sc->cct), sc(_sc),
                                                             dest_conn(_dest_conn),
@@ -1406,8 +1403,8 @@ class RGWAWSStreamObjToCloudMultipartCR : public RGWCoroutine {
   AWSSyncConfig& conf;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::Object* src_obj;
-  rgw::sal::Object* dest_obj;
+  const rgw_obj& src_obj;
+  const rgw_obj& dest_obj;
 
   uint64_t obj_size;
   string src_etag;
@@ -1429,9 +1426,9 @@ public:
 				    rgw_bucket_sync_pipe& _sync_pipe,
                                 AWSSyncConfig& _conf,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::Object* _src_obj,
+                                const rgw_obj& _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::Object* _dest_obj,
+                                const rgw_obj& _dest_obj,
                                 uint64_t _obj_size,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const rgw_rest_obj& _rest_obj) : RGWCoroutine(_sc->cct),
@@ -1576,8 +1573,6 @@ class RGWAWSHandleRemoteObjCBCR: public RGWStatRemoteObjCBCR {
   std::shared_ptr<AWSSyncConfig_Profile> target;
   bufferlist res;
   unordered_map <string, bool> bucket_created;
-  string target_bucket_name;
-  string target_obj_name;
   rgw_rest_obj rest_obj;
   int ret{0};
 
@@ -1594,12 +1589,8 @@ class RGWAWSHandleRemoteObjCBCR: public RGWStatRemoteObjCBCR {
     }
   } result;
 
-  rgw_bucket target_bucket;
-  std::unique_ptr<rgw::sal::RadosBucket> bucket;
-  std::unique_ptr<rgw::sal::RadosObject> src_obj;
-  std::unique_ptr<rgw::sal::RadosBucket> dest_bucket;
-  std::unique_ptr<rgw::sal::RadosObject> dest_obj;
-
+  rgw_obj src_obj;
+  rgw_obj dest_obj;
 
 public:
   RGWAWSHandleRemoteObjCBCR(RGWDataSyncCtx *_sc,
@@ -1639,15 +1630,15 @@ public:
       }
 
       instance.get_profile(sync_pipe.info.source_bs.bucket, &target);
-      instance.conf.get_target(target, sync_pipe.dest_bucket_info, key, &target_bucket_name, &target_obj_name);
+      instance.conf.get_target(target, sync_pipe.dest_bucket_info, key, &dest_obj.bucket.name, &dest_obj.key.name);
 
-      if (bucket_created.find(target_bucket_name) == bucket_created.end()){
+      if (bucket_created.find(dest_obj.bucket.name) == bucket_created.end()){
         yield {
-          ldpp_dout(dpp, 0) << "AWS: creating bucket " << target_bucket_name << dendl;
+          ldpp_dout(dpp, 0) << "AWS: creating bucket " << dest_obj.bucket.name << dendl;
           bufferlist bl;
           call(new RGWPutRawRESTResourceCR <bufferlist> (sc->cct, target->conn.get(),
                                                   sync_env->http_manager,
-                                                  target_bucket_name, nullptr, bl, &out_bl));
+                                                  dest_obj.bucket.name, nullptr, bl, &out_bl));
         }
         if (retcode < 0 ) {
           RGWXMLDecoder::XMLParser parser;
@@ -1675,19 +1666,14 @@ public:
           }
         }
 
-        bucket_created[target_bucket_name] = true;
+        bucket_created[dest_obj.bucket.name] = true;
       }
 
       yield {
-        bucket.reset(new rgw::sal::RadosBucket(sync_env->driver, src_bucket));
-        src_obj.reset(new rgw::sal::RadosObject(sync_env->driver, key, bucket.get()));
+        src_obj.bucket = src_bucket;
+        src_obj.key = key;
 
         /* init output */
-        target_bucket.name = target_bucket_name; /* this is only possible because we only use bucket name for
-                                                    uri resolution */
-        dest_bucket.reset(new rgw::sal::RadosBucket(sync_env->driver, target_bucket));
-        dest_obj.reset(new rgw::sal::RadosObject(sync_env->driver, rgw_obj_key(target_obj_name), dest_bucket.get()));
-
         rgw_sync_aws_src_obj_properties src_properties;
         src_properties.mtime = mtime;
         src_properties.etag = etag;
@@ -1696,10 +1682,10 @@ public:
         src_properties.versioned_epoch = versioned_epoch;
 
         if (size < instance.conf.s3.multipart_sync_threshold) {
-          call(new RGWAWSStreamObjToCloudPlainCR(sc, source_conn, src_obj.get(),
+          call(new RGWAWSStreamObjToCloudPlainCR(sc, source_conn, src_obj,
                                                  src_properties,
                                                  target,
-                                                 dest_obj.get()));
+                                                 dest_obj));
         } else {
           rgw_rest_obj rest_obj;
           rest_obj.init(key);
@@ -1707,8 +1693,8 @@ public:
             ldpp_dout(dpp, 0) << "ERROR: failed to decode rest obj out of headers=" << headers << ", attrs=" << attrs << dendl;
             return set_cr_error(-EINVAL);
           }
-          call(new RGWAWSStreamObjToCloudMultipartCR(sc, sync_pipe, instance.conf, source_conn, src_obj.get(),
-                                                     target, dest_obj.get(), size, src_properties, rest_obj));
+          call(new RGWAWSStreamObjToCloudMultipartCR(sc, sync_pipe, instance.conf, source_conn, src_obj,
+                                                     target, dest_obj, size, src_properties, rest_obj));
         }
       }
       if (retcode < 0) {

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -323,7 +323,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
   string req_id = driver->zone_unique_id(driver->get_new_req_id());
 
   std::unique_ptr<rgw::sal::Writer> processor;
-  processor = driver->get_atomic_writer(dpp, y, std::move(obj),
+  processor = driver->get_atomic_writer(dpp, y, obj.get(),
 				       owner.get_id(),
 				       nullptr, olh_epoch, req_id);
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7772,7 +7772,8 @@ next:
       }
     }
     if (need_rewrite) {
-      ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->rewrite_obj(obj.get(), dpp(), null_yield);
+      RGWRados* store = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
+      ret = store->rewrite_obj(bucket->get_info(), obj->get_obj(), dpp(), null_yield);
       if (ret < 0) {
         cerr << "ERROR: object rewrite returned: " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -7976,7 +7977,8 @@ next:
           if (!need_rewrite) {
             formatter->dump_string("status", "Skipped");
           } else {
-            r = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->rewrite_obj(obj.get(), dpp(), null_yield);
+            RGWRados* store = static_cast<rgw::sal::RadosStore*>(driver)->getRados();
+            r = store->rewrite_obj(bucket->get_info(), obj->get_obj(), dpp(), null_yield);
             if (r == 0) {
               formatter->dump_string("status", "Success");
             } else {

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1864,7 +1864,7 @@ namespace rgw {
         version_id = state->object->get_instance();
       }
     }
-    processor = get_driver()->get_atomic_writer(this, state->yield, state->object->clone(),
+    processor = get_driver()->get_atomic_writer(this, state->yield, state->object.get(),
 					 state->bucket_owner.get_id(),
 					 &state->dest_placement, 0, state->req_id);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4062,7 +4062,7 @@ void RGWPutObj::execute(optional_yield y)
     s->dest_placement = *pdest_placement;
     pdest_placement = &s->dest_placement;
     ldpp_dout(this, 20) << "dest_placement for part=" << *pdest_placement << dendl;
-    processor = upload->get_writer(this, s->yield, s->object->clone(),
+    processor = upload->get_writer(this, s->yield, s->object.get(),
 				   s->user->get_id(), pdest_placement,
 				   multipart_part_num, multipart_part_str);
   } else if(append) {
@@ -4070,7 +4070,7 @@ void RGWPutObj::execute(optional_yield y)
       op_ret = -ERR_INVALID_BUCKET_STATE;
       return;
     }
-    processor = driver->get_append_writer(this, s->yield, s->object->clone(),
+    processor = driver->get_append_writer(this, s->yield, s->object.get(),
 					 s->bucket_owner.get_id(),
 					 pdest_placement, s->req_id, position,
 					 &cur_accounted_size);
@@ -4083,7 +4083,7 @@ void RGWPutObj::execute(optional_yield y)
         version_id = s->object->get_instance();
       }
     }
-    processor = driver->get_atomic_writer(this, s->yield, s->object->clone(),
+    processor = driver->get_atomic_writer(this, s->yield, s->object.get(),
 					 s->bucket_owner.get_id(),
 					 pdest_placement, olh_epoch, s->req_id);
   }
@@ -4490,7 +4490,7 @@ void RGWPostObj::execute(optional_yield y)
     }
 
     std::unique_ptr<rgw::sal::Writer> processor;
-    processor = driver->get_atomic_writer(this, s->yield, std::move(obj),
+    processor = driver->get_atomic_writer(this, s->yield, obj.get(),
 					 s->bucket_owner.get_id(),
 					 &s->dest_placement, 0, s->req_id);
     op_ret = processor->prepare(s->yield);
@@ -7619,7 +7619,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   dest_placement.inherit_from(bucket->get_placement_rule());
 
   std::unique_ptr<rgw::sal::Writer> processor;
-  processor = driver->get_atomic_writer(this, s->yield, std::move(obj),
+  processor = driver->get_atomic_writer(this, s->yield, obj.get(),
 				       bowner.get_id(),
 				       &s->dest_placement, 0, s->req_id);
   op_ret = processor->prepare(s->yield);

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -452,7 +452,7 @@ int RGWOrphanSearch::handle_stat_result(const DoutPrefixProvider *dpp, map<int, 
 
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(dpp); miter != manifest.obj_end(dpp); ++miter) {
-      const rgw_raw_obj& loc = miter.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+      const rgw_raw_obj& loc = miter.get_location().get_raw_obj(store->getRados());
       string s = loc.oid;
       obj_oids.insert(obj_fingerprint(s));
     }
@@ -579,9 +579,9 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const DoutPrefixProvider *dpp,
         continue;
       }
 
-      std::unique_ptr<rgw::sal::Object> obj = cur_bucket->get_object(entry.key);
+      rgw_obj obj(cur_bucket->get_key(), entry.key);
 
-      RGWRados::Object op_target(store->getRados(), cur_bucket.get(), obj_ctx, obj.get());
+      RGWRados::Object op_target(store->getRados(), cur_bucket->get_info(), obj_ctx, obj);
 
       stat_ops.push_back(RGWRados::Object::Stat(&op_target));
       RGWRados::Object::Stat& op = stat_ops.back();
@@ -1042,7 +1042,7 @@ int RGWRadosList::handle_stat_result(const DoutPrefixProvider *dpp,
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(dpp); miter != manifest.obj_end(dpp); ++miter) {
       const rgw_raw_obj& loc =
-	miter.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+	miter.get_location().get_raw_obj(store->getRados());
       string s = loc.oid;
       obj_oids.insert(s);
     }
@@ -1248,9 +1248,9 @@ int RGWRadosList::process_bucket(
 	[&](const rgw_obj_key& key) -> int {
 	  int ret;
 
-	  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
-	  RGWRados::Object op_target(store->getRados(), bucket.get(),
-				     obj_ctx, obj.get());
+	  rgw_obj obj(bucket_info.bucket, key);
+	  RGWRados::Object op_target(store->getRados(), bucket_info,
+				     obj_ctx, obj);
 
 	  stat_ops.push_back(RGWRados::Object::Stat(&op_target));
 	  RGWRados::Object::Stat& op = stat_ops.back();
@@ -1536,7 +1536,7 @@ int RGWRadosList::do_incomplete_multipart(const DoutPrefixProvider *dpp,
 		 obj_it != manifest.obj_end(dpp);
 		 ++obj_it) {
 	      const rgw_raw_obj& loc =
-		obj_it.get_location().get_raw_obj(static_cast<rgw::sal::RadosStore*>(store));
+		obj_it.get_location().get_raw_obj(store->getRados());
 	      std::cout << loc.oid << std::endl;
 	    } // for (auto obj_it
 	  } // for (auto& p

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -695,22 +695,22 @@ int RGWRESTGenerateHTTPHeaders::sign(const DoutPrefixProvider *dpp, RGWAccessKey
   return 0;
 }
 
-void RGWRESTStreamS3PutObj::send_init(rgw::sal::Object* obj)
+void RGWRESTStreamS3PutObj::send_init(const rgw_obj& obj)
 {
   string resource_str;
   string resource;
   string new_url = url;
   string new_host = host;
 
-   const auto& bucket_name = obj->get_bucket()->get_name();
+   const auto& bucket_name = obj.bucket.name;
 
   if (host_style == VirtualStyle) {
-    resource_str = obj->get_oid();
+    resource_str = obj.get_oid();
 
     new_url = bucket_name + "."  + new_url;
     new_host = bucket_name + "." + new_host;
   } else {
-    resource_str = bucket_name + "/" + obj->get_oid();
+    resource_str = bucket_name + "/" + obj.get_oid();
   }
 
   //do not encode slash in object key name
@@ -752,7 +752,7 @@ void RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessK
   out_cb = new RGWRESTStreamOutCB(this);
 }
 
-void RGWRESTStreamS3PutObj::put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::Object* obj, map<string, bufferlist>& attrs)
+void RGWRESTStreamS3PutObj::put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, const rgw_obj& obj, map<string, bufferlist>& attrs)
 {
   send_init(obj);
   send_ready(dpp, key, attrs);

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -245,13 +245,13 @@ public:
                 out_cb(NULL), new_info(cct, &new_env), headers_gen(_cct, &new_env, &new_info) {}
   ~RGWRESTStreamS3PutObj() override;
 
-  void send_init(rgw::sal::Object* obj);
+  void send_init(const rgw_obj& obj);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, std::map<std::string, bufferlist>& rgw_attrs);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, const std::map<std::string, std::string>& http_attrs,
                   RGWAccessControlPolicy& policy);
   void send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key);
 
-  void put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::Object* obj, std::map<std::string, bufferlist>& attrs);
+  void put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, const rgw_obj& obj, std::map<std::string, bufferlist>& attrs);
 
   RGWGetDataCB *get_out_cb() { return out_cb; }
 };

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -127,7 +127,7 @@ int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const RGWAcc
   return req.forward_request(dpp, key, info, max_response, inbl, outbl, y, service);
 }
 
-int RGWRESTConn::put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)
+int RGWRESTConn::put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)
 {
   string url;
   int ret = get_url(url);
@@ -148,7 +148,7 @@ int RGWRESTConn::put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_p
   return 0;
 }
 
-int RGWRESTConn::put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, rgw::sal::Object* obj,
+int RGWRESTConn::put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, const rgw_obj& obj,
                                     map<string, bufferlist>& attrs,
                                     RGWRESTStreamS3PutObj **req)
 {
@@ -198,7 +198,7 @@ static void set_header(T val, map<string, string>& headers, const string& header
 }
 
 
-int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw::sal::Object* obj,
+int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw_obj& obj,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
                          bool prepend_metadata, bool get_op, bool rgwx_stat,
@@ -221,7 +221,7 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req
   return get_obj(dpp, obj, params, send, req);
 }
 
-int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw::sal::Object* obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
+int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
 {
   string url;
   int ret = get_url(url);
@@ -245,9 +245,8 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw::sal::Object* 
   if (in_params.skip_decrypt) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "skip-decrypt", ""));
   }
-  if (!obj->get_instance().empty()) {
-    const string& instance = obj->get_instance();
-    params.push_back(param_pair_t("versionId", instance));
+  if (!obj.key.instance.empty()) {
+    params.push_back(param_pair_t("versionId", obj.key.instance));
   }
   if (in_params.get_op) {
     *req = new RGWRESTStreamReadRequest(cct, url, in_params.cb, NULL, &params, api_name, host_style);
@@ -287,7 +286,7 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw::sal::Object* 
     set_header(buf, extra_headers, "RANGE");
   }
 
-  int r = (*req)->send_prepare(dpp, key, extra_headers, obj->get_obj());
+  int r = (*req)->send_prepare(dpp, key, extra_headers, obj);
   if (r < 0) {
     goto done_err;
   }

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -132,8 +132,8 @@ public:
 
 
   /* async requests */
-  int put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
-  int put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, rgw::sal::Object* obj,
+  int put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
+  int put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_user& uid, const rgw_obj& obj,
                          std::map<std::string, bufferlist>& attrs, RGWRESTStreamS3PutObj **req);
   int complete_request(RGWRESTStreamS3PutObj *req, std::string& etag,
                        ceph::real_time *mtime, optional_yield y);
@@ -164,9 +164,9 @@ public:
     uint64_t range_end{0};
   };
 
-  int get_obj(const DoutPrefixProvider *dpp, const rgw::sal::Object* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
 
-  int get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw::sal::Object* obj,
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw_obj& obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -432,7 +432,7 @@ class Driver {
     /** Get a Writer that appends to an object */
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -441,7 +441,7 @@ class Driver {
     /** Get a Writer that atomically writes an entire object */
     virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
@@ -1225,7 +1225,7 @@ public:
   /** Get a Writer to write to a part of this upload */
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,

--- a/src/rgw/rgw_sal_daos.cc
+++ b/src/rgw/rgw_sal_daos.cc
@@ -1502,7 +1502,7 @@ int DaosObject::mark_as_latest(const DoutPrefixProvider* dpp,
 
 DaosAtomicWriter::DaosAtomicWriter(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, DaosStore* _store,
+    rgw::sal::Object* obj, DaosStore* _store,
     const rgw_user& _owner, const rgw_placement_rule* _ptail_placement_rule,
     uint64_t _olh_epoch, const std::string& _unique_tag)
     : StoreWriter(dpp, y),
@@ -1511,7 +1511,7 @@ DaosAtomicWriter::DaosAtomicWriter(
       ptail_placement_rule(_ptail_placement_rule),
       olh_epoch(_olh_epoch),
       unique_tag(_unique_tag),
-      obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+      obj(_store, obj->get_key(), obj->get_bucket()) {}
 
 int DaosAtomicWriter::prepare(optional_yield y) {
   ldpp_dout(dpp, 20) << "DEBUG: prepare" << dendl;
@@ -2019,13 +2019,13 @@ int DaosMultipartUpload::get_info(const DoutPrefixProvider* dpp,
 
 std::unique_ptr<Writer> DaosMultipartUpload::get_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule, uint64_t part_num,
     const std::string& part_num_str) {
   ldpp_dout(dpp, 20) << "DaosMultipartUpload::get_writer(): enter part="
                      << part_num << " head_obj=" << _head_obj << dendl;
   return std::make_unique<DaosMultipartWriter>(
-      dpp, y, this, std::move(_head_obj), store, owner, ptail_placement_rule,
+      dpp, y, this, obj, store, owner, ptail_placement_rule,
       part_num, part_num_str);
 }
 
@@ -2163,7 +2163,7 @@ std::unique_ptr<MultipartUpload> DaosBucket::get_multipart_upload(
 
 std::unique_ptr<Writer> DaosStore::get_append_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule,
     const std::string& unique_tag, uint64_t position,
     uint64_t* cur_accounted_size) {
@@ -2173,11 +2173,11 @@ std::unique_ptr<Writer> DaosStore::get_append_writer(
 
 std::unique_ptr<Writer> DaosStore::get_atomic_writer(
     const DoutPrefixProvider* dpp, optional_yield y,
-    std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+    rgw::sal::Object* obj, const rgw_user& owner,
     const rgw_placement_rule* ptail_placement_rule, uint64_t olh_epoch,
     const std::string& unique_tag) {
   ldpp_dout(dpp, 20) << "get_atomic_writer" << dendl;
-  return std::make_unique<DaosAtomicWriter>(dpp, y, std::move(_head_obj), this,
+  return std::make_unique<DaosAtomicWriter>(dpp, y, obj, this,
                                             owner, ptail_placement_rule,
                                             olh_epoch, unique_tag);
 }

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -741,7 +741,7 @@ class DaosAtomicWriter : public StoreWriter {
 
  public:
   DaosAtomicWriter(const DoutPrefixProvider* dpp, optional_yield y,
-                   std::unique_ptr<rgw::sal::Object> _head_obj,
+                   rgw::sal::Object* obj,
                    DaosStore* _store, const rgw_user& _owner,
                    const rgw_placement_rule* _ptail_placement_rule,
                    uint64_t _olh_epoch, const std::string& _unique_tag);
@@ -780,7 +780,7 @@ class DaosMultipartWriter : public StoreWriter {
  public:
   DaosMultipartWriter(const DoutPrefixProvider* dpp, optional_yield y,
                       MultipartUpload* _upload,
-                      std::unique_ptr<rgw::sal::Object> _head_obj,
+                      rgw::sal::Object* obj,
                       DaosStore* _store, const rgw_user& owner,
                       const rgw_placement_rule* ptail_placement_rule,
                       uint64_t _part_num, const std::string& part_num_str)
@@ -874,7 +874,7 @@ class DaosMultipartUpload : public StoreMultipartUpload {
                        rgw::sal::Attrs* attrs = nullptr) override;
   virtual std::unique_ptr<Writer> get_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule, uint64_t part_num,
       const std::string& part_num_str) override;
   const std::string& get_bucket_name() { return bucket->get_name(); }
@@ -1027,13 +1027,13 @@ class DaosStore : public StoreDriver {
       std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule,
       const std::string& unique_tag, uint64_t position,
       uint64_t* cur_accounted_size) override;
   virtual std::unique_ptr<Writer> get_atomic_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
-      std::unique_ptr<rgw::sal::Object> _head_obj, const rgw_user& owner,
+      rgw::sal::Object* obj, const rgw_user& owner,
       const rgw_placement_rule* ptail_placement_rule, uint64_t olh_epoch,
       const std::string& unique_tag) override;
   virtual const std::string& get_compression_type(

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -630,7 +630,7 @@ namespace rgw::sal {
 
   int DBObject::read_attrs(const DoutPrefixProvider* dpp, DB::Object::Read &read_op, optional_yield y, rgw_obj* target_obj)
   {
-    read_op.params.attrs = &attrs;
+    read_op.params.attrs = &state.attrset;
     read_op.params.target_obj = target_obj;
     read_op.params.obj_size = &state.size;
     read_op.params.lastmod = &state.mtime;
@@ -662,8 +662,8 @@ namespace rgw::sal {
       return r;
     }
     set_atomic();
-    attrs[attr_name] = attr_val;
-    return set_obj_attrs(dpp, &attrs, nullptr, y);
+    state.attrset[attr_name] = attr_val;
+    return set_obj_attrs(dpp, &state.attrset, nullptr, y);
   }
 
   int DBObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char* attr_name, optional_yield y)

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1227,21 +1227,20 @@ namespace rgw::sal {
   std::unique_ptr<Writer> DBMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
   {
-    return std::make_unique<DBMultipartWriter>(dpp, y, this,
-				 std::move(_head_obj), store, owner,
+    return std::make_unique<DBMultipartWriter>(dpp, y, this, obj, store, owner,
 				 ptail_placement_rule, part_num, part_num_str);
   }
 
   DBMultipartWriter::DBMultipartWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
                 MultipartUpload* upload,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* obj,
 		        DBStore* _driver,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -1250,7 +1249,7 @@ namespace rgw::sal {
 			store(_driver),
                 owner(_owner),
                 ptail_placement_rule(_ptail_placement_rule),
-                head_obj(std::move(_head_obj)),
+                head_obj(obj),
                 upload_id(upload->get_upload_id()),
                 part_num(_part_num),
                 oid(head_obj->get_name() + "." + upload_id +
@@ -1390,7 +1389,7 @@ namespace rgw::sal {
 
   DBAtomicWriter::DBAtomicWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* _obj,
 		        DBStore* _driver,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -1402,7 +1401,7 @@ namespace rgw::sal {
                 ptail_placement_rule(_ptail_placement_rule),
                 olh_epoch(_olh_epoch),
                 unique_tag(_unique_tag),
-                obj(_driver, _head_obj->get_key(), _head_obj->get_bucket()),
+                obj(_driver, _obj->get_key(), _obj->get_bucket()),
                 op_target(_driver->getDB(), obj.get_bucket()->get_info(), obj.get_obj()),
                 parent_op(&op_target) {}
 
@@ -1579,7 +1578,7 @@ namespace rgw::sal {
 
   std::unique_ptr<Writer> DBStore::get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -1590,13 +1589,12 @@ namespace rgw::sal {
 
   std::unique_ptr<Writer> DBStore::get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag) {
-    return std::make_unique<DBAtomicWriter>(dpp, y,
-                    std::move(_head_obj), this, owner,
+    return std::make_unique<DBAtomicWriter>(dpp, y, obj, this, owner,
                     ptail_placement_rule, olh_epoch, unique_tag);
   }
 

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -515,7 +515,7 @@ protected:
     virtual int get_info(const DoutPrefixProvider *dpp, optional_yield y, rgw_placement_rule** rule, rgw::sal::Attrs* attrs = nullptr) override;
     virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -680,7 +680,7 @@ protected:
     public:
     DBAtomicWriter(const DoutPrefixProvider *dpp,
 	    	    optional_yield y,
-		        std::unique_ptr<rgw::sal::Object> _head_obj,
+		        rgw::sal::Object* obj,
 		        DBStore* _store,
     		    const rgw_user& _owner,
 	    	    const rgw_placement_rule *_ptail_placement_rule,
@@ -711,7 +711,7 @@ protected:
     const rgw_user& owner;
 	const rgw_placement_rule *ptail_placement_rule;
 	uint64_t olh_epoch;
-    std::unique_ptr<rgw::sal::Object> head_obj;
+    rgw::sal::Object* head_obj;
     std::string upload_id;
     int part_num;
     std::string oid; /* object->name() + "." + "upload_id" + "." + part_num */
@@ -729,7 +729,7 @@ protected:
 public:
     DBMultipartWriter(const DoutPrefixProvider *dpp,
 		       optional_yield y, MultipartUpload* upload,
-		       std::unique_ptr<rgw::sal::Object> _head_obj,
+		       rgw::sal::Object* obj,
 		       DBStore* _store,
 		       const rgw_user& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
@@ -880,7 +880,7 @@ public:
           std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
       virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
@@ -888,7 +888,7 @@ public:
 				  uint64_t *cur_accounted_size) override;
       virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -488,38 +488,34 @@ int FilterDriver::get_oidc_providers(const DoutPrefixProvider *dpp,
 
 std::unique_ptr<Writer> FilterDriver::get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  const std::string& unique_tag,
 				  uint64_t position,
 				  uint64_t *cur_accounted_size)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
-  std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, std::move(no),
+  std::unique_ptr<Writer> writer = next->get_append_writer(dpp, y, nextObject(obj),
 							   owner, ptail_placement_rule,
 							   unique_tag, position,
 							   cur_accounted_size);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 std::unique_ptr<Writer> FilterDriver::get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
 				  const std::string& unique_tag)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
-  std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, std::move(no),
+  std::unique_ptr<Writer> writer = next->get_atomic_writer(dpp, y, nextObject(obj),
 							   owner, ptail_placement_rule,
 							   olh_epoch, unique_tag);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 const std::string& FilterDriver::get_compression_type(const rgw_placement_rule& rule)
@@ -1170,19 +1166,17 @@ int FilterMultipartUpload::get_info(const DoutPrefixProvider *dpp,
 std::unique_ptr<Writer> FilterMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
-  std::unique_ptr<Object> no = nextObject(_head_obj.get())->clone();
-
   std::unique_ptr<Writer> writer;
-  writer = next->get_writer(dpp, y, std::move(no), owner,
+  writer = next->get_writer(dpp, y, nextObject(obj), owner,
 			    ptail_placement_rule, part_num, part_num_str);
 
-  return std::make_unique<FilterWriter>(std::move(writer), std::move(_head_obj));
+  return std::make_unique<FilterWriter>(std::move(writer), obj);
 }
 
 int FilterMPSerializer::try_lock(const DoutPrefixProvider *dpp, utime_t dur,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -297,7 +297,7 @@ public:
 				 providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule
 				  *ptail_placement_rule,
@@ -306,7 +306,7 @@ public:
 				  uint64_t *cur_accounted_size) override;
   virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t olh_epoch,
@@ -769,7 +769,7 @@ public:
 
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -881,10 +881,10 @@ public:
 class FilterWriter : public Writer {
 protected:
   std::unique_ptr<Writer> next;
-  std::unique_ptr<Object> head_obj;
+  Object* obj;
 public:
-  FilterWriter(std::unique_ptr<Writer> _next, std::unique_ptr<Object> _head_obj) :
-    next(std::move(_next)), head_obj(std::move(_head_obj)) {}
+  FilterWriter(std::unique_ptr<Writer> _next, Object* _obj) :
+    next(std::move(_next)), obj(_obj) {}
   virtual ~FilterWriter() = default;
 
   virtual int prepare(optional_yield y) { return next->prepare(y); }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -1606,7 +1606,7 @@ int MotrObject::swift_versioning_copy(const DoutPrefixProvider* dpp,
 
 MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
           optional_yield y,
-          std::unique_ptr<rgw::sal::Object> _head_obj,
+          rgw::sal::Object* obj,
           MotrStore* _store,
           const rgw_user& _owner,
           const rgw_placement_rule *_ptail_placement_rule,
@@ -1618,8 +1618,8 @@ MotrAtomicWriter::MotrAtomicWriter(const DoutPrefixProvider *dpp,
               ptail_placement_rule(_ptail_placement_rule),
               olh_epoch(_olh_epoch),
               unique_tag(_unique_tag),
-              obj(_store, _head_obj->get_key(), _head_obj->get_bucket()),
-              old_obj(_store, _head_obj->get_key(), _head_obj->get_bucket()) {}
+              obj(_store, obj->get_key(), obj->get_bucket()),
+              old_obj(_store, obj->get_key(), obj->get_bucket()) {}
 
 static const unsigned MAX_BUFVEC_NR = 256;
 
@@ -2984,14 +2984,14 @@ int MotrMultipartUpload::get_info(const DoutPrefixProvider *dpp, optional_yield 
 std::unique_ptr<Writer> MotrMultipartUpload::get_writer(
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y,
-				  std::unique_ptr<rgw::sal::Object> _head_obj,
+				  rgw::sal::Object* obj,
 				  const rgw_user& owner,
 				  const rgw_placement_rule *ptail_placement_rule,
 				  uint64_t part_num,
 				  const std::string& part_num_str)
 {
   return std::make_unique<MotrMultipartWriter>(dpp, y, this,
-				 std::move(_head_obj), store, owner,
+				 obj, store, owner,
 				 ptail_placement_rule, part_num, part_num_str);
 }
 
@@ -3128,7 +3128,7 @@ std::unique_ptr<MultipartUpload> MotrBucket::get_multipart_upload(const std::str
 
 std::unique_ptr<Writer> MotrStore::get_append_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         const std::string& unique_tag,
@@ -3139,13 +3139,13 @@ std::unique_ptr<Writer> MotrStore::get_append_writer(const DoutPrefixProvider *d
 
 std::unique_ptr<Writer> MotrStore::get_atomic_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         uint64_t olh_epoch,
         const std::string& unique_tag) {
   return std::make_unique<MotrAtomicWriter>(dpp, y,
-                  std::move(_head_obj), this, owner,
+                  obj, this, owner,
                   ptail_placement_rule, olh_epoch, unique_tag);
 }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -792,7 +792,7 @@ class MotrAtomicWriter : public StoreWriter {
   public:
   MotrAtomicWriter(const DoutPrefixProvider *dpp,
           optional_yield y,
-          std::unique_ptr<rgw::sal::Object> _head_obj,
+          rgw::sal::Object* obj,
           MotrStore* _store,
           const rgw_user& _owner,
           const rgw_placement_rule *_ptail_placement_rule,
@@ -827,7 +827,7 @@ protected:
   rgw::sal::MotrStore* store;
 
   // Head object.
-  std::unique_ptr<rgw::sal::Object> head_obj;
+  rgw::sal::Object* head_obj;
 
   // Part parameters.
   const uint64_t part_num;
@@ -838,12 +838,12 @@ protected:
 public:
   MotrMultipartWriter(const DoutPrefixProvider *dpp,
 		       optional_yield y, MultipartUpload* upload,
-		       std::unique_ptr<rgw::sal::Object> _head_obj,
+		       rgw::sal::Object* obj,
 		       MotrStore* _store,
 		       const rgw_user& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
 		       uint64_t _part_num, const std::string& part_num_str) :
-				  StoreWriter(dpp, y), store(_store), head_obj(std::move(_head_obj)),
+				  StoreWriter(dpp, y), store(_store), head_obj(obj),
 				  part_num(_part_num), part_num_str(part_num_str)
   {
   }
@@ -951,7 +951,7 @@ public:
   virtual int get_info(const DoutPrefixProvider *dpp, optional_yield y, rgw_placement_rule** rule, rgw::sal::Attrs* attrs = nullptr) override;
   virtual std::unique_ptr<Writer> get_writer(const DoutPrefixProvider *dpp,
 			  optional_yield y,
-			  std::unique_ptr<rgw::sal::Object> _head_obj,
+			  rgw::sal::Object* obj,
 			  const rgw_user& owner,
 			  const rgw_placement_rule *ptail_placement_rule,
 			  uint64_t part_num,
@@ -1072,7 +1072,7 @@ class MotrStore : public StoreDriver {
         std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         const std::string& unique_tag,
@@ -1080,7 +1080,7 @@ class MotrStore : public StoreDriver {
         uint64_t *cur_accounted_size) override;
     virtual std::unique_ptr<Writer> get_atomic_writer(const DoutPrefixProvider *dpp,
         optional_yield y,
-        std::unique_ptr<rgw::sal::Object> _head_obj,
+        rgw::sal::Object* obj,
         const rgw_user& owner,
         const rgw_placement_rule *ptail_placement_rule,
         uint64_t olh_epoch,

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -169,36 +169,17 @@ class StoreBucket : public Bucket {
 class StoreObject : public Object {
   protected:
     RGWObjState state;
-    Bucket* bucket;
-    Attrs attrs;
+    Bucket* bucket = nullptr;
     bool delete_marker{false};
 
   public:
-
-    struct StoreReadOp : ReadOp {
-      virtual ~StoreReadOp() = default;
-    };
-
-    struct StoreDeleteOp : DeleteOp {
-      virtual ~StoreDeleteOp() = default;
-    };
-
-    StoreObject()
-      : state(),
-      bucket(nullptr),
-      attrs()
-      {}
+    StoreObject() = default;
     StoreObject(const rgw_obj_key& _k)
-      : state(),
-      bucket(),
-      attrs()
-      { state.obj.key = _k; }
+    { state.obj.key = _k; }
     StoreObject(const rgw_obj_key& _k, Bucket* _b)
-      : state(),
-      bucket(_b),
-      attrs()
-      { state.obj.init(_b->get_key(), _k); }
-    StoreObject(StoreObject& _o) = default;
+      : bucket(_b)
+    { state.obj.init(_b->get_key(), _k); }
+    StoreObject(const StoreObject& _o) = default;
 
     virtual ~StoreObject() = default;
 


### PR DESCRIPTION
partial backport of https://github.com/ceph/ceph/pull/50169. it wasn't intended for backport, but resolves a data loss bug introduced during the reef cycle

backport tracker: https://tracker.ceph.com/issues/61454

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
