### PR TITLE
crimson/net: support connections in multiple shards

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -65,8 +65,11 @@ Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
   return (dispatched ? std::make_optional(seastar::now()) : std::nullopt);
 }
 
-void Client::ms_handle_connect(crimson::net::ConnectionRef c)
+void Client::ms_handle_connect(
+    crimson::net::ConnectionRef c,
+    seastar::shard_id new_shard)
 {
+  ceph_assert_always(new_shard == seastar::this_shard_id());
   gate.dispatch_in_background(__func__, *this, [this, c] {
     if (conn == c) {
       // ask for the mgrconfigure message

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -40,7 +40,7 @@ private:
   std::optional<seastar::future<>> ms_dispatch(
       crimson::net::ConnectionRef conn, Ref<Message> m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
-  void ms_handle_connect(crimson::net::ConnectionRef conn) final;
+  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id) final;
   seastar::future<> handle_mgr_map(crimson::net::ConnectionRef conn,
 				   Ref<MMgrMap> m);
   seastar::future<> handle_mgr_conf(crimson::net::ConnectionRef conn,

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -40,6 +40,15 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
 
   virtual ~Connection() {}
 
+  /**
+   * get_shard_id
+   *
+   * The shard id where the Connection is dispatching events and handling I/O.
+   *
+   * May be changed with the accept/connect events.
+   */
+  virtual const seastar::shard_id get_shard_id() const = 0;
+
   virtual const entity_name_t &get_peer_name() const = 0;
 
   entity_type_t get_peer_type() const { return get_peer_name().type(); }

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -71,7 +71,9 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
    * send
    *
    * Send a message over a connection that has completed its handshake.
-   * May be invoked from any core.
+   *
+   * May be invoked from any core, but that requires to chain the returned
+   * future to preserve ordering.
    */
   virtual seastar::future<> send(MessageURef msg) = 0;
 
@@ -81,7 +83,8 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
    * Send a keepalive message over a connection that has completed its
    * handshake.
    *
-   * May be invoked from any core.
+   * May be invoked from any core, but that requires to chain the returned
+   * future to preserve ordering.
    */
   virtual seastar::future<> send_keepalive() = 0;
 

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -30,9 +30,13 @@ class Dispatcher {
   // used to throttle the connection if it's too busy.
   virtual std::optional<seastar::future<>> ms_dispatch(ConnectionRef, MessageRef) = 0;
 
-  virtual void ms_handle_accept(ConnectionRef conn) {}
+  // The connection is accepted or recoverred(lossless), all the followup
+  // events and messages will be dispatched to the new_shard.
+  virtual void ms_handle_accept(ConnectionRef conn, seastar::shard_id new_shard) {}
 
-  virtual void ms_handle_connect(ConnectionRef conn) {}
+  // The connection is (re)connected, all the followup events and messages will
+  // be dispatched to the new_shard.
+  virtual void ms_handle_connect(ConnectionRef conn, seastar::shard_id new_shard) {}
 
   // a reset event is dispatched when the connection is closed unexpectedly.
   // is_replace=true means the reset connection is going to be replaced by

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -32,13 +32,18 @@ class Dispatcher {
 
   // The connection is accepted or recoverred(lossless), all the followup
   // events and messages will be dispatched to the new_shard.
-  virtual void ms_handle_accept(ConnectionRef conn, seastar::shard_id new_shard) {}
+  //
+  // is_replace=true means the accepted connection has replaced
+  // another connecting connection with the same peer_addr, which currently only
+  // happens under lossy policy when both sides wish to connect to each other.
+  virtual void ms_handle_accept(ConnectionRef conn, seastar::shard_id new_shard, bool is_replace) {}
 
   // The connection is (re)connected, all the followup events and messages will
   // be dispatched to the new_shard.
   virtual void ms_handle_connect(ConnectionRef conn, seastar::shard_id new_shard) {}
 
   // a reset event is dispatched when the connection is closed unexpectedly.
+  //
   // is_replace=true means the reset connection is going to be replaced by
   // another accepting connection with the same peer_addr, which currently only
   // happens under lossy policy when both sides wish to connect to each other.

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -117,7 +117,7 @@ FrameAssemblerV2::stop_recording()
 bool FrameAssemblerV2::has_socket() const
 {
   assert((socket && conn.socket) || (!socket && !conn.socket));
-  return socket != nullptr;
+  return bool(socket);
 }
 
 bool FrameAssemblerV2::is_socket_valid() const
@@ -125,16 +125,17 @@ bool FrameAssemblerV2::is_socket_valid() const
   return has_socket() && !socket->is_shutdown();
 }
 
-SocketRef FrameAssemblerV2::move_socket()
+SocketFRef FrameAssemblerV2::move_socket()
 {
   assert(has_socket());
   conn.set_socket(nullptr);
   return std::move(socket);
 }
 
-void FrameAssemblerV2::set_socket(SocketRef &&new_socket)
+void FrameAssemblerV2::set_socket(SocketFRef &&new_socket)
 {
   assert(!has_socket());
+  assert(new_socket);
   socket = std::move(new_socket);
   conn.set_socket(socket.get());
   assert(is_socket_valid());
@@ -152,7 +153,7 @@ void FrameAssemblerV2::shutdown_socket()
   socket->shutdown();
 }
 
-seastar::future<> FrameAssemblerV2::replace_shutdown_socket(SocketRef &&new_socket)
+seastar::future<> FrameAssemblerV2::replace_shutdown_socket(SocketFRef &&new_socket)
 {
   assert(has_socket());
   assert(socket->is_shutdown());

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -92,6 +92,9 @@ FrameAssemblerV2::to_replace()
 {
   assert(seastar::this_shard_id() == sid);
   assert(is_socket_valid());
+
+  clear();
+
   return mover_t{
       move_socket(),
       std::move(session_stream_handlers),
@@ -101,9 +104,9 @@ FrameAssemblerV2::to_replace()
 seastar::future<> FrameAssemblerV2::replace_by(FrameAssemblerV2::mover_t &&mover)
 {
   assert(seastar::this_shard_id() == sid);
-  record_io = false;
-  rxbuf.clear();
-  txbuf.clear();
+
+  clear();
+
   session_stream_handlers = std::move(mover.session_stream_handlers);
   session_comp_handlers = std::move(mover.session_comp_handlers);
   if (has_socket()) {
@@ -435,6 +438,15 @@ void FrameAssemblerV2::log_main_preamble(const ceph::bufferlist &bl)
 FrameAssemblerV2Ref FrameAssemblerV2::create(SocketConnection &conn)
 {
   return std::make_unique<FrameAssemblerV2>(conn);
+}
+
+void FrameAssemblerV2::clear()
+{
+  record_io = false;
+  rxbuf.clear();
+  txbuf.clear();
+  rx_preamble.clear();
+  rx_segments_data.clear();
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -151,6 +151,14 @@ bool FrameAssemblerV2::is_socket_valid() const
   return has_socket() && !is_socket_shutdown;
 }
 
+seastar::shard_id
+FrameAssemblerV2::get_socket_shard_id() const
+{
+  assert(seastar::this_shard_id() == sid);
+  assert(is_socket_valid());
+  return socket->get_shard_id();
+}
+
 SocketFRef FrameAssemblerV2::move_socket()
 {
   assert(has_socket());

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -27,11 +27,15 @@ seastar::logger& logger() {
 namespace crimson::net {
 
 FrameAssemblerV2::FrameAssemblerV2(SocketConnection &_conn)
-  : conn{_conn}
-{}
+  : conn{_conn}, sid{seastar::this_shard_id()}
+{
+  assert(seastar::this_shard_id() == conn.get_messenger_shard_id());
+}
 
 FrameAssemblerV2::~FrameAssemblerV2()
 {
+  assert(seastar::this_shard_id() == conn.get_messenger_shard_id());
+  assert(seastar::this_shard_id() == sid);
   if (has_socket()) {
     std::ignore = move_socket();
   }
@@ -41,6 +45,7 @@ FrameAssemblerV2::~FrameAssemblerV2()
 // should be consistent to intercept() in ProtocolV2.cc
 void FrameAssemblerV2::intercept_frame(Tag tag, bool is_write)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   if (conn.interceptor) {
     auto type = is_write ? bp_type_t::WRITE : bp_type_t::READ;
@@ -55,6 +60,7 @@ void FrameAssemblerV2::intercept_frame(Tag tag, bool is_write)
 
 void FrameAssemblerV2::set_is_rev1(bool _is_rev1)
 {
+  assert(seastar::this_shard_id() == sid);
   is_rev1 = _is_rev1;
   tx_frame_asm.set_is_rev1(_is_rev1);
   rx_frame_asm.set_is_rev1(_is_rev1);
@@ -64,12 +70,14 @@ void FrameAssemblerV2::create_session_stream_handlers(
   const AuthConnectionMeta &auth_meta,
   bool crossed)
 {
+  assert(seastar::this_shard_id() == sid);
   session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
       nullptr, auth_meta, is_rev1, crossed);
 }
 
 void FrameAssemblerV2::reset_handlers()
 {
+  assert(seastar::this_shard_id() == sid);
   session_stream_handlers = { nullptr, nullptr };
   session_comp_handlers = { nullptr, nullptr };
 }
@@ -77,6 +85,7 @@ void FrameAssemblerV2::reset_handlers()
 FrameAssemblerV2::mover_t
 FrameAssemblerV2::to_replace()
 {
+  assert(seastar::this_shard_id() == sid);
   assert(is_socket_valid());
   return mover_t{
       move_socket(),
@@ -86,6 +95,7 @@ FrameAssemblerV2::to_replace()
 
 seastar::future<> FrameAssemblerV2::replace_by(FrameAssemblerV2::mover_t &&mover)
 {
+  assert(seastar::this_shard_id() == sid);
   record_io = false;
   rxbuf.clear();
   txbuf.clear();
@@ -101,6 +111,7 @@ seastar::future<> FrameAssemblerV2::replace_by(FrameAssemblerV2::mover_t &&mover
 
 void FrameAssemblerV2::start_recording()
 {
+  assert(seastar::this_shard_id() == sid);
   record_io = true;
   rxbuf.clear();
   txbuf.clear();
@@ -109,6 +120,7 @@ void FrameAssemblerV2::start_recording()
 FrameAssemblerV2::record_bufs_t
 FrameAssemblerV2::stop_recording()
 {
+  assert(seastar::this_shard_id() == sid);
   ceph_assert_always(record_io == true);
   record_io = false;
   return record_bufs_t{std::move(rxbuf), std::move(txbuf)};
@@ -122,6 +134,7 @@ bool FrameAssemblerV2::has_socket() const
 
 bool FrameAssemblerV2::is_socket_valid() const
 {
+  assert(seastar::this_shard_id() == sid);
   return has_socket() && !socket->is_shutdown();
 }
 
@@ -134,6 +147,7 @@ SocketFRef FrameAssemblerV2::move_socket()
 
 void FrameAssemblerV2::set_socket(SocketFRef &&new_socket)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(!has_socket());
   assert(new_socket);
   socket = std::move(new_socket);
@@ -143,18 +157,21 @@ void FrameAssemblerV2::set_socket(SocketFRef &&new_socket)
 
 void FrameAssemblerV2::learn_socket_ephemeral_port_as_connector(uint16_t port)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   socket->learn_ephemeral_port_as_connector(port);
 }
 
 void FrameAssemblerV2::shutdown_socket()
 {
+  assert(seastar::this_shard_id() == sid);
   assert(is_socket_valid());
   socket->shutdown();
 }
 
 seastar::future<> FrameAssemblerV2::replace_shutdown_socket(SocketFRef &&new_socket)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   assert(socket->is_shutdown());
   auto old_socket = move_socket();
@@ -165,6 +182,7 @@ seastar::future<> FrameAssemblerV2::replace_shutdown_socket(SocketFRef &&new_soc
 
 seastar::future<> FrameAssemblerV2::close_shutdown_socket()
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   assert(socket->is_shutdown());
   return socket->close();
@@ -173,6 +191,7 @@ seastar::future<> FrameAssemblerV2::close_shutdown_socket()
 seastar::future<ceph::bufferptr>
 FrameAssemblerV2::read_exactly(std::size_t bytes)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   if (unlikely(record_io)) {
     return socket->read_exactly(bytes
@@ -188,6 +207,7 @@ FrameAssemblerV2::read_exactly(std::size_t bytes)
 seastar::future<ceph::bufferlist>
 FrameAssemblerV2::read(std::size_t bytes)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   if (unlikely(record_io)) {
     return socket->read(bytes
@@ -203,6 +223,7 @@ FrameAssemblerV2::read(std::size_t bytes)
 seastar::future<>
 FrameAssemblerV2::write(ceph::bufferlist buf)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   if (unlikely(record_io)) {
     txbuf.append(buf);
@@ -213,6 +234,7 @@ FrameAssemblerV2::write(ceph::bufferlist buf)
 seastar::future<>
 FrameAssemblerV2::flush()
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   return socket->flush();
 }
@@ -220,6 +242,7 @@ FrameAssemblerV2::flush()
 seastar::future<>
 FrameAssemblerV2::write_flush(ceph::bufferlist buf)
 {
+  assert(seastar::this_shard_id() == sid);
   assert(has_socket());
   if (unlikely(record_io)) {
     txbuf.append(buf);
@@ -230,6 +253,7 @@ FrameAssemblerV2::write_flush(ceph::bufferlist buf)
 seastar::future<FrameAssemblerV2::read_main_t>
 FrameAssemblerV2::read_main_preamble()
 {
+  assert(seastar::this_shard_id() == sid);
   rx_preamble.clear();
   return read_exactly(rx_frame_asm.get_preamble_onwire_len()
   ).then([this](auto bptr) {
@@ -250,6 +274,7 @@ FrameAssemblerV2::read_main_preamble()
 seastar::future<FrameAssemblerV2::read_payload_t*>
 FrameAssemblerV2::read_frame_payload()
 {
+  assert(seastar::this_shard_id() == sid);
   rx_segments_data.clear();
   return seastar::do_until(
     [this] {

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -44,8 +44,10 @@ void FrameAssemblerV2::intercept_frame(Tag tag, bool is_write)
   assert(has_socket());
   if (conn.interceptor) {
     auto type = is_write ? bp_type_t::WRITE : bp_type_t::READ;
+    // FIXME: doesn't support cross-core
     auto action = conn.interceptor->intercept(
-        conn, Breakpoint{tag, type});
+        conn.get_local_shared_foreign_from_this(),
+        Breakpoint{tag, type});
     socket->set_trap(type, action, &conn.interceptor->blocker);
   }
 }

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -19,7 +19,7 @@ class FrameAssemblerV2 {
 public:
   FrameAssemblerV2(SocketConnection &conn);
 
-  ~FrameAssemblerV2() = default;
+  ~FrameAssemblerV2();
 
   FrameAssemblerV2(const FrameAssemblerV2 &) = delete;
 
@@ -127,6 +127,8 @@ public:
 private:
   bool has_socket() const;
 
+  SocketRef move_socket();
+
   void log_main_preamble(const ceph::bufferlist &bl);
 
 #ifdef UNIT_TESTS_BUILT
@@ -135,7 +137,7 @@ private:
 
   SocketConnection &conn;
 
-  Socket *socket = nullptr;
+  SocketRef socket;
 
   /*
    * auth signature

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -26,6 +26,16 @@ public:
 
   FrameAssemblerV2(FrameAssemblerV2 &&) = delete;
 
+  void set_shard_id(seastar::shard_id _sid) {
+    assert(seastar::this_shard_id() == sid);
+    clear();
+    sid = _sid;
+  }
+
+  seastar::shard_id get_shard_id() const {
+    return sid;
+  }
+
   void set_is_rev1(bool is_rev1);
 
   void create_session_stream_handlers(
@@ -66,6 +76,8 @@ public:
 
   // the socket exists and not shutdown
   bool is_socket_valid() const;
+
+  seastar::shard_id get_socket_shard_id() const;
 
   void set_socket(SocketFRef &&);
 

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -80,15 +80,15 @@ public:
    * socket read and write interfaces
    */
 
-  seastar::future<Socket::tmp_buf> read_exactly(std::size_t bytes);
+  seastar::future<ceph::bufferptr> read_exactly(std::size_t bytes);
 
   seastar::future<ceph::bufferlist> read(std::size_t bytes);
 
-  seastar::future<> write(ceph::bufferlist &&);
+  seastar::future<> write(ceph::bufferlist);
 
   seastar::future<> flush();
 
-  seastar::future<> write_flush(ceph::bufferlist &&);
+  seastar::future<> write_flush(ceph::bufferlist);
 
   /*
    * frame read and write interfaces

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -38,7 +38,7 @@ public:
    */
 
   struct mover_t {
-    SocketRef socket;
+    SocketFRef socket;
     ceph::crypto::onwire::rxtx_t session_stream_handlers;
     ceph::compression::onwire::rxtx_t session_comp_handlers;
   };
@@ -66,13 +66,13 @@ public:
   // the socket exists and not shutdown
   bool is_socket_valid() const;
 
-  void set_socket(SocketRef &&);
+  void set_socket(SocketFRef &&);
 
   void learn_socket_ephemeral_port_as_connector(uint16_t port);
 
   void shutdown_socket();
 
-  seastar::future<> replace_shutdown_socket(SocketRef &&);
+  seastar::future<> replace_shutdown_socket(SocketFRef &&);
 
   seastar::future<> close_shutdown_socket();
 
@@ -127,7 +127,7 @@ public:
 private:
   bool has_socket() const;
 
-  SocketRef move_socket();
+  SocketFRef move_socket();
 
   void log_main_preamble(const ceph::bufferlist &bl);
 
@@ -137,7 +137,7 @@ private:
 
   SocketConnection &conn;
 
-  SocketRef socket;
+  SocketFRef socket;
 
   /*
    * auth signature

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -108,6 +108,7 @@ public:
 
   template <class F>
   ceph::bufferlist get_buffer(F &tx_frame) {
+    assert(seastar::this_shard_id() == sid);
 #ifdef UNIT_TESTS_BUILT
     intercept_frame(F::tag, true);
 #endif
@@ -118,6 +119,7 @@ public:
 
   template <class F>
   seastar::future<> write_flush_frame(F &tx_frame) {
+    assert(seastar::this_shard_id() == sid);
     auto bl = get_buffer(tx_frame);
     return write_flush(std::move(bl));
   }
@@ -138,6 +140,8 @@ private:
   SocketConnection &conn;
 
   SocketFRef socket;
+
+  seastar::shard_id sid;
 
   /*
    * auth signature

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -141,6 +141,8 @@ private:
 
   SocketFRef move_socket();
 
+  void clear();
+
   void log_main_preamble(const ceph::bufferlist &bl);
 
 #ifdef UNIT_TESTS_BUILT

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -47,4 +47,6 @@ using dispatchers_t = boost::container::small_vector<Dispatcher*, NUM_DISPATCHER
 class Messenger;
 using MessengerRef = seastar::shared_ptr<Messenger>;
 
+using MessageFRef = seastar::foreign_ptr<MessageURef>;
+
 } // namespace crimson::net

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -39,8 +39,6 @@ using ConnectionLRef = seastar::shared_ptr<Connection>;
 using ConnectionFRef = seastar::foreign_ptr<ConnectionLRef>;
 using ConnectionRef = ::crimson::local_shared_foreign_ptr<ConnectionLRef>;
 
-class SocketConnection;
-
 class Dispatcher;
 class ChainedDispatchers;
 constexpr std::size_t NUM_DISPATCHERS = 4u;

--- a/src/crimson/net/Interceptor.h
+++ b/src/crimson/net/Interceptor.h
@@ -116,11 +116,11 @@ struct Breakpoint {
 struct Interceptor {
   socket_blocker blocker;
   virtual ~Interceptor() {}
-  virtual void register_conn(SocketConnection& conn) = 0;
-  virtual void register_conn_ready(SocketConnection& conn) = 0;
-  virtual void register_conn_closed(SocketConnection& conn) = 0;
-  virtual void register_conn_replaced(SocketConnection& conn) = 0;
-  virtual bp_action_t intercept(SocketConnection& conn, Breakpoint bp) = 0;
+  virtual void register_conn(ConnectionRef) = 0;
+  virtual void register_conn_ready(ConnectionRef) = 0;
+  virtual void register_conn_closed(ConnectionRef) = 0;
+  virtual void register_conn_replaced(ConnectionRef) = 0;
+  virtual bp_action_t intercept(ConnectionRef, Breakpoint bp) = 0;
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -9,9 +9,11 @@ namespace crimson::net {
 MessengerRef
 Messenger::create(const entity_name_t& name,
                   const std::string& lname,
-                  const uint64_t nonce)
+                  uint64_t nonce,
+                  bool is_fixed_cpu)
 {
-  return seastar::make_shared<SocketMessenger>(name, lname, nonce);
+  return seastar::make_shared<SocketMessenger>(
+      name, lname, nonce, is_fixed_cpu);
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -10,10 +10,10 @@ MessengerRef
 Messenger::create(const entity_name_t& name,
                   const std::string& lname,
                   uint64_t nonce,
-                  bool is_fixed_cpu)
+                  bool dispatch_only_on_this_shard)
 {
   return seastar::make_shared<SocketMessenger>(
-      name, lname, nonce, is_fixed_cpu);
+      name, lname, nonce, dispatch_only_on_this_shard);
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -108,7 +108,8 @@ public:
   static MessengerRef
   create(const entity_name_t& name,
          const std::string& lname,
-         const uint64_t nonce);
+         uint64_t nonce,
+         bool is_fixed_cpu);
 
 #ifdef UNIT_TESTS_BUILT
   virtual void set_interceptor(Interceptor *) = 0;

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -109,7 +109,7 @@ public:
   create(const entity_name_t& name,
          const std::string& lname,
          uint64_t nonce,
-         bool is_fixed_cpu);
+         bool dispatch_only_on_this_shard);
 
 #ifdef UNIT_TESTS_BUILT
   virtual void set_interceptor(Interceptor *) = 0;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -109,7 +109,7 @@ void intercept(Breakpoint bp,
                bp_type_t type,
                SocketConnection& conn,
                Interceptor *interceptor,
-               SocketRef& socket) {
+               Socket *socket) {
   if (interceptor) {
     auto action = interceptor->intercept(conn, Breakpoint(bp));
     socket->set_trap(type, action, &interceptor->blocker);

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1674,8 +1674,7 @@ ProtocolV2::send_server_ident()
   logger().debug("{} UPDATE: gs={} for server ident", conn, global_seq);
 
   // this is required for the case when this connection is being replaced
-  io_handler.requeue_out_sent_up_to(0);
-  io_handler.reset_session(false);
+  io_handler.reset_peer_state();
 
   if (!conn.policy.lossy) {
     server_cookie = ceph::util::generate_random_number<uint64_t>(1, -1ll);

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -28,11 +28,17 @@ public:
  * as HandshakeListener
  */
 private:
-  void notify_out() final;
+  seastar::future<> notify_out(
+      crosscore_t::seq_t cc_seq) final;
 
-  void notify_out_fault(const char *where, std::exception_ptr, io_handler_state) final;
+  seastar::future<> notify_out_fault(
+      crosscore_t::seq_t cc_seq,
+      const char *where,
+      std::exception_ptr,
+      io_handler_state) final;
 
-  void notify_mark_down() final;
+  seastar::future<> notify_mark_down(
+      crosscore_t::seq_t cc_seq) final;
 
 /*
 * as ProtocolV2 to be called by SocketConnection
@@ -236,6 +242,8 @@ private:
 
   // asynchronously populated from io_handler
   io_handler_state io_states;
+
+  crosscore_t crosscore;
 
   bool has_socket = false;
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -41,7 +41,7 @@ public:
   void start_connect(const entity_addr_t& peer_addr,
                      const entity_name_t& peer_name);
 
-  void start_accept(SocketRef&& socket,
+  void start_accept(SocketFRef&& socket,
                     const entity_addr_t& peer_addr);
 
   seastar::future<> close_clean_yielded();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -227,6 +227,8 @@ private:
 
   FrameAssemblerV2Ref frame_assembler;
 
+  std::optional<seastar::shared_promise<>> pr_switch_io_shard;
+
   std::optional<seastar::shared_promise<>> pr_exit_io;
 
   AuthConnectionMetaRef auth_meta;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -30,7 +30,7 @@ public:
 private:
   void notify_out() final;
 
-  void notify_out_fault(const char *, std::exception_ptr) final;
+  void notify_out_fault(const char *where, std::exception_ptr, io_handler_state) final;
 
   void notify_mark_down() final;
 
@@ -57,6 +57,8 @@ public:
 
 #endif
 private:
+  using io_state_t = IOHandler::io_state_t;
+
   seastar::future<> wait_exit_io() {
     if (exit_io.has_value()) {
       return exit_io->get_shared_future();
@@ -92,7 +94,7 @@ private:
     return statenames[static_cast<int>(state)];
   }
 
-  void trigger_state(state_t state, IOHandler::io_state_t io_state, bool reentrant);
+  void trigger_state(state_t state, io_state_t io_state, bool reentrant);
 
   template <typename Func, typename T>
   void gated_execute(const char *what, T &who, Func &&func) {
@@ -214,6 +216,9 @@ private:
   SocketMessenger &messenger;
 
   IOHandler &io_handler;
+
+  // asynchronously populated from io_handler
+  io_handler_state io_states;
 
   bool has_socket = false;
 

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -19,6 +19,9 @@ seastar::logger& logger() {
   return crimson::get_logger(ceph_subsys_ms);
 }
 
+using tmp_buf = Socket::tmp_buf;
+using packet = Socket::packet;
+
 // an input_stream consumer that reads buffer segments into a bufferlist up to
 // the given number of remaining bytes
 struct bufferlist_consumer {
@@ -28,7 +31,6 @@ struct bufferlist_consumer {
   bufferlist_consumer(bufferlist& bl, size_t& remaining)
     : bl(bl), remaining(remaining) {}
 
-  using tmp_buf = seastar::temporary_buffer<char>;
   using consumption_result_type = typename seastar::input_stream<char>::consumption_result_type;
 
   // consume some or all of a buffer segment
@@ -59,9 +61,58 @@ struct bufferlist_consumer {
   };
 };
 
+seastar::future<> inject_delay()
+{
+  if (float delay_period = local_conf()->ms_inject_internal_delays;
+      delay_period) {
+    logger().debug("Socket::inject_delay: sleep for {}", delay_period);
+    return seastar::sleep(
+      std::chrono::milliseconds((int)(delay_period * 1000.0)));
+  }
+  return seastar::now();
+}
+
+void inject_failure()
+{
+  if (local_conf()->ms_inject_socket_failures) {
+    uint64_t rand =
+      ceph::util::generate_random_number<uint64_t>(1, RAND_MAX);
+    if (rand % local_conf()->ms_inject_socket_failures == 0) {
+      logger().warn("Socket::inject_failure: injecting socket failure");
+      throw std::system_error(make_error_code(
+        error::negotiation_failure));
+    }
+  }
+}
+
 } // anonymous namespace
 
-seastar::future<bufferlist> Socket::read(size_t bytes)
+Socket::Socket(
+    seastar::connected_socket &&_socket,
+    side_t _side,
+    uint16_t e_port,
+    construct_tag)
+  : sid{seastar::this_shard_id()},
+    socket(std::move(_socket)),
+    in(socket.input()),
+    // the default buffer size 8192 is too small that may impact our write
+    // performance. see seastar::net::connected_socket::output()
+    out(socket.output(65536)),
+    socket_is_shutdown(false),
+    side(_side),
+    ephemeral_port(e_port)
+{
+}
+
+Socket::~Socket()
+{
+#ifndef NDEBUG
+  assert(closed);
+#endif
+}
+
+seastar::future<bufferlist>
+Socket::read(size_t bytes)
 {
 #ifdef UNIT_TESTS_BUILT
   return try_trap_pre(next_trap_read).then([bytes, this] {
@@ -81,9 +132,9 @@ seastar::future<bufferlist> Socket::read(size_t bytes)
       });
     });
 #ifdef UNIT_TESTS_BUILT
-  }).then([this] (auto buf) {
+  }).then([this](auto buf) {
     return try_trap_post(next_trap_read
-    ).then([buf = std::move(buf)] () mutable {
+    ).then([buf = std::move(buf)]() mutable {
       return std::move(buf);
     });
   });
@@ -104,16 +155,66 @@ Socket::read_exactly(size_t bytes) {
       }
       inject_failure();
       return inject_delay(
-      ).then([buf = std::move(buf)] () mutable {
+      ).then([buf = std::move(buf)]() mutable {
         return seastar::make_ready_future<tmp_buf>(std::move(buf));
       });
     });
 #ifdef UNIT_TESTS_BUILT
-  }).then([this] (auto buf) {
+  }).then([this](auto buf) {
     return try_trap_post(next_trap_read
-    ).then([buf = std::move(buf)] () mutable {
+    ).then([buf = std::move(buf)]() mutable {
       return std::move(buf);
     });
+  });
+#endif
+}
+
+seastar::future<>
+Socket::write(packet &&buf)
+{
+#ifdef UNIT_TESTS_BUILT
+  return try_trap_pre(next_trap_write
+  ).then([buf = std::move(buf), this]() mutable {
+#endif
+    inject_failure();
+    return inject_delay(
+    ).then([buf = std::move(buf), this]() mutable {
+      return out.write(std::move(buf));
+    });
+#ifdef UNIT_TESTS_BUILT
+  }).then([this] {
+    return try_trap_post(next_trap_write);
+  });
+#endif
+}
+
+seastar::future<>
+Socket::flush()
+{
+  inject_failure();
+  return inject_delay().then([this] {
+    return out.flush();
+  });
+}
+
+seastar::future<>
+Socket::write_flush(packet &&buf)
+{
+#ifdef UNIT_TESTS_BUILT
+  return try_trap_pre(next_trap_write
+  ).then([buf = std::move(buf), this]() mutable {
+#endif
+    inject_failure();
+    return inject_delay(
+    ).then([buf = std::move(buf), this]() mutable {
+      return out.write(std::move(buf)
+      ).then([this] {
+        return out.flush();
+      });
+    });
+#ifdef UNIT_TESTS_BUILT
+  }).then([this] {
+    return try_trap_post(next_trap_write);
   });
 #endif
 }
@@ -127,17 +228,18 @@ void Socket::shutdown() {
 static inline seastar::future<>
 close_and_handle_errors(seastar::output_stream<char>& out)
 {
-  return out.close().handle_exception_type([] (const std::system_error& e) {
+  return out.close().handle_exception_type([](const std::system_error& e) {
     if (e.code() != std::errc::broken_pipe &&
         e.code() != std::errc::connection_reset) {
-      logger().error("Socket::close(): unexpected error {}", e);
+      logger().error("Socket::close(): unexpected error {}", e.what());
       ceph_abort();
     }
     // can happen when out is already shutdown, ignore
   });
 }
 
-seastar::future<> Socket::close() {
+seastar::future<>
+Socket::close() {
 #ifndef NDEBUG
   ceph_assert(!closed);
   closed = true;
@@ -148,75 +250,35 @@ seastar::future<> Socket::close() {
     close_and_handle_errors(out)
   ).then_unpack([] {
     return seastar::make_ready_future<>();
-  }).handle_exception([] (auto eptr) {
-    logger().error("Socket::close(): unexpected exception {}", eptr);
+  }).handle_exception([](auto eptr) {
+    const char *e_what;
+    try {
+      std::rethrow_exception(eptr);
+    } catch (std::exception &e) {
+      e_what = e.what();
+    }
+    logger().error("Socket::close(): unexpected exception {}", e_what);
     ceph_abort();
   });
 }
 
-seastar::future<> Socket::inject_delay () {
-  if (float delay_period = local_conf()->ms_inject_internal_delays;
-      delay_period) {
-    logger().debug("Socket::inject_delay: sleep for {}", delay_period);
-    return seastar::sleep(
-      std::chrono::milliseconds((int)(delay_period * 1000.0)));
-  }
-  return seastar::now();
-}
-
-void Socket::inject_failure()
+seastar::future<SocketRef>
+Socket::connect(const entity_addr_t &peer_addr)
 {
-  if (local_conf()->ms_inject_socket_failures) {
-    uint64_t rand =
-      ceph::util::generate_random_number<uint64_t>(1, RAND_MAX);
-    if (rand % local_conf()->ms_inject_socket_failures == 0) {
-      if (true) {
-        logger().warn("Socket::inject_failure: injecting socket failure");
-	throw std::system_error(make_error_code(
-	  crimson::net::error::negotiation_failure));
-      }
-    }
-  }
+  inject_failure();
+  return inject_delay(
+  ).then([peer_addr] {
+    return seastar::connect(peer_addr.in4_addr());
+  }).then([peer_addr](seastar::connected_socket socket) {
+    auto ret = std::make_unique<Socket>(
+      std::move(socket), side_t::connector, 0, construct_tag{});
+    logger().debug("Socket::connect(): connected to {}, socket {}",
+                   peer_addr, fmt::ptr(ret));
+    return ret;
+  });
 }
 
 #ifdef UNIT_TESTS_BUILT
-seastar::future<> Socket::try_trap_pre(bp_action_t& trap) {
-  auto action = trap;
-  trap = bp_action_t::CONTINUE;
-  switch (action) {
-   case bp_action_t::CONTINUE:
-    break;
-   case bp_action_t::FAULT:
-    logger().info("[Test] got FAULT");
-    throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
-   case bp_action_t::BLOCK:
-    logger().info("[Test] got BLOCK");
-    return blocker->block();
-   case bp_action_t::STALL:
-    trap = action;
-    break;
-   default:
-    ceph_abort("unexpected action from trap");
-  }
-  return seastar::make_ready_future<>();
-}
-
-seastar::future<> Socket::try_trap_post(bp_action_t& trap) {
-  auto action = trap;
-  trap = bp_action_t::CONTINUE;
-  switch (action) {
-   case bp_action_t::CONTINUE:
-    break;
-   case bp_action_t::STALL:
-    logger().info("[Test] got STALL and block");
-    force_shutdown();
-    return blocker->block();
-   default:
-    ceph_abort("unexpected action from trap");
-  }
-  return seastar::make_ready_future<>();
-}
-
 void Socket::set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocker_) {
   blocker = blocker_;
   if (type == bp_type_t::READ) {
@@ -233,77 +295,200 @@ void Socket::set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocke
     }
   }
 }
+
+seastar::future<>
+Socket::try_trap_pre(bp_action_t& trap) {
+  auto action = trap;
+  trap = bp_action_t::CONTINUE;
+  switch (action) {
+   case bp_action_t::CONTINUE:
+    break;
+   case bp_action_t::FAULT:
+    logger().info("[Test] got FAULT");
+    throw std::system_error(make_error_code(error::negotiation_failure));
+   case bp_action_t::BLOCK:
+    logger().info("[Test] got BLOCK");
+    return blocker->block();
+   case bp_action_t::STALL:
+    trap = action;
+    break;
+   default:
+    ceph_abort("unexpected action from trap");
+  }
+  return seastar::make_ready_future<>();
+}
+
+seastar::future<>
+Socket::try_trap_post(bp_action_t& trap) {
+  auto action = trap;
+  trap = bp_action_t::CONTINUE;
+  switch (action) {
+   case bp_action_t::CONTINUE:
+    break;
+   case bp_action_t::STALL:
+    logger().info("[Test] got STALL and block");
+    force_shutdown();
+    return blocker->block();
+   default:
+    ceph_abort("unexpected action from trap");
+  }
+  return seastar::make_ready_future<>();
+}
 #endif
 
-crimson::net::listen_ertr::future<>
+FixedCPUServerSocket::FixedCPUServerSocket(
+    seastar::shard_id cpu,
+    construct_tag)
+  : fixed_cpu{cpu}
+{
+}
+
+FixedCPUServerSocket::~FixedCPUServerSocket()
+{
+  assert(!listener);
+  // detect whether user have called destroy() properly
+  ceph_assert(!service);
+}
+
+listen_ertr::future<>
 FixedCPUServerSocket::listen(entity_addr_t addr)
 {
-  assert(seastar::this_shard_id() == cpu);
-  logger().trace("FixedCPUServerSocket::listen({})...", addr);
-  return container().invoke_on_all([addr] (auto& ss) {
-    ss.addr = addr;
+  assert(seastar::this_shard_id() == fixed_cpu);
+  logger().debug("FixedCPUServerSocket({})::listen()...", addr);
+  return container().invoke_on_all([addr](auto& ss) {
+    ss.listen_addr = addr;
     seastar::socket_address s_addr(addr.in4_addr());
     seastar::listen_options lo;
     lo.reuse_address = true;
-    lo.set_fixed_cpu(ss.cpu);
+    lo.set_fixed_cpu(ss.fixed_cpu);
     ss.listener = seastar::listen(s_addr, lo);
   }).then([] {
     return listen_ertr::now();
   }).handle_exception_type(
-    [addr] (const std::system_error& e) -> listen_ertr::future<> {
+    [addr](const std::system_error& e) -> listen_ertr::future<> {
     if (e.code() == std::errc::address_in_use) {
-      logger().trace("FixedCPUServerSocket::listen({}): address in use", addr);
+      logger().debug("FixedCPUServerSocket({})::listen(): address in use", addr);
       return crimson::ct_error::address_in_use::make();
     } else if (e.code() == std::errc::address_not_available) {
-      logger().trace("FixedCPUServerSocket::listen({}): address not available",
+      logger().debug("FixedCPUServerSocket({})::listen(): address not available",
                      addr);
       return crimson::ct_error::address_not_available::make();
     }
-    logger().error("FixedCPUServerSocket::listen({}): "
-                   "got unexpeted error {}", addr, e);
+    logger().error("FixedCPUServerSocket({})::listen(): "
+                   "got unexpeted error {}", addr, e.what());
     ceph_abort();
   });
 }
 
-seastar::future<> FixedCPUServerSocket::shutdown()
+seastar::future<>
+FixedCPUServerSocket::accept(accept_func_t &&_fn_accept)
 {
-  assert(seastar::this_shard_id() == cpu);
-  logger().trace("FixedCPUServerSocket({})::shutdown()...", addr);
-  return container().invoke_on_all([] (auto& ss) {
+  assert(seastar::this_shard_id() == fixed_cpu);
+  logger().debug("FixedCPUServerSocket({})::accept()...", listen_addr);
+  return container().invoke_on_all([_fn_accept](auto &ss) {
+    assert(ss.listener);
+    ss.fn_accept = _fn_accept;
+    // gate accepting
+    // FixedCPUServerSocket::shutdown() will drain the continuations in the gate
+    // so ignore the returned future
+    std::ignore = seastar::with_gate(ss.shutdown_gate, [&ss] {
+      return seastar::keep_doing([&ss] {
+        return ss.listener->accept(
+        ).then([&ss](seastar::accept_result accept_result) {
+          // assert seastar::listen_options::set_fixed_cpu() works
+          assert(seastar::this_shard_id() == ss.fixed_cpu);
+          auto [socket, paddr] = std::move(accept_result);
+          entity_addr_t peer_addr;
+          peer_addr.set_sockaddr(&paddr.as_posix_sockaddr());
+          peer_addr.set_type(ss.listen_addr.get_type());
+          SocketRef _socket = std::make_unique<Socket>(
+              std::move(socket), Socket::side_t::acceptor,
+              peer_addr.get_port(), Socket::construct_tag{});
+          logger().debug("FixedCPUServerSocket({})::accept(): "
+                         "accepted peer {}, socket {}",
+                         ss.listen_addr, peer_addr, fmt::ptr(_socket));
+          std::ignore = seastar::with_gate(
+              ss.shutdown_gate,
+              [socket=std::move(_socket), peer_addr, &ss]() mutable {
+            return ss.fn_accept(std::move(socket), peer_addr
+            ).handle_exception([&ss, peer_addr](auto eptr) {
+              const char *e_what;
+              try {
+                std::rethrow_exception(eptr);
+              } catch (std::exception &e) {
+                e_what = e.what();
+              }
+              logger().error("FixedCPUServerSocket({})::accept(): "
+                             "fn_accept(s, {}) got unexpected exception {}",
+                             ss.listen_addr, peer_addr, e_what);
+              ceph_abort();
+            });
+          });
+        });
+      }).handle_exception_type([&ss](const std::system_error& e) {
+        if (e.code() == std::errc::connection_aborted ||
+            e.code() == std::errc::invalid_argument) {
+          logger().debug("FixedCPUServerSocket({})::accept(): stopped ({})",
+                         ss.listen_addr, e.what());
+        } else {
+          throw;
+        }
+      }).handle_exception([&ss](auto eptr) {
+        const char *e_what;
+        try {
+          std::rethrow_exception(eptr);
+        } catch (std::exception &e) {
+          e_what = e.what();
+        }
+        logger().error("FixedCPUServerSocket({})::accept(): "
+                       "got unexpected exception {}", ss.listen_addr, e_what);
+        ceph_abort();
+      });
+    });
+  });
+}
+
+seastar::future<>
+FixedCPUServerSocket::shutdown_destroy()
+{
+  assert(seastar::this_shard_id() == fixed_cpu);
+  logger().debug("FixedCPUServerSocket({})::shutdown_destroy()...", listen_addr);
+  // shutdown shards
+  return container().invoke_on_all([](auto& ss) {
     if (ss.listener) {
       ss.listener->abort_accept();
     }
     return ss.shutdown_gate.close();
   }).then([this] {
-    return reset();
-  });
-}
-
-seastar::future<> FixedCPUServerSocket::destroy()
-{
-  assert(seastar::this_shard_id() == cpu);
-  return shutdown().then([this] {
-    // we should only construct/stop shards on #0
-    return container().invoke_on(0, [] (auto& ss) {
+    // destroy shards
+    return container().invoke_on_all([](auto& ss) {
+      assert(ss.shutdown_gate.is_closed());
+      ss.listen_addr = entity_addr_t();
+      ss.listener.reset();
+    });
+  }).then([this] {
+    // stop the sharded service: we should only construct/stop shards on #0
+    return container().invoke_on(0, [](auto& ss) {
       assert(ss.service);
       return ss.service->stop().finally([cleanup = std::move(ss.service)] {});
     });
   });
 }
 
-seastar::future<FixedCPUServerSocket*> FixedCPUServerSocket::create()
+seastar::future<FixedCPUServerSocket*>
+FixedCPUServerSocket::create()
 {
-  auto cpu = seastar::this_shard_id();
-  // we should only construct/stop shards on #0
-  return seastar::smp::submit_to(0, [cpu] {
+  auto fixed_cpu = seastar::this_shard_id();
+  // start the sharded service: we should only construct/stop shards on #0
+  return seastar::smp::submit_to(0, [fixed_cpu] {
     auto service = std::make_unique<sharded_service_t>();
-    return service->start(cpu, construct_tag{}
-    ).then([service = std::move(service)] () mutable {
+    return service->start(fixed_cpu, construct_tag{}
+    ).then([service = std::move(service)]() mutable {
       auto p_shard = service.get();
       p_shard->local().service = std::move(service);
       return p_shard;
     });
-  }).then([] (auto p_shard) {
+  }).then([](auto p_shard) {
     return &p_shard->local();
   });
 }

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -107,6 +107,7 @@ Socket::Socket(
 
 Socket::~Socket()
 {
+  assert(seastar::this_shard_id() == sid);
 #ifndef NDEBUG
   assert(closed);
 #endif
@@ -115,6 +116,7 @@ Socket::~Socket()
 seastar::future<bufferlist>
 Socket::read(size_t bytes)
 {
+  assert(seastar::this_shard_id() == sid);
 #ifdef UNIT_TESTS_BUILT
   return try_trap_pre(next_trap_read).then([bytes, this] {
 #endif
@@ -144,6 +146,7 @@ Socket::read(size_t bytes)
 
 seastar::future<bufferptr>
 Socket::read_exactly(size_t bytes) {
+  assert(seastar::this_shard_id() == sid);
 #ifdef UNIT_TESTS_BUILT
   return try_trap_pre(next_trap_read).then([bytes, this] {
 #endif
@@ -174,6 +177,7 @@ Socket::read_exactly(size_t bytes) {
 seastar::future<>
 Socket::write(bufferlist buf)
 {
+  assert(seastar::this_shard_id() == sid);
 #ifdef UNIT_TESTS_BUILT
   return try_trap_pre(next_trap_write
   ).then([buf = std::move(buf), this]() mutable {
@@ -194,6 +198,7 @@ Socket::write(bufferlist buf)
 seastar::future<>
 Socket::flush()
 {
+  assert(seastar::this_shard_id() == sid);
   inject_failure();
   return inject_delay().then([this] {
     return out.flush();
@@ -203,6 +208,7 @@ Socket::flush()
 seastar::future<>
 Socket::write_flush(bufferlist buf)
 {
+  assert(seastar::this_shard_id() == sid);
 #ifdef UNIT_TESTS_BUILT
   return try_trap_pre(next_trap_write
   ).then([buf = std::move(buf), this]() mutable {
@@ -223,7 +229,9 @@ Socket::write_flush(bufferlist buf)
 #endif
 }
 
-void Socket::shutdown() {
+void Socket::shutdown()
+{
+  assert(seastar::this_shard_id() == sid);
   socket_is_shutdown = true;
   socket.shutdown_input();
   socket.shutdown_output();
@@ -243,7 +251,9 @@ close_and_handle_errors(seastar::output_stream<char>& out)
 }
 
 seastar::future<>
-Socket::close() {
+Socket::close()
+{
+  assert(seastar::this_shard_id() == sid);
 #ifndef NDEBUG
   ceph_assert_always(!closed);
   closed = true;
@@ -284,6 +294,7 @@ Socket::connect(const entity_addr_t &peer_addr)
 
 #ifdef UNIT_TESTS_BUILT
 void Socket::set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocker_) {
+  assert(seastar::this_shard_id() == sid);
   blocker = blocker_;
   if (type == bp_type_t::READ) {
     ceph_assert_always(next_trap_read == bp_action_t::CONTINUE);

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -6,7 +6,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/net/packet.hh>
 
 #include "include/buffer.h"
 
@@ -67,15 +66,13 @@ public:
   /// read the requested number of bytes into a bufferlist
   seastar::future<bufferlist> read(size_t bytes);
 
-  using tmp_buf = seastar::temporary_buffer<char>;
-  using packet = seastar::net::packet;
-  seastar::future<tmp_buf> read_exactly(size_t bytes);
+  seastar::future<bufferptr> read_exactly(size_t bytes);
 
-  seastar::future<> write(packet &&buf);
+  seastar::future<> write(bufferlist);
 
   seastar::future<> flush();
 
-  seastar::future<> write_flush(packet &&buf);
+  seastar::future<> write_flush(bufferlist);
 
   // preemptively disable further reads or writes, can only be shutdown once.
   void shutdown();

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -21,6 +21,7 @@ namespace crimson::net {
 
 class Socket;
 using SocketRef = std::unique_ptr<Socket>;
+using SocketFRef = seastar::foreign_ptr<SocketRef>;
 
 class Socket {
   struct construct_tag {};

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -38,6 +38,10 @@ public:
 
   Socket(Socket&& o) = delete;
 
+  seastar::shard_id get_shard_id() const {
+    return sid;
+  }
+
   side_t get_side() const {
     return side;
   }
@@ -51,6 +55,7 @@ public:
   }
 
   bool is_shutdown() const {
+    assert(seastar::this_shard_id() == sid);
     return socket_is_shutdown;
   }
 
@@ -89,17 +94,20 @@ public:
 
   // shutdown for tests
   void force_shutdown() {
+    assert(seastar::this_shard_id() == sid);
     socket.shutdown_input();
     socket.shutdown_output();
   }
 
   // shutdown input_stream only, for tests
   void force_shutdown_in() {
+    assert(seastar::this_shard_id() == sid);
     socket.shutdown_input();
   }
 
   // shutdown output_stream only, for tests
   void force_shutdown_out() {
+    assert(seastar::this_shard_id() == sid);
     socket.shutdown_output();
   }
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -146,6 +146,10 @@ SocketConnection::get_local_shared_foreign_from_this()
       seastar::make_foreign(shared_from_this()));
 }
 
+void SocketConnection::set_socket(Socket *s) {
+  socket = s;
+}
+
 void SocketConnection::print(ostream& out) const {
     out << (void*)this << " ";
     messenger.print(out);

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -70,21 +70,15 @@ bool SocketConnection::peer_wins() const
 
 seastar::future<> SocketConnection::send(MessageURef _msg)
 {
+  // may be invoked from any core
   MessageFRef msg = seastar::make_foreign(std::move(_msg));
-  return seastar::smp::submit_to(
-    io_handler->get_shard_id(),
-    [this, msg=std::move(msg)]() mutable {
-      return io_handler->send(std::move(msg));
-    });
+  return io_handler->send(std::move(msg));
 }
 
 seastar::future<> SocketConnection::send_keepalive()
 {
-  return seastar::smp::submit_to(
-    io_handler->get_shard_id(),
-    [this] {
-      return io_handler->send_keepalive();
-    });
+  // may be invoked from any core
+  return io_handler->send_keepalive();
 }
 
 SocketConnection::clock_t::time_point

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -28,8 +28,7 @@ namespace crimson::net {
 
 SocketConnection::SocketConnection(SocketMessenger& messenger,
                                    ChainedDispatchers& dispatchers)
-  : core(messenger.get_shard_id()),
-    messenger(messenger)
+  : msgr_sid{messenger.get_shard_id()}, messenger(messenger)
 {
   auto ret = create_handlers(dispatchers, *this);
   io_handler = std::move(ret.io_handler);
@@ -46,33 +45,33 @@ SocketConnection::~SocketConnection() {}
 
 bool SocketConnection::is_connected() const
 {
-  assert(seastar::this_shard_id() == shard_id());
   return io_handler->is_connected();
 }
 
 #ifdef UNIT_TESTS_BUILT
 bool SocketConnection::is_closed() const
 {
-  assert(seastar::this_shard_id() == shard_id());
+  assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed();
 }
 
 bool SocketConnection::is_closed_clean() const
 {
-  assert(seastar::this_shard_id() == shard_id());
+  assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed_clean();
 }
 
 #endif
 bool SocketConnection::peer_wins() const
 {
+  assert(seastar::this_shard_id() == msgr_sid);
   return (messenger.get_myaddr() > peer_addr || policy.server);
 }
 
 seastar::future<> SocketConnection::send(MessageURef msg)
 {
   return seastar::smp::submit_to(
-    shard_id(),
+    io_handler->get_shard_id(),
     [this, msg=std::move(msg)]() mutable {
       return io_handler->send(std::move(msg));
     });
@@ -81,7 +80,7 @@ seastar::future<> SocketConnection::send(MessageURef msg)
 seastar::future<> SocketConnection::send_keepalive()
 {
   return seastar::smp::submit_to(
-    shard_id(),
+    io_handler->get_shard_id(),
     [this] {
       return io_handler->send_keepalive();
     });
@@ -106,7 +105,6 @@ void SocketConnection::set_last_keepalive_ack(clock_t::time_point when)
 
 void SocketConnection::mark_down()
 {
-  assert(seastar::this_shard_id() == shard_id());
   io_handler->mark_down();
 }
 
@@ -114,6 +112,7 @@ void
 SocketConnection::start_connect(const entity_addr_t& _peer_addr,
                                 const entity_name_t& _peer_name)
 {
+  assert(seastar::this_shard_id() == msgr_sid);
   protocol->start_connect(_peer_addr, _peer_name);
 }
 
@@ -121,47 +120,89 @@ void
 SocketConnection::start_accept(SocketRef&& sock,
                                const entity_addr_t& _peer_addr)
 {
+  assert(seastar::this_shard_id() == msgr_sid);
   protocol->start_accept(std::move(sock), _peer_addr);
 }
 
 seastar::future<>
 SocketConnection::close_clean_yielded()
 {
+  assert(seastar::this_shard_id() == msgr_sid);
   return protocol->close_clean_yielded();
 }
 
-seastar::shard_id SocketConnection::shard_id() const {
-  return core;
-}
-
 seastar::socket_address SocketConnection::get_local_address() const {
+  assert(seastar::this_shard_id() == msgr_sid);
   return socket->get_local_address();
 }
 
 ConnectionRef
 SocketConnection::get_local_shared_foreign_from_this()
 {
-  assert(seastar::this_shard_id() == shard_id());
+  assert(seastar::this_shard_id() == msgr_sid);
   return make_local_shared_foreign(
       seastar::make_foreign(shared_from_this()));
 }
 
+SocketMessenger &
+SocketConnection::get_messenger() const
+{
+  assert(seastar::this_shard_id() == msgr_sid);
+  return messenger;
+}
+
+void SocketConnection::set_peer_type(entity_type_t peer_type) {
+  assert(seastar::this_shard_id() == msgr_sid);
+  // it is not allowed to assign an unknown value when the current
+  // value is known
+  assert(!(peer_type == 0 &&
+           peer_name.type() != 0));
+  // it is not allowed to assign a different known value when the
+  // current value is also known.
+  assert(!(peer_type != 0 &&
+           peer_name.type() != 0 &&
+           peer_type != peer_name.type()));
+  peer_name._type = peer_type;
+}
+
+void SocketConnection::set_peer_id(int64_t peer_id) {
+  assert(seastar::this_shard_id() == msgr_sid);
+  // it is not allowed to assign an unknown value when the current
+  // value is known
+  assert(!(peer_id == entity_name_t::NEW &&
+           peer_name.num() != entity_name_t::NEW));
+  // it is not allowed to assign a different known value when the
+  // current value is also known.
+  assert(!(peer_id != entity_name_t::NEW &&
+           peer_name.num() != entity_name_t::NEW &&
+           peer_id != peer_name.num()));
+  peer_name._num = peer_id;
+}
+
+void SocketConnection::set_features(uint64_t f) {
+  assert(seastar::this_shard_id() == msgr_sid);
+  features = f;
+}
+
 void SocketConnection::set_socket(Socket *s) {
+  assert(seastar::this_shard_id() == msgr_sid);
   socket = s;
 }
 
 void SocketConnection::print(ostream& out) const {
-    out << (void*)this << " ";
-    messenger.print(out);
-    if (!socket) {
-      out << " >> " << get_peer_name() << " " << peer_addr;
-    } else if (socket->get_side() == Socket::side_t::acceptor) {
-      out << " >> " << get_peer_name() << " " << peer_addr
-          << "@" << socket->get_ephemeral_port();
-    } else { // socket->get_side() == Socket::side_t::connector
-      out << "@" << socket->get_ephemeral_port()
-          << " >> " << get_peer_name() << " " << peer_addr;
-    }
+  out << (void*)this << " ";
+  messenger.print(out);
+  if (seastar::this_shard_id() != msgr_sid) {
+    out << " >> " << get_peer_name() << " " << peer_addr;
+  } else if (!socket) {
+    out << " >> " << get_peer_name() << " " << peer_addr;
+  } else if (socket->get_side() == Socket::side_t::acceptor) {
+    out << " >> " << get_peer_name() << " " << peer_addr
+        << "@" << socket->get_ephemeral_port();
+  } else { // socket->get_side() == Socket::side_t::connector
+    out << "@" << socket->get_ephemeral_port()
+        << " >> " << get_peer_name() << " " << peer_addr;
+  }
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -68,8 +68,9 @@ bool SocketConnection::peer_wins() const
   return (messenger.get_myaddr() > peer_addr || policy.server);
 }
 
-seastar::future<> SocketConnection::send(MessageURef msg)
+seastar::future<> SocketConnection::send(MessageURef _msg)
 {
+  MessageFRef msg = seastar::make_foreign(std::move(_msg));
   return seastar::smp::submit_to(
     io_handler->get_shard_id(),
     [this, msg=std::move(msg)]() mutable {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -28,7 +28,7 @@ namespace crimson::net {
 
 SocketConnection::SocketConnection(SocketMessenger& messenger,
                                    ChainedDispatchers& dispatchers)
-  : core(messenger.shard_id()),
+  : core(messenger.get_shard_id()),
     messenger(messenger)
 {
   auto ret = create_handlers(dispatchers, *this);

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -152,6 +152,12 @@ SocketConnection::get_messenger() const
   return messenger;
 }
 
+seastar::shard_id
+SocketConnection::get_messenger_shard_id() const
+{
+  return msgr_sid;
+}
+
 void SocketConnection::set_peer_type(entity_type_t peer_type) {
   assert(seastar::this_shard_id() == msgr_sid);
   // it is not allowed to assign an unknown value when the current

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -118,7 +118,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
 }
 
 void
-SocketConnection::start_accept(SocketRef&& sock,
+SocketConnection::start_accept(SocketFRef&& sock,
                                const entity_addr_t& _peer_addr)
 {
   assert(seastar::this_shard_id() == msgr_sid);

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -36,7 +36,7 @@ SocketConnection::SocketConnection(SocketMessenger& messenger,
 #ifdef UNIT_TESTS_BUILT
   if (messenger.interceptor) {
     interceptor = messenger.interceptor;
-    interceptor->register_conn(*this);
+    interceptor->register_conn(this->get_local_shared_foreign_from_this());
   }
 #endif
 }

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -25,6 +25,7 @@ namespace crimson::net {
 
 class ProtocolV2;
 class SocketMessenger;
+class SocketConnection;
 using SocketConnectionRef = seastar::shared_ptr<SocketConnection>;
 
 #ifdef UNIT_TESTS_BUILT

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -47,6 +47,8 @@ public:
   ConnectionHandler &operator=(const ConnectionHandler &) = delete;
   ConnectionHandler &operator=(ConnectionHandler &&) = delete;
 
+  virtual seastar::shard_id get_shard_id() const = 0;
+
   virtual bool is_connected() const = 0;
 
   virtual seastar::future<> send(MessageURef) = 0;
@@ -66,32 +68,6 @@ protected:
 };
 
 class SocketConnection : public Connection {
-  const seastar::shard_id core;
-
-  SocketMessenger& messenger;
-
-  std::unique_ptr<ConnectionHandler> io_handler;
-
-  std::unique_ptr<ProtocolV2> protocol;
-
-  Socket *socket = nullptr;
-
-  entity_name_t peer_name = {0, entity_name_t::NEW};
-
-  entity_addr_t peer_addr;
-
-  // which of the peer_addrs we're connecting to (as client)
-  // or should reconnect to (as peer)
-  entity_addr_t target_addr;
-
-  uint64_t features = 0;
-
-  ceph::net::Policy<crimson::common::Throttle> policy;
-
-  uint64_t peer_global_id = 0;
-
-  std::unique_ptr<user_private_t> user_private;
-
  // Connection interfaces, public to users
  public:
   SocketConnection(SocketMessenger& messenger,
@@ -145,7 +121,10 @@ class SocketConnection : public Connection {
 
   void print(std::ostream& out) const override;
 
- // public to SocketMessenger
+ /*
+  * Public to SocketMessenger
+  * Working in SocketMessenger::get_shard_id();
+  */
  public:
   /// start a handshake from the client's perspective,
   /// only call when SocketConnection first construct
@@ -161,49 +140,21 @@ class SocketConnection : public Connection {
 
   seastar::socket_address get_local_address() const;
 
-  SocketMessenger &get_messenger() const {
-    return messenger;
-  }
+  SocketMessenger &get_messenger() const;
 
   ConnectionRef get_local_shared_foreign_from_this();
 
 private:
-  seastar::shard_id shard_id() const;
+  void set_peer_type(entity_type_t peer_type);
 
-  void set_peer_type(entity_type_t peer_type) {
-    // it is not allowed to assign an unknown value when the current
-    // value is known
-    assert(!(peer_type == 0 &&
-             peer_name.type() != 0));
-    // it is not allowed to assign a different known value when the
-    // current value is also known.
-    assert(!(peer_type != 0 &&
-             peer_name.type() != 0 &&
-             peer_type != peer_name.type()));
-    peer_name._type = peer_type;
-  }
-
-  void set_peer_id(int64_t peer_id) {
-    // it is not allowed to assign an unknown value when the current
-    // value is known
-    assert(!(peer_id == entity_name_t::NEW &&
-             peer_name.num() != entity_name_t::NEW));
-    // it is not allowed to assign a different known value when the
-    // current value is also known.
-    assert(!(peer_id != entity_name_t::NEW &&
-             peer_name.num() != entity_name_t::NEW &&
-             peer_id != peer_name.num()));
-    peer_name._num = peer_id;
-  }
+  void set_peer_id(int64_t peer_id);
 
   void set_peer_name(entity_name_t name) {
     set_peer_type(name.type());
     set_peer_id(name.num());
   }
 
-  void set_features(uint64_t f) {
-    features = f;
-  }
+  void set_features(uint64_t f);
 
   void set_socket(Socket *s);
 
@@ -220,6 +171,42 @@ private:
   // peer wins if myaddr > peeraddr
   bool peer_wins() const;
 #endif
+
+private:
+  const seastar::shard_id msgr_sid;
+
+  /*
+   * Core owner is messenger core, may allow to access from the I/O core.
+   */
+  SocketMessenger& messenger;
+
+  std::unique_ptr<ProtocolV2> protocol;
+
+  Socket *socket = nullptr;
+
+  entity_name_t peer_name = {0, entity_name_t::NEW};
+
+  entity_addr_t peer_addr;
+
+  // which of the peer_addrs we're connecting to (as client)
+  // or should reconnect to (as peer)
+  entity_addr_t target_addr;
+
+  uint64_t features = 0;
+
+  ceph::net::Policy<crimson::common::Throttle> policy;
+
+  uint64_t peer_global_id = 0;
+
+  /*
+   * Core owner is I/O core (mutable).
+   */
+  std::unique_ptr<ConnectionHandler> io_handler;
+
+  /*
+   * Core owner is up to the connection user.
+   */
+  std::unique_ptr<user_private_t> user_private;
 
   friend class IOHandler;
   friend class ProtocolV2;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -74,7 +74,7 @@ class SocketConnection : public Connection {
 
   std::unique_ptr<ProtocolV2> protocol;
 
-  SocketRef socket;
+  Socket *socket = nullptr;
 
   entity_name_t peer_name = {0, entity_name_t::NEW};
 
@@ -204,6 +204,8 @@ private:
   void set_features(uint64_t f) {
     features = f;
   }
+
+  void set_socket(Socket *s);
 
 #ifdef UNIT_TESTS_BUILT
   bool is_closed_clean() const override;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -141,6 +141,8 @@ class SocketConnection : public Connection {
 
   seastar::socket_address get_local_address() const;
 
+  seastar::shard_id get_messenger_shard_id() const;
+
   SocketMessenger &get_messenger() const;
 
   ConnectionRef get_local_shared_foreign_from_this();

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -134,7 +134,7 @@ class SocketConnection : public Connection {
 
   /// start a handshake from the server's perspective,
   /// only call when SocketConnection first construct
-  void start_accept(SocketRef&& socket,
+  void start_accept(SocketFRef&& socket,
                     const entity_addr_t& peer_addr);
 
   seastar::future<> close_clean_yielded();

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -52,7 +52,7 @@ public:
 
   virtual bool is_connected() const = 0;
 
-  virtual seastar::future<> send(MessageURef) = 0;
+  virtual seastar::future<> send(MessageFRef) = 0;
 
   virtual seastar::future<> send_keepalive() = 0;
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -36,6 +36,8 @@ class Interceptor;
  * ConnectionHandler
  *
  * The interface class to implement Connection, called by SocketConnection.
+ *
+ * The operations must be done in get_shard_id().
  */
 class ConnectionHandler {
 public:
@@ -69,12 +71,19 @@ protected:
 };
 
 class SocketConnection : public Connection {
- // Connection interfaces, public to users
+ /*
+  * Connection interfaces, public to users
+  * Working in ConnectionHandler::get_shard_id()
+  */
  public:
   SocketConnection(SocketMessenger& messenger,
                    ChainedDispatchers& dispatchers);
 
   ~SocketConnection() override;
+
+  const seastar::shard_id get_shard_id() const override {
+    return io_handler->get_shard_id();
+  }
 
   const entity_name_t &get_peer_name() const override {
     return peer_name;

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -92,7 +92,7 @@ SocketMessenger::do_listen(const entity_addrvec_t& addrs)
   set_myaddrs(addrs);
   return seastar::futurize_invoke([this] {
     if (!listener) {
-      return ShardedServerSocket<true>::create(
+      return ShardedServerSocket::create(true
       ).then([this] (auto _listener) {
         listener = _listener;
       });
@@ -218,6 +218,7 @@ seastar::future<> SocketMessenger::start(
     ceph_assert(get_myaddr().get_port() > 0);
 
     return listener->accept([this](SocketRef socket, entity_addr_t peer_addr) {
+      assert(listener->is_fixed());
       assert(seastar::this_shard_id() == sid);
       assert(get_myaddr().is_msgr2());
       SocketConnectionRef conn =

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -255,7 +255,7 @@ seastar::future<> SocketMessenger::shutdown()
     if (listener) {
       auto d_listener = listener;
       listener = nullptr;
-      return d_listener->destroy();
+      return d_listener->shutdown_destroy();
     } else {
       return seastar::now();
     }

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -34,10 +34,12 @@ namespace crimson::net {
 
 SocketMessenger::SocketMessenger(const entity_name_t& myname,
                                  const std::string& logic_name,
-                                 uint32_t nonce)
+                                 uint32_t nonce,
+                                 bool is_fixed_cpu)
   : sid{seastar::this_shard_id()},
     logic_name{logic_name},
     nonce{nonce},
+    is_fixed_cpu{is_fixed_cpu},
     my_name{myname}
 {}
 
@@ -92,7 +94,7 @@ SocketMessenger::do_listen(const entity_addrvec_t& addrs)
   set_myaddrs(addrs);
   return seastar::futurize_invoke([this] {
     if (!listener) {
-      return ShardedServerSocket::create(true
+      return ShardedServerSocket::create(is_fixed_cpu
       ).then([this] (auto _listener) {
         listener = _listener;
       });

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -214,7 +214,7 @@ seastar::future<> SocketMessenger::start(
     ceph_assert(get_myaddr().is_msgr2());
     ceph_assert(get_myaddr().get_port() > 0);
 
-    return listener->accept([this] (SocketRef socket, entity_addr_t peer_addr) {
+    return listener->accept([this](SocketRef socket, entity_addr_t peer_addr) {
       assert(seastar::this_shard_id() == master_sid);
       assert(get_myaddr().is_msgr2());
       SocketConnectionRef conn =

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -91,7 +91,8 @@ SocketMessenger::do_listen(const entity_addrvec_t& addrs)
   set_myaddrs(addrs);
   return seastar::futurize_invoke([this] {
     if (!listener) {
-      return FixedCPUServerSocket::create().then([this] (auto _listener) {
+      return ShardedServerSocket<true>::create(
+      ).then([this] (auto _listener) {
         listener = _listener;
       });
     } else {

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -36,7 +36,8 @@ class SocketMessenger final : public Messenger {
 public:
   SocketMessenger(const entity_name_t& myname,
                   const std::string& logic_name,
-                  uint32_t nonce);
+                  uint32_t nonce,
+                  bool is_fixed_cpu);
 
   ~SocketMessenger() override;
 
@@ -164,6 +165,7 @@ private:
   // Distinguish messengers with meaningful names for debugging
   const std::string logic_name;
   const uint32_t nonce;
+  const bool is_fixed_cpu;
 
   entity_name_t my_name;
   entity_addrvec_t my_addrs;

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -152,6 +152,8 @@ public:
 #endif
 
 private:
+  seastar::future<> accept(SocketFRef &&, const entity_addr_t &);
+
   listen_ertr::future<> do_listen(const entity_addrvec_t& addr);
 
   /// try to bind to the first unused port of given address

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -33,38 +33,12 @@ template <bool IS_FIXED_CPU>
 class ShardedServerSocket;
 
 class SocketMessenger final : public Messenger {
-  const seastar::shard_id master_sid;
-  // Distinguish messengers with meaningful names for debugging
-  const std::string logic_name;
-  const uint32_t nonce;
-
-  entity_name_t my_name;
-  entity_addrvec_t my_addrs;
-  crimson::auth::AuthClient* auth_client = nullptr;
-  crimson::auth::AuthServer* auth_server = nullptr;
-
-  ShardedServerSocket<true> *listener = nullptr;
-  ChainedDispatchers dispatchers;
-  std::map<entity_addr_t, SocketConnectionRef> connections;
-  std::set<SocketConnectionRef> accepting_conns;
-  std::vector<SocketConnectionRef> closing_conns;
-  ceph::net::PolicySet<Throttle> policy_set;
-  // specifying we haven't learned our addr; set false when we find it.
-  bool need_addr = true;
-  uint32_t global_seq = 0;
-  bool started = false;
-  seastar::promise<> shutdown_promise;
-
-  listen_ertr::future<> do_listen(const entity_addrvec_t& addr);
-  /// try to bind to the first unused port of given address
-  bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
-                               uint32_t min_port, uint32_t max_port);
-
-
- public:
+// Messenger public interfaces
+public:
   SocketMessenger(const entity_name_t& myname,
                   const std::string& logic_name,
                   uint32_t nonce);
+
   ~SocketMessenger() override;
 
   const entity_name_t &get_myname() const override {
@@ -77,18 +51,18 @@ class SocketMessenger final : public Messenger {
 
   void set_myaddrs(const entity_addrvec_t& addr) override;
 
+  bool set_addr_unknowns(const entity_addrvec_t &addr) override;
+
   void set_auth_client(crimson::auth::AuthClient *ac) override {
+    assert(seastar::this_shard_id() == sid);
     auth_client = ac;
   }
 
   void set_auth_server(crimson::auth::AuthServer *as) override {
+    assert(seastar::this_shard_id() == sid);
     auth_server = as;
   }
 
-
-  bool set_addr_unknowns(const entity_addrvec_t &addr) override;
-  // Messenger interfaces are assumed to be called from its own shard, but its
-  // behavior should be symmetric when called from any shard.
   bind_ertr::future<> bind(const entity_addrvec_t& addr) override;
 
   seastar::future<> start(const dispatchers_t& dispatchers) override;
@@ -97,20 +71,23 @@ class SocketMessenger final : public Messenger {
                         const entity_name_t& peer_name) override;
 
   bool owns_connection(Connection &conn) const override {
+    assert(seastar::this_shard_id() == sid);
     return this == &static_cast<SocketConnection&>(conn).get_messenger();
   }
 
   // can only wait once
   seastar::future<> wait() override {
-    assert(seastar::this_shard_id() == master_sid);
+    assert(seastar::this_shard_id() == sid);
     return shutdown_promise.get_future();
   }
 
   void stop() override {
+    assert(seastar::this_shard_id() == sid);
     dispatchers.clear();
   }
 
   bool is_started() const override {
+    assert(seastar::this_shard_id() == sid);
     return !dispatchers.empty();
   }
 
@@ -132,10 +109,17 @@ class SocketMessenger final : public Messenger {
 
   void set_policy_throttler(entity_type_t peer_type, Throttle* throttle) override;
 
- public:
-  crimson::auth::AuthClient* get_auth_client() const { return auth_client; }
+// SocketMessenger public interfaces
+public:
+  crimson::auth::AuthClient* get_auth_client() const {
+    assert(seastar::this_shard_id() == sid);
+    return auth_client;
+  }
 
-  crimson::auth::AuthServer* get_auth_server() const { return auth_server; }
+  crimson::auth::AuthServer* get_auth_server() const {
+    assert(seastar::this_shard_id() == sid);
+    return auth_server;
+  }
 
   uint32_t get_global_seq(uint32_t old=0);
 
@@ -143,16 +127,21 @@ class SocketMessenger final : public Messenger {
                     const SocketConnection& conn);
 
   SocketConnectionRef lookup_conn(const entity_addr_t& addr);
+
   void accept_conn(SocketConnectionRef);
+
   void unaccept_conn(SocketConnectionRef);
+
   void register_conn(SocketConnectionRef);
+
   void unregister_conn(SocketConnectionRef);
+
   void closing_conn(SocketConnectionRef);
+
   void closed_conn(SocketConnectionRef);
 
-  seastar::shard_id shard_id() const {
-    assert(seastar::this_shard_id() == master_sid);
-    return master_sid;
+  seastar::shard_id get_shard_id() const {
+    return sid;
   }
 
 #ifdef UNIT_TESTS_BUILT
@@ -162,6 +151,35 @@ class SocketMessenger final : public Messenger {
 
   Interceptor *interceptor = nullptr;
 #endif
+
+private:
+  listen_ertr::future<> do_listen(const entity_addrvec_t& addr);
+
+  /// try to bind to the first unused port of given address
+  bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
+                               uint32_t min_port, uint32_t max_port);
+
+  const seastar::shard_id sid;
+  // Distinguish messengers with meaningful names for debugging
+  const std::string logic_name;
+  const uint32_t nonce;
+
+  entity_name_t my_name;
+  entity_addrvec_t my_addrs;
+  crimson::auth::AuthClient* auth_client = nullptr;
+  crimson::auth::AuthServer* auth_server = nullptr;
+
+  ShardedServerSocket<true> *listener = nullptr;
+  ChainedDispatchers dispatchers;
+  std::map<entity_addr_t, SocketConnectionRef> connections;
+  std::set<SocketConnectionRef> accepting_conns;
+  std::vector<SocketConnectionRef> closing_conns;
+  ceph::net::PolicySet<Throttle> policy_set;
+  // specifying we haven't learned our addr; set false when we find it.
+  bool need_addr = true;
+  uint32_t global_seq = 0;
+  bool started = false;
+  seastar::promise<> shutdown_promise;
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -29,7 +29,6 @@
 
 namespace crimson::net {
 
-template <bool IS_FIXED_CPU>
 class ShardedServerSocket;
 
 class SocketMessenger final : public Messenger {
@@ -169,7 +168,7 @@ private:
   crimson::auth::AuthClient* auth_client = nullptr;
   crimson::auth::AuthServer* auth_server = nullptr;
 
-  ShardedServerSocket<true> *listener = nullptr;
+  ShardedServerSocket *listener = nullptr;
   ChainedDispatchers dispatchers;
   std::map<entity_addr_t, SocketConnectionRef> connections;
   std::set<SocketConnectionRef> accepting_conns;

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -29,7 +29,8 @@
 
 namespace crimson::net {
 
-class FixedCPUServerSocket;
+template <bool IS_FIXED_CPU>
+class ShardedServerSocket;
 
 class SocketMessenger final : public Messenger {
   const seastar::shard_id master_sid;
@@ -42,7 +43,7 @@ class SocketMessenger final : public Messenger {
   crimson::auth::AuthClient* auth_client = nullptr;
   crimson::auth::AuthServer* auth_server = nullptr;
 
-  FixedCPUServerSocket* listener = nullptr;
+  ShardedServerSocket<true> *listener = nullptr;
   ChainedDispatchers dispatchers;
   std::map<entity_addr_t, SocketConnectionRef> connections;
   std::set<SocketConnectionRef> accepting_conns;

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -37,7 +37,7 @@ public:
   SocketMessenger(const entity_name_t& myname,
                   const std::string& logic_name,
                   uint32_t nonce,
-                  bool is_fixed_cpu);
+                  bool dispatch_only_on_this_shard);
 
   ~SocketMessenger() override;
 
@@ -165,7 +165,7 @@ private:
   // Distinguish messengers with meaningful names for debugging
   const std::string logic_name;
   const uint32_t nonce;
-  const bool is_fixed_cpu;
+  const bool dispatch_only_on_sid;
 
   entity_name_t my_name;
   entity_addrvec_t my_addrs;

--- a/src/crimson/net/chained_dispatchers.cc
+++ b/src/crimson/net/chained_dispatchers.cc
@@ -39,10 +39,12 @@ ChainedDispatchers::ms_dispatch(crimson::net::ConnectionRef conn,
 }
 
 void
-ChainedDispatchers::ms_handle_accept(crimson::net::ConnectionRef conn) {
+ChainedDispatchers::ms_handle_accept(
+    crimson::net::ConnectionRef conn,
+    seastar::shard_id new_shard) {
   try {
     for (auto& dispatcher : dispatchers) {
-      dispatcher->ms_handle_accept(conn);
+      dispatcher->ms_handle_accept(conn, new_shard);
     }
   } catch (...) {
     logger().error("{} got unexpected exception in ms_handle_accept() {}",
@@ -52,10 +54,12 @@ ChainedDispatchers::ms_handle_accept(crimson::net::ConnectionRef conn) {
 }
 
 void
-ChainedDispatchers::ms_handle_connect(crimson::net::ConnectionRef conn) {
+ChainedDispatchers::ms_handle_connect(
+    crimson::net::ConnectionRef conn,
+    seastar::shard_id new_shard) {
   try {
     for(auto& dispatcher : dispatchers) {
-      dispatcher->ms_handle_connect(conn);
+      dispatcher->ms_handle_connect(conn, new_shard);
     }
   } catch (...) {
     logger().error("{} got unexpected exception in ms_handle_connect() {}",

--- a/src/crimson/net/chained_dispatchers.cc
+++ b/src/crimson/net/chained_dispatchers.cc
@@ -41,10 +41,11 @@ ChainedDispatchers::ms_dispatch(crimson::net::ConnectionRef conn,
 void
 ChainedDispatchers::ms_handle_accept(
     crimson::net::ConnectionRef conn,
-    seastar::shard_id new_shard) {
+    seastar::shard_id new_shard,
+    bool is_replace) {
   try {
     for (auto& dispatcher : dispatchers) {
-      dispatcher->ms_handle_accept(conn, new_shard);
+      dispatcher->ms_handle_accept(conn, new_shard, is_replace);
     }
   } catch (...) {
     logger().error("{} got unexpected exception in ms_handle_accept() {}",

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <seastar/core/smp.hh>
+
 #include "Fwd.h"
 #include "crimson/common/log.h"
 
@@ -24,8 +26,8 @@ public:
     return dispatchers.empty();
   }
   seastar::future<> ms_dispatch(crimson::net::ConnectionRef, MessageRef);
-  void ms_handle_accept(crimson::net::ConnectionRef conn);
-  void ms_handle_connect(crimson::net::ConnectionRef conn);
+  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id);
+  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id);
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace);
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn);
 

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -26,7 +26,7 @@ public:
     return dispatchers.empty();
   }
   seastar::future<> ms_dispatch(crimson::net::ConnectionRef, MessageRef);
-  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id);
+  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id, bool is_replace);
   void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id);
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace);
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn);

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -192,7 +192,9 @@ void IOHandler::set_io_state(
     dispatch_in = true;
 #ifdef UNIT_TESTS_BUILT
     if (conn.interceptor) {
-      conn.interceptor->register_conn_ready(conn);
+      // FIXME: doesn't support cross-core
+      conn.interceptor->register_conn_ready(
+          conn.get_local_shared_foreign_from_this());
     }
 #endif
   } else if (io_state == io_state_t::open) {

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -408,7 +408,7 @@ void IOHandler::dispatch_accept()
   // happening to a connected connection.
   protocol_is_connected = true;
   ceph_assert_always(conn_ref);
-  dispatchers.ms_handle_accept(conn_ref);
+  dispatchers.ms_handle_accept(conn_ref, get_shard_id());
 }
 
 void IOHandler::dispatch_connect()
@@ -419,7 +419,7 @@ void IOHandler::dispatch_connect()
   ceph_assert_always(protocol_is_connected == false);
   protocol_is_connected = true;
   ceph_assert_always(conn_ref);
-  dispatchers.ms_handle_connect(conn_ref);
+  dispatchers.ms_handle_connect(conn_ref, get_shard_id());
 }
 
 void IOHandler::dispatch_reset(bool is_replace)

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -85,7 +85,7 @@ ceph::bufferlist IOHandler::sweep_out_pending_msgs_to_sent(
   std::for_each(
       out_pending_msgs.begin(),
       out_pending_msgs.begin()+num_msgs,
-      [this, &bl](const MessageURef& msg) {
+      [this, &bl](const MessageFRef& msg) {
     // set priority
     msg->get_header().src = conn.messenger.get_myname();
 
@@ -122,7 +122,7 @@ ceph::bufferlist IOHandler::sweep_out_pending_msgs_to_sent(
   return bl;
 }
 
-seastar::future<> IOHandler::send(MessageURef msg)
+seastar::future<> IOHandler::send(MessageFRef msg)
 {
   ceph_assert_always(seastar::this_shard_id() == sid);
   if (io_state != io_state_t::drop) {
@@ -272,7 +272,7 @@ void IOHandler::requeue_out_sent()
   out_seq -= out_sent_msgs.size();
   logger().debug("{} requeue {} items, revert out_seq to {}",
                  conn, out_sent_msgs.size(), out_seq);
-  for (MessageURef& msg : out_sent_msgs) {
+  for (MessageFRef& msg : out_sent_msgs) {
     msg->clear_payload();
     msg->set_seq(0);
   }

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -203,7 +203,7 @@ void IOHandler::set_io_state(
     protocol_is_connected = false;
     assert(fa == nullptr);
     ceph_assert_always(frame_assembler->is_socket_valid());
-    frame_assembler->shutdown_socket();
+    frame_assembler->shutdown_socket<false>(nullptr);
     if (out_dispatching) {
       ceph_assert_always(!out_exit_dispatching.has_value());
       out_exit_dispatching = seastar::promise<>();

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -331,7 +331,11 @@ public:
     return shard_states->get_io_state();
   }
 
+  seastar::future<> send_redirected(MessageFRef msg);
+
   seastar::future<> do_send(MessageFRef msg);
+
+  seastar::future<> send_keepalive_redirected();
 
   seastar::future<> do_send_keepalive();
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -218,6 +218,11 @@ public:
   };
   void print_io_stat(std::ostream &out) const;
 
+  seastar::future<> set_accepted_sid(
+      crosscore_t::seq_t cc_seq,
+      seastar::shard_id sid,
+      ConnectionFRef conn_fref);
+
   /*
    * may be called cross-core
    */

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -151,11 +151,13 @@ public:
    */
 
   void set_handshake_listener(HandshakeListener &hl) {
+    assert(seastar::this_shard_id() == get_shard_id());
     ceph_assert_always(handshake_listener == nullptr);
     handshake_listener = &hl;
   }
 
   io_handler_state get_states() const {
+    assert(seastar::this_shard_id() == get_shard_id());
     return {in_seq, is_out_queued(), has_out_sent()};
   }
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -70,7 +70,7 @@ private:
     return protocol_is_connected;
   }
 
-  seastar::future<> send(MessageURef msg) final;
+  seastar::future<> send(MessageFRef msg) final;
 
   seastar::future<> send_keepalive() final;
 
@@ -227,10 +227,10 @@ private:
   seq_num_t out_seq = 0;
 
   // messages to be resent after connection gets reset
-  std::deque<MessageURef> out_pending_msgs;
+  std::deque<MessageFRef> out_pending_msgs;
 
   // messages sent, but not yet acked by peer
-  std::deque<MessageURef> out_sent_msgs;
+  std::deque<MessageFRef> out_sent_msgs;
 
   bool need_keepalive = false;
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -62,7 +62,8 @@ struct io_handler_state {
  *
  * The interface class for IOHandler to notify the ProtocolV2.
  *
- * The notifications may be cross-core and asynchronous.
+ * The notifications may be cross-core and must be sent to
+ * SocketConnection::get_messenger_shard_id()
  */
 class HandshakeListener {
 public:
@@ -145,6 +146,10 @@ public:
  * The calls may be cross-core and asynchronous
  */
 public:
+  /*
+   * should not be called cross-core
+   */
+
   void set_handshake_listener(HandshakeListener &hl) {
     ceph_assert_always(handshake_listener == nullptr);
     handshake_listener = &hl;
@@ -158,6 +163,10 @@ public:
     const IOHandler &io_handler;
   };
   void print_io_stat(std::ostream &out) const;
+
+  /*
+   * may be called cross-core
+   */
 
   seastar::future<> close_io(bool is_dispatch_reset, bool is_replace);
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -143,6 +143,8 @@ public:
 
   void reset_session(bool full);
 
+  void reset_peer_state();
+
   void requeue_out_sent_up_to(seq_num_t seq);
 
   void requeue_out_sent();
@@ -171,7 +173,11 @@ public:
             next_keepalive_ack.has_value());
   }
 
+  void reset_in();
+
   void reset_out();
+
+  void discard_out_sent();
 
   seastar::future<stop_t> try_exit_out_dispatch();
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -61,7 +61,12 @@ public:
  * as ConnectionHandler
  */
 private:
+  seastar::shard_id get_shard_id() const final {
+    return sid;
+  }
+
   bool is_connected() const final {
+    ceph_assert_always(seastar::this_shard_id() == sid);
     return protocol_is_connected;
   }
 
@@ -70,14 +75,17 @@ private:
   seastar::future<> send_keepalive() final;
 
   clock_t::time_point get_last_keepalive() const final {
+    ceph_assert_always(seastar::this_shard_id() == sid);
     return last_keepalive;
   }
 
   clock_t::time_point get_last_keepalive_ack() const final {
+    ceph_assert_always(seastar::this_shard_id() == sid);
     return last_keepalive_ack;
   }
 
   void set_last_keepalive_ack(clock_t::time_point when) final {
+    ceph_assert_always(seastar::this_shard_id() == sid);
     last_keepalive_ack = when;
   }
 
@@ -183,6 +191,8 @@ public:
   void do_in_dispatch();
 
 private:
+  seastar::shard_id sid;
+
   ChainedDispatchers &dispatchers;
 
   SocketConnection &conn;

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <seastar/core/shared_future.hh>
 #include <seastar/util/later.hh>
 
 #include "crimson/common/gated.h"
@@ -11,6 +12,54 @@
 #include "FrameAssemblerV2.h"
 
 namespace crimson::net {
+
+/**
+ * crosscore_t
+ *
+ * To preserve the event order across cores.
+ */
+class crosscore_t {
+public:
+  using seq_t = uint64_t;
+
+  crosscore_t() = default;
+  ~crosscore_t() = default;
+
+  seq_t get_in_seq() const {
+    return in_seq;
+  }
+
+  seq_t prepare_submit() {
+    ++out_seq;
+    return out_seq;
+  }
+
+  bool proceed_or_wait(seq_t seq) {
+    if (seq == in_seq + 1) {
+      ++in_seq;
+      if (unlikely(in_pr_wait.has_value())) {
+        in_pr_wait->set_value();
+        in_pr_wait = std::nullopt;
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  seastar::future<> wait(seq_t seq) {
+    assert(seq != in_seq + 1);
+    if (!in_pr_wait.has_value()) {
+      in_pr_wait = seastar::shared_promise<>();
+    }
+    return in_pr_wait->get_shared_future();
+  }
+
+private:
+  seq_t out_seq = 0;
+  seq_t in_seq = 0;
+  std::optional<seastar::shared_promise<>> in_pr_wait;
+};
 
 /**
  * io_handler_state
@@ -74,14 +123,17 @@ public:
   HandshakeListener &operator=(const HandshakeListener &) = delete;
   HandshakeListener &operator=(HandshakeListener &&) = delete;
 
-  virtual void notify_out() = 0;
+  virtual seastar::future<> notify_out(
+      crosscore_t::seq_t cc_seq) = 0;
 
-  virtual void notify_out_fault(
+  virtual seastar::future<> notify_out_fault(
+      crosscore_t::seq_t cc_seq,
       const char *where,
       std::exception_ptr,
       io_handler_state) = 0;
 
-  virtual void notify_mark_down() = 0;
+  virtual seastar::future<> notify_mark_down(
+      crosscore_t::seq_t cc_seq) = 0;
 
 protected:
   HandshakeListener() = default;
@@ -157,7 +209,7 @@ public:
   }
 
   io_handler_state get_states() const {
-    assert(seastar::this_shard_id() == get_shard_id());
+    // might be called from prv_sid during wait_io_exit_dispatching()
     return {in_seq, is_out_queued(), has_out_sent()};
   }
 
@@ -170,7 +222,10 @@ public:
    * may be called cross-core
    */
 
-  seastar::future<> close_io(bool is_dispatch_reset, bool is_replace);
+  seastar::future<> close_io(
+      crosscore_t::seq_t cc_seq,
+      bool is_dispatch_reset,
+      bool is_replace);
 
   /**
    * io_state_t
@@ -188,30 +243,43 @@ public:
   };
   friend class fmt::formatter<io_state_t>;
 
-  void set_io_state(
+  seastar::future<> set_io_state(
+      crosscore_t::seq_t cc_seq,
       io_state_t new_state,
-      FrameAssemblerV2Ref fa = nullptr,
-      bool set_notify_out = false);
+      FrameAssemblerV2Ref fa,
+      bool set_notify_out);
 
   struct exit_dispatching_ret {
     FrameAssemblerV2Ref frame_assembler;
     io_handler_state io_states;
   };
-  seastar::future<exit_dispatching_ret> wait_io_exit_dispatching();
+  seastar::future<exit_dispatching_ret>
+  wait_io_exit_dispatching(
+      crosscore_t::seq_t cc_seq);
 
-  void reset_session(bool full);
+  seastar::future<> reset_session(
+      crosscore_t::seq_t cc_seq,
+      bool full);
 
-  void reset_peer_state();
+  seastar::future<> reset_peer_state(
+      crosscore_t::seq_t cc_seq);
 
-  void requeue_out_sent_up_to(seq_num_t seq);
+  seastar::future<> requeue_out_sent_up_to(
+      crosscore_t::seq_t cc_seq,
+      seq_num_t msg_seq);
 
-  void requeue_out_sent();
+  seastar::future<> requeue_out_sent(
+      crosscore_t::seq_t cc_seq);
 
   seastar::future<> dispatch_accept(
-      seastar::shard_id new_sid, ConnectionFRef);
+      crosscore_t::seq_t cc_seq,
+      seastar::shard_id new_sid,
+      ConnectionFRef);
 
   seastar::future<> dispatch_connect(
-      seastar::shard_id new_sid, ConnectionFRef);
+      crosscore_t::seq_t cc_seq,
+      seastar::shard_id new_sid,
+      ConnectionFRef);
 
  private:
   class shard_states_t;
@@ -348,9 +416,19 @@ public:
     std::optional<seastar::promise<>> in_exit_dispatching;
   };
 
+  void do_set_io_state(
+      io_state_t new_state,
+      std::optional<crosscore_t::seq_t> cc_seq = std::nullopt,
+      FrameAssemblerV2Ref fa = nullptr,
+      bool set_notify_out = false);
+
   io_state_t get_io_state() const {
     return shard_states->get_io_state();
   }
+
+  void do_requeue_out_sent();
+
+  void do_requeue_out_sent_up_to(seq_num_t seq);
 
   void assign_frame_assembler(FrameAssemblerV2Ref);
 
@@ -410,6 +488,8 @@ public:
 
 private:
   shard_states_ref_t shard_states;
+
+  crosscore_t crosscore;
 
   // drop was happening in the previous sid
   std::optional<seastar::shard_id> maybe_dropped_sid;

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -360,7 +360,7 @@ public:
 
   void discard_out_sent();
 
-  seastar::future<> do_out_dispatch();
+  seastar::future<> do_out_dispatch(shard_states_t &ctx);
 
   ceph::bufferlist sweep_out_pending_msgs_to_sent(
       bool require_keepalive,
@@ -374,6 +374,7 @@ public:
   void ack_out_sent(seq_num_t seq);
 
   seastar::future<> read_message(
+      shard_states_t &ctx,
       utime_t throttle_stamp,
       std::size_t msg_size);
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -279,7 +279,8 @@ public:
   seastar::future<> dispatch_accept(
       crosscore_t::seq_t cc_seq,
       seastar::shard_id new_sid,
-      ConnectionFRef);
+      ConnectionFRef,
+      bool is_replace);
 
   seastar::future<> dispatch_connect(
       crosscore_t::seq_t cc_seq,

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -236,8 +236,11 @@ void Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replac
   }
 }
 
-void Heartbeat::ms_handle_connect(crimson::net::ConnectionRef conn)
+void Heartbeat::ms_handle_connect(
+    crimson::net::ConnectionRef conn,
+    seastar::shard_id new_shard)
 {
+  ceph_assert_always(seastar::this_shard_id() == new_shard);
   auto peer = conn->get_peer_id();
   if (conn->get_peer_type() != entity_name_t::TYPE_OSD ||
       peer == entity_name_t::NEW) {
@@ -249,8 +252,11 @@ void Heartbeat::ms_handle_connect(crimson::net::ConnectionRef conn)
   }
 }
 
-void Heartbeat::ms_handle_accept(crimson::net::ConnectionRef conn)
+void Heartbeat::ms_handle_accept(
+    crimson::net::ConnectionRef conn,
+    seastar::shard_id new_shard)
 {
+  ceph_assert_always(seastar::this_shard_id() == new_shard);
   auto peer = conn->get_peer_id();
   if (conn->get_peer_type() != entity_name_t::TYPE_OSD ||
       peer == entity_name_t::NEW) {

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -254,7 +254,8 @@ void Heartbeat::ms_handle_connect(
 
 void Heartbeat::ms_handle_accept(
     crimson::net::ConnectionRef conn,
-    seastar::shard_id new_shard)
+    seastar::shard_id new_shard,
+    bool is_replace)
 {
   ceph_assert_always(seastar::this_shard_id() == new_shard);
   auto peer = conn->get_peer_id();
@@ -264,7 +265,7 @@ void Heartbeat::ms_handle_accept(
   }
   if (auto found = peers.find(peer);
       found != peers.end()) {
-    found->second.handle_accept(conn);
+    found->second.handle_accept(conn, is_replace);
   }
 }
 
@@ -433,42 +434,57 @@ bool Heartbeat::Connection::matches(crimson::net::ConnectionRef _conn) const
   return (conn && conn == _conn);
 }
 
-void Heartbeat::Connection::accepted(crimson::net::ConnectionRef accepted_conn)
+bool Heartbeat::Connection::accepted(
+    crimson::net::ConnectionRef accepted_conn,
+    bool is_replace)
 {
-  if (!conn) {
-    if (accepted_conn->get_peer_addr() == listener.get_peer_addr(type)) {
-      logger().info("Heartbeat::Connection::accepted(): "
-                    "{} racing resolved", *this);
-      conn = accepted_conn;
-      set_connected();
+  ceph_assert(accepted_conn);
+  ceph_assert(accepted_conn != conn);
+  if (accepted_conn->get_peer_addr() != listener.get_peer_addr(type)) {
+    return false;
+  }
+
+  if (is_replace) {
+    logger().info("Heartbeat::Connection::accepted(): "
+                  "{} racing", *this);
+    racing_detected = true;
+  }
+  if (conn) {
+    // there is no assumption about the ordering of the reset and accept
+    // events for the 2 racing connections.
+    if (is_connected) {
+      logger().warn("Heartbeat::Connection::accepted(): "
+                    "{} is accepted while connected, is_replace={}",
+                    *this, is_replace);
+      conn->mark_down();
+      set_unconnected();
     }
-  } else if (conn == accepted_conn) {
-    set_connected();
   }
+  conn = accepted_conn;
+  set_connected();
+  return true;
 }
 
-void Heartbeat::Connection::replaced()
+void Heartbeat::Connection::reset(bool is_replace)
 {
-  assert(!is_connected);
-  auto replaced_conn = conn;
-  // set the racing connection, will be handled by handle_accept()
-  conn = msgr.connect(replaced_conn->get_peer_addr(),
-                      replaced_conn->get_peer_name());
-  racing_detected = true;
-  logger().warn("Heartbeat::Connection::replaced(): {} racing", *this);
-  assert(conn != replaced_conn);
-}
+  if (is_replace) {
+    logger().info("Heartbeat::Connection::reset(): "
+                  "{} racing, waiting for the replacing accept",
+                  *this);
+    racing_detected = true;
+  }
 
-void Heartbeat::Connection::reset()
-{
-  conn = nullptr;
   if (is_connected) {
-    is_connected = false;
-    listener.decrease_connected();
-  }
-  if (!racing_detected || is_winner_side) {
-    connect();
+    set_unconnected();
   } else {
+    conn = nullptr;
+  }
+
+  if (is_replace) {
+    // waiting for the replacing accept event
+  } else if (!racing_detected || is_winner_side) {
+    connect();
+  } else { // racing_detected && !is_winner_side
     logger().info("Heartbeat::Connection::reset(): "
                   "{} racing detected and lose, "
                   "waiting for peer connect me", *this);
@@ -510,9 +526,20 @@ void Heartbeat::Connection::retry()
 
 void Heartbeat::Connection::set_connected()
 {
+  assert(conn);
   assert(!is_connected);
+  ceph_assert(conn->is_connected());
   is_connected = true;
   listener.increase_connected();
+}
+
+void Heartbeat::Connection::set_unconnected()
+{
+  assert(conn);
+  assert(is_connected);
+  conn = nullptr;
+  is_connected = false;
+  listener.decrease_connected();
 }
 
 void Heartbeat::Connection::connect()
@@ -601,6 +628,64 @@ void Heartbeat::Peer::send_heartbeat(
       session.set_inactive_history(now);
       pending_send = true;
     }
+  }
+}
+
+void Heartbeat::Peer::handle_reset(
+    crimson::net::ConnectionRef conn, bool is_replace)
+{
+  int cnt = 0;
+  for_each_conn([&] (auto& _conn) {
+    if (_conn.matches(conn)) {
+      ++cnt;
+      _conn.reset(is_replace);
+    }
+  });
+
+  if (cnt == 0) {
+    logger().info("Heartbeat::Peer::handle_reset(): {} ignores conn, is_replace={} -- {}",
+                  *this, is_replace, *conn);
+  } else if (cnt > 1) {
+    logger().error("Heartbeat::Peer::handle_reset(): {} handles conn {} times -- {}",
+                  *this, cnt, *conn);
+  }
+}
+
+void Heartbeat::Peer::handle_connect(crimson::net::ConnectionRef conn)
+{
+  int cnt = 0;
+  for_each_conn([&] (auto& _conn) {
+    if (_conn.matches(conn)) {
+      ++cnt;
+      _conn.connected();
+    }
+  });
+
+  if (cnt == 0) {
+    logger().error("Heartbeat::Peer::handle_connect(): {} ignores conn -- {}",
+                   *this, *conn);
+    conn->mark_down();
+  } else if (cnt > 1) {
+    logger().error("Heartbeat::Peer::handle_connect(): {} handles conn {} times -- {}",
+                  *this, cnt, *conn);
+  }
+}
+
+void Heartbeat::Peer::handle_accept(crimson::net::ConnectionRef conn, bool is_replace)
+{
+  int cnt = 0;
+  for_each_conn([&] (auto& _conn) {
+    if (_conn.accepted(conn, is_replace)) {
+      ++cnt;
+    }
+  });
+
+  if (cnt == 0) {
+    logger().warn("Heartbeat::Peer::handle_accept(): {} ignores conn -- {}",
+                  *this, *conn);
+  } else if (cnt > 1) {
+    logger().error("Heartbeat::Peer::handle_accept(): {} handles conn {} times -- {}",
+                  *this, cnt, *conn);
   }
 }
 

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -52,8 +52,8 @@ public:
   std::optional<seastar::future<>> ms_dispatch(
       crimson::net::ConnectionRef conn, MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
-  void ms_handle_connect(crimson::net::ConnectionRef conn) override;
-  void ms_handle_accept(crimson::net::ConnectionRef conn) override;
+  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id) override;
+  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id) override;
 
   void print(std::ostream&) const;
 private:

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -53,7 +53,7 @@ public:
       crimson::net::ConnectionRef conn, MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
   void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id) override;
-  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id) override;
+  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id, bool is_replace) override;
 
   void print(std::ostream&) const;
 private:
@@ -189,9 +189,8 @@ class Heartbeat::Connection {
   void connected() {
     set_connected();
   }
-  void accepted(crimson::net::ConnectionRef);
-  void replaced();
-  void reset();
+  bool accepted(crimson::net::ConnectionRef, bool is_replace);
+  void reset(bool is_replace=false);
   seastar::future<> send(MessageURef msg);
   void validate();
   // retry connection if still pending
@@ -199,6 +198,7 @@ class Heartbeat::Connection {
 
  private:
   void set_connected();
+  void set_unconnected();
   void connect();
 
   const osd_id_t peer;
@@ -239,18 +239,14 @@ class Heartbeat::Connection {
   crimson::net::ConnectionRef conn;
   bool is_connected = false;
 
- friend std::ostream& operator<<(std::ostream& os, const Connection& c) {
-   if (c.type == type_t::front) {
-     return os << "con_front(osd." << c.peer << ")";
-   } else {
-     return os << "con_back(osd." << c.peer << ")";
-   }
- }
+  friend std::ostream& operator<<(std::ostream& os, const Connection& c) {
+    if (c.type == type_t::front) {
+      return os << "con_front(osd." << c.peer << ")";
+    } else {
+      return os << "con_back(osd." << c.peer << ")";
+    }
+  }
 };
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<Heartbeat::Connection> : fmt::ostream_formatter {};
-#endif
 
 /*
  * Track the ping history and ping reply (the pong) from the same session, clean up
@@ -425,29 +421,12 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   void send_heartbeat(
       clock::time_point, ceph::signedspan, std::vector<seastar::future<>>&);
   seastar::future<> handle_reply(crimson::net::ConnectionRef, Ref<MOSDPing>);
-  void handle_reset(crimson::net::ConnectionRef conn, bool is_replace) {
-    for_each_conn([&] (auto& _conn) {
-      if (_conn.matches(conn)) {
-        if (is_replace) {
-          _conn.replaced();
-        } else {
-          _conn.reset();
-        }
-      }
-    });
-  }
-  void handle_connect(crimson::net::ConnectionRef conn) {
-    for_each_conn([&] (auto& _conn) {
-      if (_conn.matches(conn)) {
-        _conn.connected();
-      }
-    });
-  }
-  void handle_accept(crimson::net::ConnectionRef conn) {
-    for_each_conn([&] (auto& _conn) {
-      _conn.accepted(conn);
-    });
-  }
+
+  void handle_reset(crimson::net::ConnectionRef conn, bool is_replace);
+
+  void handle_connect(crimson::net::ConnectionRef conn);
+
+  void handle_accept(crimson::net::ConnectionRef conn, bool is_replace);
 
  private:
   entity_addr_t get_peer_addr(type_t type) override;
@@ -469,8 +448,14 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   bool pending_send = false;
   Connection con_front;
   Connection con_back;
+
+  friend std::ostream& operator<<(std::ostream& os, const Peer& p) {
+    return os << "peer(osd." << p.peer << ")";
+  }
 };
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<Heartbeat> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<Heartbeat::Connection> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<Heartbeat::Peer> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -192,7 +192,8 @@ int main(int argc, const char* argv[])
                                     make_pair(std::ref(hb_back_msgr), "hb_back"s)}) {
             msgr = crimson::net::Messenger::create(entity_name_t::OSD(whoami),
                                                    name,
-                                                   nonce);
+                                                   nonce,
+                                                   true);
           }
           auto store = crimson::os::FuturizedStore::create(
             local_conf().get_val<std::string>("osd_objectstore"),

--- a/src/crimson/osd/main_config_bootstrap_helpers.cc
+++ b/src/crimson/osd/main_config_bootstrap_helpers.cc
@@ -55,7 +55,8 @@ seastar::future<> populate_config_from_mon()
     auto auth_handler = std::make_unique<DummyAuthHandler>();
     auto msgr = crimson::net::Messenger::create(entity_name_t::CLIENT(),
                                                 "temp_mon_client",
-                                                get_nonce());
+                                                get_nonce(),
+                                                true);
     crimson::mon::Client monc{*msgr, *auth_handler};
     msgr->set_auth_client(&monc);
     msgr->start({&monc}).get();

--- a/src/crimson/tools/perf_crimson_msgr.cc
+++ b/src/crimson/tools/perf_crimson_msgr.cc
@@ -301,7 +301,10 @@ static seastar::future<> run(
         return nr_depth - depth.current();
       }
 
-      void ms_handle_connect(crimson::net::ConnectionRef conn) override {
+      void ms_handle_connect(
+          crimson::net::ConnectionRef conn,
+          seastar::shard_id new_shard) override {
+        ceph_assert_always(new_shard == seastar::this_shard_id());
         conn_stats.connected_time = mono_clock::now();
       }
       std::optional<seastar::future<>> ms_dispatch(

--- a/src/crimson/tools/perf_crimson_msgr.cc
+++ b/src/crimson/tools/perf_crimson_msgr.cc
@@ -174,7 +174,9 @@ static seastar::future<> run(
       seastar::future<> init(const entity_addr_t& addr) {
         return seastar::smp::submit_to(msgr_sid, [addr, this] {
           // server msgr is always with nonce 0
-          msgr = crimson::net::Messenger::create(entity_name_t::OSD(msgr_sid), lname, 0);
+          msgr = crimson::net::Messenger::create(
+              entity_name_t::OSD(msgr_sid),
+              lname, 0, true);
           msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
           msgr->set_auth_client(&dummy_auth);
           msgr->set_auth_server(&dummy_auth);
@@ -339,7 +341,9 @@ static seastar::future<> run(
       seastar::future<> init() {
         return container().invoke_on_all([] (auto& client) {
           if (client.is_active()) {
-            client.msgr = crimson::net::Messenger::create(entity_name_t::OSD(client.sid), client.lname, client.sid);
+            client.msgr = crimson::net::Messenger::create(
+                entity_name_t::OSD(client.sid),
+                client.lname, client.sid, true);
             client.msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
             client.msgr->set_auth_client(&client.dummy_auth);
             client.msgr->set_auth_server(&client.dummy_auth);

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -166,7 +166,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
   if (role == echo_role::as_server) {
     return seastar::do_with(
         seastar_pingpong::Server{crimson::net::Messenger::create(
-            entity_name_t::OSD(0), "server", addr.get_nonce())},
+            entity_name_t::OSD(0), "server", addr.get_nonce(), true)},
         [addr, count](auto& server) mutable {
       std::cout << "server listening at " << addr << std::endl;
       // bind the server
@@ -193,7 +193,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
   } else {
     return seastar::do_with(
         seastar_pingpong::Client{crimson::net::Messenger::create(
-            entity_name_t::OSD(1), "client", addr.get_nonce())},
+            entity_name_t::OSD(1), "client", addr.get_nonce(), true)},
         [addr, count](auto& client) {
       std::cout << "client sending to " << addr << std::endl;
       client.msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -123,7 +123,10 @@ static seastar::future<> test_echo(unsigned rounds,
         return found->second;
       }
 
-      void ms_handle_connect(crimson::net::ConnectionRef conn) override {
+      void ms_handle_connect(
+          crimson::net::ConnectionRef conn,
+          seastar::shard_id new_shard) override {
+        assert(new_shard == seastar::this_shard_id());
         auto session = seastar::make_shared<PingSession>();
         auto [i, added] = sessions.emplace(conn, session);
         std::ignore = i;
@@ -851,7 +854,10 @@ class FailoverSuite : public Dispatcher {
     return {seastar::now()};
   }
 
-  void ms_handle_accept(ConnectionRef conn) override {
+  void ms_handle_accept(
+      ConnectionRef conn,
+      seastar::shard_id new_shard) override {
+    assert(new_shard == seastar::this_shard_id());
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
       logger().error("Untracked accepted connection: {}", *conn);
@@ -874,7 +880,10 @@ class FailoverSuite : public Dispatcher {
     std::ignore = flush_pending_send();
   }
 
-  void ms_handle_connect(ConnectionRef conn) override {
+  void ms_handle_connect(
+      ConnectionRef conn,
+      seastar::shard_id new_shard) override {
+    assert(new_shard == seastar::this_shard_id());
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
       logger().error("Untracked connected connection: {}", *conn);
@@ -1432,7 +1441,10 @@ class FailoverSuitePeer : public Dispatcher {
     return {seastar::now()};
   }
 
-  void ms_handle_accept(ConnectionRef conn) override {
+  void ms_handle_accept(
+      ConnectionRef conn,
+      seastar::shard_id new_shard) override {
+    assert(new_shard == seastar::this_shard_id());
     logger().info("[TestPeer] got accept from Test");
     ceph_assert(!tracked_conn ||
                 tracked_conn->is_closed() ||
@@ -1587,7 +1599,10 @@ class FailoverTestPeer : public Dispatcher {
     return {seastar::now()};
   }
 
-  void ms_handle_accept(ConnectionRef conn) override {
+  void ms_handle_accept(
+      ConnectionRef conn,
+      seastar::shard_id new_shard) override {
+    assert(new_shard == seastar::this_shard_id());
     cmd_conn = conn;
   }
 

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -75,7 +75,8 @@ static seastar::future<> test_echo(unsigned rounds,
                              const std::string& lname,
                              const uint64_t nonce,
                              const entity_addr_t& addr) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -154,7 +155,8 @@ static seastar::future<> test_echo(unsigned rounds,
       seastar::future<> init(const entity_name_t& name,
                              const std::string& lname,
                              const uint64_t nonce) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -303,7 +305,8 @@ static seastar::future<> test_concurrent_dispatch()
                              const std::string& lname,
                              const uint64_t nonce,
                              const entity_addr_t& addr) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -331,7 +334,8 @@ static seastar::future<> test_concurrent_dispatch()
       seastar::future<> init(const entity_name_t& name,
                              const std::string& lname,
                              const uint64_t nonce) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -392,7 +396,8 @@ seastar::future<> test_preemptive_shutdown() {
                              const std::string& lname,
                              const uint64_t nonce,
                              const entity_addr_t& addr) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -431,7 +436,8 @@ seastar::future<> test_preemptive_shutdown() {
       seastar::future<> init(const entity_name_t& name,
                              const std::string& lname,
                              const uint64_t nonce) {
-        msgr = crimson::net::Messenger::create(name, lname, nonce);
+        msgr = crimson::net::Messenger::create(
+            name, lname, nonce, true);
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
@@ -1120,7 +1126,11 @@ class FailoverSuite : public Dispatcher {
          entity_addr_t test_peer_addr,
          const TestInterceptor& interceptor) {
     auto suite = std::make_unique<FailoverSuite>(
-        Messenger::create(entity_name_t::OSD(TEST_OSD), "Test", TEST_NONCE),
+        Messenger::create(
+          entity_name_t::OSD(TEST_OSD),
+          "Test",
+          TEST_NONCE,
+          true),
         test_peer_addr, interceptor);
     return suite->init(test_addr, test_policy
     ).then([suite = std::move(suite)] () mutable {
@@ -1334,7 +1344,11 @@ class FailoverTest : public Dispatcher {
          entity_addr_t cmd_peer_addr,
          entity_addr_t test_peer_addr) {
     auto test = seastar::make_lw_shared<FailoverTest>(
-        Messenger::create(entity_name_t::OSD(CMD_CLI_OSD), "CmdCli", CMD_CLI_NONCE),
+        Messenger::create(
+          entity_name_t::OSD(CMD_CLI_OSD),
+          "CmdCli",
+          CMD_CLI_NONCE,
+          true),
         test_addr, test_peer_addr);
     return test->init(cmd_peer_addr).then([test] {
       logger().info("CmdCli ready");
@@ -1554,7 +1568,8 @@ class FailoverSuitePeer : public Dispatcher {
       Messenger::create(
         entity_name_t::OSD(TEST_PEER_OSD),
         "TestPeer",
-        TEST_PEER_NONCE),
+        TEST_PEER_NONCE,
+        true),
       op_callback
     );
     return suite->init(test_peer_addr, policy
@@ -1679,7 +1694,11 @@ class FailoverTestPeer : public Dispatcher {
   static seastar::future<std::unique_ptr<FailoverTestPeer>>
   create(entity_addr_t cmd_peer_addr, entity_addr_t test_peer_addr) {
     auto test_peer = std::make_unique<FailoverTestPeer>(
-        Messenger::create(entity_name_t::OSD(CMD_SRV_OSD), "CmdSrv", CMD_SRV_NONCE),
+        Messenger::create(
+          entity_name_t::OSD(CMD_SRV_OSD),
+          "CmdSrv",
+          CMD_SRV_NONCE,
+          true),
         test_peer_addr);
     return test_peer->init(cmd_peer_addr
     ).then([test_peer = std::move(test_peer)] () mutable {

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -862,7 +862,8 @@ class FailoverSuite : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard) override {
+      seastar::shard_id new_shard,
+      bool is_replace) override {
     assert(new_shard == seastar::this_shard_id());
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
@@ -1457,7 +1458,8 @@ class FailoverSuitePeer : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard) override {
+      seastar::shard_id new_shard,
+      bool is_replace) override {
     assert(new_shard == seastar::this_shard_id());
     logger().info("[TestPeer] got accept from Test");
     ceph_assert(!tracked_conn ||
@@ -1616,7 +1618,8 @@ class FailoverTestPeer : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard) override {
+      seastar::shard_id new_shard,
+      bool is_replace) override {
     assert(new_shard == seastar::this_shard_id());
     cmd_conn = conn;
   }

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -134,12 +134,18 @@ class SyntheticDispatcher final
     }
   }
 
-  void ms_handle_accept(crimson::net::ConnectionRef conn) {
+  void ms_handle_accept(
+      crimson::net::ConnectionRef conn,
+      seastar::shard_id new_shard) {
     logger().info("{} - Connection:{}", __func__, *conn);
+    assert(new_shard == seastar::this_shard_id());
   }
 
-  void ms_handle_connect(crimson::net::ConnectionRef conn) {
+  void ms_handle_connect(
+      crimson::net::ConnectionRef conn,
+      seastar::shard_id new_shard) {
     logger().info("{} - Connection:{}", __func__, *conn);
+    assert(new_shard == seastar::this_shard_id());
   }
 
   void ms_handle_reset(crimson::net::ConnectionRef con, bool is_replace);

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -354,7 +354,8 @@ class SyntheticWorkload {
                           const uint64_t nonce,
                           const entity_addr_t& addr) {
      crimson::net::MessengerRef msgr =
-       crimson::net::Messenger::create(name, lname, nonce);
+       crimson::net::Messenger::create(
+           name, lname, nonce, true);
      msgr->set_default_policy(server_policy);
      msgr->set_auth_client(&dummy_auth);
      msgr->set_auth_server(&dummy_auth);
@@ -375,7 +376,8 @@ class SyntheticWorkload {
                           const std::string& lname,
                           const uint64_t nonce) {
      crimson::net::MessengerRef msgr =
-       crimson::net::Messenger::create(name, lname, nonce);
+       crimson::net::Messenger::create(
+           name, lname, nonce, true);
      msgr->set_default_policy(client_policy);
      msgr->set_auth_client(&dummy_auth);
      msgr->set_auth_server(&dummy_auth);

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -105,7 +105,7 @@ class SyntheticDispatcher final
   }
 
   std::optional<seastar::future<>> ms_dispatch(crimson::net::ConnectionRef con,
-                                               MessageRef m) {
+                                               MessageRef m) final {
     if (verbose) {
       logger().warn("{}: con = {}", __func__, *con);
     }
@@ -136,21 +136,22 @@ class SyntheticDispatcher final
 
   void ms_handle_accept(
       crimson::net::ConnectionRef conn,
-      seastar::shard_id new_shard) {
+      seastar::shard_id new_shard,
+      bool is_replace) final {
     logger().info("{} - Connection:{}", __func__, *conn);
     assert(new_shard == seastar::this_shard_id());
   }
 
   void ms_handle_connect(
       crimson::net::ConnectionRef conn,
-      seastar::shard_id new_shard) {
+      seastar::shard_id new_shard) final {
     logger().info("{} - Connection:{}", __func__, *conn);
     assert(new_shard == seastar::this_shard_id());
   }
 
-  void ms_handle_reset(crimson::net::ConnectionRef con, bool is_replace);
+  void ms_handle_reset(crimson::net::ConnectionRef con, bool is_replace) final;
 
-  void ms_handle_remote_reset(crimson::net::ConnectionRef con) {
+  void ms_handle_remote_reset(crimson::net::ConnectionRef con) final {
     clear_pending(con);
   }
 

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -41,7 +41,7 @@ static seastar::future<> test_monc()
   }).then([] {
     return crimson::common::sharded_perf_coll().start();
   }).then([]() mutable {
-    auto msgr = crimson::net::Messenger::create(entity_name_t::OSD(0), "monc", 0);
+    auto msgr = crimson::net::Messenger::create(entity_name_t::OSD(0), "monc", 0, true);
     return seastar::do_with(MonClient{*msgr, dummy_handler},
                             [msgr](auto& monc) mutable {
       return msgr->start({&monc}).then([&monc] {

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -341,7 +341,8 @@ class Connection {
           } else {
             return socket->read_exactly(DATA_SIZE * sizeof(uint64_t)
             ).then([this](auto buf) {
-              auto read_data = reinterpret_cast<const uint64_t*>(buf.get());
+              uint64_t read_data[DATA_SIZE];
+              std::memcpy(read_data, buf.get(), DATA_SIZE * sizeof(uint64_t));
               verify_data_read(read_data);
             });
           }

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -93,7 +93,7 @@ future<> test_bind_same() {
           // runtime error: member access within null pointer of type 'struct promise_base'
           return seastar::now();
         })).then([pss2] {
-          return pss2->destroy();
+          return pss2->shutdown_destroy();
         });
       });
     }, listen_ertr::all_same_way(
@@ -102,7 +102,7 @@ future<> test_bind_same() {
                    saddr);
       ceph_abort();
     })).then([pss1] {
-      return pss1->destroy();
+      return pss1->shutdown_destroy();
     }).handle_exception([] (auto eptr) {
       logger.error("test_bind_same() got unexpeted exception {}", eptr);
       ceph_abort();
@@ -143,7 +143,7 @@ future<> test_accept() {
     }).then([] {
       logger.info("test_accept() ok\n");
     }).then([pss] {
-      return pss->destroy();
+      return pss->shutdown_destroy();
     }).handle_exception([] (auto eptr) {
       logger.error("test_accept() got unexpeted exception {}", eptr);
       ceph_abort();
@@ -199,7 +199,7 @@ class SocketFactory {
     }).then([psf] {
       if (psf->pss) {
         return seastar::smp::submit_to(1u, [psf] {
-          return psf->pss->destroy();
+          return psf->pss->shutdown_destroy();
         });
       }
       return seastar::now();

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -32,61 +32,62 @@ using crimson::net::stop_t;
 
 using SocketFRef = seastar::foreign_ptr<SocketRef>;
 
-static seastar::logger logger{"crimsontest"};
-static entity_addr_t get_server_addr() {
-  static int port = 9020;
-  ++port;
-  ceph_assert(port < 9030 && "socket and messenger test ports should not overlap");
+seastar::logger &logger() {
+  return crimson::get_logger(ceph_subsys_test);
+}
+
+entity_addr_t get_server_addr() {
   entity_addr_t saddr;
   saddr.parse("127.0.0.1", nullptr);
-  saddr.set_port(port);
+  saddr.set_port(9020);
   return saddr;
 }
 
 future<SocketRef> socket_connect(const entity_addr_t& saddr) {
-  logger.debug("socket_connect() to {} ...", saddr);
-  return Socket::connect(saddr).then([] (auto socket) {
-    logger.debug("socket_connect() connected");
+  logger().debug("socket_connect() to {} ...", saddr);
+  return Socket::connect(saddr).then([](auto socket) {
+    logger().debug("socket_connect() connected");
     return socket;
   });
 }
 
 future<> test_refused() {
-  logger.info("test_refused()...");
+  logger().info("test_refused()...");
   auto saddr = get_server_addr();
   return socket_connect(saddr).discard_result().then([saddr] {
-    logger.error("test_refused(): connection to {} is not refused", saddr);
+    logger().error("test_refused(): connection to {} is not refused", saddr);
     ceph_abort();
-  }).handle_exception_type([] (const std::system_error& e) {
+  }).handle_exception_type([](const std::system_error& e) {
     if (e.code() != std::errc::connection_refused) {
-      logger.error("test_refused() got unexpeted error {}", e);
+      logger().error("test_refused() got unexpeted error {}", e);
       ceph_abort();
     } else {
-      logger.info("test_refused() ok\n");
+      logger().info("test_refused() ok\n");
     }
-  }).handle_exception([] (auto eptr) {
-    logger.error("test_refused() got unexpeted exception {}", eptr);
+  }).handle_exception([](auto eptr) {
+    logger().error("test_refused() got unexpeted exception {}", eptr);
     ceph_abort();
   });
 }
 
 future<> test_bind_same() {
-  logger.info("test_bind_same()...");
-  return FixedCPUServerSocket::create().then([] (auto pss1) {
+  logger().info("test_bind_same()...");
+  return FixedCPUServerSocket::create().then([](auto pss1) {
     auto saddr = get_server_addr();
     return pss1->listen(saddr).safe_then([saddr] {
       // try to bind the same address
-      return FixedCPUServerSocket::create().then([saddr] (auto pss2) {
+      return FixedCPUServerSocket::create(
+      ).then([saddr](auto pss2) {
         return pss2->listen(saddr).safe_then([] {
-          logger.error("test_bind_same() should raise address_in_use");
+          logger().error("test_bind_same() should raise address_in_use");
           ceph_abort();
         }, listen_ertr::all_same_way(
-            [] (const std::error_code& e) {
+            [](const std::error_code& e) {
           if (e == std::errc::address_in_use) {
             // successful!
-            logger.info("test_bind_same() ok\n");
+            logger().info("test_bind_same() ok\n");
           } else {
-            logger.error("test_bind_same() got unexpected error {}", e);
+            logger().error("test_bind_same() got unexpected error {}", e);
             ceph_abort();
           }
           // Note: need to return a explicit ready future, or there will be a
@@ -97,25 +98,28 @@ future<> test_bind_same() {
         });
       });
     }, listen_ertr::all_same_way(
-        [saddr] (const std::error_code& e) {
-      logger.error("test_bind_same(): there is another instance running at {}",
-                   saddr);
+        [saddr](const std::error_code& e) {
+      logger().error("test_bind_same(): there is another instance running at {}",
+                     saddr);
       ceph_abort();
     })).then([pss1] {
       return pss1->shutdown_destroy();
-    }).handle_exception([] (auto eptr) {
-      logger.error("test_bind_same() got unexpeted exception {}", eptr);
+    }).handle_exception([](auto eptr) {
+      logger().error("test_bind_same() got unexpeted exception {}", eptr);
       ceph_abort();
     });
   });
 }
 
 future<> test_accept() {
-  logger.info("test_accept()");
-  return FixedCPUServerSocket::create().then([] (auto pss) {
+  logger().info("test_accept()");
+  return FixedCPUServerSocket::create(
+  ).then([](auto pss) {
     auto saddr = get_server_addr();
-    return pss->listen(saddr).safe_then([pss] {
+    return pss->listen(saddr
+    ).safe_then([pss] {
       return pss->accept([](auto socket, auto paddr) {
+        logger().info("test_accept(): accepted at shard {}", seastar::this_shard_id());
         // simple accept
         return seastar::sleep(100ms
         ).then([socket = std::move(socket)]() mutable {
@@ -124,69 +128,76 @@ future<> test_accept() {
         });
       });
     }, listen_ertr::all_same_way(
-        [saddr] (const std::error_code& e) {
-      logger.error("test_accept(): there is another instance running at {}",
-                   saddr);
+        [saddr](const std::error_code& e) {
+      logger().error("test_accept(): there is another instance running at {}",
+                     saddr);
       ceph_abort();
     })).then([saddr] {
       return seastar::when_all(
-        socket_connect(saddr).then([] (auto socket) {
+        socket_connect(saddr).then([](auto socket) {
           return socket->close().finally([cleanup = std::move(socket)] {}); }),
-        socket_connect(saddr).then([] (auto socket) {
+        socket_connect(saddr).then([](auto socket) {
           return socket->close().finally([cleanup = std::move(socket)] {}); }),
-        socket_connect(saddr).then([] (auto socket) {
+        socket_connect(saddr).then([](auto socket) {
           return socket->close().finally([cleanup = std::move(socket)] {}); })
       ).discard_result();
     }).then([] {
       // should be enough to be connected locally
       return seastar::sleep(50ms);
     }).then([] {
-      logger.info("test_accept() ok\n");
+      logger().info("test_accept() ok\n");
     }).then([pss] {
       return pss->shutdown_destroy();
-    }).handle_exception([] (auto eptr) {
-      logger.error("test_accept() got unexpeted exception {}", eptr);
+    }).handle_exception([](auto eptr) {
+      logger().error("test_accept() got unexpeted exception {}", eptr);
       ceph_abort();
     });
   });
 }
 
 class SocketFactory {
+  static constexpr seastar::shard_id CLIENT_CPU = 0u;
   SocketRef client_socket;
-  SocketFRef server_socket;
-  FixedCPUServerSocket *pss = nullptr;
   seastar::promise<> server_connected;
 
+  static constexpr seastar::shard_id SERVER_CPU = 1u;
+  FixedCPUServerSocket *pss = nullptr;
+  SocketRef server_socket;
+
  public:
-  // cb_client() on CPU#0, cb_server() on CPU#1
   template <typename FuncC, typename FuncS>
   static future<> dispatch_sockets(FuncC&& cb_client, FuncS&& cb_server) {
-    assert(seastar::this_shard_id() == 0u);
+    ceph_assert_always(seastar::this_shard_id() == CLIENT_CPU);
     auto owner = std::make_unique<SocketFactory>();
     auto psf = owner.get();
     auto saddr = get_server_addr();
-    return seastar::smp::submit_to(1u, [psf, saddr] {
-      return FixedCPUServerSocket::create().then([psf, saddr] (auto pss) {
+    return seastar::smp::submit_to(SERVER_CPU, [psf, saddr] {
+      return FixedCPUServerSocket::create(
+      ).then([psf, saddr](auto pss) {
         psf->pss = pss;
         return pss->listen(saddr
-        ).safe_then([]{}, listen_ertr::all_same_way(
-            [saddr] (const std::error_code& e) {
-          logger.error("dispatch_sockets(): there is another instance running at {}",
-                       saddr);
+        ).safe_then([] {
+        }, listen_ertr::all_same_way([saddr](const std::error_code& e) {
+          logger().error("dispatch_sockets(): there is another instance running at {}",
+                         saddr);
           ceph_abort();
         }));
       });
     }).then([psf, saddr] {
       return seastar::when_all_succeed(
-        seastar::smp::submit_to(0u, [psf, saddr] {
-          return socket_connect(saddr).then([psf] (auto socket) {
+        seastar::smp::submit_to(CLIENT_CPU, [psf, saddr] {
+          return socket_connect(saddr).then([psf](auto socket) {
+            ceph_assert_always(seastar::this_shard_id() == CLIENT_CPU);
             psf->client_socket = std::move(socket);
           });
         }),
-        seastar::smp::submit_to(1u, [psf] {
-          return psf->pss->accept([psf] (auto socket, auto paddr) {
-            psf->server_socket = seastar::make_foreign(std::move(socket));
-            return seastar::smp::submit_to(0u, [psf] {
+        seastar::smp::submit_to(SERVER_CPU, [psf] {
+          return psf->pss->accept([psf](auto socket, auto paddr) {
+            logger().info("dispatch_sockets(): accepted at shard {}",
+                          seastar::this_shard_id());
+            ceph_assert_always(SERVER_CPU == seastar::this_shard_id());
+            psf->server_socket = std::move(socket);
+            return seastar::smp::submit_to(CLIENT_CPU, [psf] {
               psf->server_connected.set_value();
             });
           });
@@ -198,35 +209,35 @@ class SocketFactory {
       return psf->server_connected.get_future();
     }).then([psf] {
       if (psf->pss) {
-        return seastar::smp::submit_to(1u, [psf] {
+        return seastar::smp::submit_to(SERVER_CPU, [psf] {
           return psf->pss->shutdown_destroy();
         });
       }
       return seastar::now();
     }).then([psf,
              cb_client = std::move(cb_client),
-             cb_server = std::move(cb_server)] () mutable {
-      logger.debug("dispatch_sockets(): client/server socket are ready");
+             cb_server = std::move(cb_server)]() mutable {
+      logger().debug("dispatch_sockets(): client/server socket are ready");
       return seastar::when_all_succeed(
-        seastar::smp::submit_to(0u, [socket = psf->client_socket.get(),
-                                     cb_client = std::move(cb_client)] {
+        seastar::smp::submit_to(CLIENT_CPU,
+            [socket = psf->client_socket.get(), cb_client = std::move(cb_client)] {
           return cb_client(socket).then([socket] {
-            logger.debug("closing client socket...");
+            logger().debug("closing client socket...");
             return socket->close();
-          }).handle_exception([] (auto eptr) {
-            logger.error("dispatch_sockets():"
-                " cb_client() got unexpeted exception {}", eptr);
+          }).handle_exception([](auto eptr) {
+            logger().error("dispatch_sockets():"
+                           " cb_client() got unexpeted exception {}", eptr);
             ceph_abort();
           });
         }),
-        seastar::smp::submit_to(1u, [socket = psf->server_socket.get(),
-                                     cb_server = std::move(cb_server)] {
+        seastar::smp::submit_to(SERVER_CPU,
+            [socket = psf->server_socket.get(), cb_server = std::move(cb_server)] {
           return cb_server(socket).then([socket] {
-            logger.debug("closing server socket...");
+            logger().debug("closing server socket...");
             return socket->close();
-          }).handle_exception([] (auto eptr) {
-            logger.error("dispatch_sockets():"
-                " cb_server() got unexpeted exception {}", eptr);
+          }).handle_exception([](auto eptr) {
+            logger().error("dispatch_sockets():"
+                           " cb_server() got unexpeted exception {}", eptr);
             ceph_abort();
           });
         })
@@ -257,15 +268,15 @@ class Connection {
   }
 
   future<> dispatch_write(unsigned round = 0, bool force_shut = false) {
-    logger.debug("dispatch_write(round={}, force_shut={})...", round, force_shut);
+    logger().debug("dispatch_write(round={}, force_shut={})...", round, force_shut);
     return seastar::repeat([this, round, force_shut] {
       if (round != 0 && round <= write_count) {
         return seastar::futurize_invoke([this, force_shut] {
           if (force_shut) {
-            logger.debug("dispatch_write() done, force shutdown output");
+            logger().debug("dispatch_write() done, force shutdown output");
             socket->force_shutdown_out();
           } else {
-            logger.debug("dispatch_write() done");
+            logger().debug("dispatch_write() done");
           }
         }).then([] {
           return seastar::make_ready_future<stop_t>(stop_t::yes);
@@ -288,30 +299,30 @@ class Connection {
     return dispatch_write(
     ).then([] {
       ceph_abort();
-    }).handle_exception_type([this] (const std::system_error& e) {
+    }).handle_exception_type([this](const std::system_error& e) {
       if (e.code() != std::errc::broken_pipe &&
           e.code() != std::errc::connection_reset) {
-        logger.error("dispatch_write_unbounded(): "
-                     "unexpected error {}", e);
+        logger().error("dispatch_write_unbounded(): "
+                       "unexpected error {}", e);
         throw;
       }
       // successful
-      logger.debug("dispatch_write_unbounded(): "
-                   "expected error {}", e);
+      logger().debug("dispatch_write_unbounded(): "
+                     "expected error {}", e);
       shutdown();
     });
   }
 
   future<> dispatch_read(unsigned round = 0, bool force_shut = false) {
-    logger.debug("dispatch_read(round={}, force_shut={})...", round, force_shut);
+    logger().debug("dispatch_read(round={}, force_shut={})...", round, force_shut);
     return seastar::repeat([this, round, force_shut] {
       if (round != 0 && round <= read_count) {
         return seastar::futurize_invoke([this, force_shut] {
           if (force_shut) {
-            logger.debug("dispatch_read() done, force shutdown input");
+            logger().debug("dispatch_read() done, force shutdown input");
             socket->force_shutdown_in();
           } else {
-            logger.debug("dispatch_read() done");
+            logger().debug("dispatch_read() done");
           }
         }).then([] {
           return seastar::make_ready_future<stop_t>(stop_t::yes);
@@ -321,7 +332,7 @@ class Connection {
           // we want to test both Socket::read() and Socket::read_exactly()
           if (read_count % 2) {
             return socket->read(DATA_SIZE * sizeof(uint64_t)
-            ).then([this] (ceph::bufferlist bl) {
+            ).then([this](ceph::bufferlist bl) {
               uint64_t read_data[DATA_SIZE];
               auto p = bl.cbegin();
               ::ceph::decode_raw(read_data, p);
@@ -329,7 +340,7 @@ class Connection {
             });
           } else {
             return socket->read_exactly(DATA_SIZE * sizeof(uint64_t)
-            ).then([this] (auto buf) {
+            ).then([this](auto buf) {
               auto read_data = reinterpret_cast<const uint64_t*>(buf.get());
               verify_data_read(read_data);
             });
@@ -346,16 +357,16 @@ class Connection {
     return dispatch_read(
     ).then([] {
       ceph_abort();
-    }).handle_exception_type([this] (const std::system_error& e) {
+    }).handle_exception_type([this](const std::system_error& e) {
       if (e.code() != error::read_eof
        && e.code() != std::errc::connection_reset) {
-        logger.error("dispatch_read_unbounded(): "
-                     "unexpected error {}", e);
+        logger().error("dispatch_read_unbounded(): "
+                       "unexpected error {}", e);
         throw;
       }
       // successful
-      logger.debug("dispatch_read_unbounded(): "
-                   "expected error {}", e);
+      logger().debug("dispatch_read_unbounded(): "
+                     "expected error {}", e);
       shutdown();
     });
   }
@@ -367,10 +378,10 @@ class Connection {
  public:
   static future<> dispatch_rw_bounded(Socket* socket, unsigned round,
                                       bool force_shut = false) {
-    logger.debug("dispatch_rw_bounded(round={}, force_shut={})...",
-                 round, force_shut);
+    logger().debug("dispatch_rw_bounded(round={}, force_shut={})...",
+                   round, force_shut);
     return seastar::do_with(Connection{socket},
-                            [round, force_shut] (auto& conn) {
+                            [round, force_shut](auto& conn) {
       ceph_assert(round != 0);
       return seastar::when_all_succeed(
         conn.dispatch_write(round, force_shut),
@@ -382,15 +393,15 @@ class Connection {
   }
 
   static future<> dispatch_rw_unbounded(Socket* socket, bool preemptive_shut = false) {
-    logger.debug("dispatch_rw_unbounded(preemptive_shut={})...", preemptive_shut);
-    return seastar::do_with(Connection{socket}, [preemptive_shut] (auto& conn) {
+    logger().debug("dispatch_rw_unbounded(preemptive_shut={})...", preemptive_shut);
+    return seastar::do_with(Connection{socket}, [preemptive_shut](auto& conn) {
       return seastar::when_all_succeed(
         conn.dispatch_write_unbounded(),
         conn.dispatch_read_unbounded(),
         seastar::futurize_invoke([&conn, preemptive_shut] {
           if (preemptive_shut) {
             return seastar::sleep(100ms).then([&conn] {
-              logger.debug("dispatch_rw_unbounded() shutdown socket preemptively(100ms)");
+              logger().debug("dispatch_rw_unbounded() shutdown socket preemptively(100ms)");
               conn.shutdown();
             });
           } else {
@@ -405,63 +416,63 @@ class Connection {
 };
 
 future<> test_read_write() {
-  logger.info("test_read_write()...");
+  logger().info("test_read_write()...");
   return SocketFactory::dispatch_sockets(
-    [] (auto cs) { return Connection::dispatch_rw_bounded(cs, 128); },
-    [] (auto ss) { return Connection::dispatch_rw_bounded(ss, 128); }
+    [](auto cs) { return Connection::dispatch_rw_bounded(cs, 128); },
+    [](auto ss) { return Connection::dispatch_rw_bounded(ss, 128); }
   ).then([] {
-    logger.info("test_read_write() ok\n");
-  }).handle_exception([] (auto eptr) {
-    logger.error("test_read_write() got unexpeted exception {}", eptr);
+    logger().info("test_read_write() ok\n");
+  }).handle_exception([](auto eptr) {
+    logger().error("test_read_write() got unexpeted exception {}", eptr);
     ceph_abort();
   });
 }
 
 future<> test_unexpected_down() {
-  logger.info("test_unexpected_down()...");
+  logger().info("test_unexpected_down()...");
   return SocketFactory::dispatch_sockets(
-    [] (auto cs) { 
+    [](auto cs) {
       return Connection::dispatch_rw_bounded(cs, 128, true
-        ).handle_exception_type([] (const std::system_error& e) {
-        logger.debug("test_unexpected_down(): client get error {}", e);
+        ).handle_exception_type([](const std::system_error& e) {
+        logger().debug("test_unexpected_down(): client get error {}", e);
         ceph_assert(e.code() == error::read_eof);
       });
     },
-    [] (auto ss) { return Connection::dispatch_rw_unbounded(ss); }
+    [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }
   ).then([] {
-    logger.info("test_unexpected_down() ok\n");
-  }).handle_exception([] (auto eptr) {
-    logger.error("test_unexpected_down() got unexpeted exception {}", eptr);
+    logger().info("test_unexpected_down() ok\n");
+  }).handle_exception([](auto eptr) {
+    logger().error("test_unexpected_down() got unexpeted exception {}", eptr);
     ceph_abort();
   });
 }
 
 future<> test_shutdown_propagated() {
-  logger.info("test_shutdown_propagated()...");
+  logger().info("test_shutdown_propagated()...");
   return SocketFactory::dispatch_sockets(
-    [] (auto cs) {
-      logger.debug("test_shutdown_propagated() shutdown client socket");
+    [](auto cs) {
+      logger().debug("test_shutdown_propagated() shutdown client socket");
       cs->shutdown();
       return seastar::now();
     },
-    [] (auto ss) { return Connection::dispatch_rw_unbounded(ss); }
+    [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }
   ).then([] {
-    logger.info("test_shutdown_propagated() ok\n");
-  }).handle_exception([] (auto eptr) {
-    logger.error("test_shutdown_propagated() got unexpeted exception {}", eptr);
+    logger().info("test_shutdown_propagated() ok\n");
+  }).handle_exception([](auto eptr) {
+    logger().error("test_shutdown_propagated() got unexpeted exception {}", eptr);
     ceph_abort();
   });
 }
 
 future<> test_preemptive_down() {
-  logger.info("test_preemptive_down()...");
+  logger().info("test_preemptive_down()...");
   return SocketFactory::dispatch_sockets(
-    [] (auto cs) { return Connection::dispatch_rw_unbounded(cs, true); },
-    [] (auto ss) { return Connection::dispatch_rw_unbounded(ss); }
+    [](auto cs) { return Connection::dispatch_rw_unbounded(cs, true); },
+    [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }
   ).then([] {
-    logger.info("test_preemptive_down() ok\n");
-  }).handle_exception([] (auto eptr) {
-    logger.error("test_preemptive_down() got unexpeted exception {}", eptr);
+    logger().info("test_preemptive_down() ok\n");
+  }).handle_exception([](auto eptr) {
+    logger().error("test_preemptive_down() got unexpeted exception {}", eptr);
     ceph_abort();
   });
 }
@@ -477,37 +488,36 @@ seastar::future<int> do_test(seastar::app_template& app)
                                               CEPH_ENTITY_TYPE_CLIENT,
                                               &cluster,
                                               &conf_file_list);
-  return crimson::common::sharded_conf().start(init_params.name, cluster)
-  .then([conf_file_list] {
+  return crimson::common::sharded_conf().start(init_params.name, cluster
+  ).then([conf_file_list] {
     return local_conf().parse_config_files(conf_file_list);
   }).then([] {
-      return local_conf().set_val("ms_inject_internal_delays", "0")
-    .then([] {
-      return test_refused();
-    }).then([] {
-      return test_bind_same();
-    }).then([] {
-      return test_accept();
-    }).then([] {
-      return test_read_write();
-    }).then([] {
-      return test_unexpected_down();
-    }).then([] {
-      return test_shutdown_propagated();
-    }).then([] {
-      return test_preemptive_down();
-    }).then([] {
-      logger.info("All tests succeeded");
-      // Seastar has bugs to have events undispatched during shutdown,
-      // which will result in memory leak and thus fail LeakSanitizer.
-      return seastar::sleep(100ms);
-    });
+    return local_conf().set_val("ms_inject_internal_delays", "0");
+  }).then([] {
+    return test_refused();
+  }).then([] {
+    return test_bind_same();
+  }).then([] {
+    return test_accept();
+  }).then([] {
+    return test_read_write();
+  }).then([] {
+    return test_unexpected_down();
+  }).then([] {
+    return test_shutdown_propagated();
+  }).then([] {
+    return test_preemptive_down();
+  }).then([] {
+    logger().info("All tests succeeded");
+    // Seastar has bugs to have events undispatched during shutdown,
+    // which will result in memory leak and thus fail LeakSanitizer.
+    return seastar::sleep(100ms);
   }).then([] {
     return crimson::common::sharded_conf().stop();
   }).then([] {
     return 0;
-  }).handle_exception([] (auto eptr) {
-    logger.error("Test failed: got exception {}", eptr);
+  }).handle_exception([](auto eptr) {
+    logger().error("Test failed: got exception {}", eptr);
     return 1;
   });
 }

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -115,10 +115,12 @@ future<> test_accept() {
   return FixedCPUServerSocket::create().then([] (auto pss) {
     auto saddr = get_server_addr();
     return pss->listen(saddr).safe_then([pss] {
-      return pss->accept([] (auto socket, auto paddr) {
+      return pss->accept([](auto socket, auto paddr) {
         // simple accept
-        return seastar::sleep(100ms).then([socket = std::move(socket)] () mutable {
-          return socket->close().finally([cleanup = std::move(socket)] {});
+        return seastar::sleep(100ms
+        ).then([socket = std::move(socket)]() mutable {
+          return socket->close(
+          ).finally([cleanup = std::move(socket)] {});
         });
       });
     }, listen_ertr::all_same_way(

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -291,8 +291,10 @@ class Connection {
         });
       } else {
         data[0] = write_count;
-        return socket->write(seastar::net::packet(
-            reinterpret_cast<const char*>(&data), sizeof(data))
+        bufferlist bl;
+        bl.append(buffer::copy(
+          reinterpret_cast<const char*>(&data), sizeof(data)));
+        return socket->write(bl
         ).then([this] {
           return socket->flush();
         }).then([this] {
@@ -348,9 +350,9 @@ class Connection {
             });
           } else {
             return socket->read_exactly(DATA_SIZE * sizeof(uint64_t)
-            ).then([this](auto buf) {
+            ).then([this](auto bptr) {
               uint64_t read_data[DATA_SIZE];
-              std::memcpy(read_data, buf.get(), DATA_SIZE * sizeof(uint64_t));
+              std::memcpy(read_data, bptr.c_str(), DATA_SIZE * sizeof(uint64_t));
               verify_data_read(read_data);
             });
           }

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -202,7 +202,7 @@ class SocketFactory {
             logger().info("dispatch_sockets(): accepted at shard {}",
                           seastar::this_shard_id());
             psf->server_socket_CPU = seastar::this_shard_id();
-            if (psf->pss->is_fixed()) {
+            if (psf->pss->is_fixed_shard_dispatching()) {
               ceph_assert_always(SERVER_CPU == seastar::this_shard_id());
             }
             SocketFRef socket = seastar::make_foreign(std::move(_socket));


### PR DESCRIPTION
This PR implements multi-shard support in Crimson Messenger, following up https://github.com/ceph/ceph/pull/49420 and https://github.com/ceph/ceph/pull/50835.

Generally, all handshakes in protocol v2 are done in a dedicated shard for a Crimson Messenger as before, hopefully this will make further integrations with Crimson OSD simpler, because the dependent logic (such as the authentication) in OSD is not sharded, and the internal connection registration as well as replacements can remain atomic. Apart from that, the events and message dispatching are distributed to all the available shards per connection, determined by where the shard `seastar::connected_socket` lives. Due to the limitation that `connected_socket` cannot be moved to a different shard once established, the working connection shard can only available with the connected and accepted events. For lossless connection, this means that the working connection shard can be changed during connction recovery and upon reconnect and reaccept.

Also see https://github.com/ceph/ceph/pull/49420#issue-1495754209.

TODOs:
* Make sure there is no regression to all the existing logic using the single-shard Crimson Messenger;
* ~~Integrate multi-shard Crimson Messenger with perf-crimson-msgr;~~ https://github.com/ceph/ceph/pull/52091
* Understand the performance impacts;
* Extend the unit tests to validate the multi-shard Crimson Messenger;
* Integrate multi-shard Crimson Messenger with Crimson OSD;

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
