### PR TITLE
rbd-mirror: add additional logs to PoolReplayer

### DIFF
--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -406,6 +406,7 @@ void PoolReplayer<I>::init(const std::string& site_name) {
 
 template <typename I>
 void PoolReplayer<I>::shut_down() {
+  dout(20) << dendl;
   {
     std::lock_guard l{m_lock};
     m_stopping = true;
@@ -453,6 +454,10 @@ int PoolReplayer<I>::init_rados(const std::string &cluster_name,
 			        const std::string &description,
 			        RadosRef *rados_ref,
                                 bool strip_cluster_overrides) {
+  dout(10) << "cluster_name=" << cluster_name << ", client_name=" << client_name
+	   << ", mon_host=" << mon_host << ", strip_cluster_overrides="
+	   << strip_cluster_overrides << dendl;
+
   // NOTE: manually bootstrap a CephContext here instead of via
   // the librados API to avoid mixing global singletons between
   // the librados shared library and the daemon
@@ -723,6 +728,7 @@ void PoolReplayer<I>::update_namespace_replayers() {
 template <typename I>
 int PoolReplayer<I>::list_mirroring_namespaces(
     std::set<std::string> *namespaces) {
+  dout(20) << dendl;
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   std::vector<std::string> names;
@@ -756,6 +762,7 @@ int PoolReplayer<I>::list_mirroring_namespaces(
 template <typename I>
 void PoolReplayer<I>::reopen_logs()
 {
+  dout(20) << dendl;
   std::lock_guard locker{m_lock};
 
   if (m_local_rados) {
@@ -769,6 +776,7 @@ void PoolReplayer<I>::reopen_logs()
 template <typename I>
 void PoolReplayer<I>::namespace_replayer_acquire_leader(const std::string &name,
                                                         Context *on_finish) {
+  dout(20) << dendl;
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   auto it = m_namespace_replayers.find(name);


### PR DESCRIPTION
This commit adds logs to some PoolReplayer functions in order to make debugging easier.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
