### PR TITLE
mgr: heartbeat_webhook module

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1895,6 +1895,7 @@ fi
 %{_datadir}/ceph/mgr/stats
 %{_datadir}/ceph/mgr/status
 %{_datadir}/ceph/mgr/telegraf
+%{_datadir}/ceph/mgr/heartbeat_webhook
 %{_datadir}/ceph/mgr/telemetry
 %{_datadir}/ceph/mgr/test_orchestrator
 %{_datadir}/ceph/mgr/volumes

--- a/doc/mgr/heartbeat_webhook.rst
+++ b/doc/mgr/heartbeat_webhook.rst
@@ -1,0 +1,60 @@
+heartbeat_webhook module
+========================
+
+This module is designed to be used with a heartbeat style 
+webhook receiver. This allows for very simple and robust 
+state monitoring.
+
+This module will send a webhook to the specified
+webhook URL once per interval when the cluster is in a 
+``HEALTH_OK`` state. In the case that the webhook stops being
+received, the monitoring service should trigger an alert. 
+
+This module was tested against 
+`Dead Mans Snitch <https://deadmanssnitch.com>`_, but it should
+work for any similar service (such as Robodash, Cronitor, 
+Alerta heartbeats, etc.)
+
+Configuration
+-------------
+
+For this module to function, a webhook URL must be specified::
+
+    ceph config set mgr mgr/heartbeat_webhook/webhook_url "https://example.com/webhook"
+
+Below is a complete list of configuration options:
+
+.. list-table:: Configuration Options
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Type
+     - Default Value
+     - Required
+   * - webhook_url
+     - Url to which HTTP POST requests are sent
+     - string
+     - ''
+     - true
+   * - interval
+     - Time between webhooks
+     - seconds
+     - 60
+     - talse
+   * - send_on_warn
+     - When true, webhooks will also be sent when the cluster is ``HEALTH_WARN``
+     - bool
+     - false
+     - false
+
+Commands
+--------
+
+heartbeat_webhook exposes one command for testing
+the configured webhook receiver::
+
+    ceph heartbeat_webhook test
+
+This will send a test webhook and return the heartbeat code 
+and body of the response.

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -34,6 +34,7 @@ sensible.
     DiskPrediction module <diskprediction>
     Local pool module <localpool>
     RESTful module <restful>
+    Heartbeat Webhook module <heartbeat_webhook>
     Zabbix module <zabbix>
     Prometheus module <prometheus>
     Influx module <influx>

--- a/src/pybind/mgr/heartbeat_webhook/__init__.py
+++ b/src/pybind/mgr/heartbeat_webhook/__init__.py
@@ -1,0 +1,1 @@
+from .module import HeartbeatWebhook

--- a/src/pybind/mgr/heartbeat_webhook/module.py
+++ b/src/pybind/mgr/heartbeat_webhook/module.py
@@ -1,0 +1,126 @@
+import logging
+import json
+from mgr_module import MgrModule, Option, HandleCommandResult, CLIReadCommand
+from typing import Any, List, TYPE_CHECKING
+from threading import Event
+import urllib3
+
+
+class HeartbeatWebhook(MgrModule):
+    MODULE_OPTIONS = [
+        Option(
+            name='interval',
+            type='secs',
+            default=60,
+            desc='How frequently to reexamine health status',
+            runtime=True),
+        Option(
+            name='webhook_url',
+            type='string',
+            default='',
+            desc='Url to send webhooks to',
+            runtime=True),
+        Option(
+            name='send_on_warn',
+            type='bool',
+            default=False,
+            desc="Continue sending webhooks if the cluster health is HEALTH_WARN")
+    ]
+    NATIVE_OPTIONS: List[str] = [
+    ]
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(HeartbeatWebhook, self).__init__(*args, **kwargs)
+
+        self.run = True
+        self.event = Event()
+        
+        self.config_notify()
+
+        self.log.info("Initializing heartbeat_webhook module")
+
+        self.http = urllib3.PoolManager()
+
+        if TYPE_CHECKING:
+            self.interval = 60
+            self.webhook_url = ''
+
+    def config_notify(self) -> None:
+        for opt in self.MODULE_OPTIONS:
+            setattr(self,
+                    opt['name'],
+                    self.get_module_option(opt['name']))
+            self.log.debug(' mgr option %s = %s',
+                           opt['name'], getattr(self, opt['name']))
+        # Do the same for the native options.
+        for opt in self.NATIVE_OPTIONS:
+            setattr(self,
+                    opt,
+                    self.get_ceph_option(opt))
+            self.log.debug(' native option %s = %s', opt, getattr(self, opt))
+
+    def _get_fsid(self) -> str:
+        mon_map = self.get('mon_map')
+        return mon_map['fsid']
+
+    @CLIReadCommand('heartbeat_webhook test')
+    def webhook_test(self):
+        status = json.loads(self.get('health')['json'])
+        webhook_data = {'ceph_status': status['status'], 'fsid': self._get_fsid(), 'origin': 'Ceph mgr heartbeat_webhook module'}
+        response = self.http.request('POST',
+                                    self.webhook_url,
+                                    body = json.dumps(webhook_data),
+                                    headers = {'Content-Type': 'application/json'},
+                                    retries = False)
+        stdout = f"Response code: {response.status} Response data: {response.data}"
+        return HandleCommandResult(retval=0, stdout=stdout, stderr='')
+        
+    def _check(self) -> None:
+        # If we don't have a mon connection, we will likely have stale data that we shouldn't trust
+        if self.have_mon_connection():
+            status = json.loads(self.get('health')['json'])
+            webhook_data = {'ceph_status': status['status'], 'fsid': self._get_fsid(), 'origin': 'Ceph mgr heartbeat_webhook module'}
+            self.log.debug(f"Found status: {status}")
+            if status['status'] == "HEALTH_OK":
+                self.log.info("Cluster status is 'HEALTH_OK', sending status webhook")
+                self._send_webhook(webhook_data)
+                
+            elif status['status'] == "HEALTH_WARN":
+                if self.send_on_warn:
+                    self.log.info(f"Cluster status is 'HEALTH_WARN' but send_on_warn option is set, sending status webhook.")
+                    self._send_webhook(webhook_data)
+                else:
+                     self.log.info(f"Cluster status is 'HEALTH_WARN', not sending status webhook")
+        else:
+            self.log.error("Not sending webhook, mgr is disconnected from mons")
+
+    def _send_webhook(self, webhook_data: dict) -> None:
+                response = self.http.request('POST',
+                                        self.webhook_url,
+                                        body = json.dumps(webhook_data),
+                                        headers = {'Content-Type': 'application/json'},
+                                        retries = False)
+                if response.status >= 200 and response.status < 400:
+                     self.log.info("Webhook sent successfuly")
+                else:
+                    self.log.error(f"Error sending webhook: {response.data}")
+
+    def serve(self) -> None:
+        """
+        This method is called by the mgr when the module starts and can be
+        used for any background activity.
+        """
+        self.log.info("Starting")
+        while self.run:
+            self._check()
+            self.log.debug(f"Sleeping for {self.interval} seconds")
+            self.event.wait(self.interval)
+            self.event.clear()
+
+    def shutdown(self) -> None:
+        """
+        This method is called by the mgr when the module needs to shut
+        down (i.e., when the serve() function needs to exit).
+        """
+        self.log.info('Stopping')
+        self.run = False
+        self.event.set()


### PR DESCRIPTION
This adds a new mgr module called heartbeat_webhook. This will send webhooks to the specified url as long as the cluster status is `HEALTH_OK`, and will stop sending them if the cluster enters a warning or critical state. This allows heartbeat based monitoring systems to easily and robustly alert for failed Ceph clusters without external monitoring scripts.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
