### PR TITLE
qa/cephadm: testing for extra daemon/container features

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -1,0 +1,74 @@
+roles:
+- - host.a
+  - mon.a
+  - mgr.a
+  - osd.0
+- - host.b
+  - mon.b
+  - mgr.b
+  - osd.1
+tasks:
+- install:
+- cephadm:
+- exec:
+    all-hosts:
+      - mkdir /etc/cephadm_testing
+- cephadm.apply:
+    specs:
+      - service_type: mon
+        placement:
+          host_pattern: '*'
+        extra_container_args:
+          - "--cpus=2"
+        extra_entrypoint_args:
+          - "--debug_ms 10"
+      - service_type: container
+        service_id: foo
+        placement:
+          host_pattern: '*'
+        spec:
+          image: "quay.io/fedora/fedora:latest"
+          entrypoint: "bash"
+        extra_container_args:
+          - "-v"
+          - "/etc/cephadm_testing:/root/cephadm_testing"
+        extra_entrypoint_args:
+          - "/root/write_thing_to_file.sh"
+          - "-c"
+          - "testing_custom_containers"
+          - "-o"
+          - "/root/cephadm_testing/testing.txt"
+        custom_configs:
+          - mount_path: "/root/write_thing_to_file.sh"
+            content: |
+              while getopts "o:c:" opt; do
+                case ${opt} in
+                o )
+                  OUT_FILE=${OPTARG}
+                  ;;
+                c )
+                  CONTENT=${OPTARG}
+                esac
+              done
+              echo $CONTENT > $OUT_FILE
+              sleep infinity
+- cephadm.wait_for_service:
+    service: mon
+- cephadm.wait_for_service:
+    service: container.foo
+- exec:
+    host.a:
+      - |
+        set -ex
+        FSID=$(/home/ubuntu/cephtest/cephadm shell -- ceph fsid)
+        sleep 60
+        # check extra container and entrypoint args written to mon unit run file
+        grep "\-\-cpus=2" /var/lib/ceph/$FSID/mon.*/unit.run
+        grep "\-\-debug_ms 10" /var/lib/ceph/$FSID/mon.*/unit.run
+        # check that custom container properly wrote content to file.
+        # This requires the custom config, extra container args, and
+        # entrypoint args to all be working in order for this to have
+        # been written. The container entrypoint was set up with custom_configs,
+        # the content and where to write to with the entrypoint args, and the mounting
+        # of the /etc/cephadm_testing dir with extra container args
+        grep "testing_custom_containers" /etc/cephadm_testing/testing.txt

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1747,6 +1747,7 @@ class MONSpec(ServiceSpec):
                  preview_only: bool = False,
                  networks: Optional[List[str]] = None,
                  extra_container_args: Optional[GeneralArgList] = None,
+                 extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  crush_locations: Optional[Dict[str, List[str]]] = None,
                  ):
@@ -1759,6 +1760,7 @@ class MONSpec(ServiceSpec):
                                       preview_only=preview_only,
                                       networks=networks,
                                       extra_container_args=extra_container_args,
+                                      extra_entrypoint_args=extra_entrypoint_args,
                                       custom_configs=custom_configs)
 
         self.crush_locations = crush_locations

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1282,7 +1282,6 @@ class CustomContainerSpec(ServiceSpec):
                  preview_only: bool = False,
                  image: Optional[str] = None,
                  entrypoint: Optional[str] = None,
-                 extra_entrypoint_args: Optional[GeneralArgList] = None,
                  uid: Optional[int] = None,
                  gid: Optional[int] = None,
                  volume_mounts: Optional[Dict[str, str]] = {},
@@ -1294,6 +1293,9 @@ class CustomContainerSpec(ServiceSpec):
                  ports: Optional[List[int]] = [],
                  dirs: Optional[List[str]] = [],
                  files: Optional[Dict[str, Any]] = {},
+                 extra_container_args: Optional[GeneralArgList] = None,
+                 extra_entrypoint_args: Optional[GeneralArgList] = None,
+                 custom_configs: Optional[List[CustomConfig]] = None,
                  ):
         assert service_type == 'container'
         assert service_id is not None
@@ -1303,7 +1305,9 @@ class CustomContainerSpec(ServiceSpec):
             service_type, service_id,
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config,
-            networks=networks, extra_entrypoint_args=extra_entrypoint_args)
+            networks=networks, extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args,
+            custom_configs=custom_configs)
 
         self.image = image
         self.entrypoint = entrypoint
@@ -1335,6 +1339,19 @@ class CustomContainerSpec(ServiceSpec):
             if value is not None:
                 config_json[prop] = value
         return config_json
+
+    def validate(self) -> None:
+        super(CustomContainerSpec, self).validate()
+
+        if self.args and self.extra_container_args:
+            raise SpecValidationError(
+                '"args" and "extra_container_args" are mutually exclusive '
+                '(and both serve the same purpose)')
+
+        if self.files and self.custom_configs:
+            raise SpecValidationError(
+                '"files" and "custom_configs" are mutually exclusive '
+                '(and both serve the same purpose)')
 
 
 yaml.add_representer(CustomContainerSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1909,6 +1909,7 @@ class CephExporterSpec(ServiceSpec):
                  unmanaged: bool = False,
                  preview_only: bool = False,
                  extra_container_args: Optional[GeneralArgList] = None,
+                 extra_entrypoint_args: Optional[GeneralArgList] = None,
                  ):
         assert service_type == 'ceph-exporter'
 
@@ -1917,7 +1918,8 @@ class CephExporterSpec(ServiceSpec):
             placement=placement,
             unmanaged=unmanaged,
             preview_only=preview_only,
-            extra_container_args=extra_container_args)
+            extra_container_args=extra_container_args,
+            extra_entrypoint_args=extra_entrypoint_args)
 
         self.service_type = service_type
         self.sock_dir = sock_dir


### PR DESCRIPTION
Specifically, the three features: extra_container_args, extra_entrypoint_args, and custom_configs.

This PR does three things

1.  add support for extra_container_args and custom_configs to custom containers. There is technically overlap between these options and some options custom containers already support. But I think allowing these things to be set the way they are set for other daemons is desirable, and validation is being added so that they can't be set in both ways in one spec file.
2. Adds support for extra_entrypoint_args to the mon spec. There was no reason this wasn't supported before, and I think it's absence was just an oversight caused by the MonSpec class and extra_entrypoint_args being added in around the same time in separate PRs.
3. A new test for the aforementioned 3 features. The bulk of the testing is setting up a custom container that uses all 3 features in order to write text into a file within a directory mounted from the host into the container. We can then check that that write happened properly in order to make sure all the features are working properly. There is also a brief portion of the test setting up extra container and entrypoint args for the mon service and then checking for that in a mon daemon's unit.run file.

Signed-off-by: Adam King <adking@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
