### PR TITLE
rgw: s3 object lock avoids overflow in retention date

### DIFF
--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -58,7 +58,7 @@ ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime)
   if (!rule_exist) {
     return ceph::real_time();
   }
-  int days = get_days();
+  int64_t days = get_days();
   if (days <= 0) {
     days = get_years()*365;
   }

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -58,11 +58,10 @@ ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime)
   if (!rule_exist) {
     return ceph::real_time();
   }
-  int64_t days = get_days();
-  if (days <= 0) {
-    days = get_years()*365;
+  if (int days = get_days(); days > 0) {
+    return mtime + std::chrono::days(days);
   }
-  return mtime + make_timespan(days*24*60*60);
+  return mtime + std::chrono::years(get_years());
 }
 
 void RGWObjectRetention::decode_xml(XMLObj *obj) {


### PR DESCRIPTION
with `int days`, `days*24*60*60` would overflow above 24855

Fixes: https://tracker.ceph.com/issues/56993

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
