### PR TITLE
quincy: test: correct osd pool default size

### DIFF
--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -16,7 +16,7 @@ override:
   ceph:
     conf:
       mon:
-        osd default pool size: 3
+        osd pool default size: 3
         osd min pg log entries: 5
         osd max pg log entries: 10
 tasks:

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -12,11 +12,11 @@ openstack:
   - volumes: # attached to each instance
       count: 3
       size: 10 # GB
-override:
+overrides:
   ceph:
     conf:
       mon:
-        osd default pool size: 3
+        osd pool default size: 3
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61449

---

backport of https://github.com/ceph/ceph/pull/51527
parent tracker: https://tracker.ceph.com/issues/49888

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh