### PR TITLE
rbd_mirror: do not interpret mirror_uuid with remote_mirror_uuid

### DIFF
--- a/src/tools/rbd_mirror/RemotePoolPoller.cc
+++ b/src/tools/rbd_mirror/RemotePoolPoller.cc
@@ -80,21 +80,20 @@ void RemotePoolPoller<I>::get_mirror_uuid() {
 template <typename I>
 void RemotePoolPoller<I>::handle_get_mirror_uuid(int r) {
   dout(10) << "r=" << r << dendl;
-  std::string remote_mirror_uuid;
+  std::string mirror_uuid;
   if (r >= 0) {
     auto it = m_out_bl.cbegin();
-    r = librbd::cls_client::mirror_uuid_get_finish(&it, &remote_mirror_uuid);
-    if (r >= 0 && remote_mirror_uuid.empty()) {
+    r = librbd::cls_client::mirror_uuid_get_finish(&it, &mirror_uuid);
+    if (r >= 0 && mirror_uuid.empty()) {
       r = -ENOENT;
     }
   }
 
   if (r < 0) {
     if (r == -ENOENT) {
-      dout(5) << "remote mirror uuid missing" << dendl;
+      dout(5) << "mirror uuid missing" << dendl;
     } else {
-      derr << "failed to retrieve remote mirror uuid: " << cpp_strerror(r)
-           << dendl;
+      derr << "failed to retrieve mirror uuid: " << cpp_strerror(r) << dendl;
     }
 
     m_remote_pool_meta.mirror_uuid = "";
@@ -110,9 +109,9 @@ void RemotePoolPoller<I>::handle_get_mirror_uuid(int r) {
     m_state = STATE_POLLING;
   }
 
-  dout(10) << "remote_mirror_uuid=" << remote_mirror_uuid << dendl;
-  if (m_remote_pool_meta.mirror_uuid != remote_mirror_uuid) {
-    m_remote_pool_meta.mirror_uuid = remote_mirror_uuid;
+  dout(10) << "mirror_uuid=" << mirror_uuid << dendl;
+  if (m_remote_pool_meta.mirror_uuid != mirror_uuid) {
+    m_remote_pool_meta.mirror_uuid = mirror_uuid;
     m_updated = true;
   }
 


### PR DESCRIPTION
fix the naming of variable and log message for remote_mirror_uuid with mirror_uuid


Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
