### PR TITLE
Quincy: bluestore & bluestore-rdr to Elastic Shared Blobs

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -349,6 +349,11 @@ class Activate(object):
             help='force bluestore objectstore activation',
         )
         parser.add_argument(
+            '--bluestore-rdr',
+            action='store_true',
+            help='Use the bluestore-rdr objectstore. (Experimental).',
+        )
+        parser.add_argument(
             '--filestore',
             action='store_true',
             help='force filestore objectstore activation',
@@ -374,6 +379,13 @@ class Activate(object):
             print(sub_command_help)
             return
         args = parser.parse_args(self.argv)
+        if args.bluestore and args.bluestore_rdr:
+            raise SystemExit('--bluestore and --bluestore-rdr are mutually exclusive.')
+        if args.bluestore_rdr:
+            args.bluestore = True
+        for objectstore in ['filestore', 'bluestore']:
+            if args.__dict__.get(objectstore,):
+                args.objectstore = objectstore.replace('_', '-')
         if args.activate_all:
             self.activate_all(args)
         else:

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -247,6 +247,11 @@ class Batch(object):
             help='bluestore objectstore (default)',
         )
         parser.add_argument(
+            '--bluestore-rdr',
+            action='store_true',
+            help='Use the bluestore-rdr objectstore. (Experimental).',
+        )
+        parser.add_argument(
             '--filestore',
             action='store_true',
             help='filestore objectstore',
@@ -420,13 +425,18 @@ class Batch(object):
 
         # Default to bluestore here since defaulting it in add_argument may
         # cause both to be True
-        if not self.args.bluestore and not self.args.filestore:
+        if not self.args.bluestore \
+            and not self.args.bluestore_rdr \
+            and not self.args.filestore:
             self.args.bluestore = True
+
+        for objectstore in ['filestore', 'bluestore', 'bluestore_rdr']:
+            if self.args.__dict__.get(objectstore,):
+                self.args.objectstore = objectstore.replace('_', '-')
 
         if (self.args.auto and not self.args.db_devices and not
             self.args.wal_devices and not self.args.journal_devices):
             self._sort_rotational_disks()
-
         self._check_slot_args()
 
         ensure_disjoint_device_lists(self.args.devices,
@@ -453,6 +463,8 @@ class Batch(object):
         defaults = common.get_default_args()
         global_args = [
             'bluestore',
+            'objectstore',
+            'bluestore_rdr',
             'filestore',
             'dmcrypt',
             'crush_device_class',

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -88,6 +88,10 @@ bluestore_args = {
         'action': 'store_true',
         'help': 'Use the bluestore objectstore',
     },
+    '--bluestore-rdr': {
+        'action': 'store_true',
+        'help': 'Use the bluestore-rdr objectstore. (Experimental).',
+    },
     '--block.db': {
         'dest': 'block_db',
         'help': 'Path to bluestore block.db logical volume or device',

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -54,4 +54,10 @@ def create_parser(prog, description):
         action='store_true',
         help='Enable device encryption via dm-crypt',
     )
+    parser.add_argument(
+        '--osd-id',
+        help='Reuse an existing OSD id',
+        default=None,
+        type=arg_validators.valid_osd_id,
+    )
     return parser

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -22,6 +22,11 @@ def create_parser(prog, description):
         action='store_true',
         help='Use BlueStore backend')
     parser.add_argument(
+        '--bluestore-rdr',
+        action='store_true',
+        help='Use the bluestore-rdr objectstore. (Experimental).',
+    )
+    parser.add_argument(
         '--crush-device-class',
         dest='crush_device_class',
         help='Crush device class to assign this OSD to',

--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -42,7 +42,7 @@ def _get_bluestore_info(dev):
         if oj[dev]['description'] == 'main':
             whoami = oj[dev]['whoami']
             r.update({
-                'type': 'bluestore',
+                'type': oj[dev]['type'],
                 'osd_id': int(whoami),
                 'ceph_fsid': oj[dev]['ceph_fsid'],
                 'device': dev,

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -130,7 +130,9 @@ class Prepare(object):
 
         # reuse a given ID if it exists, otherwise create a new ID
         self.osd_id = prepare_utils.create_id(
-            osd_fsid, json.dumps(secrets))
+            osd_fsid,
+            json.dumps(secrets),
+            osd_id=self.args.osd_id)
 
 
         prepare_bluestore(

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -35,7 +35,14 @@ def prepare_dmcrypt(key, device, device_type, fsid):
 
     return '/dev/mapper/{}'.format(mapping)
 
-def prepare_bluestore(block, wal, db, secrets, osd_id, fsid, tmpfs):
+def prepare_bluestore(block,
+                      wal,
+                      db,
+                      secrets,
+                      osd_id,
+                      fsid,
+                      tmpfs,
+                      objectstore):
     """
     :param block: The name of the logical volume for the bluestore data
     :param wal: a regular/plain disk or logical volume, to be used for block.wal
@@ -65,7 +72,8 @@ def prepare_bluestore(block, wal, db, secrets, osd_id, fsid, tmpfs):
         osd_id, fsid,
         keyring=cephx_secret,
         wal=wal,
-        db=db
+        db=db,
+        objectstore=objectstore
     )
 
 
@@ -124,6 +132,7 @@ class Prepare(object):
         self.osd_id = prepare_utils.create_id(
             osd_fsid, json.dumps(secrets))
 
+
         prepare_bluestore(
             self.args.data,
             wal,
@@ -132,6 +141,7 @@ class Prepare(object):
             self.osd_id,
             osd_fsid,
             tmpfs,
+            self.args.objectstore
         )
 
     def main(self):
@@ -157,9 +167,14 @@ class Prepare(object):
             print(sub_command_help)
             return
         self.args = parser.parse_args(self.argv)
-        if not self.args.bluestore:
-            terminal.error('must specify --bluestore (currently the only supported backend)')
-            raise SystemExit(1)
+        if self.args.bluestore and self.args.bluestore_rdr:
+            raise SystemExit('--bluestore and --bluestore-rdr are mutually exclusive.')
+        if not self.args.bluestore and not self.args.bluestore_rdr:
+            self.args.bluestore = True
+        for objectstore in ['bluestore', 'bluestore_rdr']:
+            if self.args.__dict__.get(objectstore,):
+                self.args.objectstore = objectstore.replace('_', '-')
+
         if self.args.dmcrypt and not os.getenv('CEPH_VOLUME_DMCRYPT_SECRET'):
             terminal.error('encryption was requested (--dmcrypt) but environment variable ' \
                            'CEPH_VOLUME_DMCRYPT_SECRET is not set, you must set ' \

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -328,6 +328,17 @@ class TestBatch(object):
         osds = batch.get_lvm_osds(mock_lvs, args)
         assert len(osds) == 1
 
+    def test_main_default_bluestore(self, capsys):
+        b = batch.Batch([])
+        b.args.devices = MagicMock()
+        b.args.yes = True
+        b._check_slot_args = MagicMock()
+        b._execute = MagicMock()
+        b.get_plan = MagicMock()
+        b.main()
+        assert b.args.bluestore
+        assert not b.args.filestore
+        assert not b.args.bluestore_rdr
 
 class TestBatchOsd(object):
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -165,6 +165,22 @@ class TestOsdMkfsBluestore(object):
         assert '--bluestore-block-db-path' in fake_call.calls[0]['args'][0]
         assert '/dev/smm2' in fake_call.calls[0]['args'][0]
 
+    def test_objectstore_is_bluestore(self, fake_call, monkeypatch):
+        monkeypatch.setattr(system, 'chown', lambda path: True)
+        prepare.osd_mkfs_bluestore(1, 'asdf', objectstore='bluestore')
+        calls_args = fake_call.calls[0]['args'][0]
+        assert '--osd-objectstore' in fake_call.calls[0]['args'][0]
+        index_of_osd_objectstore = calls_args.index('--osd-objectstore')
+        assert calls_args[index_of_osd_objectstore+1] == 'bluestore'
+
+    def test_objectstore_is_bluestore_rdr(self, fake_call, monkeypatch):
+        monkeypatch.setattr(system, 'chown', lambda path: True)
+        prepare.osd_mkfs_bluestore(1, 'asdf', objectstore='bluestore-rdr')
+        calls_args = fake_call.calls[0]['args'][0]
+        assert '--osd-objectstore' in fake_call.calls[0]['args'][0]
+        index_of_osd_objectstore = calls_args.index('--osd-objectstore')
+        assert calls_args[index_of_osd_objectstore+1] == 'bluestore-rdr'
+
 
 class TestMountOSD(object):
 

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -410,7 +410,7 @@ def get_osdspec_affinity():
     return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
 
 
-def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
+def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False, objectstore='bluestore'):
     """
     Create the files for the OSD to function. A normal call will look like:
 
@@ -432,7 +432,7 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
     base_command = [
         'ceph-osd',
         '--cluster', conf.cluster,
-        '--osd-objectstore', 'bluestore',
+        '--osd-objectstore', objectstore,
         '--mkfs',
         '-i', osd_id,
         '--monmap', monmap,

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5222,11 +5222,6 @@ options:
   level: dev
   default: 0
   with_legacy: true
-- name: bluestore_debug_inject_bug21040
-  type: bool
-  level: dev
-  default: false
-  with_legacy: true
 - name: bluestore_debug_inject_csum_err_probability
   type: float
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3692,6 +3692,7 @@ options:
   default: bluestore
   enum_values:
   - bluestore
+  - bluestore-rdr
   - filestore
   - memstore
   - kstore

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -18,6 +18,7 @@ set(libos_srcs
   kstore/KStore.cc
   kstore/kstore_types.cc
   fs/FS.cc)
+set (libos_exp_srcs)
 
 if(WITH_BLUESTORE)
   list(APPEND libos_srcs
@@ -36,6 +37,9 @@ if(WITH_BLUESTORE)
     bluestore/AvlAllocator.cc
     bluestore/BtreeAllocator.cc
     bluestore/HybridAllocator.cc
+  )
+  list (APPEND libos_exp_srcs
+    bluestore/BlueStore.cc
   )
 endif(WITH_BLUESTORE)
 
@@ -66,8 +70,10 @@ if(HAVE_LIBZFS)
 endif()
 
 add_library(os STATIC ${libos_srcs})
-target_link_libraries(os blk)
+add_library(os_exp STATIC ${libos_exp_srcs})
+target_compile_definitions(os_exp PRIVATE -DWITH_EXPERIMENTAL)
 
+target_link_libraries(os blk)
 target_link_libraries(os heap_profiler kv)
 
 if(WITH_BLUEFS)
@@ -98,6 +104,9 @@ if(WITH_JAEGER)
 endif()
 
 target_link_libraries(os kv)
+target_link_libraries(os_exp os)
+target_link_libraries(os_exp kv)
+target_link_libraries(os os_exp)
 
 add_dependencies(os compressor_plugins)
 add_dependencies(os crypto_plugins)

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -23,6 +23,7 @@
 #include "memstore/MemStore.h"
 #if defined(WITH_BLUESTORE)
 #include "bluestore/BlueStore.h"
+#include "bluestore/BlueStore_exp.h"
 #endif
 #ifndef WITH_SEASTAR
 #include "kstore/KStore.h"
@@ -39,8 +40,22 @@ std::unique_ptr<ObjectStore> ObjectStore::create(
     return std::make_unique<MemStore>(cct, data);
   }
 #if defined(WITH_BLUESTORE)
-  if (type == "bluestore" || type == "random") {
+  if (type == "bluestore") {
     return std::make_unique<BlueStore>(cct, data);
+#ifndef WITH_SEASTAR
+  } else if (type == "bluestore-rdr") {
+    return std::make_unique<ceph::experimental::BlueStore>(cct, data);
+#endif
+  } else if (type == "random") {
+#ifndef WITH_SEASTAR
+    if (rand() % 2) {
+      return std::make_unique<BlueStore>(cct, data);
+    } else {
+      return std::make_unique<ceph::experimental::BlueStore>(cct, data);
+    }
+#else
+    return std::make_unique<BlueStore>(cct, data);
+#endif
   }
 #endif
   return nullptr;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1218,6 +1218,11 @@ struct LruOnodeCacheShard : public BlueStore::OnodeCacheShard {
     *onodes += num;
     *pinned_onodes += num - lru.size();
   }
+#ifdef DEBUG_CACHE
+  void _audit(const char *when) override
+  {
+  }
+#endif
 };
 
 // OnodeCacheShard
@@ -1318,7 +1323,7 @@ struct LruBufferCacheShard : public BlueStore::BufferCacheShard {
     *bytes += buffer_bytes;
   }
 #ifdef DEBUG_CACHE
-  void _audit(const char *s) override
+  void _audit(const char *when) override
   {
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;
@@ -1624,7 +1629,7 @@ public:
   }
 
 #ifdef DEBUG_CACHE
-  void _audit(const char *s) override
+  void _audit(const char *when) override
   {
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1634,6 +1634,7 @@ public:
     dout(10) << __func__ << " " << when << " start" << dendl;
     uint64_t s = 0;
     for (auto i = hot.begin(); i != hot.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_HOT);
       s += i->length;
     }
 
@@ -1647,6 +1648,7 @@ public:
     }
 
     for (auto i = warm_in.begin(); i != warm_in.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_WARM_IN);
       s += i->length;
     }
 
@@ -1665,6 +1667,10 @@ public:
       ceph_assert(s == buffer_bytes);
     }
 
+    for (auto i = warm_out.begin(); i != warm_out.end(); ++i) {
+      ceph_assert(i->cache_private == BUFFER_WARM_OUT);
+      ceph_assert(i->is_empty());
+    }
     dout(20) << __func__ << " " << when << " buffer_bytes " << buffer_bytes
              << " ok" << dendl;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3155,6 +3155,78 @@ void BlueStore::ExtentMap::reblob_extents(uint32_t blob_start, uint32_t blob_end
   }
 }
 
+// Convert blobs in selected range to shared blobs.
+void BlueStore::ExtentMap::make_range_shared_maybe_merge(
+  BlueStore* store, TransContext* txc, CollectionRef& c,
+  OnodeRef& oldo, uint64_t srcoff, uint64_t length)
+{
+  uint64_t end = srcoff + length;
+  uint32_t dirty_range_begin = OBJECT_MAX_SIZE;
+  uint32_t dirty_range_end = 0;
+  // load entire object; in most cases we clone entire object anyway
+  oldo->extent_map.fault_range(c->store->db, 0, OBJECT_MAX_SIZE);
+  std::multimap<uint64_t /*blob_start*/, Blob*> candidates;
+  scan_shared_blobs(c, oldo, srcoff, length, candidates);
+
+  for (auto ep = oldo->extent_map.seek_lextent(srcoff);
+    ep != oldo->extent_map.extent_map.end(); ) {
+    auto& e = *ep;
+    if (e.logical_offset >= end) {
+      break;
+    }
+    dout(25) << __func__ << " src " << e
+	     << " bc=" << e.blob->bc << dendl;
+    const bluestore_blob_t& blob = e.blob->get_blob();
+    // make sure it is shared
+    if (!blob.is_shared()) {
+      dirty_range_begin = std::min<uint32_t>(dirty_range_begin, e.blob_start());
+      // first try to find a shared blob nearby
+      // that can accomodate extra extents
+      uint32_t blob_width; //to signal when extents end
+      dout(20) << __func__ << std::hex
+	       << " e.blob_start=" << e.blob_start()
+	       << " e.logical_offset=" << e.logical_offset
+	       << std::dec << dendl;
+      Blob* b = blob.is_compressed() ? nullptr :
+	find_mergable_companion(e.blob.get(), e.blob_start(), blob_width, candidates);
+      if (b) {
+	dout(20) << __func__ << " merging to: " << *b << " bc=" << b->bc << dendl;
+	e.blob->discard_unused_buffers(store->cct, oldo->c->cache);
+	b->discard_unused_buffers(store->cct, oldo->c->cache);
+	uint32_t b_logical_length = b->merge_blob(store->cct, e.blob.get());
+	for (auto p : blob.get_extents()) {
+	  if (p.is_valid()) {
+	    b->shared_blob->get_ref(p.offset, p.length);
+	  }
+	}
+	// reblob extents might erase e
+	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.blob_start() + b_logical_length);
+	uint32_t goto_logical_offset = e.logical_offset + e.length;
+	reblob_extents(e.blob_start(), e.blob_start() + blob_width,
+		       e.blob, b);
+	ep = oldo->extent_map.seek_lextent(goto_logical_offset);
+	dout(20) << __func__ << " merged: " << *b << dendl;
+      } else {
+	// no candidate, has to convert to shared
+	c->make_blob_shared(store->_assign_blobid(txc), e.blob);
+	ceph_assert(e.logical_end() > 0);
+	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.logical_end());
+	++ep;
+      }
+    } else {
+      c->load_shared_blob(e.blob->shared_blob);
+      ++ep;
+    }
+  }
+  if (dirty_range_begin < dirty_range_end) {
+    // source onode got modified in the process
+    oldo->extent_map.dirty_range(dirty_range_begin,
+				 dirty_range_end - dirty_range_begin);
+    oldo->extent_map.maybe_reshard(dirty_range_begin, dirty_range_end);
+    txc->write_onode(oldo);
+  }
+}
+
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2668,6 +2668,233 @@ void BlueStore::Blob::copy_extents_over_empty(
   dout(20) << __func__ << " result=" << *this << dendl;
 }
 
+// Checks if two Blobs can be joined together.
+// The important (unchecked) condition is that both Blobs belong to the same object.
+// Verifies if 'other' Blob can be deleted but its content moved to 'this' Blob.
+// Requirements:
+// 1) checksums: same type and size
+// 2) tracker: same au size
+// 3) extents: must be disjointed
+// 4) unused: ignored, will be cleared
+//
+// Returns:
+// false - Blobs are incompatible
+// true - Blobs can be merged
+//
+// Returned blob_width is a distance between 'other' Blob's blob_start() and last logical_offset
+// that can refer to 'other' Blob extents. It is used to limit iteration on ExtentMap.
+bool BlueStore::Blob::can_merge_blob(const Blob* other, uint32_t& blob_width) const
+{
+  const Blob* x = other;
+  const Blob* y = this;
+  // checksums
+  const bluestore_blob_t& xb = x->get_blob();
+  const bluestore_blob_t& yb = y->get_blob();
+  if (xb.has_csum() != yb.has_csum()) return false;
+  if (xb.has_csum()) {
+    if (xb.csum_type != yb.csum_type) return false;
+    if (xb.csum_chunk_order != yb.csum_chunk_order) return false;
+  }
+  // trackers
+  const bluestore_blob_use_tracker_t& xtr = x->get_blob_use_tracker();
+  const bluestore_blob_use_tracker_t& ytr = y->get_blob_use_tracker();
+  if (xtr.au_size != ytr.au_size) return false;
+  // unused
+  // ignore unused, we will clear it up anyway
+  // extents
+  // the success is when there is no offset that is used by both blobs
+  auto skip_empty = [&](const PExtentVector& list, PExtentVector::const_iterator& it, uint32_t& pos) {
+    while (it != list.end() && !it->is_valid()) {
+      pos += it->length;
+      ++it;
+    }
+  };
+  bool can_merge = true;
+  const PExtentVector& xe = x->get_blob().get_extents();
+  const PExtentVector& ye = y->get_blob().get_extents();
+  PExtentVector::const_iterator xi = xe.begin();
+  PExtentVector::const_iterator yi = ye.begin();
+  uint32_t xp = 0;
+  uint32_t yp = 0;
+
+  skip_empty(xe, xi, xp);
+  skip_empty(ye, yi, yp);
+
+  while (xi != xe.end() && yi != ye.end()) {
+    if (xp <= yp) {
+      if (yp < xp + xi->length) {
+	// collision
+	can_merge = false;
+	break;
+      }
+      xp += xi->length;
+      ++xi;
+      skip_empty(xe, xi, xp);
+    } else {
+      if (xp < yp + yi->length) {
+	// collision
+	can_merge = false;
+	break;
+      }
+      yp += yi->length;
+      ++yi;
+      skip_empty(ye, yi, yp);
+    }
+  }
+  if (can_merge) {
+    // scan remaining extents in x
+    while (xi != xe.end()) {
+      xp += xi->length;
+      ++xi;
+    }
+    blob_width = xp;
+  }
+  return can_merge;
+}
+
+// Merges 2 blobs together. Move extents, csum, tracker from src to dst.
+uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
+{
+  Blob* dst = this;
+  Blob* src = blob_to_dissolve;
+  const bluestore_blob_t& src_blob = src->get_blob();
+  bluestore_blob_t& dst_blob = dst->dirty_blob();
+  dout(20) << __func__ << " to=" << *dst << " from" << *src << dendl;
+
+  // drop unused, do not recalc it, unlikely those chunks could be used in future
+  dst_blob.clear_flag(bluestore_blob_t::FLAG_HAS_UNUSED);
+  if (dst_blob.get_logical_length() < src_blob.get_logical_length()) {
+    // expand to accomodate
+    ceph_assert(!dst_blob.is_compressed());
+    dst_blob.add_tail(src_blob.get_logical_length());
+    used_in_blob.add_tail(src_blob.get_logical_length(), used_in_blob.au_size);
+  }
+  const PExtentVector& src_extents = src_blob.get_extents();
+  const PExtentVector& dst_extents = dst_blob.get_extents();
+  PExtentVector tmp_extents;
+  tmp_extents.reserve(src_extents.size() + dst_extents.size());
+  constexpr uint32_t end_pos = std::numeric_limits<uint32_t>::max();
+
+  uint32_t csum_chunk_order = src_blob.csum_chunk_order;
+  uint32_t csum_value_size;
+  const char* src_csum_ptr;
+  char* dst_csum_ptr;
+  if (src_blob.has_csum()) {
+    csum_value_size = src_blob.get_csum_value_size();
+    src_csum_ptr = src_blob.csum_data.c_str();
+    dst_csum_ptr = dst_blob.csum_data.c_str();
+  }
+  const bluestore_blob_use_tracker_t& src_tracker = src->get_blob_use_tracker();
+  bluestore_blob_use_tracker_t& dst_tracker = dst->dirty_blob_use_tracker();
+  ceph_assert(src_tracker.au_size == dst_tracker.au_size);
+  uint32_t tracker_au_size = src_tracker.au_size;
+  const uint32_t* src_tracker_aus = src_tracker.get_au_array();
+  uint32_t* dst_tracker_aus = dst_tracker.dirty_au_array();
+
+  auto skip_empty = [&](const PExtentVector& list, PExtentVector::const_iterator& it, uint32_t& pos) {
+    while (it != list.end()) {
+      if (it->is_valid()) {
+	return;
+      }
+      pos += it->length;
+      ++it;
+    }
+    pos = end_pos;
+    return;
+  };
+
+  auto move_data = [&](uint32_t pos, uint32_t len) {
+    if (src_blob.has_csum()) {
+      // copy csum
+      ceph_assert((pos % (1 << csum_chunk_order)) == 0);
+      ceph_assert((len % (1 << csum_chunk_order)) == 0);
+      uint32_t start = p2align(pos, uint32_t(1 << csum_chunk_order));
+      uint32_t end = p2roundup(pos + len, uint32_t(1 << csum_chunk_order));
+      uint32_t item_no = start >> csum_chunk_order;
+      uint32_t item_cnt = (end - start) >> csum_chunk_order;
+      ceph_assert(dst_blob.csum_data.length() >= (item_no + item_cnt) * csum_value_size);
+      memcpy(dst_csum_ptr + item_no * csum_value_size,
+	     src_csum_ptr + item_no * csum_value_size,
+	     item_cnt * csum_value_size);
+    }
+    uint32_t start = p2align(pos, tracker_au_size) / tracker_au_size;
+    uint32_t end = p2roundup(pos + len, tracker_au_size) / tracker_au_size;
+    for (uint32_t i = start; i < end; i++) {
+      ceph_assert(i < dst_tracker.get_num_au());
+      dst_tracker_aus[i] += src_tracker_aus[i];
+    }
+  };
+
+  // Main loop creates new PExtentVector by merging src and dst PExtentVectors.
+  // It will replace dst's PExtentVector.
+  // When we process extent from dst, csum and tracer data is already in place.
+  // When we process extent from src, we need to copy csum and tracer to dst.
+
+  uint32_t src_pos = 0; //offset of next non-empty extent
+  uint32_t dst_pos = 0;
+  uint32_t pos = 0; //already processed amount
+  auto src_it = src_extents.begin(); // iterator to next non-empty extent
+  auto dst_it = dst_extents.begin();
+
+  skip_empty(src_extents, src_it, src_pos);
+  skip_empty(dst_extents, dst_it, dst_pos);
+  while (src_it != src_extents.end() || dst_it != dst_extents.end()) {
+    if (src_pos > pos) {
+      if (dst_pos > pos) {
+	// empty space
+	uint32_t m = std::min(src_pos - pos, dst_pos - pos);
+	// emit empty
+	tmp_extents.emplace_back(bluestore_pextent_t::INVALID_OFFSET, m);
+	pos += m;
+      } else {
+	// copy from dst, src must not have conflicting extent
+	ceph_assert(src_pos >= dst_pos + dst_it->length);
+	// use extent from destination
+	tmp_extents.push_back(*dst_it);
+	dst_pos += dst_it->length;
+	pos = dst_pos;
+	++dst_it;
+	skip_empty(dst_extents, dst_it, dst_pos);
+      }
+    } else {
+      // copy from src, dst must not have conflicting extent
+      ceph_assert(dst_pos >= src_pos + src_it->length);
+      // use extent from source
+      tmp_extents.push_back(*src_it);
+      // copy blob data
+      move_data(src_pos, src_it->length);
+      src_pos += src_it->length;
+      pos = src_pos;
+      ++src_it;
+      skip_empty(src_extents, src_it, src_pos);
+    }
+  }
+  if (pos < dst_blob.get_logical_length()) {
+    // this is a candidate for improvement;
+    // instead of artifically add extents, trim blob
+    tmp_extents.emplace_back(bluestore_pextent_t::INVALID_OFFSET, dst_blob.get_logical_length() - pos);
+  }
+  // now apply freshly merged tmp_extents into dst blob
+  dst_blob.dirty_extents().swap(tmp_extents);
+
+  // move BufferSpace buffers
+  while(!src->bc.buffer_map.empty()) {
+    auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
+    dst->bc.buffer_map.insert(std::move(buf));
+  }
+  // move BufferSpace writing
+  auto wrt_dst_it = dst->bc.writing.begin();
+  while(!src->bc.writing.empty()) {
+    Buffer& buf = src->bc.writing.front();
+    src->bc.writing.pop_front();
+    while (wrt_dst_it != dst->bc.writing.end() && wrt_dst_it->seq < buf.seq) {
+      ++wrt_dst_it;
+    }
+    dst->bc.writing.insert(wrt_dst_it, buf);
+  }
+  dout(20) << __func__ << " result=" << *dst << dendl;
+  return dst_blob.get_logical_length();
+}
 
 #undef dout_context
 #define dout_context coll->store->cct
@@ -4369,7 +4596,8 @@ void BlueStore::Collection::make_blob_shared(uint64_t sbid, BlobRef b)
   // update blob
   bluestore_blob_t& blob = b->dirty_blob();
   blob.set_flag(bluestore_blob_t::FLAG_SHARED);
-
+  // drop any unused parts, unlikely we could use them in future
+  blob.clear_flag(bluestore_blob_t::FLAG_HAS_UNUSED);
   // update shared blob
   b->shared_blob->loaded = true;
   b->shared_blob->persistent = new bluestore_shared_blob_t(sbid);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2648,6 +2648,7 @@ void BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
 	if (encode_some(p->shard_info->offset, endoff - p->shard_info->offset,
 			bl, &p->extents)) {
 	  if (force) {
+	    _dump_extent_map<-1>(cct, *this);
 	    derr << __func__ << "  encode_some needs reshard" << dendl;
 	    ceph_assert(!force);
 	  }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2912,7 +2912,9 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
   while(!src->bc.buffer_map.empty()) {
     auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
     buf.mapped()->space = &dst->bc;
-    dst->bc.buffer_map.insert(std::move(buf));
+    if (dst->bc.buffer_map.count(buf.key()) == 0) {
+      dst->bc.buffer_map[buf.key()] = std::move(buf.mapped());
+    }
   }
   // move BufferSpace writing
   auto wrt_dst_it = dst->bc.writing.begin();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3342,13 +3342,15 @@ void BlueStore::ExtentMap::fault_range(
 {
   dout(30) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
+  if (shards.size() == 0) {
+    // no sharding yet; everyting is loaded
+    return;
+  }
   auto start = seek_shard(offset);
   auto last = seek_shard(offset + length);
-
-  if (start < 0)
-    return;
-
   ceph_assert(last >= start);
+  ceph_assert(start >= 0);
+
   string key;
   while (start <= last) {
     ceph_assert((size_t)start < shards.size());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2444,6 +2444,7 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
     }
 
     if (new_blen > blen) {
+      ceph_assert(dirty_blob().is_mutable());
       dirty_blob().add_tail(new_blen);
       used_in_blob.add_tail(new_blen,
                             get_blob().get_release_size(min_alloc_size));
@@ -2451,6 +2452,225 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
   }
   return true;
 }
+
+void BlueStore::Blob::dup(const Blob& from, bool copy_used_in_blob)
+{
+  shared_blob = from.shared_blob;
+  blob.dup(from.blob);
+  if (copy_used_in_blob) {
+    used_in_blob = from.used_in_blob;
+  } else {
+    ceph_assert(from.blob.is_compressed());
+    ceph_assert(from.used_in_blob.num_au <= 1);
+    used_in_blob.init(from.used_in_blob.au_size, from.used_in_blob.au_size);
+  }
+  for (auto p : blob.get_extents()) {
+    if (p.is_valid()) {
+      shared_blob->get_ref(p.offset, p.length);
+    }
+  }
+}
+
+// copies part of a Blob
+// it is used to create a consistent blob out of parts of other blobs
+void BlueStore::Blob::copy_from(
+  CephContext* cct, const Blob& from, uint32_t min_release_size, uint32_t start, uint32_t len)
+{
+  dout(20) << __func__ << " to=" << *this << " from=" << from
+	   << " [" << std::hex << start << "~" << len
+	   << "] min_release=" << min_release_size << std::dec << dendl;
+
+  auto& bto = blob;
+  auto& bfrom = from.blob;
+  ceph_assert(!bfrom.is_compressed()); // not suitable for compressed (immutable) blobs
+  ceph_assert(!bfrom.has_unused());
+  // below to asserts are not required to make function work
+  // they check if it is run in desired context
+  ceph_assert(bfrom.is_shared());
+  ceph_assert(shared_blob);
+  ceph_assert(shared_blob == from.shared_blob);
+
+  // split len to pre_len, main_len, post_len
+  uint32_t start_aligned = p2align(start, min_release_size);
+  uint32_t start_roundup = p2roundup(start, min_release_size);
+  uint32_t end_aligned = p2align(start + len, min_release_size);
+  uint32_t end_roundup = p2roundup(start + len, min_release_size);
+  dout(25) << __func__ << " extent split:"
+	   << std::hex << start_aligned << "~" << start_roundup << "~"
+	   << end_aligned << "~" << end_roundup << std::dec << dendl;
+
+  if (bto.get_logical_length() == 0) {
+    // this is initialization
+    bto.adjust_to(from.blob, end_roundup);
+    ceph_assert(min_release_size == from.used_in_blob.au_size);
+    used_in_blob.init(end_roundup, min_release_size);
+  } else if (bto.get_logical_length() < end_roundup) {
+    ceph_assert(!bto.is_compressed());
+    bto.add_tail(end_roundup);
+    used_in_blob.add_tail(end_roundup, used_in_blob.au_size);
+  }
+
+  if (end_aligned >= start_roundup) {
+    copy_extents(cct, from, start_aligned,
+		 start_roundup - start_aligned,/*pre_len*/
+		 end_aligned - start_roundup,/*main_len*/
+		 end_roundup - end_aligned/*post_len*/);
+  } else {
+    // it is uncommon case that <start, start + len) in single allocation unit
+    copy_extents(cct, from, start_aligned,
+		 start_roundup - start_aligned,/*pre_len*/
+		 0 /*main_len*/, 0/*post_len*/);
+  }
+  // copy relevant csum items
+  if (bto.has_csum()) {
+    size_t csd_value_size = bto.get_csum_value_size();
+    size_t csd_item_start = p2align(start, uint32_t(1 << bto.csum_chunk_order)) >> bto.csum_chunk_order;
+    size_t csd_item_end = p2roundup(start + len, uint32_t(1 << bto.csum_chunk_order)) >> bto.csum_chunk_order;
+    ceph_assert(bto.  csum_data.length() >= csd_item_end * csd_value_size);
+    ceph_assert(bfrom.csum_data.length() >= csd_item_end * csd_value_size);
+    memcpy(bto.  csum_data.c_str() + csd_item_start * csd_value_size,
+	   bfrom.csum_data.c_str() + csd_item_start * csd_value_size,
+	   (csd_item_end - csd_item_start) * csd_value_size);
+  }
+  used_in_blob.get(start, len);
+  dout(20) << __func__ << " result=" << *this << dendl;
+}
+
+void BlueStore::Blob::copy_extents(
+  CephContext* cct, const Blob& from, uint32_t start,
+  uint32_t pre_len, uint32_t main_len, uint32_t post_len)
+{
+  constexpr uint64_t invalid = bluestore_pextent_t::INVALID_OFFSET;
+  auto at = [&](const PExtentVector& e, uint32_t pos, uint32_t len) -> uint64_t {
+    auto it = e.begin();
+    while (it != e.end() && pos >= it->length) {
+      pos -= it->length;
+      ++it;
+    }
+    if (it == e.end()) {
+      return invalid;
+    }
+    if (!it->is_valid()) {
+      return invalid;
+    }
+    ceph_assert(pos + len <= it->length); // post_len should be single au, and we do not split
+    return it->offset + pos;
+  };
+  const PExtentVector& exfrom = from.blob.get_extents();
+  PExtentVector& exto = blob.dirty_extents();
+  dout(20) << __func__ << " 0x" << std::hex << start << " "
+	   << pre_len << "/" << main_len << "/" << post_len << std::dec << dendl;
+
+  // the extents that cover same area must be the same
+  if (pre_len > 0) {
+    uint64_t au_from = at(exfrom, start, pre_len);
+    ceph_assert(au_from != bluestore_pextent_t::INVALID_OFFSET);
+    uint64_t au_to = at(exto, start, pre_len);
+    if (au_to == bluestore_pextent_t::INVALID_OFFSET) {
+      main_len += pre_len; // also copy pre_len
+    } else {
+      ceph_assert(au_from == au_to);
+      start += pre_len; // skip, already there
+    }
+  }
+  if (post_len > 0) {
+    uint64_t au_from = at(exfrom, start + main_len, post_len);
+    ceph_assert(au_from != bluestore_pextent_t::INVALID_OFFSET);
+    uint64_t au_to = at(exto, start + main_len, post_len);
+    if (au_to == bluestore_pextent_t::INVALID_OFFSET) {
+      main_len += post_len; // also copy post_len
+    } else {
+      ceph_assert(au_from == au_to);
+      // skip, already there
+    }
+  }
+  // it is possible that here is nothing to copy
+  if (main_len > 0) {
+    copy_extents_over_empty(cct, from, start, main_len);
+  }
+}
+
+// assumes that target (this->extents) has hole in relevant location
+void BlueStore::Blob::copy_extents_over_empty(
+  CephContext* cct, const Blob& from, uint32_t start, uint32_t len)
+{
+  dout(20) << __func__ << " to=" << *this << " from=" << from
+	   << "[0x" << std::hex << start << "~" << len << std::dec << "]" << dendl;
+  uint32_t padding;
+  auto& exto = blob.dirty_extents();
+  auto ito = exto.begin();
+  PExtentVector::iterator prev = exto.end();
+  uint32_t sto = start;
+
+  auto try_append = [&](PExtentVector::iterator& it, uint64_t disk_offset, uint32_t disk_len) {
+    if (prev != exto.end()) {
+      if (prev->is_valid()) {
+	if (prev->offset + prev->length == disk_offset) {
+	  shared_blob->get_ref(prev->offset + prev->length, disk_len);
+	  prev->length += disk_len;
+	  return;
+	}
+      }
+    }
+    it = exto.insert(it, bluestore_pextent_t(disk_offset, disk_len));
+    prev = it;
+    ++it;
+    shared_blob->get_ref(disk_offset, disk_len);
+  };
+
+  while (ito != exto.end() && sto >= ito->length) {
+    sto -= ito->length;
+    prev = ito;
+    ++ito;
+  }
+  if (ito == exto.end()) {
+    // putting data after end, just expand / push back
+    if (sto > 0) {
+      exto.emplace_back(bluestore_pextent_t::INVALID_OFFSET, sto);
+      ito = exto.end();
+      prev = ito;
+    }
+    padding = 0;
+  } else {
+    ceph_assert(!ito->is_valid()); // there can be no collision
+    ceph_assert(ito->length >= sto + len); // for at least len, starting with remainder sto
+    padding = ito->length - (sto + len); // add this much after copying
+    ito = exto.erase(ito); // cut a hole
+    if (sto > 0) {
+      ito = exto.insert(ito, bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, sto));
+      prev = ito;
+      ++ito;
+    }
+  }
+
+  const auto& exfrom = from.blob.get_extents();
+  auto itf = exfrom.begin();
+  uint32_t sf = start;
+  while (itf != exfrom.end() && sf >= itf->length) {
+    sf -= itf->length;
+    ++itf;
+  }
+
+  uint32_t skip_on_first = sf;
+  while (itf != exfrom.end() && len > 0) {
+    ceph_assert(itf->is_valid());
+    uint32_t to_copy = std::min<uint32_t>(itf->length - skip_on_first, len);
+    try_append(ito, itf->offset + skip_on_first, to_copy);
+    len -= to_copy;
+    skip_on_first = 0;
+    ++itf;
+  }
+  ceph_assert(len == 0);
+
+  if (padding > 0) {
+    exto.insert(ito, bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, padding));
+  }
+  dout(20) << __func__ << " result=" << *this << dendl;
+}
+
+
+#undef dout_context
+#define dout_context coll->store->cct
 
 #ifdef WITH_ESB
 void BlueStore::Blob::finish_write(uint64_t seq)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1890,6 +1890,27 @@ void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint64_t seq
   cache->_audit("finish_write end");
 }
 
+/*
+  copy Buffers that are in writing queue
+  returns:
+  true  if something copied
+  false if nothing copied
+*/
+bool BlueStore::BufferSpace::_dup_writing(BufferCacheShard* cache, BufferSpace* to)
+{
+  bool copied = false;
+  if (!writing.empty()) {
+    copied = true;
+    for (auto it = writing.begin(); it != writing.end(); ++it) {
+      Buffer& b = *it;
+      Buffer* to_b = new Buffer(to, b.state, b.seq, b.offset, b.data, b.flags);
+      ceph_assert(to_b->is_writing());
+      to->_add_buffer(cache, to_b, 0, nullptr);
+    }
+  }
+  return copied;
+}
+
 void BlueStore::BufferSpace::split(BufferCacheShard* cache, size_t pos, BlueStore::BufferSpace &r)
 {
   std::lock_guard lk(cache->lock);
@@ -2580,6 +2601,16 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       e.blob->last_encoded_id = n;
       id_to_blob[n] = cb;
       e.blob->dup(*cb);
+      // By default do not copy buffers to clones, and let them read data by themselves.
+      // The exception are 'writing' buffers, which are not yet stable on device.
+      bool some_copied = e.blob->bc._dup_writing(cb->shared_blob->get_cache(), &cb->bc);
+      if (some_copied) {
+	// Pretend we just wrote those buffers;
+	// we need to get _finish_write called, so we can clear then from writing list.
+	// Otherwise it will be stuck until someone does write-op on clone.
+	txc->blobs_written.insert(cb);
+      }
+
       // bump the extent refs on the copied blob's extents
       for (auto p : blob.get_extents()) {
         if (p.is_valid()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1943,6 +1943,23 @@ void BlueStore::BufferSpace::split(BufferCacheShard* cache, size_t pos, BlueStor
   cache->_trim();
 }
 
+// lists content of BufferSpace
+// BufferSpace must be under exclusive access
+std::ostream& operator<<(std::ostream& out, const BlueStore::BufferSpace& bc)
+{
+  for (auto& [i, j] : bc.buffer_map) {
+    out << " [0x" << std::hex << i << "]=" << *j << std::dec;
+  }
+  if (!bc.writing.empty()) {
+    out << " writing:";
+    for (auto i = bc.writing.begin(); i != bc.writing.end(); ++i) {
+      out << " " << *i;
+    }
+  }
+  return out;
+}
+
+
 // OnodeSpace
 
 #undef dout_prefix

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3615,9 +3615,7 @@ BlueStore::Extent *BlueStore::ExtentMap::set_lextent(
 
   Extent *le = new Extent(logical_offset, blob_offset, length, b);
   extent_map.insert(*le);
-  if (spans_shard(logical_offset, length)) {
-    request_reshard(logical_offset, logical_offset + length);
-  }
+  maybe_reshard(logical_offset, logical_offset + length);
   return le;
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4216,19 +4216,23 @@ void BlueStore::Collection::split_cache(
       // move over shared blobs and buffers.  cover shared blobs from
       // both extent map and spanning blob map (the full extent map
       // may not be faulted in)
-      vector<Blob*> bvec;
-      for (auto& e : o->extent_map.extent_map) {
-	bvec.push_back(e.blob.get());
-      }
-      for (auto& b : o->extent_map.spanning_blob_map) {
-	bvec.push_back(b.second.get());
-      }
-      for (auto b : bvec) {
+
+      auto rehome_blob = [&](Blob* b) {
+	for (auto& i : b->bc.buffer_map) {
+	  if (!i.second->is_writing()) {
+	    ldout(store->cct, 1) << __func__ << "   moving " << *i.second
+				 << dendl;
+	    dest->cache->_move(cache, i.second.get());
+	  } else {
+	    ldout(store->cct, 1) << __func__ << "   not moving " << *i.second
+				 << dendl;
+	  }
+	}
 	SharedBlob* sb = b->shared_blob.get();
 	if (sb->coll == dest) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
 				<< dendl;
-	  continue;
+	  return;
 	}
 	ldout(store->cct, 20) << __func__ << "  moving " << *sb << dendl;
 	if (sb->get_sbid()) {
@@ -4238,14 +4242,30 @@ void BlueStore::Collection::split_cache(
 	  dest->shared_blob_set.add(dest, sb);
 	}
 	sb->coll = dest;
-	if (dest->cache != cache) {
-	  for (auto& i : b->bc.buffer_map) {
-	    if (!i.second->is_writing()) {
-	      ldout(store->cct, 20) << __func__ << "   moving " << *i.second
-				    << dendl;
-	      dest->cache->_move(cache, i.second.get());
-	    }
-	  }
+      };
+
+      for (auto& e : o->extent_map.extent_map) {
+	e.blob->last_encoded_id = -1;
+      }
+      for (auto& b : o->extent_map.spanning_blob_map) {
+	b.second->last_encoded_id = -1;
+      }
+      for (auto& e : o->extent_map.extent_map) {
+	Blob* tb = e.blob.get();
+	if (tb->last_encoded_id == -1) {
+	  rehome_blob(tb);
+	  tb->last_encoded_id = 0;
+	}
+      }
+      for (auto& b : o->extent_map.spanning_blob_map) {
+	Blob* tb = b.second.get();
+	if (tb->last_encoded_id == -1) {
+	  // Having blob in spanning but not mapped is an error.
+	  // It will be dropped during encode_some(),
+	  // but in the meantime we want cache to be consistent.
+	  ldout(store->cct, 10) << __func__ << " spanning blob not in map " << *tb << dendl;
+	  rehome_blob(tb);
+	  tb->last_encoded_id = 0;
 	}
       }
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2807,9 +2807,9 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
   constexpr uint32_t end_pos = std::numeric_limits<uint32_t>::max();
 
   uint32_t csum_chunk_order = src_blob.csum_chunk_order;
-  uint32_t csum_value_size;
-  const char* src_csum_ptr;
-  char* dst_csum_ptr;
+  uint32_t csum_value_size = 0;
+  const char* src_csum_ptr = nullptr;
+  char* dst_csum_ptr = nullptr;
   if (src_blob.has_csum()) {
     csum_value_size = src_blob.get_csum_value_size();
     src_csum_ptr = src_blob.csum_data.c_str();
@@ -3227,10 +3227,24 @@ void BlueStore::ExtentMap::make_range_shared_maybe_merge(
   }
 }
 
+#ifdef WITH_ESB
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {
+  BufferCacheShard* bcs = c->cache;
+  bcs->lock.lock();
+  while(bcs != c->cache) {
+    bcs->lock.unlock();
+    bcs = c->cache;
+    bcs->lock.lock();
+  }
 
+  dout(25) << __func__ << " start oldo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *oldo);
+  dout(25) << __func__ << " start newo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *newo);
+
+  make_range_shared_maybe_merge(b, txc, c, oldo, srcoff, length);
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
     e.blob->last_encoded_id = -1;
@@ -3254,43 +3268,39 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     if (e.blob->last_encoded_id >= 0) {
       cb = id_to_blob[e.blob->last_encoded_id];
       blob_duped = false;
-    } else { 
+    } else {
       // dup the blob
       const bluestore_blob_t& blob = e.blob->get_blob();
-      // make sure it is shared
-      if (!blob.is_shared()) {
-        c->make_blob_shared(b->_assign_blobid(txc), e.blob);
-	if (!src_dirty) {
-          src_dirty = true;
-          dirty_range_begin = e.logical_offset;
-	}        
-        ceph_assert(e.logical_end() > 0);
-        // -1 to exclude next potential shard
-        dirty_range_end = e.logical_end() - 1;
-      } else {
-        c->load_shared_blob(e.blob->shared_blob);
-      }
+      ceph_assert(blob.is_shared());
+      ceph_assert(e.blob->shared_blob->is_loaded());
+      ceph_assert(!blob.has_unused());
       cb = new Blob();
       e.blob->last_encoded_id = n;
       id_to_blob[n] = cb;
-      e.blob->dup(*cb);
-#ifdef WITH_ESB
+      ceph_assert(ep->blob_start() < end);
+      // dup entire blob or dup parts only
+      if (blob.is_compressed()) {
+	// copy whole blob, but without used_in_blob
+	cb->dup(*e.blob, false);
+      } else if (e.blob_start() >= srcoff && e.blob_end() <= end) {
+	// copy whole blob, including used_in_blob
+	cb->dup(*e.blob, true);
+      } else {
+	// we must copy source blob diligently region-by-region
+	// initialize shared_blob
+	cb->dirty_blob().set_flag(bluestore_blob_t::FLAG_SHARED);
+	cb->shared_blob = e.blob->shared_blob;
+      }
       // By default do not copy buffers to clones, and let them read data by themselves.
       // The exception are 'writing' buffers, which are not yet stable on device.
       bool some_copied = e.blob->bc._dup_writing(cb->shared_blob->get_cache(), &cb->bc);
       if (some_copied) {
 	// Pretend we just wrote those buffers;
 	// we need to get _finish_write called, so we can clear then from writing list.
-	// Otherwise it will be stuck until someone does write-op on clone.
+	// Otherwise it will be stuck until someone does write-op on the clone.
 	txc->blobs_written.insert(cb);
       }
-#endif
-      // bump the extent refs on the copied blob's extents
-      for (auto p : blob.get_extents()) {
-        if (p.is_valid()) {
-          e.blob->shared_blob->get_ref(p.offset, p.length);
-        }
-      }
+
       txc->write_shared_blob(e.blob->shared_blob);
       dout(20) << __func__ << "    new " << *cb << dendl;
     }
@@ -3310,7 +3320,19 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     Extent* ne = new Extent(e.logical_offset + skip_front + dstoff - srcoff,
       e.blob_offset + skip_front, e.length - skip_front - skip_back, cb);
     newo->extent_map.extent_map.insert(*ne);
-    ne->blob->get_ref(c.get(), ne->blob_offset, ne->length);
+    if (e.blob->get_blob().is_compressed()) {
+      // blob itself was copied, but used_in_blob was not
+      cb->get_ref(c.get(), e.blob_offset + skip_front, e.length - skip_front - skip_back);
+    } else
+      if (e.blob_start() >= srcoff && e.blob_end() <= end) {
+      // blob already copied
+    } else {
+      // copy part
+      uint32_t min_release_size = e.blob->get_blob().get_release_size(c->store->min_alloc_size);
+      cb->copy_from(b->cct, *e.blob, min_release_size,
+		    e.blob_offset + skip_front, e.length - skip_front - skip_back);
+    }
+
     // fixme: we may leave parts of new blob unreferenced that could
     // be freed (relative to the shared_blob).
     txc->statfs_delta.stored() += ne->length;
@@ -3329,13 +3351,21 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       dirty_range_end - dirty_range_begin);
     txc->write_onode(oldo);
   }
-  txc->write_onode(newo);
 
   if (dstoff + length > newo->onode.size) {
     newo->onode.size = dstoff + length;
   }
   newo->extent_map.dirty_range(dstoff, length);
+  newo->extent_map.maybe_reshard(dstoff, dstoff + length);
+  txc->write_onode(newo);
+  dout(25) << __func__ << " end oldo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *oldo);
+  dout(25) << __func__ << " end newo=" << dendl;
+  _dump_onode<25>(onode->c->store->cct, *newo);
+  bcs->lock.unlock();
 }
+#endif
+
 void BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
                                   bool force)
 {
@@ -4137,7 +4167,7 @@ void BlueStore::ExtentMap::dirty_range(
   uint32_t offset,
   uint32_t length)
 {
-  dout(30) << __func__ << " 0x" << std::hex << offset << "~" << length
+  dout(20) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
   if (shards.empty()) {
     dout(20) << __func__ << " mark inline shard dirty" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2767,6 +2767,12 @@ void BlueStore::ExtentMap::reshard(
     dout(20) << __func__ << "   shards [" << si_begin << "," << si_end << ")"
 	     << " over 0x[" << std::hex << needs_reshard_begin << ","
 	     << needs_reshard_end << ")" << std::dec << dendl;
+  } else {
+    // When sharding is not applied yet, it is an error to request reshard on range.
+    // The problem is that reshard() function will not touch any extent outside the range.
+    // Thus initial reshard() must encompass whole object.
+    needs_reshard_begin = 0;
+    needs_reshard_end = OBJECT_MAX_SIZE;
   }
 
   fault_range(db, needs_reshard_begin, (needs_reshard_end - needs_reshard_begin));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2581,9 +2581,6 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   CollectionRef& c, OnodeRef& oldo, OnodeRef& newo, uint64_t& srcoff,
   uint64_t& length, uint64_t& dstoff) {
 
-  auto cct = onode->c->store->cct;
-  bool inject_21040 =
-    cct->_conf->bluestore_debug_inject_bug21040;  
   vector<BlobRef> id_to_blob(oldo->extent_map.extent_map.size());
   for (auto& e : oldo->extent_map.extent_map) {
     e.blob->last_encoded_id = -1;
@@ -2613,12 +2610,9 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       // make sure it is shared
       if (!blob.is_shared()) {
         c->make_blob_shared(b->_assign_blobid(txc), e.blob);
-	if (!inject_21040 && !src_dirty) {
+	if (!src_dirty) {
           src_dirty = true;
           dirty_range_begin = e.logical_offset;
-	} else if (inject_21040 &&
-	           dirty_range_begin == 0 && dirty_range_end == 0) {
-	  dirty_range_begin = e.logical_offset;
 	}        
         ceph_assert(e.logical_end() > 0);
         // -1 to exclude next potential shard
@@ -2680,8 +2674,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
     dout(20) << __func__ << "  dst " << *ne << dendl;
     ++n;
   }
-  if ((!inject_21040 && src_dirty) ||
-       (inject_21040 && dirty_range_end > dirty_range_begin)) {
+  if (src_dirty) {
     oldo->extent_map.dirty_range(dirty_range_begin,
       dirty_range_end - dirty_range_begin);
     txc->write_onode(oldo);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2911,6 +2911,7 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
   // move BufferSpace buffers
   while(!src->bc.buffer_map.empty()) {
     auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
+    buf.mapped()->space = &dst->bc;
     dst->bc.buffer_map.insert(std::move(buf));
   }
   // move BufferSpace writing
@@ -3053,6 +3054,71 @@ void BlueStore::ExtentMap::dump(Formatter* f) const
       f->dump_object("extent", e);
   }
   f->close_section();
+}
+
+void BlueStore::ExtentMap::scan_shared_blobs(
+  CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
+  std::multimap<uint64_t /*blob.logical_offset*/, Blob*>& candidates)
+{
+
+  uint64_t end = start + length;
+  // last_encoded_id will be used to process each blob only once
+  // so reset them first
+  auto ep_start = oldo->extent_map.seek_lextent(start);
+  for (auto ep = ep_start;
+       ep != oldo->extent_map.extent_map.end();
+       ++ep) {
+    // ep->logical_offset and ep->blob_start() are different
+    // ep->blob_start() allows us to include blobs that do have some empty space in the beginning
+    if (ep->blob_start() >= end) {
+      break;
+    }
+    ep->blob->last_encoded_id = -1;
+  }
+
+  for (auto ep = ep_start; // reuse, extent_map could not change
+       ep != oldo->extent_map.extent_map.end();
+       ++ep) {
+    if (ep->blob_start() >= end) {
+      break;
+    }
+    if (ep->blob->last_encoded_id == -1) {
+      const bluestore_blob_t& blob = ep->blob->get_blob();
+      if (blob.is_shared()) {
+	// excellent time to load the blob
+	c->load_shared_blob(ep->blob->shared_blob);
+	if (!blob.is_compressed()) {
+	  // Restrict elastic shared blobs to non-compressed blobs.
+	  // Fsck cannot handle case when one shared blob contains refs to
+	  // both shared and non-shared blobs.
+
+	  // todo consider change to emplace_hint
+	  candidates.emplace(ep->blob_start(), ep->blob.get());
+	}
+      }
+      // mark as processed
+      ep->blob->last_encoded_id = 0;
+    }
+  }
+}
+
+BlueStore::Blob* BlueStore::ExtentMap::find_mergable_companion(
+  Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
+  std::multimap<uint64_t /*blob_start*/, Blob*>& candidates)
+{
+  dout(30) << __func__ << std::hex << " blob_start=0x" << blob_start << std::dec << dendl;
+  Blob* result = nullptr;
+  for (auto it = candidates.find(blob_start);
+       it != candidates.end() && it->first == blob_start;
+       ++it) {
+    dout(30) << __func__ << " trying " << it->second << dendl;
+    if (it->second->can_merge_blob(blob_to_dissolve, blob_width)) {
+      dout(20) << __func__ << " merging " << blob_to_dissolve << " to " << it->second << dendl;
+      result = it->second;
+      break;
+    }
+  }
+  return result;
 }
 
 void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16496,7 +16496,14 @@ int BlueStore::_do_remove(
   if (!h || !h->exists) {
     return 0;
   }
+  // Set maybe_unshared_blobs contains those shared blobs that have all nref=1.
+  // Is .head object is using all those segments?
+  // If it is using all, then no one else can use the shared blob,
+  // and we can fallback to regular non-shared blob.
 
+  // Note. We only process loaded shared blobs.
+  // This is very smart optimization - there is no way that we can unshare blob
+  // that is not yet loaded! We must have had inspected it to even check nrefs.
   dout(20) << __func__ << " checking for unshareable blobs on " << h
 	   << " " << h->oid << dendl;
   map<SharedBlob*,bluestore_extent_ref_map_t> expect;
@@ -16509,6 +16516,7 @@ int BlueStore::_do_remove(
       if (b.is_compressed()) {
 	expect[sb].get(0, b.get_ondisk_length());
       } else {
+	// todo: it seems to be an overkill to go through map()
 	b.map(e.blob_offset, e.length, [&](uint64_t off, uint64_t len) {
 	    expect[sb].get(off, len);
 	    return 0;
@@ -16517,11 +16525,13 @@ int BlueStore::_do_remove(
     }
   }
 
+  // expect has now refs set exactly as .head is using it
   vector<SharedBlob*> unshared_blobs;
   unshared_blobs.reserve(maybe_unshared_blobs.size());
   for (auto& p : expect) {
     dout(20) << " ? " << *p.first << " vs " << p.second << dendl;
     if (p.first->persistent->ref_map == p.second) {
+      // yup, .head is only one that is using the shared blob now
       SharedBlob *sb = p.first;
       dout(20) << __func__ << "  unsharing " << *sb << dendl;
       unshared_blobs.push_back(sb);
@@ -16537,6 +16547,7 @@ int BlueStore::_do_remove(
     return 0;
   }
 
+  // And now a run through .head extents to clear up freshly unshared blobs.
   for (auto& e : h->extent_map.extent_map) {
     const bluestore_blob_t& b = e.blob->get_blob();
     SharedBlob *sb = e.blob->shared_blob.get();
@@ -16546,6 +16557,18 @@ int BlueStore::_do_remove(
       dout(20) << __func__ << "  unsharing " << e << dendl;
       bluestore_blob_t& blob = e.blob->dirty_blob();
       blob.clear_flag(bluestore_blob_t::FLAG_SHARED);
+      if (e.blob->shared_blob->nref > 1) {
+	// Each blob on creation gets its own unique (empty) shared_blob.
+	// In function ExtentMap::dup() we sometimes merge 2 blobs,
+	// so they share common shared_blob used for ref counting.
+	// Imagine 2 blobs having same shared_blob, and shared blob gets just unshared.
+	// We cleared shared_blob content so it is now logically empty,
+	// but now those 2 blobs share it.
+	// This is illegal, as empty shared blobs should be unique.
+	// Fixing by re-creation.
+	e.blob->shared_blob = new SharedBlob(c.get());
+	dout(20) << __func__ << " recreated empty shared blob " << e << dendl;
+      }
       h->extent_map.dirty_range(e.logical_offset, 1);
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10228,6 +10228,9 @@ void BlueStore::inject_global_statfs(const store_statfs_t& new_statfs)
   v.encode(bl);
   t->set(PREFIX_STAT, BLUESTORE_GLOBAL_STATFS_KEY, bl);
   db->submit_transaction_sync(t);
+  // must set these; are needed at _close_db() statfs persisting
+  per_pool_stat_collection = false;
+  vstatfs = new_statfs;
 }
 
 void BlueStore::inject_misreference(coll_t cid1, ghobject_t oid1,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4550,6 +4550,94 @@ BlueStore::BlobRef BlueStore::ExtentMap::split_blob(
   return rb;
 }
 
+BlueStore::ExtentMap::debug_au_vector_t
+BlueStore::ExtentMap::debug_list_disk_layout()
+{
+  BlueStore::ExtentMap::debug_au_vector_t res;
+  uint32_t l_pos = 0;
+  for (auto ep = extent_map.begin(); ep != extent_map.end(); ++ep) {
+    if (l_pos < ep->logical_offset) {
+      // a hole in logical mapping, mark it
+      res.emplace_back(-1ULL, ep->logical_offset - l_pos, 0, 0);
+    }
+    l_pos = ep->logical_offset + ep->length;
+    const bluestore_blob_t& bblob = ep->blob->get_blob();
+    uint32_t chunk_size = bblob.get_chunk_size(onode->c->store->block_size);
+    uint32_t length_left = ep->length;
+
+    bluestore_extent_ref_map_t* ref_map = nullptr;
+    if (bblob.is_shared()) {
+      ceph_assert(ep->blob->shared_blob->is_loaded());
+      bluestore_shared_blob_t* bsblob = ep->blob->shared_blob->persistent;
+      ref_map = &bsblob->ref_map;
+    }
+
+    unsigned csum_i = 0;
+    size_t csum_cnt;
+    uint32_t length;
+    if (bblob.has_csum()) {
+      csum_cnt = bblob.get_csum_count();
+      uint32_t csum_chunk_size = bblob.get_csum_chunk_size();
+      uint64_t csum_offset_align = p2align(ep->blob_offset, csum_chunk_size);
+      csum_i = csum_offset_align / csum_chunk_size;
+      // size of first chunk
+      length = p2align(ep->blob_offset + csum_chunk_size, csum_chunk_size) - ep->blob_offset;
+      length = std::min<uint32_t>(length_left, length);
+      if (csum_chunk_size < chunk_size) {
+	chunk_size = csum_chunk_size;
+      }
+    } else {
+      length = p2align(ep->blob_offset + chunk_size, chunk_size) - ep->blob_offset;
+      length = std::min<uint32_t>(length_left, length);
+    }
+
+    uint32_t bo = ep->blob_offset;
+    while (length_left > 0) {
+      uint64_t csum_val = 0;
+      if (bblob.has_csum()) {
+	ceph_assert(csum_cnt > csum_i);
+	csum_val = bblob.get_csum_item(csum_i);
+	++csum_i;
+      }
+      //extract AU from extents
+      uint64_t disk_extent_left; // length till the end of disk extent
+      uint64_t disk_offset = bblob.calc_offset(bo, &disk_extent_left);
+      bluestore_extent_ref_map_t::debug_len_cnt l_c = {0, std::numeric_limits<uint32_t>::max()};
+      if (bblob.is_shared()) {
+	l_c = ref_map->debug_peek(disk_offset);
+	if (l_c.len < length) {
+	  length = l_c.len;
+	}
+      }
+      res.emplace_back(disk_offset, length, csum_val, l_c.cnt);
+      bo += length;
+      length_left -= length;
+      length = chunk_size;
+    };
+  }
+  return res;
+}
+
+std::ostream& operator<<(std::ostream& out, const BlueStore::ExtentMap::debug_au_vector_t& auv)
+{
+  out << "[";
+  for (size_t i = 0; i < auv.size(); ++i) {
+    if (i != 0) {
+      out << " ";
+    }
+    out << "0x" << std::hex;
+    if (auv[i].disk_offset != -1ULL) {
+      out << auv[i].disk_offset << "~" << auv[i].disk_length
+	  << "(" << std::dec << int32_t(auv[i].ref_cnts)
+	  << "):" << std::hex << auv[i].chksum;
+    } else {
+      out << "~" << auv[i].disk_length << std::dec;
+    }
+  }
+  out << "]" << std::dec;
+  return out;
+}
+
 // Onode
 
 #undef dout_prefix
@@ -16836,7 +16924,8 @@ void BlueStore::_wctx_finish(
   set<SharedBlob*> *maybe_unshared_blobs)
 {
 #ifdef HAVE_LIBZBD
-  if (bdev->is_smr()) {
+  bool is_smr = bdev && bdev->is_smr();
+  if (is_smr) {
     for (auto& w : wctx->writes) {
       for (auto& e : w.b->get_blob().get_extents()) {
 	if (!e.is_valid()) {
@@ -16884,7 +16973,7 @@ void BlueStore::_wctx_finish(
 	    unshare_ptr);
 #ifdef HAVE_LIBZBD
 	  // we also drop zone ref for shared blob extents
-	  if (bdev->is_smr() && e.is_valid()) {
+	  if (is_smr && e.is_valid()) {
 	    zones_with_releases.insert(e.offset / zone_size);
 	  }
 #endif
@@ -16915,7 +17004,7 @@ void BlueStore::_wctx_finish(
         txc->statfs_delta.compressed_allocated() -= e.length;
       }
 #ifdef HAVE_LIBZBD
-      if (bdev->is_smr() && e.is_valid()) {
+      if (is_smr && e.is_valid()) {
 	zones_with_releases.insert(e.offset / zone_size);
       }
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -632,7 +632,7 @@ void _dump_extent_map(CephContext *cct, const BlueStore::ExtentMap &em)
 		      << dendl;
     }
     std::lock_guard l(e.blob->shared_blob->get_cache()->lock);
-    for (auto& i : e.blob->shared_blob->bc.buffer_map) {
+    for (auto& i : e.blob->bc.buffer_map) {
       dout(LogLevelV) << __func__ << "       0x" << std::hex << i.first
 		      << "~" << i.second->length << std::dec
 		      << " " << *i.second << dendl;
@@ -2154,8 +2154,6 @@ void BlueStore::SharedBlob::put()
 	// race with lookup
 	return;
       }
-      bc._clear(coll_snap->cache);
-      coll_snap->cache->rm_blob();
     }
     delete this;
   }
@@ -2194,6 +2192,25 @@ void BlueStore::SharedBlobSet::dump(CephContext *cct)
 
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.blob(" << this << ") "
+
+BlueStore::Blob::~Blob()
+{
+  SharedBlob* sb = shared_blob.get();
+  if (!sb) {
+    ceph_assert(bc.buffer_map.empty());
+    return;
+  }
+ again:
+  auto coll_cache = sb->get_cache();
+  if (coll_cache) {
+    std::lock_guard l(coll_cache->lock);
+    if (coll_cache != sb->get_cache()) {
+      goto again;
+    }
+    bc._clear(coll_cache);
+    coll_cache->rm_blob();
+  }
+}
 
 void BlueStore::Blob::dump(Formatter* f) const
 {
@@ -2240,7 +2257,7 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
     ceph_assert(discard == all_invalid); // in case of compressed blob all
 				    // or none pextents are invalid.
     if (discard) {
-      shared_blob->bc.discard(shared_blob->get_cache(), 0,
+      bc.discard(shared_blob->get_cache(), 0,
                               get_blob().get_logical_length());
     }
   } else {
@@ -2250,7 +2267,7 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
 	dout(20) << __func__ << " 0x" << std::hex << pos
 		 << "~" << e.length
 		 << std::dec << dendl;
-	shared_blob->bc.discard(shared_blob->get_cache(), pos, e.length);
+	bc.discard(shared_blob->get_cache(), pos, e.length);
       }
       pos += e.length;
     }
@@ -2400,7 +2417,7 @@ void BlueStore::Blob::finish_write(uint64_t seq)
 	       << dendl;
       continue;
     }
-    shared_blob->bc._finish_write(cache, seq);
+    bc._finish_write(cache, seq);
     break;
   }
 }
@@ -2419,7 +2436,7 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
     &(r->used_in_blob));
 
   lb.split(blob_offset, rb);
-  shared_blob->bc.split(shared_blob->get_cache(), blob_offset, r->shared_blob->bc);
+  bc.split(shared_blob->get_cache(), blob_offset, r->bc);
 
   dout(10) << __func__ << " 0x" << std::hex << blob_offset << std::dec
 	   << " finish " << *this << dendl;
@@ -4199,14 +4216,15 @@ void BlueStore::Collection::split_cache(
       // move over shared blobs and buffers.  cover shared blobs from
       // both extent map and spanning blob map (the full extent map
       // may not be faulted in)
-      vector<SharedBlob*> sbvec;
+      vector<Blob*> bvec;
       for (auto& e : o->extent_map.extent_map) {
-	sbvec.push_back(e.blob->shared_blob.get());
+	bvec.push_back(e.blob.get());
       }
       for (auto& b : o->extent_map.spanning_blob_map) {
-	sbvec.push_back(b.second->shared_blob.get());
+	bvec.push_back(b.second.get());
       }
-      for (auto sb : sbvec) {
+      for (auto b : bvec) {
+	SharedBlob* sb = b->shared_blob.get();
 	if (sb->coll == dest) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
 				<< dendl;
@@ -4221,7 +4239,7 @@ void BlueStore::Collection::split_cache(
 	}
 	sb->coll = dest;
 	if (dest->cache != cache) {
-	  for (auto& i : sb->bc.buffer_map) {
+	  for (auto& i : b->bc.buffer_map) {
 	    if (!i.second->is_writing()) {
 	      ldout(store->cct, 20) << __func__ << "   moving " << *i.second
 				    << dendl;
@@ -10923,7 +10941,7 @@ void BlueStore::_read_cache(
 
     ready_regions_t cache_res;
     interval_set<uint32_t> cache_interval;
-    bptr->shared_blob->bc.read(
+    bptr->bc.read(
       bptr->shared_blob->get_cache(), b_off, b_len, cache_res, cache_interval,
       read_cache_policy);
     dout(20) << __func__ << "  blob " << *bptr << std::hex
@@ -11091,7 +11109,7 @@ int BlueStore::_generate_read_result_bl(
       if (r < 0)
         return r;
       if (buffered) {
-        bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(), 0,
+        bptr->bc.did_read(bptr->shared_blob->get_cache(), 0,
                                        raw_bl);
       }
       for (auto& req : r2r) {
@@ -11108,7 +11126,7 @@ int BlueStore::_generate_read_result_bl(
           return -EIO;
         }
         if (buffered) {
-          bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(),
+          bptr->bc.did_read(bptr->shared_blob->get_cache(),
                                          req.r_off, req.bl);
         }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8201,21 +8201,6 @@ int BlueStore::mkfs()
     }
   }
 
-  {
-    string type;
-    r = read_meta("type", &type);
-    if (r == 0) {
-      if (type != BS_FLAVOR) {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
-	return -EIO;
-      }
-    } else {
-      r = write_meta("type", BS_FLAVOR);
-      if (r < 0)
-        return r;
-    }
-  }
-
   r = _open_path();
   if (r < 0)
     return r;
@@ -8268,6 +8253,22 @@ int BlueStore::mkfs()
   r = _open_bdev(true);
   if (r < 0)
     goto out_close_fsid;
+
+  {
+    string type;
+    r = read_meta("type", &type);
+    if (r == 0) {
+      if (type != BS_FLAVOR) {
+	derr << __func__ << " expected bluestore, but type is " << type << dendl;
+	r = -EIO;
+	goto out_close_fsid;
+      }
+    } else {
+      r = write_meta("type", BS_FLAVOR);
+      if (r < 0)
+	goto out_close_fsid;
+    }
+  }
 
   // choose freelist manager
 #ifdef HAVE_LIBZBD

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7510,7 +7510,7 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
     }
 
     if (type != BS_FLAVOR) {
-      derr << __func__ << " expected bluestore, but type is " << type << dendl;
+      derr << __func__ << " expected "<< BS_FLAVOR << ", but type is " << type << dendl;
       return -EIO;
     }
   }
@@ -8269,7 +8269,7 @@ int BlueStore::mkfs()
     r = read_meta("type", &type);
     if (r == 0) {
       if (type != BS_FLAVOR) {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
+	derr << __func__ << " expected " << BS_FLAVOR << ", but type is " << type << dendl;
 	r = -EIO;
 	goto out_close_fsid;
       }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -57,7 +57,7 @@
 #include "ZonedFreelistManager.h"
 #endif
 
-#if defined(WITH_LTTNG)
+#if defined(WITH_LTTNG) && !defined(WITH_EXPERIMENTAL)
 #define TRACEPOINT_DEFINE
 #define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/bluestore.h"
@@ -70,8 +70,31 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 
-using bid_t = decltype(BlueStore::Blob::id);
+#ifdef WITH_EXPERIMENTAL
+#  define BS_FLAVOR "bluestore-rdr"
+#else
+#  define BS_FLAVOR "bluestore"
+#endif
 
+#ifdef WITH_EXPERIMENTAL
+// bluestore_cache_onode
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::Onode, bluestore_onode_exp,
+			      bluestore_cache_onode);
+
+// bluestore_cache_other
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::Buffer, bluestore_buffer_exp,
+			      bluestore_Buffer);
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::Extent, bluestore_extent_exp,
+			      bluestore_Extent);
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::Blob, bluestore_blob_exp,
+			      bluestore_Blob);
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::SharedBlob, bluestore_shared_blob_exp,
+			      bluestore_SharedBlob);
+
+// bluestore_txc
+MEMPOOL_DEFINE_OBJECT_FACTORY(ceph::experimental::BlueStore::TransContext, bluestore_transcontext_exp,
+			      bluestore_txc);
+#else
 // bluestore_cache_onode
 MEMPOOL_DEFINE_OBJECT_FACTORY(BlueStore::Onode, bluestore_onode,
 			      bluestore_cache_onode);
@@ -89,6 +112,14 @@ MEMPOOL_DEFINE_OBJECT_FACTORY(BlueStore::SharedBlob, bluestore_shared_blob,
 // bluestore_txc
 MEMPOOL_DEFINE_OBJECT_FACTORY(BlueStore::TransContext, bluestore_transcontext,
 			      bluestore_txc);
+#endif // WITH_EXPERIMENTAL
+
+#ifdef WITH_EXPERIMENTAL
+namespace ceph::experimental {
+#endif
+
+using bid_t = decltype(BlueStore::Blob::id);
+
 using std::byte;
 using std::deque;
 using std::min;
@@ -1699,7 +1730,7 @@ BlueStore::BufferCacheShard *BlueStore::BufferCacheShard::create(
 // BufferSpace
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.BufferSpace(" << this << " in " << cache << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".BufferSpace(" << this << " in " << cache << ") "
 
 void BlueStore::BufferSpace::_clear(BufferCacheShard* cache)
 {
@@ -1987,7 +2018,7 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::BufferSpace& bc)
 // OnodeSpace
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.OnodeSpace(" << this << " in " << cache << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".OnodeSpace(" << this << " in " << cache << ") "
 
 BlueStore::OnodeRef BlueStore::OnodeSpace::add_onode(const ghobject_t& oid,
   OnodeRef& o)
@@ -2119,7 +2150,7 @@ void BlueStore::OnodeSpace::dump(CephContext *cct)
 // SharedBlob
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.sharedblob(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".sharedblob(" << this << ") "
 #undef dout_context
 #define dout_context coll->store->cct
 
@@ -2224,7 +2255,7 @@ void BlueStore::SharedBlob::finish_write(uint64_t seq)
 // SharedBlobSet
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.sharedblobset(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".sharedblobset(" << this << ") "
 
 template <int LogLevelV = 30>
 void BlueStore::SharedBlobSet::dump(CephContext *cct)
@@ -2238,7 +2269,7 @@ void BlueStore::SharedBlobSet::dump(CephContext *cct)
 // Blob
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.blob(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".blob(" << this << ") "
 
 #ifdef WITH_ESB
 BlueStore::Blob::~Blob()
@@ -2455,7 +2486,7 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
 }
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.blob(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".blob(" << this << ") "
 #undef dout_context
 #define dout_context cct
 
@@ -3054,7 +3085,7 @@ BlueStore::OldExtent* BlueStore::OldExtent::create(CollectionRef c,
 // ExtentMap
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.extentmap(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".extentmap(" << this << ") "
 #undef dout_context
 #define dout_context onode->c->store->cct
 
@@ -4642,7 +4673,7 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::ExtentMap::debug_au
 // Onode
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.onode(" << this << ")." << __func__ << " "
+#define dout_prefix *_dout << BS_FLAVOR ".onode(" << this << ")." << __func__ << " "
 
 const std::string& BlueStore::Onode::calc_omap_prefix(uint8_t flags)
 {
@@ -4848,7 +4879,7 @@ bool BlueStore::WriteContext::has_conflict(
 
 // DeferredBatch
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.DeferredBatch(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".DeferredBatch(" << this << ") "
 #undef dout_context
 #define dout_context cct
 
@@ -4959,7 +4990,7 @@ void BlueStore::DeferredBatch::_audit(CephContext *cct)
 // Collection
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore(" << store->path << ").collection(" << cid << " " << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR "(" << store->path << ").collection(" << cid << " " << this << ") "
 
 BlueStore::Collection::Collection(BlueStore *store_, OnodeCacheShard *oc, BufferCacheShard *bc, coll_t cid)
   : CollectionImpl(store_->cct, cid),
@@ -5307,7 +5338,7 @@ void BlueStore::Collection::split_cache(
 // MempoolThread
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.MempoolThread(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".MempoolThread(" << this << ") "
 #undef dout_context
 #define dout_context store->cct
 
@@ -5545,7 +5576,7 @@ void BlueStore::MempoolThread::_update_cache_settings()
 // OmapIteratorImpl
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore.OmapIteratorImpl(" << this << ") "
+#define dout_prefix *_dout << BS_FLAVOR ".OmapIteratorImpl(" << this << ") "
 
 BlueStore::OmapIteratorImpl::OmapIteratorImpl(
   CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it)
@@ -5690,7 +5721,7 @@ bufferlist BlueStore::OmapIteratorImpl::value()
 // =====================================
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore(" << path << ") "
+#define dout_prefix *_dout << BS_FLAVOR "(" << path << ") "
 #undef dout_context
 #define dout_context cct
 
@@ -7468,7 +7499,7 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
       return r;
     }
 
-    if (type != "bluestore") {
+    if (type != BS_FLAVOR) {
       derr << __func__ << " expected bluestore, but type is " << type << dendl;
       return -EIO;
     }
@@ -8174,12 +8205,12 @@ int BlueStore::mkfs()
     string type;
     r = read_meta("type", &type);
     if (r == 0) {
-      if (type != "bluestore") {
+      if (type != BS_FLAVOR) {
 	derr << __func__ << " expected bluestore, but type is " << type << dendl;
 	return -EIO;
       }
     } else {
-      r = write_meta("type", "bluestore");
+      r = write_meta("type", BS_FLAVOR);
       if (r < 0)
         return r;
     }
@@ -19343,7 +19374,7 @@ bool RocksDBBlueFSVolumeSelector::compare(BlueFSVolumeSelector* other) {
 //================================================================================================================
 
 #undef dout_prefix
-#define dout_prefix *_dout << "bluestore::NCB::" << __func__ << "::"
+#define dout_prefix *_dout << BS_FLAVOR "::NCB::" << __func__ << "::"
 
 static const std::string allocator_dir    = "ALLOCATOR_NCB_DIR";
 static const std::string allocator_file   = "ALLOCATOR_NCB_FILE";
@@ -19426,7 +19457,13 @@ struct allocator_image_header {
     }
   }
 };
+#ifdef WITH_EXPERIMENTAL
+}
+WRITE_CLASS_DENC(ceph::experimental::allocator_image_header)
+namespace ceph::experimental {
+#else
 WRITE_CLASS_DENC(allocator_image_header)
+#endif
 
 // 56 Bytes trailer for on-disk alloator image
 struct allocator_image_trailer {
@@ -19539,7 +19576,13 @@ struct allocator_image_trailer {
     denc(v.allocation_size, p);
   }
 };
+#ifdef WITH_EXPERIMENTAL
+}
+WRITE_CLASS_DENC(ceph::experimental::allocator_image_trailer)
+namespace ceph::experimental {
+#else
 WRITE_CLASS_DENC(allocator_image_trailer)
+#endif
 
 
 //-------------------------------------------------------------------------------------
@@ -20777,3 +20820,7 @@ int BlueStore::commit_to_real_manager()
 
 //================================================================================================================
 //================================================================================================================
+
+#ifdef WITH_EXPERIMENTAL
+} // namespace ceph::experimental
+#endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -49,6 +49,7 @@
 #include "common/blkdev.h"
 #include "common/numa.h"
 #include "common/pretty_binary.h"
+#include "common/WorkQueue.h"
 #include "kv/KeyValueHistogram.h"
 
 #ifdef HAVE_LIBZBD
@@ -9551,8 +9552,6 @@ BlueStore::OnodeRef BlueStore::fsck_check_objects_shallow(
 
   return o;
 }
-
-#include "common/WorkQueue.h"
 
 class ShallowFSCKThreadPool : public ThreadPool
 {
@@ -20328,8 +20327,6 @@ int BlueStore::read_allocation_from_drive_on_startup()
 // Not meant to be run by customers
 #ifdef CEPH_BLUESTORE_TOOL_RESTORE_ALLOCATION
 
-#include <stdlib.h>
-#include <algorithm>
 //---------------------------------------------------------
 int cmpfunc (const void * a, const void * b)
 {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2176,23 +2176,6 @@ void BlueStore::SharedBlob::put_ref(uint64_t offset, uint32_t length,
     unshare && !*unshare ? unshare : nullptr);
 }
 
-void BlueStore::SharedBlob::finish_write(uint64_t seq)
-{
-  while (true) {
-    BufferCacheShard *cache = coll->cache;
-    std::lock_guard l(cache->lock);
-    if (coll->cache != cache) {
-      dout(20) << __func__
-	       << " raced with sb cache update, was " << cache
-	       << ", now " << coll->cache << ", retrying"
-	       << dendl;
-      continue;
-    }
-    bc._finish_write(cache, seq);
-    break;
-  }
-}
-
 // SharedBlobSet
 
 #undef dout_prefix
@@ -2402,6 +2385,24 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
     }
   }
   return true;
+}
+
+void BlueStore::Blob::finish_write(uint64_t seq)
+{
+  while (true) {
+    auto coll = shared_blob->coll;
+    BufferCacheShard *cache = coll->cache;
+    std::lock_guard l(cache->lock);
+    if (coll->cache != cache) {
+      dout(20) << __func__
+	       << " raced with sb cache update, was " << cache
+	       << ", now " << coll->cache << ", retrying"
+	       << dendl;
+      continue;
+    }
+    shared_blob->bc._finish_write(cache, seq);
+    break;
+  }
 }
 
 void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
@@ -12989,7 +12990,7 @@ void BlueStore::_txc_finish(TransContext *txc)
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
   for (auto& sb : txc->blobs_written) {
-    sb->shared_blob->finish_write(txc->seq);
+    sb->finish_write(txc->seq);
   }
   txc->blobs_written.clear();
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8016,7 +8016,7 @@ void BlueStore::_fsck_check_statfs(
 }
 
 void BlueStore::_fsck_foreach_shared_blob(
-  std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb) {
+  std::function< bool (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb) {
   auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
   if (it) {
     CollectionRef c;
@@ -8066,12 +8066,15 @@ void BlueStore::_fsck_foreach_shared_blob(
 	auto& b = e.blob->get_blob();
 	if (b.is_shared() && passed_sbs.count(e.blob) == 0) {
 	  auto sbid = e.blob->shared_blob->get_sbid();
-	  cb(c->cid, oid, sbid, b);
+	  if (cb(c->cid, oid, sbid, b) == false) {
+	    goto stop_iterating;
+	  }
 	  passed_sbs.emplace(e.blob);
 	}
       } // for ... extent_map
     } // for ... it->valid
   } //if (it(PREFIX_OBJ))
+ stop_iterating:;
 }
 
 void BlueStore::_fsck_repair_shared_blobs(
@@ -8094,7 +8097,7 @@ void BlueStore::_fsck_repair_shared_blobs(
                            const bluestore_blob_t& b) {
     auto it = refs_map.lower_bound(sbid);
     if(it != refs_map.end() && it->first == sbid) {
-      return;
+      return true;
     }
     for (auto& p : b.get_extents()) {
       if (p.is_valid() &&
@@ -8105,11 +8108,12 @@ void BlueStore::_fsck_repair_shared_blobs(
         dout(20) << __func__
                  << " broken shared blob found for col:" << cid
 	         << " obj:" << oid
-	         << " sbid 0x " << std::hex << sbid << std::dec
+	         << " sbid 0x" << std::hex << sbid << std::dec
 	         << dendl;
 	break;
       }
     }
+    return true;
   });
 
   // second iteration over objects to build new ref map for the broken sbids
@@ -8119,7 +8123,7 @@ void BlueStore::_fsck_repair_shared_blobs(
                            const bluestore_blob_t& b) {
     auto it = refs_map.find(sbid);
     if(it == refs_map.end()) {
-      return;
+      return true;
     }
     for (auto& p : b.get_extents()) {
       if (p.is_valid()) {
@@ -8127,6 +8131,7 @@ void BlueStore::_fsck_repair_shared_blobs(
 	break;
       }
     }
+    return true;
   });
 
   // update shared blob records
@@ -9460,6 +9465,29 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
          << " shared blob references aren't matching, at least "
          << sb_ref_mismatches << " found" << dendl;
     errors += sb_ref_mismatches;
+    if (!repair) {
+      uint32_t cnts = 0;
+      _fsck_foreach_shared_blob( [&](coll_t cid,
+				     ghobject_t oid,
+				     uint64_t sbid,
+				     const bluestore_blob_t& b) {
+	for (auto& p : b.get_extents()) {
+	  if (p.is_valid() &&
+	      !sb_ref_counts.test_all_zero_range(sbid,
+						 p.offset,
+						 p.length)) {
+	    derr << "fsck possibly broken shared blob found for col:" << cid
+		 << " obj:" << oid
+		 << " sbid 0x" << std::hex << sbid << std::dec
+		 << " " << p
+		 << dendl;
+	    ++cnts;
+	    break;
+	  }
+	}
+	return cnts <= MAX_FSCK_ERROR_LINES;
+      });
+    }
   }
 
   if (depth != FSCK_SHALLOW && repair) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12988,10 +12988,10 @@ void BlueStore::_txc_finish(TransContext *txc)
   dout(20) << __func__ << " " << txc << " onodes " << txc->onodes << dendl;
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
-  for (auto& sb : txc->shared_blobs_written) {
-    sb->finish_write(txc->seq);
+  for (auto& sb : txc->blobs_written) {
+    sb->shared_blob->finish_write(txc->seq);
   }
-  txc->shared_blobs_written.clear();
+  txc->blobs_written.clear();
 
   while (!txc->removed_collections.empty()) {
     _queue_reap_collection(txc->removed_collections.front());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8015,6 +8015,65 @@ void BlueStore::_fsck_check_statfs(
   }
 }
 
+void BlueStore::_fsck_foreach_shared_blob(
+  std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb) {
+  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+  if (it) {
+    CollectionRef c;
+    spg_t pgid;
+    for (it->lower_bound(string()); it->valid(); it->next()) {
+      dout(30) << __func__ << " key "
+	       << pretty_binary_string(it->key())
+	       << dendl;
+      if (is_extent_shard_key(it->key())) {
+	continue;
+      }
+
+      ghobject_t oid;
+      int r = get_key_object(it->key(), &oid);
+      if (r < 0) {
+	continue;
+      }
+
+      if (!c ||
+	  oid.shard_id != pgid.shard ||
+	  oid.hobj.get_logical_pool() != (int64_t)pgid.pool() ||
+	  !c->contains(oid)) {
+	c = nullptr;
+	for (auto& p : coll_map) {
+	  if (p.second->contains(oid)) {
+	    c = p.second;
+	    break;
+	  }
+	}
+	if (!c) {
+	  continue;
+	}
+      }
+      dout(20) << __func__
+	       << " inspecting shared blob refs for col:" << c->cid
+	       << " obj:" << oid
+	       << dendl;
+
+      OnodeRef o;
+      o.reset(Onode::create_decode(c, oid, it->key(), it->value()));
+      o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
+
+      _dump_onode<30>(cct, *o);
+
+      mempool::bluestore_fsck::set<BlobRef> passed_sbs;
+      for (auto& e : o->extent_map.extent_map) {
+	auto& b = e.blob->get_blob();
+	if (b.is_shared() && passed_sbs.count(e.blob) == 0) {
+	  auto sbid = e.blob->shared_blob->get_sbid();
+	  cb(c->cid, oid, sbid, b);
+	  passed_sbs.emplace(e.blob);
+	}
+      } // for ... extent_map
+    } // for ... it->valid
+  } //if (it(PREFIX_OBJ))
+}
+
 void BlueStore::_fsck_repair_shared_blobs(
   BlueStoreRepairer& repairer,
   shared_blob_2hash_tracker_t& sb_ref_counts,
@@ -8026,73 +8085,10 @@ void BlueStore::_fsck_repair_shared_blobs(
   if (!sb_ref_mismatches) // not expected to succeed, just in case
     return;
 
-
-  auto foreach_shared_blob = [&](std::function<
-    void (coll_t,
-          ghobject_t,
-          uint64_t,
-          const bluestore_blob_t&)> cb) {
-      auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
-      if (it) {
-        CollectionRef c;
-        spg_t pgid;
-        for (it->lower_bound(string()); it->valid(); it->next()) {
-          dout(30) << __func__ << " key "
-	           << pretty_binary_string(it->key())
-	           << dendl;
-          if (is_extent_shard_key(it->key())) {
-	    continue;
-          }
-
-          ghobject_t oid;
-          int r = get_key_object(it->key(), &oid);
-          if (r < 0) {
-	    continue;
-          }
-
-          if (!c ||
-	    oid.shard_id != pgid.shard ||
-	    oid.hobj.get_logical_pool() != (int64_t)pgid.pool() ||
-	    !c->contains(oid)) {
-	    c = nullptr;
-	    for (auto& p : coll_map) {
-	      if (p.second->contains(oid)) {
-	        c = p.second;
-	        break;
-	      }
-	    }
-	    if (!c) {
-	      continue;
-	    }
-          }
-          dout(20) << __func__
-                   << " inspecting shared blob refs for col:" << c->cid
-	           << " obj:" << oid
-	           << dendl;
-
-          OnodeRef o;
-          o.reset(Onode::create_decode(c, oid, it->key(), it->value()));
-          o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
-
-          _dump_onode<30>(cct, *o);
-
-          mempool::bluestore_fsck::set<BlobRef> passed_sbs;
-          for (auto& e : o->extent_map.extent_map) {
-	    auto& b = e.blob->get_blob();
-	    if (b.is_shared() && passed_sbs.count(e.blob) == 0) {
-	      auto sbid = e.blob->shared_blob->get_sbid();
-	      cb(c->cid, oid, sbid, b);
-	      passed_sbs.emplace(e.blob);
-	    }
-          } // for ... extent_map
-        } // for ... it->valid
-      } //if (it(PREFIX_OBJ))
-    }; //foreach_shared_blob fn declaration
-
   mempool::bluestore_fsck::map<uint64_t, bluestore_extent_ref_map_t> refs_map;
 
   // first iteration over objects to identify all the broken sbids
-  foreach_shared_blob( [&](coll_t cid,
+  _fsck_foreach_shared_blob( [&](coll_t cid,
                            ghobject_t oid,
                            uint64_t sbid,
                            const bluestore_blob_t& b) {
@@ -8117,7 +8113,7 @@ void BlueStore::_fsck_repair_shared_blobs(
   });
 
   // second iteration over objects to build new ref map for the broken sbids
-  foreach_shared_blob( [&](coll_t cid,
+  _fsck_foreach_shared_blob( [&](coll_t cid,
                            ghobject_t oid,
                            uint64_t sbid,
                            const bluestore_blob_t& b) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -632,7 +632,7 @@ void _dump_extent_map(CephContext *cct, const BlueStore::ExtentMap &em)
 		      << dendl;
     }
     std::lock_guard l(e.blob->shared_blob->get_cache()->lock);
-    for (auto& i : e.blob->bc.buffer_map) {
+    for (auto& i : e.blob->get_bc().buffer_map) {
       dout(LogLevelV) << __func__ << "       0x" << std::hex << i.first
 		      << "~" << i.second->length << std::dec
 		      << " " << *i.second << dendl;
@@ -1890,6 +1890,7 @@ void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint64_t seq
   cache->_audit("finish_write end");
 }
 
+#ifdef WITH_ESB
 /*
   copy Buffers that are in writing queue
   returns:
@@ -1910,6 +1911,7 @@ bool BlueStore::BufferSpace::_dup_writing(BufferCacheShard* cache, BufferSpace* 
   }
   return copied;
 }
+#endif
 
 void BlueStore::BufferSpace::split(BufferCacheShard* cache, size_t pos, BlueStore::BufferSpace &r)
 {
@@ -2175,6 +2177,10 @@ void BlueStore::SharedBlob::put()
 	// race with lookup
 	return;
       }
+#ifndef WITH_ESB
+      bc._clear(coll_snap->cache);
+      coll_snap->cache->rm_blob();
+#endif
     }
     delete this;
   }
@@ -2195,6 +2201,25 @@ void BlueStore::SharedBlob::put_ref(uint64_t offset, uint32_t length,
     unshare && !*unshare ? unshare : nullptr);
 }
 
+#ifndef WITH_ESB
+void BlueStore::SharedBlob::finish_write(uint64_t seq)
+{
+  while (true) {
+    BufferCacheShard *cache = coll->cache;
+    std::lock_guard l(cache->lock);
+    if (coll->cache != cache) {
+      dout(20) << __func__
+	       << " raced with sb cache update, was " << cache
+	       << ", now " << coll->cache << ", retrying"
+	       << dendl;
+      continue;
+    }
+    bc._finish_write(cache, seq);
+    break;
+  }
+}
+#endif
+
 // SharedBlobSet
 
 #undef dout_prefix
@@ -2214,6 +2239,7 @@ void BlueStore::SharedBlobSet::dump(CephContext *cct)
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.blob(" << this << ") "
 
+#ifdef WITH_ESB
 BlueStore::Blob::~Blob()
 {
   SharedBlob* sb = shared_blob.get();
@@ -2232,6 +2258,7 @@ BlueStore::Blob::~Blob()
     coll_cache->rm_blob();
   }
 }
+#endif
 
 void BlueStore::Blob::dump(Formatter* f) const
 {
@@ -2278,7 +2305,7 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
     ceph_assert(discard == all_invalid); // in case of compressed blob all
 				    // or none pextents are invalid.
     if (discard) {
-      bc.discard(shared_blob->get_cache(), 0,
+      dirty_bc().discard(shared_blob->get_cache(), 0,
                               get_blob().get_logical_length());
     }
   } else {
@@ -2288,7 +2315,7 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
 	dout(20) << __func__ << " 0x" << std::hex << pos
 		 << "~" << e.length
 		 << std::dec << dendl;
-	bc.discard(shared_blob->get_cache(), pos, e.length);
+	dirty_bc().discard(shared_blob->get_cache(), pos, e.length);
       }
       pos += e.length;
     }
@@ -2425,6 +2452,7 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
   return true;
 }
 
+#ifdef WITH_ESB
 void BlueStore::Blob::finish_write(uint64_t seq)
 {
   while (true) {
@@ -2442,6 +2470,7 @@ void BlueStore::Blob::finish_write(uint64_t seq)
     break;
   }
 }
+#endif
 
 void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 {
@@ -2457,7 +2486,7 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
     &(r->used_in_blob));
 
   lb.split(blob_offset, rb);
-  bc.split(shared_blob->get_cache(), blob_offset, r->bc);
+  dirty_bc().split(shared_blob->get_cache(), blob_offset, r->dirty_bc());
 
   dout(10) << __func__ << " 0x" << std::hex << blob_offset << std::dec
 	   << " finish " << *this << dendl;
@@ -2601,6 +2630,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       e.blob->last_encoded_id = n;
       id_to_blob[n] = cb;
       e.blob->dup(*cb);
+#ifdef WITH_ESB
       // By default do not copy buffers to clones, and let them read data by themselves.
       // The exception are 'writing' buffers, which are not yet stable on device.
       bool some_copied = e.blob->bc._dup_writing(cb->shared_blob->get_cache(), &cb->bc);
@@ -2610,7 +2640,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
 	// Otherwise it will be stuck until someone does write-op on clone.
 	txc->blobs_written.insert(cb);
       }
-
+#endif
       // bump the extent refs on the copied blob's extents
       for (auto p : blob.get_extents()) {
         if (p.is_valid()) {
@@ -4202,6 +4232,88 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   return onode_space.add_onode(oid, o);
 }
 
+#ifndef WITH_ESB
+void BlueStore::Collection::split_cache(
+  Collection *dest)
+{
+  ldout(store->cct, 10) << __func__ << " to " << dest << dendl;
+
+  auto *ocache = get_onode_cache();
+  auto *ocache_dest = dest->get_onode_cache();
+
+ // lock cache shards
+  std::lock(ocache->lock, ocache_dest->lock, cache->lock, dest->cache->lock);
+  std::lock_guard l(ocache->lock, std::adopt_lock);
+  std::lock_guard l2(ocache_dest->lock, std::adopt_lock);
+  std::lock_guard l3(cache->lock, std::adopt_lock);
+  std::lock_guard l4(dest->cache->lock, std::adopt_lock);
+
+  int destbits = dest->cnode.bits;
+  spg_t destpg;
+  bool is_pg = dest->cid.is_pg(&destpg);
+  ceph_assert(is_pg);
+
+  auto p = onode_space.onode_map.begin();
+  while (p != onode_space.onode_map.end()) {
+    OnodeRef o = p->second;
+    if (!p->second->oid.match(destbits, destpg.pgid.ps())) {
+      // onode does not belong to this child
+      ldout(store->cct, 20) << __func__ << " not moving " << o << " " << o->oid
+			    << dendl;
+      ++p;
+    } else {
+      ldout(store->cct, 20) << __func__ << " moving " << o << " " << o->oid
+			    << dendl;
+
+      // ensuring that nref is always >= 2 and hence onode is pinned
+      OnodeRef o_pin = o;
+
+      p = onode_space.onode_map.erase(p);
+      dest->onode_space.onode_map[o->oid] = o;
+      if (o->cached) {
+        get_onode_cache()->_move_pinned(dest->get_onode_cache(), o.get());
+      }
+      o->c = dest;
+
+      // move over shared blobs and buffers.  cover shared blobs from
+      // both extent map and spanning blob map (the full extent map
+      // may not be faulted in)
+      vector<SharedBlob*> sbvec;
+      for (auto& e : o->extent_map.extent_map) {
+	sbvec.push_back(e.blob->shared_blob.get());
+      }
+      for (auto& b : o->extent_map.spanning_blob_map) {
+	sbvec.push_back(b.second->shared_blob.get());
+      }
+      for (auto sb : sbvec) {
+	if (sb->coll == dest) {
+	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
+				<< dendl;
+	  continue;
+	}
+	ldout(store->cct, 20) << __func__ << "  moving " << *sb << dendl;
+	if (sb->get_sbid()) {
+	  ldout(store->cct, 20) << __func__
+				<< "   moving registration " << *sb << dendl;
+	  shared_blob_set.remove(sb);
+	  dest->shared_blob_set.add(dest, sb);
+	}
+	sb->coll = dest;
+	if (dest->cache != cache) {
+	  for (auto& i : sb->bc.buffer_map) {
+	    if (!i.second->is_writing()) {
+	      ldout(store->cct, 20) << __func__ << "   moving " << *i.second
+				    << dendl;
+	      dest->cache->_move(cache, i.second.get());
+	    }
+	  }
+	}
+      }
+    }
+  }
+  dest->cache->_trim();
+}
+#else
 void BlueStore::Collection::split_cache(
   Collection *dest)
 {
@@ -4303,7 +4415,7 @@ void BlueStore::Collection::split_cache(
   }
   dest->cache->_trim();
 }
-
+#endif
 // =======================================================
 
 // MempoolThread
@@ -10992,7 +11104,7 @@ void BlueStore::_read_cache(
 
     ready_regions_t cache_res;
     interval_set<uint32_t> cache_interval;
-    bptr->bc.read(
+    bptr->dirty_bc().read(
       bptr->shared_blob->get_cache(), b_off, b_len, cache_res, cache_interval,
       read_cache_policy);
     dout(20) << __func__ << "  blob " << *bptr << std::hex
@@ -11160,7 +11272,7 @@ int BlueStore::_generate_read_result_bl(
       if (r < 0)
         return r;
       if (buffered) {
-        bptr->bc.did_read(bptr->shared_blob->get_cache(), 0,
+        bptr->dirty_bc().did_read(bptr->shared_blob->get_cache(), 0,
                                        raw_bl);
       }
       for (auto& req : r2r) {
@@ -11177,7 +11289,7 @@ int BlueStore::_generate_read_result_bl(
           return -EIO;
         }
         if (buffered) {
-          bptr->bc.did_read(bptr->shared_blob->get_cache(),
+          bptr->dirty_bc().did_read(bptr->shared_blob->get_cache(),
                                          req.r_off, req.bl);
         }
 
@@ -13058,11 +13170,17 @@ void BlueStore::_txc_finish(TransContext *txc)
   dout(20) << __func__ << " " << txc << " onodes " << txc->onodes << dendl;
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
+#ifndef WITH_ESB
+  for (auto& sb : txc->shared_blobs_written) {
+    sb->finish_write(txc->seq);
+  }
+  txc->shared_blobs_written.clear();
+#else
   for (auto& sb : txc->blobs_written) {
     sb->finish_write(txc->seq);
   }
   txc->blobs_written.clear();
-
+#endif
   while (!txc->removed_collections.empty()) {
     _queue_reap_collection(txc->removed_collections.front());
     txc->removed_collections.pop_front();
@@ -16588,6 +16706,7 @@ int BlueStore::_do_remove(
       dout(20) << __func__ << "  unsharing " << e << dendl;
       bluestore_blob_t& blob = e.blob->dirty_blob();
       blob.clear_flag(bluestore_blob_t::FLAG_SHARED);
+#ifdef WITH_ESB
       if (e.blob->shared_blob->nref > 1) {
 	// Each blob on creation gets its own unique (empty) shared_blob.
 	// In function ExtentMap::dup() we sometimes merge 2 blobs,
@@ -16600,6 +16719,7 @@ int BlueStore::_do_remove(
 	e.blob->shared_blob = new SharedBlob(c.get());
 	dout(20) << __func__ << " recreated empty shared blob " << e << dendl;
       }
+#endif
       h->extent_map.dirty_range(e.logical_offset, 1);
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -57,12 +57,22 @@
 #include "ZonedFreelistManager.h"
 #endif
 
-#if defined(WITH_LTTNG) && !defined(WITH_EXPERIMENTAL)
+#if defined(WITH_LTTNG)
+
+#ifdef WITH_EXPERIMENTAL
+namespace ceph::experimental {
+#endif
+
 #define TRACEPOINT_DEFINE
 #define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #include "tracing/bluestore.h"
 #undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
 #undef TRACEPOINT_DEFINE
+
+#ifdef WITH_EXPERIMENTAL
+} //namespace ceph::experimental
+#endif
+
 #else
 #define tracepoint(...)
 #endif

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -456,6 +456,7 @@ public:
       discard(cache, offset, (uint32_t)-1 - offset);
     }
 
+    bool _dup_writing(BufferCacheShard* cache, BufferSpace* bc);
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
     void dump(BufferCacheShard* cache, ceph::Formatter *f) const {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2787,8 +2787,9 @@ private:
     int64_t& errors,
     int64_t &warnings,
     BlueStoreRepairer* repairer);
+  // When cb returns false stops iterating.
   void _fsck_foreach_shared_blob(
-    std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
+    std::function< bool (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
   void _fsck_repair_shared_blobs(
     BlueStoreRepairer& repairer,
     shared_blob_2hash_tracker_t& sb_ref_counts,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2787,6 +2787,8 @@ private:
     int64_t& errors,
     int64_t &warnings,
     BlueStoreRepairer* repairer);
+  void _fsck_foreach_shared_blob(
+    std::function< void (coll_t, ghobject_t, uint64_t, const bluestore_blob_t&)> cb);
   void _fsck_repair_shared_blobs(
     BlueStoreRepairer& repairer,
     shared_blob_2hash_tracker_t& sb_ref_counts,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -61,6 +61,10 @@ class FreelistManager;
 class SimpleBitmap;
 
 #ifdef WITH_EXPERIMENTAL
+
+// enable particular experimental features of BlueStore
+#define WITH_ESB
+
 namespace ceph::experimental {
 #endif
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -58,8 +58,13 @@
 
 class Allocator;
 class FreelistManager;
-class BlueStoreRepairer;
 class SimpleBitmap;
+
+#ifdef WITH_EXPERIMENTAL
+namespace ceph::experimental {
+#endif
+
+class BlueStoreRepairer;
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
 #undef WITH_ESB
@@ -4399,4 +4404,7 @@ public:
   bool compare(BlueFSVolumeSelector* other) override;
 };
 
+#ifdef WITH_EXPERIMENTAL
+} // namespace ceph::experimental
+#endif
 #endif

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -469,6 +469,7 @@ public:
       }
       f->close_section();
     }
+    friend std::ostream& operator<<(std::ostream& out, const BufferSpace& bc);
   };
 
   struct SharedBlobSet;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -518,8 +518,6 @@ public:
     void put_ref(uint64_t offset, uint32_t length,
 		 PExtentVector *r, bool *unshare);
 
-    void finish_write(uint64_t seq);
-
     friend bool operator==(const SharedBlob &l, const SharedBlob &r) {
       return l.get_sbid() == r.get_sbid();
     }
@@ -670,7 +668,8 @@ public:
     /// put logical references, and get back any released extents
     bool put_ref(Collection *coll, uint32_t offset, uint32_t length,
 		 PExtentVector *r);
-
+    // update caches to reflect content up to seq
+    void finish_write(uint64_t seq);
     /// split the blob
     void split(Collection *coll, uint32_t blob_offset, Blob *o);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1129,6 +1129,28 @@ public:
 
     /// split a blob (and referring extents)
     BlobRef split_blob(BlobRef lb, uint32_t blob_offset, uint32_t pos);
+
+    /// allocation unit status
+    struct debug_au_state_t {
+      uint64_t disk_offset; //< offset of the data on disk (in bytes)
+      uint32_t disk_length; //< length of the data on disk
+                            //  <offset, offset + length) never crosses AU boundary
+      uint32_t chksum;      //< checksum of the AU
+      uint32_t ref_cnts;    //< how many times AU is shared
+      debug_au_state_t(
+	uint64_t disk_offset, uint32_t disk_length,
+	uint32_t chksum, uint32_t ref_cnts)
+	: disk_offset(disk_offset)
+	, disk_length(disk_length)
+	, chksum(chksum)
+	, ref_cnts(ref_cnts) {}
+    };
+    using debug_au_vector_t = std::vector<debug_au_state_t>;
+    /// Produces a sequence of allocation units representing logical offsets.
+    /// If there is a discontinuity, it is encoded as disk_offset==-1.
+    debug_au_vector_t debug_list_disk_layout();
+
+    friend std::ostream& operator<<(std::ostream& out, const debug_au_vector_t& auv);
   };
 
   /// Compressed Blob Garbage collector
@@ -3366,6 +3388,18 @@ public:
   }
   bool has_builtin_csum() const override {
     return true;
+  }
+  // a debug punch_hole function, to use internals of _wctx_finish
+  // to remove old_extents from object
+  void debug_punch_hole(
+    CollectionRef& c,
+    OnodeRef& o,
+    uint32_t off,
+    uint32_t len) {
+    BlueStore::TransContext txc(cct, c.get(), nullptr, nullptr);
+    BlueStore::WriteContext wctx;
+    o->extent_map.punch_hole(c, off, len, &wctx.old_extents);
+    _wctx_finish(&txc, c, o, &wctx, nullptr);
   }
 
   inline void log_latency(const char* name,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -486,7 +486,6 @@ public:
       uint64_t sbid_unloaded;              ///< sbid if persistent isn't loaded
       bluestore_shared_blob_t *persistent; ///< persistent part of the shared blob if any
     };
-    BufferSpace bc;             ///< buffer cache
 
     SharedBlob(Collection *_coll) : coll(_coll), sbid_unloaded(0) {
       if (get_cache()) {
@@ -593,7 +592,7 @@ public:
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
-
+    BufferSpace bc;
   private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
 #ifdef CACHE_BLOB_BL
@@ -627,7 +626,7 @@ public:
     bool can_split() const {
       std::lock_guard l(shared_blob->get_cache()->lock);
       // splitting a BufferSpace writing list is too hard; don't try.
-      return shared_blob->bc.writing.empty() &&
+      return bc.writing.empty() &&
              used_in_blob.can_split() &&
              get_blob().can_split();
     }
@@ -680,7 +679,7 @@ public:
       if (--nref == 0)
 	delete this;
     }
-
+    ~Blob();
 
 #ifdef CACHE_BLOB_BL
     void _encode() const {
@@ -2812,7 +2811,7 @@ private:
     uint64_t offset,
     ceph::buffer::list& bl,
     unsigned flags) {
-    b->shared_blob->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
+    b->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
     txc->blobs_written.insert(b);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -59,6 +59,8 @@
 class Allocator;
 class FreelistManager;
 class SimpleBitmap;
+class ZonedAllocator;
+class ZonedFreelistManager;
 
 #ifdef WITH_EXPERIMENTAL
 
@@ -2843,8 +2845,8 @@ private:
   void _zoned_cleaner_stop();
   void _zoned_cleaner_thread();
   void _zoned_clean_zone(uint64_t zone_num,
-			 class ZonedAllocator *a,
-			 class ZonedFreelistManager *f);
+			 ZonedAllocator *a,
+			 ZonedFreelistManager *f);
   void _clean_some(ghobject_t oid, uint32_t zone_num);
 #endif
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -623,6 +623,9 @@ public:
     const bluestore_blob_use_tracker_t& get_blob_use_tracker() const {
       return used_in_blob;
     }
+    bluestore_blob_use_tracker_t& dirty_blob_use_tracker() {
+      return used_in_blob;
+    }
     bool is_referenced() const {
       return used_in_blob.is_not_empty();
     }
@@ -641,6 +644,9 @@ public:
              used_in_blob.can_split() &&
              get_blob().can_split();
     }
+
+    bool can_merge_blob(const Blob* other, uint32_t& blob_end) const;
+    uint32_t merge_blob(CephContext* cct, Blob* blob_to_dissolve);
 
     bool can_split_at(uint32_t blob_offset) const {
       return used_in_blob.can_split_at(blob_offset) &&

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -890,6 +890,14 @@ public:
 	needs_reshard_end = end;
       }
     }
+    // signals that there was a modification on range <begin, end)
+    // if this spans over a shard boundary, then shards no longer
+    // can be encoded separately, and reshard run is needed
+    void maybe_reshard(uint32_t begin, uint32_t end) {
+      if (spans_shard(begin, end - begin)) {
+	request_reshard(begin, end);
+      }
+    }
 
     struct DeleteDisposer {
       void operator()(Extent *e) { delete e; }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -667,12 +667,14 @@ public:
       o.blob_bl = blob_bl;
 #endif
     }
+#ifdef WITH_ESB
     void dup(const Blob& from, bool copy_used_in_blob);
     void copy_from(CephContext* cct, const Blob& from,
 		   uint32_t min_release_size, uint32_t start, uint32_t len);
     void copy_extents(CephContext* cct, const Blob& from, uint32_t start,
 		      uint32_t pre_len, uint32_t main_len, uint32_t post_len);
     void copy_extents_over_empty(CephContext* cct, const Blob& from, uint32_t start, uint32_t len);
+#endif
 
     inline const bluestore_blob_t& get_blob() const {
       return blob;
@@ -683,8 +685,10 @@ public:
 #endif
       return blob;
     }
+#ifdef WITH_ESB
     /// clear buffers from unused sections
     void discard_unused_buffers(CephContext* cct, BufferCacheShard* cache);
+#endif
 
     inline const BufferSpace& get_bc() const {
 #ifdef WITH_ESB
@@ -919,6 +923,7 @@ public:
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
 
+#ifdef WITH_ESB
     void scan_shared_blobs(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
 			   std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
     Blob* find_mergable_companion(Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
@@ -927,6 +932,7 @@ public:
 			BlobRef from_blob, BlobRef to_blob);
     void make_range_shared_maybe_merge(BlueStore* store, TransContext* txc, CollectionRef& c,
 				       OnodeRef& oldo, uint64_t srcoff, uint64_t length);
+#endif
 
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -459,7 +459,7 @@ public:
     }
 
 #ifdef WITH_ESB
-    bool _dup_writing(BufferCacheShard* cache, BufferSpace* bc);
+    bool _dup_writing(BufferCacheShard* cache, BufferSpace* to);
 #endif
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
@@ -918,6 +918,12 @@ public:
 
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
+
+    void scan_shared_blobs(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
+			   std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
+
+    Blob* find_mergable_companion(Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
+				  std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
 
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -66,12 +66,14 @@ class SimpleBitmap;
 #define WITH_ESB
 
 namespace ceph::experimental {
+#else
+#undef WITH_ESB
 #endif
 
 class BlueStoreRepairer;
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
-#undef WITH_ESB
+
 
 
 // constants for Buffer::optimize()

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -393,7 +393,8 @@ public:
     void _rm_buffer(BufferCacheShard* cache, Buffer *b) {
       _rm_buffer(cache, buffer_map.find(b->offset));
     }
-    void _rm_buffer(BufferCacheShard* cache,
+    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator
+    _rm_buffer(BufferCacheShard* cache,
 		    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator p) {
       ceph_assert(p != buffer_map.end());
       cache->_audit("_rm_buffer start");
@@ -402,8 +403,9 @@ public:
       } else {
 	cache->_rm(p->second.get());
       }
-      buffer_map.erase(p);
+      p = buffer_map.erase(p);
       cache->_audit("_rm_buffer end");
+      return p;
     }
 
     std::map<uint32_t,std::unique_ptr<Buffer>>::iterator _data_lower_bound(
@@ -681,6 +683,8 @@ public:
 #endif
       return blob;
     }
+    /// clear buffers from unused sections
+    void discard_unused_buffers(CephContext* cct, BufferCacheShard* cache);
 
     inline const BufferSpace& get_bc() const {
 #ifdef WITH_ESB

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -62,7 +62,7 @@ class BlueStoreRepairer;
 class SimpleBitmap;
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
-
+#undef WITH_ESB
 
 
 // constants for Buffer::optimize()
@@ -456,7 +456,9 @@ public:
       discard(cache, offset, (uint32_t)-1 - offset);
     }
 
+#ifdef WITH_ESB
     bool _dup_writing(BufferCacheShard* cache, BufferSpace* bc);
+#endif
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
     void dump(BufferCacheShard* cache, ceph::Formatter *f) const {
@@ -487,6 +489,9 @@ public:
       uint64_t sbid_unloaded;              ///< sbid if persistent isn't loaded
       bluestore_shared_blob_t *persistent; ///< persistent part of the shared blob if any
     };
+#ifndef WITH_ESB
+    BufferSpace bc;             ///< buffer cache
+#endif
 
     SharedBlob(Collection *_coll) : coll(_coll), sbid_unloaded(0) {
       if (get_cache()) {
@@ -517,7 +522,9 @@ public:
     /// put logical references, and get back any released extents
     void put_ref(uint64_t offset, uint32_t length,
 		 PExtentVector *r, bool *unshare);
-
+#ifndef WITH_ESB
+    void finish_write(uint64_t seq);
+#endif
     friend bool operator==(const SharedBlob &l, const SharedBlob &r) {
       return l.get_sbid() == r.get_sbid();
     }
@@ -593,7 +600,10 @@ public:
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
+
+#ifdef WITH_ESB
     BufferSpace bc;
+#endif
   private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
 #ifdef CACHE_BLOB_BL
@@ -627,7 +637,7 @@ public:
     bool can_split() const {
       std::lock_guard l(shared_blob->get_cache()->lock);
       // splitting a BufferSpace writing list is too hard; don't try.
-      return bc.writing.empty() &&
+      return get_bc().writing.empty() &&
              used_in_blob.can_split() &&
              get_blob().can_split();
     }
@@ -660,6 +670,21 @@ public:
       return blob;
     }
 
+    inline const BufferSpace& get_bc() const {
+#ifdef WITH_ESB
+      return bc;
+#else
+      return shared_blob->bc;
+#endif
+    }
+    inline BufferSpace& dirty_bc() {
+#ifdef WITH_ESB
+      return bc;
+#else
+      return shared_blob->bc;
+#endif
+    }
+
     /// discard buffers for unallocated regions
     void discard_unallocated(Collection *coll);
 
@@ -668,8 +693,10 @@ public:
     /// put logical references, and get back any released extents
     bool put_ref(Collection *coll, uint32_t offset, uint32_t length,
 		 PExtentVector *r);
+#ifdef WITH_ESB
     // update caches to reflect content up to seq
     void finish_write(uint64_t seq);
+#endif
     /// split the blob
     void split(Collection *coll, uint32_t blob_offset, Blob *o);
 
@@ -680,7 +707,10 @@ public:
       if (--nref == 0)
 	delete this;
     }
+
+#ifdef WITH_ESB
     ~Blob();
+#endif
 
 #ifdef CACHE_BLOB_BL
     void _encode() const {
@@ -1778,8 +1808,11 @@ private:
 #endif
     
     std::set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
+#ifdef WITH_ESB
     std::set<BlobRef> blobs_written; ///< update these on io completion
-
+#else
+    std::set<SharedBlobRef> shared_blobs_written; ///< update these on io completion
+#endif
     KeyValueDB::Transaction t; ///< then we will commit this
     std::list<Context*> oncommits;  ///< more commit completions
     std::list<CollectionRef> removed_collections; ///< colls we removed
@@ -2812,9 +2845,13 @@ private:
     uint64_t offset,
     ceph::buffer::list& bl,
     unsigned flags) {
-    b->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
+    b->dirty_bc().write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
+#ifdef WITH_ESB
     txc->blobs_written.insert(b);
+#else
+    txc->shared_blobs_written.insert(b->shared_blob);
+#endif
   }
 
   int _collection_list(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -921,9 +921,10 @@ public:
 
     void scan_shared_blobs(CollectionRef& c, OnodeRef& oldo, uint64_t start, uint64_t length,
 			   std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
-
     Blob* find_mergable_companion(Blob* blob_to_dissolve, uint32_t blob_start, uint32_t& blob_width,
 				  std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
+    void reblob_extents(uint32_t blob_start, uint32_t blob_end,
+			BlobRef from_blob, BlobRef to_blob);
 
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -659,6 +659,12 @@ public:
       o.blob_bl = blob_bl;
 #endif
     }
+    void dup(const Blob& from, bool copy_used_in_blob);
+    void copy_from(CephContext* cct, const Blob& from,
+		   uint32_t min_release_size, uint32_t start, uint32_t len);
+    void copy_extents(CephContext* cct, const Blob& from, uint32_t start,
+		      uint32_t pre_len, uint32_t main_len, uint32_t post_len);
+    void copy_extents_over_empty(CephContext* cct, const Blob& from, uint32_t start, uint32_t len);
 
     inline const bluestore_blob_t& get_blob() const {
       return blob;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2056,7 +2056,7 @@ private:
 	conf->bluestore_throttle_deferred_bytes);
 #if defined(WITH_LTTNG)
       double rate = conf.get_val<double>("bluestore_throttle_trace_rate");
-      trace_period_mcs = rate > 0 ? floor((1/rate) * 1000000.0) : 0;
+      trace_period_mcs = rate > 0 ? std::floor((1/rate) * 1000000.0) : 0;
 #endif
     }
   } throttle;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -925,6 +925,8 @@ public:
 				  std::multimap<uint64_t /*blob_start*/, Blob*>& candidates);
     void reblob_extents(uint32_t blob_start, uint32_t blob_end,
 			BlobRef from_blob, BlobRef to_blob);
+    void make_range_shared_maybe_merge(BlueStore* store, TransContext* txc, CollectionRef& c,
+				       OnodeRef& oldo, uint64_t srcoff, uint64_t length);
 
     void dup(BlueStore* b, TransContext*, CollectionRef&, OnodeRef&, OnodeRef&,
       uint64_t&, uint64_t&, uint64_t&);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1779,7 +1779,7 @@ private:
 #endif
     
     std::set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
-    std::set<SharedBlobRef> shared_blobs_written; ///< update these on io completion
+    std::set<BlobRef> blobs_written; ///< update these on io completion
 
     KeyValueDB::Transaction t; ///< then we will commit this
     std::list<Context*> oncommits;  ///< more commit completions
@@ -2815,7 +2815,7 @@ private:
     unsigned flags) {
     b->shared_blob->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
-    txc->shared_blobs_written.insert(b->shared_blob);
+    txc->blobs_written.insert(b);
   }
 
   int _collection_list(

--- a/src/os/bluestore/BlueStore_exp.h
+++ b/src/os/bluestore/BlueStore_exp.h
@@ -1,0 +1,24 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_OSD_BLUESTORE_EXP_H
+#define CEPH_OSD_BLUESTORE_EXP_H
+
+#define WITH_EXPERIMENTAL
+#undef CEPH_OSD_BLUESTORE_H
+#include "BlueStore.h"
+// let others include regular bluestore too. Double inclusion
+// of bluestore-rdr is guarded by CEPH_OSD_BLUESTORE_EXP_H.
+#undef CEPH_OSD_BLUESTORE_H
+
+#endif // CEPH_OSD_BLUESTORE_EXP_H

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -91,6 +91,11 @@ BlueStorePair open_bluestore(CephContext *cct, const string& path)
     exit(EXIT_FAILURE);
   }
   string bluestore_type = label.meta["type"];
+  // when upgraded from non-rdr aware build there is no "type" in label.meta
+  if (bluestore_type == "") {
+    // so it had to be bluestore
+    bluestore_type = "bluestore";
+  }
   if (bluestore_type != "bluestore" && bluestore_type != "bluestore-rdr") {
     cerr << "expected bluestore, but type is " << bluestore_type << std::endl;
     exit(EXIT_FAILURE);
@@ -683,6 +688,11 @@ int main(int argc, char **argv)
     label.meta["path_block"] = devs.front();
     //now type is stored in label, this allows bluestore-rdr
     //label.meta["type"] = "bluestore";
+    //but it can happen that we upgraded bluestore from previous version
+    //and now we need to patch it
+    if (label.meta["type"] == "") {
+      label.meta["type"] = "bluestore";
+    }
     label.meta["fsid"] = stringify(label.osd_uuid);
     
     for (auto kk : {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -681,7 +681,8 @@ int main(int argc, char **argv)
     // kludge some things into the map that we want to populate into
     // target dir
     label.meta["path_block"] = devs.front();
-    label.meta["type"] = "bluestore";
+    //now type is stored in label, this allows bluestore-rdr
+    //label.meta["type"] = "bluestore";
     label.meta["fsid"] = stringify(label.osd_uuid);
     
     for (auto kk : {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -20,6 +20,7 @@
 
 #include "os/bluestore/BlueFS.h"
 #include "os/bluestore/BlueStore.h"
+#include "os/bluestore/BlueStore_exp.h"
 #include "common/admin_socket.h"
 #include "kv/RocksDBStore.h"
 
@@ -41,7 +42,7 @@ void validate_path(CephContext *cct, const string& path, bool bluefs)
     cerr << "failed to load os-type: " << cpp_strerror(r) << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (type != "bluestore") {
+  if ((type != "bluestore") && (type != "bluestore-rdr")) {
     cerr << "expected bluestore, but type is " << type << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -71,6 +72,53 @@ void validate_path(CephContext *cct, const string& path, bool bluefs)
     exit(EXIT_FAILURE);
   }
 }
+
+struct BlueStorePair
+{
+  std::unique_ptr<ObjectStore> os;
+  BlueStore* b1 = nullptr;
+  ceph::experimental::BlueStore* b2 = nullptr;
+};
+
+BlueStorePair open_bluestore(CephContext *cct, const string& path)
+{
+  bluestore_bdev_label_t label;
+  // assume that _read_bdev_label and bluestore_bdev_label_t are the same for all BlueStores
+  int r = BlueStore::_read_bdev_label(cct, path + "/block", &label);
+  if (r < 0) {
+    cerr << "unable to read label for " << path << ": "
+	 << cpp_strerror(r) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  string bluestore_type = label.meta["type"];
+  if (bluestore_type != "bluestore" && bluestore_type != "bluestore-rdr") {
+    cerr << "expected bluestore, but type is " << bluestore_type << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  std::unique_ptr<ObjectStore> os = ObjectStore::create(cct, bluestore_type, path);
+  if (os == nullptr) {
+    cerr << "cannot open '" << bluestore_type << "' at " << path << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  BlueStorePair bsp;
+  bsp.os = std::move(os);
+  bsp.b1 = dynamic_cast<BlueStore*>(bsp.os.get());
+  bsp.b2 = dynamic_cast<ceph::experimental::BlueStore*>(bsp.os.get());
+
+  if (bsp.b1 == nullptr && bsp.b2 == nullptr) {
+    cerr << "objectstore at " << path << " is not bluestore" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  ceph_assert(bsp.b1 == nullptr || bsp.b2 == nullptr);
+  return bsp;
+}
+
+// attempt action
+#define BLUESTORE_ACTION(bsp, action) { if (bsp.b1) { bsp.b1->action; } else { bsp.b2->action; } }
+
+// attempt func
+#define BLUESTORE_FUNC(bsp, func) (bsp.b1 ? bsp.b1->func : bsp.b2->func)
 
 const char* find_device_path(
   int id,
@@ -240,14 +288,14 @@ static void bluefs_import(
     cerr << "open " << input_file.c_str() << " failed: " << cpp_strerror(r) << std::endl;
     exit(EXIT_FAILURE);
   }
-  BlueStore bluestore(cct, path);
+  auto bsp = open_bluestore(cct, path);
   KeyValueDB *db_ptr;
-  r = bluestore.open_db_environment(&db_ptr, false);
+  r = BLUESTORE_FUNC(bsp, open_db_environment(&db_ptr, false));
   if (r < 0) {
     cerr << "error preparing db environment: " << cpp_strerror(r) << std::endl;
     exit(EXIT_FAILURE);
   }
-  BlueFS* bs = bluestore.get_bluefs();
+  BlueFS* bs = BLUESTORE_FUNC(bsp, get_bluefs());
 
   BlueFS::FileWriter *h;
   fs::path file_path(dest_file);
@@ -267,7 +315,7 @@ static void bluefs_import(
   f.close();
   bs->fsync(h);
   bs->close_writer(h);
-  bluestore.close_db_environment();
+  BLUESTORE_ACTION(bsp, close_db_environment());
   return;
 }
 
@@ -554,8 +602,8 @@ int main(int argc, char **argv)
 #else
     cout << action << " bluestore.restore_cfb" << std::endl;
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.push_allocation_to_rocksdb();
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, push_allocation_to_rocksdb());
     if (r < 0) {
       cerr << action << " failed: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -571,8 +619,8 @@ int main(int argc, char **argv)
 #else
     cout << action << " bluestore.allocmap" << std::endl;
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.read_allocation_from_drive_for_bluestore_tool();
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, read_allocation_from_drive_for_bluestore_tool());
     if (r < 0) {
       cerr << action << " failed: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -588,8 +636,8 @@ int main(int argc, char **argv)
 #else
     cout << action << " bluestore.quick-fsck" << std::endl;
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.read_allocation_from_drive_for_bluestore_tool();
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, read_allocation_from_drive_for_bluestore_tool());
     if (r < 0) {
       cerr << action << " failed: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -602,14 +650,14 @@ int main(int argc, char **argv)
       action == "repair" ||
       action == "quick-fix") {
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
+    auto bsp = open_bluestore(cct.get(), path);
     int r;
     if (action == "fsck") {
-      r = bluestore.fsck(fsck_deep);
+      r = BLUESTORE_FUNC(bsp, fsck(fsck_deep));
     } else if (action == "repair") {
-      r = bluestore.repair(fsck_deep);
+      r = BLUESTORE_FUNC(bsp, repair(fsck_deep));
     } else {
-      r = bluestore.quick_fix();
+      r = BLUESTORE_FUNC(bsp, quick_fix());
     }
     if (r < 0) {
       cerr << action << " failed: " << cpp_strerror(r) << std::endl;
@@ -742,12 +790,12 @@ int main(int argc, char **argv)
     }
   }
   else if (action == "bluefs-bdev-sizes") {
-    BlueStore bluestore(cct.get(), path);
-    bluestore.dump_bluefs_sizes(cout);
+    auto bsp = open_bluestore(cct.get(), path);
+    BLUESTORE_ACTION(bsp, dump_bluefs_sizes(cout));
   }
   else if (action == "bluefs-bdev-expand") {
-    BlueStore bluestore(cct.get(), path);
-    auto r = bluestore.expand_devices(cout);
+    auto bsp = open_bluestore(cct.get(), path);
+    auto r = BLUESTORE_FUNC(bsp, expand_devices(cout));
     if (r <0) {
       cerr << "failed to expand bluestore devices: "
 	   << cpp_strerror(r) << std::endl;
@@ -905,10 +953,10 @@ int main(int argc, char **argv)
 	return EXIT_FAILURE;
       }
     }
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.add_new_bluefs_device(
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, add_new_bluefs_device(
       need_db ? BlueFS::BDEV_NEWDB : BlueFS::BDEV_NEWWAL,
-      target_path);
+      target_path));
     if (r == 0) {
       cout << (need_db ? "DB" : "WAL") << " device added " << target_path
 	   << std::endl;
@@ -955,10 +1003,10 @@ int main(int argc, char **argv)
 	exit(EXIT_FAILURE);
       }
 
-      BlueStore bluestore(cct.get(), path);
-      int r = bluestore.migrate_to_existing_bluefs_device(
+      auto bsp = open_bluestore(cct.get(), path);
+      int r = BLUESTORE_FUNC(bsp, migrate_to_existing_bluefs_device(
 	src_dev_ids,
-	dev_target_id);
+	dev_target_id));
       if (r == 0) {
 	for(auto src : src_devs) {
 	  if (src.second != BlueFS::BDEV_SLOW) {
@@ -1001,13 +1049,13 @@ int main(int argc, char **argv)
 	exit(EXIT_FAILURE);
       }
 
-      BlueStore bluestore(cct.get(), path);
+      auto bsp = open_bluestore(cct.get(), path);
 
       bool need_db = dev_target_id == BlueFS::BDEV_NEWDB;
-      int r = bluestore.migrate_to_new_bluefs_device(
+      int r = BLUESTORE_FUNC(bsp, migrate_to_new_bluefs_device(
 	src_dev_ids,
 	dev_target_id,
-	target_path);
+	target_path));
       if (r == 0) {
 	for(auto src : src_devs) {
 	  if (src.second != BlueFS::BDEV_SLOW) {
@@ -1034,8 +1082,8 @@ int main(int argc, char **argv)
     std::string action_name = action == "free-dump" ? "dump" :
                               action == "free-score" ? "score" : "fragmentation";
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.cold_open();
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, cold_open());
     if (r < 0) {
       cerr << "error from cold_open: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -1055,13 +1103,13 @@ int main(int argc, char **argv)
       }
     }
 
-    bluestore.cold_close();
+    BLUESTORE_ACTION(bsp, cold_close());
   } else  if (action == "bluefs-stats") {
     AdminSocket* admin_socket = g_ceph_context->get_admin_socket();
     ceph_assert(admin_socket);
     validate_path(cct.get(), path, false);
-    BlueStore bluestore(cct.get(), path);
-    int r = bluestore.cold_open();
+    auto bsp = open_bluestore(cct.get(), path);
+    int r = BLUESTORE_FUNC(bsp, cold_open());
     if (r < 0) {
       cerr << "error from cold_open: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -1077,7 +1125,7 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
     cout << std::string(out.c_str(), out.length()) << std::endl;
-     bluestore.cold_close();
+    BLUESTORE_ACTION(bsp, cold_close());
   } else if (action == "reshard") {
     auto get_ctrl = [&](size_t& val) {
       if (!resharding_ctrl.empty()) {
@@ -1097,7 +1145,7 @@ int main(int argc, char **argv)
 	}
       }
     };
-    BlueStore bluestore(cct.get(), path);
+    auto bsp = open_bluestore(cct.get(), path);
     KeyValueDB *db_ptr;
     RocksDBStore::resharding_ctrl ctrl;
     if (!resharding_ctrl.empty()) {
@@ -1110,7 +1158,7 @@ int main(int argc, char **argv)
 	exit(EXIT_FAILURE);
       }
     }
-    int r = bluestore.open_db_environment(&db_ptr, true);
+    int r = BLUESTORE_FUNC(bsp, open_db_environment(&db_ptr, true));
     if (r < 0) {
       cerr << "error preparing db environment: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -1124,11 +1172,11 @@ int main(int argc, char **argv)
     } else {
       cout << "reshard success" << std::endl;
     }
-    bluestore.close_db_environment();
+    BLUESTORE_FUNC(bsp, close_db_environment());
   } else if (action == "show-sharding") {
-    BlueStore bluestore(cct.get(), path);
+    auto bsp = open_bluestore(cct.get(), path);
     KeyValueDB *db_ptr;
-    int r = bluestore.open_db_environment(&db_ptr, false);
+    int r = BLUESTORE_FUNC(bsp, open_db_environment(&db_ptr, false));
     if (r < 0) {
       cerr << "error preparing db environment: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
@@ -1138,7 +1186,7 @@ int main(int argc, char **argv)
     ceph_assert(rocks_db);
     std::string sharding;
     bool res = rocks_db->get_sharding(sharding);
-    bluestore.close_db_environment();
+    BLUESTORE_ACTION(bsp, close_db_environment());
     if (!res) {
       cerr << "failed to retrieve sharding def" << std::endl;
       exit(EXIT_FAILURE);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -720,6 +720,8 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
 	<< " -> 0x"
 	<< o.get_compressed_payload_length()
 	<< std::dec;
+  } else {
+    out << " llen=0x" << std::hex << o.get_logical_length() << std::dec;
   }
   if (o.flags) {
     out << " " << o.get_flags_string();

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -726,7 +726,8 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
   }
   if (o.has_csum()) {
     out << " " << Checksummer::get_csum_type_string(o.csum_type)
-	<< "/0x" << std::hex << (1ull << o.csum_chunk_order) << std::dec;
+	<< "/0x" << std::hex << (1ull << o.csum_chunk_order) << std::dec
+	<< "/" << o.csum_data.length();
   }
   if (o.has_unused())
     out << " unused=0x" << std::hex << o.unused << std::dec;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& out, const bluestore_cnode_t& l);
 template <typename OFFS_TYPE, typename LEN_TYPE>
 struct bluestore_interval_t
 {
-  static const uint64_t INVALID_OFFSET = ~0ull;
+  static constexpr uint64_t INVALID_OFFSET = ~0ull;
 
   OFFS_TYPE offset = 0;
   LEN_TYPE length = 0;
@@ -300,6 +300,29 @@ struct bluestore_blob_use_tracker_t {
   }
   bool is_empty() const {
     return !is_not_empty();
+  }
+  // Returns how many allocation units are currently tracked.
+  // Simplifies logic when num_au = 0, but in reality we track just one
+  uint32_t get_num_au() const {
+    return num_au == 0 ? 1 : num_au;
+  }
+  // Returns array of used sizes per au.
+  // It has at least get_num_au() elements.
+  const uint32_t* get_au_array() const {
+    if (num_au > 0) {
+      return bytes_per_au;
+    } else {
+      return &total_bytes;
+    }
+  }
+  // Returns array of used sizes per au.
+  // It has at least get_num_au() elements.
+  uint32_t* dirty_au_array() {
+    if (num_au > 0) {
+      return bytes_per_au;
+    } else {
+      return &total_bytes;
+    }
   }
   void prune_tail(uint32_t new_len) {
     if (num_au) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5201,10 +5201,10 @@ void StoreTest::doSyntheticLimitedTest(
     if (option(1)) test_obj.fsck(false);
     if (option(1)) test_obj.scan();
     if (option(497)) test_obj.stat();
-    if (option(500)) test_obj.zero();
+    if (option(1000)) test_obj.zero();
     if (option(1500)) test_obj.read();
     if (option(1500)) test_obj.write();
-    if (option(1000)) test_obj.truncate();
+    if (option(500)) test_obj.truncate();
     if (option(1000)) test_obj.clone_range();
     if (option(1000)) test_obj.stash();
     if (option(1500)) test_obj.unlink();
@@ -5246,13 +5246,37 @@ TEST_P(StoreTestSpecificAUSize, SyntheticLimited) {
     return;
 
   const char *m[][10] = {
-    { "bluestore_min_alloc_size", "4096", 0 }, // must be the first!
+    { "bluestore_min_alloc_size", "65536", "4096", 0 }, // must be the first!
     { "num_ops", "10000", 0 },
     { "max_write", "65536", 0 },
     { "max_size", "262144", 0 },
     { "alignment", "4096", 0 },
-    { "start_object_count", "3000", "1000", "200", "50", 0 },
+    { "start_object_count", "1000", "200", "50", 0 },
     { "bluestore_max_blob_size", "65536", 0 },
+    { "bluestore_default_buffered_read", "true", 0 },
+    { "bluestore_default_buffered_write", "true", 0 },
+    { "bluestore_compression_mode", "force", "none", 0},
+    { "bluestore_prefer_deferred_size", "32768", "0", 0},
+    { 0 },
+  };
+  do_matrix(m, &StoreTestSpecificAUSize::SyntheticLimitedTest);
+}
+
+TEST_P(StoreTestSpecificAUSize, SyntheticShardingLimited) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  const char *m[][10] = {
+    { "bluestore_min_alloc_size", "65536", "4096", 0 }, // must be the first!
+    { "num_ops", "10000", 0 },
+    { "max_write", "65536", 0 },
+    { "max_size", "262144", 0 },
+    { "alignment", "4096", 0 },
+    { "start_object_count", "1000", "200", "50", 0 },
+    { "bluestore_max_blob_size", "65536", 0 },
+    { "bluestore_extent_map_shard_min_size", "60", 0 },
+    { "bluestore_extent_map_shard_max_size", "300", 0 },
+    { "bluestore_extent_map_shard_target_size", "150", 0 },
     { "bluestore_default_buffered_read", "true", 0 },
     { "bluestore_default_buffered_write", "true", 0 },
     { 0 },

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4572,6 +4572,7 @@ public:
 
     if (srcoff > srcdata.length() - 1) {
       srcoff = srcdata.length() - 1;
+      dstoff = srcoff;
     }
     if (srcoff + len > srcdata.length()) {
       len = srcdata.length() - srcoff;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1285,6 +1285,380 @@ TEST(ExtentMap, compress_extent_map)
   ASSERT_EQ(6u, em.extent_map.size());
 }
 
+class ExtentMapFixture : virtual public ::testing::Test {
+
+public:
+  BlueStore store;
+  BlueStore::OnodeCacheShard *oc;
+  BlueStore::BufferCacheShard *bc;
+  BlueStore::CollectionRef coll;
+
+  static constexpr uint32_t au_size = 4096;
+  uint32_t blob_size = 65536;
+  size_t csum_order = 12; //1^12 = 4096 bytes
+
+  struct au {
+    uint32_t chksum;
+    uint32_t refs;
+  };
+  std::vector<au> disk;
+
+  // test onode that glues some simplifications in representation
+  // with actual BlueStore's onode
+  struct t_onode {
+    BlueStore::OnodeRef onode; //actual BS onode
+    std::vector<uint32_t> data; //map to AUs
+    static constexpr uint32_t empty = std::numeric_limits<uint32_t>::max();
+  };
+  void print(std::ostream& out, t_onode& onode)
+  {
+    for (size_t i = 0; i < onode.data.size(); ++i) {
+      if (i != 0) out << " ";
+      if (onode.data[i] == t_onode::empty) {
+	out << "-";
+      } else {
+	out << std::hex << onode.data[i]
+	    << "/" << disk[onode.data[i]].chksum
+	    << ":" << std::dec << disk[onode.data[i]].refs;
+      }
+    }
+  }
+  explicit ExtentMapFixture()
+    : store(g_ceph_context, "", au_size)
+  {
+    oc = BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+    bc = BlueStore::BufferCacheShard::create(g_ceph_context, "lru", NULL);
+    coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
+  }
+
+  void SetUp() override {
+  }
+  void TearDown() override {
+  }
+
+  // takes new space from disk, initializes csums
+  // returns index of first au
+  uint32_t allocate(uint32_t num_au) {
+    uint32_t pos = disk.size();
+    disk.resize(pos + num_au);
+    for (uint32_t i = 0; i < num_au; i++) {
+      uint32_t p = pos + i;
+      disk[p].chksum = 2 * p + 1;
+      disk[p].refs = 0;
+    }
+    return pos;
+  }
+  void release(uint32_t& au_idx) {
+    if (au_idx != t_onode::empty) {
+      disk_unref(au_idx);
+    }
+    au_idx = t_onode::empty;
+  }
+  void disk_ref(uint32_t au_idx) {
+    ++disk[au_idx].refs;
+  }
+  void disk_unref(uint32_t au_idx) {
+    ceph_assert(disk[au_idx].refs > 0);
+    --disk[au_idx].refs;
+  }
+
+  t_onode create() {
+    t_onode res;
+    res.onode = new BlueStore::Onode(coll.get(), ghobject_t(), "");
+    return res;
+  }
+
+  void fillup(t_onode& onode, uint32_t end) {
+    if (end > onode.data.size()) {
+      size_t e = onode.data.size();
+      onode.data.resize(end);
+      for (; e < end; ++e) {
+	onode.data[e] = t_onode::empty;
+      }
+    }
+  }
+  void punch_hole(t_onode& onode, uint32_t off, uint32_t len) {
+    ceph_assert((off % au_size) == 0);
+    ceph_assert((len % au_size) == 0);
+    uint32_t i = off / au_size;
+    uint32_t end = (off + len) / au_size;
+    fillup(onode, end);
+    while (i < end && i < onode.data.size()) {
+      if (onode.data[i] != t_onode::empty)
+	release(onode.data[i]);
+      onode.data[i] = t_onode::empty;
+      i++;
+    }
+    store.debug_punch_hole(coll, onode.onode, off, len);
+  }
+
+  void write(t_onode& onode, uint32_t off, uint32_t len) {
+    ceph_assert((off % au_size) == 0);
+    ceph_assert((len % au_size) == 0);
+    punch_hole(onode, off, len);
+
+    uint32_t i = off / au_size;
+    uint32_t end = (off + len) / au_size;
+    fillup(onode, end);
+
+    uint32_t au_idx = allocate(end - i);
+    uint32_t idx = au_idx;
+    while (i < end) {
+      onode.data[i] = idx;
+      disk_ref(idx);
+      ++idx;
+      ++i;
+    }
+
+    // below simulation of write performed by BlueStore::do_write()
+    auto helper_blob_write = [&](
+      uint32_t log_off,   // logical offset of blob to put to onode
+      uint32_t empty_aus, // amount of unreferenced aus in the beginning
+      uint32_t first_au,  // first au that will be referenced
+      uint32_t num_aus     // number of aus, first, first+1.. first+num_au-1
+    ) {
+      uint32_t blob_length = (empty_aus + num_aus) * au_size;
+      BlueStore::BlobRef b(new BlueStore::Blob);
+      b->shared_blob = new BlueStore::SharedBlob(coll.get());
+      bluestore_blob_t& bb = b->dirty_blob();
+      bb.init_csum(Checksummer::CSUM_CRC32C, csum_order, blob_length);
+      for(size_t i = 0; i < num_aus; ++i) {
+	bb.set_csum_item(empty_aus + i, disk[first_au + i].chksum);
+      }
+
+      PExtentVector pextents;
+      pextents.emplace_back(first_au * au_size, num_aus * au_size);
+      bb.allocated(empty_aus * au_size, num_aus * au_size, pextents);
+
+      auto *ext = new BlueStore::Extent(log_off, empty_aus * au_size,
+					 num_aus * au_size, b);
+      onode.onode->extent_map.extent_map.insert(*ext);
+      b->get_ref(coll.get(), empty_aus * au_size, num_aus * au_size);
+      bb.mark_used(empty_aus * au_size, num_aus * au_size);
+    };
+
+    size_t off_blob_aligned = p2align(off, blob_size);
+    size_t off_blob_roundup = p2align(off + blob_size, blob_size);
+    uint32_t skip_aus = (off - off_blob_aligned) / au_size;
+    size_t l = std::min<size_t>(off_blob_roundup - off, len);
+    uint32_t num_aus = l / au_size;
+
+    while (len > 0) {
+      helper_blob_write(off, skip_aus, au_idx, num_aus);
+      skip_aus = 0;
+      au_idx += num_aus;
+      len -= num_aus * au_size;
+      off += (skip_aus + num_aus) * au_size;
+      l = std::min<size_t>(blob_size, len);
+      num_aus = l / au_size;
+    };
+  }
+
+  void dup(t_onode& ofrom, t_onode& oto, uint64_t off, uint64_t len) {
+    ceph_assert((off % au_size) == 0);
+    ceph_assert((len % au_size) == 0);
+    punch_hole(oto, off, len);
+
+    uint32_t i = off / au_size;
+    uint32_t end = (off + len) / au_size;
+    fillup(ofrom, end);
+    ceph_assert(end <= ofrom.data.size());
+    while (i < end) {
+      oto.data[i] = ofrom.data[i];
+      if (oto.data[i] != t_onode::empty) {
+	disk_ref(oto.data[i]);
+      }
+      ++i;
+    }
+    BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
+    ofrom.onode->extent_map.dup(&store, &txc, coll, ofrom.onode, oto.onode, off, len, off);
+  }
+
+  int32_t compare(t_onode& onode) {
+    BlueStore::ExtentMap::debug_au_vector_t debug =
+      onode.onode->extent_map.debug_list_disk_layout();
+    size_t pos = 0;
+    for (size_t i = 0; i < debug.size(); ++i) {
+      if (debug[i].disk_offset == -1ULL) {
+	size_t len = debug[i].disk_length;
+	size_t l = len / au_size;
+	if (pos + l > onode.data.size()) {
+	  return pos + l;
+	}
+	while (l > 0) {
+	  if (onode.data[pos] != t_onode::empty) {
+	    return pos;
+	  }
+	  --l;
+	  ++pos;
+	};
+      } else {
+	ceph_assert(pos < onode.data.size());
+	uint32_t au = onode.data[pos];
+	if (debug[i].disk_offset != au * au_size ||
+	    debug[i].disk_length != au_size      ||
+	    debug[i].chksum != disk[au].chksum) {
+	  return pos;
+	}
+	if ((int32_t)debug[i].ref_cnts == -1) {
+	  if (disk[au].refs != 1) {
+	    return pos;
+	  }
+	} else {
+	  if (disk[au].refs != debug[i].ref_cnts) {
+	    return pos;
+	  }
+	}
+	++pos;
+      }
+    }
+    // remaining aus must be empty
+    while (pos < onode.data.size()) {
+      if (onode.data[pos] != t_onode::empty) {
+	return pos;
+      }
+      ++pos;
+    }
+    return -1;
+  }
+
+  bool check(t_onode& onode) {
+    int32_t res = compare(onode);
+    if (res != -1) {
+      cout << "Discrepancy at 0x" << std::hex << res * au_size << std::dec << std::endl;
+      cout << "Simulated: ";
+      print(cout, onode);
+      cout << std::endl;
+      cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout() << std::endl;
+      return false;
+    }
+    return true;
+  }
+  void print(t_onode& onode) {
+    cout << "Simulated: ";
+    print(cout, onode);
+    cout << std::endl;
+    cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout() << std::endl;
+  }
+};
+
+TEST_F(ExtentMapFixture, walk)
+{
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < 100; i++) {
+    X.push_back(create());
+  }
+
+  for (size_t i = 0; i < 100 - 1; i++) {
+    write(X[i], (i + 2) * au_size, 4 * au_size);
+    dup(X[i], X[i+1], (i + 1) * au_size, 8 * au_size);
+  }
+  for (size_t i = 0; i < 100; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
+
+TEST_F(ExtentMapFixture, pyramid)
+{
+  constexpr size_t H = 100;
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < H; i++) {
+    X.push_back(create());
+  }
+  write(X[0], 0, (H * 2 + 1) * au_size);
+
+  for (size_t i = 0; i < H - 1; i++) {
+    dup(X[i], X[i + 1], i * au_size, (H * 2 + 1 - i * 2) * au_size);
+  }
+  for (size_t i = 0; i < H; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
+
+TEST_F(ExtentMapFixture, rain)
+{
+  constexpr size_t H = 100;
+  constexpr size_t W = 100;
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < H; i++) {
+    X.push_back(create());
+  }
+  for (size_t i = 0; i < H - 1; i++) {
+    write(X[i], (rand() % W - 1) * au_size, au_size);
+    dup(X[i], X[i + 1], 0, W * au_size);
+  }
+  for (size_t i = 0; i < H; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
+
+TEST_F(ExtentMapFixture, pollock)
+{
+  constexpr size_t H = 100;
+  constexpr size_t W = 100;
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < H; i++) {
+    X.push_back(create());
+  }
+  for (size_t i = 0; i < H - 1; i++) {
+    size_t w = rand() % (W / 3) + 1;
+    size_t l = rand() % (W - w);
+    write(X[i], l * au_size, w * au_size);
+    w = rand() % (W / 3) + 1;
+    l = rand() % (W - w);
+    dup(X[i], X[i + 1], l * au_size, w * au_size);
+  }
+  for (size_t i = 0; i < H; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
+
+TEST_F(ExtentMapFixture, carousel)
+{
+  constexpr size_t R = 10;
+  constexpr size_t CNT = 300;
+  constexpr size_t W = 100;
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < R; i++) {
+    X.push_back(create());
+  }
+  for (size_t i = 0; i < CNT; i++) {
+    size_t w = rand() % (W / 3) + 1;
+    size_t l = rand() % (W - w);
+    write(X[i % R], l * au_size, w * au_size);
+    w = rand() % (W / 3) + 1;
+    l = rand() % (W - w);
+    dup(X[i % R], X[(i + 1) % R], l * au_size, w * au_size);
+  }
+  for (size_t i = 0; i < R; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
+
+TEST_F(ExtentMapFixture, petri)
+{
+  constexpr size_t R = 10;
+  constexpr size_t CNT = 300;
+  constexpr size_t W = 100;
+  std::vector<t_onode> X;
+  for (size_t i = 0; i < R; i++) {
+    X.push_back(create());
+    write(X[i], 0 * au_size, W * au_size);
+  }
+  for (size_t i = 0; i < CNT; i++) {
+    size_t from = rand() % R;
+    size_t to = from;
+    while (to == from) {
+      to = rand() % R;
+    }
+    size_t w = rand() % (W / 5) + 1;
+    size_t l = rand() % (W - w);
+    dup(X[from], X[to], l * au_size, w * au_size);
+  }
+  for (size_t i = 0; i < R; i++) {
+    ASSERT_EQ(check(X[i]), true);
+  }
+}
 
 TEST(ExtentMap, dup_extent_map)
 {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1286,6 +1286,172 @@ TEST(ExtentMap, compress_extent_map)
 }
 
 
+TEST(ExtentMap, dup_extent_map)
+{
+  BlueStore store(g_ceph_context, "", 4096);
+  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
+    g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
+    g_ceph_context, "lru", NULL);
+
+  size_t csum_order = 12; //1^12 = 4096 bytes
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
+  std::unique_ptr<ceph::Formatter> formatter(Formatter::create("json"));
+
+  ///////////////////////////
+  //constructing onode1
+  BlueStore::OnodeRef onode1(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  
+  //BlueStore::ExtentMap em1(&onode1,
+  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap& em1 = onode1->extent_map;
+  ///////////////////////////
+  // constructing extent/Blob: 0x0~2000 at <0x100000~2000>
+  size_t ext1_offs = 0x0;
+  size_t ext1_len = 0x2000;
+  size_t ext1_boffs = 0x0;
+  BlueStore::BlobRef b1(new BlueStore::Blob);
+  b1->shared_blob = new BlueStore::SharedBlob(coll.get());
+  auto &_b1 = b1->dirty_blob();
+  _b1.init_csum(Checksummer::CSUM_CRC32C, csum_order, ext1_len);
+  for(size_t i = 0; i < _b1.get_csum_count(); i++) {
+    *(_b1.get_csum_item_ptr(i)) = i + 1;
+  }
+  PExtentVector pextents;
+  pextents.emplace_back(0x100000, ext1_len);
+  _b1.allocated(0, ext1_len, pextents);
+
+  auto *ext1 = new BlueStore::Extent(ext1_offs, ext1_boffs, ext1_len, b1);
+  em1.extent_map.insert(*ext1);
+  b1->get_ref(coll.get(), ext1->blob_offset, ext1->length);
+  _b1.mark_used(ext1->blob_offset, ext1->length);
+
+  ///////////////////////////
+  //constructing onode2 which is a full clone from onode1
+  BlueStore::OnodeRef onode2(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  //BlueStore::ExtentMap em2(&onode2,
+  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap& em2 = onode2->extent_map;
+  {
+    BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
+
+    //em1.dup(&store, &txc, coll, em2, ext1_offs, ext1_len, ext1_offs);
+    onode1->extent_map.dup(&store, &txc, coll, onode1, onode2, ext1_offs, ext1_len, ext1_offs);
+
+    em1.dump(formatter.get()); // see the log if any
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+    em2.dump(formatter.get());
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+
+    ASSERT_TRUE(b1->get_blob().is_shared());
+    ASSERT_EQ(b1->get_referenced_bytes(), ext1_len);
+
+    BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
+    ASSERT_TRUE(b2->get_blob().is_shared());
+    ASSERT_EQ(b2->get_referenced_bytes(), ext1_len);
+    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
+    auto &_b2 = b2->get_blob();
+    ASSERT_EQ(_b1.get_csum_count(), _b2.get_csum_count());
+    for(size_t i = 0; i < _b2.get_csum_count(); i++) {
+      ASSERT_EQ(*(_b1.get_csum_item_ptr(i)), *(_b2.get_csum_item_ptr(i)));
+    }
+  }
+
+  ///////////////////////////
+  //constructing onode3 which is partial clone (tail part) from onode2
+  BlueStore::OnodeRef onode3(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  //BlueStore::ExtentMap em3(&onode3,
+  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap& em3 = onode3->extent_map;
+  {
+    size_t clone_shift = 0x1000;
+    ceph_assert(ext1_len > clone_shift);
+    size_t clone_offs = ext1_offs + clone_shift;
+    size_t clone_len = ext1_len - clone_shift;
+    BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
+
+    onode1->extent_map.dup(&store, &txc, coll, onode1, onode3, clone_offs, clone_len, clone_offs);
+    em1.dump(formatter.get()); // see the log if any
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+    em3.dump(formatter.get());
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+
+    // make sure (basically) onode1&2 are unmodified
+    BlueStore::BlobRef b1 = em1.seek_lextent(ext1_offs)->blob;
+    BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
+    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
+
+    BlueStore::Extent &ext3 = *em3.seek_lextent(clone_offs);
+    ASSERT_EQ(ext3.blob_offset, clone_shift);
+    ASSERT_EQ(ext3.length, clone_len);
+    BlueStore::BlobRef b3 = ext3.blob;
+    ASSERT_TRUE(b3->get_blob().is_shared());
+    ASSERT_EQ(b3->shared_blob, b1->shared_blob);
+    ASSERT_EQ(b3->get_referenced_bytes(), clone_len);
+    auto ll = b3->get_blob().get_logical_length();
+    ASSERT_EQ(ll, ext1_len);
+    auto &_b3 = b3->get_blob();
+    ASSERT_EQ(_b1.get_csum_count(), _b3.get_csum_count());
+    for(size_t i = 0; i < _b3.get_csum_count(); i++) {
+      ASSERT_EQ(*(_b1.get_csum_item_ptr(i)), *(_b3.get_csum_item_ptr(i)));
+    }
+  }
+
+  ///////////////////////////
+  //constructing onode4 which is partial clone (head part) from onode2
+  BlueStore::OnodeRef onode4(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  //BlueStore::ExtentMap em4(&onode4,
+  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap& em4 = onode4->extent_map;
+
+  {
+    size_t clone_shift = 0;
+    size_t clone_len = 0x1000;
+    ceph_assert(ext1_len >= clone_shift + clone_len);
+    size_t clone_offs = ext1_offs + clone_shift;
+    BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
+
+    onode2->extent_map.dup(&store, &txc, coll, onode2, onode4, clone_offs, clone_len, clone_offs);
+    em2.dump(formatter.get()); // see the log if any
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+    em4.dump(formatter.get());
+    formatter->flush(std::cout);
+    std::cout << std::endl;
+
+    // make sure (basically) onode1&2 are unmodified
+    BlueStore::BlobRef b1 = em1.seek_lextent(ext1_offs)->blob;
+    BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
+    BlueStore::BlobRef b3 = em3.seek_lextent(ext1_offs)->blob;
+    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
+    ASSERT_EQ(b1->shared_blob, b3->shared_blob);
+    auto &_b2 = b2->get_blob();
+
+    BlueStore::Extent &ext4 = *em4.seek_lextent(clone_offs);
+    ASSERT_EQ(ext4.blob_offset, clone_shift);
+    ASSERT_EQ(ext4.length, clone_len);
+    BlueStore::BlobRef b4 = ext4.blob;
+    ASSERT_TRUE(b4->get_blob().is_shared());
+    ASSERT_EQ(b4->shared_blob, b2->shared_blob);
+    ASSERT_EQ(b4->get_referenced_bytes(), clone_len);
+    auto &_b4 = b4->get_blob();
+    auto ll = _b4.get_logical_length();
+    auto csum_entries = ll / (1 << csum_order);
+    ASSERT_EQ(ll, clone_len);
+    ASSERT_EQ(csum_entries, _b4.get_csum_count());
+
+    ASSERT_GT(_b2.get_csum_count(), csum_entries);
+    for(size_t i = 0; i < csum_entries; i++) {
+      ASSERT_EQ(*(_b2.get_csum_item_ptr(i)), *(_b4.get_csum_item_ptr(i)));
+    }
+  }
+}
+
+
 void clear_and_dispose(BlueStore::old_extent_map_t& old_em)
 {
   auto oep = old_em.begin();

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1332,6 +1332,9 @@ public:
   }
 
   void SetUp() override {
+#ifndef WITH_ESB
+    GTEST_SKIP() << "ESB(elastic shared blob) is off";
+#endif
   }
   void TearDown() override {
   }
@@ -1662,6 +1665,9 @@ TEST_F(ExtentMapFixture, petri)
 
 TEST(ExtentMap, dup_extent_map)
 {
+#ifndef WITH_ESB
+  GTEST_SKIP() << "ESB(elastic shared blob) is off";
+#endif
   BlueStore store(g_ceph_context, "", 4096);
   BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
     g_ceph_context, "lru", NULL);

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -11,6 +11,7 @@
 #include "include/buffer_fwd.h"
 #ifdef WITH_BLUESTORE
 #include "os/bluestore/BlueStore.h"
+#include "os/bluestore/BlueStore_exp.h"
 #endif
 
 class KeyValueDB;
@@ -20,14 +21,18 @@ class StoreTool
 #ifdef WITH_BLUESTORE
   struct Deleter {
     BlueStore *bluestore;
+    ceph::experimental::BlueStore *bluestorex;
     Deleter()
-      : bluestore(nullptr) {}
-    Deleter(BlueStore *store)
-      : bluestore(store) {}
+      : bluestore(nullptr), bluestorex(nullptr) {}
+    Deleter(BlueStore *store, ceph::experimental::BlueStore *storex)
+      : bluestore(store), bluestorex(storex) {}
     void operator()(KeyValueDB *db) {
       if (bluestore) {
 	bluestore->umount();
 	delete bluestore;
+      } else if (bluestorex) {
+	bluestorex->umount();
+	delete bluestorex;
       } else {
 	delete db;
       }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -222,6 +222,7 @@ options:
 	--rgw_compression specify the rgw compression plugin
 	--seastore use seastore as crimson osd backend
 	-b, --bluestore use bluestore as the osd objectstore backend (default)
+	--bluestore-rdr use experimental, RDR variant of bluestore as the osd objectstore backend
 	-f, --filestore use filestore as the osd objectstore backend
 	-K, --kstore use kstore as the osd objectstore backend
 	--cyanstore use cyanstore as the osd objectstore backend
@@ -452,6 +453,9 @@ case $1 in
         ;;
     -b | --bluestore)
         objectstore="bluestore"
+        ;;
+    --bluestore-rdr)
+        objectstore="bluestore-rdr"
         ;;
     -f | --filestore)
         objectstore="filestore"
@@ -714,7 +718,7 @@ EOF
         COSDSHORT="        osd max object name len = 460
         osd max object namespace len = 64"
     fi
-    if [ "$objectstore" == "bluestore" ]; then
+    if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr"]; then
         if [ "$spdk_enabled" -eq 1 ]; then
             BLUESTORE_OPTS="        bluestore_block_db_path = \"\"
         bluestore_block_db_size = 0
@@ -979,7 +983,7 @@ EOF
                     ln -s ${secondary_block_devs[$osd]} $CEPH_DEV_DIR/osd$osd/block.segmented.1
                 fi
             fi
-            if [ "$objectstore" == "bluestore" ]; then
+            if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr"]; then
                 wconf <<EOF
         bluestore fsck on mount = false
 EOF

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -718,7 +718,7 @@ EOF
         COSDSHORT="        osd max object name len = 460
         osd max object namespace len = 64"
     fi
-    if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr"]; then
+    if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr" ]; then
         if [ "$spdk_enabled" -eq 1 ]; then
             BLUESTORE_OPTS="        bluestore_block_db_path = \"\"
         bluestore_block_db_size = 0
@@ -983,7 +983,7 @@ EOF
                     ln -s ${secondary_block_devs[$osd]} $CEPH_DEV_DIR/osd$osd/block.segmented.1
                 fi
             fi
-            if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr"]; then
+            if [ "$objectstore" == "bluestore" -o "$objectstore" == "bluestore-rdr" ]; then
                 wconf <<EOF
         bluestore fsck on mount = false
 EOF


### PR DESCRIPTION
This is continuation of work in:
https://github.com/rzarzynski/ceph/commits/wip-os-bluestore-exp-quincy2
which in turn bases on 
https://github.com/ceph/ceph/pull/51451

New coding to allow tools to work on both bluestore and bluestore-rdr.
Related tools are: ceph-kvstore-tool and ceph-bluestore-tool.

Minor fixes to rdr implementation.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
