### PR TITLE
pacific: rgw: multisite data log flag not used

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6930,9 +6930,11 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, const RGWBuck
     return r;
   }
 
-  r = svc.datalog_rados->add_entry(dpp, bucket_info, bs.shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed writing data log" << dendl;
+  if (log_data_change) {
+    r = svc.datalog_rados->add_entry(dpp, bucket_info, bs.shard_id);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed writing data log" << dendl;
+    }
   }
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61433

---

backport of https://github.com/ceph/ceph/pull/51516
parent tracker: https://tracker.ceph.com/issues/61198

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh