### PR TITLE
crimson/osd/watch: fix notify_ack() lifetime

### DIFF
--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -123,14 +123,21 @@ seastar::future<> Watch::notify_ack(
   const ceph::bufferlist& reply_bl)
 {
   logger().info("{}", __func__);
-  return seastar::do_for_each(in_progress_notifies,
-    [this_shared=shared_from_this(), reply_bl] (auto notify) {
-      return notify->complete_watcher(this_shared, reply_bl);
+  return seastar::do_until(
+    [this, reply_bl] { return in_progress_notifies.empty(); },
+    [this, reply_bl] {
+      auto notify_iter = in_progress_notifies.begin();
+      auto notify = notify_iter->get();
+      logger().debug("Watch::notify_ack gid={} cookie={} notify(id={})",
+                     get_watcher_gid(),
+                     get_cookie(),
+                     notify->ninfo.notify_id);
+      return notify->complete_watcher(shared_from_this(), reply_bl
+      ).then([this, notify_iter] {
+        in_progress_notifies.erase(notify_iter);
+      });
     }
-  ).then([this] {
-    in_progress_notifies.clear();
-    return seastar::now();
-  });
+  );
 }
 
 seastar::future<> Watch::send_disconnect_msg()


### PR DESCRIPTION
Before the change:
```
INFO  2023-06-06 09:44:07,607 [shard 2] osd - notify_ack watch_cookie=107271103492224, notify_id=163208757298
DEBUG 2023-06-06 09:44:07,607 [shard 2] osd - Watch::notify_ack gid=4188 cookie=107271103492224 notify(id=163208757298)
DEBUG 2023-06-06 09:44:07,607 [shard 2] osd - complete_watcher for notify(id=163208757298)
DEBUG 2023-06-06 09:44:07,607 [shard 2] osd - remove_watcher for notify(id=163208757298)
// deleting notify(id=163208757298)
DEBUG 2023-06-06 09:44:07,607 [shard 2] osd - ~Notify for notify(id=163208757298)
// acking notify(id=163208757298)
INFO  2023-06-06 09:44:07,608 [shard 2] osd - notify_ack watch_cookie=107271103791744, notify_id=163208757298
DEBUG 2023-06-06 09:44:07,608 [shard 2] osd - notify_ack gid=4188 cookie=107271103791744
DEBUG 2023-06-06 09:44:07,608 [shard 2] osd - Watch::notify_ack complete gid=4188 cookie=107271103791744
```

* This should also resolve the recent rbd api freezes regression.

*  Debugged w/ #51852

Fixes: https://tracker.ceph.com/issues/61504

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
