### PR TITLE
quincy: rgw: avoid string_view to temporary in RGWBulkUploadOp

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7648,7 +7648,7 @@ void RGWBulkUploadOp::execute(optional_yield y)
         case rgw::tar::FileType::NORMAL_FILE: {
           ldpp_dout(this, 2) << "handling regular file" << dendl;
 
-          std::string_view filename;
+          std::string filename;
 	  if (bucket_path.empty())
 	    filename = header->get_filename();
 	  else


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57642

---

backport of https://github.com/ceph/ceph/pull/47905
parent tracker: https://tracker.ceph.com/issues/57326

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh