### PR TITLE
ceph-volume: set lvm membership for mpath type devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -230,7 +230,7 @@ class Device(object):
             self.disk_api = dev
             device_type = dev.get('TYPE', '')
             # always check is this is an lvm member
-            valid_types = ['part', 'disk']
+            valid_types = ['part', 'disk', 'mpath']
             if allow_loop_devices():
                 valid_types.append('loop')
             if device_type in valid_types:


### PR DESCRIPTION
If any lvs is present, self.lvs should be set accordingly for mpath type devices as well.
Otherwise, when re-running a command like following:

```
ceph-volume lvm batch --bluestore --no-auto  /dev/mapper/mpatha /dev/mapper/mpathb
```

fails with error : "Device /dev/mapper/mpatha has a filesystem."

where the expected behavior is:

```
--> passed data devices: 2 physical, 0 LVM
--> relative data size: 1.0
--> All data devices are unavailable

Total OSDs: 0

  Type            Path                                                    LV Size         % of device
```

Fixes: https://tracker.ceph.com/issues/61673
