### PR TITLE
rgw: D3N: cache objects which oid contains slash

### DIFF
--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -48,7 +48,7 @@ struct D3nCacheAioWriteRequest {
 	CephContext *cct;
 
 	D3nCacheAioWriteRequest(CephContext *_cct) : cct(_cct) {}
-	int d3n_prepare_libaio_write_op(bufferlist& bl, unsigned int len, std::string oid, std::string cache_location);
+	int d3n_libaio_prepare_write_op(bufferlist& bl, unsigned int len, std::string oid, std::string cache_location);
 
   ~D3nCacheAioWriteRequest() {
     ::close(fd);

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -102,13 +102,13 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
 }
 
 
-Aio::OpFunc d3n_cache_aio_abstract(const DoutPrefixProvider *dpp, optional_yield y, off_t read_ofs, off_t read_len, std::string& location) {
-  return [dpp, y, read_ofs, read_len, location] (Aio* aio, AioResult& r) mutable {
+Aio::OpFunc d3n_cache_aio_abstract(const DoutPrefixProvider *dpp, optional_yield y, off_t read_ofs, off_t read_len, std::string& cache_location) {
+  return [dpp, y, read_ofs, read_len, cache_location] (Aio* aio, AioResult& r) mutable {
     // d3n data cache requires yield context (rgw_beast_enable_async=true)
     ceph_assert(y);
     auto c = std::make_unique<D3nL1CacheRequest>();
     lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: d3n_cache_aio_abstract(): libaio Read From Cache, oid=" << r.obj.oid << dendl;
-    c->file_aio_read_abstract(dpp, y.get_io_context(), y.get_yield_context(), location, read_ofs, read_len, aio, r);
+    c->file_aio_read_abstract(dpp, y.get_io_context(), y.get_yield_context(), cache_location, read_ofs, read_len, aio, r);
   };
 }
 
@@ -139,8 +139,8 @@ Aio::OpFunc Aio::librados_op(librados::IoCtx ctx,
 }
 
 Aio::OpFunc Aio::d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
-                              off_t read_ofs, off_t read_len, std::string& location) {
-  return d3n_cache_aio_abstract(dpp, y, read_ofs, read_len, location);
+                              off_t read_ofs, off_t read_len, std::string& cache_location) {
+  return d3n_cache_aio_abstract(dpp, y, read_ofs, read_len, cache_location);
 }
 
 } // namespace rgw

--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -48,14 +48,14 @@ struct D3nL1CacheRequest {
     using Signature = void(boost::system::error_code, bufferlist);
     using Completion = ceph::async::Completion<Signature, AsyncFileReadOp>;
 
-    int init(const DoutPrefixProvider *dpp, const std::string& file_path, off_t read_ofs, off_t read_len, void* arg) {
-      ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): file_path=" << file_path << dendl;
+    int init_async_read(const DoutPrefixProvider *dpp, const std::string& location, off_t read_ofs, off_t read_len, void* arg) {
+      ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
       aio_cb.reset(new struct aiocb);
       memset(aio_cb.get(), 0, sizeof(struct aiocb));
-      aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
+      aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(location.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
       if(aio_cb->aio_fildes < 0) {
         int err = errno;
-        ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << file_path << " : " << cpp_strerror(err) << dendl;
+        ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << location << " : " << cpp_strerror(err) << dendl;
         return -err;
       }
       if (g_conf()->rgw_d3n_l1_fadvise != POSIX_FADV_NORMAL)
@@ -96,7 +96,7 @@ struct D3nL1CacheRequest {
   };
 
   template <typename ExecutionContext, typename CompletionToken>
-  auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& file_path,
+  auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& location,
                   off_t read_ofs, off_t read_len, CompletionToken&& token) {
     using Op = AsyncFileReadOp;
     using Signature = typename Op::Signature;
@@ -104,8 +104,8 @@ struct D3nL1CacheRequest {
     auto p = Op::create(ctx.get_executor(), init.completion_handler);
     auto& op = p->user_data;
 
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): file_path=" << file_path << dendl;
-    int ret = op.init(dpp, file_path, read_ofs, read_len, p.get());
+    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
+    int ret = op.init_async_read(dpp, location, read_ofs, read_len, p.get());
     if(0 == ret) {
       ret = ::aio_read(op.aio_cb.get());
     }
@@ -131,14 +131,14 @@ struct D3nL1CacheRequest {
   };
 
   void file_aio_read_abstract(const DoutPrefixProvider *dpp, boost::asio::io_context& context, yield_context yield,
-                              std::string& file_path, off_t read_ofs, off_t read_len,
+                              std::string& cache_location, off_t read_ofs, off_t read_len,
                               rgw::Aio* aio, rgw::AioResult& r) {
     using namespace boost::asio;
     async_completion<yield_context, void()> init(yield);
     auto ex = get_associated_executor(init.completion_handler);
 
     ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << r.obj.oid << dendl;
-    async_read(dpp, context, file_path+"/"+r.obj.oid, read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
+    async_read(dpp, context, cache_location+"/"+url_encode(r.obj.oid, true), read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
   }
 
 };


### PR DESCRIPTION

allow D3N caching of objects names for example:
```
sudo ./bin/rados ls -p default.rgw.buckets.data
...
ec43cdb3-59d1-4304-8511-9a3c180f048b.4231.3__shadow_warehouse/cephs3/parkingcitations/parkingcitations_5.csv.2~wcGD_MF_W9hEBAV8x3l9uHKHKQC5_mn.88_1
ec43cdb3-59d1-4304-8511-9a3c180f048b.4231.3__shadow_warehouse/cephs3/parkingcitations/parkingcitations_2.csv.2~eJyQZhfiayNv9Z-27_IfUb4mDwQnSmv.4_1
ec43cdb3-59d1-4304-8511-9a3c180f048b.4231.3__shadow_warehouse/cephs3/parkingcitations/parkingcitations_3.csv.2~VY905gVNZ-nXxfBLgko84z1TUv_c74f.85_
                                                             ^      ^
```

and refactor to clean up the D3N storage location variables for uniformity.
(manual testing for the correctness of cache _writing->reading->expiration_ were performed)


Fixes: https://tracker.ceph.com/issues/59739

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
