### PR TITLE
pacific: mgr/dashboard: SSO error: AttributeError: 'str' object has no attribute 'decode'

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -70,7 +70,10 @@ class Saml2(BaseController, ControllerAuthMixin):
 
             token = JwtManager.gen_token(username)
             JwtManager.set_user(JwtManager.decode_token(token))
-            token = token.decode('utf-8')
+
+            # For backward-compatibility: PyJWT versions < 2.0.0 return bytes.
+            token = token.decode('utf-8') if isinstance(token, bytes) else token
+
             self._set_token_cookie(url_prefix, token)
             raise cherrypy.HTTPRedirect("{}/#/login?access_token={}".format(url_prefix, token))
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61280

---

backport of https://github.com/ceph/ceph/pull/51406
parent tracker: https://tracker.ceph.com/issues/59689

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh