### PR TITLE
quincy: mgr/dashboard: add popover to cluster status card

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -21,11 +21,27 @@
              class="col-sm-6 px-3 d-flex"
              aria-label="Status card">
       <div class="d-flex ms-4 me-4 mb-5 center-content">
+        <ng-template #healthChecks>
+          <ng-container *ngTemplateOutlet="logsLink"></ng-container>
+          <ul>
+            <li *ngFor="let check of healthData.health.checks">
+              <span [ngStyle]="check.severity | healthColor"
+                    [class.health-warn-description]="check.severity === 'HEALTH_WARN'">
+              {{ check.type }}</span>: {{ check.summary.message }}
+            </li>
+          </ul>
+        </ng-template>
         <i *ngIf="healthData.health?.status"
            [ngClass]="[healthData.health.status | healthIcon, icons.large2x]"
            [ngStyle]="healthData.health.status | healthColor"
            [title]="healthData.health.status"></i>
+        <a class="ms-2 mt-n1 lead text-primary"
+           [ngbPopover]="healthChecks"
+           popoverClass="info-card-popover-cluster-status"
+           *ngIf="healthData.health?.checks?.length"
+           i18n>Cluster</a>
         <span class="ms-2 mt-n1 lead"
+              *ngIf="!healthData.health?.checks?.length"
               i18n>Cluster</span>
       </div>
       <section class="border-top mt-5"
@@ -257,5 +273,12 @@
       </div>
       <hr>
     </div>
+  </ng-container>
+</ng-template>
+
+<ng-template #logsLink>
+  <ng-container *ngIf="permissions.log.read">
+    <p class="logs-link"
+       i18n><i [ngClass]="[icons.infoCircle]"></i> See <a routerLink="/logs">Logs</a> for more details.</p>
   </ng-container>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.spec.ts
@@ -295,6 +295,29 @@ describe('Dashbord Component', () => {
     expect(dangerAlerts).toBe(null);
   });
 
+  it('should render "Status" card text that is not clickable', () => {
+    fixture.detectChanges();
+
+    const clusterStatusCard = fixture.debugElement.query(By.css('cd-card[cardTitle="Status"]'));
+    const clickableContent = clusterStatusCard.query(By.css('.lead.text-primary'));
+    expect(clickableContent).toBeNull();
+  });
+
+  it('should render "Status" card text that is clickable (popover)', () => {
+    const payload = _.cloneDeep(healthPayload);
+    payload.health['status'] = 'HEALTH_WARN';
+    payload.health['checks'] = [
+      { severity: 'HEALTH_WARN', type: 'WRN', summary: { message: 'fake warning' } }
+    ];
+
+    getHealthSpy.and.returnValue(of(payload));
+    fixture.detectChanges();
+
+    const clusterStatusCard = fixture.debugElement.query(By.css('cd-card[cardTitle="Status"]'));
+    const clickableContent = clusterStatusCard.query(By.css('.lead.text-primary'));
+    expect(clickableContent).not.toBeNull();
+  });
+
   describe('features disabled', () => {
     beforeEach(() => {
       fakeFeatureTogglesService.and.returnValue(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61655

---

backport of https://github.com/ceph/ceph/pull/51953
parent tracker: https://tracker.ceph.com/issues/61611

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh