### PR TITLE
cephfs-journal-tool: disambiguate usage of all keyword (in tool help).

### DIFF
--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -62,7 +62,7 @@ void JournalTool::usage()
     << "    <output>: [summary|list|binary|json] [--path <path>]\n"
     << "\n"
     << "General options:\n"
-    << "  --rank=filesystem:mds-rank|all Journal rank (mandatory)\n"
+    << "  --rank=filesystem:{mds-rank|all} journal rank or \"all\" ranks (mandatory)\n"
     << "  --journal=<mdlog|purge_queue>  Journal type (purge_queue means\n"
     << "                                 this journal is used to queue for purge operation,\n"
     << "                                 default is mdlog, and only mdlog support event mode)\n"


### PR DESCRIPTION
       The fs:all for rank option description was confusing. It seemd like the fs was optional, but it is mandatory. This change modifies the help message to reflect the correct way to use all in the --rank option.

Now 
```
→ ./bin/cephfs-journal-tool -h                                                                                                                                                                                                                                                                                                                                                         
Usage:                                                                                                                                                                                                                                                                                                                                                                                 
  cephfs-journal-tool [options] journal <command>                                                                                                                                                                                                                                                                                                                                      
    <command>:                                                                                                                                                                                                                                                                                                                                                                         
      inspect                                                                                                                                                                                                                                                                                                                                                                          
      import <path> [--force]                                                                                                                                                                                                                                                                                                                                                          
      export <path>                                                                                                                                                                                                                                                                                                                                                                    
      reset [--force]                                                                                                                                                                                                                                                                                                                                                                  
  cephfs-journal-tool [options] header <get|set> <field> <value>
    <field>: [trimmed_pos|expire_pos|write_pos|pool_id]
  cephfs-journal-tool [options] event <effect> <selector> <output> [special options]
    <selector>:
      --range=<start>..<end>
      --path=<substring>
      --inode=<integer>
      --type=<UPDATE|OPEN|SESSION...><
      --frag=<ino>.<frag> [--dname=<dentry string>]
      --client=<session id integer>
    <effect>: [get|recover_dentries|splice]
    <output>: [summary|list|binary|json] [--path <path>]

General options:
  --rank=filesystem:{mds-rank|all} Journal rank or all (mandatory)
  --journal=<mdlog|purge_queue>  Journal type (purge_queue means
                                 this journal is used to queue for purge operation,
                                 default is mdlog, and only mdlog support event mode)

Special options
  --alternate-pool <name>     Alternative metadata pool to target
                              when using recover_dentries.
  --conf/-c FILE    read configuration from the given configuration file
  --id ID           set ID portion of my name
  --name/-n TYPE.ID set name
  --cluster NAME    set cluster name (default: ceph)
  --setuser USER    set uid to user or uid (and gid to user's gid)
  --setgroup GROUP  set gid to group or gid
  --version         show version and quit

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
