### PR TITLE
quincy: PendingReleaseNotes: Document mClock scheduler fixes and enhancements

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,6 +5,29 @@
   registered a RADOS client in the `name` field added to elements of the
   `active_clients` array. Previously, only the address of a module's RADOS
   client was shown in the `active_clients` array.
+* mClock Scheduler: The mClock scheduler (default scheduler in Quincy) has
+  undergone significant usability and design improvements to address the slow
+  backfill issue. Some important changes are:
+  * The 'balanced' profile is set as the default mClock profile because it
+    represents a compromise between prioritizing client IO or recovery IO. Users
+    can then choose either the 'high_client_ops' profile to prioritize client IO
+    or the 'high_recovery_ops' profile to prioritize recovery IO.
+  * QoS parameters like reservation and limit are now specified in terms of a
+    fraction (range: 0.0 to 1.0) of the OSD's IOPS capacity.
+  * The cost parameters (osd_mclock_cost_per_io_usec_* and
+    osd_mclock_cost_per_byte_usec_*) have been removed. The cost of an operation
+    is now determined using the random IOPS and maximum sequential bandwidth
+    capability of the OSD's underlying device.
+  * Degraded object recovery is given higher priority when compared to misplaced
+    object recovery because degraded objects present a data safety issue not
+    present with objects that are merely misplaced. Therefore, backfilling
+    operations with the 'balanced' and 'high_client_ops' mClock profiles may
+    progress slower than what was seen with the 'WeightedPriorityQueue' (WPQ)
+    scheduler.
+  * The QoS allocations in all the mClock profiles are optimized based on the above
+    fixes and enhancements.
+  * For more detailed information see:
+    https://docs.ceph.com/en/quincy/rados/configuration/mclock-config-ref/
 
 >=17.2.6
 --------


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61624

---

backport of https://github.com/ceph/ceph/pull/51917
parent tracker: https://tracker.ceph.com/issues/61623

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh