### PR TITLE
pacific: qa/suites/rados: whitelist POOL_APP_NOT_ENABLED for cls tests

### DIFF
--- a/qa/suites/rados/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/basic/tasks/rados_cls_all.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd_class_load_list: "*"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61602

---

backport of https://github.com/ceph/ceph/pull/51925
parent tracker: https://tracker.ceph.com/issues/59192

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh