### PR TITLE
reef: mgr/dashboard: fix test_dashboard_e2e.sh failure

### DIFF
--- a/qa/workunits/cephadm/test_dashboard_e2e.sh
+++ b/qa/workunits/cephadm/test_dashboard_e2e.sh
@@ -58,7 +58,7 @@ EOF
 cypress_run () {
     local specs="$1"
     local timeout="$2"
-    local override_config="ignoreTestFiles=*.po.ts,retries=0,testFiles=${specs}"
+    local override_config="excludeSpecPattern=*.po.ts,retries=0,specPattern=${specs}"
 
     if [ x"$timeout" != "x" ]; then
         override_config="${override_config},defaultCommandTimeout=${timeout}"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61554

---

backport of https://github.com/ceph/ceph/pull/51844
parent tracker: https://tracker.ceph.com/issues/61519

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh