### PR TITLE
pacific: mon/MonClient: before complete auth with error, reopen session

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -675,6 +675,11 @@ void MonClient::_finish_auth(int auth_err)
   if (!auth_err && active_con) {
     ceph_assert(auth);
     _check_auth_tickets();
+  } else if (auth_err == -EAGAIN && !active_con) {
+    ldout(cct,10) << __func__ 
+                  << " auth returned EAGAIN, reopening the session to try again"
+                  << dendl;
+    _reopen_session();
   }
   auth_cond.notify_all();
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61740

---

backport of https://github.com/ceph/ceph/pull/51424
parent tracker: https://tracker.ceph.com/issues/58379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh