### PR TITLE
doc/rgw: fix multisite resharding feature to say Reef instead of Quincy

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1577,7 +1577,7 @@ Supported Features
 +---------------------------+---------+
 | Feature                   | Release |
 +===========================+=========+
-| :ref:`feature_resharding` | Quincy  |
+| :ref:`feature_resharding` | Reef    |
 +---------------------------+---------+
 
 .. _feature_resharding:


### PR DESCRIPTION
will need reef backport

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
