### PR TITLE
pacific: rgw/beast: add max_header_size option with 16k default, up from 4k

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -127,6 +127,14 @@ Options
 :Type: Integer
 :Default: ``65000``
 
+``max_header_size``
+
+:Description: The maximum number of header bytes available for a single request.
+
+:Type: Integer
+:Default: ``16384``
+:Maximum: ``65536``
+
 
 Civetweb
 ========


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61728

---

backport of https://github.com/ceph/ceph/pull/44029
parent tracker: https://tracker.ceph.com/issues/61727

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh