### PR TITLE
quincy: Fix FTBFS on gcc 13

### DIFF
--- a/src/common/Cycles.h
+++ b/src/common/Cycles.h
@@ -32,6 +32,8 @@
 #ifndef CEPH_CYCLES_H
 #define CEPH_CYCLES_H
 
+#include <cstdint>
+
 /**
  * This class provides static methods that read the fine-grain CPU
  * cycle counter and translate between cycle-level times and absolute

--- a/src/librbd/api/PoolMetadata.h
+++ b/src/librbd/api/PoolMetadata.h
@@ -7,6 +7,7 @@
 #include "include/buffer_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/msg/async/compression_onwire.h
+++ b/src/msg/async/compression_onwire.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_COMPRESSION_ONWIRE_H
 #define CEPH_COMPRESSION_ONWIRE_H
 
+#include <cstdint>
 #include <optional>
 
 #include "compressor/Compressor.h"

--- a/src/test/librados/op_speed.cc
+++ b/src/test/librados/op_speed.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*
 // vim: ts=8 sw=2 smarttab
 
+#include <cstdint>
+
 #include "include/rados/librados.hpp"
 
 constexpr int to_create = 10'000'000;

--- a/src/test/mon/test_log_rss_usage.cc
+++ b/src/test/mon/test_log_rss_usage.cc
@@ -1,4 +1,5 @@
 #include <sys/types.h>
+#include <cstdint>
 #include <dirent.h>
 #include <errno.h>
 #include <vector>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61381

---

backport of https://github.com/ceph/ceph/pull/50438
parent tracker: https://tracker.ceph.com/issues/58477

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh