### PR TITLE
common/compressor: update the interfaces and data structures

### DIFF
--- a/src/compressor/QatAccel.cc
+++ b/src/compressor/QatAccel.cc
@@ -42,36 +42,26 @@ void QzSessionDeleter::operator() (struct QzSession_S *session) {
   delete session;
 }
 
-static bool get_qz_params(const std::string &alg, QzSessionParams_T &params) {
-  int rc;
-  rc = qzGetDefaults(&params);
-  if (rc != QZ_OK)
-    return false;
-  params.direction = QZ_DIR_BOTH;
-  params.is_busy_polling = true;
-  if (alg == "zlib") {
-    params.comp_algorithm = QZ_DEFLATE;
-    params.data_fmt = QZ_DEFLATE_RAW;
-    params.comp_lvl = g_ceph_context->_conf->compressor_zlib_level;
-  }
-  else {
-    // later, there also has lz4.
-    return false;
-  }
-
-  rc = qzSetDefaults(&params);
-  if (rc != QZ_OK)
-      return false;
-  return true;
-}
-
-static bool setup_session(QatAccel::session_ptr &session, QzSessionParams_T &params) {
+static bool setup_session(const std::string &alg, QatAccel::session_ptr &session) {
   int rc;
   rc = qzInit(session.get(), QZ_SW_BACKUP_DEFAULT);
   if (rc != QZ_OK && rc != QZ_DUPLICATE)
     return false;
-  rc = qzSetupSession(session.get(), &params);
-  if (rc != QZ_OK) {
+  if (alg == "zlib") {
+    QzSessionParamsDeflate_T params;
+    rc = qzGetDefaultsDeflate(&params);
+    if (rc != QZ_OK)
+      return false;
+    params.data_fmt = QZ_DEFLATE_RAW;
+    params.common_params.comp_algorithm = QZ_DEFLATE;
+    params.common_params.comp_lvl = g_ceph_context->_conf->compressor_zlib_level;
+    params.common_params.direction = QZ_DIR_BOTH;
+    rc = qzSetupSessionDeflate(session.get(), &params);
+    if (rc != QZ_OK)
+      return false;
+  }
+  else {
+    // later, there also has lz4.
     return false;
   }
   return true;
@@ -113,10 +103,9 @@ QatAccel::session_ptr QatAccel::get_session() {
 
   // If there are no available session to use, we try allocate a new
   // session.
-  QzSessionParams_T params = {(QzHuffmanHdr_T)0,};
   session_ptr session(new struct QzSession_S());
   memset(session.get(), 0, sizeof(struct QzSession_S));
-  if (get_qz_params(alg_name, params) && setup_session(session, params)) {
+  if (setup_session(alg_name, session)) {
     return session;
   } else {
     return nullptr;


### PR DESCRIPTION
Since the QAT device is updated from 1.7 to 2.0 generation[1], the interfaces and data structures of QATzip library has also changed. Relevant interfaces and data structures need to be updated to make it compatible with the latest QATzip library, allowing compression with QAT.

[1] https://www.intel.com/content/www/us/en/developer/topic-technology/open/quick-assist-technology/overview.html

Signed-off-by: Liu Miaomiao <miaomiao.liu@intel.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
