### PR TITLE
Crimson/osd: Disable concurrent MOSDMap handling

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -997,6 +997,8 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
     }
     return check_osdmap_features().then([this] {
       // yay!
+      logger().info("osd.{}: committed_osd_maps: broadcasting osdmaps up"
+                    " to {} epoch to pgs", whoami, osdmap->get_epoch());
       return pg_shard_manager.broadcast_map_to_pgs(osdmap->get_epoch());
     });
   }).then([m, this] {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -168,10 +168,8 @@ private:
 
   bool require_mon_peer(crimson::net::Connection *conn, Ref<Message> m);
 
-  seastar::future<> handle_osd_map(crimson::net::ConnectionRef conn,
-                                   Ref<MOSDMap> m);
-  seastar::future<> _handle_osd_map(crimson::net::ConnectionRef conn,
-                                    Ref<MOSDMap> m);
+  seastar::future<> handle_osd_map(Ref<MOSDMap> m);
+  seastar::future<> _handle_osd_map(Ref<MOSDMap> m);
   seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
 				     Ref<MOSDPGCreate2> m);
   seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -90,6 +90,8 @@ class OSD final : public crimson::net::Dispatcher,
 
   ceph::mono_time startup_time;
 
+  seastar::shared_mutex handle_osd_map_lock;
+
   OSDSuperblock superblock;
 
   // Dispatcher methods
@@ -168,6 +170,8 @@ private:
 
   seastar::future<> handle_osd_map(crimson::net::ConnectionRef conn,
                                    Ref<MOSDMap> m);
+  seastar::future<> _handle_osd_map(crimson::net::ConnectionRef conn,
+                                    Ref<MOSDMap> m);
   seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
 				     Ref<MOSDPGCreate2> m);
   seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -30,8 +30,8 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
                     osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
     read_errorator::all_same_way([e] {
-      throw std::runtime_error(fmt::format("read gave enoent on {}",
-                                           osdmap_oid(e)));
+      ceph_abort_msg(fmt::format("{} read gave enoent on {}",
+                                 __func__, osdmap_oid(e)));
     }));
 }
 

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -54,6 +54,10 @@ seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
 
 template <OSDMapGateType OSDMapGateTypeV>
 void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
+  if (epoch == 0) {
+    return;
+  }
+  ceph_assert(epoch > current);
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -535,7 +535,7 @@ void PG::on_active_advmap(const OSDMapRef &osdmap)
     }
     logger().info("{}: {} new removed snaps {}, snap_trimq now{}",
                   *this, __func__, it->second, snap_trimq);
-    assert(!bad || local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
+    assert(!bad || !local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
   }
 }
 

--- a/src/crimson/osd/pg_shard_manager.cc
+++ b/src/crimson/osd/pg_shard_manager.cc
@@ -117,6 +117,9 @@ seastar::future<> PGShardManager::broadcast_map_to_pgs(epoch_t epoch)
       local_service, epoch
     );
   }).then([this, epoch] {
+    logger().debug("PGShardManager::broadcast_map_to_pgs "
+                   "broadcasted up to {}",
+                    epoch);
     get_osd_singleton_state().osdmap_gate.got_map(epoch);
     return seastar::now();
   });

--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -211,7 +211,7 @@ public:
 	      auto &&trigger) {
 	    return shard_services.get_or_create_pg(
 	      std::move(trigger),
-	      opref.get_pgid(), opref.get_epoch(),
+	      opref.get_pgid(),
 	      std::move(opref.get_create_info())
 	    );
 	  }).safe_then([&logger, &shard_services, &opref](Ref<PG> pgref) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -611,7 +611,6 @@ ShardServices::get_or_create_pg_ret
 ShardServices::get_or_create_pg(
   PGMap::PGCreationBlockingEvent::TriggerI&& trigger,
   spg_t pgid,
-  epoch_t epoch,
   std::unique_ptr<PGCreateInfo> info)
 {
   if (info) {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -405,14 +405,14 @@ seastar::future<std::map<epoch_t, bufferlist>> OSDSingletonState::load_map_bls(
 seastar::future<std::unique_ptr<OSDMap>> OSDSingletonState::load_map(epoch_t e)
 {
   auto o = std::make_unique<OSDMap>();
-  if (e > 0) {
-    return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
-      o->decode(bl);
-      return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
-    });
-  } else {
+  logger().info("{} osdmap.{}", __func__, e);
+  if (e == 0) {
     return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
   }
+  return load_map_bl(e).then([o=std::move(o)](bufferlist bl) mutable {
+    o->decode(bl);
+    return seastar::make_ready_future<std::unique_ptr<OSDMap>>(std::move(o));
+  });
 }
 
 seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -349,8 +349,10 @@ OSDSingletonState::get_local_map(epoch_t e)
 {
   // TODO: use LRU cache for managing osdmap, fallback to disk if we have to
   if (auto found = osdmaps.find(e); found) {
+    logger().debug("{} osdmap.{} found in cache", __func__, e);
     return seastar::make_ready_future<local_cached_map_t>(std::move(found));
   } else {
+    logger().debug("{} loading osdmap.{} from disk", __func__, e);
     return load_map(e).then([e, this](std::unique_ptr<OSDMap> osdmap) {
       return seastar::make_ready_future<local_cached_map_t>(
 	osdmaps.insert(e, std::move(osdmap)));
@@ -370,8 +372,10 @@ seastar::future<bufferlist> OSDSingletonState::load_map_bl(
   epoch_t e)
 {
   if (std::optional<bufferlist> found = map_bl_cache.find(e); found) {
+    logger().debug("{} osdmap.{} found in cache", __func__, e);
     return seastar::make_ready_future<bufferlist>(*found);
   } else {
+    logger().debug("{} loading osdmap.{} from disk", __func__, e);
     return meta_coll->load_map(e);
   }
 }
@@ -421,12 +425,15 @@ seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
       if (auto p = m->maps.find(e); p != m->maps.end()) {
 	auto o = std::make_unique<OSDMap>();
 	o->decode(p->second);
-	logger().info("store_maps osdmap.{}", e);
+	logger().info("store_maps storing osdmap.{}", e);
 	store_map_bl(t, e, std::move(std::move(p->second)));
 	osdmaps.insert(e, std::move(o));
 	return seastar::now();
       } else if (auto p = m->incremental_maps.find(e);
 		 p != m->incremental_maps.end()) {
+	logger().info("store_maps found osdmap.{} incremental map, "
+	              "loading osdmap.{}", e, e - 1);
+	ceph_assert(std::cmp_greater(e, 0u));
 	return load_map(e - 1).then([e, bl=p->second, &t, this](auto o) {
 	  OSDMap::Incremental inc;
 	  auto i = bl.cbegin();
@@ -434,6 +441,7 @@ seastar::future<> OSDSingletonState::store_maps(ceph::os::Transaction& t,
 	  o->apply_incremental(inc);
 	  bufferlist fbl;
 	  o->encode(fbl, inc.encode_features | CEPH_FEATURE_RESERVED);
+	  logger().info("store_maps storing osdmap.{}", o->get_epoch());
 	  store_map_bl(t, e, std::move(fbl));
 	  osdmaps.insert(e, std::move(o));
 	  return seastar::now();
@@ -700,6 +708,9 @@ seastar::future<> OSDSingletonState::send_incremental_map(
   crimson::net::Connection &conn,
   epoch_t first)
 {
+  logger().info("{}: first osdmap: {} "
+                "superblock's oldest map: {}",
+                __func__, first, superblock.oldest_map);
   if (first >= superblock.oldest_map) {
     return load_map_bls(
       first, superblock.newest_map

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -428,7 +428,6 @@ public:
   get_or_create_pg_ret get_or_create_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&,
     spg_t pgid,
-    epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
 
   using wait_for_pg_ertr = PGMap::wait_for_pg_ertr;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/59165

Note: This PR is originated from #51425 and #51860 attempts to avoid introducing new `seastar::shared_mutex` member. However, in order to avoid unnecessary complexity in the code for non-significant impact on performance the current change was favoured.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
