### PR TITLE
reef: Fix FTBFS on gcc 13

### DIFF
--- a/src/common/Cycles.h
+++ b/src/common/Cycles.h
@@ -32,6 +32,8 @@
 #ifndef CEPH_CYCLES_H
 #define CEPH_CYCLES_H
 
+#include <cstdint>
+
 /**
  * This class provides static methods that read the fine-grain CPU
  * cycle counter and translate between cycle-level times and absolute

--- a/src/librbd/api/PoolMetadata.h
+++ b/src/librbd/api/PoolMetadata.h
@@ -7,6 +7,7 @@
 #include "include/buffer_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/msg/async/compression_onwire.h
+++ b/src/msg/async/compression_onwire.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_COMPRESSION_ONWIRE_H
 #define CEPH_COMPRESSION_ONWIRE_H
 
+#include <cstdint>
 #include <optional>
 
 #include "compressor/Compressor.h"

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -1171,23 +1171,23 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
 
   if (auth.digest_present && candidate.digest_present &&
       auth.digest != candidate.digest) {
-    format_to(std::back_inserter(out),
-              "data_digest {:#x} != data_digest {:#x} from shard {}",
-              candidate.digest,
-              auth.digest,
-              auth_shard);
+    fmt::format_to(std::back_inserter(out),
+                   "data_digest {:#x} != data_digest {:#x} from shard {}",
+                   candidate.digest,
+                   auth.digest,
+                   auth_shard);
     error = true;
     obj_result.set_data_digest_mismatch();
   }
 
   if (auth.omap_digest_present && candidate.omap_digest_present &&
       auth.omap_digest != candidate.omap_digest) {
-    format_to(std::back_inserter(out),
-              "{}omap_digest {:#x} != omap_digest {:#x} from shard {}",
-              sep(error),
-              candidate.omap_digest,
-              auth.omap_digest,
-              auth_shard);
+    fmt::format_to(std::back_inserter(out),
+                   "{}omap_digest {:#x} != omap_digest {:#x} from shard {}",
+                   sep(error),
+                   candidate.omap_digest,
+                   auth.omap_digest,
+                   auth_shard);
     obj_result.set_omap_digest_mismatch();
   }
 
@@ -1195,24 +1195,24 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
   if (m_is_replicated) {
     if (auth_oi.is_data_digest() && candidate.digest_present &&
         auth_oi.data_digest != candidate.digest) {
-      format_to(std::back_inserter(out),
-                "{}data_digest {:#x} != data_digest {:#x} from auth oi {}",
-                sep(error),
-                candidate.digest,
-                auth_oi.data_digest,
-                auth_oi);
+      fmt::format_to(std::back_inserter(out),
+                     "{}data_digest {:#x} != data_digest {:#x} from auth oi {}",
+                     sep(error),
+                     candidate.digest,
+                     auth_oi.data_digest,
+                     auth_oi);
       shard_result.set_data_digest_mismatch_info();
     }
 
     // for replicated:
     if (auth_oi.is_omap_digest() && candidate.omap_digest_present &&
         auth_oi.omap_digest != candidate.omap_digest) {
-      format_to(std::back_inserter(out),
-                "{}omap_digest {:#x} != omap_digest {:#x} from auth oi {}",
-                sep(error),
-                candidate.omap_digest,
-                auth_oi.omap_digest,
-                auth_oi);
+      fmt::format_to(std::back_inserter(out),
+                     "{}omap_digest {:#x} != omap_digest {:#x} from auth oi {}",
+                     sep(error),
+                     candidate.omap_digest,
+                     auth_oi.omap_digest,
+                     auth_oi);
       shard_result.set_omap_digest_mismatch_info();
     }
   }
@@ -1241,7 +1241,9 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
     auth_bl.push_back(auth_attr->second);
 
     if (!can_bl.contents_equal(auth_bl)) {
-      format_to(std::back_inserter(out), "{}object info inconsistent ", sep(error));
+      fmt::format_to(std::back_inserter(out),
+		     "{}object info inconsistent ",
+		     sep(error));
       obj_result.set_object_info_inconsistency();
     }
   }
@@ -1261,7 +1263,9 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
       auth_bl.push_back(auth_attr->second);
 
       if (!can_bl.contents_equal(auth_bl)) {
-        format_to(std::back_inserter(out), "{}snapset inconsistent ", sep(error));
+        fmt::format_to(std::back_inserter(out),
+		       "{}snapset inconsistent ",
+		       sep(error));
         obj_result.set_snapset_inconsistency();
       }
     }
@@ -1284,7 +1288,9 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
       auth_bl.push_back(auth_hi->second);
 
       if (!can_bl.contents_equal(auth_bl)) {
-        format_to(std::back_inserter(out), "{}hinfo inconsistent ", sep(error));
+        fmt::format_to(std::back_inserter(out),
+		       "{}hinfo inconsistent ",
+		       sep(error));
         obj_result.set_hinfo_inconsistency();
       }
     }
@@ -1296,22 +1302,22 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
 
   uint64_t oi_size = logical_to_ondisk_size(auth_oi.size);
   if (oi_size != candidate.size) {
-    format_to(std::back_inserter(out),
-              "{}size {} != size {} from auth oi {}",
-              sep(error),
-              candidate.size,
-              oi_size,
-              auth_oi);
+    fmt::format_to(std::back_inserter(out),
+                   "{}size {} != size {} from auth oi {}",
+                   sep(error),
+                   candidate.size,
+                   oi_size,
+                   auth_oi);
     shard_result.set_size_mismatch_info();
   }
 
   if (auth.size != candidate.size) {
-    format_to(std::back_inserter(out),
-              "{}size {} != size {} from shard {}",
-              sep(error),
-              candidate.size,
-              auth.size,
-              auth_shard);
+    fmt::format_to(std::back_inserter(out),
+                   "{}size {} != size {} from shard {}",
+                   sep(error),
+                   candidate.size,
+                   auth.size,
+                   auth_shard);
     obj_result.set_size_mismatch();
   }
 
@@ -1320,11 +1326,11 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
   if (candidate.size > m_conf->osd_max_object_size &&
       !obj_result.has_size_too_large()) {
 
-    format_to(std::back_inserter(out),
-              "{}size {} > {} is too large",
-              sep(error),
-              candidate.size,
-              m_conf->osd_max_object_size);
+    fmt::format_to(std::back_inserter(out),
+                   "{}size {} > {} is too large",
+                   sep(error),
+                   candidate.size,
+                   m_conf->osd_max_object_size);
     obj_result.set_size_too_large();
   }
 
@@ -1340,10 +1346,16 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
 
     auto cand = candidate.attrs.find(k);
     if (cand == candidate.attrs.end()) {
-      format_to(std::back_inserter(out), "{}attr name mismatch '{}'", sep(error), k);
+      fmt::format_to(std::back_inserter(out),
+		     "{}attr name mismatch '{}'",
+		     sep(error),
+		     k);
       obj_result.set_attr_name_mismatch();
     } else if (cand->second.cmp(v)) {
-      format_to(std::back_inserter(out), "{}attr value mismatch '{}'", sep(error), k);
+      fmt::format_to(std::back_inserter(out),
+		     "{}attr value mismatch '{}'",
+		     sep(error),
+		     k);
       obj_result.set_attr_value_mismatch();
     }
   }
@@ -1356,7 +1368,10 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
 
     auto in_auth = auth.attrs.find(k);
     if (in_auth == auth.attrs.end()) {
-      format_to(std::back_inserter(out), "{}attr name mismatch '{}'", sep(error), k);
+      fmt::format_to(std::back_inserter(out),
+		     "{}attr name mismatch '{}'",
+		     sep(error),
+		     k);
       obj_result.set_attr_name_mismatch();
     }
   }

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -183,20 +183,20 @@ struct fmt::formatter<shard_as_auth_t> {
       // note: 'if' chain, as hard to consistently (on all compilers) avoid some
       // warnings for a switch plus multiple return paths
       if (as_auth.possible_auth == shard_as_auth_t::usable_t::not_usable) {
-        return format_to(ctx.out(),
-                         "{{shard-not-usable:{}}}",
-                         as_auth.error_text);
+        return fmt::format_to(ctx.out(),
+                              "{{shard-not-usable:{}}}",
+                              as_auth.error_text);
       }
       if (as_auth.possible_auth == shard_as_auth_t::usable_t::not_found) {
-        return format_to(ctx.out(), "{{shard-not-found}}");
+        return fmt::format_to(ctx.out(), "{{shard-not-found}}");
       }
-      return format_to(ctx.out(),
-                       "{{shard-usable: soid:{} {{txt:{}}} }}",
-                       as_auth.oi.soid,
-                       as_auth.error_text);
+      return fmt::format_to(ctx.out(),
+                            "{{shard-usable: soid:{} {{txt:{}}} }}",
+                            as_auth.oi.soid,
+                            as_auth.error_text);
 
     } else {
-      return format_to(
+      return fmt::format_to(
         ctx.out(),
         "usable:{} soid:{} {{txt:{}}}",
         (as_auth.possible_auth == shard_as_auth_t::usable_t::usable) ? "yes"

--- a/src/test/librados/op_speed.cc
+++ b/src/test/librados/op_speed.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*
 // vim: ts=8 sw=2 smarttab
 
+#include <cstdint>
+
 #include "include/rados/librados.hpp"
 
 constexpr int to_create = 10'000'000;

--- a/src/test/mon/test_log_rss_usage.cc
+++ b/src/test/mon/test_log_rss_usage.cc
@@ -1,4 +1,5 @@
 #include <sys/types.h>
+#include <cstdint>
 #include <dirent.h>
 #include <errno.h>
 #include <vector>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61380

---

backport of https://github.com/ceph/ceph/pull/50438
parent tracker: https://tracker.ceph.com/issues/58477

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh