### PR TITLE
pacific: doc/cephadm: Revert "doc/cephadm: update about disabling logging to journald for quincy"

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -43,17 +43,17 @@ monitor hosts as well as to the monitor daemons' stderr.
 Ceph daemon logs
 ================
 
-Logging to journald
--------------------
+Logging to stdout
+-----------------
 
-Ceph daemons traditionally write logs to ``/var/log/ceph``. Ceph daemons log to
-journald by default and Ceph logs are captured by the container runtime
-environment. They are accessible via ``journalctl``.
+Ceph daemons traditionally write logs to ``/var/log/ceph``. Ceph
+daemons log to stderr by default and Ceph logs are captured by the
+container runtime environment. By default, most systems send these
+logs to journald, which means that they are accessible via
+``journalctl``.
 
-.. note:: Prior to Quincy, ceph daemons logged to stderr.
-
-Example of logging to journald
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Example of logging to stdout 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For example, to view the logs for the daemon ``mon.foo`` for a cluster
 with ID ``5c5a50ae-272a-455d-99e9-32c6a013e694``, the command would be
@@ -69,11 +69,11 @@ Logging to files
 ----------------
 
 You can also configure Ceph daemons to log to files instead of to
-journald if you prefer logs to appear in files (as they did in earlier,
+stderr if you prefer logs to appear in files (as they did in earlier,
 pre-cephadm, pre-Octopus versions of Ceph).  When Ceph logs to files,
 the logs appear in ``/var/log/ceph/<cluster-fsid>``. If you choose to
-configure Ceph to log to files instead of to journald, remember to
-configure Ceph so that it will not log to journald (the commands for
+configure Ceph to log to files instead of to stderr, remember to
+configure Ceph so that it will not log to stderr (the commands for
 this are covered below).
 
 Enabling logging to files
@@ -86,10 +86,10 @@ To enable logging to files, run the following commands:
   ceph config set global log_to_file true
   ceph config set global mon_cluster_log_to_file true
 
-Disabling logging to journald
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Disabling logging to stderr
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you choose to log to files, we recommend disabling logging to journald or else
+If you choose to log to files, we recommend disabling logging to stderr or else
 everything will be logged twice. Run the following commands to disable logging
 to stderr:
 
@@ -97,11 +97,6 @@ to stderr:
 
   ceph config set global log_to_stderr false
   ceph config set global mon_cluster_log_to_stderr false
-  ceph config set global log_to_journald false
-  ceph config set global mon_cluster_log_to_journald false
-
-.. note:: You can change the default by passing --log-to-file during
-   bootstrapping a new cluster.
 
 Modifying the log retention schedule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This reverts commit bdb2241ca5a9758e8c52d47320d8b5ea0766aea9.

This commit https://github.com/ceph/ceph/commit/bdb2241ca5a9758e8c52d47320d8b5ea0766aea9 was updating on logging changes in quincy, but seems to have been erroneously included in a pacific batch backport https://github.com/ceph/ceph/pull/42736

This stuff doesn't work in pacific. For example,

```
[ceph: root@vm-00 /]# ceph version
ceph version 16.2.13-257-gd8c5d349 (d8c5d34975dce1c5eb0aa3a7979a4d9b9a99d1ec) pacific (stable)
[ceph: root@vm-00 /]# ceph config set global log_to_journald false
Error EINVAL: unrecognized config option 'log_to_journald'
```

so we shouldn't have it in the pacific docs
