### PR TITLE
mon: Fix ceph versions command

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3962,8 +3962,8 @@ void Monitor::handle_command(MonOpRequestRef op)
     }
     f->close_section();
 
+    mgrmon()->count_metadata("ceph_version", &mgr);
     if (!mgr.empty()) {
-      mgrmon()->count_metadata("ceph_version", &mgr);
       f->open_object_section("mgr");
       for (auto& p : mgr) {
         f->dump_int(p.first.c_str(), p.second);
@@ -3972,8 +3972,8 @@ void Monitor::handle_command(MonOpRequestRef op)
       f->close_section();
     }
 
+    osdmon()->count_metadata("ceph_version", &osd);
     if (!osd.empty()) {
-      osdmon()->count_metadata("ceph_version", &osd);
       f->open_object_section("osd");
       for (auto& p : osd) {
         f->dump_int(p.first.c_str(), p.second);
@@ -3982,8 +3982,8 @@ void Monitor::handle_command(MonOpRequestRef op)
       f->close_section();
     }
 
+    mdsmon()->count_metadata("ceph_version", &mds);
     if (!mds.empty()) {
-      mdsmon()->count_metadata("ceph_version", &mds);
       f->open_object_section("mds");
       for (auto& p : mds) {
         f->dump_int(p.first.c_str(), p.second);


### PR DESCRIPTION
    The commit-id d3cca1d has introduced a bug where mgr/osd/mds
    version information goes missing during the cluster upgrade.
    Collect version information before checking the emptiness
    of the map.
    
    Fixes: https://tracker.ceph.com/issues/61453
    
    Signed-off-by: Prashant D <pdhange@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
