### PR TITLE
quincy: ceph-volume: set lvm membership for mpath type devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -226,7 +226,7 @@ class Device(object):
             self.disk_api = dev
             device_type = dev.get('TYPE', '')
             # always check is this is an lvm member
-            valid_types = ['part', 'disk']
+            valid_types = ['part', 'disk', 'mpath']
             if allow_loop_devices():
                 valid_types.append('loop')
             if device_type in valid_types:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61699

---

backport of https://github.com/ceph/ceph/pull/52058
parent tracker: https://tracker.ceph.com/issues/61673

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh