### PR TITLE
librbd: avoid object map corruption in snapshots taken under I/O

### DIFF
--- a/qa/suites/krbd/thrash/workloads/krbd_diff_continuous.yaml
+++ b/qa/suites/krbd/thrash/workloads/krbd_diff_continuous.yaml
@@ -1,0 +1,12 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+        - pv
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/diff_continuous.sh
+    env:
+      RBD_DEVICE_TYPE: "krbd"

--- a/qa/suites/rbd/nbd/workloads/rbd_nbd_diff_continuous.yaml
+++ b/qa/suites/rbd/nbd/workloads/rbd_nbd_diff_continuous.yaml
@@ -1,0 +1,14 @@
+overrides:
+  install:
+    ceph:
+      extra_packages:
+        - rbd-nbd
+      extra_system_packages:
+        - pv
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/diff_continuous.sh
+    env:
+      RBD_DEVICE_TYPE: "nbd"

--- a/qa/workunits/rbd/diff_continuous.sh
+++ b/qa/workunits/rbd/diff_continuous.sh
@@ -1,60 +1,106 @@
 #!/usr/bin/env bash
+
 set -ex
+set -o pipefail
 
-max=20
-size=1500
-
-iosize=16384
-iototal=16384000
-iothreads=16
-
-parent=`uuidgen`"-parent"
-src=`uuidgen`"-src";
-dst=`uuidgen`"-dst";
-
-function cleanup() {
-    rbd snap purge $src || :
-    rbd rm $src || :
-    rbd snap purge $dst || :
-    rbd rm $dst || :
-    rbd snap unprotect $parent --snap parent || :
-    rbd snap purge $parent || :
-    rbd rm $parent || :
+function untar_workload() {
+    local i
+    for ((i = 0; i < 10; i++)); do
+        pv -L 10M linux-5.4.tar.gz > "${MOUNT}/linux-5.4.tar.gz"
+        tar -C "${MOUNT}" -xzf "${MOUNT}/linux-5.4.tar.gz"
+        sync "${MOUNT}"
+        rm -rf "${MOUNT}"/linux-5.4*
+    done
 }
-trap cleanup EXIT
 
-# start from a clone
-rbd create $parent --size $size --image-format 2 --stripe-count 8 --stripe-unit 65536
-rbd bench --io-type write $parent --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand
-rbd snap create $parent --snap parent
-rbd snap protect $parent --snap parent
-rbd clone $parent@parent $src --stripe-count 4 --stripe-unit 262144
-rbd create $dst --size $size --image-format 2 --order 19
+function check_object_map() {
+    local spec="$1"
 
-# mirror for a while
-for s in `seq 1 $max`; do
-    rbd snap create $src --snap=snap$s
-    rbd export-diff $src@snap$s - $lastsnap | rbd import-diff - $dst  &
-    rbd bench --io-type write $src --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand  &
-    wait
-    lastsnap="--from-snap snap$s"
+    rbd object-map check "${spec}"
+
+    local flags
+    flags="$(rbd info "${spec}" | grep 'flags: ')"
+    if [[ "${flags}" =~ object\ map\ invalid ]]; then
+        echo "Object map invalid at ${spec}"
+        exit 1
+    fi
+    if [[ "${flags}" =~ fast\ diff\ invalid ]]; then
+        echo "Fast diff invalid at ${spec}"
+        exit 1
+    fi
+}
+
+# RBD_DEVICE_TYPE is intended to be set from yaml, default to krbd
+readonly DEVICE_TYPE="${RBD_DEVICE_TYPE:-krbd}"
+
+BASE_UUID="$(uuidgen)"
+readonly BASE_UUID
+
+readonly SIZE="2G"
+readonly SRC="${BASE_UUID}-src"
+readonly DST="${BASE_UUID}-dst"
+readonly MOUNT="${BASE_UUID}-mnt"
+
+rbd create -s "${SIZE}" --stripe-unit 64K --stripe-count 8 \
+    --image-feature exclusive-lock,object-map,fast-diff "${SRC}"
+rbd create -s "${SIZE}" --object-size 512K "${DST}"
+
+dev="$(sudo rbd device map -t "${DEVICE_TYPE}" "${SRC}")"
+sudo mkfs.ext4 "${dev}"
+mkdir "${MOUNT}"
+sudo mount "${dev}" "${MOUNT}"
+sudo chown "$(whoami)" "${MOUNT}"
+
+# start untar in the background
+wget https://download.ceph.com/qa/linux-5.4.tar.gz
+untar_workload &
+untar_pid=$!
+
+# export initial incremental
+snap_num=1
+rbd snap create "${SRC}@snap${snap_num}"
+rbd export-diff "${SRC}@snap${snap_num}" "${BASE_UUID}@snap${snap_num}.diff"
+
+# keep exporting successive incrementals while untar is running
+while kill -0 "${untar_pid}"; do
+    snap_num=$((snap_num + 1))
+    rbd snap create "${SRC}@snap${snap_num}"
+    sleep $((RANDOM % 4 + 1))
+    rbd export-diff --whole-object --from-snap "snap$((snap_num - 1))" \
+        "${SRC}@snap${snap_num}" "${BASE_UUID}@snap${snap_num}.diff"
 done
 
-#trap "" EXIT
-#exit 0
+sudo umount "${MOUNT}"
+sudo rbd device unmap -t "${DEVICE_TYPE}" "${dev}"
+
+if ! wait "${untar_pid}"; then
+    echo "untar_workload failed"
+    exit 1
+fi
+
+echo "Exported ${snap_num} incrementals"
+if ((snap_num < 30)); then
+    echo "Too few incrementals"
+    exit 1
+fi
 
 # validate
-for s in `seq 1 $max`; do
-    ssum=`rbd export $src@snap$s - | md5sum`
-    dsum=`rbd export $dst@snap$s - | md5sum`
-    if [ "$ssum" != "$dsum" ]; then
-	echo different sum at snap$s
-	exit 1
+for ((i = 1; i <= snap_num; i++)); do
+    rbd import-diff "${BASE_UUID}@snap${i}.diff" "${DST}"
+    src_sum="$(rbd export "${SRC}@snap${i}" - | md5sum | awk '{print $1}')"
+    dst_sum="$(rbd export "${DST}@snap${i}" - | md5sum | awk '{print $1}')"
+    if [[ "${src_sum}" != "${dst_sum}" ]]; then
+        echo "Mismatch at snap${i}: ${src_sum} != ${dst_sum}"
+        exit 1
     fi
+    check_object_map "${SRC}@snap${i}"
+    # FIXME: this reproduces http://tracker.ceph.com/issues/37876
+    # there is no fstrim involved but "rbd import-diff" can produce
+    # write-zeroes requests which turn into discards under the hood
+    # actual: EXISTS, expected: EXISTS_CLEAN inconsistency is harmless
+    # from a data integrity POV and data is validated above regardless,
+    # so just waive it for now
+    #check_object_map "${DST}@snap${i}"
 done
 
-cleanup
-trap "" EXIT
-
 echo OK
-

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -269,8 +269,7 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
 
   auto req = io::ImageDispatchSpec::create_write(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-      {{off, len}}, io::ImageArea::DATA, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+      {{off, len}}, io::ImageArea::DATA, std::move(bl), op_flags, trace);
   req->send();
 }
 
@@ -301,8 +300,7 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
 
   auto req = io::ImageDispatchSpec::create_discard(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes,
-      image_ctx.get_data_io_context(), trace);
+      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -334,8 +332,7 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
 
   auto req = io::ImageDispatchSpec::create_write_same(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-      {{off, len}}, io::ImageArea::DATA, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+      {{off, len}}, io::ImageArea::DATA, std::move(bl), op_flags, trace);
   req->send();
 }
 
@@ -408,8 +405,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       aio_comp->aio_type = io::AIO_TYPE_WRITE;
       auto req = io::ImageDispatchSpec::create_write(
           image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{off, len}}, io::ImageArea::DATA, std::move(bl),
-          image_ctx.get_data_io_context(), op_flags, trace);
+          {{off, len}}, io::ImageArea::DATA, std::move(bl), op_flags, trace);
       req->send();
       return;
     } else if (prepend_length == 0 && append_length == 0) {
@@ -419,8 +415,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
       auto req = io::ImageDispatchSpec::create_write_same(
           image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{off, len}}, io::ImageArea::DATA, std::move(bl),
-          image_ctx.get_data_io_context(), op_flags, trace);
+          {{off, len}}, io::ImageArea::DATA, std::move(bl), op_flags, trace);
       req->send();
       return;
     }
@@ -449,7 +444,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto prepend_req = io::ImageDispatchSpec::create_write(
           image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
           {{prepend_offset, prepend_length}}, io::ImageArea::DATA,
-          std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          std::move(bl), op_flags, trace);
       prepend_req->send();
     }
 
@@ -463,7 +458,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto append_req = io::ImageDispatchSpec::create_write(
           image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
           {{append_offset, append_length}}, io::ImageArea::DATA,
-          std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          std::move(bl), op_flags, trace);
       append_req->send();
     }
 
@@ -476,7 +471,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
     auto req = io::ImageDispatchSpec::create_write_same(
         image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
         {{write_same_offset, write_same_length}}, io::ImageArea::DATA,
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+        std::move(bl), op_flags, trace);
     req->send();
     return;
   }
@@ -486,8 +481,7 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
   auto req = io::ImageDispatchSpec::create_discard(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes,
-      image_ctx.get_data_io_context(), trace);
+      {{off, len}}, io::ImageArea::DATA, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -522,7 +516,7 @@ void Io<I>::aio_compare_and_write(I &image_ctx, io::AioCompletion *aio_comp,
   auto req = io::ImageDispatchSpec::create_compare_and_write(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
       {{off, len}}, io::ImageArea::DATA, std::move(cmp_bl), std::move(bl),
-      mismatch_off, image_ctx.get_data_io_context(), op_flags, trace);
+      mismatch_off, op_flags, trace);
   req->send();
 }
 

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -56,7 +56,7 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
   auto req = io::ImageDispatchSpec::create_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), io::ImageArea::DATA, std::move(bl),
-    image_ctx->get_data_io_context(), fadvise_flags, trace);
+    fadvise_flags, trace);
   req->send();
 }
 
@@ -75,8 +75,7 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_discard(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    {{offset, length}}, io::ImageArea::DATA, discard_granularity_bytes,
-    image_ctx->get_data_io_context(), trace);
+    {{offset, length}}, io::ImageArea::DATA, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -114,7 +113,7 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
   auto req = io::ImageDispatchSpec::create_write_same(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     {{offset, length}}, io::ImageArea::DATA, std::move(bl),
-    image_ctx->get_data_io_context(), fadvise_flags, trace);
+    fadvise_flags, trace);
   req->send();
 }
 
@@ -136,8 +135,7 @@ void ImageWriteback<I>::aio_compare_and_write(Extents &&image_extents,
   auto req = io::ImageDispatchSpec::create_compare_and_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), io::ImageArea::DATA, std::move(cmp_bl),
-    std::move(bl), mismatch_offset, image_ctx->get_data_io_context(),
-    fadvise_flags, trace);
+    std::move(bl), mismatch_offset, fadvise_flags, trace);
   req->send();
 }
 

--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -71,7 +71,7 @@ bool WriteLogImageDispatch<I>::read(
 template <typename I>
 bool WriteLogImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -97,8 +97,7 @@ bool WriteLogImageDispatch<I>::write(
 template <typename I>
 bool WriteLogImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -126,10 +125,9 @@ bool WriteLogImageDispatch<I>::discard(
 
 template <typename I>
 bool WriteLogImageDispatch<I>::write_same(
-    io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    bufferlist &&bl, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {
@@ -156,10 +154,10 @@ bool WriteLogImageDispatch<I>::write_same(
 
 template <typename I>
 bool WriteLogImageDispatch<I>::compare_and_write(
-    io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    io::AioCompletion* aio_comp, io::Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   if (*image_dispatch_flags & io::IMAGE_DISPATCH_FLAG_CRYPTO_HEADER) {

--- a/src/librbd/cache/WriteLogImageDispatch.h
+++ b/src/librbd/cache/WriteLogImageDispatch.h
@@ -48,30 +48,27 @@ public:
       Context* on_dispatched) override;
     bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -35,10 +35,9 @@ public:
   }
 
   bool write(
-      io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -46,19 +45,17 @@ public:
 
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
   }
 
   bool write_same(
-      io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -67,7 +64,7 @@ public:
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/crypto/luks/FlattenRequest.cc
+++ b/src/librbd/crypto/luks/FlattenRequest.cc
@@ -97,7 +97,7 @@ void FlattenRequest<I>::write_header() {
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
           {{0, m_bl.length()}}, io::ImageArea::CRYPTO_HEADER,
-          std::move(m_bl), m_image_ctx->get_data_io_context(), 0, trace);
+          std::move(m_bl), 0, trace);
   req->send();
 }
 

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -167,8 +167,7 @@ void FormatRequest<I>::send() {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, bl.length()}}, io::ImageArea::DATA, std::move(bl),
-          m_image_ctx->get_data_io_context(), 0, trace);
+          {{0, bl.length()}}, io::ImageArea::DATA, std::move(bl), 0, trace);
   req->send();
 }
 

--- a/src/librbd/exclusive_lock/ImageDispatch.cc
+++ b/src/librbd/exclusive_lock/ImageDispatch.cc
@@ -125,7 +125,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -143,9 +143,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -162,7 +161,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -181,7 +180,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/exclusive_lock/ImageDispatch.h
+++ b/src/librbd/exclusive_lock/ImageDispatch.h
@@ -58,27 +58,26 @@ public:
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -75,8 +75,7 @@ bool ImageDispatch<I>::write(
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
   ImageRequest<I>::aio_write(m_image_ctx, aio_comp, std::move(image_extents),
-                             area, std::move(bl), io_context, op_flags,
-                             parent_trace);
+                             area, std::move(bl), op_flags, parent_trace);
   return true;
 }
 
@@ -97,8 +96,7 @@ bool ImageDispatch<I>::discard(
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
   ImageRequest<I>::aio_discard(m_image_ctx, aio_comp, std::move(image_extents),
-                               area, discard_granularity_bytes, io_context,
-                               parent_trace);
+                               area, discard_granularity_bytes, parent_trace);
   return true;
 }
 
@@ -119,7 +117,7 @@ bool ImageDispatch<I>::write_same(
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
   ImageRequest<I>::aio_writesame(m_image_ctx, aio_comp,
                                  std::move(image_extents), area, std::move(bl),
-                                 io_context, op_flags, parent_trace);
+                                 op_flags, parent_trace);
   return true;
 }
 
@@ -142,7 +140,7 @@ bool ImageDispatch<I>::compare_and_write(
   ImageRequest<I>::aio_compare_and_write(m_image_ctx, aio_comp,
                                          std::move(image_extents), area,
                                          std::move(cmp_bl), std::move(bl),
-                                         mismatch_offset, io_context, op_flags,
+                                         mismatch_offset, op_flags,
                                          parent_trace);
   return true;
 }

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -62,7 +62,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -82,9 +82,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -103,7 +102,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -123,10 +122,10 @@ bool ImageDispatch<I>::write_same(
 
 template <typename I>
 bool ImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/ImageDispatch.h
+++ b/src/librbd/io/ImageDispatch.h
@@ -42,28 +42,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -40,28 +40,27 @@ struct ImageDispatchInterface {
       Context* on_dispatched) = 0;
   virtual bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool flush(

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -139,39 +139,36 @@ public:
   static ImageDispatchSpec* create_discard(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace) {
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents), area,
                                  Discard{discard_granularity_bytes},
-                                 io_context, 0, parent_trace);
+                                 {}, 0, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_write(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace) {
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents), area,
                                  Write{std::move(bl)},
-                                 io_context, op_flags, parent_trace);
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_write_same(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace) {
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents), area,
                                  WriteSame{std::move(bl)},
-                                 io_context, op_flags, parent_trace);
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
@@ -179,14 +176,14 @@ public:
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace) {
+      int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents), area,
                                  CompareAndWrite{std::move(cmp_bl),
                                                  std::move(bl),
                                                  mismatch_offset},
-                                 io_context, op_flags, parent_trace);
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -53,9 +53,8 @@ struct ImageDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
     return image_dispatch->discard(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents),
-      discard.discard_granularity_bytes, image_dispatch_spec->io_context,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      discard.discard_granularity_bytes, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
@@ -65,33 +64,31 @@ struct ImageDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
     return image_dispatch->write(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents), std::move(write.bl),
-      image_dispatch_spec->io_context, image_dispatch_spec->op_flags,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
   }
 
-  bool  operator()(ImageDispatchSpec::WriteSame& write_same) const {
+  bool operator()(ImageDispatchSpec::WriteSame& write_same) const {
     return image_dispatch->write_same(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents), std::move(write_same.bl),
-      image_dispatch_spec->io_context, image_dispatch_spec->op_flags,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
   }
 
-  bool  operator()(
+  bool operator()(
       ImageDispatchSpec::CompareAndWrite& compare_and_write) const {
     return image_dispatch->compare_and_write(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents),
       std::move(compare_and_write.cmp_bl), std::move(compare_and_write.bl),
-      compare_and_write.mismatch_offset, image_dispatch_spec->io_context,
+      compare_and_write.mismatch_offset,
       image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
       image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -38,26 +38,23 @@ public:
                        const ZTracer::Trace &parent_trace);
   static void aio_write(ImageCtxT *ictx, AioCompletion *c,
                         Extents &&image_extents, ImageArea area,
-                        bufferlist &&bl, IOContext io_context, int op_flags,
+                        bufferlist &&bl, int op_flags,
 			const ZTracer::Trace &parent_trace);
   static void aio_discard(ImageCtxT *ictx, AioCompletion *c,
                           Extents &&image_extents, ImageArea area,
                           uint32_t discard_granularity_bytes,
-                          IOContext io_context,
                           const ZTracer::Trace &parent_trace);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c,
                         FlushSource flush_source,
                         const ZTracer::Trace &parent_trace);
   static void aio_writesame(ImageCtxT *ictx, AioCompletion *c,
                             Extents &&image_extents, ImageArea area,
-                            bufferlist &&bl, IOContext io_context, int op_flags,
+                            bufferlist &&bl, int op_flags,
                             const ZTracer::Trace &parent_trace);
-
   static void aio_compare_and_write(ImageCtxT *ictx, AioCompletion *c,
                                     Extents &&image_extents, ImageArea area,
-                                    bufferlist &&cmp_bl,
-                                    bufferlist &&bl, uint64_t *mismatch_offset,
-                                    IOContext io_context, int op_flags,
+                                    bufferlist &&cmp_bl, bufferlist &&bl,
+                                    uint64_t *mismatch_offset, int op_flags,
                                     const ZTracer::Trace &parent_trace);
 
   void send();
@@ -73,15 +70,13 @@ protected:
   AioCompletion *m_aio_comp;
   Extents m_image_extents;
   ImageArea m_image_area;
-  IOContext m_io_context;
   ZTracer::Trace m_trace;
 
   ImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
-               Extents &&image_extents, ImageArea area, IOContext io_context,
-               const char *trace_name, const ZTracer::Trace &parent_trace)
+               Extents &&image_extents, ImageArea area, const char *trace_name,
+               const ZTracer::Trace &parent_trace)
     : m_image_ctx(image_ctx), m_aio_comp(aio_comp),
       m_image_extents(std::move(image_extents)), m_image_area(area),
-      m_io_context(io_context),
       m_trace(librbd::util::create_trace(image_ctx, trace_name, parent_trace)) {
     m_trace.event("start");
   }
@@ -110,7 +105,9 @@ protected:
   const char *get_request_type() const override {
     return "aio_read";
   }
+
 private:
+  IOContext m_io_context;
   int m_op_flags;
   int m_read_flags;
 };
@@ -127,10 +124,10 @@ protected:
 
   AbstractImageWriteRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                             Extents &&image_extents, ImageArea area,
-                            IOContext io_context, const char *trace_name,
+                            const char *trace_name,
 			    const ZTracer::Trace &parent_trace)
     : ImageRequest<ImageCtxT>(image_ctx, aio_comp, std::move(image_extents),
-                              area, io_context, trace_name, parent_trace),
+                              area, trace_name, parent_trace),
       m_synchronous(false) {
   }
 
@@ -159,10 +156,9 @@ class ImageWriteRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageWriteRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                     Extents &&image_extents, ImageArea area, bufferlist &&bl,
-                    IOContext io_context, int op_flags,
-		    const ZTracer::Trace &parent_trace)
+                    int op_flags, const ZTracer::Trace &parent_trace)
     : AbstractImageWriteRequest<ImageCtxT>(
-        image_ctx, aio_comp, std::move(image_extents), area, io_context,
+        image_ctx, aio_comp, std::move(image_extents), area,
         "write", parent_trace),
       m_bl(std::move(bl)), m_op_flags(op_flags) {
   }
@@ -197,10 +193,10 @@ class ImageDiscardRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageDiscardRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                       Extents&& image_extents, ImageArea area,
-		      uint32_t discard_granularity_bytes, IOContext io_context,
+                      uint32_t discard_granularity_bytes,
                       const ZTracer::Trace &parent_trace)
     : AbstractImageWriteRequest<ImageCtxT>(
-        image_ctx, aio_comp, std::move(image_extents), area, io_context,
+        image_ctx, aio_comp, std::move(image_extents), area,
         "discard", parent_trace),
       m_discard_granularity_bytes(discard_granularity_bytes) {
   }
@@ -237,7 +233,7 @@ public:
                     const ZTracer::Trace &parent_trace)
     : ImageRequest<ImageCtxT>(image_ctx, aio_comp, {},
                               ImageArea::DATA /* dummy for {} */,
-                              {}, "flush", parent_trace),
+                              "flush", parent_trace),
       m_flush_source(flush_source) {
   }
 
@@ -265,10 +261,10 @@ class ImageWriteSameRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageWriteSameRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                         Extents&& image_extents, ImageArea area,
-                        bufferlist &&bl, IOContext io_context, int op_flags,
+                        bufferlist &&bl, int op_flags,
                         const ZTracer::Trace &parent_trace)
     : AbstractImageWriteRequest<ImageCtxT>(
-        image_ctx, aio_comp, std::move(image_extents), area, io_context,
+        image_ctx, aio_comp, std::move(image_extents), area,
         "writesame", parent_trace),
       m_data_bl(std::move(bl)), m_op_flags(op_flags) {
   }
@@ -302,10 +298,10 @@ public:
   ImageCompareAndWriteRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                               Extents &&image_extents, ImageArea area,
                               bufferlist &&cmp_bl, bufferlist &&bl,
-                              uint64_t *mismatch_offset, IOContext io_context,
-                              int op_flags, const ZTracer::Trace &parent_trace)
+                              uint64_t *mismatch_offset, int op_flags,
+                              const ZTracer::Trace &parent_trace)
       : AbstractImageWriteRequest<ImageCtxT>(
-          image_ctx, aio_comp, std::move(image_extents), area, io_context,
+          image_ctx, aio_comp, std::move(image_extents), area,
           "compare_and_write", parent_trace),
         m_cmp_bl(std::move(cmp_bl)), m_bl(std::move(bl)),
         m_mismatch_offset(mismatch_offset), m_op_flags(op_flags) {

--- a/src/librbd/io/QosImageDispatch.cc
+++ b/src/librbd/io/QosImageDispatch.cc
@@ -144,7 +144,7 @@ bool QosImageDispatch<I>::read(
 template <typename I>
 bool QosImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -167,9 +167,8 @@ bool QosImageDispatch<I>::write(
 template <typename I>
 bool QosImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -191,7 +190,7 @@ bool QosImageDispatch<I>::discard(
 template <typename I>
 bool QosImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -213,10 +212,10 @@ bool QosImageDispatch<I>::write_same(
 
 template <typename I>
 bool QosImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -62,28 +62,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -54,7 +54,7 @@ bool QueueImageDispatch<I>::read(
 template <typename I>
 bool QueueImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -67,8 +67,7 @@ bool QueueImageDispatch<I>::write(
 template <typename I>
 bool QueueImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -81,7 +80,7 @@ bool QueueImageDispatch<I>::discard(
 template <typename I>
 bool QueueImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -93,10 +92,10 @@ bool QueueImageDispatch<I>::write_same(
 
 template <typename I>
 bool QueueImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/QueueImageDispatch.h
+++ b/src/librbd/io/QueueImageDispatch.h
@@ -46,28 +46,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/RefreshImageDispatch.cc
+++ b/src/librbd/io/RefreshImageDispatch.cc
@@ -49,7 +49,7 @@ bool RefreshImageDispatch<I>::read(
 template <typename I>
 bool RefreshImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -67,9 +67,8 @@ bool RefreshImageDispatch<I>::write(
 template <typename I>
 bool RefreshImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -86,7 +85,7 @@ bool RefreshImageDispatch<I>::discard(
 template <typename I>
 bool RefreshImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -103,10 +102,10 @@ bool RefreshImageDispatch<I>::write_same(
 
 template <typename I>
 bool RefreshImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/RefreshImageDispatch.h
+++ b/src/librbd/io/RefreshImageDispatch.h
@@ -42,28 +42,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/WriteBlockImageDispatch.cc
+++ b/src/librbd/io/WriteBlockImageDispatch.cc
@@ -127,7 +127,7 @@ void WriteBlockImageDispatch<I>::wait_on_writes_unblocked(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -140,9 +140,8 @@ bool WriteBlockImageDispatch<I>::write(
 template <typename I>
 bool WriteBlockImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -154,7 +153,7 @@ bool WriteBlockImageDispatch<I>::discard(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -166,10 +165,10 @@ bool WriteBlockImageDispatch<I>::write_same(
 
 template <typename I>
 bool WriteBlockImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/WriteBlockImageDispatch.h
+++ b/src/librbd/io/WriteBlockImageDispatch.h
@@ -57,28 +57,27 @@ public:
   }
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -357,8 +357,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
     io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp,
                                      {{event.offset, event.length}},
                                      io::ImageArea::DATA,
-                                     event.discard_granularity_bytes,
-                                     m_image_ctx.get_data_io_context(), {});
+                                     event.discard_granularity_bytes, {});
   }
 
   if (flush_required) {
@@ -393,7 +392,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
     io::ImageRequest<I>::aio_write(&m_image_ctx, aio_comp,
                                    {{event.offset, event.length}},
                                    io::ImageArea::DATA, std::move(data),
-                                   m_image_ctx.get_data_io_context(), 0, {});
+                                   0, {});
   }
 
   if (flush_required) {
@@ -447,8 +446,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp,
                                        {{event.offset, event.length}},
                                        io::ImageArea::DATA, std::move(data),
-                                       m_image_ctx.get_data_io_context(), 0,
-                                       {});
+                                       0, {});
   }
 
   if (flush_required) {
@@ -483,9 +481,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
                                                io::ImageArea::DATA,
                                                std::move(cmp_data),
                                                std::move(write_data),
-                                               nullptr,
-                                               m_image_ctx.get_data_io_context(),
-                                               0, {});
+                                               nullptr, 0, {});
   }
 
   if (flush_required) {

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -52,7 +52,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -66,9 +66,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes,
-    IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -81,7 +80,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -96,7 +95,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -42,27 +42,26 @@ public:
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -211,7 +211,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_1(
     mock_image_ctx, aio_comp_1, {{0, 1}}, ImageArea::DATA, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_1.send();
@@ -224,7 +224,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_2(
     mock_image_ctx, aio_comp_2, {{0, 1}}, ImageArea::DATA, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_2.send();
@@ -306,7 +306,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscard) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{16, 63}, {84, 100}}, ImageArea::DATA,
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -334,7 +334,7 @@ TEST_F(TestMockIoImageRequest, TailDiscard) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{ictx->layout.object_size - 1024, 1024}}, ImageArea::DATA,
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -364,8 +364,7 @@ TEST_F(TestMockIoImageRequest, DiscardGranularity) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ImageArea::DATA, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    ImageArea::DATA, ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -397,7 +396,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscardJournalAppendEnabled) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{16, 63}, {84, 100}}, ImageArea::DATA,
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -431,7 +430,7 @@ TEST_F(TestMockIoImageRequest, TailDiscardJournalAppendEnabled) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{ictx->layout.object_size - 1024, 1024}}, ImageArea::DATA,
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -460,9 +459,8 @@ TEST_F(TestMockIoImageRequest, PruneRequiredDiscardJournalAppendEnabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{96, 31}},
-    ImageArea::DATA, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{96, 31}}, ImageArea::DATA,
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -491,9 +489,8 @@ TEST_F(TestMockIoImageRequest, LengthModifiedDiscardJournalAppendEnabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{16, 63}},
-    ImageArea::DATA, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{16, 63}}, ImageArea::DATA,
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -531,8 +528,7 @@ TEST_F(TestMockIoImageRequest, DiscardGranularityJournalAppendEnabled) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ImageArea::DATA, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    ImageArea::DATA, ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -562,8 +558,7 @@ TEST_F(TestMockIoImageRequest, AioWriteJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write(
-    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();
@@ -592,7 +587,7 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA,
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -650,8 +645,7 @@ TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteSameRequest mock_aio_image_writesame(
-    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA, std::move(bl), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_writesame.send();
@@ -685,8 +679,7 @@ TEST_F(TestMockIoImageRequest, AioCompareAndWriteJournalAppendDisabled) {
   uint64_t mismatch_offset;
   MockImageCompareAndWriteRequest mock_aio_image_write(
     mock_image_ctx, aio_comp, {{0, 1}}, ImageArea::DATA,
-    std::move(cmp_bl), std::move(write_bl), &mismatch_offset,
-    mock_image_ctx.get_data_io_context(), 0, {});
+    std::move(cmp_bl), std::move(write_bl), &mismatch_offset, 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -32,7 +32,7 @@ struct ImageRequest<MockReplayImageCtx> {
                                const bufferlist &bl, int op_flags));
   static void aio_write(MockReplayImageCtx *ictx, AioCompletion *c,
                         Extents&& image_extents, ImageArea area,
-                        bufferlist&& bl, IOContext io_context, int op_flags,
+                        bufferlist&& bl, int op_flags,
                         const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_write(c, image_extents, bl, op_flags);
@@ -43,7 +43,6 @@ struct ImageRequest<MockReplayImageCtx> {
   static void aio_discard(MockReplayImageCtx *ictx, AioCompletion *c,
                           Extents&& image_extents, ImageArea area,
                           uint32_t discard_granularity_bytes,
-                          IOContext io_context,
                           const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_discard(c, image_extents, discard_granularity_bytes);
@@ -62,7 +61,7 @@ struct ImageRequest<MockReplayImageCtx> {
                                    int op_flags));
   static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
                             Extents&& image_extents, ImageArea area,
-                            bufferlist&& bl, IOContext io_context, int op_flags,
+                            bufferlist&& bl, int op_flags,
                             const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_writesame(c, image_extents, bl, op_flags);
@@ -75,8 +74,7 @@ struct ImageRequest<MockReplayImageCtx> {
   static void aio_compare_and_write(MockReplayImageCtx *ictx, AioCompletion *c,
                                     Extents&& image_extents, ImageArea area,
                                     bufferlist&& cmp_bl, bufferlist&& bl,
-                                    uint64_t* mismatch_offset,
-                                    IOContext io_context, int op_flags,
+                                    uint64_t* mismatch_offset, int op_flags,
                                     const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_compare_and_write(c, image_extents, cmp_bl, bl,

--- a/src/test/librbd/mock/io/MockImageDispatch.h
+++ b/src/test/librbd/mock/io/MockImageDispatch.h
@@ -32,7 +32,7 @@ public:
 
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -41,9 +41,8 @@ public:
 
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -51,7 +50,7 @@ public:
 
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -59,10 +58,10 @@ public:
   }
 
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
