### PR TITLE
client: ignore the MAY_READ access mode check if __FMODE_EXEC is set

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6083,7 +6083,7 @@ out:
 
 int Client::may_open(Inode *in, int flags, const UserPerm& perms)
 {
-  ldout(cct, 20) << __func__ << " " << *in << "; " << perms << dendl;
+  ldout(cct, 20) << __func__ << " " << *in << "; flags " << flags << " " << perms << dendl;
   unsigned want = 0;
 
   if ((flags & O_ACCMODE) == O_WRONLY)
@@ -6094,6 +6094,10 @@ int Client::may_open(Inode *in, int flags, const UserPerm& perms)
     want = CLIENT_MAY_READ;
   if (flags & O_TRUNC)
     want |= CLIENT_MAY_WRITE;
+
+  if (flags & CEPH_O_FMODE_EXEC) {
+    want &= ~MAY_READ;
+  }
 
   int r = 0;
   switch (in->mode & S_IFMT) {
@@ -6169,7 +6173,8 @@ out:
   return r;
 }
 
-int Client::may_delete(const char *relpath, const UserPerm& perms) {
+int Client::may_delete(const char *relpath, const UserPerm& perms)
+{
   ldout(cct, 20) << __func__ << " " << relpath << "; " << perms << dendl;
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
@@ -15542,7 +15547,7 @@ int Client::ll_open(Inode *in, int flags, Fh **fhp, const UserPerm& perms)
 
   vinodeno_t vino = _get_vino(in);
 
-  ldout(cct, 3) << "ll_open " << vino << " " << ceph_flags_sys2wire(flags) << dendl;
+  ldout(cct, 3) << "ll_open " << vino << " " << ceph_flags_sys2wire(flags) << " flags: " << flags << dendl;
   tout(cct) << "ll_open" << std::endl;
   tout(cct) << vino.ino.val << std::endl;
   tout(cct) << ceph_flags_sys2wire(flags) << std::endl;

--- a/src/common/ceph_fs.cc
+++ b/src/common/ceph_fs.cc
@@ -78,6 +78,7 @@ int ceph_flags_sys2wire(int flags)
        ceph_sys2wire(O_TRUNC);
 
        #ifndef _WIN32
+       ceph_sys2wire(O_FMODE_EXEC);
        ceph_sys2wire(O_DIRECTORY);
        ceph_sys2wire(O_NOFOLLOW);
        // In some cases, FILE_FLAG_BACKUP_SEMANTICS may be used instead

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -464,12 +464,15 @@ extern const char *ceph_mds_op_name(int op);
 #define CEPH_O_RDONLY          00000000
 #define CEPH_O_WRONLY          00000001
 #define CEPH_O_RDWR            00000002
+#define CEPH_O_FMODE_EXEC      00000040
 #define CEPH_O_CREAT           00000100
 #define CEPH_O_EXCL            00000200
 #define CEPH_O_TRUNC           00001000
 #define CEPH_O_LAZY            00020000
 #define CEPH_O_DIRECTORY       00200000
 #define CEPH_O_NOFOLLOW        00400000
+
+#define O_FMODE_EXEC           CEPH_O_FMODE_EXEC
 
 int ceph_flags_sys2wire(int flags);
 


### PR DESCRIPTION
The execlp(),etc system call will ignore the 'r' permission in VFS,
and allowed a file without 'r' permission still could be excuted if
'x' is set.

The kernel VFS and FUSE will pass the 'O_READONLY | __FMODE_EXEC' to
libcephfs in the open_flags when opening the file and if the
'fuse_default_permissions' option is disabled we can check the
'__FMODE_EXEC' flags. If '__FMODE_EXEC' is set then we should ignore
the 'r' permissio check.

Fixes: https://tracker.ceph.com/issues/61501
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
