### PR TITLE
test/pybind: replace nose with pytest

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -13,4 +13,4 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - rados/test_python.sh --eval-attr 'not (wait or tier or ec or bench or stats)'
+        - rados/test_python.sh -m 'not (wait or tier or ec or bench or stats)'

--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -8,6 +8,10 @@ overrides:
     - \(OSD_
     - \(OBJECT_
     - \(POOL_APP_NOT_ENABLED\)
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     timeout: 1h

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
@@ -3,6 +3,10 @@ overrides:
     log-ignorelist:
       - \(SLOW_OPS\)
       - slow request
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
@@ -7,6 +7,6 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'
+        - rbd/test_librbd_python.sh -m 'not skip_if_crimson'
     env:
       RBD_FEATURES: "61"

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
@@ -3,6 +3,10 @@ overrides:
     log-ignorelist:
       - \(SLOW_OPS\)
       - slow request
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
@@ -7,4 +7,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rbd/test_librbd_python.sh --eval-attr 'not (SKIP_IF_CRIMSON)'
+        - rbd/test_librbd_python.sh -m 'not skip_if_crimson'

--- a/qa/suites/fs/libcephfs/tasks/libcephfs_python.yaml
+++ b/qa/suites/fs/libcephfs/tasks/libcephfs_python.yaml
@@ -3,6 +3,13 @@ overrides:
     disabled: true
   kclient:
     disabled: true
+  install:
+    ceph:
+      extra_system_packages:
+        deb:
+        - python3-pytest
+        rpm:
+        - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/rados/basic/tasks/rados_python.yaml
@@ -8,6 +8,13 @@ overrides:
     - \(OSD_
     - \(OBJECT_
     - \(POOL_APP_NOT_ENABLED\)
+  install:
+    ceph:
+      extra_system_packages:
+        rpm:
+        - python3-pytest
+        deb:
+        - python3-pytest
 tasks:
 - workunit:
     timeout: 1h

--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -3,6 +3,10 @@ overrides:
     log-ignorelist:
       - \(SLOW_OPS\)
       - slow request
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/rados_python.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_python.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - ceph:
     log-ignorelist:

--- a/qa/suites/smoke/basic/tasks/test/rbd_python_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rbd_python_api_tests.yaml
@@ -1,3 +1,8 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 tasks:
 - ceph:
 - ceph-fuse:

--- a/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/workload/test_rbd_python.yaml
@@ -1,6 +1,11 @@
 meta:
 - desc: |
    librbd python api tests
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 workload:
   full_sequential:
     - print: "**** done start test_rbd_python.yaml"

--- a/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/workload/test_rbd_python.yaml
@@ -1,6 +1,11 @@
 meta:
 - desc: |
    librbd python api tests
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+      - python3-pytest
 workload:
   full_sequential:
     - print: "**** done start test_rbd_python.yaml"

--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -2,5 +2,5 @@
 
 # Running as root because the filesystem root directory will be
 # owned by uid 0, and that's where we're writing.
-sudo python3 -m nose -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
+sudo python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
 exit 0

--- a/qa/workunits/rados/test_python.sh
+++ b/qa/workunits/rados/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
 
 ceph osd pool create rbd
-${PYTHON:-python3} -m nose -v $(dirname $0)/../../../src/test/pybind/test_rados.py "$@"
+${PYTHON:-python3} -m pytest -v $(dirname $0)/../../../src/test/pybind/test_rados.py "$@"
 exit 0

--- a/qa/workunits/rbd/test_librbd_python.sh
+++ b/qa/workunits/rbd/test_librbd_python.sh
@@ -5,8 +5,8 @@ relpath=$(dirname $0)/../../../src/test/pybind
 if [ -n "${VALGRIND}" ]; then
   valgrind ${VALGRIND} --suppressions=${TESTDIR}/valgrind.supp \
     --errors-for-leak-kinds=definite --error-exitcode=1 \
-    python3 -m nose -v $relpath/test_rbd.py "$@"
+    python3 -m pytest -v $relpath/test_rbd.py "$@"
 else
-    python3 -m nose -v $relpath/test_rbd.py "$@"
+    python3 -m pytest -v $relpath/test_rbd.py "$@"
 fi
 exit 0

--- a/src/test/pybind/assertions.py
+++ b/src/test/pybind/assertions.py
@@ -1,0 +1,23 @@
+def assert_equal(a, b):
+    assert a == b
+
+def assert_not_equal(a, b):
+    assert a != b
+
+def assert_greater_equal(a, b):
+    assert a >= b
+
+def assert_raises(excClass, callableObj, *args, **kwargs):
+    """
+    Like unittest.TestCase.assertRaises, but returns the exception.
+    """
+    try:
+        callableObj(*args, **kwargs)
+    except excClass as e:
+        return e
+    else:
+        if hasattr(excClass, '__name__'):
+            excName = excClass.__name__
+        else:
+            excName = str(excClass)
+        raise AssertionError("%s not raised" % excName)

--- a/src/test/pybind/assertions.py
+++ b/src/test/pybind/assertions.py
@@ -4,6 +4,9 @@ def assert_equal(a, b):
 def assert_not_equal(a, b):
     assert a != b
 
+def assert_greater(a, b):
+    assert a > b
+
 def assert_greater_equal(a, b):
     assert a >= b
 

--- a/src/test/pybind/pytest.ini
+++ b/src/test/pybind/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    skip_if_crimson

--- a/src/test/pybind/pytest.ini
+++ b/src/test/pybind/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 markers =
+    bench
+    ec
+    rollback
     skip_if_crimson
+    stats
+    tier
+    watch

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1,10 +1,11 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
 import collections
 collections.Callable = collections.abc.Callable
-from nose.tools import assert_raises, assert_equal, assert_not_equal, assert_greater, with_setup
+from assertions import assert_raises, assert_equal, assert_not_equal, assert_greater
 import cephfs as libcephfs
 import fcntl
 import os
+import pytest
 import random
 import time
 import stat
@@ -49,7 +50,8 @@ def purge_dir(path, is_snap = False):
         dent = cephfs.readdir(d)
     cephfs.closedir(d)
 
-def setup_test():
+@pytest.fixture
+def testdir():
     purge_dir(b"/")
 
     cephfs.chdir(b"/")
@@ -59,29 +61,24 @@ def setup_test():
     for xattr in xattrs[:-1]:
         cephfs.removexattr("/", xattr)
 
-@with_setup(setup_test)
-def test_conf_get():
+def test_conf_get(testdir):
     fsid = cephfs.conf_get("fsid")
     assert(len(fsid) > 0)
 
-@with_setup(setup_test)
 def test_version():
     cephfs.version()
 
-@with_setup(setup_test)
-def test_fstat():
+def test_fstat(testdir):
     fd = cephfs.open(b'file-1', 'w', 0o755)
     stat = cephfs.fstat(fd)
     assert(len(stat) == 13)
     cephfs.close(fd)
 
-@with_setup(setup_test)
-def test_statfs():
+def test_statfs(testdir):
     stat = cephfs.statfs(b'/')
     assert(len(stat) == 11)
 
-@with_setup(setup_test)
-def test_statx():
+def test_statx(testdir):
     stat = cephfs.statx(b'/', libcephfs.CEPH_STATX_MODE, 0)
     assert('mode' in stat.keys())
     stat = cephfs.statx(b'/', libcephfs.CEPH_STATX_BTIME, 0)
@@ -97,12 +94,10 @@ def test_statx():
     cephfs.unlink(b'file-2')
     cephfs.unlink(b'file-1')
 
-@with_setup(setup_test)
-def test_syncfs():
+def test_syncfs(testdir):
     stat = cephfs.sync_fs()
 
-@with_setup(setup_test)
-def test_fsync():
+def test_fsync(testdir):
     fd = cephfs.open(b'file-1', 'w', 0o755)
     cephfs.write(fd, b"asdf", 0)
     stat = cephfs.fsync(fd, 0)
@@ -112,8 +107,7 @@ def test_fsync():
     #sync on non-existing fd (assume fd 12345 is not exists)
     assert_raises(libcephfs.Error, cephfs.fsync, 12345, 0)
 
-@with_setup(setup_test)
-def test_directory():
+def test_directory(testdir):
     cephfs.mkdir(b"/temp-directory", 0o755)
     cephfs.mkdirs(b"/temp-directory/foo/bar", 0o755)
     cephfs.chdir(b"/temp-directory")
@@ -123,8 +117,7 @@ def test_directory():
     cephfs.rmdir(b"/temp-directory")
     assert_raises(libcephfs.ObjectNotFound, cephfs.chdir, b"/temp-directory")
 
-@with_setup(setup_test)
-def test_walk_dir():
+def test_walk_dir(testdir):
     cephfs.chdir(b"/")
     dirs = [b"dir-1", b"dir-2", b"dir-3"]
     for i in dirs:
@@ -142,8 +135,7 @@ def test_walk_dir():
         cephfs.rmdir(i)
     cephfs.closedir(handler)
 
-@with_setup(setup_test)
-def test_xattr():
+def test_xattr(testdir):
     assert_raises(libcephfs.OperationNotSupported, cephfs.setxattr, "/", "key", b"value", 0)
     cephfs.setxattr("/", "user.key", b"value", 0)
     assert_equal(b"value", cephfs.getxattr("/", "user.key"))
@@ -165,8 +157,7 @@ def test_xattr():
     assert_equal(9, ret_val)
     assert_equal("user.big\x00", ret_buff.decode('utf-8'))
 
-@with_setup(setup_test)
-def test_ceph_mirror_xattr():
+def test_ceph_mirror_xattr(testdir):
     def gen_mirror_xattr():
         cluster_id = str(uuid.uuid4())
         fs_id = random.randint(1, 10)
@@ -206,8 +197,7 @@ def test_ceph_mirror_xattr():
     # check mirror info xattr format
     assert_raises(libcephfs.InvalidValue, cephfs.setxattr, '/', 'ceph.mirror.info', b"unknown", 0)
 
-@with_setup(setup_test)
-def test_fxattr():
+def test_fxattr(testdir):
     fd = cephfs.open(b'/file-fxattr', 'w', 0o755)
     assert_raises(libcephfs.OperationNotSupported, cephfs.fsetxattr, fd, "key", b"value", 0)
     assert_raises(TypeError, cephfs.fsetxattr, "fd", "user.key", b"value", 0)
@@ -235,8 +225,7 @@ def test_fxattr():
     cephfs.close(fd)
     cephfs.unlink(b'/file-fxattr')
 
-@with_setup(setup_test)
-def test_rename():
+def test_rename(testdir):
     cephfs.mkdir(b"/a", 0o755)
     cephfs.mkdir(b"/a/b", 0o755)
     cephfs.rename(b"/a", b"/b")
@@ -244,8 +233,7 @@ def test_rename():
     cephfs.rmdir(b"/b/b")
     cephfs.rmdir(b"/b")
 
-@with_setup(setup_test)
-def test_open():
+def test_open(testdir):
     assert_raises(libcephfs.ObjectNotFound, cephfs.open, b'file-1', 'r')
     assert_raises(libcephfs.ObjectNotFound, cephfs.open, b'file-1', 'r+')
     fd = cephfs.open(b'file-1', 'w', 0o755)
@@ -270,8 +258,7 @@ def test_open():
     assert_raises(libcephfs.OperationNotSupported, cephfs.open, b'file-1', 'a')
     cephfs.unlink(b'file-1')
 
-@with_setup(setup_test)
-def test_link():
+def test_link(testdir):
     fd = cephfs.open(b'file-1', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     cephfs.close(fd)
@@ -287,8 +274,7 @@ def test_link():
     cephfs.close(fd)
     cephfs.unlink(b'file-2')
 
-@with_setup(setup_test)
-def test_symlink():
+def test_symlink(testdir):
     fd = cephfs.open(b'file-1', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     cephfs.close(fd)
@@ -304,8 +290,7 @@ def test_symlink():
     cephfs.close(fd)
     cephfs.unlink(b'file-2')
 
-@with_setup(setup_test)
-def test_readlink():
+def test_readlink(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     cephfs.close(fd)
@@ -315,8 +300,7 @@ def test_readlink():
     cephfs.unlink(b'/file-2')
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_delete_cwd():
+def test_delete_cwd(testdir):
     assert_equal(b"/", cephfs.getcwd())
 
     cephfs.mkdir(b"/temp-directory", 0o755)
@@ -328,8 +312,7 @@ def test_delete_cwd():
     # whether it really still exists
     assert_equal(b"/temp-directory", cephfs.getcwd())
 
-@with_setup(setup_test)
-def test_flock():
+def test_flock(testdir):
     fd = cephfs.open(b'file-1', 'w', 0o755)
 
     cephfs.flock(fd, fcntl.LOCK_EX, 123);
@@ -341,15 +324,13 @@ def test_flock():
 
     cephfs.close(fd)
 
-@with_setup(setup_test)
-def test_mount_unmount():
-    test_directory()
+def test_mount_unmount(testdir):
+    test_directory(testdir)
     cephfs.unmount()
     cephfs.mount()
-    test_open()
+    test_open(testdir)
 
-@with_setup(setup_test)
-def test_lxattr():
+def test_lxattr(testdir):
     fd = cephfs.open(b'/file-lxattr', 'w', 0o755)
     cephfs.close(fd)
     cephfs.setxattr(b"/file-lxattr", "user.key", b"value", 0)
@@ -378,8 +359,7 @@ def test_lxattr():
     cephfs.unlink(b'/file-lxattr')
     cephfs.unlink(b'/file-sym-lxattr')
 
-@with_setup(setup_test)
-def test_mount_root():
+def test_mount_root(testdir):
     cephfs.mkdir(b"/mount-directory", 0o755)
     cephfs.unmount()
     cephfs.mount(mount_root = b"/mount-directory")
@@ -388,8 +368,7 @@ def test_mount_root():
     cephfs.unmount()
     cephfs.mount()
 
-@with_setup(setup_test)
-def test_utime():
+def test_utime(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
     cephfs.close(fd)
@@ -415,8 +394,7 @@ def test_utime():
 
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_futime():
+def test_futime(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
 
@@ -442,8 +420,7 @@ def test_futime():
     cephfs.close(fd)
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_utimes():
+def test_utimes(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
     cephfs.close(fd)
@@ -469,8 +446,7 @@ def test_utimes():
 
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_lutimes():
+def test_lutimes(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
     cephfs.close(fd)
@@ -504,8 +480,7 @@ def test_lutimes():
     cephfs.unlink(b'/file-2')
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_futimes():
+def test_futimes(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
 
@@ -531,8 +506,7 @@ def test_futimes():
     cephfs.close(fd)
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_futimens():
+def test_futimens(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
 
@@ -558,8 +532,7 @@ def test_futimens():
     cephfs.close(fd)
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_lchmod():
+def test_lchmod(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b'0000', 0)
     cephfs.close(fd)
@@ -583,8 +556,7 @@ def test_lchmod():
     cephfs.unlink(b'/file-2')
     cephfs.unlink(b'/file-1')
 
-@with_setup(setup_test)
-def test_fchmod():
+def test_fchmod(testdir):
     fd = cephfs.open(b'/file-fchmod', 'w', 0o655)
     st = cephfs.statx(b'/file-fchmod', libcephfs.CEPH_STATX_MODE, 0)
     mode = st["mode"] | stat.S_IXUSR
@@ -596,8 +568,7 @@ def test_fchmod():
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchmod')
 
-@with_setup(setup_test)
-def test_fchown():
+def test_fchown(testdir):
     fd = cephfs.open(b'/file-fchown', 'w', 0o655)
     uid = os.getuid()
     gid = os.getgid()
@@ -614,8 +585,7 @@ def test_fchown():
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchown')
 
-@with_setup(setup_test)
-def test_truncate():
+def test_truncate(testdir):
     fd = cephfs.open(b'/file-truncate', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     cephfs.truncate(b'/file-truncate', 0)
@@ -625,8 +595,7 @@ def test_truncate():
     cephfs.close(fd)
     cephfs.unlink(b'/file-truncate')
 
-@with_setup(setup_test)
-def test_ftruncate():
+def test_ftruncate(testdir):
     fd = cephfs.open(b'/file-ftruncate', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     assert_raises(TypeError, cephfs.ftruncate, b'/file-ftruncate', 0)
@@ -637,8 +606,7 @@ def test_ftruncate():
     cephfs.close(fd)
     cephfs.unlink(b'/file-ftruncate')
 
-@with_setup(setup_test)
-def test_fallocate():
+def test_fallocate(testdir):
     fd = cephfs.open(b'/file-fallocate', 'w', 0o755)
     assert_raises(TypeError, cephfs.fallocate, b'/file-fallocate', 0, 10)
     cephfs.fallocate(fd, 0, 10)
@@ -648,16 +616,14 @@ def test_fallocate():
     cephfs.close(fd)
     cephfs.unlink(b'/file-fallocate')
 
-@with_setup(setup_test)
-def test_mknod():
+def test_mknod(testdir):
     mode = stat.S_IFIFO | stat.S_IRUSR | stat.S_IWUSR
     cephfs.mknod(b'/file-fifo', mode)
     st = cephfs.statx(b'/file-fifo', libcephfs.CEPH_STATX_MODE, 0)
     assert_equal(st["mode"] & mode, mode)
     cephfs.unlink(b'/file-fifo')
 
-@with_setup(setup_test)
-def test_lazyio():
+def test_lazyio(testdir):
     fd = cephfs.open(b'/file-lazyio', 'w', 0o755)
     assert_raises(TypeError, cephfs.lazyio, "fd", 1)
     assert_raises(TypeError, cephfs.lazyio, fd, "1")
@@ -679,8 +645,7 @@ def test_lazyio():
     cephfs.close(fd)
     cephfs.unlink(b'/file-lazyio')
 
-@with_setup(setup_test)
-def test_replication():
+def test_replication(testdir):
     fd = cephfs.open(b'/file-rep', 'w', 0o755)
     assert_raises(TypeError, cephfs.get_file_replication, "fd")
     l_dict = cephfs.get_layout(fd)
@@ -695,8 +660,7 @@ def test_replication():
     cephfs.close(fd)
     cephfs.unlink(b'/file-rep')
 
-@with_setup(setup_test)
-def test_caps():
+def test_caps(testdir):
     fd = cephfs.open(b'/file-caps', 'w', 0o755)
     timeout = cephfs.get_cap_return_timeout()
     assert_equal(timeout, 300)
@@ -706,19 +670,16 @@ def test_caps():
     cephfs.close(fd)
     cephfs.unlink(b'/file-caps')
 
-@with_setup(setup_test)
-def test_setuuid():
+def test_setuuid(testdir):
     ses_id_uid = uuid.uuid1()
     ses_id_str = str(ses_id_uid)
     cephfs.set_uuid(ses_id_str)
 
-@with_setup(setup_test)
-def test_session_timeout():
+def test_session_timeout(testdir):
     assert_raises(TypeError, cephfs.set_session_timeout, "300")
     cephfs.set_session_timeout(300)
 
-@with_setup(setup_test)
-def test_readdirops():
+def test_readdirops(testdir):
     cephfs.chdir(b"/")
     dirs = [b"dir-1", b"dir-2", b"dir-3"]
     for i in dirs:
@@ -759,8 +720,7 @@ def test_preadv_pwritev():
     cephfs.close(fd)
     cephfs.unlink(b'file-1')
 
-@with_setup(setup_test)
-def test_setattrx():
+def test_setattrx(testdir):
     fd = cephfs.open(b'file-setattrx', 'w', 0o655)
     cephfs.write(fd, b"1111", 0)
     cephfs.close(fd)
@@ -797,8 +757,7 @@ def test_setattrx():
     assert_equal(10, st1["size"])
     cephfs.unlink(b'file-setattrx')
 
-@with_setup(setup_test)
-def test_fsetattrx():
+def test_fsetattrx(testdir):
     fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
     cephfs.write(fd, b"1111", 0)
     st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)
@@ -835,8 +794,7 @@ def test_fsetattrx():
     cephfs.close(fd)
     cephfs.unlink(b'file-fsetattrx')
 
-@with_setup(setup_test)
-def test_get_layout():
+def test_get_layout(testdir):
     fd = cephfs.open(b'file-get-layout', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
     assert_raises(TypeError, cephfs.get_layout, "fd")
@@ -850,14 +808,12 @@ def test_get_layout():
     cephfs.close(fd)
     cephfs.unlink(b'file-get-layout')
 
-@with_setup(setup_test)
-def test_get_default_pool():
+def test_get_default_pool(testdir):
     dp_dict = cephfs.get_default_pool()
     assert('pool_id' in dp_dict.keys())
     assert('pool_name' in dp_dict.keys())
 
-@with_setup(setup_test)
-def test_get_pool():
+def test_get_pool(testdir):
     dp_dict = cephfs.get_default_pool()
     assert('pool_id' in dp_dict.keys())
     assert('pool_name' in dp_dict.keys())
@@ -867,8 +823,7 @@ def test_get_pool():
     size=int(s.split(" ")[-1])
     assert_equal(cephfs.get_pool_replication(dp_dict["pool_id"]), size)
 
-@with_setup(setup_test)
-def test_disk_quota_exceeeded_error():
+def test_disk_quota_exceeeded_error(testdir):
     cephfs.mkdir("/dir-1", 0o755)
     cephfs.setxattr("/dir-1", "ceph.quota.max_bytes", b"4096", 0)
     fd = cephfs.open(b'/dir-1/file-1', 'w', 0o755)
@@ -878,8 +833,7 @@ def test_disk_quota_exceeeded_error():
     cephfs.close(fd)
     cephfs.unlink(b"/dir-1/file-1")
 
-@with_setup(setup_test)
-def test_empty_snapshot_info():
+def test_empty_snapshot_info(testdir):
     cephfs.mkdir("/dir-1", 0o755)
 
     # snap without metadata
@@ -892,8 +846,7 @@ def test_empty_snapshot_info():
     # remove directory
     cephfs.rmdir("/dir-1")
 
-@with_setup(setup_test)
-def test_snapshot_info():
+def test_snapshot_info(testdir):
     cephfs.mkdir("/dir-1", 0o755)
 
     # snap with custom metadata
@@ -909,24 +862,20 @@ def test_snapshot_info():
     # remove directory
     cephfs.rmdir("/dir-1")
 
-@with_setup(setup_test)
-def test_set_mount_timeout_post_mount():
+def test_set_mount_timeout_post_mount(testdir):
     assert_raises(libcephfs.LibCephFSStateError, cephfs.set_mount_timeout, 5)
 
-@with_setup(setup_test)
-def test_set_mount_timeout():
+def test_set_mount_timeout(testdir):
     cephfs.unmount()
     cephfs.set_mount_timeout(5)
     cephfs.mount()
 
-@with_setup(setup_test)
-def test_set_mount_timeout_lt0():
+def test_set_mount_timeout_lt0(testdir):
     cephfs.unmount()
     assert_raises(libcephfs.InvalidValue, cephfs.set_mount_timeout, -5)
     cephfs.mount()
 
-@with_setup(setup_test)
-def test_snapdiff():
+def test_snapdiff(testdir):
     cephfs.mkdir("/snapdiff_test", 0o755)
     fd = cephfs.open('/snapdiff_test/file-1', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
-from nose import SkipTest
-from nose.plugins.attrib import attr
-from nose.tools import eq_ as eq, ok_ as ok, assert_raises
+from assertions import assert_equal as eq, assert_raises
 from rados import (Rados, Error, RadosStateError, Object, ObjectExists,
                    ObjectNotFound, ObjectBusy, NotConnected,
                    LIBRADOS_ALL_NSPACES, WriteOpCtx, ReadOpCtx, LIBRADOS_CREATE_EXCLUSIVE,
@@ -13,6 +11,7 @@ import threading
 import json
 import errno
 import os
+import pytest
 import re
 import sys
 
@@ -98,7 +97,7 @@ class TestRadosStateError(object):
 
 class TestRados(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.conf_parse_env('FOO_DOES_NOT_EXIST_BLAHBLAH')
         self.rados.conf_parse_env()
@@ -107,7 +106,7 @@ class TestRados(object):
         # Assume any pre-existing pools are the cluster's defaults
         self.default_pools = self.rados.list_pools()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.rados.shutdown()
 
     def test_ping_monitor(self):
@@ -124,7 +123,7 @@ class TestRados(object):
                     break
 
     def test_annotations(self):
-        with assert_raises(TypeError):
+        with pytest.raises(TypeError):
             self.rados.create_pool(0xf00)
 
     def test_create(self):
@@ -175,7 +174,7 @@ class TestRados(object):
         eq(set(['a' * 500]), self.list_non_default_pools())
         self.rados.delete_pool('a' * 500)
 
-    @attr('tier')
+    @pytest.mark.tier
     def test_get_pool_base_tier(self):
         self.rados.create_pool('foo')
         try:
@@ -213,7 +212,7 @@ class TestRados(object):
     def test_blocklist_add(self):
         self.rados.blocklist_add("1.2.3.4/123", 1)
 
-    @attr('stats')
+    @pytest.mark.stats
     def test_get_cluster_stats(self):
         stats = self.rados.get_cluster_stats()
         assert stats['kb'] > 0
@@ -241,14 +240,14 @@ class TestRados(object):
 
 class TestIoctx(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.rados.create_pool('test_pool')
         assert self.rados.pool_exists('test_pool')
         self.ioctx = self.rados.open_ioctx('test_pool')
 
-    def tearDown(self):
+    def teardown_method(self, method):
         cmd = {"prefix":"osd unset", "key":"noup"}
         self.rados.mon_command(json.dumps(cmd), b'')
         self.ioctx.close()
@@ -399,7 +398,7 @@ class TestIoctx(object):
         self.ioctx.remove_snap('foo')
         eq(list(self.ioctx.list_snaps()), [])
 
-    @attr('rollback')
+    @pytest.mark.rollback
     def test_snap_rollback(self):
         self.ioctx.write("insnap", b"contents1")
         self.ioctx.create_snap("snap1")
@@ -409,7 +408,7 @@ class TestIoctx(object):
         self.ioctx.remove_snap("snap1")
         self.ioctx.remove_object("insnap")
 
-    @attr('rollback')
+    @pytest.mark.rollback
     def test_snap_rollback_removed(self):
         self.ioctx.write("insnap", b"contents1")
         self.ioctx.create_snap("snap1")
@@ -518,7 +517,7 @@ class TestIoctx(object):
 
             write_op.remove()
             self.ioctx.operate_write_op(write_op, "write_ops")
-            with assert_raises(ObjectNotFound):
+            with pytest.raises(ObjectNotFound):
                 self.ioctx.read('write_ops')
 
     def test_execute_op(self):
@@ -547,7 +546,7 @@ class TestIoctx(object):
         with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3","4",), omap_key_type=bytes)
             eq(ret, 0)
-            with assert_raises(ObjectNotFound):
+            with pytest.raises(ObjectNotFound):
                 self.ioctx.operate_read_op(read_op, "no_such")
 
     def test_get_omap_keys(self):
@@ -564,7 +563,7 @@ class TestIoctx(object):
         with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_keys(read_op,"",2)
             eq(ret, 0)
-            with assert_raises(ObjectNotFound):
+            with pytest.raises(ObjectNotFound):
                 self.ioctx.operate_read_op(read_op, "no_such")
 
     def test_clear_omap(self):
@@ -798,7 +797,7 @@ class TestIoctx(object):
             while count[0] < 1:
                 lock.wait()
         eq(comp.get_return_value(), 0)
-        with assert_raises(NoData):
+        with pytest.raises(NoData):
             self.ioctx.get_xattr("xyz", "key")
 
     def test_aio_write_no_comp_ref(self):
@@ -946,7 +945,7 @@ class TestIoctx(object):
         r, _, _ = self.rados.mon_command(json.dumps(cmd), b'')
         eq(r, 0)
 
-    @attr('wait')
+    @pytest.mark.wait
     def test_aio_read_wait_for_complete(self):
         # use wait_for_complete() and wait for cb by
         # watching retval[0]
@@ -982,7 +981,7 @@ class TestIoctx(object):
         eq(retval[0], payload)
         eq(sys.getrefcount(comp), 2)
 
-    @attr('wait')
+    @pytest.mark.wait
     def test_aio_read_wait_for_complete_and_cb(self):
         # use wait_for_complete_and_cb(), verify retval[0] is
         # set by the time we regain control
@@ -1010,7 +1009,7 @@ class TestIoctx(object):
         eq(retval[0], payload)
         eq(sys.getrefcount(comp), 2)
 
-    @attr('wait')
+    @pytest.mark.wait
     def test_aio_read_wait_for_complete_and_cb_error(self):
         # error case, use wait_for_complete_and_cb(), verify retval[0] is
         # set by the time we regain control
@@ -1123,7 +1122,7 @@ class TestIoctx(object):
         release = json.loads(buf.decode("utf-8")).get("require_osd_release",
                                                       None)
         if not release or release[0] < 'l':
-            raise SkipTest
+            pytest.skip('required_osd_release >= l')
 
         eq([], self.ioctx.application_list())
 
@@ -1160,10 +1159,10 @@ class TestIoctx(object):
         eq(self.ioctx.alignment(), None)
 
 
-@attr('ec')
+@pytest.mark.ec
 class TestIoctxEc(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.pool = 'test-ec'
@@ -1171,17 +1170,17 @@ class TestIoctxEc(object):
         cmd = {"prefix": "osd erasure-code-profile set",
                "name": self.profile, "profile": ["k=2", "m=1", "crush-failure-domain=osd"]}
         ret, buf, out = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
-        eq(ret, 0, msg=out)
+        assert ret == 0, out
         # create ec pool with profile created above
         cmd = {'prefix': 'osd pool create', 'pg_num': 8, 'pgp_num': 8,
                'pool': self.pool, 'pool_type': 'erasure',
                'erasure_code_profile': self.profile}
         ret, buf, out = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
-        eq(ret, 0, msg=out)
+        assert ret == 0, out
         assert self.rados.pool_exists(self.pool)
         self.ioctx = self.rados.open_ioctx(self.pool)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         cmd = {"prefix": "osd unset", "key": "noup"}
         self.rados.mon_command(json.dumps(cmd), b'')
         self.ioctx.close()
@@ -1194,7 +1193,7 @@ class TestIoctxEc(object):
 
 class TestIoctx2(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.rados.create_pool('test_pool')
@@ -1203,7 +1202,7 @@ class TestIoctx2(object):
         assert pool_id > 0
         self.ioctx2 = self.rados.open_ioctx2(pool_id)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         cmd = {"prefix": "osd unset", "key": "noup"}
         self.rados.mon_command(json.dumps(cmd), b'')
         self.ioctx2.close()
@@ -1232,7 +1231,7 @@ class TestIoctx2(object):
 
 class TestObject(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.rados.create_pool('test_pool')
@@ -1241,7 +1240,7 @@ class TestObject(object):
         self.ioctx.write('foo', b'bar')
         self.object = Object(self.ioctx, 'foo')
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.ioctx.close()
         self.ioctx = None
         self.rados.delete_pool('test_pool')
@@ -1266,21 +1265,21 @@ class TestObject(object):
         eq(self.object.read(3), b'baz')
 
 class TestIoCtxSelfManagedSnaps(object):
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.rados.create_pool('test_pool')
         assert self.rados.pool_exists('test_pool')
         self.ioctx = self.rados.open_ioctx('test_pool')
 
-    def tearDown(self):
+    def teardown_method(self, method):
         cmd = {"prefix":"osd unset", "key":"noup"}
         self.rados.mon_command(json.dumps(cmd), b'')
         self.ioctx.close()
         self.rados.delete_pool('test_pool')
         self.rados.shutdown()
 
-    @attr('rollback')
+    @pytest.mark.rollback
     def test(self):
         # cannot mix-and-match pool and self-managed snapshot mode
         self.ioctx.set_self_managed_snap_write([])
@@ -1305,11 +1304,11 @@ class TestIoCtxSelfManagedSnaps(object):
 
 class TestCommand(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.rados.shutdown()
 
     def test_monmap_dump(self):
@@ -1358,7 +1357,7 @@ class TestCommand(object):
         e = json.loads(buf.decode("utf-8"))
         assert('release' in e)
 
-    @attr('bench')
+    @pytest.mark.bench
     def test_osd_bench(self):
         cmd = dict(prefix='bench', size=4096, count=8192)
         ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), b'',
@@ -1379,11 +1378,11 @@ class TestCommand(object):
         eq(u"pool '\u9ec5' created", out)
 
 
-@attr('watch')
+@pytest.mark.watch
 class TestWatchNotify(object):
     OID = "test_watch_notify"
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rados = Rados(conffile='')
         self.rados.connect()
         self.rados.create_pool('test_pool')
@@ -1399,7 +1398,7 @@ class TestWatchNotify(object):
         self.ack_data = {}
         self.instance_id = self.rados.get_instance_id()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.ioctx.close()
         self.rados.delete_pool('test_pool')
         self.rados.shutdown()
@@ -1497,23 +1496,23 @@ class TestWatchNotify(object):
         with self.ioctx.watch(self.OID, self.make_callback_reply(),
                               self.make_error_callback()) as watch1:
             watch_id1 = watch1.get_id()
-            ok(watch_id1 > 0)
+            assert watch_id1 > 0
 
             with self.rados.open_ioctx('test_pool') as ioctx:
                 watch2 = ioctx.watch(self.OID, self.make_callback_reply(),
                                      self.make_error_callback())
             watch_id2 = watch2.get_id()
-            ok(watch_id2 > 0)
+            assert watch_id2 > 0
 
             comp = self.ioctx.aio_notify(self.OID, self.notify_callback, msg='test')
             comp.wait_for_complete_and_cb()
             with self.lock:
-                ok(self.instance_id in self.ack_cnt)
+                assert self.instance_id in self.ack_cnt
                 eq(self.ack_cnt[self.instance_id], 2)
                 eq(self.ack_data[self.instance_id], b'test')
 
-            ok(watch1.check() >= timedelta())
-            ok(watch2.check() >= timedelta())
+            assert watch1.check() >= timedelta()
+            assert watch2.check() >= timedelta()
 
             comp = self.ioctx.aio_notify(self.OID, self.notify_callback, msg='best')
             comp.wait_for_complete_and_cb()

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -7,14 +7,13 @@ import json
 import socket
 import os
 import platform
+import pytest
 import time
 import sys
 
-from datetime import datetime, timedelta
-from nose import with_setup, SkipTest
-from nose.plugins.attrib import attr
-from nose.tools import (eq_ as eq, assert_raises, assert_not_equal,
+from assertions import (assert_equal as eq, assert_raises, assert_not_equal,
                         assert_greater_equal)
+from datetime import datetime, timedelta
 from rados import (Rados,
                    LIBRADOS_OP_FLAG_FADVISE_DONTNEED,
                    LIBRADOS_OP_FLAG_FADVISE_NOCACHE,
@@ -121,6 +120,12 @@ def remove_image():
     if image_name is not None:
         RBD().remove(ioctx, image_name)
 
+@pytest.fixture
+def tmp_image():
+    create_image()
+    yield
+    remove_image()
+
 def create_group():
     global group_name
     group_name = get_temp_group_name()
@@ -129,6 +134,12 @@ def create_group():
 def remove_group():
     if group_name is not None:
         RBD().group_remove(ioctx, group_name)
+
+@pytest.fixture
+def tmp_group():
+    create_group()
+    yield
+    remove_group()
 
 def rename_group():
     new_group_name = "new" + group_name
@@ -139,7 +150,7 @@ def require_new_format():
         def _require_new_format(*args, **kwargs):
             global features
             if features is None:
-                raise SkipTest
+                pytest.skip('requires new format')
             return fn(*args, **kwargs)
         return functools.wraps(fn)(_require_new_format)
     return wrapper
@@ -149,10 +160,10 @@ def require_features(required_features):
         def _require_features(*args, **kwargs):
             global features
             if features is None:
-                raise SkipTest
+                pytest.skip('requires new format')
             for feature in required_features:
                 if feature & features != feature:
-                    raise SkipTest
+                    pytest.skip('missing required feature')
             return fn(*args, **kwargs)
         return functools.wraps(fn)(_require_features)
     return wrapper
@@ -161,7 +172,7 @@ def require_linux():
     def wrapper(fn):
         def _require_linux(*args, **kwargs):
             if platform.system() != "Linux":
-                raise SkipTest
+                pytest.skip('requires linux')
             return fn(*args, **kwargs)
         return functools.wraps(fn)(_require_linux)
     return wrapper
@@ -172,7 +183,7 @@ def blocklist_features(blocklisted_features):
             global features
             for feature in blocklisted_features:
                 if features is not None and feature & features == feature:
-                    raise SkipTest
+                    pytest.skip('blocklisted feature enabled')
             return fn(*args, **kwargs)
         return functools.wraps(fn)(_blocklist_features)
     return wrapper
@@ -380,16 +391,15 @@ def test_remove_dne():
 def test_list_empty():
     eq([], RBD().list(ioctx))
 
-@with_setup(create_image, remove_image)
-def test_list():
+def test_list(tmp_image):
     eq([image_name], RBD().list(ioctx))
 
     with Image(ioctx, image_name) as image:
         image_id = image.id()
     eq([{'id': image_id, 'name': image_name}], list(RBD().list2(ioctx)))
 
-@with_setup(create_image)
 def test_remove_with_progress():
+    create_image()
     d = {'received_callback': False}
     def progress_cb(current, total):
         d['received_callback'] = True
@@ -398,16 +408,14 @@ def test_remove_with_progress():
     RBD().remove(ioctx, image_name, on_progress=progress_cb)
     eq(True, d['received_callback'])
 
-@with_setup(create_image)
-def test_remove_canceled():
+def test_remove_canceled(tmp_image):
     def progress_cb(current, total):
         return -ECANCELED
 
     assert_raises(OperationCanceled, RBD().remove, ioctx, image_name,
                   on_progress=progress_cb)
 
-@with_setup(create_image, remove_image)
-def test_rename():
+def test_rename(tmp_image):
     rbd = RBD()
     image_name2 = get_temp_image_name()
     rbd.rename(ioctx, image_name, image_name2)
@@ -566,12 +574,12 @@ def test_features_from_string():
 
 class TestImage(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rbd = RBD()
         create_image()
         self.image = Image(ioctx, image_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.image.close()
         remove_image()
         self.image = None
@@ -783,7 +791,7 @@ class TestImage(object):
         self._test_copy(features, self.image.stat()['order'],
                         self.image.stripe_unit(), self.image.stripe_count())
 
-    @attr('SKIP_IF_CRIMSON')
+    @pytest.mark.skip_if_crimson
     def test_deep_copy(self):
         global ioctx
         global features
@@ -1410,13 +1418,13 @@ class TestImage(object):
 
 class TestImageId(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rbd = RBD()
         create_image()
         self.image = Image(ioctx, image_name)
         self.image2 = Image(ioctx, None, None, False, self.image.id())
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.image.close()
         self.image2.close()
         remove_image()
@@ -1447,7 +1455,7 @@ def check_diff(image, offset, length, from_snapshot, expected):
 class TestClone(object):
 
     @require_features([RBD_FEATURE_LAYERING])
-    def setUp(self):
+    def setup_method(self, method):
         global ioctx
         global features
         self.rbd = RBD()
@@ -1463,7 +1471,7 @@ class TestClone(object):
                        features)
         self.clone = Image(ioctx, self.clone_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         global ioctx
         self.clone.close()
         self.rbd.remove(ioctx, self.clone_name)
@@ -1548,7 +1556,7 @@ class TestClone(object):
         # can't remove a snapshot that has dependent clones
         assert_raises(ImageBusy, self.image.remove_snap, 'snap1')
 
-        # validate parent info of clone created by TestClone.setUp
+        # validate parent info of clone created by TestClone.setup_method
         (pool, image, snap) = self.clone.parent_info()
         eq(pool, pool_name)
         eq(image, image_name)
@@ -1914,7 +1922,7 @@ class TestClone(object):
 class TestExclusiveLock(object):
 
     @require_features([RBD_FEATURE_EXCLUSIVE_LOCK])
-    def setUp(self):
+    def setup_method(self, method):
         global rados2
         rados2 = Rados(conffile='')
         rados2.connect()
@@ -1922,7 +1930,7 @@ class TestExclusiveLock(object):
         ioctx2 = rados2.open_ioctx(pool_name)
         create_image()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         remove_image()
         global ioctx2
         ioctx2.close()
@@ -2036,7 +2044,7 @@ class TestExclusiveLock(object):
             image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE)
             image.lock_release()
 
-    @attr('SKIP_IF_CRIMSON')
+    @pytest.mark.skip_if_crimson
     def test_break_lock(self):
         blocklist_rados = Rados(conffile='')
         blocklist_rados.connect()
@@ -2087,14 +2095,14 @@ class TestMirroring(object):
         if primary is not None:
             eq(primary, info['primary'])
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rbd = RBD()
         self.initial_mirror_mode = self.rbd.mirror_mode_get(ioctx)
         self.rbd.mirror_mode_set(ioctx, RBD_MIRROR_MODE_POOL)
         create_image()
         self.image = Image(ioctx, image_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.image.close()
         remove_image()
         self.rbd.mirror_mode_set(ioctx, self.initial_mirror_mode)
@@ -2387,14 +2395,14 @@ class TestMirroring(object):
 
 class TestTrash(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         global rados2
         rados2 = Rados(conffile='')
         rados2.connect()
         global ioctx2
         ioctx2 = rados2.open_ioctx(pool_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         global ioctx2
         ioctx2.close()
         global rados2
@@ -2524,18 +2532,17 @@ def test_rename_group():
 def test_list_groups_empty():
     eq([], RBD().group_list(ioctx))
 
-@with_setup(create_group, remove_group)
-def test_list_groups():
+def test_list_groups(tmp_group):
     eq([group_name], RBD().group_list(ioctx))
 
-@with_setup(create_group)
 def test_list_groups_after_removed():
+    create_group()
     remove_group()
     eq([], RBD().group_list(ioctx))
 
 class TestGroups(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         global snap_name
         self.rbd = RBD()
         create_image()
@@ -2546,7 +2553,7 @@ class TestGroups(object):
         snap_name = get_temp_snap_name()
         self.group = Group(ioctx, group_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         remove_group()
         self.image = None
         for name in self.image_names:
@@ -2702,11 +2709,6 @@ class TestGroups(object):
         eq([], list(self.group.list_images()))
         self.group.remove_snap(snap_name)
         eq([], list(self.group.list_snaps()))
-
-@with_setup(create_image, remove_image)
-def test_rename():
-    rbd = RBD()
-    image_name2 = get_temp_image_name()
 
 class TestMigration(object):
 

--- a/src/test/pybind/test_rgwfs.py
+++ b/src/test/pybind/test_rgwfs.py
@@ -1,5 +1,6 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
-from nose.tools import assert_raises, assert_equal, with_setup
+import pytest
+from assertions import assert_raises, assert_equal
 import rgw as librgwfs
 
 rgwfs = None
@@ -19,7 +20,8 @@ def teardown_module():
     rgwfs.shutdown()
 
 
-def setup_test():
+@pytest.fixture
+def testdir():
     global root_dir_handler
 
     names = []
@@ -36,13 +38,11 @@ def setup_test():
         rgwfs.unlink(root_dir_handler, name, 0)
 
 
-@with_setup(setup_test)
 def test_version():
     rgwfs.version()
 
 
-@with_setup(setup_test)
-def test_fstat():
+def test_fstat(testdir):
     stat = rgwfs.fstat(root_dir_handler)
     assert(len(stat) == 13)
     file_handler = rgwfs.create(root_dir_handler, b'file-1', 0)
@@ -51,14 +51,12 @@ def test_fstat():
     rgwfs.close(file_handler)
 
 
-@with_setup(setup_test)
-def test_statfs():
+def test_statfs(testdir):
     stat = rgwfs.statfs()
     assert(len(stat) == 11)
 
 
-@with_setup(setup_test)
-def test_fsync():
+def test_fsync(testdir):
     fd = rgwfs.create(root_dir_handler, b'file-1', 0)
     rgwfs.write(fd, 0, b"asdf")
     rgwfs.fsync(fd, 0)
@@ -67,15 +65,13 @@ def test_fsync():
     rgwfs.close(fd)
 
 
-@with_setup(setup_test)
-def test_directory():
+def test_directory(testdir):
     dir_handler = rgwfs.mkdir(root_dir_handler, b"temp-directory", 0)
     rgwfs.close(dir_handler)
     rgwfs.unlink(root_dir_handler, b"temp-directory")
 
 
-@with_setup(setup_test)
-def test_walk_dir():
+def test_walk_dir(testdir):
     dirs = [b"dir-1", b"dir-2", b"dir-3"]
     handles = []
     for i in dirs:
@@ -96,8 +92,7 @@ def test_walk_dir():
         rgwfs.unlink(root_dir_handler, name)
 
 
-@with_setup(setup_test)
-def test_rename():
+def test_rename(testdir):
     file_handler = rgwfs.create(root_dir_handler, b"a", 0)
     rgwfs.close(file_handler)
     rgwfs.rename(root_dir_handler, b"a", root_dir_handler, b"b")
@@ -107,8 +102,7 @@ def test_rename():
     rgwfs.unlink(root_dir_handler, b"b")
 
 
-@with_setup(setup_test)
-def test_open():
+def test_open(testdir):
     assert_raises(librgwfs.ObjectNotFound, rgwfs.open,
                   root_dir_handler, b'file-1', 0)
     assert_raises(librgwfs.ObjectNotFound, rgwfs.open,
@@ -131,8 +125,7 @@ def test_open():
     rgwfs.unlink(root_dir_handler, b"file-1")
 
 
-@with_setup(setup_test)
-def test_mount_unmount():
+def test_mount_unmount(testdir):
     global root_handler
     global root_dir_handler
     test_directory()


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61567

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
