### PR TITLE
quincy: osd/OSDCap: allow rbd.metadata_list method under rbd-read-only profile

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -339,7 +339,8 @@ void OSDCapGrant::expand_profile()
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_CLS_R)));
     profile_grants.emplace_back(OSDCapMatch(string(), "rbd_mirroring"),
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_CLS_R)));
-    profile_grants.emplace_back(OSDCapMatch(profile.pool_namespace.pool_name),
+    profile_grants.emplace_back(OSDCapMatch(profile.pool_namespace.pool_name,
+                                            "", "rbd_info"),
                                 OSDCapSpec("rbd", "metadata_list"));
     profile_grants.emplace_back(OSDCapMatch(profile.pool_namespace),
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_R |
@@ -348,6 +349,9 @@ void OSDCapGrant::expand_profile()
   }
   if (profile.name == "rbd-read-only") {
     // RBD read-only grant
+    profile_grants.emplace_back(OSDCapMatch(profile.pool_namespace.pool_name,
+                                            "", "rbd_info"),
+                                OSDCapSpec("rbd", "metadata_list"));
     profile_grants.emplace_back(OSDCapMatch(profile.pool_namespace),
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_R |
                                                       OSD_CAP_CLS_R)));

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -1338,6 +1338,49 @@ TEST(OSDCap, AllowProfile) {
                              {{"rbd", "child_detach", true, true, true}}, addr));
   ASSERT_FALSE(cap.is_capable("abc", "", {}, "rbd_header.ABC", false, false,
                               {{"rbd", "other function", true, true, true}}, addr));
+
+  cap.grants.clear();
+  ASSERT_TRUE(cap.parse("profile rbd pool pool1 namespace ns1", nullptr));
+  ASSERT_TRUE(cap.is_capable("pool1", "", {}, "rbd_info", false, false,
+                             {{"rbd", "metadata_list", true, false, true}},
+                             addr));
+  ASSERT_TRUE(cap.is_capable("pool1", "ns1", {}, "rbd_info", false, false,
+                             {{"rbd", "metadata_list", true, false, true}},
+                             addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "ns2", {}, "rbd_info", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool2", "", {}, "rbd_info", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "", {}, "asdf", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "", {}, "rbd_info", false, false,
+                              {{"rbd", "other_method", true, false, true}},
+                              addr));
+
+  cap.grants.clear();
+  ASSERT_TRUE(cap.parse("profile rbd-read-only pool pool1 namespace ns1",
+                        nullptr));
+  ASSERT_TRUE(cap.is_capable("pool1", "", {}, "rbd_info", false, false,
+                             {{"rbd", "metadata_list", true, false, true}},
+                             addr));
+  ASSERT_TRUE(cap.is_capable("pool1", "ns1", {}, "rbd_info", false, false,
+                             {{"rbd", "metadata_list", true, false, true}},
+                             addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "ns2", {}, "rbd_info", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool2", "", {}, "rbd_info", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "", {}, "asdf", false, false,
+                              {{"rbd", "metadata_list", true, false, true}},
+                              addr));
+  ASSERT_FALSE(cap.is_capable("pool1", "", {}, "rbd_info", false, false,
+                              {{"rbd", "other_method", true, false, true}},
+                              addr));
 }
 
 TEST(OSDCap, network) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61530

---

backport of https://github.com/ceph/ceph/pull/51814
parent tracker: https://tracker.ceph.com/issues/61382