### PR TITLE
client/mds: revoke the Fx caps to trigger dirty metadatas to be flushed from client

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14625,7 +14625,7 @@ int Client::_mknod(Inode *dir, const char *name, mode_t mode, dev_t rdev,
   req->set_filepath(path);
   req->set_inode(dir);
   req->head.args.mknod.rdev = rdev;
-  req->dentry_drop = CEPH_CAP_FILE_SHARED  | CEPH_CAP_AUTH_EXCL;
+  req->dentry_drop = CEPH_CAP_FILE_SHARED  | CEPH_CAP_AUTH_EXCL | CEPH_CAP_XATTR_EXCL;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
 
   bufferlist xattrs_bl;
@@ -14781,7 +14781,7 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
   else
     req->head.args.open.mask = 0;
   req->head.args.open.pool = pool_id;
-  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL;
+  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL | CEPH_CAP_XATTR_EXCL;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
 
   mode |= S_IFREG;
@@ -14850,7 +14850,7 @@ int Client::_mkdir(Inode *dir, const char *name, mode_t mode, const UserPerm& pe
   path.push_dentry(name);
   req->set_filepath(path);
   req->set_inode(dir);
-  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL;
+  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL | CEPH_CAP_XATTR_EXCL;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
   req->set_alternate_name(std::move(alternate_name));
 
@@ -14992,7 +14992,7 @@ int Client::_symlink(Inode *dir, const char *name, const char *target,
   req->set_alternate_name(std::move(alternate_name));
   req->set_inode(dir);
   req->set_string2(target);
-  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL;
+  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_AUTH_EXCL | CEPH_CAP_XATTR_EXCL;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
 
   Dentry *de = get_or_create(dir, name);
@@ -15114,7 +15114,7 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
   in = otherin.get();
   req->set_other_inode(in);
   in->break_all_delegs();
-  req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
+  req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL | CEPH_CAP_XATTR_EXCL;
 
   req->set_inode(dir);
 
@@ -15165,7 +15165,7 @@ int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms)
   req->set_filepath(path);
   req->set_inode(dir);
 
-  req->dentry_drop = CEPH_CAP_FILE_SHARED;
+  req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_XATTR_EXCL;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
   req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
 
@@ -15268,12 +15268,12 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
   int res;
   if (op == CEPH_MDS_OP_RENAME) {
     req->set_old_dentry(oldde);
-    req->old_dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_LINK_EXCL;
+    req->old_dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_LINK_EXCL | CEPH_CAP_XATTR_EXCL;
     req->old_dentry_unless = CEPH_CAP_FILE_EXCL;
 
     de->is_renaming = true;
     req->set_dentry(de);
-    req->dentry_drop = CEPH_CAP_FILE_SHARED;
+    req->dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_XATTR_EXCL;
     req->dentry_unless = CEPH_CAP_FILE_EXCL;
 
     InodeRef oldin, otherin;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -15268,7 +15268,7 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
   int res;
   if (op == CEPH_MDS_OP_RENAME) {
     req->set_old_dentry(oldde);
-    req->old_dentry_drop = CEPH_CAP_FILE_SHARED;
+    req->old_dentry_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_LINK_EXCL;
     req->old_dentry_unless = CEPH_CAP_FILE_EXCL;
 
     de->is_renaming = true;
@@ -15389,7 +15389,7 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
   req->set_filepath2(existing);
 
   req->set_inode(dir);
-  req->inode_drop = CEPH_CAP_FILE_SHARED;
+  req->inode_drop = CEPH_CAP_FILE_SHARED | CEPH_CAP_LINK_EXCL;
   req->inode_unless = CEPH_CAP_FILE_EXCL;
 
   Dentry *de = get_or_create(dir, newname);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -497,6 +497,8 @@ public:
 
   void mark_complete();
 
+  bool is_dir() const override { return true; }
+
   // -- reference counting --
   void first_get() override;
   void last_put() override;

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -119,6 +119,7 @@ class MDSCacheObject {
   void state_set(unsigned mask) { state |= mask; }
   void state_reset(unsigned s) { state = s; }
 
+  virtual bool is_dir() const { return false; }
   bool is_auth() const { return state_test(STATE_AUTH); }
   bool is_dirty() const { return state_test(STATE_DIRTY); }
   bool is_clean() const { return !is_dirty(); }

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -359,13 +359,23 @@ public:
     return get_sm()->states[state].can_wrlock == ANY ||
       (get_sm()->states[state].can_wrlock == AUTH && parent->is_auth()) ||
       (get_sm()->states[state].can_wrlock == XCL && client >= 0 && (get_xlock_by_client() == client ||
-								    get_excl_client() == client));
+                                                                    (get_excl_client() == client &&
+                                                                     !(parent->is_dir() &&
+                                                                       (type->type == CEPH_LOCK_IFILE ||
+                                                                        type->type == CEPH_LOCK_IAUTH ||
+                                                                        type->type == CEPH_LOCK_ILINK ||
+                                                                        type->type == CEPH_LOCK_IXATTR)))));
   }
   bool can_force_wrlock(client_t client) const {
     return get_sm()->states[state].can_force_wrlock == ANY ||
       (get_sm()->states[state].can_force_wrlock == AUTH && parent->is_auth()) ||
       (get_sm()->states[state].can_force_wrlock == XCL && client >= 0 && (get_xlock_by_client() == client ||
-									  get_excl_client() == client));
+                                                                          (get_excl_client() == client &&
+                                                                           !(parent->is_dir() &&
+                                                                             (type->type == CEPH_LOCK_IFILE ||
+                                                                              type->type == CEPH_LOCK_IAUTH ||
+                                                                              type->type == CEPH_LOCK_ILINK ||
+                                                                              type->type == CEPH_LOCK_IXATTR)))));
   }
   bool can_xlock(client_t client) const {
     return get_sm()->states[state].can_xlock == ANY ||


### PR DESCRIPTION
If the 'Fx' caps is issued the client will cache the dirty metadatas,
while if a write request, mkdir request for example, comes it will
try to update the parents' mtime without trigger to revoke the
corresponding caps. This will cause the mtime will be overwrote
later after the dirty caps is flushed from clients.

We need to acquire the xlock for the parent inode.

And also we could voluntarily drop Xx/Lx/Ax caps for some requests
to avoid revocation msgs.

Fixes: https://tracker.ceph.com/issues/61584


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
