### PR TITLE
quincy: os/bluestore: proper override rocksdb::WritableFile::Allocate

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -285,14 +285,12 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
     return rocksdb::Status::OK();
   }
 
-  using rocksdb::WritableFile::RangeSync;
   // Sync a file range with disk.
   // offset is the starting byte of the file range to be synchronized.
   // nbytes specifies the length of the range to be synchronized.
   // This asks the OS to initiate flushing the cached data to disk,
   // without waiting for completion.
-  // Default implementation does nothing.
-  rocksdb::Status RangeSync(off_t offset, off_t nbytes) {
+  rocksdb::Status RangeSync(uint64_t offset, uint64_t nbytes) override {
     // round down to page boundaries
     int partial = offset & 4095;
     offset -= partial;
@@ -304,11 +302,10 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
   }
 
  protected:
-  using rocksdb::WritableFile::Allocate;
   /*
    * Pre-allocate space for a file.
    */
-  rocksdb::Status Allocate(off_t offset, off_t len) {
+  rocksdb::Status Allocate(uint64_t offset, uint64_t len) override {
     int r = fs->preallocate(h->file, offset, len);
     return err_to_status(r);
   }

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10429,6 +10429,8 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixedTest) {
     return;
   }
 
+  SetVal(g_conf(), "bluestore_block_wal_create", "true");
+  SetVal(g_conf(), "bluestore_block_wal_size", stringify(1400ull*1024*1024).c_str());
   SetVal(g_conf(), "bluestore_block_db_create", "true");
   SetVal(g_conf(), "bluestore_block_db_size", "3221225472");
   SetVal(g_conf(), "bluestore_volume_selection_policy", "use_some_extra");
@@ -10457,12 +10459,12 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixed2Test) {
     return;
   }
 
+  SetVal(g_conf(), "bluestore_block_wal_create", "true");
+  SetVal(g_conf(), "bluestore_block_wal_size", stringify(1200ull*1024*1024).c_str());
   SetVal(g_conf(), "bluestore_block_db_create", "true");
-  SetVal(g_conf(), "bluestore_block_db_size", "3221225472");
+  SetVal(g_conf(), "bluestore_block_db_size", stringify(3200ull*1024*1024).c_str());
   SetVal(g_conf(), "bluestore_volume_selection_policy", "use_some_extra");
-  //default 2.0 factor results in too high threshold, using less value
-  // that results in less but still present spillover.
-  SetVal(g_conf(), "bluestore_volume_selection_reserved_factor", "0.5");
+  SetVal(g_conf(), "bluestore_volume_selection_reserved", stringify(2900ull*1024*1024).c_str());
 
   g_conf().apply_changes(nullptr);
 


### PR DESCRIPTION
Failing to do that makes BlueFS file frgmentation higher.

backport of https://github.com/ceph/ceph/pull/50469

backport tracker: https://tracker.ceph.com/issues/61308
parent tracker: https://tracker.ceph.com/issues/58966

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>
(cherry picked from commit 2d8b9e9ed58bca4917b90ea5eaa43264a89dff75)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>

