### PR TITLE
qa: suppress SyscallParam error during startup on jammy

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -184,6 +184,22 @@
    fun:*GetStackTrace*
 }
 {
+   tcmalloc: param points to uninit bytes under call_init (jammy)
+   Memcheck:Param
+   write(buf)
+   fun:syscall
+   obj:*libunwind*
+   obj:*libunwind*
+   obj:*libunwind*
+   obj:*libunwind*
+   fun:_ULx86_64_step
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   fun:call_init.part.0
+}
+{
 	tcmalloc: string
 	Memcheck:Leak
 	...


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61428

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
