### PR TITLE
reef: mon: fix timestamp formatting in cluster log

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -61,6 +61,7 @@
 #include "include/str_list.h"
 #include "include/str_map.h"
 #include "include/compat.h"
+#include "include/utime_fmt.h"
 
 #define dout_subsys ceph_subsys_mon
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61579

---

backport of https://github.com/ceph/ceph/pull/51892
parent tracker: https://tracker.ceph.com/issues/61547

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh