### PR TITLE
crimson/osd: Introduce maybe_handle_osd_maps ()

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1009,7 +1009,7 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
 	return seastar::now();
       }
     });
-  }).then([m, this] {
+  }).then([m, this, first, last] {
     if (osdmap->is_up(whoami)) {
       const auto up_from = osdmap->get_up_from(whoami);
       logger().info("osd.{}: map e {} marked me up: up_from {}, bind_epoch {}, state {}",
@@ -1032,9 +1032,11 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
 	return seastar::now();
       }
     }
-    return check_osdmap_features().then([this] {
+    return check_osdmap_features().then([this, first, last] {
       // yay!
-      return pg_shard_manager.broadcast_map_to_pgs(osdmap->get_epoch());
+      logger().info("osd.{}: committed_osd_maps: broadcasting osdmaps of {}"
+                    " through {} to pgs", whoami, first, last);
+      return pg_shard_manager.broadcast_map_to_pgs(first -1, last);
     });
   }).then([m, this] {
     if (pg_shard_manager.is_active()) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -707,7 +707,7 @@ OSD::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
                                                 m=std::move(m), &dispatched] {
     switch (m->get_type()) {
     case CEPH_MSG_OSD_MAP:
-      return handle_osd_map(conn, boost::static_pointer_cast<MOSDMap>(m));
+      return maybe_handle_osd_maps(conn, boost::static_pointer_cast<MOSDMap>(m));
     case CEPH_MSG_OSD_OP:
       return handle_osd_op(conn, boost::static_pointer_cast<MOSDOp>(m));
     case MSG_OSD_PG_CREATE2:
@@ -853,8 +853,58 @@ bool OSD::require_mon_peer(crimson::net::Connection *conn, Ref<Message> m)
   return true;
 }
 
-seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
-                                      Ref<MOSDMap> m)
+interval_set<epoch_t> OSD::calc_new_osd_maps(
+  epoch_t origin_first,
+  epoch_t origin_last)
+{
+  interval_set<epoch_t> origin_epochs;
+  logger().info("{} first {} last {} handled {}",
+                __func__, origin_first,
+                origin_last, handled_epochs);
+  origin_epochs.insert(origin_first,
+                       origin_last - origin_first + 1);
+  logger().info("{} message's epochs {}", __func__, origin_epochs);
+  interval_set<epoch_t> old_epochs;
+  old_epochs.intersection_of(handled_epochs, origin_epochs);
+  logger().info("{} already handled epochs {}", __func__, old_epochs);
+  // new ones
+  origin_epochs.subtract(old_epochs);
+  logger().info("{} new epochs {}", __func__, origin_epochs);
+  logger().info("{} returning first {} last {} new epochs: {}",
+                __func__, origin_epochs.begin().get_start(),
+                origin_epochs.begin().get_end() - 1,
+                !origin_epochs.empty());
+  return origin_epochs;
+}
+
+seastar::future<> OSD::maybe_handle_osd_maps(crimson::net::ConnectionRef conn,
+                                             Ref<MOSDMap> m)
+{
+  logger().info("{} ", __func__);
+  interval_set<epoch_t> to_handle =
+    calc_new_osd_maps(m->get_first(), m->get_last());
+  //todo: is it safe to assume that we will at most
+  //      have one continuous interval to handle?
+  logger().info("{} num intervals to handle {}",
+                __func__, to_handle.num_intervals());
+  std::vector<seastar::future<>> futures;
+  for (auto it = to_handle.begin(); it != to_handle.end(); ++it) {
+    logger().info("{} will handle - first: {} last: {}",
+                  __func__, it.get_start(),
+                  it.get_end() - 1);
+    futures.push_back(
+      _handle_osd_map(conn, m, it.get_start(), it.get_end() - 1)
+    );
+  }
+  return seastar::do_with(std::move(futures), [] (auto& futures) {
+    return seastar::when_all_succeed(futures.begin(), futures.end());
+  });
+}
+
+seastar::future<> OSD::_handle_osd_map(crimson::net::ConnectionRef conn,
+                                      Ref<MOSDMap> m,
+                                      epoch_t first,
+                                      epoch_t last)
 {
   logger().info("handle_osd_map {}", *m);
   if (m->fsid != superblock.cluster_fsid) {
@@ -865,9 +915,6 @@ seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
     logger().warn("i am still initializing");
     return seastar::now();
   }
-
-  const auto first = m->get_first();
-  const auto last = m->get_last();
   logger().info("handle_osd_map epochs [{}..{}], i have {}, src has [{}..{}]",
                 first, last, superblock.newest_map,
                 m->cluster_osdmap_trim_lower_bound, m->newest_map);
@@ -897,9 +944,16 @@ seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
     start = first;
   }
 
+  interval_set<epoch_t> handled;
+  handled.insert(start, last - start + 1);
+  logger().info("handle_osd_map uniting handled {}"
+                " with {}",
+                handled_epochs, handled);
+  handled_epochs.union_of(handled);
+
   return seastar::do_with(ceph::os::Transaction{},
                           [=, this](auto& t) {
-    return pg_shard_manager.store_maps(t, start, m).then([=, this, &t] {
+    return pg_shard_manager.store_maps(t, start, last, m).then([=, this, &t] {
       // even if this map isn't from a mon, we may have satisfied our subscription
       monc->sub_got("osdmap", last);
       if (!superblock.oldest_map || skip_maps) {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -88,6 +88,12 @@ class OSD final : public crimson::net::Dispatcher,
   //< since when there is no more pending pg creates from mon
   epoch_t last_pg_create_epoch = 0;
 
+  interval_set<epoch_t> handled_epochs;
+
+  interval_set<epoch_t> calc_new_osd_maps(
+    epoch_t origin_first,
+    epoch_t origin_last);
+
   ceph::mono_time startup_time;
 
   OSDSuperblock superblock;
@@ -166,8 +172,12 @@ private:
 
   bool require_mon_peer(crimson::net::Connection *conn, Ref<Message> m);
 
-  seastar::future<> handle_osd_map(crimson::net::ConnectionRef conn,
-                                   Ref<MOSDMap> m);
+  seastar::future<> maybe_handle_osd_maps(crimson::net::ConnectionRef conn,
+                                         Ref<MOSDMap> m);
+  seastar::future<> _handle_osd_map(crimson::net::ConnectionRef conn,
+                                   Ref<MOSDMap> m,
+                                   epoch_t first,
+                                   epoch_t last);
   seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
 				     Ref<MOSDPGCreate2> m);
   seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -30,8 +30,8 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
                     osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
     read_errorator::all_same_way([e] {
-      throw std::runtime_error(fmt::format("read gave enoent on {}",
-                                           osdmap_oid(e)));
+      ceph_abort_msg(fmt::format("{} read gave enoent on {}",
+                                 __func__, osdmap_oid(e)));
     }));
 }
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -35,7 +35,7 @@ void PGAdvanceMap::print(std::ostream &lhs) const
 {
   lhs << "PGAdvanceMap("
       << "pg=" << pg->get_pgid()
-      << " from=" << (from ? *from : -1)
+      << " from=" << from
       << " to=" << to;
   if (do_init) {
     lhs << " do_init";
@@ -47,9 +47,7 @@ void PGAdvanceMap::dump_detail(Formatter *f) const
 {
   f->open_object_section("PGAdvanceMap");
   f->dump_stream("pgid") << pg->get_pgid();
-  if (from) {
-    f->dump_int("from", *from);
-  }
+  f->dump_int("from", from);
   f->dump_int("to", to);
   f->dump_bool("do_init", do_init);
   f->close_section();
@@ -73,9 +71,9 @@ seastar::future<> PGAdvanceMap::start()
       });
     }
     return fut.then([this] {
-      ceph_assert(std::cmp_less_equal(*from, to));
+      ceph_assert(std::cmp_less_equal(from, to));
       return seastar::do_for_each(
-	boost::make_counting_iterator(*from + 1),
+	boost::make_counting_iterator(from + 1),
 	boost::make_counting_iterator(to + 1),
 	[this](epoch_t next_epoch) {
 	  logger().debug("{}: start: getting map {}",

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -29,8 +29,7 @@ protected:
   Ref<PG> pg;
   PipelineHandle handle;
 
-  std::optional<epoch_t> from;
-  epoch_t to;
+  const epoch_t from, to;
 
   PeeringCtx rctx;
   const bool do_init;

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -37,7 +37,7 @@ protected:
 
 public:
   PGAdvanceMap(
-    ShardServices &shard_services, Ref<PG> pg, epoch_t to,
+    ShardServices &shard_services, Ref<PG> pg, epoch_t from, epoch_t to,
     PeeringCtx &&rctx, bool do_init);
   ~PGAdvanceMap();
 

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -54,6 +54,9 @@ seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
 
 template <OSDMapGateType OSDMapGateTypeV>
 void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
+  if (current >= epoch) {
+    return;
+  }
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -535,7 +535,7 @@ void PG::on_active_advmap(const OSDMapRef &osdmap)
     }
     logger().info("{}: {} new removed snaps {}, snap_trimq now{}",
                   *this, __func__, it->second, snap_trimq);
-    assert(!bad || local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
+    assert(!bad || !local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
   }
 }
 

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -321,7 +321,7 @@ public:
     return get_osd_singleton_state().pg_to_shard_mapping.get_num_pgs();
   }
 
-  seastar::future<> broadcast_map_to_pgs(epoch_t epoch);
+  seastar::future<> broadcast_map_to_pgs(epoch_t from, epoch_t to);
 
   template <typename F>
   auto with_pg(spg_t pgid, F &&f) {

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -211,7 +211,7 @@ public:
 	      auto &&trigger) {
 	    return shard_services.get_or_create_pg(
 	      std::move(trigger),
-	      opref.get_pgid(), opref.get_epoch(),
+	      opref.get_pgid(),
 	      std::move(opref.get_create_info())
 	    );
 	  }).safe_then([&logger, &shard_services, &opref](Ref<PG> pgref) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -406,14 +406,14 @@ seastar::future<std::map<epoch_t, bufferlist>> OSDSingletonState::load_map_bls(
 seastar::future<std::unique_ptr<OSDMap>> OSDSingletonState::load_map(epoch_t e)
 {
   auto o = std::make_unique<OSDMap>();
-  if (e > 0) {
-    return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
-      o->decode(bl);
-      return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
-    });
-  } else {
+  logger().info("{} osdmap.{}", __func__, e);
+  if (e == 0) {
     return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
   }
+  return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
+    o->decode(bl);
+    return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
+  });
 }
 
 seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -412,11 +412,11 @@ seastar::future<std::unique_ptr<OSDMap>> OSDSingletonState::load_map(epoch_t e)
 }
 
 seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
-                                  epoch_t start, Ref<MOSDMap> m)
+                                  epoch_t start, epoch_t last, Ref<MOSDMap> m)
 {
   return seastar::do_for_each(
     boost::make_counting_iterator(start),
-    boost::make_counting_iterator(m->get_last() + 1),
+    boost::make_counting_iterator(last + 1),
     [&t, m, this](epoch_t e) {
       if (auto p = m->maps.find(e); p != m->maps.end()) {
 	auto o = std::make_unique<OSDMap>();

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -612,7 +612,6 @@ ShardServices::get_or_create_pg_ret
 ShardServices::get_or_create_pg(
   PGMap::PGCreationBlockingEvent::TriggerI&& trigger,
   spg_t pgid,
-  epoch_t epoch,
   std::unique_ptr<PGCreateInfo> info)
 {
   if (info) {

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -113,7 +113,8 @@ class PerShardState {
   std::map<pg_t, pg_stat_t> get_pg_stats() const;
   seastar::future<> broadcast_map_to_pgs(
     ShardServices &shard_services,
-    epoch_t epoch);
+    epoch_t from,
+    epoch_t to);
 
   Ref<PG> get_pg(spg_t pgid);
   template <typename F>

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -314,7 +314,7 @@ private:
   void store_map_bl(ceph::os::Transaction& t,
                     epoch_t e, bufferlist&& bl);
   seastar::future<> store_maps(ceph::os::Transaction& t,
-                               epoch_t start, Ref<MOSDMap> m);
+                               epoch_t start, epoch_t last, Ref<MOSDMap> m);
 };
 
 /**

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -429,7 +429,6 @@ public:
   get_or_create_pg_ret get_or_create_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&,
     spg_t pgid,
-    epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
 
   using wait_for_pg_ertr = PGMap::wait_for_pg_ertr;


### PR DESCRIPTION
* Before the change:  

      handled osd_map messages may have epochs intersections,
      while we are trying to avoid processing the same map more than once,
      we can only assure than it is safe to skip an already handled osd map
      *only* after it was processed (and written to the superblock).
* Logs:
```
INFO  2023-05-15 12:28:50,249 [shard 0] osd - handle_osd_map epochs [1..5], i have 0, src has [1..5]                                                                       
INFO  2023-05-15 12:28:51,245 [shard 0] osd - handle_osd_map epochs [5..6], i have 5, src has [1..6]                                                                       
INFO  2023-05-15 12:28:51,246 [shard 0] osd - handle_osd_map epochs [6..6], i have 6, src has [1..6]                                                                       
INFO  2023-05-15 12:28:55,309 [shard 0] osd - handle_osd_map epochs [6..7], i have 6, src has [1..7]                                                                       
INFO  2023-05-15 12:28:58,339 [shard 0] osd - handle_osd_map epochs [7..8], i have 7, src has [1..8]                                                                       
INFO  2023-05-15 12:29:04,389 [shard 0] osd - handle_osd_map epochs [8..10], i have 8, src has [8..10]                                                                     
INFO  2023-05-15 12:29:04,390 [shard 0] osd - handle_osd_map epochs [8..10], i have 10, src has [8..10]                                                                    
INFO  2023-05-15 12:29:08,256 [shard 0] osd - handle_osd_map epochs [10..12], i have 10, src has [10..12]
INFO  2023-05-15 12:29:08,257 [shard 0] osd - handle_osd_map epochs [10..12], i have 12, src has [10..12]
INFO  2023-05-15 12:29:08,367 [shard 0] osd - handle_osd_map epochs [12..13], i have 12, src has [1..13]
INFO  2023-05-15 12:29:09,368 [shard 0] osd - handle_osd_map epochs [13..14], i have 13, src has [1..14]
INFO  2023-05-15 12:29:14,256 [shard 0] osd - handle_osd_map epochs [14..15], i have 14, src has [14..15]
INFO  2023-05-15 12:29:14,257 [shard 0] osd - handle_osd_map epochs [14..15], i have 15, src has [14..15]
INFO  2023-05-15 12:29:14,259 [shard 0] osd - handle_osd_map epochs [14..16], i have 15, src has [14..16]
INFO  2023-05-15 12:29:14,261 [shard 0] osd - handle_osd_map epochs [14..16], i have 16, src has [14..16]
INFO  2023-05-15 12:29:18,430 [shard 0] osd - handle_osd_map epochs [16..17], i have 16, src has [16..17]
INFO  2023-05-15 12:29:18,431 [shard 0] osd - handle_osd_map epochs [16..17], i have 17, src has [16..17]
INFO  2023-05-15 12:29:25,405 [shard 0] osd - handle_osd_map epochs [17..18], i have 17, src has [1..18]
INFO  2023-05-15 12:29:26,409 [shard 0] osd - handle_osd_map epochs [19..19], i have 18, src has [1..19]
INFO  2023-05-15 12:29:26,411 [shard 0] osd - handle_osd_map epochs [18..19], i have 19, src has [1..19]
INFO  2023-05-15 12:29:27,411 [shard 0] osd - handle_osd_map epochs [20..20], i have 19, src has [1..20]
INFO  2023-05-15 12:29:27,452 [shard 0] osd - handle_osd_map epochs [19..20], i have 20, src has [1..20]
INFO  2023-05-15 12:29:29,360 [shard 0] osd - handle_osd_map epochs [20..21], i have 20, src has [20..21]
INFO  2023-05-15 12:29:29,361 [shard 0] osd - handle_osd_map epochs [20..21], i have 21, src has [20..21]
```

---

* After the change:  

      each handled epoch range is exclusive since we omit the already handled ones earlier (`calc_new_maps`)
* Logs:
```
INFO  2023-05-31 14:48:53,777 [shard 0] osd - handle_osd_map epochs [1..5], i have 0, src has [1..5]                                                                       
INFO  2023-05-31 14:48:54,766 [shard 0] osd - handle_osd_map epochs [6..6], i have 5, src has [1..6]                                                                       
INFO  2023-05-31 14:48:58,558 [shard 0] osd - handle_osd_map epochs [7..7], i have 6, src has [1..7]                                                                       
INFO  2023-05-31 14:49:01,866 [shard 0] osd - handle_osd_map epochs [8..8], i have 7, src has [1..8]                                                                       
INFO  2023-05-31 14:49:07,948 [shard 0] osd - handle_osd_map epochs [9..10], i have 8, src has [8..10]                                                                     
INFO  2023-05-31 14:49:11,784 [shard 0] osd - handle_osd_map epochs [11..12], i have 10, src has [10..12]                                                                  
INFO  2023-05-31 14:49:12,780 [shard 0] osd - handle_osd_map epochs [13..13], i have 12, src has [1..13]                                                                   
INFO  2023-05-31 14:49:13,781 [shard 0] osd - handle_osd_map epochs [14..14], i have 13, src has [1..14]                                                                   
INFO  2023-05-31 14:49:17,784 [shard 0] osd - handle_osd_map epochs [15..15], i have 14, src has [14..15]
INFO  2023-05-31 14:49:17,788 [shard 0] osd - handle_osd_map epochs [16..16], i have 15, src has [14..16]
INFO  2023-05-31 14:49:22,862 [shard 0] osd - handle_osd_map epochs [17..17], i have 16, src has [16..17]
INFO  2023-05-31 14:50:58,018 [shard 0] osd - handle_osd_map epochs [18..18], i have 17, src has [1..18]
INFO  2023-05-31 14:50:59,021 [shard 0] osd - handle_osd_map epochs [19..19], i have 18, src has [1..19]
INFO  2023-05-31 14:51:04,816 [shard 0] osd - handle_osd_map epochs [20..20], i have 19, src has [19..20]
INFO  2023-05-31 14:51:05,785 [shard 0] osd - handle_osd_map epochs [21..21], i have 20, src has [20..21]
INFO  2023-05-31 14:51:22,016 [shard 0] osd - handle_osd_map epochs [22..22], i have 21, src has [1..22]
INFO  2023-05-31 14:51:23,067 [shard 0] osd - handle_osd_map epochs [23..23], i have 22, src has [1..23]
```


Resulting in also exclusive `PGAdvanceMap` from and to epochs
```
EBUG 2023-05-31 14:11:12,742 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=443 to=444)): created
DEBUG 2023-05-31 14:11:13,607 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=444 to=445)): created
DEBUG 2023-05-31 14:11:14,603 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=445 to=446)): created
DEBUG 2023-05-31 14:11:15,615 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=446 to=447)): created
DEBUG 2023-05-31 14:11:17,304 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=447 to=448)): created
DEBUG 2023-05-31 14:11:17,633 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=448 to=449)): created
DEBUG 2023-05-31 14:11:18,627 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=449 to=450)): created
DEBUG 2023-05-31 14:11:19,633 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=450 to=451)): created
DEBUG 2023-05-31 14:11:20,706 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=451 to=452)): created
DEBUG 2023-05-31 14:11:21,638 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=452 to=453)): created
DEBUG 2023-05-31 14:11:22,875 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=453 to=454)): created
DEBUG 2023-05-31 14:11:24,413 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=454 to=455)): created
DEBUG 2023-05-31 14:11:24,692 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=455 to=456)): created
DEBUG 2023-05-31 14:11:26,708 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=456 to=458)): created
DEBUG 2023-05-31 14:11:27,710 [shard 0] osd - pg_advance_map(id=0, detail=PGAdvanceMap(pg=1.0 from=458 to=459)): created
```

Fixes: https://tracker.ceph.com/issues/59165


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
