### PR TITLE
rgw: pick http_date in case of http_x_amz_date absence

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -436,8 +436,11 @@ static inline int parse_v4_auth_header(const req_info& info,               /* in
   const char *d = info.env->get("HTTP_X_AMZ_DATE");
 
   struct tm t;
+  if (unlikely(d == NULL)) {
+    d = info.env->get("HTTP_DATE");
+  }
   if (!d || !parse_iso8601(d, &t, NULL, false)) {
-    ldpp_dout(dpp, 10) << "error reading date via http_x_amz_date" << dendl;
+    ldpp_dout(dpp, 10) << "error reading date via http_x_amz_date and http_date" << dendl;
     return -EACCES;
   }
   date = d;


### PR DESCRIPTION
From the AWS doc:
> The request date can be specified by using either the HTTP Date or the x-amz-date header. If both headers are present, x-amz-date takes precedence. 

Refs: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html

Fixes: https://tracker.ceph.com/issues/61629