### PR TITLE
[RFC] mgr: load python module classes via a function call

### DIFF
--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -54,6 +54,11 @@ private:
   std::string get_site_packages();
   int load_subclass_of(const char* class_name, PyObject** py_class);
 
+  int load_dynamic_class_from(
+      const char* fn_name,
+      const char* assert_subclass_of,
+      PyObject** py_class);
+
   // Did the MgrMap identify this module as one that should run?
   bool enabled = false;
 

--- a/src/pybind/mgr/nfs/__init__.py
+++ b/src/pybind/mgr/nfs/__init__.py
@@ -1,7 +1,13 @@
 # flake8: noqa
 
+import typing
 import os
 if 'UNITTEST' in os.environ:
     import tests
 
-from .module import Module
+
+def _get_ceph_mgr_module_class(name: str) -> typing.Any:
+    "Return a MgrModule subclass for the ceph mgr."
+    from .module import Module
+
+    return Module

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -11,7 +11,7 @@ from mgr_module import MgrModule, NFS_POOL_NAME
 from rados import ObjectNotFound
 
 from ceph.deployment.service_spec import NFSServiceSpec
-from nfs import Module
+from nfs.module import Module
 from nfs.export import ExportMgr, normalize_path
 from nfs.ganesha_conf import GaneshaConfParser, Export, RawBlock
 from nfs.cluster import NFSCluster

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -28,7 +28,6 @@ from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, P
 from ceph.utils import datetime_now
 from ceph.deployment.drive_selection.matchers import SizeMatcher
 from nfs.cluster import create_ganesha_pool
-from nfs.module import Module
 from nfs.export import NFSRados
 from mgr_module import NFS_POOL_NAME
 from mgr_util import merge_dicts
@@ -1092,7 +1091,6 @@ class RookCluster(object):
         #      PlacementSpec.
         assert spec.service_id, "service id in NFS service spec cannot be an empty string or None " # for mypy typing
         service_id = spec.service_id
-        mgr_module = cast(Module, mgr)
         count = spec.placement.count or 1
         def _update_nfs(new: cnfs.CephNFS) -> cnfs.CephNFS:
             new.spec.server.active = count
@@ -1120,7 +1118,7 @@ class RookCluster(object):
             return rook_nfsgw
 
         create_ganesha_pool(mgr)
-        NFSRados(mgr_module.rados, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
+        NFSRados(mgr.rados, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
         return self._create_or_patch(cnfs.CephNFS, 'cephnfses', service_id,
                 _update_nfs, _create_nfs)
 


### PR DESCRIPTION
Previously, the mgr would load a python module and then search through
the top-level items in the module for subclasses of either MgrModule or
MgrStandbyModule (for optional standby modules). The naming is slightly
confusing to a Python programmer but what are called modules in the mgr
are in fact classes.

This patch adds a new way of loading these module classes. The code will
call functions named "_get_ceph_mgr_module_class" and
"_get_ceph_mgr_standby_module_class" respectively. If these functions
are not found then the previous method is used. The function names are a
bit verbose but try to reflect that the mgr's modules are python
classes.

The benefits of this new method include:
* No need to search through a modules namespace, making it very clear
  and explicit (which is better than implicit) what class will be used no chance of 
  hitting a "only one MgrModule class is loaded from each plugin" error
* A small potential performance increase for the above when loading a
  large python module
* The ability to defer imports so that only the mgr needs so that the
  __init__.py doesn't have to unconditionally include (import) MgrModule
  classes. This can avoid "namespace pollution" when one python module
  under src/pybind/mgr imports another
* The ability to dynamically construct the classes, for example a
  factory function that differs mostly on naming/branding or other
  small ways be used for >1 mgr module.
* In time we may even be able to drop the necessity of using a specific
  subclass and instead by able to do more pythonic duck-typing (or
  typing.Protocol interfaces).

This work was mainly inspired by the 3rd bullet, specifically to
begin fixing: https://tracker.ceph.com/issues/61186

While I think this new method is generally better than the old I do not
plan on dropping the older method soon as to avoid having to change all
the modules quickly and I'm not clear on how many mgr modules in python
exist outside of the ceph git tree. However, I'd be in favor of
eventually dropping the older method in time.


Leaving this as an RFC at first to solicit some general opinions about the approach. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
