### PR TITLE
pacific: librbd: avoid decrementing iterator before first element

### DIFF
--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -105,7 +105,8 @@ bool SimpleSchedulerObjectDispatch<I>::ObjectRequests::try_delay_request(
 
     // try to merge back to an existing request
     iter = m_delayed_requests.lower_bound(object_off);
-    if (iter == m_delayed_requests.end() || iter->first > object_off) {
+    if (iter != m_delayed_requests.begin() &&
+        (iter == m_delayed_requests.end() || iter->first > object_off)) {
       iter--;
     }
     if (iter != m_delayed_requests.end() &&


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61525

---

backport of https://github.com/ceph/ceph/pull/51828
parent tracker: https://tracker.ceph.com/issues/61503

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh