### PR TITLE
mgr/dashboard: allow embedding of dashboard when url is set

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/_auth.py
+++ b/src/pybind/mgr/dashboard/controllers/_auth.py
@@ -1,5 +1,6 @@
 import cherrypy
 
+from .. import mgr
 
 class ControllerAuthMixin:
     @staticmethod
@@ -10,9 +11,12 @@ class ControllerAuthMixin:
 
     @staticmethod
     def _set_token_cookie(url_prefix, token):
+        allow_embedding_url = mgr.get_module_option('allow_embedding_url', '')
         cherrypy.response.cookie['token'] = token
         if url_prefix == 'https':
             cherrypy.response.cookie['token']['secure'] = True
         cherrypy.response.cookie['token']['HttpOnly'] = True
         cherrypy.response.cookie['token']['path'] = '/'
         cherrypy.response.cookie['token']['SameSite'] = 'Strict'
+        if url_prefix == 'https' and allow_embedding_url and allow_embedding_url != 'None':
+            cherrypy.response.cookie['token']['SameSite'] = 'None'

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -16,7 +16,6 @@ from .access_control import LocalAuthenticator, UserDoesNotExist
 
 cherrypy.config.update({
     'response.headers.server': 'Ceph-Dashboard',
-    'response.headers.content-security-policy': "frame-ancestors 'self';",
     'response.headers.x-content-type-options': 'nosniff',
     'response.headers.strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
 })


### PR DESCRIPTION
Allow Embedding when URL is set in config_opt

you have to update the `allow_embedding_url` with the url of the requesting entity.

The url can be set using
`ceph dashboard set-embed-urls https://localhost:4200`

Multiple urls can be set using
`ceph dashboard set-embed-urls 'https://localhost:4200
https://localhost:4202'`

And dump all the urls using
`ceph dashboard get-embed-urls`




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
