### PR TITLE
LogClient: do not output meaningless logs by default

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -186,13 +186,13 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
 
   // log to syslog?
   if (do_log_to_syslog()) {
-    ldout(cct,0) << __func__ << " log to syslog"  << dendl;
+    ldout(cct,30) << __func__ << " log to syslog"  << dendl;
     e.log_to_syslog(get_log_prio(), get_syslog_facility());
   }
 
   // log to graylog?
   if (do_log_to_graylog()) {
-    ldout(cct,0) << __func__ << " log to graylog"  << dendl;
+    ldout(cct,30) << __func__ << " log to graylog"  << dendl;
     graylog->log_log_entry(&e);
   }
 }


### PR DESCRIPTION
```
- the default output log to syslog/graylog is meaningless
- it will consume a lot of log resources
```

We are using syslog to dump ceph logs,
During use, it is found that each normal log entry will be preceded by a "do_log log to syslog" log entry,
After code analysis, it is found that the log level of "do_log log to syslog" is 0,
This will double the amount of data in the logging system,
It is recommended to increase the log level of"do_log log to syslog"  from 0 to 30, which exists as a debug log
