### PR TITLE
blkdev: fix nodiscard warning in get_device_metadata()

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -1186,7 +1186,7 @@ void get_device_metadata(
       }
       devpaths += dev + "=" + path;
     } else {
-      (*errs)[dev] + " no unique device path for "s + dev + ": " + err;
+      (*errs)[dev] += " no unique device path for "s + dev + ": " + err;
     }
   }
 }


### PR DESCRIPTION
```
[124/894] Building CXX object src/common/CMakeFiles/common-common-objs.dir/blkdev.cc.o /home/cbodley/ceph/src
/common/blkdev.cc: In function ‘void get_device_metadata(const std::set<std::__cxx11::basic_string<char> >&, 
std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >*, std::map<std::__cxx11::basic_string<char>, 
std::__cxx11::basic_string<char> >*)’: /home/cbodley/ceph/src/common/blkdev.cc:1189:71: warning: ignoring return value of 
‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, 
_Allocator>&&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&) [with _CharT = char; _Traits = char_traits<char>; 
_Alloc = allocator<char>]’, declared with attribute ‘nodiscard’ [-Wunused-result]
 1189 |       (*errs)[dev] + " no unique device path for "s + dev + ": " + err;
      |                                                                       ^
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
