### PR TITLE
rgw: Add coverity annotations for resource leak false positives

### DIFF
--- a/src/rgw/driver/rados/cls_fifo_legacy.h
+++ b/src/rgw/driver/rados/cls_fifo_legacy.h
@@ -314,6 +314,7 @@ public:
 					       &cb);
     auto c = p->_cur;
     p.release();
+    // coverity[RESOURCE_LEAK:FALSE]
     return c;
   }
   static void complete(Ptr&& p, int r) {

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -214,6 +214,7 @@ int RGWGC::async_defer_chain(const string& tag, const cls_rgw_obj_chain& chain)
 
   int ret = store->gc_aio_operate(obj_names[i], state->completion, &op);
   if (ret == 0) {
+    // coverity[RESOURCE_LEAK:FALSE]
     state.release(); // release ownership until async_defer_callback()
   }
   return ret;

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -57,6 +57,7 @@ AioResultList BlockingAioThrottle::get(rgw_raw_obj obj,
     std::move(f)(this, *static_cast<AioResult*>(p.get()));
     lock.lock();
   }
+  // coverity[RESOURCE_LEAK:FALSE]
   p.release();
   return std::move(completed);
 }
@@ -146,6 +147,7 @@ AioResultList YieldingAioThrottle::get(rgw_raw_obj obj,
     pending.push_back(*p);
     std::move(f)(this, *static_cast<AioResult*>(p.get()));
   }
+  // coverity[RESOURCE_LEAK:FALSE]
   p.release();
   return std::move(completed);
 }

--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -114,6 +114,7 @@ struct D3nL1CacheRequest {
       auto ec = boost::system::error_code{-ret, boost::system::system_category()};
       ceph::async::post(std::move(p), ec, bufferlist{});
     } else {
+      // coverity[RESOURCE_LEAK:FALSE]
       (void)p.release();
     }
     return init.result.get();

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -449,6 +449,7 @@ private:
     } else {
         ldout(conn->cct, 20) << "Kafka publish (no callback): OK" << dendl;
     }
+    // coverity[RESOURCE_LEAK:FALSE]
   }
 
   // the managers thread:

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -418,6 +418,8 @@ RGWKMIPManagerImpl::add_request(RGWKMIPTransceiver *req)
   std::unique_lock l{lock};
   if (going_down)
     return -ECANCELED;
+  // requests is a boost::intrusive::list, which manages pointers and does not copy the instance
+  // coverity[RESOURCE_LEAK:FALSE]
   requests.push_back(*new Request{*req});
   l.unlock();
   if (worker)

--- a/src/rgw/rgw_period_history.cc
+++ b/src/rgw/rgw_period_history.cc
@@ -133,6 +133,7 @@ RGWPeriodHistory::Impl::Impl(CephContext* cct, Puller* puller,
     history->periods.push_back(current_period);
 
     // insert as our current history
+    // coverity[RESOURCE_LEAK:FALSE]
     current_history = histories.insert(*history).first;
 
     // get a cursor to the current period
@@ -245,6 +246,7 @@ Cursor RGWPeriodHistory::Impl::insert_locked(RGWPeriod&& period)
     // create a new history for this period
     auto history = new History;
     history->periods.emplace_back(std::move(period));
+    // coverity[RESOURCE_LEAK:FALSE]
     histories.insert(last, *history);
 
     i = Set::s_iterator_to(*history);
@@ -294,6 +296,7 @@ Cursor RGWPeriodHistory::Impl::insert_locked(RGWPeriod&& period)
   // create a new history for this period
   auto history = new History;
   history->periods.emplace_back(std::move(period));
+  // coverity[RESOURCE_LEAK:FALSE]
   histories.insert(i, *history);
 
   i = Set::s_iterator_to(*history);


### PR DESCRIPTION
Fixes coverity defects:
```
1510440
1510835
1511231
1512176
1514852
1515099
1515406
1523400
1523401
```


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
