### PR TITLE
client: only when trying to clear suid/sgid will allow perm check pass

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5884,7 +5884,7 @@ int Client::may_setattr(Inode *in, struct ceph_statx *stx, int mask,
   }
   if (mask & CEPH_SETATTR_GID) {
     if (perms.uid() != 0 && (perms.uid() != in->uid ||
-      	       (!perms.gid_in_groups(stx->stx_gid) && stx->stx_gid != in->gid)))
+        (!perms.gid_in_groups(stx->stx_gid) && stx->stx_gid != in->gid)))
       goto out;
   }
 
@@ -5900,7 +5900,7 @@ int Client::may_setattr(Inode *in, struct ceph_statx *stx, int mask,
 	 *
 	 * Only allow unprivileged users to clear S_ISUID and S_ISUID.
 	 */
-	(m & ~(S_ISUID | S_ISGID)))
+	((m & ~(S_ISUID | S_ISGID)) || !(m & (S_ISUID | S_ISGID))))
       goto out;
 
     gid_t i_gid = (mask & CEPH_SETATTR_GID) ? stx->stx_gid : in->gid;


### PR DESCRIPTION
When an unprivileged user tries to change the file mode, which the corresponding mode is already there, for example:

$ ll
-rw-r--r-- 1 root   root       0 Jun  1 12:36 fileA
$ su ${unprivileged-user} -c "chmod a+r fileA"

Currently it will succeed. While this is incorrect and won't comply with the Posix and the existing filesystems.

We should fail it anyway and only when it's trying to clear the suid/sgid will pass the permission check.

Introduced-by db10cfc8077("client: allow unprivileged users to clear suid/sgid")
Fixes: https://tracker.ceph.com/issues/61552
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
