### PR TITLE
doc: drop mention of rbd_mirror_journal_max_fetch_bytes option

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -304,11 +304,10 @@ For example::
 
 .. tip:: ``rbd-mirror`` tunables are set by default to values suitable for
    mirroring an entire pool.  When using ``rbd-mirror`` to migrate single
-   volumes been clusters you may achieve substantial performance gains
-   by setting ``rbd_mirror_journal_max_fetch_bytes=33554432`` and
-   ``rbd_journal_max_payload_bytes=8388608`` within the ``[client]`` config
-   section of the local or centralized configuration.  Note that these
-   settings may allow ``rbd-mirror`` to present a substantial write workload
+   volumes between clusters you may achieve substantial performance gains
+   by setting ``rbd_journal_max_payload_bytes=8388608`` within the ``[client]``
+   config section of the local or centralized configuration.  Note that this
+   setting may allow ``rbd-mirror`` to present a substantial write workload
    to the destination cluster:  monitor cluster performance closely during
    migrations and test carefully before running multiple migrations in parallel.
 


### PR DESCRIPTION
It was removed in commit 1ef12ea0d29f ("rbd-mirror: remove rbd_mirror_journal_max_fetch_bytes option") in 2019.  Commit 32375cb789d7 ("doc: misc clarity and capitalization") added a "tip" mentioning it in 2020 in an attempt to capture advice [1].
    
[1] https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/IHMGNFLWCD5E5R4W5S2BSSKEB5X3N4S4/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
