### PR TITLE
src/osd: OSDShard adaptive threading and double buffering

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -853,7 +853,7 @@ options:
 - name: osd_op_num_threads_per_shard_ssd
   type: int
   level: advanced
-  default: 8 
+  default: 16
   see_also:
   - osd_op_num_threads_per_shard
   flags:
@@ -873,7 +873,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for rotational media).
-  default: 2 
+  default: 2
   see_also:
   - osd_op_num_shards
   flags:
@@ -883,7 +883,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for solid state media).
-  default: 4 
+  default: 2
   see_also:
   - osd_op_num_shards
   flags:
@@ -895,6 +895,15 @@ options:
   desc: Do not store full-object checksums if the backend (bluestore) does its own
     checksums.  Only usable with all BlueStore OSDs.
   default: false
+- name: osd_shard_primary_thread_poll_time
+  type: float
+  level: dev
+  desc: How long the primary thread in each shard should poll before going to
+    sleep if there are no items to process.
+  default: 0
+  flags:
+  - startup
+  with_legacy: true
 - name: osd_waitgroup_la
   type: int
   level: dev
@@ -918,7 +927,7 @@ options:
   level: dev
   desc: constant in a 2nd degree polynomial of form la*i^2+lb*i+lc
     governing OSD thread sleep behavior in a given shard.
-  default: 0 
+  default: 2
   flags:
   - startup
   with_legacy: true
@@ -927,7 +936,7 @@ options:
   level: dev
   desc: first coefficient of a 2nd degree polynomial of form ha*i^2+hb*i+hc 
     governing OSD thread wake behavior in a given shard.
-  default: 2
+  default: 0
   flags:
   - startup
   with_legacy: true
@@ -936,7 +945,7 @@ options:
   level: dev
   desc: second coefficient of a 2nd degree polynomial of form ha*i^2+hb*i+hc
     governing OSD thread wake behavior in a given shard.
-  default: 2
+  default: 4
   flags:
   - startup
   with_legacy: true
@@ -945,7 +954,7 @@ options:
   level: dev
   desc: constant in a 2nd degree polynomial of form ha*i^2+hb*i+hc
     governing OSD thread wake behavior in a given shard.
-  default: 0
+  default: 16
   flags:
   - startup
   with_legacy: true

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -844,7 +844,7 @@ options:
 - name: osd_op_num_threads_per_shard_hdd
   type: int
   level: advanced
-  default: 1
+  default: 2 
   see_also:
   - osd_op_num_threads_per_shard
   flags:
@@ -853,7 +853,7 @@ options:
 - name: osd_op_num_threads_per_shard_ssd
   type: int
   level: advanced
-  default: 2
+  default: 8 
   see_also:
   - osd_op_num_threads_per_shard
   flags:
@@ -873,7 +873,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for rotational media).
-  default: 5
+  default: 2 
   see_also:
   - osd_op_num_shards
   flags:
@@ -883,7 +883,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for solid state media).
-  default: 8
+  default: 4 
   see_also:
   - osd_op_num_shards
   flags:
@@ -895,6 +895,60 @@ options:
   desc: Do not store full-object checksums if the backend (bluestore) does its own
     checksums.  Only usable with all BlueStore OSDs.
   default: false
+- name: osd_waitgroup_la
+  type: int
+  level: dev
+  desc: first coefficient of a 2nd degree polynomial of form la*i^2+lb*i+lc 
+    governing OSD thread sleep behavior in a given shard.
+  default: 0
+  flags:
+  - startup
+  with_legacy: true
+- name: osd_waitgroup_lb
+  type: int
+  level: dev
+  desc: second coefficient of a 2nd degree polynomial of form la*i^2+lb*i+lc 
+    governing OSD thread sleep behavior in a given shard.
+  default: 1
+  flags:
+  - startup
+  with_legacy: true
+- name: osd_waitgroup_lc
+  type: int
+  level: dev
+  desc: constant in a 2nd degree polynomial of form la*i^2+lb*i+lc
+    governing OSD thread sleep behavior in a given shard.
+  default: 0 
+  flags:
+  - startup
+  with_legacy: true
+- name: osd_waitgroup_ha
+  type: int
+  level: dev
+  desc: first coefficient of a 2nd degree polynomial of form ha*i^2+hb*i+hc 
+    governing OSD thread wake behavior in a given shard.
+  default: 2
+  flags:
+  - startup
+  with_legacy: true
+- name: osd_waitgroup_hb
+  type: int
+  level: dev
+  desc: second coefficient of a 2nd degree polynomial of form ha*i^2+hb*i+hc
+    governing OSD thread wake behavior in a given shard.
+  default: 2
+  flags:
+  - startup
+  with_legacy: true
+- name: osd_waitgroup_hc
+  type: int
+  level: dev
+  desc: constant in a 2nd degree polynomial of form ha*i^2+hb*i+hc
+    governing OSD thread wake behavior in a given shard.
+  default: 0
+  flags:
+  - startup
+  with_legacy: true
 # PrioritzedQueue (prio), Weighted Priority Queue (wpq ; default),
 # mclock_opclass, mclock_client, or debug_random. "mclock_opclass"
 # and "mclock_client" are based on the mClock/dmClock algorithm

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10736,9 +10736,18 @@ OSDShard::OSDShard(
     context_queue(sdata_wait_lock, sdata_cond)
 {
   dout(0) << "using op scheduler " << *scheduler << dendl;
+  uint32_t la = cct->_conf->osd_waitgroup_la;
+  uint32_t lb = cct->_conf->osd_waitgroup_lb;
+  uint32_t lc = cct->_conf->osd_waitgroup_lc;
+  uint32_t ha = cct->_conf->osd_waitgroup_ha;
+  uint32_t hb = cct->_conf->osd_waitgroup_hb;
+  uint32_t hc = cct->_conf->osd_waitgroup_hc;
+
   wgv.emplace_back(new WaitGroup_P(0, cct, osd, this));
   for (uint32_t i = 1; i < osd->num_threads_per_shard; i++) {
-    wgv.emplace_back(new WaitGroup_S(i, cct, osd, this, i*i+2*i, i*i+8*i));
+    uint32_t lt = (la * i * i) + (lb * i) + lc;
+    uint32_t ht = (ha * i * i) + (hb * i) + hc;
+    wgv.emplace_back(new WaitGroup_S(i, cct, osd, this, lt, ht));
   }
 }
 

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -406,7 +406,6 @@ void mClockScheduler::enqueue(OpSchedulerItem&& item)
       id,
       cost);
   }
-
  dout(20) << __func__ << " client_count: " << scheduler.client_count()
           << " queue_sizes: [ "
 	  << " high_priority_queue: " << high_priority.size()

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -19,6 +19,7 @@
 #include <ostream>
 #include <map>
 #include <vector>
+#include <atomic>
 
 #include "boost/variant.hpp"
 
@@ -239,6 +240,10 @@ public:
   // Returns if the queue is empty
   bool empty() const final {
     return scheduler.empty() && high_priority.empty();
+  }
+
+  uint32_t size() const final {
+    return scheduler.request_count() + high_priority.size();
   }
 
   // Formatted output of the queue


### PR DESCRIPTION
More details to come.  Basic idea:  We only wake up threads when the scheduler (or now double buffer) queue grows large.  We only let them go to sleep when the queue gets small (governed by the per-shard thread id)  We try to avoid contention on the shard lock and wait lock.  We try to avoid notify spam by having per-thread condition variables and wait locks.  In single OSD tests this has shown only minor improvement, however in multi-OSD tests with lots of per-node resource contention (8 NVMe, 3X rep, 1 Officinalis node) the results are fairly dramatic. These tests are with 3 shards, 8 threads each, 1 msgr thread vs main defaults:

test | main | wip-osd-threading
-- | -- | --
4krandread iops | 345K | 480K
4krandread cycles/op | 399K | 266K
4krandwrite iops | 65.7K | 83.8K
4krandwrite cycles/op | 2.90M | 1.88M

Most of the focus now is on async messenger threading behavior and OSD interaction.  We still want multiple messenger threads in some cases but we need to change their behavior to achieve good cycles/op numbers going forward.  That, combined with on-going work inside bluestore to approve effiency should yield some nice gains.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
