### PR TITLE
rgw:multisite hang when update and commit period

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -714,6 +714,7 @@ int RGWRemoteDataLog::init(const rgw_zone_id& _source_zone, RGWRESTConn *_conn, 
 
 void RGWRemoteDataLog::finish()
 {
+  http_manager.stop();
   stop();
 }
 


### PR DESCRIPTION
Performing period update and commit will hang http_manager thread, because that http_manager not invoke stop().

https://tracker.ceph.com/issues/61461