### PR TITLE
pacific: rgw/sts: AssumeRole no longer writes to user metadata

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -685,7 +685,6 @@ struct RGWUserInfo
   RGWQuotaInfo user_quota;
   uint32_t type;
   set<string> mfa_ids;
-  string assumed_role_arn;
 
   RGWUserInfo()
     : suspended(0),
@@ -750,7 +749,10 @@ struct RGWUserInfo
      encode(admin, bl);
      encode(type, bl);
      encode(mfa_ids, bl);
-     encode(assumed_role_arn, bl);
+     {
+       std::string assumed_role_arn; // removed
+       encode(assumed_role_arn, bl);
+     }
      encode(user_id.ns, bl);
      ENCODE_FINISH(bl);
   }
@@ -834,6 +836,7 @@ struct RGWUserInfo
       decode(mfa_ids, bl);
     }
     if (struct_v >= 21) {
+      std::string assumed_role_arn; // removed
       decode(assumed_role_arn, bl);
     }
     if (struct_v >= 22) {

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -316,24 +316,6 @@ std::tuple<int, RGWRole> STSService::getRoleInfo(const DoutPrefixProvider *dpp,
   }
 }
 
-int STSService::storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y)
-{
-  int ret = 0;
-  RGWUserInfo info;
-  if (ret = rgw_get_user_info_by_uid(dpp, store->ctl()->user, user_id, info, y); ret < 0) {
-    return -ERR_NO_SUCH_ENTITY;
-  }
-
-  info.assumed_role_arn = arn;
-
-  RGWObjVersionTracker objv_tracker;
-  if (ret = rgw_store_user_info(dpp, store->ctl()->user, info, &info, &objv_tracker, real_time(),
-				false, y); ret < 0) {
-    return -ERR_INTERNAL_ERROR;
-  }
-  return ret;
-}
-
 AssumeRoleWithWebIdentityResponse STSService::assumeRoleWithWebIdentity(AssumeRoleWithWebIdentityRequest& req)
 {
   AssumeRoleWithWebIdentityResponse response;
@@ -441,13 +423,6 @@ AssumeRoleResponse STSService::assumeRole(const DoutPrefixProvider *dpp,
                                               boost::none,
                                               boost::none,
                                               user_id, nullptr);
-  if (response.retCode < 0) {
-    return response;
-  }
-
-  //Save ARN with the user
-  string arn = response.user.getARN();
-  response.retCode = storeARN(dpp, arn, y);
   if (response.retCode < 0) {
     return response;
   }

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -238,7 +238,6 @@ class STSService {
   rgw_user user_id;
   RGWRole role;
   rgw::auth::Identity* identity;
-  int storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y);
 public:
   STSService() = default;
   STSService(CephContext* cct, rgw::sal::RGWRadosStore *store, rgw_user user_id,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59610

---

backport of https://github.com/ceph/ceph/pull/51161
parent tracker: https://tracker.ceph.com/issues/59495

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh