### PR TITLE
mgr/cephadm: mark host is offline in osd rm status

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -937,10 +937,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def mark_host_offline(self, host: str) -> None:
         if host not in self.offline_hosts:
             self.offline_hosts.add(host)
+        self.to_remove_osds.mark_osd_host_offline(host)
 
     def offline_hosts_remove(self, host: str) -> None:
         if host in self.offline_hosts:
             self.offline_hosts.remove(host)
+        self.to_remove_osds.mark_osd_host_online(host)
 
     def update_failed_daemon_health_check(self) -> None:
         failed_daemons = []
@@ -3263,6 +3265,7 @@ Then run the following:
                                                 zap=zap,
                                                 no_destroy=no_destroy,
                                                 hostname=daemon.hostname,
+                                                host_offline=(daemon.hostname in self.offline_hosts),
                                                 process_started_at=datetime_now(),
                                                 remove_util=self.to_remove_osds.rm_util))
             except NotFoundError:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -934,6 +934,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ) if d.daemon_type in RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES]
         self.offline_watcher.set_hosts(list(set([h for h in hosts_to_watch if h is not None])))
 
+    def mark_host_offline(self, host: str) -> None:
+        if host not in self.offline_hosts:
+            self.offline_hosts.add(host)
+
     def offline_hosts_remove(self, host: str) -> None:
         if host in self.offline_hosts:
             self.offline_hosts.remove(host)

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -614,6 +614,7 @@ class OSD:
                  replace: bool = False,
                  force: bool = False,
                  hostname: Optional[str] = None,
+                 host_offline: bool = False,
                  zap: bool = False,
                  no_destroy: bool = False):
         # the ID of the OSD
@@ -646,6 +647,9 @@ class OSD:
         self.force = force
         # The name of the node
         self.hostname = hostname
+
+        # is node OSD is deployed on offline
+        self.host_offline = host_offline
 
         # mgr obj to make mgr/mon calls
         self.rm_util: RemoveUtil = remove_util
@@ -697,6 +701,12 @@ class OSD:
         self.stopped = True
         self.stop_draining()
 
+    def mark_host_offline(self) -> None:
+        self.host_offline = True
+
+    def mark_host_online(self) -> None:
+        self.host_offline = False
+
     @property
     def is_draining(self) -> bool:
         """
@@ -741,6 +751,8 @@ class OSD:
         return str(self.osd_id) in self.rm_util.get_osds_in_cluster()
 
     def drain_status_human(self) -> str:
+        if self.host_offline:
+            return 'host is offline'
         default_status = 'not started'
         status = 'started' if self.started and not self.draining else default_status
         status = 'draining' if self.draining else status
@@ -760,6 +772,7 @@ class OSD:
         out['force'] = self.force
         out['zap'] = self.zap
         out['hostname'] = self.hostname  # type: ignore
+        out['host_offline'] = self.host_offline
 
         for k in ['drain_started_at', 'drain_stopped_at', 'drain_done_at', 'process_started_at']:
             if getattr(self, k):
@@ -963,6 +976,18 @@ class OSDRemovalQueue(object):
             except KeyError:
                 logger.debug(f"Could not find {osd} in queue.")
                 raise KeyError
+
+    def mark_osd_host_offline(self, hostname: str) -> None:
+        with self.lock:
+            host_osds = [osd for osd in self.osds if osd.hostname == hostname]
+            for osd in host_osds:
+                osd.mark_host_offline()
+
+    def mark_osd_host_online(self, hostname: str) -> None:
+        with self.lock:
+            host_osds = [osd for osd in self.osds if osd.hostname == hostname]
+            for osd in host_osds:
+                osd.mark_host_online()
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OSDRemovalQueue):

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -121,19 +121,19 @@ class SSHManager:
         try:
             yield
         except OSError as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             log_content = log_string.getvalue()
             msg = f"Can't communicate with remote host `{addr}`, possibly because the host is not reachable or python3 is not installed on the host. {str(e)}"
             logger.exception(msg)
             raise HostConnectionError(msg, host, addr)
         except asyncssh.Error as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             log_content = log_string.getvalue()
             msg = f'Failed to connect to {host} ({addr}). {str(e)}' + '\n' + f'Log: {log_content}'
             logger.debug(msg)
             raise HostConnectionError(msg, host, addr)
         except Exception as e:
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             log_content = log_string.getvalue()
             logger.exception(str(e))
             raise HostConnectionError(
@@ -175,19 +175,19 @@ class SSHManager:
             # SSH connection closed or broken, will create new connection next call
             logger.debug(f'Connection to {host} failed. {str(e)}')
             await self._reset_con(host)
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             raise HostConnectionError(f'Unable to reach remote host {host}. {str(e)}', host, address)
         except asyncssh.ProcessError as e:
             msg = f"Cannot execute the command '{cmd}' on the {host}. {str(e.stderr)}."
             logger.debug(msg)
             await self._reset_con(host)
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             raise HostConnectionError(msg, host, address)
         except Exception as e:
             msg = f"Generic error while executing command '{cmd}' on the host {host}. {str(e)}."
             logger.debug(msg)
             await self._reset_con(host)
-            self.mgr.offline_hosts.add(host)
+            self.mgr.mark_host_offline(host)
             raise HostConnectionError(msg, host, address)
 
         def _rstrip(v: Union[bytes, str, None]) -> str:

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1881,7 +1881,7 @@ class TestCephadm(object):
 
         # mark host2 as maintenance and host3 as offline
         cephadm_module.inventory._inventory['host2']['status'] = 'maintenance'
-        cephadm_module.offline_hosts.add('host3')
+        cephadm_module.mark_host_offline('host3')
 
         # verify host2 and host3 are correctly marked as unreachable but host1 is not
         assert 'host1' not in [h.hostname for h in cephadm_module.cache.get_unreachable_hosts()]


### PR DESCRIPTION
If a host we are trying to remove the OSD on is
offline, removal of the OSD will never totally
complete as the OSD container itself cannot
be cleaned up by cephadm. This means the status
shown in "ceph orch osd rm status" will just
sit at "started", "draining", etc. permanently.
Instead we should report in the status that
the host the OSD is on is offline so users have
a better idea why the removal is not finishing.
    
Fixes: https://tracker.ceph.com/issues/61663
    
Signed-off-by: Adam King <adking@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
