### PR TITLE
Bluestore: added the retry operation for failed to open block.db bdev

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6205,7 +6205,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
     bluefs_layout.dedicated_db = true;
   } else {
     r = -errno;
-    if (::lstat(bfn.c_str(), &st) == -1) {
+    if (::lstat(bfn.c_str(), &st) == -1 && errno == ENOENT) {
       r = 0;
       bluefs_layout.shared_bdev = BlueFS::BDEV_DB;
     } else {


### PR DESCRIPTION
When block.db symlink exists but trget unusable and returns ENOENT, restart the block.db device
Signed-off-by: Wangwenjuan <wangwenjuan_yewu@cmss.chinamobile.com>
