### PR TITLE
reef: ceph-volume: fix a bug in `get_lvm_fast_allocs()` (batch)

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -171,7 +171,7 @@ def group_devices_by_vg(devices):
 def get_lvm_fast_allocs(lvs):
     return [("{}/{}".format(d.vg_name, d.lv_name), 100.0,
              disk.Size(b=int(d.lvs[0].lv_size)), 1) for d in lvs if not
-            d.used_by_ceph]
+            d.journal_used_by_ceph]
 
 
 class Batch(object):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -529,6 +529,15 @@ class Device(object):
         return any(osd_ids)
 
     @property
+    def journal_used_by_ceph(self):
+        # similar to used_by_ceph() above. This is for 'journal' devices (db/wal/..)
+        # needed by get_lvm_fast_allocs() in devices/lvm/batch.py
+        # see https://tracker.ceph.com/issues/59640
+        osd_ids = [lv.tags.get("ceph.osd_id") is not None for lv in self.lvs
+                   if lv.tags.get("ceph.type") in ["db", "wal"]]
+        return any(osd_ids)
+
+    @property
     def vg_free_percent(self):
         if self.vgs:
             return [vg.free_percent for vg in self.vgs]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61152

---

backport of https://github.com/ceph/ceph/pull/51343
parent tracker: https://tracker.ceph.com/issues/59640

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh