### PR TITLE
doc: update the cephadm download instructions

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -171,6 +171,45 @@ A successful ``which cephadm`` command will return this:
 
    /usr/sbin/cephadm
 
+* Although the standalone cephadm is sufficient to get a cluster started, it is
+  convenient to have the ``cephadm`` command installed on the host.  To install
+  the packages that provide the ``cephadm`` command, run the following
+  commands:
+
+update cephadm
+--------------
+
+The cephadm binary can be used to bootstrap a cluster and for a variety
+of other management and debugging tasks. The Ceph team strongly recommends
+using an actively supported version of cephadm. Additionally, although
+the standalone cephadm is sufficient to get a cluster started, it is
+convenient to have the ``cephadm`` command installed on the host. Older or LTS
+distros may also have ``cephadm`` packages that are out-of-date and
+running the commands below can help install a more recent version
+from the Ceph project's repositories.
+
+To install the packages provided by the Ceph project that provide the
+``cephadm`` command, run the following commands:
+
+.. prompt:: bash #
+   :substitutions:
+
+   ./cephadm add-repo --release |stable-release|
+   ./cephadm install
+
+Confirm that ``cephadm`` is now in your PATH by running ``which`` or
+``command -v``:
+
+.. prompt:: bash #
+
+   which cephadm
+
+A successful ``which cephadm`` command will return this:
+
+.. code-block:: bash
+
+   /usr/sbin/cephadm
+
 
 
 Bootstrap a new cluster


### PR DESCRIPTION
Starting with reef, cephadm is a compiled (zipapp) python application. The cephadm script has been renamed and thus the old curl-based download instructions will no loner work. While cephadm still has no dependencies outside the Python stdlib, this will be changed in future versions so it is no longer appropriate to just download the source file of cephadm and run it either.

This change updates the `Install cephadm` section of the doc to explain how to acquire a "compiled" version of cephadm as well as:
* moving and tweaking the note that the two installation methods are distinct
* adding a new note linking to instructions on building cephadm
* moving the distribution-specific installations before the curl-based installation to subtly hint that we prefer you to get it using packages if you can
* Noting cephadm's minimal required python verision and how to run it with a particular python version.

Signed-off-by: John Mulligan <jmulligan@redhat.com>
(cherry picked from commit d11cf0e82aab8d4cef9d423e5d463a373eaf383a)

doc: make instructions to get an updated cephadm common

As discussed in person and over the ceph orch weekly, we want all users to use a recent supported version of cephadm. Previously, the instructions only had those downloading cephadm with curl using the "add-repo" and "install" commands to get a up-to-date cephadm build. According to ADK we've seen cases of users get "old" distro packages in the past. Change the instructions so that the "update cephadm" steps are common after acquiring a "bootstrap copy" of cephadm.

Signed-off-by: John Mulligan <jmulligan@redhat.com>
(cherry picked from commit d7921e88d69b4bc355da9c0327cc33e59e7d7abb)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
