### PR TITLE
common/options: Update RocksDB CF Tuning

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4964,7 +4964,7 @@ options:
   type: str
   level: advanced
   desc: Full set of rocksdb settings to override
-  default: compression=kNoCompression,max_write_buffer_number=128,min_write_buffer_number_to_merge=16,compaction_style=kCompactionStyleLevel,write_buffer_size=8388608,max_background_jobs=4,level0_file_num_compaction_trigger=8,max_bytes_for_level_base=1073741824,max_bytes_for_level_multiplier=8,compaction_readahead_size=2MB,max_total_wal_size=1073741824,writable_file_max_buffer_size=0,ttl=21600
+  default: compression=kNoCompression,max_write_buffer_number=64,min_write_buffer_number_to_merge=6,compaction_style=kCompactionStyleLevel,write_buffer_size=16777216,max_background_jobs=4,level0_file_num_compaction_trigger=8,max_bytes_for_level_base=1073741824,max_bytes_for_level_multiplier=8,compaction_readahead_size=2MB,max_total_wal_size=1073741824,writable_file_max_buffer_size=0
   with_legacy: true
 - name: bluestore_rocksdb_options_annex
   type: str
@@ -5010,7 +5010,7 @@ options:
     The optimal value depends on multiple factors, and modification is invadvisable.
     This setting is used only when OSD is doing ``--mkfs``.
     Next runs of OSD retrieve sharding from disk.
-  default: m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P
+  default: m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L=min_write_buffer_number_to_merge=32 P=min_write_buffer_number_to_merge=32
 - name: bluestore_qfsck_on_mount
   type: bool
   level: dev


### PR DESCRIPTION
In #47221 we updated the bluestore RocksDB Tunings to reduce overhead in the bluestore kv sync thread and improve small random write performance.  In the original testing we saw a slight write-amp increase, but it was far lower than in previous testing of similar options:

https://ceph.io/en/news/blog/2022/rocksdb-tuning-deep-dive/

Recently in rate-limited testing performed by Paul Cuzner at IBM, Paul observed higher CPU overhead in RocksDB get requests via extentmap::fault_range along with higher IOPS amplification on the underlying devices.  Last week I was able to replicate those findings by running similar tests on the upstream mako cluster.  Reverting back to the quincy rocksdb defaults reduced the disk write-amplification, but also lowered 4K IOPS (in rate unlimited tests), increased latency, and especially increased 99% tail latency.  This is the historic problem we've faced with RocksDB.  On one hand we want to hold onto pgmeta data long enough that tombstones prevent pglog entries from entering the database.  On the other hand, we don't want to hold onto any data longer than we have to because this increases the work that RocksDB has to do in the bstore_kv_sync thread to keep records in sorted order.  Sadly the new tuning in #47221 didn't reduce leakage of pgmeta data into the database when using small memtables as much as I initially thought.

The good news is that back in 2021 we laid the groundwork in PR #38855 to separate pgmeta data into a separate column family, allowing us to potentially tune pgmeta and deferred column families differently than other CFs: Mainly onode data.  In an attempt to retain the benefits of the new reef rocksdb tunings with the write-amplification behavior the old settings, we specifically tune the pgmeta and deferred column families to retain a large amount of data in memtables before flushing them, while doubling down on quickly flushing other column families (mainly onode) to help reduce the amount of work being done in the bstore_kv_sync thread.

The RocksDB behavior overall looks much closer to Quincy:

rate-limited tests mimicking Paul Cuzner's testing:

Compaction Statistics | v17.2.6 (librbd) | v17.2.6 (krbd) | v17.2.6 (kcephfs) | reef (librbd) | reef (krbd) | reef (kcephfs) | reef new (librbd) | reef new (krbd) | reef new (kcephfs)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Total OSD Log Duration (seconds) | 3174.725 | 3660.688 | 3352.91 | 3187.756 | 3753.734 | 3360.273 | 3174.826 | 3676.494 | 3331.977
Number of Compaction Events | 79 | 72 | 62 | 108 | 103 | 93 | 58 | 51 | 42
Avg Compaction Time (seconds) | 1.2 | 1.5 | 1.5 | 1.9 | 2.1 | 2.1 | 1.6 | 1.9 | 2.1
Total Compaction Time (seconds) | 91.6 | 104.6 | 92.7 | 207.6 | 218.7 | 194.5 | 95.0 | 99.2 | 88.4
Avg Output Size: (MB) | 143.3 | 171.6 | 172.2 | 258.5 | 284.1 | 282.0 | 192.6 | 240.1 | 240.3
Total Output Size: (MB) | 11316.9 | 12352.8 | 10678.4 | 27918.6 | 29263.2 | 26229.4 | 11168.5 | 12244.9 | 10092.4
Total Input Records | 172517209 | 183830873 | 172921746 | 341281440 | 354601953 | 330362204 | 151630197 | 159038412 | 143201639
Total Output Records | 106776939 | 114160771 | 107240383 | 266427868 | 278340843 | 258230363 | 83881563 | 86861138 | 76251202
Avg Output Throughput (MB/s) | 115.2 | 133.2 | 128.3 | 125.1 | 134.5 | 135.5 | 100.0 | 128.4 | 118.1
Avg Input Records/second | 1551454.4 | 1759918.6 | 1915039.9 | 1496781.8 | 1605701.4 | 1682837.4 | 1182177.6 | 1396317.2 | 1466980.0
Avg Output Records/second | 802347.3 | 906671.3 | 990708.0 | 1151879.9 | 1255532.3 | 1311169.5 | 620226.0 | 719748.2 | 748543.6
Avg Output/Input Ratio | 0.51 | 0.50 | 0.51 | 0.69 | 0.72 | 0.73 | 0.44 | 0.45 | 0.45

And in full-speed tests:

Compaction Statistics | Reef - New Tuning | Reef - Original Tuning | v17.2.6 - Stock
-- | -- | -- | --
Total OSD Log Duration (seconds) | 11478.59 | 11520.46 | 11490.44
Number of Compaction Events | 200 | 412 | 254
Avg Compaction Time (seconds) | 2.47 | 2.81 | 1.96
Total Compaction Time (seconds) | 494.62 | 1158.81 | 499.10
Avg Output Size: (MB) | 205.04 | 268.45 | 129.98
Total Output Size: (MB) | 41007.52 | 110602.42 | 33015.77
Total Input Records | 615400246 | 1381251268 | 646524292
Total Output Records | 348137162 | 1103275376 | 413326509
Avg Output Throughput (MB/s) | 85.78 | 94.76 | 79.52
Avg Input Records/second | 1100049.03 | 1156592.64 | 1397685.03
Avg Output Records/second | 556637.88 | 884706.70 | 710541.65
Avg Output/Input Ratio | 0.44 | 0.72 | 0.51

However, the new tuning is showing the same 4K random write performance improvement as the existing reef tuning, along with better latency and significantly better tail latencies in the rate limited tests (though not as good as the original reef tuning).  While performance in the rate-unlimited 4K random write tests showed the same improvement vs Quincy as the original tuning, tail latencies were only slightly better than the Quincy tuning.  The original reef tuning is still superior in this regard.

Overall this PR is expected to reduce write-amplification in RocksDB to being closer to Quincy levels while retaining most of the benefits of the original Reef tunings.

Overview of the specific changes:

1. Remove ttl=21600.  This was added in reef to help combat the tombstone iteration issues we've had, but tends to introduce write-amplification over time.  With the introduction of the compact-on-iteration feature in #47221, this no longer appears to be needed based on community testing and feedback.  We'll no longer introduce this as a default behavior in Reef.
2. Switch from max 128 8MB to max 64 16MB buffers.  This had a very slight latency reduction in the rate-limited tests while still allowing for fine tuning of the write-amplification (such as increasing the number of memtables to fill before flushing).  Jumping to 32 32MB buffers slightly hurt the unlimited rate tests so we stick with 16MB buffers.
3. Switch the default min_write_buffer_number_to_merge from 16 8MB buffers to 6 16MB buffers.  This primarily affects the onode column families.  This is set even lower than the Reef defaults to help offset the other change we are going to make for the pgmeta and deferred write column families.  If we want to lower write-amplification (potentially at the expense of higher CPU in the bstore_kv_sync thread, higher tail latency, and lower 4K randwrite IOPS), we can increase this to 7 or 8 buffers.
4. For the pgmeta (P) and deferred (L) column families, set the min_write_buffer_number_to_merge to 32 16MB buffers.  This allows more data to accumulate in the memtables and leak less of these kinds of writes into the database since they are both generally short lived.

Detailed performance data for Quincy, the original Reef tuning, and this change is available:

Tests to mimic Paul Cuzner's rate-limited mixed-workload tests:
https://docs.google.com/spreadsheets/d/1HFFn0dAqLazLe8AYIUum5r8zHDBFzxEpZRu8OveT9K4/edit?usp=sharing

Rate-Unlimited Tests:
https://docs.google.com/spreadsheets/d/1srz_vY0_cllgRWxQb1UyzdMw2F1iaIfD-AT1E9Paqpo/edit?usp=sharing

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
