### PR TITLE
qa/lsan.supp: update heap_profiler suppression and ASAN_OPTIONS

### DIFF
--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -1,10 +1,11 @@
 # leak suppressions needed to run vstart.sh with WITH_ASAN=ON
 # to enable, add this to the environment:
 # LSAN_OPTIONS="suppressions=../qa/lsan.supp"
+# export ASAN_OPTIONS="detect_odr_violation=0"
 
 # from perfglue/heap_profiler.cc
 # gperftools allocates a singleton and never frees it
-leak:^MallocExtension::Register
+leak:^InitModule
 
 # from src/ceph.in
 # python3.6


### PR DESCRIPTION
In continuation to: 8c099a534044bf7182e04f250e342aab76bc3e54

---

Regsiter singleton leak seems to be replaced by:
```
-----------------------------------------------------
Suppressions used:
  count      bytes template
      1          8 ^InitModule
-----------------------------------------------------
```

In similarity to Crimson's suppression: 6ed8d839b421442a64410444ca8f88f157ae28b3

---

`ASAN_OPTIONS="detect_odr_violation=0"` is added to avoid:

```
==2841973==ERROR: AddressSanitizer: odr-violation (0x5624b9734a40):
  [1] size=16 'alloc_pgmap_inc' ../src/mon/PGMap.cc:42:1
  [2] size=16 'alloc_pgmap_inc' ../src/mon/PGMap.cc:42:1
```







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
