### PR TITLE
mon: improvements and cleanup for AuthMonitor

### DIFF
--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -89,7 +89,7 @@ public:
   void remove(const EntityName& name) {
     keys.erase(name);
   }
-  void set_caps(EntityName& name, std::map<std::string, ceph::buffer::list>& caps) {
+  void set_caps(const EntityName& name, std::map<std::string, ceph::buffer::list>& caps) {
     keys[name].caps = caps;
   }
   void set_key(EntityName& ename, CryptoKey& key) {

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -177,6 +177,9 @@ private:
     bufferlist& rdata, Formatter* fmtr, bool pending_key=false,
     std::map<std::string, bufferlist>* caps=nullptr);
 
+  int _check_and_encode_caps(const std::map<std::string, std::string>& caps,
+    std::map<std::string, bufferlist>& encoded_caps, std::stringstream& ss);
+
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);
 

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -166,6 +166,16 @@ private:
   bool preprocess_command(MonOpRequestRef op);
   bool prepare_command(MonOpRequestRef op);
 
+  void _encode_keyring(KeyRing& kr, const EntityName& entity,
+    bufferlist& rdata, Formatter* fmtr,
+    std::map<std::string, bufferlist>* wanted_caps=nullptr);
+  void _encode_auth(const EntityName& entity, const EntityAuth& eauth,
+    bufferlist& rdata, Formatter* fmtr, bool pending_key=false,
+    std::map<std::string, bufferlist>* caps=nullptr);
+  void _encode_key(const EntityName& entity, const EntityAuth& eauth,
+    bufferlist& rdata, Formatter* fmtr, bool pending_key=false,
+    std::map<std::string, bufferlist>* caps=nullptr);
+
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);
 

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -119,8 +119,12 @@ private:
     pending_auth.push_back(inc);
   }
 
-  /* validate mon/osd/mds caps; fail on unrecognized service/type */
-  bool valid_caps(const std::string& type, const std::string& caps, std::ostream *out);
+  template<typename CAP_ENTITY_CLASS>
+  bool _was_parsing_fine(const std::string& entity, const std::string& caps,
+    std::ostream* out);
+  /* validate mon/osd/mgr/mds caps; fail on unrecognized service/type */
+  bool valid_caps(const std::string& entity, const std::string& caps,
+		  std::ostream *out);
   bool valid_caps(const std::string& type, const ceph::buffer::list& bl, std::ostream *out) {
     auto p = bl.begin();
     std::string v;

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -133,7 +133,8 @@ private:
     }
     return valid_caps(type, v, out);
   }
-  bool valid_caps(const std::vector<std::string>& caps, std::ostream *out);
+  bool valid_caps(const std::map<std::string, std::string>& caps,
+		  std::ostream *out);
 
   void on_active() override;
   bool should_propose(double& delay) override;

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -180,6 +180,17 @@ private:
   int _check_and_encode_caps(const std::map<std::string, std::string>& caps,
     std::map<std::string, bufferlist>& encoded_caps, std::stringstream& ss);
 
+  int _update_or_create_entity(const EntityName& entity,
+    const std::map<std::string, std::string>& caps, MonOpRequestRef op,
+    std::stringstream& ds, bufferlist* rdata=nullptr, Formatter* fmtr=nullptr,
+    bool create_entity=false);
+  int _create_entity(const EntityName& entity,
+    const std::map<std::string, std::string>& caps, MonOpRequestRef op,
+    std::stringstream& ds, bufferlist* rdata, Formatter* fmtr);
+  int _update_caps(const EntityName& entity,
+    const std::map<std::string, std::string>& caps, MonOpRequestRef op,
+    std::stringstream& ds, bufferlist* rdata, Formatter* fmtr);
+
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);
 


### PR DESCRIPTION
The commits originally were part of https://github.com/ceph/ceph/pull/41779.

This PR contains creates and uses helper functions to not only reduce code duplication but also improve readability. Helper functions have been added for encoding keyrings (fully as well as partially), updating caps for an entity, creating new entity and checking and encoding caps. Besides, it also replace vectors by maps for storing caps.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>