### PR TITLE
rbd-mirror: don't refer to (remote) mirror_uuid as peer_uuid

### DIFF
--- a/src/tools/rbd_mirror/ImageMap.h
+++ b/src/tools/rbd_mirror/ImageMap.h
@@ -40,7 +40,7 @@ public:
   void shut_down(Context *on_finish);
 
   // update (add/remove) images
-  void update_images(const std::string &peer_uuid,
+  void update_images(const std::string &mirror_uuid,
                      std::set<std::string> &&added_global_image_ids,
                      std::set<std::string> &&removed_global_image_ids);
 
@@ -156,11 +156,12 @@ private:
   void schedule_rebalance_task();
 
   void notify_listener_acquire_release_images(const Updates &acquire, const Updates &release);
-  void notify_listener_remove_images(const std::string &peer_uuid, const Updates &remove);
+  void notify_listener_remove_images(const std::string &mirror_uuid,
+                                     const Updates &remove);
 
-  void update_images_added(const std::string &peer_uuid,
+  void update_images_added(const std::string &mirror_uuid,
                            const std::set<std::string> &global_image_ids);
-  void update_images_removed(const std::string &peer_uuid,
+  void update_images_removed(const std::string &mirror_uuid,
                              const std::set<std::string> &global_image_ids);
 
   void filter_instance_ids(const std::vector<std::string> &instance_ids,


### PR DESCRIPTION
peer_uuid and mirror_uuid are different identifiers, we should not use peer_uuid naming for remote mirror_uuid.


Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
