### PR TITLE
test: unmount the mountpoint just before exiting

### DIFF
--- a/src/test/fs/test_trim_caps.cc
+++ b/src/test/fs/test_trim_caps.cc
@@ -46,7 +46,6 @@ int main(int argc, char *argv[])
 		ret = ceph_rename(cmount, "2", "1");
 		assert(ret >= 0);
 
-		ceph_unmount(cmount);
 		printf("child exits\n");
 	} else {
 		ret = ceph_mkdirs(cmount, "1/2", 0755);
@@ -78,8 +77,10 @@ int main(int argc, char *argv[])
 		ret = ceph_statx(cmount, ".", &stx, 0, 0);
 		assert(ret >= 0);
 
-		printf("waiting for crash\n");
-        sleep(60);
+		printf("waiting for 60 seconds to see whether will it crash\n");
+		sleep(60);
+		printf("parent exits\n");
 	}
+	ceph_unmount(cmount);
 	return 0;
 }


### PR DESCRIPTION
Without this the qa test may fail by evicting the unresponsive client after 300 seconds.

Fixes: https://tracker.ceph.com/issues/61394





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
