### PR TITLE
qa/suites/upgrade: enable default RBD image features

### DIFF
--- a/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_api.yaml
@@ -9,4 +9,6 @@ workload:
         clients:
           client.0:
               - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
     - print: "**** done end test_rbd_api.yaml"

--- a/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_python.yaml
@@ -9,5 +9,7 @@ workload:
         clients:
           client.0:
             - rbd/test_librbd_python.sh
+        env:
+          RBD_FEATURES: "61"
     - print: "**** done end test_rbd_python.yaml"
 

--- a/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,4 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,4 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_api.yaml
@@ -9,4 +9,6 @@ workload:
         clients:
           client.0:
               - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
     - print: "**** done end test_rbd_api.yaml"

--- a/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_python.yaml
@@ -9,5 +9,7 @@ workload:
         clients:
           client.0:
             - rbd/test_librbd_python.sh
+        env:
+          RBD_FEATURES: "61"
     - print: "**** done end test_rbd_python.yaml"
 

--- a/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,4 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,4 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
+        env:
+          RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"


### PR DESCRIPTION
Until commit 9fe05da41370 ("Revert "test: adjust rbd test case guards to handle new defaults""), default RBD image features were enabled only in Python API tests; C/C++ API tests were still exercising format 1 (6-7 years after its deprecation!).

Enable format 2 with default image features universally across upgrade suites.

Fixes: https://tracker.ceph.com/issues/61505





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
