### PR TITLE
crimson/os/seastore/cached_extent: add prepare_commit interface

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -564,7 +564,7 @@ struct FixedKVInternalNode
     return this->get_split_pivot().get_offset();
   }
 
-  void prepare_write() final {
+  void prepare_commit() final {
     if (this->is_initial_pending()) {
       if (this->is_rewrite()) {
 	this->set_children_from_prior_instance();
@@ -1004,7 +1004,7 @@ struct FixedKVLeafNode
     }
   }
 
-  void prepare_write() final {
+  void prepare_commit() final {
     if constexpr (has_children) {
       if (this->is_initial_pending()) {
 	if (this->is_rewrite()) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1098,6 +1098,7 @@ record_t Cache::prepare_record(
 
     i->prepare_write();
     i->set_io_wait();
+    i->prepare_commit();
 
     assert(i->get_version() > 0);
     auto final_crc = i->get_crc32c();
@@ -1200,6 +1201,7 @@ record_t Cache::prepare_record(
 
     bufferlist bl;
     i->prepare_write();
+    i->prepare_commit();
     bl.append(i->get_bptr());
     if (i->get_type() == extent_types_t::ROOT) {
       ceph_assert(0 == "ROOT never gets written as a fresh block");
@@ -1240,6 +1242,7 @@ record_t Cache::prepare_record(
     assert(!i->is_inline());
     get_by_ext(efforts.fresh_ool_by_ext,
                i->get_type()).increment(i->get_length());
+    i->prepare_commit();
     if (is_backref_mapped_extent_node(i)) {
       alloc_delta.alloc_blk_ranges.emplace_back(
 	i->get_paddr(),

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -251,6 +251,14 @@ public:
   virtual void prepare_write() {}
 
   /**
+   * prepare_commit
+   *
+   * Called prior to committing the transaction in which this extent
+   * is living.
+   */
+  virtual void prepare_commit() {}
+
+  /**
    * on_initial_write
    *
    * Called after commit of extent.  State will be CLEAN.


### PR DESCRIPTION
move new fixedkv-btree nodes' inter-node pointer adjustments into the prepare_commit interface

Fixes: https://tracker.ceph.com/issues/61608
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
