### PR TITLE
quincy: librados: aio operate functions can set mtimes

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -751,12 +751,13 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 
 int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
-				     const SnapContext& snap_context, int flags,
+				     const SnapContext& snap_context,
+				     const ceph::real_time *pmtime, int flags,
                                      const blkin_trace_info *trace_info)
 {
   FUNCTRACE(client->cct);
   OID_EVENT_TRACE(oid.name.c_str(), "RADOS_WRITE_OP_BEGIN");
-  auto ut = ceph::real_clock::now();
+  const ceph::real_time ut = (pmtime ? *pmtime : ceph::real_clock::now());
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
@@ -1137,7 +1138,7 @@ int librados::IoCtxImpl::aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.rmxattr(name);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
@@ -1146,7 +1147,7 @@ int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.setxattr(name, bl);
-  return aio_operate(oid, &op, c, snapc, 0);
+  return aio_operate(oid, &op, c, snapc, nullptr, 0);
 }
 
 namespace {

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -158,7 +158,8 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags, const blkin_trace_info *trace_info = nullptr);
+		  const ceph::real_time *pmtime, int flags,
+		  const blkin_trace_info *trace_info = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 

--- a/src/librados/ObjectOperationImpl.h
+++ b/src/librados/ObjectOperationImpl.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "common/ceph_time.h"
+#include "osdc/Objecter.h"
+
+namespace librados {
+
+// Wraps Objecter's ObjectOperation with storage for an optional mtime argument.
+struct ObjectOperationImpl {
+  ::ObjectOperation o;
+  ceph::real_time rt;
+  ceph::real_time *prt = nullptr;
+};
+
+} // namespace librados

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -4020,10 +4020,16 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
 {
   tracepoint(librados, rados_aio_write_op_operate_enter, write_op, io, completion, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = to_object_operation(write_op);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
-  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, nullptr, translate_flags(flags));
+
+  if (mtime) {
+    oimpl->rt = ceph::real_clock::from_time_t(*mtime);
+    oimpl->prt = &oimpl->rt;
+  }
+
+  int retval = ctx->aio_operate(obj, &oimpl->o, c, ctx->snapc, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_aio_write_op_operate_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -4018,7 +4018,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
   ::ObjectOperation *oo = (::ObjectOperation *) write_op;
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
-  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, translate_flags(flags));
+  int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, nullptr, translate_flags(flags));
   tracepoint(librados, rados_aio_write_op_operate_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -3967,18 +3967,15 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate)(
 {
   tracepoint(librados, rados_write_op_operate_enter, write_op, io, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = to_object_operation(write_op);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (mtime) {
-    rt = ceph::real_clock::from_time_t(*mtime);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_time_t(*mtime);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }
@@ -3993,18 +3990,15 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate2)(
 {
   tracepoint(librados, rados_write_op_operate2_enter, write_op, io, oid, ts, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = to_object_operation(write_op);
+  auto oimpl = static_cast<librados::ObjectOperationImpl*>(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
-  ceph::real_time *prt = NULL;
-  ceph::real_time rt;
-
   if (ts) {
-    rt = ceph::real_clock::from_timespec(*ts);
-    prt = &rt;
+    oimpl->rt = ceph::real_clock::from_timespec(*ts);
+    oimpl->prt = &oimpl->rt;
   }
 
-  int retval = ctx->operate(obj, oo, prt, translate_flags(flags));
+  int retval = ctx->operate(obj, &oimpl->o, oimpl->prt, translate_flags(flags));
   tracepoint(librados, rados_write_op_operate_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -19,6 +19,7 @@
 #include "librados/librados_c.h"
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
@@ -3570,7 +3571,7 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_break_lock);
 extern "C" rados_write_op_t LIBRADOS_C_API_DEFAULT_F(rados_create_write_op)()
 {
   tracepoint(librados, rados_create_write_op_enter);
-  rados_write_op_t retval = new (std::nothrow)::ObjectOperation;
+  rados_write_op_t retval = new (std::nothrow) librados::ObjectOperationImpl;
   tracepoint(librados, rados_create_write_op_exit, retval);
   return retval;
 }
@@ -3580,17 +3581,22 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_release_write_op)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_release_write_op_enter, write_op);
-  delete (::ObjectOperation*)write_op;
+  delete static_cast<librados::ObjectOperationImpl*>(write_op);
   tracepoint(librados, rados_release_write_op_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_release_write_op);
+
+static ::ObjectOperation* to_object_operation(rados_write_op_t write_op)
+{
+  return &static_cast<librados::ObjectOperationImpl*>(write_op)->o;
+}
 
 extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_flags)(
   rados_write_op_t write_op,
   int flags)
 {
   tracepoint(librados, rados_write_op_set_flags_enter, write_op, flags);
-  ((::ObjectOperation *)write_op)->set_last_op_flags(get_op_flags(flags));
+  to_object_operation(write_op)->set_last_op_flags(get_op_flags(flags));
   tracepoint(librados, rados_write_op_set_flags_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_flags);
@@ -3600,7 +3606,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_version)(
   uint64_t ver)
 {
   tracepoint(librados, rados_write_op_assert_version_enter, write_op, ver);
-  ((::ObjectOperation *)write_op)->assert_version(ver);
+  to_object_operation(write_op)->assert_version(ver);
   tracepoint(librados, rados_write_op_assert_version_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_version);
@@ -3609,7 +3615,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_assert_exists)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_assert_exists_enter, write_op);
-  ((::ObjectOperation *)write_op)->stat(nullptr, nullptr, nullptr);
+  to_object_operation(write_op)->stat(nullptr, nullptr, nullptr);
   tracepoint(librados, rados_write_op_assert_exists_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_assert_exists);
@@ -3623,7 +3629,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpext)(
 {
   tracepoint(librados, rados_write_op_cmpext_enter, write_op, cmp_buf,
 	     cmp_len, off, prval);
-  ((::ObjectOperation *)write_op)->cmpext(off, cmp_len, cmp_buf, prval);
+  to_object_operation(write_op)->cmpext(off, cmp_len, cmp_buf, prval);
   tracepoint(librados, rados_write_op_cmpext_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpext);
@@ -3638,10 +3644,10 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_cmpxattr)(
   tracepoint(librados, rados_write_op_cmpxattr_enter, write_op, name, comparison_operator, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->cmpxattr(name,
-					    comparison_operator,
-					    CEPH_OSD_CMPXATTR_MODE_STRING,
-					    bl);
+  to_object_operation(write_op)->cmpxattr(name,
+					  comparison_operator,
+					  CEPH_OSD_CMPXATTR_MODE_STRING,
+					  bl);
   tracepoint(librados, rados_write_op_cmpxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_cmpxattr);
@@ -3672,7 +3678,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp)(
   int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, strlen(key), val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
@@ -3688,7 +3694,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_cmp2)(
   int *prval)
 {
   tracepoint(librados, rados_write_op_omap_cmp_enter, write_op, key, comparison_operator, val, val_len, prval);
-  rados_c_omap_cmp((::ObjectOperation *)write_op, key, comparison_operator,
+  rados_c_omap_cmp(to_object_operation(write_op), key, comparison_operator,
                    val, key_len, val_len, prval);
   tracepoint(librados, rados_write_op_omap_cmp_exit);
 }
@@ -3703,7 +3709,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_setxattr)(
   tracepoint(librados, rados_write_op_setxattr_enter, write_op, name, value, value_len);
   bufferlist bl;
   bl.append(value, value_len);
-  ((::ObjectOperation *)write_op)->setxattr(name, bl);
+  to_object_operation(write_op)->setxattr(name, bl);
   tracepoint(librados, rados_write_op_setxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_setxattr);
@@ -3713,7 +3719,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_rmxattr)(
   const char *name)
 {
   tracepoint(librados, rados_write_op_rmxattr_enter, write_op, name);
-  ((::ObjectOperation *)write_op)->rmxattr(name);
+  to_object_operation(write_op)->rmxattr(name);
   tracepoint(librados, rados_write_op_rmxattr_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_rmxattr);
@@ -3724,8 +3730,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_create)(
   const char* category) // unused
 {
   tracepoint(librados, rados_write_op_create_enter, write_op, exclusive);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
-  oo->create(!!exclusive);
+  to_object_operation(write_op)->create(!!exclusive);
   tracepoint(librados, rados_write_op_create_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_create);
@@ -3739,7 +3744,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write)(
   tracepoint(librados, rados_write_op_write_enter, write_op, buffer, len, offset);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write(offset, bl);
+  to_object_operation(write_op)->write(offset, bl);
   tracepoint(librados, rados_write_op_write_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write);
@@ -3752,7 +3757,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_write_full)(
   tracepoint(librados, rados_write_op_write_full_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->write_full(bl);
+  to_object_operation(write_op)->write_full(bl);
   tracepoint(librados, rados_write_op_write_full_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_write_full);
@@ -3767,7 +3772,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_writesame)(
   tracepoint(librados, rados_write_op_writesame_enter, write_op, buffer, data_len, write_len, offset);
   bufferlist bl;
   bl.append(buffer, data_len);
-  ((::ObjectOperation *)write_op)->writesame(offset, write_len, bl);
+  to_object_operation(write_op)->writesame(offset, write_len, bl);
   tracepoint(librados, rados_write_op_writesame_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_writesame);
@@ -3780,7 +3785,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_append)(
   tracepoint(librados, rados_write_op_append_enter, write_op, buffer, len);
   bufferlist bl;
   bl.append(buffer,len);
-  ((::ObjectOperation *)write_op)->append(bl);
+  to_object_operation(write_op)->append(bl);
   tracepoint(librados, rados_write_op_append_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_append);
@@ -3789,7 +3794,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_remove)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_remove_enter, write_op);
-  ((::ObjectOperation *)write_op)->remove();
+  to_object_operation(write_op)->remove();
   tracepoint(librados, rados_write_op_remove_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_remove);
@@ -3799,7 +3804,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_truncate)(
   uint64_t offset)
 {
   tracepoint(librados, rados_write_op_truncate_enter, write_op, offset);
-  ((::ObjectOperation *)write_op)->truncate(offset);
+  to_object_operation(write_op)->truncate(offset);
   tracepoint(librados, rados_write_op_truncate_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_truncate);
@@ -3810,7 +3815,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_zero)(
   uint64_t len)
 {
   tracepoint(librados, rados_write_op_zero_enter, write_op, offset, len);
-  ((::ObjectOperation *)write_op)->zero(offset, len);
+  to_object_operation(write_op)->zero(offset, len);
   tracepoint(librados, rados_write_op_zero_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_zero);
@@ -3826,7 +3831,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_exec)(
   tracepoint(librados, rados_write_op_exec_enter, write_op, cls, method, in_buf, in_len, prval);
   bufferlist inbl;
   inbl.append(in_buf, in_len);
-  ((::ObjectOperation *)write_op)->call(cls, method, inbl, NULL, NULL, prval);
+  to_object_operation(write_op)->call(cls, method, inbl, NULL, NULL, prval);
   tracepoint(librados, rados_write_op_exec_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_exec);
@@ -3846,7 +3851,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set)(
     bl.append(vals[i], lens[i]);
     entries[keys[i]] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set);
@@ -3867,7 +3872,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_set2)(
     string key(keys[i], key_lens[i]);
     entries[key] = bl;
   }
-  ((::ObjectOperation *)write_op)->omap_set(entries);
+  to_object_operation(write_op)->omap_set(entries);
   tracepoint(librados, rados_write_op_omap_set_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_set2);
@@ -3882,7 +3887,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys)(
     tracepoint(librados, rados_write_op_omap_rm_keys_entry, keys[i]);
   }
   std::set<std::string> to_remove(keys, keys + keys_len);
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys);
@@ -3898,7 +3903,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_keys2)(
   for(size_t i = 0; i < keys_len; i++) {
     to_remove.emplace(keys[i], key_lens[i]);
   }
-  ((::ObjectOperation *)write_op)->omap_rm_keys(to_remove);
+  to_object_operation(write_op)->omap_rm_keys(to_remove);
   tracepoint(librados, rados_write_op_omap_rm_keys_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys2);
@@ -3912,8 +3917,8 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_rm_range2)(
 {
   tracepoint(librados, rados_write_op_omap_rm_range_enter,
              write_op, key_begin, key_end);
-  ((::ObjectOperation *)write_op)->omap_rm_range({key_begin, key_begin_len},
-                                                 {key_end, key_end_len});
+  to_object_operation(write_op)->omap_rm_range({key_begin, key_begin_len},
+                                               {key_end, key_end_len});
   tracepoint(librados, rados_write_op_omap_rm_range_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_range2);
@@ -3922,7 +3927,7 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_omap_clear)(
   rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_omap_clear_enter, write_op);
-  ((::ObjectOperation *)write_op)->omap_clear();
+  to_object_operation(write_op)->omap_clear();
   tracepoint(librados, rados_write_op_omap_clear_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_clear);
@@ -3933,8 +3938,8 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint)(
   uint64_t expected_write_size)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint_enter, write_op, expected_object_size, expected_write_size);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size, 0);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size, 0);
   tracepoint(librados, rados_write_op_set_alloc_hint_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint);
@@ -3946,9 +3951,9 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_write_op_set_alloc_hint2)(
   uint32_t flags)
 {
   tracepoint(librados, rados_write_op_set_alloc_hint2_enter, write_op, expected_object_size, expected_write_size, flags);
-  ((::ObjectOperation *)write_op)->set_alloc_hint(expected_object_size,
-                                                  expected_write_size,
-						  flags);
+  to_object_operation(write_op)->set_alloc_hint(expected_object_size,
+                                                expected_write_size,
+						flags);
   tracepoint(librados, rados_write_op_set_alloc_hint2_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_set_alloc_hint2);
@@ -3962,7 +3967,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate)(
 {
   tracepoint(librados, rados_write_op_operate_enter, write_op, io, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   ceph::real_time *prt = NULL;
@@ -3988,7 +3993,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_write_op_operate2)(
 {
   tracepoint(librados, rados_write_op_operate2_enter, write_op, io, oid, ts, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   ceph::real_time *prt = NULL;
@@ -4015,7 +4020,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_aio_write_op_operate)(
 {
   tracepoint(librados, rados_aio_write_op_operate_enter, write_op, io, completion, oid, mtime, flags);
   object_t obj(oid);
-  ::ObjectOperation *oo = (::ObjectOperation *) write_op;
+  ::ObjectOperation *oo = to_object_operation(write_op);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   librados::AioCompletionImpl *c = (librados::AioCompletionImpl*)completion;
   int retval = ctx->aio_operate(obj, oo, c, ctx->snapc, nullptr, translate_flags(flags));

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1559,7 +1559,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc, 0);
+				  io_ctx_impl->snapc, o->impl->prt, 0);
 }
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 ObjectWriteOperation *o, int flags)
@@ -1568,7 +1568,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  io_ctx_impl->snapc,
+				  io_ctx_impl->snapc, o->impl->prt,
 				  translate_flags(flags));
 }
 
@@ -1585,7 +1585,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  snapc, 0);
+				  snapc, o->impl->prt, 0);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1602,7 +1602,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-          snapc, 0, trace_info);
+          snapc, o->impl->prt, 0, trace_info);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -1618,7 +1618,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   for (size_t i = 0; i < snaps.size(); ++i)
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
-  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc,
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc, snapc, o->impl->prt,
                                   translate_flags(flags), trace_info);
 }
 

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -29,6 +29,7 @@
 
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
+#include "librados/ObjectOperationImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
 #include "librados/RadosClient.h"
 #include "librados/RadosXattrIter.h"
@@ -87,18 +88,6 @@ static TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tra
  * |          RadosClient                 |
  * +--------------------------------------+
  */
-
-namespace librados {
-
-struct ObjectOperationImpl {
-  ::ObjectOperation o;
-  real_time rt;
-  real_time *prt;
-
-  ObjectOperationImpl() : prt(NULL) {}
-};
-
-}
 
 size_t librados::ObjectOperation::size()
 {

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -775,6 +775,36 @@ TEST(LibRadosAio, SimpleStat) {
   rados_aio_release(my_completion2);
 }
 
+TEST(LibRadosAio, OperateMtime)
+{
+  AioTestData test_data;
+  ASSERT_EQ("", test_data.init());
+
+  time_t set_mtime = 1457129052;
+  {
+    rados_write_op_t op = rados_create_write_op();
+    rados_write_op_create(op, LIBRADOS_CREATE_IDEMPOTENT, nullptr);
+    rados_completion_t completion;
+    ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &completion));
+    ASSERT_EQ(0, rados_aio_write_op_operate(op, test_data.m_ioctx, completion,
+                                            "foo", &set_mtime, 0));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
+    }
+    ASSERT_EQ(0, rados_aio_get_return_value(completion));
+    rados_aio_release(completion);
+    rados_release_write_op(op);
+  }
+  {
+    uint64_t size;
+    time_t mtime;
+    ASSERT_EQ(0, rados_stat(test_data.m_ioctx, "foo", &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime, mtime);
+  }
+}
+
 TEST(LibRadosAio, SimpleStatNS) {
   AioTestData test_data;
   rados_completion_t my_completion;

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -929,6 +929,62 @@ TEST(LibRadosAio, SimpleStatPP) {
   ASSERT_EQ(sizeof(buf), psize);
 }
 
+TEST(LibRadosAio, OperateMtime)
+{
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+
+  time_t set_mtime = 1457129052;
+  {
+    auto c = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+    librados::ObjectWriteOperation op;
+    op.mtime(&set_mtime);
+    op.create(false);
+    ASSERT_EQ(0, test_data.m_ioctx.aio_operate(test_data.m_oid, c.get(), &op));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, c->wait_for_complete());
+    }
+    ASSERT_EQ(0, c->get_return_value());
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, test_data.m_ioctx.stat2(test_data.m_oid, &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime, mtime.tv_sec);
+    EXPECT_EQ(0, mtime.tv_nsec);
+  }
+}
+
+TEST(LibRadosAio, OperateMtime2)
+{
+  AioTestDataPP test_data;
+  ASSERT_EQ("", test_data.init());
+
+  timespec set_mtime{1457129052, 123456789};
+  {
+    auto c = std::unique_ptr<AioCompletion>{Rados::aio_create_completion()};
+    librados::ObjectWriteOperation op;
+    op.mtime2(&set_mtime);
+    op.create(false);
+    ASSERT_EQ(0, test_data.m_ioctx.aio_operate(test_data.m_oid, c.get(), &op));
+    {
+      TestAlarm alarm;
+      ASSERT_EQ(0, c->wait_for_complete());
+    }
+    ASSERT_EQ(0, c->get_return_value());
+  }
+  {
+    uint64_t size;
+    timespec mtime;
+    ASSERT_EQ(0, test_data.m_ioctx.stat2(test_data.m_oid, &size, &mtime));
+    EXPECT_EQ(0, size);
+    EXPECT_EQ(set_mtime.tv_sec, mtime.tv_sec);
+    EXPECT_EQ(set_mtime.tv_nsec, mtime.tv_nsec);
+  }
+}
+
 TEST(LibRadosAio, StatRemovePP) {
   AioTestDataPP test_data;
   ASSERT_EQ("", test_data.init());

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -446,7 +446,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
-  return ctx->aio_operate(oid, *ops, c->pc, NULL, 0);
+  return ctx->aio_operate(oid, *ops, c->pc, nullptr, nullptr, 0);
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -462,7 +462,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(seq, snv);
 
-  return ctx->aio_operate(oid, *ops, c->pc, &snapc, flags);
+  return ctx->aio_operate(oid, *ops, c->pc, &snapc, nullptr, flags);
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -44,11 +44,13 @@ public:
     return TestMemIoCtxImpl::aio_notify(o, c, bl, timeout_ms, pbl);
   }
 
-  MOCK_METHOD5(aio_operate, int(const std::string&, TestObjectOperationImpl&,
-                                AioCompletionImpl*, SnapContext*, int));
+  MOCK_METHOD6(aio_operate, int(const std::string&, TestObjectOperationImpl&,
+                                AioCompletionImpl*, SnapContext*,
+                                const ceph::real_time*, int));
   int do_aio_operate(const std::string& o, TestObjectOperationImpl& ops,
-                     AioCompletionImpl* c, SnapContext* snapc, int flags) {
-    return TestMemIoCtxImpl::aio_operate(o, ops, c, snapc, flags);
+                     AioCompletionImpl* c, SnapContext* snapc,
+                     const ceph::real_time* pmtime, int flags) {
+    return TestMemIoCtxImpl::aio_operate(o, ops, c, snapc, pmtime, flags);
   }
 
   MOCK_METHOD4(aio_watch, int(const std::string& o, AioCompletionImpl *c,
@@ -214,7 +216,7 @@ public:
 
     ON_CALL(*this, clone()).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_clone));
     ON_CALL(*this, aio_notify(_, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_notify));
-    ON_CALL(*this, aio_operate(_, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_operate));
+    ON_CALL(*this, aio_operate(_, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_operate));
     ON_CALL(*this, aio_watch(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_watch));
     ON_CALL(*this, aio_unwatch(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_unwatch));
     ON_CALL(*this, assert_exists(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_assert_exists));

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -548,7 +548,7 @@ void RADOS::execute(const Object& o, const IOContext& ioc, WriteOp&& op,
   }
 
   auto completion = create_aio_completion(std::move(c));
-  auto r = io_ctx->aio_operate(std::string{o}, *ops, completion, &snapc, 0U);
+  auto r = io_ctx->aio_operate(std::string{o}, *ops, completion, &snapc, nullptr, 0U);
   ceph_assert(r == 0);
 }
 

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -107,7 +107,7 @@ void TestIoCtxImpl::aio_notify(const std::string& oid, AioCompletionImpl *c,
 
 int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, SnapContext *snap_context,
-                               int flags) {
+                               const ceph::real_time *pmtime, int flags) {
   // TODO flags for now
   ops.get();
   m_pending_ops++;

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -88,7 +88,7 @@ public:
                           bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl);
   virtual int aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                           AioCompletionImpl *c, SnapContext *snap_context,
-                          int flags);
+                          const ceph::real_time *pmtime, int flags);
   virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, int flags,
                                bufferlist *pbl, uint64_t snap_id,

--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -169,7 +169,7 @@ public:
   void expect_mirror_status_update(
       const MirrorImageSiteStatuses& mirror_image_site_statuses,
       const std::string& mirror_uuid, int r) {
-    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
       .WillOnce(Invoke([this](auto&&... args) {
           int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
           m_mock_local_io_ctx->aio_flush();
@@ -203,7 +203,7 @@ public:
 
   void expect_mirror_status_removes(const std::set<std::string>& mirror_images,
                                     int r) {
-    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
       .WillOnce(Invoke([this](auto&&... args) {
           int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
           m_mock_local_io_ctx->aio_flush();
@@ -439,7 +439,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveStatus) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond remove_flush_ctx;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke([this, &remove_flush_ctx](auto&&... args) {
         int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
         m_mock_local_io_ctx->aio_flush();
@@ -506,7 +506,7 @@ TEST_F(TestMockMirrorStatusUpdater, OverwriteStatusInFlight) {
   Context* update_task = nullptr;
   fire_timer_event(&timer_event, &update_task);
 
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke([this, &mock_mirror_status_updater](auto&&... args) {
         mock_mirror_status_updater.set_mirror_image_status(
           "1", {"", cls::rbd::MIRROR_IMAGE_STATUS_STATE_REPLAYING,
@@ -617,7 +617,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveRefreshInFlightStatus) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond on_removed;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke(
       [this, &mock_mirror_status_updater, &on_removed](auto&&... args) {
         mock_mirror_status_updater.remove_refresh_mirror_image_status(
@@ -652,7 +652,7 @@ TEST_F(TestMockMirrorStatusUpdater, ShutDownWhileUpdating) {
   fire_timer_event(&timer_event, &update_task);
 
   C_SaferCond on_shutdown;
-  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _, _))
     .WillOnce(Invoke(
       [this, &mock_mirror_status_updater, &on_shutdown](auto&&... args) {
         mock_mirror_status_updater.shut_down(&on_shutdown);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61731

---

backport of https://github.com/ceph/ceph/pull/51681
parent tracker: https://tracker.ceph.com/issues/61349

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh