### PR TITLE
reef: rgw: multisite data log flag not used

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -7057,7 +7057,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     return r;
   }
 
-  add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id, y);
+  if (log_data_change) {
+    add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id, y);
+  }
 
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61432

---

backport of https://github.com/ceph/ceph/pull/51516
parent tracker: https://tracker.ceph.com/issues/61198

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh