### PR TITLE
rgw: pass boost intrusive_ptr to DataLogBackends flat_map

### DIFF
--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -440,10 +440,14 @@ bs::error_code DataLogBackends::handle_init(entries_t e) noexcept {
     try {
       switch (gen.type) {
       case log_type::omap:
-	emplace(gen_id, new RGWDataChangesOmap(ioctx, datalog, gen_id, shards));
+	emplace(gen_id,
+    boost::intrusive_ptr<RGWDataChangesBE>(new RGWDataChangesOmap(ioctx, datalog, gen_id, shards))
+  );
 	break;
       case log_type::fifo:
-	emplace(gen_id, new RGWDataChangesFIFO(ioctx, datalog, gen_id, shards));
+	emplace(gen_id,
+    boost::intrusive_ptr<RGWDataChangesBE>(new RGWDataChangesFIFO(ioctx, datalog, gen_id, shards))
+  );
 	break;
       default:
 	lderr(datalog.cct)


### PR DESCRIPTION
When emplacing a new backend, use an explicitly constructed intrusive_ptr so that it gets destroyed if the emplace fails.

Though the destructor is already called, this behaviour cannot be relied upon. std::map does not exhibit the same behaviour, and would have leaked memory had it been used instead.

Fixes coverity defect ID `1511072`

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
