### PR TITLE
mgr/dashboard: Create Default pool for Ceph Block

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -11,6 +11,7 @@ import cherrypy
 import rbd
 
 from .. import mgr
+from ..controllers.pool import RBDPool
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.ceph_service import CephService
@@ -205,9 +206,19 @@ class RbdStatus(BaseController):
         status = {'available': True, 'message': None}
         if not CephService.get_pool_list('rbd'):
             status['available'] = False
-            status['message'] = 'No RBD pools in the cluster. Please create a pool '\
-                                'with the "rbd" application label.'  # type: ignore
+            status['message'] = 'No Block Pool is available in the cluster. Please click ' \
+                                'on \"Configure Default Pool\" button to ' \
+                                'get started.'  # type: ignore
         return status
+
+    @Endpoint('POST')
+    @EndpointDoc('Configure Default Block Pool')
+    @CreatePermission
+    def configure(self):
+        rbd_pool = RBDPool()
+
+        if not CephService.get_pool_list('rbd'):
+            rbd_pool.create('rbd')
 
 
 @APIRouter('/block/image/{image_spec}/snap', Scope.RBD_IMAGE)

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -651,7 +651,10 @@ class RbdMirroringStatus(BaseController):
             return status
         if not CephService.get_service_list('rbd-mirror') and not CephService.get_pool_list('rbd'):
             status['available'] = False
-            status['message'] = 'RBD mirroring is not configured'  # type: ignore
+            status['message'] = 'No default "rbd" pool or "rbd-mirror" service ' \
+                                'in the cluster. Please click on ' \
+                                '"Configure Block Mirroring" ' \
+                                'button to get started.'  # type: ignore
         return status
 
     @Endpoint('POST')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -96,9 +96,11 @@ const routes: Routes = [
       moduleStatusGuardConfig: {
         uiApiPath: 'block/rbd',
         redirectTo: 'error',
-        header: 'No RBD pools available',
-        button_name: 'Create RBD pool',
-        button_route: '/pool/create'
+        header: $localize`Block Pool is not configured`,
+        button_name: $localize`Configure Default pool`,
+        button_route: '/pool/create',
+        component: 'Default Pool',
+        uiConfig: true
       },
       breadcrumbs: 'Images'
     },
@@ -154,10 +156,10 @@ const routes: Routes = [
       moduleStatusGuardConfig: {
         uiApiPath: 'block/mirroring',
         redirectTo: 'error',
-        header: $localize`RBD mirroring is not configured`,
-        button_name: $localize`Configure RBD Mirroring`,
-        button_title: $localize`This will create rbd-mirror service and a replicated RBD pool`,
-        component: 'RBD Mirroring',
+        header: $localize`Block Mirroring is not configured`,
+        button_name: $localize`Configure Block Mirroring`,
+        button_title: $localize`This will create \"rbd-mirror\" service and a replicated Block pool`,
+        component: 'Block Mirroring',
         uiConfig: true
       },
       breadcrumbs: 'Mirroring'


### PR DESCRIPTION
- Create Default pool "rbd" if your cluster doesn't hav rbd pool
- Fix the messaging consistency between block images and block mirroring
- Fix condition on RBD mirroring page for default service and pool creation



[Screencast from 2023-06-01 18-28-32.webm](https://github.com/ceph/ceph/assets/6695156/341bacf1-a28d-4219-8a69-c18aaffbdb17)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
