### PR TITLE
pacific: tools/ceph-dencoder: Fix incorrect type define for trash_watcher

### DIFF
--- a/src/tools/ceph-dencoder/rbd_types.h
+++ b/src/tools/ceph-dencoder/rbd_types.h
@@ -6,7 +6,7 @@ TYPE(librbd::journal::TagData)
 #include "librbd/mirroring_watcher/Types.h"
 TYPE(librbd::mirroring_watcher::NotifyMessage)
 #include "librbd/trash_watcher/Types.h"
-TYPE(librbd::mirroring_watcher::NotifyMessage)
+TYPE(librbd::trash_watcher::NotifyMessage)
 #include "librbd/WatchNotifyTypes.h"
 TYPE_NOCOPY(librbd::watch_notify::NotifyMessage)
 TYPE(librbd::watch_notify::ResponseMessage)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61422

---

backport of https://github.com/ceph/ceph/pull/51749
parent tracker: https://tracker.ceph.com/issues/61368