### PR TITLE
quincy: qa/suites/rados: remove rook coverage from the rados suite

### DIFF
--- a/qa/suites/rados/rook
+++ b/qa/suites/rados/rook
@@ -1,1 +1,0 @@
-../orch/rook


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61606

---

backport of https://github.com/ceph/ceph/pull/51927
parent tracker: https://tracker.ceph.com/issues/58585

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh