### PR TITLE
qa/rgw/s3tests: make extra_attrs additive

### DIFF
--- a/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml
@@ -12,5 +12,4 @@ tasks:
     client.0:
       dbstore_tests: True
       rgw_server: client.0
-      extra_attrs: ["not fails_on_rgw","not fails_on_dbstore"]
-
+      extra_attrs: ["not fails_on_dbstore"]

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -384,11 +384,9 @@ def run_tests(ctx, config):
         if not client_config.get('with-sse-s3'):
             attrs += ['not sse_s3']
        
-        if 'extra_attrs' in client_config:
-            attrs += client_config.get('extra_attrs')
+        attrs += client_config.get('extra_attrs', [])
         args += ['tox', '--', '-v', '-m', ' and '.join(attrs)]
-        if 'extra_args' in client_config:
-            args.append(client_config['extra_args'])
+        args += client_config.get('extra_args', [])
 
         toxvenv_sh(ctx, remote, args, label="s3 tests against rgw")
     yield

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -385,7 +385,7 @@ def run_tests(ctx, config):
             attrs += ['not sse_s3']
        
         if 'extra_attrs' in client_config:
-            attrs = client_config.get('extra_attrs') 
+            attrs += client_config.get('extra_attrs')
         args += ['tox', '--', '-v', '-m', ' and '.join(attrs)]
         if 'extra_args' in client_config:
             args.append(client_config['extra_args'])

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -377,7 +377,6 @@ def run_tests(ctx, config):
             args += ['REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt']
         else:
             args += ['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']
-        # civetweb > 1.8 && beast parsers are strict on rfc2616
         attrs = ["not fails_on_rgw", "not lifecycle_expiration", "not test_of_sts", "not webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['not fails_with_subdomain']


### PR DESCRIPTION
the s3tests.py task is filtering out several attrs by default. but when dbstore uses `extra_attrs` to add 'not fails_on_dbstore', it overwrites those other filters

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
