### PR TITLE
reef: qa: suppress SyscallParam error during startup on jammy

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -184,6 +184,22 @@
    fun:*GetStackTrace*
 }
 {
+   tcmalloc: param points to uninit bytes under call_init (jammy)
+   Memcheck:Param
+   write(buf)
+   fun:syscall
+   obj:*libunwind*
+   obj:*libunwind*
+   obj:*libunwind*
+   obj:*libunwind*
+   fun:_ULx86_64_step
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   obj:*tcmalloc*
+   fun:call_init.part.0
+}
+{
 	tcmalloc: string
 	Memcheck:Leak
 	...


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61665

---

backport of https://github.com/ceph/ceph/pull/52012
parent tracker: https://tracker.ceph.com/issues/61428

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh