### PR TITLE
[DNM] libcephfs: fscrypt support

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -8,6 +8,7 @@ set(libclient_srcs
   MetaSession.cc
   Trace.cc
   posix_acl.cc
-  Delegation.cc)
+  Delegation.cc
+  FSCrypt.cc)
 add_library(client STATIC ${libclient_srcs})
 target_link_libraries(client osdc)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5538,8 +5538,7 @@ void Client::handle_cap_trunc(MetaSession *session, Inode *in, const MConstRef<M
 
   uint64_t size = m->get_size();
   if (in->is_fscrypt_enabled()) {
-    size = std::stoll(std::string(std::rbegin(m->fscrypt_file),
-                                  std::rend(m->fscrypt_file)));
+    size = *(ceph_le64 *)in->fscrypt_file.data();
   }
   ldout(cct, 10) << __func__ << " on ino " << *in
 	   << " size " << in->size << " -> " << m->get_size()

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1058,6 +1058,9 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->snap_btime = st->snap_btime;
     in->snap_metadata = st->snap_metadata;
     in->fscrypt_auth = st->fscrypt_auth;
+    in->fscrypt_ctx = in->init_fscrypt_ctx();
+
+
 ldout(cct, 0) << __func__ << " XXXXX ino=" << in->ino << " in->fscrypt_auth.size()=" << in->fscrypt_auth.size() << dendl;
 if (in->fscrypt_auth.size() > 0) {
   bufferlist bl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1420,7 +1420,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 
       if (fscrypt_denc) {
         enc_name = orig_dname;
-        int r = fscrypt_denc->get_decrypted_fname(orig_dname, &dname);
+        int r = fscrypt_denc->get_decrypted_fname(orig_dname, dlease.alternate_name, &dname);
         if (r < 0) {
           ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
           dname = orig_dname;
@@ -1596,7 +1596,7 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
     auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
     if (fscrypt_denc) {
       enc_name = dname;
-      int r = fscrypt_denc->get_decrypted_fname(enc_name, &dname);
+      int r = fscrypt_denc->get_decrypted_fname(enc_name, dlease.alternate_name, &dname);
       if (r < 0) {
         ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
         dname = enc_name;
@@ -1673,7 +1673,7 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
     auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
     if (fscrypt_denc) {
       enc_name = dname;
-      int r = fscrypt_denc->get_decrypted_fname(enc_name, &dname);
+      int r = fscrypt_denc->get_decrypted_fname(enc_name, dlease.alternate_name, &dname);
       if (r < 0) {
         ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
         dname = enc_name;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3695,8 +3695,12 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 	 if ((endoff >= (loff_t)in->max_size ||
 	      endoff > (loff_t)(in->size << 1)) &&
 	     endoff > (loff_t)in->wanted_max_size) {
-	   ldout(cct, 10) << "wanted_max_size " << in->wanted_max_size << " -> " << endoff << dendl;
-	   in->wanted_max_size = endoff;
+           ldout(cct, 10) << "wanted_max_size " << in->wanted_max_size << " -> " << endoff << dendl;
+           uint64_t want = endoff;
+           if (in->fscrypt_auth.size()) {
+             want = fscrypt_block_start(endoff + FSCRYPT_BLOCK_SIZE - 1);
+           }
+	   in->wanted_max_size = want;
 	 }
 	 if (in->wanted_max_size > in->max_size &&
 	     in->wanted_max_size > in->requested_max_size)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1076,7 +1076,9 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
   if (new_version ||
       (new_issued & (CEPH_CAP_ANY_FILE_RD | CEPH_CAP_ANY_FILE_WR))) {
     in->layout = st->layout;
-    in->fscrypt_file = st->fscrypt_file;
+    if (st->fscrypt_file.size() >= sizeof(uint64_t)) {
+      in->fscrypt_file = st->fscrypt_file;
+    }
     update_inode_file_size(in, issued, st->size, st->truncate_seq, st->truncate_size);
   }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1401,12 +1401,11 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
     _readdir_drop_dirp_buffer(dirp);
     dirp->buffer.reserve(numdn);
 
-    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator);
+    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
 
     string orig_dname;
     string dname;
     LeaseStat dlease;
-    char dec_fname[NAME_MAX + FSCRYPT_KEY_SIZE]; /* some extra just in case */
 
     for (unsigned i=0; i<numdn; i++) {
       decode(orig_dname, p);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1057,6 +1057,15 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->snap_btime = st->snap_btime;
     in->snap_metadata = st->snap_metadata;
     in->fscrypt_auth = st->fscrypt_auth;
+ldout(cct, 0) << __func__ << " XXXXX ino=" << in->ino << " in->fscrypt_auth.size()=" << in->fscrypt_auth.size() << dendl;
+if (in->fscrypt_auth.size() > 0) {
+  bufferlist bl;
+  auto data = bl.append_hole(in->fscrypt_auth.size());
+  data.copy_in(in->fscrypt_auth.size(), (const char *)in->fscrypt_auth.data());
+  std::stringstream ss;
+  bl.hexdump(ss, false);
+  ldout(cct, 0) << __func__ << " XXXXX " << ss.str() << dendl;
+}
     need_snapdir_attr_refresh = true;
   }
 
@@ -1075,6 +1084,15 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
       (new_issued & (CEPH_CAP_ANY_FILE_RD | CEPH_CAP_ANY_FILE_WR))) {
     in->layout = st->layout;
     in->fscrypt_file = st->fscrypt_file;
+ldout(cct, 0) << __func__ << " XXXXX ino=" << in->ino << " in->fscrypt_file.size()=" << in->fscrypt_file.size() << dendl;
+if (in->fscrypt_file.size() > 0) {
+  bufferlist bl;
+  auto data = bl.append_hole(in->fscrypt_file.size());
+  data.copy_in(in->fscrypt_file.size(), (const char *)in->fscrypt_file.data());
+  std::stringstream ss;
+  bl.hexdump(ss, false);
+  ldout(cct, 0) << __func__ << " XXXXX " << ss.str() << dendl;
+}
     update_inode_file_size(in, issued, st->size, st->truncate_seq, st->truncate_size);
   }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10338,20 +10338,12 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
     cflags |= CEPH_O_LAZY;
 
   int cmode = ceph_flags_to_mode(cflags);
-#if 0
-  if (in->dir) {
-    auto diri = in->dir->parent_inode;
-    if (diri && diri->fscrypt_ctx) {
-      if (want & CEPH_FILE_MODE_WR) {
-        want |= CEPH_FILE_MODE_RD;
-      }
-    }
-  }
-#endif
-#warning FIXME
-  if (cmode & CEPH_FILE_MODE_WR) {
+
+  if (in->fscrypt_ctx &&
+      cmode & CEPH_FILE_MODE_WR) {
     cmode |= CEPH_FILE_MODE_RD;
   }
+
   int want = ceph_caps_for_mode(cmode);
   int result = 0;
 
@@ -14945,8 +14937,8 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
 
   int cmode = ceph_flags_to_mode(cflags);
 
-#warning FIXME caps
-  if (cmode & CEPH_FILE_MODE_WR) {
+  if (dir->fscrypt_ctx &&
+      cmode & CEPH_FILE_MODE_WR) {
     cmode |= CEPH_FILE_MODE_RD;
   }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7177,7 +7177,35 @@ int Client::_do_lookup(Inode *dir, const string& name, int mask,
   MetaRequest *req = new MetaRequest(op);
   filepath path;
   dir->make_nosnap_relative_path(path);
-  path.push_dentry(name);
+
+  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
+  if (fscrypt_denc) {
+    int dec_size = (name.size() + 31) & ~31; // FIXME, need to be based on policy
+
+    char orig[dec_size];
+    memcpy(orig, name.c_str(), name.size());
+    memset(orig + name.size(), 0, dec_size - name.size());
+
+    char enc_name[NAME_MAX + 64]; /* some extra just in case */
+    int r = fscrypt_denc->encrypt(orig, dec_size,
+                                  enc_name, sizeof(enc_name));
+
+    if (r < 0) {
+      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
+      return r;
+    }
+
+    int enc_len = r;
+
+    int b64_len = NAME_MAX * 2; // name.size() * 2;
+    char b64_name[b64_len]; // large enough
+    fscrypt_fname_armor(enc_name, enc_len, b64_name, b64_len);
+
+    path.push_dentry(string(b64_name));
+  } else {
+    path.push_dentry(name);
+  }
+
   req->set_filepath(path);
   req->set_inode(dir);
   if (cct->_conf->client_debug_getattr_caps && op == CEPH_MDS_OP_LOOKUP)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7163,6 +7163,36 @@ void Client::renew_caps(MetaSession *session)
   session->con->send_message2(make_message<MClientSession>(CEPH_SESSION_REQUEST_RENEWCAPS, seq));
 }
 
+int Client::_prepare_req_path(Inode *dir, MetaRequest *req, filepath& path, const char *name,
+                              Dentry **pdn)
+{
+  dir->make_nosnap_relative_path(path);
+
+  std::optional<string> enc_name;
+  const char *plain_name = name;
+  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
+  if (fscrypt_denc) {
+    string _enc_name;
+    int r = fscrypt_denc->get_encrypted_fname(name, &_enc_name);
+    if (r < 0) {
+      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
+      return r;
+    }
+    path.push_dentry(_enc_name);
+    enc_name = std::move(_enc_name);
+  } else {
+    path.push_dentry(plain_name);
+  }
+
+  req->set_filepath(path);
+
+  if (pdn) {
+    *pdn = get_or_create(dir, plain_name, enc_name);
+  }
+
+  return 0;
+}
+
 
 // ===============================================================
 // high level (POSIXy) interface
@@ -7173,24 +7203,13 @@ int Client::_do_lookup(Inode *dir, const string& name, int mask,
   int op = dir->snapid == CEPH_SNAPDIR ? CEPH_MDS_OP_LOOKUPSNAP : CEPH_MDS_OP_LOOKUP;
   MetaRequest *req = new MetaRequest(op);
   filepath path;
-  dir->make_nosnap_relative_path(path);
 
-  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
-  if (fscrypt_denc) {
-    string enc_name;
-    int r = fscrypt_denc->get_encrypted_fname(name, &enc_name);
-
-    if (r < 0) {
-      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
-      return r;
-    }
-
-    path.push_dentry(enc_name);
-  } else {
-    path.push_dentry(name);
+  int r = _prepare_req_path(dir, req, path, name.c_str(), nullptr);
+  if (r < 0) {
+    delete req;
+    return r;
   }
 
-  req->set_filepath(path);
   req->set_inode(dir);
   if (cct->_conf->client_debug_getattr_caps && op == CEPH_MDS_OP_LOOKUP)
       mask |= DEBUG_GETATTR_CAPS;
@@ -7198,7 +7217,7 @@ int Client::_do_lookup(Inode *dir, const string& name, int mask,
 
   ldout(cct, 10) << __func__ << " on " << path << dendl;
 
-  int r = make_request(req, perms, target);
+  r = make_request(req, perms, target);
   ldout(cct, 10) << __func__ << " res is " << r << dendl;
   return r;
 }
@@ -14674,28 +14693,19 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
       return -CEPHFS_ERANGE;  // bummer!
   }
 
-  std::optional<string> enc_name;
-  const char *plain_name = name;
-  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
-  if (fscrypt_denc) {
-    string _enc_name;
-    int r = fscrypt_denc->get_encrypted_fname(name, &_enc_name);
-    if (r < 0) {
-      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
-      return r;
-    }
-    enc_name = std::move(_enc_name);
-    name = enc_name->c_str();
-  }
-
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_CREATE);
 
   req->set_inode_owner_uid_gid(perms.uid(), perms.gid());
 
   filepath path;
-  dir->make_nosnap_relative_path(path);
-  path.push_dentry(name);
-  req->set_filepath(path);
+  Dentry *de;
+
+  int r = _prepare_req_path(dir, req, path, name, &de);
+  if (r < 0) {
+    delete req;
+    return r;
+  }
+
   req->set_alternate_name(std::move(alternate_name));
   req->set_inode(dir);
   req->head.args.open.flags = cflags | CEPH_O_CREAT;
@@ -14722,7 +14732,6 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
   if (xattrs_bl.length() > 0)
     req->set_data(xattrs_bl);
 
-  Dentry *de = get_or_create(dir, plain_name, enc_name);
   req->set_dentry(de);
 
   res = make_request(req, perms, inp, created);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1364,10 +1364,21 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
     string readdir_start = dirp->last_name;
     ceph_assert(!readdir_start.empty() || readdir_offset == 2);
 
+    string readdir_start_enc;
+
+    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
+    if (!readdir_start.empty() && fscrypt_denc) {
+      string alt;
+      int r = fscrypt_denc->get_encrypted_fname(readdir_start, &readdir_start_enc, &alt);
+      if (r < 0) {
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
+      }
+    }
+
     unsigned last_hash = 0;
     if (hash_order) {
       if (!readdir_start.empty()) {
-	last_hash = ceph_frag_value(diri->hash_dentry_name(readdir_start));
+	last_hash = ceph_frag_value(diri->hash_dentry_name((readdir_start_enc.empty() ? readdir_start : readdir_start_enc)));
       } else if (flags & CEPH_READDIR_OFFSET_HASH) {
 	/* mds understands offset_hash */
 	last_hash = offset_hash;
@@ -1403,8 +1414,6 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 
     _readdir_drop_dirp_buffer(dirp);
     dirp->buffer.reserve(numdn);
-
-    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
 
     string orig_dname;
     std::optional<string> enc_name;
@@ -1496,7 +1505,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
     }
 
     if (numdn > 0)
-      dirp->last_name = dname;
+      dirp->last_name = orig_dname;
     if (end)
       dirp->next_offset = 2;
     else
@@ -9417,6 +9426,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
 						  dirp->offset, dentry_off_lt());
 
   string dn_name;
+  std::optional<string> enc_name;
   while (true) {
     int mask = caps;
     if (!dirp->inode->is_complete_and_ordered())
@@ -9465,12 +9475,13 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
     }
 
     dn_name = dn->name; // fill in name while we have lock
+    enc_name = dn->enc_name; // fill in name while we have lock
 
     client_lock.unlock();
     r = cb(p, &de, &stx, next_off, in);  // _next_ offset
     client_lock.lock();
     ldout(cct, 15) << " de " << de.d_name << " off " << hex << dn->offset << dec
-		   << " = " << r << dendl;
+		   << " idx " << idx << " cache.size=" << dir->readdir_cache.size() << " = " << r << dendl;
     if (r < 0) {
       return r;
     }
@@ -9480,7 +9491,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
       dirp->next_offset = 2;
     else
       dirp->next_offset = dirp->offset_low();
-    dirp->last_name = dn_name; // we successfully returned this one; update!
+    dirp->last_name = (enc_name ? *enc_name : dn_name); // we successfully returned this one; update!
     dirp->release_count = 0; // last_name no longer match cache index
     if (r > 0)
       return r;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -587,6 +587,7 @@ void Client::_pre_init()
 
   objecter_finisher.start();
   filer.reset(new Filer(objecter, &objecter_finisher));
+  fscrypt.reset(new FSCrypt());
 
   objectcacher->start();
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1059,17 +1059,6 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->snap_metadata = st->snap_metadata;
     in->fscrypt_auth = st->fscrypt_auth;
     in->fscrypt_ctx = in->init_fscrypt_ctx();
-
-
-ldout(cct, 0) << __func__ << " XXXXX ino=" << in->ino << " in->fscrypt_auth.size()=" << in->fscrypt_auth.size() << dendl;
-if (in->fscrypt_auth.size() > 0) {
-  bufferlist bl;
-  auto data = bl.append_hole(in->fscrypt_auth.size());
-  data.copy_in(in->fscrypt_auth.size(), (const char *)in->fscrypt_auth.data());
-  std::stringstream ss;
-  bl.hexdump(ss, false);
-  ldout(cct, 0) << __func__ << " XXXXX " << ss.str() << dendl;
-}
     need_snapdir_attr_refresh = true;
   }
 
@@ -1088,15 +1077,6 @@ if (in->fscrypt_auth.size() > 0) {
       (new_issued & (CEPH_CAP_ANY_FILE_RD | CEPH_CAP_ANY_FILE_WR))) {
     in->layout = st->layout;
     in->fscrypt_file = st->fscrypt_file;
-ldout(cct, 0) << __func__ << " XXXXX ino=" << in->ino << " in->fscrypt_file.size()=" << in->fscrypt_file.size() << dendl;
-if (in->fscrypt_file.size() > 0) {
-  bufferlist bl;
-  auto data = bl.append_hole(in->fscrypt_file.size());
-  data.copy_in(in->fscrypt_file.size(), (const char *)in->fscrypt_file.data());
-  std::stringstream ss;
-  bl.hexdump(ss, false);
-  ldout(cct, 0) << __func__ << " XXXXX " << ss.str() << dendl;
-}
     update_inode_file_size(in, issued, st->size, st->truncate_seq, st->truncate_size);
   }
 
@@ -1421,14 +1401,34 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
     _readdir_drop_dirp_buffer(dirp);
     dirp->buffer.reserve(numdn);
 
+    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx);
+
     string dname;
     LeaseStat dlease;
+    char dec_fname[NAME_MAX + FSCRYPT_KEY_SIZE]; /* some extra just in case */
+
     for (unsigned i=0; i<numdn; i++) {
       decode(dname, p);
       dlease.decode(p, features);
       InodeStat ist(p, features);
 
       ldout(cct, 15) << "" << i << ": '" << dname << "'" << dendl;
+
+      if (fscrypt_denc) {
+        char enc[NAME_MAX];
+        int len = fscrypt_fname_unarmor(dname.c_str(), dname.size(),
+                                        enc, sizeof(enc));
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": base64 decoded fname orig len=" << dname.size() << " dest len=" << len << dendl;
+
+        int r = fscrypt_denc->decrypt(enc, len,
+                                      dec_fname, sizeof(dec_fname));
+
+        if (r >= 0) {
+          dname = dec_fname;
+        } else {
+          ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename" << dendl;
+        }
+      }
 
       Inode *in = add_update_inode(&ist, request->sent_stamp, session,
 				   request->perms);
@@ -8100,6 +8100,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->fscrypt_auth = *aux;
+      in->fscrypt_ctx = in->init_fscrypt_ctx();
       in->mark_caps_dirty(CEPH_CAP_AUTH_EXCL);
       mask &= ~CEPH_SETATTR_FSCRYPT_AUTH;
     } else if (!in->caps_issued_mask(CEPH_CAP_AUTH_SHARED) ||

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8547,12 +8547,7 @@ int Client::fill_stat(Inode *in, struct stat *st, frag_info_t *dirstat, nest_inf
     st->st_blocks = 1;
 #endif
   } else {
-    if (!in->fscrypt_file.empty() &&
-      in->fscrypt_file.size() >= sizeof(ceph_le64)) {
-      st->st_size = *(ceph_le64 *)in->fscrypt_file.data();
-    } else {
-      st->st_size = in->size;
-    }
+    st->st_size = in->effective_size();
 #ifndef _WIN32
     st->st_blocks = (in->size + 511) >> 9;
 #endif
@@ -10416,7 +10411,7 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   case SEEK_END:
-    pos = in->size + offset;
+    pos = in->effective_size() + offset;
     break;
 
 #ifdef SEEK_DATA

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3757,11 +3757,11 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
       waitfor_caps = true;
     }
 
-    if ((need & CEPH_CAP_FILE_WR) &&
-	((in->auth_cap && in->auth_cap->session->readonly) ||
-	 // userland clients are only allowed to read if fscrypt enabled
-	 in->is_fscrypt_enabled()))
-      return -CEPHFS_EROFS;
+     if ((need & CEPH_CAP_FILE_WR) &&
+       ((in->auth_cap && in->auth_cap->session->readonly) ||
+        // userland clients are only allowed to read if fscrypt enabled but no fscrypt ctx exists
+        // (is locked)
+        (in->is_fscrypt_enabled() && !in->fscrypt_ctx)))
 
     if (in->flags & I_CAP_DROPPED) {
       int mds_wanted = in->caps_mds_wanted();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1211,7 +1211,8 @@ Dentry *Client::insert_dentry_inode(Dir *dir, const string& dname, LeaseStat *dl
     }
     Inode *diri = dir->parent_inode;
     clear_dir_complete_and_ordered(diri, false);
-    dn = link(dir, dname, in, dn);
+#warning revisit nullopt here
+    dn = link(dir, dname, std::nullopt, in, dn);
 
     if (old_dentry) {
       dn->is_renaming = false;
@@ -1404,6 +1405,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
     auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
 
     string orig_dname;
+    std::optional<string> enc_name;
     string dname;
     LeaseStat dlease;
 
@@ -1415,6 +1417,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
       ldout(cct, 15) << "" << i << ": '" << orig_dname << "'" << dendl;
 
       if (fscrypt_denc) {
+        enc_name = orig_dname;
         int r = fscrypt_denc->get_decrypted_fname(orig_dname, &dname);
         if (r < 0) {
           ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
@@ -1441,7 +1444,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 	if (olddn->inode != in) {
 	  // replace incorrect dentry
 	  unlink(olddn, true, true);  // keep dir, dentry
-	  dn = link(effective_dir, dname, in, olddn);
+	  dn = link(effective_dir, dname, enc_name, in, olddn);
 	  ceph_assert(dn == olddn);
 	} else {
 	  // keep existing dn
@@ -1450,7 +1453,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 	}
       } else {
 	// new dn
-	dn = link(effective_dir, dname, in, NULL);
+	dn = link(effective_dir, dname, enc_name, in, NULL);
       }
       dn->alternate_name = std::move(dlease.alternate_name);
 
@@ -1626,7 +1629,8 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
       if (dlease.duration_ms > 0) {
 	if (!dn) {
 	  Dir *dir = diri->open_dir();
-	  dn = link(dir, dname, NULL, NULL);
+#warning revisit nullopt here
+	  dn = link(dir, dname, std::nullopt, NULL, NULL);
 	}
 	update_dentry_lease(dn, &dlease, request->sent_stamp, session);
       }
@@ -3475,11 +3479,12 @@ void Client::close_dir(Dir *dir)
    * leave dn set to default NULL unless you're trying to add
    * a new inode to a pre-created Dentry
    */
-Dentry* Client::link(Dir *dir, const string& name, Inode *in, Dentry *dn)
+Dentry* Client::link(Dir *dir, const string& name, std::optional<std::string> enc_name, Inode *in, Dentry *dn)
 {
   if (!dn) {
     // create a new Dentry
     dn = new Dentry(dir, name);
+    dn->enc_name = enc_name;
 
     lru.lru_insert_mid(dn);    // mid or top?
 
@@ -7355,15 +7360,20 @@ relookup:
   return r;
 }
 
-Dentry *Client::get_or_create(Inode *dir, const char* name)
+Dentry *Client::get_or_create(Inode *dir, const char* plain_name, std::optional<std::string> enc_name)
 {
   // lookup
-  ldout(cct, 20) << __func__ << " " << *dir << " name " << name << dendl;
+  ldout(cct, 20) << __func__ << " " << *dir << " plain_name " << plain_name << " enc_name=" << enc_name.value_or(string()) << dendl;
   dir->open_dir();
-  if (dir->dir->dentries.count(name))
-    return dir->dir->dentries[name];
-  else // otherwise link up a new one
-    return link(dir->dir, name, NULL, NULL);
+  if (dir->dir->dentries.count(plain_name)) {
+    auto dn = dir->dir->dentries[plain_name];
+    if (!dn->enc_name && enc_name) {
+      dn->enc_name = enc_name;
+    }
+    return dn;
+  } else { // otherwise link up a new one
+    return link(dir->dir, plain_name, enc_name, NULL, NULL);
+  }
 }
 
 int Client::walk(std::string_view path, walk_dentry_result* wdr, const UserPerm& perms, bool followsym)
@@ -14540,7 +14550,8 @@ int Client::_mknod(Inode *dir, const char *name, mode_t mode, dev_t rdev,
   if (xattrs_bl.length() > 0)
     req->set_data(xattrs_bl);
 
-  Dentry *de = get_or_create(dir, name);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, name, std::nullopt);
   req->set_dentry(de);
 
   res = make_request(req, perms, inp);
@@ -14663,6 +14674,20 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
       return -CEPHFS_ERANGE;  // bummer!
   }
 
+  std::optional<string> enc_name;
+  const char *plain_name = name;
+  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
+  if (fscrypt_denc) {
+    string _enc_name;
+    int r = fscrypt_denc->get_encrypted_fname(name, &_enc_name);
+    if (r < 0) {
+      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
+      return r;
+    }
+    enc_name = std::move(_enc_name);
+    name = enc_name->c_str();
+  }
+
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_CREATE);
 
   req->set_inode_owner_uid_gid(perms.uid(), perms.gid());
@@ -14697,7 +14722,7 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
   if (xattrs_bl.length() > 0)
     req->set_data(xattrs_bl);
 
-  Dentry *de = get_or_create(dir, name);
+  Dentry *de = get_or_create(dir, plain_name, enc_name);
   req->set_dentry(de);
 
   res = make_request(req, perms, inp, created);
@@ -14777,7 +14802,8 @@ int Client::_mkdir(Inode *dir, const char *name, mode_t mode, const UserPerm& pe
     req->set_data(bl);
   }
 
-  Dentry *de = get_or_create(dir, name);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, name, std::nullopt);
   req->set_dentry(de);
 
   ldout(cct, 10) << "_mkdir: making request" << dendl;
@@ -14897,7 +14923,8 @@ int Client::_symlink(Inode *dir, const char *name, const char *target,
   req->dentry_drop = CEPH_CAP_FILE_SHARED;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
 
-  Dentry *de = get_or_create(dir, name);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, name, std::nullopt);
   req->set_dentry(de);
 
   int res = make_request(req, perms, inp);
@@ -15002,7 +15029,8 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
 
   InodeRef otherin;
   Inode *in;
-  Dentry *de = get_or_create(dir, name);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, name, std::nullopt);
   req->set_dentry(de);
   req->dentry_drop = CEPH_CAP_FILE_SHARED;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
@@ -15073,7 +15101,8 @@ int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms)
 
   InodeRef in;
 
-  Dentry *de = get_or_create(dir, name);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, name, std::nullopt);
   if (op == CEPH_MDS_OP_RMDIR)
     req->set_dentry(de);
   else
@@ -15164,8 +15193,10 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
   req->set_filepath2(from);
   req->set_alternate_name(std::move(alternate_name));
 
-  Dentry *oldde = get_or_create(fromdir, fromname);
-  Dentry *de = get_or_create(todir, toname);
+#warning revisit nullopt here
+  Dentry *oldde = get_or_create(fromdir, fromname, std::nullopt);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(todir, toname, std::nullopt);
 
   int res;
   if (op == CEPH_MDS_OP_RENAME) {
@@ -15281,6 +15312,17 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
     return -CEPHFS_EDQUOT;
   }
 
+  string enc_name;
+  auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
+  if (fscrypt_denc) {
+    int r = fscrypt_denc->get_encrypted_fname(newname, &enc_name);
+    if (r < 0) {
+      ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
+      return r;
+    }
+    newname = enc_name.c_str();
+  }
+
   in->break_all_delegs();
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LINK);
 
@@ -15294,7 +15336,8 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
   req->inode_drop = CEPH_CAP_FILE_SHARED;
   req->inode_unless = CEPH_CAP_FILE_EXCL;
 
-  Dentry *de = get_or_create(dir, newname);
+#warning revisit nullopt here
+  Dentry *de = get_or_create(dir, newname, std::nullopt);
   req->set_dentry(de);
 
   int res = make_request(req, perm, inp);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8553,7 +8553,12 @@ int Client::fill_stat(Inode *in, struct stat *st, frag_info_t *dirstat, nest_inf
     st->st_blocks = 1;
 #endif
   } else {
-    st->st_size = in->size;
+    if (!in->fscrypt_file.empty() &&
+      in->fscrypt_file.size() >= sizeof(ceph_le64)) {
+      st->st_size = *(ceph_le64 *)in->fscrypt_file.data();
+    } else {
+      st->st_size = in->size;
+    }
 #ifndef _WIN32
     st->st_blocks = (in->size + 511) >> 9;
 #endif

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1577,14 +1577,29 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
   InodeStat dirst;
   DirStat dst;
   string dname;
+  string enc_name;
   LeaseStat dlease;
   InodeStat ist;
+
+  Inode *diri = NULL;
 
   if (reply->head.is_dentry) {
     dirst.decode(p, features);
     dst.decode(p, features);
     decode(dname, p);
     dlease.decode(p, features);
+
+    diri = add_update_inode(&dirst, request->sent_stamp, session,
+			    request->perms);
+    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
+    if (fscrypt_denc) {
+      enc_name = dname;
+      int r = fscrypt_denc->get_decrypted_fname(enc_name, &dname);
+      if (r < 0) {
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
+        dname = enc_name;
+      }
+    }
   }
 
   Inode *in = 0;
@@ -1606,10 +1621,7 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
 			  request->perms);
   }
 
-  Inode *diri = NULL;
   if (reply->head.is_dentry) {
-    diri = add_update_inode(&dirst, request->sent_stamp, session,
-			    request->perms);
     mds_rank_t from_mds = mds_rank_t(reply->get_source().num());
     update_dir_dist(diri, &dst, from_mds);  // dir stat info is attached to ..
 
@@ -1646,6 +1658,16 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
     
     string dname = request->path.last_dentry();
     
+    auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx, &diri->fscrypt_key_validator, true);
+    if (fscrypt_denc) {
+      enc_name = dname;
+      int r = fscrypt_denc->get_decrypted_fname(enc_name, &dname);
+      if (r < 0) {
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
+        dname = enc_name;
+      }
+    }
+
     LeaseStat dlease;
     dlease.duration_ms = 0;
 
@@ -9944,7 +9966,7 @@ int Client::create_and_open(int dirfd, const char *relpath, int flags,
     return r;
   }
 
-  if (dirinode->fscrypt_ctx) {
+  if (dirinode->is_fscrypt_enabled()) {
     if (mask & CEPH_FILE_MODE_WR) {
       mask |= CEPH_FILE_MODE_RD;
     }
@@ -14854,6 +14876,11 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
 
   int cmode = ceph_flags_to_mode(cflags);
 
+#warning FIXME caps
+  if (cmode & CEPH_FILE_MODE_WR) {
+    cmode |= CEPH_FILE_MODE_RD;
+  }
+
   int64_t pool_id = -1;
   if (data_pool && *data_pool) {
     pool_id = objecter->with_osdmap(
@@ -14878,6 +14905,7 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
   }
 
   req->set_alternate_name(std::move(alternate_name));
+  dir->gen_inherited_fscrypt_auth(&req->fscrypt_auth);
   req->set_inode(dir);
   req->head.args.open.flags = cflags | CEPH_O_CREAT;
 
@@ -14964,6 +14992,7 @@ int Client::_mkdir(Inode *dir, const char *name, mode_t mode, const UserPerm& pe
   req->dentry_drop = CEPH_CAP_FILE_SHARED;
   req->dentry_unless = CEPH_CAP_FILE_EXCL;
   req->set_alternate_name(std::move(alternate_name));
+  dir->gen_inherited_fscrypt_auth(&req->fscrypt_auth);
 
   mode |= S_IFDIR;
   bufferlist bl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1403,22 +1403,23 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 
     auto fscrypt_denc = fscrypt->get_fname_denc(diri->fscrypt_ctx);
 
+    string orig_dname;
     string dname;
     LeaseStat dlease;
     char dec_fname[NAME_MAX + FSCRYPT_KEY_SIZE]; /* some extra just in case */
 
     for (unsigned i=0; i<numdn; i++) {
-      decode(dname, p);
+      decode(orig_dname, p);
       dlease.decode(p, features);
       InodeStat ist(p, features);
 
-      ldout(cct, 15) << "" << i << ": '" << dname << "'" << dendl;
+      ldout(cct, 15) << "" << i << ": '" << orig_dname << "'" << dendl;
 
       if (fscrypt_denc) {
         char enc[NAME_MAX];
-        int len = fscrypt_fname_unarmor(dname.c_str(), dname.size(),
+        int len = fscrypt_fname_unarmor(orig_dname.c_str(), orig_dname.size(),
                                         enc, sizeof(enc));
-        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": base64 decoded fname orig len=" << dname.size() << " dest len=" << len << dendl;
+        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": base64 decoded fname orig len=" << orig_dname.size() << " dest len=" << len << dendl;
 
         int r = fscrypt_denc->decrypt(enc, len,
                                       dec_fname, sizeof(dec_fname));
@@ -1428,6 +1429,8 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
         } else {
           ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename" << dendl;
         }
+      } else {
+        dname = orig_dname;
       }
 
       Inode *in = add_update_inode(&ist, request->sent_stamp, session,
@@ -1462,7 +1465,11 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
 
       update_dentry_lease(dn, &dlease, request->sent_stamp, session);
       if (hash_order) {
+<<<<<<< HEAD
 	unsigned hash = ceph_frag_value(effective_diri->hash_dentry_name(dname));
+=======
+	unsigned hash = ceph_frag_value(diri->hash_dentry_name(orig_dname));
+>>>>>>> a648a309db0 (fscrypt: hash_dentry based on unencrypted fname)
 	if (hash != last_hash)
 	  readdir_offset = 2;
 	last_hash = hash;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1439,7 +1439,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
       }
 
       Inode *in = add_update_inode(&ist, request->sent_stamp, session,
-				   request->perms);
+                                   request->perms);
       auto *effective_dir = dir;
       auto *effective_diri = diri;
 
@@ -1451,37 +1451,37 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
       }
       Dentry *dn;
       if (effective_dir->dentries.count(dname)) {
-	Dentry *olddn = effective_dir->dentries[dname];
-	if (olddn->inode != in) {
-	  // replace incorrect dentry
-	  unlink(olddn, true, true);  // keep dir, dentry
-	  dn = link(effective_dir, dname, enc_name, in, olddn);
-	  ceph_assert(dn == olddn);
-	} else {
-	  // keep existing dn
-	  dn = olddn;
-	  touch_dn(dn);
-	}
+        Dentry *olddn = effective_dir->dentries[dname];
+        if (olddn->inode != in) {
+          // replace incorrect dentry
+          unlink(olddn, true, true);  // keep dir, dentry
+          dn = link(effective_dir, dname, enc_name, in, olddn);
+          ceph_assert(dn == olddn);
+        } else {
+          // keep existing dn
+          dn = olddn;
+          touch_dn(dn);
+        }
       } else {
-	// new dn
-	dn = link(effective_dir, dname, enc_name, in, NULL);
+        // new dn
+        dn = link(effective_dir, dname, enc_name, in, NULL);
       }
       dn->alternate_name = std::move(dlease.alternate_name);
 
       update_dentry_lease(dn, &dlease, request->sent_stamp, session);
       if (hash_order) {
-	unsigned hash = ceph_frag_value(effective_diri->hash_dentry_name(orig_dname));
-	if (hash != last_hash)
-	  readdir_offset = 2;
-	last_hash = hash;
-	dn->offset = dir_result_t::make_fpos(hash, readdir_offset++, true);
+        unsigned hash = ceph_frag_value(effective_diri->hash_dentry_name(orig_dname));
+        if (hash != last_hash)
+          readdir_offset = 2;
+        last_hash = hash;
+        dn->offset = dir_result_t::make_fpos(hash, readdir_offset++, true);
       } else {
-	dn->offset = dir_result_t::make_fpos(fg, readdir_offset++, false);
+        dn->offset = dir_result_t::make_fpos(fg, readdir_offset++, false);
       }
       // add to readdir cache
       if (!snapdiff_req &&
           dirp->release_count == effective_diri->dir_release_count &&
-	  dirp->ordered_count == effective_diri->dir_ordered_count &&
+          dirp->ordered_count == effective_diri->dir_ordered_count &&
 	  dirp->start_shared_gen == effective_diri->shared_gen) {
 	if (dirp->cache_index == effective_dir->readdir_cache.size()) {
 	  if (i == 0) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13258,6 +13258,8 @@ Inode *Client::open_snapdir(Inode *diri)
   vinodeno_t vino(diri->ino, CEPH_SNAPDIR);
   if (!inode_map.count(vino)) {
     in = new Inode(this, vino, &diri->layout);
+    in->fscrypt_auth = diri->fscrypt_auth; /* borrow parent fscrypt data */
+    in->fscrypt_ctx = in->init_fscrypt_ctx();
     refresh_snapdir_attrs(in, diri);
     diri->flags |= I_SNAPDIR_OPEN;
     inode_map[vino] = in;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1415,18 +1415,10 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session,
       ldout(cct, 15) << "" << i << ": '" << orig_dname << "'" << dendl;
 
       if (fscrypt_denc) {
-        char enc[NAME_MAX];
-        int len = fscrypt_fname_unarmor(orig_dname.c_str(), orig_dname.size(),
-                                        enc, sizeof(enc));
-        ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": base64 decoded fname orig len=" << orig_dname.size() << " dest len=" << len << dendl;
-
-        int r = fscrypt_denc->decrypt(enc, len,
-                                      dec_fname, sizeof(dec_fname));
-
-        if (r >= 0) {
-          dname = dec_fname;
-        } else {
-          ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename" << dendl;
+        int r = fscrypt_denc->get_decrypted_fname(orig_dname, &dname);
+        if (r < 0) {
+          ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to decrypt filename (r=" << r << ")" << dendl;
+          dname = orig_dname;
         }
       } else {
         dname = orig_dname;
@@ -7180,28 +7172,15 @@ int Client::_do_lookup(Inode *dir, const string& name, int mask,
 
   auto fscrypt_denc = fscrypt->get_fname_denc(dir->fscrypt_ctx, &dir->fscrypt_key_validator, true);
   if (fscrypt_denc) {
-    int dec_size = (name.size() + 31) & ~31; // FIXME, need to be based on policy
-
-    char orig[dec_size];
-    memcpy(orig, name.c_str(), name.size());
-    memset(orig + name.size(), 0, dec_size - name.size());
-
-    char enc_name[NAME_MAX + 64]; /* some extra just in case */
-    int r = fscrypt_denc->encrypt(orig, dec_size,
-                                  enc_name, sizeof(enc_name));
+    string enc_name;
+    int r = fscrypt_denc->get_encrypted_fname(name, &enc_name);
 
     if (r < 0) {
       ldout(cct, 0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
       return r;
     }
 
-    int enc_len = r;
-
-    int b64_len = NAME_MAX * 2; // name.size() * 2;
-    char b64_name[b64_len]; // large enough
-    fscrypt_fname_armor(enc_name, enc_len, b64_name, b64_len);
-
-    path.push_dentry(string(b64_name));
+    path.push_dentry(enc_name);
   } else {
     path.push_dentry(name);
   }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1392,11 +1392,13 @@ private:
                      bool is_file_write, utime_t start, Fh *f, Inode *in,
                      uint64_t fpos, int64_t req_ofs, uint64_t req_size,
                      int64_t offset, uint64_t size,
-                     bool do_fsync, bool syncdataonly)
+                     bool do_fsync, bool syncdataonly,
+                     bool encrypted)
       : clnt(clnt), onfinish(onfinish),
         is_file_write(is_file_write), start(start), f(f), in(in), fpos(fpos),
         req_ofs(req_ofs), req_size(req_size),
-        offset(offset), size(size), syncdataonly(syncdataonly) {
+        offset(offset), size(size), syncdataonly(syncdataonly),
+        encrypted(encrypted) {
       iofinished_r = 0;
       onuninlinefinished_r = 0;
       fsync_r = 0;
@@ -1422,6 +1424,7 @@ private:
     int64_t offset;
     uint64_t size;
     bool syncdataonly;
+    bool encrypted;
     int64_t iofinished_r;
     int64_t onuninlinefinished_r;
     int64_t fsync_r;
@@ -1678,7 +1681,8 @@ private:
   void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
   int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
                          int64_t request_offset, uint64_t request_size,
-                         int64_t offset, uint64_t size, Inode *in);
+                         int64_t offset, uint64_t size, Inode *in,
+                         bool encrypted);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt, Context *onfinish = nullptr,
           bool do_fsync = false, bool syncdataonly = false);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -42,6 +42,7 @@
 #include "InodeRef.h"
 #include "MetaSession.h"
 #include "UserPerm.h"
+#include "FSCrypt.h"
 
 #include <fstream>
 #include <map>
@@ -912,8 +913,11 @@ public:
   std::unique_ptr<PerfCounters> logger;
   std::unique_ptr<MDSMap> mdsmap;
 
+  std::unique_ptr<FSCrypt> fscrypt;
+
   bool fuse_default_permissions;
   bool _collect_and_send_global_metrics;
+
 
 protected:
   std::list<ceph::condition_variable*> waiting_for_reclaim;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1375,17 +1375,26 @@ private:
   class C_Read_Async_Finisher : public Context {
   public:
     C_Read_Async_Finisher(Client *clnt, Context *onfinish, Fh *f, Inode *in,
-                          uint64_t fpos, uint64_t off, uint64_t len)
-      : clnt(clnt), onfinish(onfinish), f(f), in(in), off(off), len(len) {}
+                          bufferlist *bl,
+                          uint64_t fpos, uint64_t off, uint64_t len,
+                          FSCryptFDataDencRef denc,
+                          uint64_t read_start,
+                          uint64_t read_len)
+      : clnt(clnt), onfinish(onfinish), f(f), in(in), bl(bl), off(off), len(len),
+        denc(denc), read_start(read_start), read_len(read_len) {}
 
   private:
     Client *clnt;
     Context *onfinish;
     Fh *f;
     Inode *in;
+    bufferlist *bl;
     uint64_t off;
     uint64_t len;
 
+    FSCryptFDataDencRef denc;
+    uint64_t read_start;
+    uint64_t read_len;
     void finish(int r) override;
   };
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1602,6 +1602,9 @@ private:
 
   bool _dentry_valid(const Dentry *dn);
 
+  int _prepare_req_path(Inode *dir, MetaRequest *req, filepath& path, const char *name,
+                        Dentry **pdn);
+
   // internal interface
   //   call these with client_lock held!
   int _do_lookup(Inode *dir, const std::string& name, int mask, InodeRef *target,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1603,7 +1603,7 @@ private:
   bool _dentry_valid(const Dentry *dn);
 
   int _prepare_req_path(Inode *dir, MetaRequest *req, filepath& path, const char *name,
-                        Dentry **pdn);
+                        bool set_filepath, Dentry **pdn);
 
   // internal interface
   //   call these with client_lock held!

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1058,7 +1058,7 @@ protected:
    * leave dn set to default NULL unless you're trying to add
    * a new inode to a pre-created Dentry
    */
-  Dentry* link(Dir *dir, const std::string& name, Inode *in, Dentry *dn);
+  Dentry* link(Dir *dir, const std::string& name, std::optional<std::string> enc_name, Inode *in, Dentry *dn);
   void unlink(Dentry *dn, bool keepdir, bool keepdentry);
 
   int fill_stat(Inode *in, struct stat *st, frag_info_t *dirstat=0, nest_info_t *rstat=0);
@@ -1695,7 +1695,7 @@ private:
   int _flock(Fh *fh, int cmd, uint64_t owner);
   int _lazyio(Fh *fh, int enable);
 
-  Dentry *get_or_create(Inode *dir, const char* name);
+  Dentry *get_or_create(Inode *dir, const char* plain_name, std::optional<std::string> enc_name);
 
   int xattr_permission(Inode *in, const char *name, unsigned want,
 		       const UserPerm& perms);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1395,7 +1395,261 @@ private:
     FSCryptFDataDencRef denc;
     uint64_t read_start;
     uint64_t read_len;
+
     void finish(int r) override;
+  };
+
+  struct aio_collection {
+    ceph::mutex lock = ceph::make_mutex("Client::aio_collection");
+
+    aio_collection() {}
+
+    struct aio_status {
+      int r = 0;
+      bool complete{false};
+    };
+
+    int num_complete = 0;
+    int total = 0;
+
+    int retcode = 0;
+
+    std::vector<aio_status> status;
+
+    int add_io() {
+      std::unique_lock l{lock};
+      int old_total = total++;
+      status.resize(total);
+
+      return old_total;
+    }
+
+    bool is_complete() {
+      std::unique_lock l{lock};
+      return num_complete == total;
+    }
+
+    int finish_io(int id, int r) {
+      std::unique_lock l{lock};
+      status[id].r = r;
+      status[id].complete = true;
+
+      ++num_complete;
+
+      if (r < 0 && retcode == 0) {
+        retcode = r;
+      }
+
+      return r;
+    }
+
+    int get_retcode() {
+      std::unique_lock l{lock};
+      return retcode;
+    }
+  };
+
+  template<typename T>
+  struct iofinish_method_ctx {
+    struct _Ctx : Context {
+      iofinish_method_ctx *ioc;
+
+      _Ctx(iofinish_method_ctx *_ioc) : ioc(_ioc) {}
+
+      void finish(int r) override {
+        ioc->finish(r);
+      }
+    };
+
+    std::unique_ptr<_Ctx> _ctx;
+
+    T& t;
+    void (T::*call)(int);
+    ceph::mutex lock = ceph::make_mutex("Client::iofinish_method_ctx");
+    ceph::condition_variable cond;
+    bool done{false};
+    bool canceled{false};
+
+    aio_collection *aioc;
+    int io_id;
+
+    iofinish_method_ctx(T& _t, void (T::*_call)(int), aio_collection *_aioc) : t(_t), call(_call),
+                                                                               aioc(_aioc) {
+      _ctx.reset(new _Ctx(this));
+
+      if (aioc) {
+        io_id = aioc->add_io();
+      }
+    }
+
+    Context *ctx() { return _ctx.get(); }
+
+    void wait() {
+      std::unique_lock l{lock};
+      if (!done) {
+        cond.wait(l);
+      }
+    }
+
+    Context *release() {
+      auto ctx = _ctx.release();
+      _ctx.reset();
+      return ctx;
+    }
+
+    void cancel(int r) {
+      std::unique_lock l{lock};
+      canceled = true;
+      done = true;
+      if (aioc) {
+        aioc->finish_io(io_id, r);
+      }
+    }
+
+    void finish(int r) {
+      std::unique_lock l{lock};
+      if (!canceled) {
+        /* avoid any callback when canceled, calling object might have been destroyed */
+        if (aioc) {
+          aioc->finish_io(io_id, r);
+        }
+        (t.*(call))(r);
+      }
+      done = true;
+      cond.notify_all();
+    }
+  };
+
+  struct CWF_iofinish;
+
+  class WriteEncMgr : public RefCountedObject {
+  protected:
+    Client *clnt;
+    client_t const whoami;
+
+    CephContext *cct;
+    FSCrypt *fscrypt;
+
+    ceph::mutex lock = ceph::make_mutex("Client::WriteEncMgr");
+
+    Fh *f;
+    Inode *in;
+
+    Context *iofinish{nullptr};
+
+    int64_t offset;
+    uint64_t size;
+
+    bufferlist bl;
+    bufferlist encbl;
+    bufferlist *pbl;
+
+    bool async;
+
+    FSCryptFDataDencRef denc;
+
+    uint64_t start_block;
+    uint64_t start_block_ofs;
+    uint64_t ofs_in_start_block;
+    uint64_t end_block;
+    uint64_t end_block_ofs;
+    uint64_t ofs_in_end_block;
+
+    uint64_t endoff;
+
+    bool need_read_start{false};
+    bool need_read_end{false};
+
+    int read_start_size;
+
+    bufferlist startbl;
+    bufferlist endbl;
+
+    aio_collection aioc;
+
+    bool is_ready_to_finish{false};
+    bool is_finished{false};
+
+    std::unique_ptr<iofinish_method_ctx<WriteEncMgr> > finish_read_start_ctx;
+    std::unique_ptr<iofinish_method_ctx<WriteEncMgr> > finish_read_end_ctx;
+
+    bool try_finish(int r) {
+      if (is_finished) {
+        return true;
+      }
+
+      if (!is_ready_to_finish) {
+        return false;
+      }
+
+      is_finished = do_try_finish(r);
+
+      return is_finished;
+    }
+
+    int read_async(uint64_t off, uint64_t len, bufferlist *bl, iofinish_method_ctx<WriteEncMgr> *ioctx);
+
+  protected:
+    virtual int do_write() = 0;
+    virtual void update_write_params() = 0;
+
+  public:
+    WriteEncMgr(Client *clnt,
+                Fh *f, int64_t offset, uint64_t size,
+                bufferlist& bl,
+                bool async);
+    virtual ~WriteEncMgr();
+
+    int init();
+
+    void get_write_params(int64_t *poffset, uint64_t *psize, bufferlist **ppbl) const {
+      *poffset = offset;
+      *psize = size;
+      *ppbl = pbl;
+    }
+
+    bool encrypted() const {
+      return !!denc;
+    }
+
+    int read_modify_write(Context *iofinish);
+
+    void finish_read_start_cb(int r) {
+      finish_read_start(r);
+      put();
+    }
+    void finish_read_end_cb(int r) {
+      finish_read_end(r);
+      put();
+    }
+    void finish_read_start(int r);
+    void finish_read_end(int r);
+    bool do_try_finish(int r);
+
+    int64_t get_ofs() { return offset; }
+    uint64_t get_size() { return size; }
+  };
+
+  class WriteEncMgr_Buffered : public WriteEncMgr {
+  public:
+    WriteEncMgr_Buffered(Client *clnt,
+                         Fh *f, int64_t offset, uint64_t size,
+                         bufferlist& bl,
+                         bool async) : WriteEncMgr(clnt, f, offset, size, bl, async) {}
+
+    void update_write_params() override;
+    int do_write() override;
+  };
+
+  class WriteEncMgr_NotBuffered : public WriteEncMgr {
+  public:
+    WriteEncMgr_NotBuffered(Client *clnt,
+                         Fh *f, int64_t offset, uint64_t size,
+                         bufferlist& bl,
+                         bool async) : WriteEncMgr(clnt, f, offset, size, bl, async) {}
+
+    void update_write_params() override {}
+    int do_write() override;
   };
 
   class C_Write_Finisher : public Context {
@@ -1425,6 +1679,11 @@ private:
 
     void finish(int r) override {
       // We need to override finish, but have nothing to do.
+    }
+
+    void update_write_params(int64_t _ofs, uint64_t _size) {
+      offset = _ofs;
+      size = _size;
     }
 
   private:

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1390,10 +1390,12 @@ private:
 
     C_Write_Finisher(Client *clnt, Context *onfinish, bool dont_need_uninline,
                      bool is_file_write, utime_t start, Fh *f, Inode *in,
-                     uint64_t fpos, int64_t offset, uint64_t size,
+                     uint64_t fpos, int64_t req_ofs, uint64_t req_size,
+                     int64_t offset, uint64_t size,
                      bool do_fsync, bool syncdataonly)
       : clnt(clnt), onfinish(onfinish),
         is_file_write(is_file_write), start(start), f(f), in(in), fpos(fpos),
+        req_ofs(req_ofs), req_size(req_size),
         offset(offset), size(size), syncdataonly(syncdataonly) {
       iofinished_r = 0;
       onuninlinefinished_r = 0;
@@ -1415,6 +1417,8 @@ private:
     Fh *f;
     Inode *in;
     uint64_t fpos;
+    int64_t req_ofs;
+    uint64_t req_size;
     int64_t offset;
     uint64_t size;
     bool syncdataonly;
@@ -1673,7 +1677,8 @@ private:
   		Context *onfinish = nullptr);
   void do_readahead(Fh *f, Inode *in, uint64_t off, uint64_t len);
   int64_t _write_success(Fh *fh, utime_t start, uint64_t fpos,
-          int64_t offset, uint64_t size, Inode *in);
+                         int64_t request_offset, uint64_t request_size,
+                         int64_t offset, uint64_t size, Inode *in);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt, Context *onfinish = nullptr,
           bool do_fsync = false, bool syncdataonly = false);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -328,6 +328,11 @@ public:
     return fscid;
   }
 
+  /* fscrypt */
+  int add_fscrypt_key(const char *key_data, int key_len, ceph_fscrypt_key_identifier *kid);
+  int remove_fscrypt_key(const ceph_fscrypt_key_identifier& kid);
+  int set_fscrypt_policy_v2(int fd, const struct fscrypt_policy_v2& policy);
+
   int mds_command(
     const std::string &mds_spec,
     const std::vector<std::string>& cmd,
@@ -667,6 +672,8 @@ public:
   bool ll_handle_umask() {
     return acl_type != NO_ACL;
   }
+
+  int ll_set_fscrypt_policy_v2(Inode *in, const struct fscrypt_policy_v2& policy);
 
   int ll_get_stripe_osd(struct Inode *in, uint64_t blockno,
 			file_layout_t* layout);

--- a/src/client/Dentry.h
+++ b/src/client/Dentry.h
@@ -82,6 +82,7 @@ public:
 
   Dir	   *dir;
   const std::string name;
+  std::optional<std::string> enc_name;
   InodeRef inode;
   int	   ref = 1; // 1 if there's a dir beneath me.
   int64_t offset = 0;

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -181,3 +181,12 @@ int FSCryptKeyStore::find(const struct ceph_fscrypt_key_identifier& id, FSCryptK
 
   return 0;
 }
+
+int FSCryptKeyStore::remove(const struct ceph_fscrypt_key_identifier& id)
+{
+  std::unique_lock rl{lock};
+
+  m.erase(id);
+
+  return 0;
+}

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -386,9 +386,28 @@ void FSCryptContext::generate_iv(uint64_t block_num, FSCryptIV& iv) const
   iv.u.block_num = block_num;
 }
 
-int FSCryptKeyStore::create(const char *k, int klen, FSCryptKeyRef& key)
+void FSCryptKeyHandler::reset(int64_t _epoch, FSCryptKeyRef k)
 {
-  key = std::make_shared<FSCryptKey>();
+  std::unique_lock wl{lock};
+  epoch = _epoch;
+  key = k;
+}
+
+int64_t FSCryptKeyHandler::get_epoch()
+{
+  std::shared_lock rl{lock};
+  return epoch;
+}
+
+FSCryptKeyRef& FSCryptKeyHandler::get_key()
+{
+  std::shared_lock rl{lock};
+  return key;
+}
+
+int FSCryptKeyStore::create(const char *k, int klen, FSCryptKeyHandlerRef& key_handler)
+{
+  auto key = std::make_shared<FSCryptKey>();
 
   int r = key->init(k, klen);
   if (r < 0) {
@@ -401,35 +420,63 @@ int FSCryptKeyStore::create(const char *k, int klen, FSCryptKeyRef& key)
   
   auto iter = m.find(id);
   if (iter != m.end()) {
-    return -EEXIST;
+    /* found a key handler entry, check that there is a key there */
+    key_handler = iter->second;
+    if (key_handler->get_key()) {
+      return -EEXIST;
+    }
+    key_handler->reset(++epoch, key);
+  } else {
+    key_handler = std::make_shared<FSCryptKeyHandler>(++epoch, key);
+    m[id] = key_handler;
   }
-
-  m[id] = key;
 
   return 0;
 }
 
-int FSCryptKeyStore::find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyRef& key)
+int FSCryptKeyStore::_find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyHandlerRef& kh)
 {
-  std::shared_lock rl{lock};
-
   auto iter = m.find(id);
   if (iter == m.end()) {
     return -ENOENT;
   }
 
-  key = iter->second;
+  kh = iter->second;
 
   return 0;
 }
 
-int FSCryptKeyStore::remove(const struct ceph_fscrypt_key_identifier& id)
+int FSCryptKeyStore::find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyHandlerRef& kh)
+{
+  std::shared_lock rl{lock};
+
+  return _find(id, kh);
+}
+
+int FSCryptKeyStore::invalidate(const struct ceph_fscrypt_key_identifier& id)
 {
   std::unique_lock rl{lock};
+
+  FSCryptKeyHandlerRef kh;
+  int r = _find(id, kh);
+  if (r == -ENOENT) {
+    return 0;
+  } else if (r < 0) {
+    return r;
+  }
+
+  kh->reset(++epoch, nullptr);
 
   m.erase(id);
 
   return 0;
+}
+
+FSCryptKeyValidator::FSCryptKeyValidator(CephContext *cct, FSCryptKeyHandlerRef& kh, int64_t e) : cct(cct), handler(kh), epoch(e) {
+}
+
+bool FSCryptKeyValidator::is_valid() const {
+  return (handler->get_epoch() == epoch);
 }
 
 FSCryptDenc::FSCryptDenc(): cipher(EVP_CIPHER_fetch(NULL, "AES-256-CBC-CTS", NULL)),
@@ -490,18 +537,32 @@ FSCryptDenc::~FSCryptDenc()
   EVP_CIPHER_CTX_free(cipher_ctx);
 }
 
-FSCryptDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx)
+FSCryptDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv)
 {
   if (!ctx) {
     return nullptr;
   }
 
-  FSCryptKeyRef master_key;
-  int r = key_store.find(ctx->master_key_identifier, master_key);
+  FSCryptKeyHandlerRef master_kh;
+  int r = key_store.find(ctx->master_key_identifier, master_kh);
   if (r == 0) {
-    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key found" << dendl;
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key handler found" << dendl;
   } else if (r == -ENOENT) {
-    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key not found" << dendl;
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key handler not found" << dendl;
+    return nullptr;
+  } else {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": error: r=" << r << dendl;
+    return nullptr;
+  }
+
+  if (kv) {
+    *kv = make_shared<FSCryptKeyValidator>(cct, master_kh, master_kh->get_epoch());
+  }
+
+  auto& master_key = master_kh->get_key();
+
+  if (!master_key) {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key key is null" << dendl;
     return nullptr;
   }
 

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -107,12 +107,9 @@ static int b64_encode(char *dst, char * const dst_end, const char *src, const ch
 				SET_DST(encode_bits(c & 63));
 			} else {
 				SET_DST(encode_bits((b & 15) << 2));
-				SET_DST('=');
 			}
 		} else {
 			SET_DST(encode_bits(((a & 3) << 4)));
-			SET_DST('=');
-			SET_DST('=');
 		}
 		olen += 4;
 		line += 4;

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -1,0 +1,20 @@
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "common/errno.h"
+#include "common/safe_io.h"
+#include "common/config.h"
+#include "include/ceph_assert.h"
+
+#include "client/FSCrypt.h"

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -133,6 +133,14 @@ int ceph_fscrypt_key_identifier::init(const char *k, int klen) {
   return 0;
 }
 
+int ceph_fscrypt_key_identifier::init(const struct fscrypt_key_specifier& k) {
+  if (k.type != FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
+    return -ENOTSUP;
+  }
+
+  return init((const char *)k.u.identifier, sizeof(k.u.identifier));
+}
+
 bool ceph_fscrypt_key_identifier::operator<(const struct ceph_fscrypt_key_identifier& r) const {
   return (memcmp(raw, r.raw, sizeof(raw)) < 0);
 }

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -15,6 +15,95 @@
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/config.h"
+#include "common/ceph_crypto.h"
 #include "include/ceph_assert.h"
 
 #include "client/FSCrypt.h"
+
+
+using ceph::crypto::HMACSHA512;
+
+static int calc_hmac_sha512(const char *key, int key_len,
+                             const char *msg, int msg_len,
+                             char *dest, int dest_len)
+{
+  char hash_sha512[CEPH_CRYPTO_HMACSHA512_DIGESTSIZE];
+
+  HMACSHA512 hmac((const unsigned char *)key, key_len);
+  hmac.Update((const unsigned char *)msg, msg_len);
+  hmac.Final((unsigned char *)hash_sha512);
+
+  auto len = std::min(dest_len, CEPH_CRYPTO_HMACSHA512_DIGESTSIZE);
+
+  memcpy(dest, hash_sha512, len);
+
+  return len;
+}
+
+#define SALT_LEN_DEFAULT 32
+
+static char default_salt[SALT_LEN_DEFAULT] = { 0 };
+
+static int hkdf_extract(const char *_salt, int salt_len,
+                         const char *ikm, int ikm_len,
+                         char *dest, int dest_len) {
+  const char *salt = _salt;
+  if (!_salt) {
+    salt = default_salt;
+    salt_len = SALT_LEN_DEFAULT;
+  }
+
+  return calc_hmac_sha512(salt, salt_len, ikm, ikm_len, dest, dest_len);
+}
+
+static int hkdf_expand(const char *data, int data_len,
+                       const char *info, int info_len,
+                       char *dest, int dest_len)
+{
+  int total_len = 0;
+
+  char info_buf[info_len + 16];
+  memcpy(info_buf, info, info_len);
+
+  char *p = dest;
+
+  for (char i = 1; total_len < dest_len; i++) {
+    *(char *)(info_buf + info_len) =  i;
+
+    int r = calc_hmac_sha512(data, data_len,
+                         info_buf, info_len  + 1,
+                         p, dest_len - total_len);
+    if (r < 0) {
+      return r;
+    }
+    if (r == 0) {
+      return -EINVAL;
+    }
+
+    total_len += r;
+  }
+
+  return total_len;
+}
+
+
+int fscrypt_calc_hkdf(const char *salt, int salt_len,
+                      const char *key, int key_len,
+                      char *dest, int dest_len)
+{
+  char extract_buf[CEPH_CRYPTO_HMACSHA512_DIGESTSIZE];
+  int r = hkdf_extract(salt, salt_len,
+                       key, key_len,
+                       extract_buf, sizeof(extract_buf));
+  if (r < 0) {
+    return r;
+  }
+
+  int extract_len = r;
+
+#define FSCRYPT_INFO_STR "fscrypt\x00\x01"
+
+  return hkdf_expand(extract_buf, extract_len,
+                     FSCRYPT_INFO_STR, sizeof(FSCRYPT_INFO_STR) - 1,
+                     dest, dest_len);
+}

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -229,46 +229,7 @@ int fscrypt_fname_unarmor(const char *src, int src_len,
                     src, src + src_len);
 }
 
-int fscrypt_decrypt_fname(const uint8_t *enc, int enc_len,
-                          uint8_t *key, uint8_t *iv,
-                          uint8_t *result)
 {
-    EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-256-CBC-CTS", NULL);
-    EVP_CIPHER_CTX *ctx;
-    OSSL_PARAM params[2] = {
-	    OSSL_PARAM_construct_utf8_string(OSSL_CIPHER_PARAM_CTS_MODE, (char *)"CS3", 0),
-	    OSSL_PARAM_construct_end()
-    };
-
-    int total_len;
-
-    if(!(ctx = EVP_CIPHER_CTX_new())) {
-      return -EIO;
-    }
-
-    if (!EVP_CipherInit_ex2(ctx, cipher, key, iv,
-			    0, params)) {
-      return -EINVAL;
-    }
-
-    int len;
-
-    if (EVP_DecryptUpdate(ctx, result, &len, enc, enc_len) != 1) {
-      return -EINVAL;
-    }
-
-    total_len = len;
-
-    if(EVP_DecryptFinal_ex(ctx, result + len, &len) != 1) {
-      return -EINVAL;
-    }
-
-    total_len += len;
-
-    /* Clean up */
-    EVP_CIPHER_CTX_free(ctx);
-
-    return total_len;
 }
 
 int fscrypt_calc_hkdf(char hkdf_context,

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -519,7 +519,7 @@ int FSCryptDenc::decrypt(const char *in_data, int in_len,
 
     int key_size = key.size();
 
-    if (out_len < ((in_len + (key_size - 1)) & ~(key_size - 1))) {
+    if (out_len < (fscrypt_align_ofs(in_len))) {
       return -ERANGE;
     }
 

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -16,14 +16,151 @@
 #include "common/safe_io.h"
 #include "common/config.h"
 #include "common/ceph_crypto.h"
+#include "common/debug.h"
 #include "include/ceph_assert.h"
 
 #include "client/FSCrypt.h"
 
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/core_names.h>
+
 #include <string.h>
 
+#define dout_context g_ceph_context
 
 using ceph::crypto::HMACSHA512;
+/*
+ * base64 encode/decode.
+ */
+
+
+
+/* FIXME: this was copy pasted from common/armor.c with slight modification
+ * as needed to use alternative translation table. Code can and should be
+ * combined, but need to make sure we do it in a way that doesn't hurt
+ * compiler optimizations in the general case.
+ * Also relaxed decoding to make it compatible with the kernel client */
+static const char *pem_key = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,";
+
+static int encode_bits(int c)
+{
+	return pem_key[c];
+}
+
+static int decode_bits(char c)
+{
+	if (c >= 'A' && c <= 'Z')
+		return c - 'A';
+	if (c >= 'a' && c <= 'z')
+		return c - 'a' + 26;
+	if (c >= '0' && c <= '9')
+		return c - '0' + 52;
+	if (c == '+' || c == '-')
+		return 62;
+	if (c == ',' || c == '/' || c == '_')
+		return 63;
+	if (c == '=')
+		return 0; /* just non-negative, please */
+	return -EINVAL;	
+}
+
+static int set_str_val(char **pdst, const char *end, char c)
+{
+	if (*pdst < end) {
+		char *p = *pdst;
+		*p = c;
+		(*pdst)++;
+	} else
+		return -ERANGE;
+
+	return 0;
+}
+
+static int b64_encode(char *dst, char * const dst_end, const char *src, const char *end)
+{
+        char *orig_dst = dst;
+	int olen = 0;
+	int line = 0;
+
+#define SET_DST(c) do { \
+	int __ret = set_str_val(&dst, dst_end, c); \
+	if (__ret < 0) \
+		return __ret; \
+} while (0);
+
+	while (src < end) {
+		unsigned char a;
+
+		a = *src++;
+		SET_DST(encode_bits(a >> 2));
+		if (src < end) {
+			unsigned char b;
+			b = *src++;
+			SET_DST(encode_bits(((a & 3) << 4) | (b >> 4)));
+			if (src < end) {
+				unsigned char c;
+				c = *src++;
+				SET_DST(encode_bits(((b & 15) << 2) |
+								(c >> 6)));
+				SET_DST(encode_bits(c & 63));
+			} else {
+				SET_DST(encode_bits((b & 15) << 2));
+				SET_DST('=');
+			}
+		} else {
+			SET_DST(encode_bits(((a & 3) << 4)));
+			SET_DST('=');
+			SET_DST('=');
+		}
+		olen += 4;
+		line += 4;
+	}
+	*dst = '\0';
+	return (dst - orig_dst);
+}
+
+static char get_unarmor_src(const char *src, const char *end, int ofs)
+{
+  if (src + ofs < end) {
+    return src[ofs];
+  }
+  return '=';
+}
+
+int b64_decode(char *dst, char * const dst_end, const char *src, const char *end)
+{
+	int olen = 0;
+
+	while (src < end) {
+		int a, b, c, d;
+
+		if (src[0] == '\n') {
+			src++;
+			continue;
+		}
+
+		a = decode_bits(get_unarmor_src(src, end, 0));
+		b = decode_bits(get_unarmor_src(src, end, 1));
+		c = decode_bits(get_unarmor_src(src, end, 2));
+		d = decode_bits(get_unarmor_src(src, end, 3));
+		if (a < 0 || b < 0 || c < 0 || d < 0) {
+			return -EINVAL;
+                }
+
+		SET_DST((a << 2) | (b >> 4));
+		if (get_unarmor_src(src, end, 2) == '=')
+			return olen + 1;
+		SET_DST(((b & 15) << 4) | (c >> 2));
+		if (get_unarmor_src(src, end, 3) == '=')
+			return olen + 2;
+		SET_DST(((c & 3) << 6) | d);
+		olen += 3;
+		src += 4;
+	}
+	return olen;
+}
 
 static int calc_hmac_sha512(const char *key, int key_len,
                              const char *msg, int msg_len,
@@ -88,8 +225,58 @@ static int hkdf_expand(const char *data, int data_len,
   return total_len;
 }
 
+int fscrypt_fname_unarmor(const char *src, int src_len,
+                          char *result, int max_len)
+{
+  return b64_decode(result, result + max_len,
+                    src, src + src_len);
+}
 
-int fscrypt_calc_hkdf(const char *salt, int salt_len,
+int fscrypt_decrypt_fname(const uint8_t *enc, int enc_len,
+                          uint8_t *key, uint8_t *iv,
+                          uint8_t *result)
+{
+    EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-256-CBC-CTS", NULL);
+    EVP_CIPHER_CTX *ctx;
+    OSSL_PARAM params[2] = {
+	    OSSL_PARAM_construct_utf8_string(OSSL_CIPHER_PARAM_CTS_MODE, (char *)"CS3", 0),
+	    OSSL_PARAM_construct_end()
+    };
+
+    int total_len;
+
+    if(!(ctx = EVP_CIPHER_CTX_new())) {
+      return -EIO;
+    }
+
+    if (!EVP_CipherInit_ex2(ctx, cipher, key, iv,
+			    0, params)) {
+      return -EINVAL;
+    }
+
+    int len;
+
+    if (EVP_DecryptUpdate(ctx, result, &len, enc, enc_len) != 1) {
+      return -EINVAL;
+    }
+
+    total_len = len;
+
+    if(EVP_DecryptFinal_ex(ctx, result + len, &len) != 1) {
+      return -EINVAL;
+    }
+
+    total_len += len;
+
+    /* Clean up */
+    EVP_CIPHER_CTX_free(ctx);
+
+    return total_len;
+}
+
+int fscrypt_calc_hkdf(char hkdf_context,
+                      const char *nonce, int nonce_len,
+                      const char *salt, int salt_len,
                       const char *key, int key_len,
                       char *dest, int dest_len)
 {
@@ -103,15 +290,46 @@ int fscrypt_calc_hkdf(const char *salt, int salt_len,
 
   int extract_len = r;
 
-#define FSCRYPT_INFO_STR "fscrypt\x00\x01"
+#define FSCRYPT_INFO_STR "fscrypt\x00?"
 
-  return hkdf_expand(extract_buf, extract_len,
-                     FSCRYPT_INFO_STR, sizeof(FSCRYPT_INFO_STR) - 1,
-                     dest, dest_len);
+  char info_str[sizeof(FSCRYPT_INFO_STR) + nonce_len];
+
+  int len = sizeof(FSCRYPT_INFO_STR) - 1;
+  memcpy(info_str, FSCRYPT_INFO_STR, len);
+
+  info_str[len - 1] = hkdf_context;
+
+  if (nonce && nonce_len) {
+    memcpy(info_str + len, nonce, nonce_len);
+    len += nonce_len;
+  }
+
+  r =  hkdf_expand(extract_buf, extract_len,
+                   info_str, len,
+                   dest, dest_len);
+
+  return r;
+}
+
+static std::string hex_str(const void *p, int len)
+{
+  bufferlist bl;
+  bl.append_hole(len);
+  memcpy(bl.c_str(), p, len);
+  std::stringstream ss;
+  bl.hexdump(ss);
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& out, const ceph_fscrypt_key_identifier& kid) {
+  out << hex_str(kid.raw, sizeof(kid.raw));
+  return out;
 }
 
 int FSCryptKey::init(const char *k, int klen) {
-  int r = fscrypt_calc_hkdf(nullptr, 0,
+  int r = fscrypt_calc_hkdf(HKDF_CONTEXT_KEY_IDENTIFIER,
+                            nullptr, 0, /* nonce */
+                            nullptr, 0, /* salt */
                             (const char *)k, klen,
                             identifier.raw, sizeof(identifier.raw));
   if (r < 0) {
@@ -120,6 +338,21 @@ int FSCryptKey::init(const char *k, int klen) {
 
   key.append_hole(klen);
   memcpy(key.c_str(), k, klen);
+
+  return 0;
+}
+
+int FSCryptKey::calc_hkdf(char ctx_identifier,
+                          const char *nonce, int nonce_len,
+                          char *result, int result_len) {
+  int r = fscrypt_calc_hkdf(ctx_identifier,
+                            nonce, nonce_len, /* nonce */
+                            nullptr, 0, /* salt */
+                            (const char *)key.c_str(), key.length(),
+                            result, result_len);
+  if (r < 0) {
+    return r;
+  }
 
   return 0;
 }
@@ -143,6 +376,14 @@ int ceph_fscrypt_key_identifier::init(const struct fscrypt_key_specifier& k) {
 
 bool ceph_fscrypt_key_identifier::operator<(const struct ceph_fscrypt_key_identifier& r) const {
   return (memcmp(raw, r.raw, sizeof(raw)) < 0);
+}
+
+void FSCryptContext::generate_iv(uint64_t block_num, FSCryptIV& iv) const
+{
+  memset(&iv, 0, sizeof(iv));
+
+  // memcpy(iv.u.nonce, nonce, FSCRYPT_FILE_NONCE_SIZE);
+  iv.u.block_num = block_num;
 }
 
 int FSCryptKeyStore::create(const char *k, int klen, FSCryptKeyRef& key)
@@ -190,3 +431,88 @@ int FSCryptKeyStore::remove(const struct ceph_fscrypt_key_identifier& id)
 
   return 0;
 }
+
+FSCryptDenc::FSCryptDenc(): cipher(EVP_CIPHER_fetch(NULL, "AES-256-CBC-CTS", NULL)),
+                            cipher_ctx(EVP_CIPHER_CTX_new()),
+  cipher_params({ OSSL_PARAM_construct_utf8_string(OSSL_CIPHER_PARAM_CTS_MODE, (char *)"CS3", 0),
+                                                 OSSL_PARAM_construct_end()} )
+{
+}
+
+int FSCryptDenc::init(char ctx_identifier,
+                      FSCryptContextRef& ctx,
+                      FSCryptKeyRef& master_key)
+{
+  int r = master_key->calc_hkdf(ctx_identifier,
+                                (const char *)ctx->nonce, sizeof(ctx->nonce),
+                                key, sizeof(key));
+  if (r < 0) {
+    return r;
+  }
+  ctx->generate_iv(0, iv);
+
+  return 0;
+}
+
+int FSCryptDenc::decrypt(const char *in_data, int in_len,
+                         char *out_data, int out_len)
+{
+    int total_len;
+
+    if (out_len < ((in_len + (FSCRYPT_KEY_SIZE - 1)) & ~(FSCRYPT_KEY_SIZE - 1))) {
+      return -ERANGE;
+    }
+
+    if (!EVP_CipherInit_ex2(cipher_ctx, cipher, (const uint8_t *)key, iv.raw,
+			    0, cipher_params.data())) {
+      return -EINVAL;
+    }
+
+    int len;
+
+    if (EVP_DecryptUpdate(cipher_ctx, (uint8_t *)out_data, &len, (const uint8_t *)in_data, in_len) != 1) {
+      return -EINVAL;
+    }
+
+    total_len = len;
+
+    if (EVP_DecryptFinal_ex(cipher_ctx, (uint8_t *)out_data + len, &len) != 1) {
+      return -EINVAL;
+    }
+
+    total_len += len;
+
+    return total_len;
+}
+
+FSCryptDenc::~FSCryptDenc()
+{
+  EVP_CIPHER_CTX_free(cipher_ctx);
+}
+
+FSCryptDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx)
+{
+  if (!ctx) {
+    return nullptr;
+  }
+
+  FSCryptKeyRef master_key;
+  int r = key_store.find(ctx->master_key_identifier, master_key);
+  if (r == 0) {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key found" << dendl;
+  } else if (r == -ENOENT) {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": fscrypt_key not found" << dendl;
+    return nullptr;
+  }
+
+  auto fscrypt_denc = std::make_shared<FSCryptDenc>();
+
+  r = fscrypt_denc->init_fname(ctx, master_key);
+  if (r < 0) {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to init dencoder: r=" << r << dendl;
+    return nullptr;
+  }
+
+  return fscrypt_denc;
+}
+

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -18,6 +18,7 @@
 #include "common/ceph_crypto.h"
 #include "common/debug.h"
 #include "include/ceph_assert.h"
+#include "auth/Crypto.h"
 
 #include "client/FSCrypt.h"
 
@@ -346,6 +347,11 @@ void FSCryptContext::generate_iv(uint64_t block_num, FSCryptIV& iv) const
 
   // memcpy(iv.u.nonce, nonce, FSCRYPT_FILE_NONCE_SIZE);
   iv.u.block_num = block_num;
+}
+
+void FSCryptContext::generate_new_nonce()
+{
+  g_ceph_context->random()->get_bytes((char *)nonce, sizeof(nonce));
 }
 
 void FSCryptKeyHandler::reset(int64_t _epoch, FSCryptKeyRef k)

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -580,15 +580,20 @@ int FSCryptFNameDenc::get_encrypted_fname(const std::string& plain, std::string 
   return len;
 }
 
-int FSCryptFNameDenc::get_decrypted_fname(const std::string& b64enc, std::string *decrypted)
+int FSCryptFNameDenc::get_decrypted_fname(const std::string& b64enc, const std::string& alt_name, std::string *decrypted)
 {
   char enc[NAME_MAX];
-  int len = fscrypt_fname_unarmor(b64enc.c_str(), b64enc.size(),
-                                  enc, sizeof(enc));
+  int len = alt_name.size();
 
-generic_dout(0) << __FILE__ << ":" << __LINE__ << ":" << __func__ << " len=" << len << dendl;
+  const char *penc = (len == 0 ? enc : alt_name.c_str());
+
+  if (len == 0) {
+    len = fscrypt_fname_unarmor(b64enc.c_str(), b64enc.size(),
+                                enc, sizeof(enc));
+  }
+
   char dec_fname[NAME_MAX + 64]; /* some extra just in case */
-  int r = decrypt(enc, len, dec_fname, sizeof(dec_fname));
+  int r = decrypt(penc, len, dec_fname, sizeof(dec_fname));
 
   if (r >= 0) {
     dec_fname[r] = '\0';

--- a/src/client/FSCrypt.cc
+++ b/src/client/FSCrypt.cc
@@ -545,7 +545,55 @@ FSCryptDenc::~FSCryptDenc()
   EVP_CIPHER_CTX_free(cipher_ctx);
 }
 
-FSCryptDencRef FSCrypt::init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv,
+int FSCryptFNameDenc::get_encrypted_fname(const std::string& plain, std::string *encrypted)
+{
+  auto plain_size = plain.size();
+  int dec_size = (plain.size() + 31) & ~31; // FIXME, need to be based on policy
+
+  char orig[dec_size];
+  memcpy(orig, plain.c_str(), plain_size);
+  memset(orig + plain_size, 0, dec_size - plain_size);
+
+  char enc_name[NAME_MAX + 64]; /* some extra just in case */
+  int r = encrypt(orig, dec_size,
+                  enc_name, sizeof(enc_name));
+
+  if (r < 0) {
+    generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to encrypt filename" << dendl;
+    return r;
+  }
+
+  int enc_len = r;
+
+  int b64_len = NAME_MAX * 2; // name.size() * 2;
+  char b64_name[b64_len]; // large enough
+  int len = fscrypt_fname_armor(enc_name, enc_len, b64_name, b64_len);
+
+  *encrypted = std::string(b64_name, len);
+
+  return len;
+}
+
+int FSCryptFNameDenc::get_decrypted_fname(const std::string& b64enc, std::string *decrypted)
+{
+  char enc[NAME_MAX];
+  int len = fscrypt_fname_unarmor(b64enc.c_str(), b64enc.size(),
+                                  enc, sizeof(enc));
+
+  char dec_fname[NAME_MAX + 64]; /* some extra just in case */
+  int r = decrypt(enc, len, dec_fname, sizeof(dec_fname));
+
+  if (r >= 0) {
+    dec_fname[r] = '\0';
+    *decrypted = dec_fname;
+  } else {
+    return r;
+  }
+
+  return r;
+}
+
+FSCryptDenc *FSCrypt::init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv,
                                   std::function<FSCryptDenc *()> gen_denc)
 {
   if (!ctx) {
@@ -575,20 +623,22 @@ FSCryptDencRef FSCrypt::init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef
     return nullptr;
   }
 
-  auto fscrypt_denc = std::shared_ptr<FSCryptDenc>(gen_denc());
+  auto fscrypt_denc = gen_denc();
 
   fscrypt_denc->setup(ctx, master_key);
 
   return fscrypt_denc;
 }
 
-FSCryptDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv, bool calc_key)
+FSCryptFNameDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv, bool calc_key)
 {
-  auto denc = init_denc(ctx, kv,
+  auto pdenc = init_denc(ctx, kv,
                          []() { return new FSCryptFNameDenc(); });
-  if (!denc) {
+  if (!pdenc) {
     return nullptr;
   }
+
+  auto denc = std::shared_ptr<FSCryptFNameDenc>((FSCryptFNameDenc *)pdenc);
 
   if (calc_key) {
     int r = denc->calc_fname_key();
@@ -603,7 +653,12 @@ FSCryptDencRef FSCrypt::get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidat
 
 FSCryptDencRef FSCrypt::get_fdata_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv)
 {
-  return init_denc(ctx, kv,
-                   []() { return new FSCryptFDataDenc(); });
+  auto pdenc = init_denc(ctx, kv,
+                         []() { return new FSCryptFDataDenc(); });
+  if (!pdenc) {
+    return nullptr;
+  }
+
+  return std::shared_ptr<FSCryptDenc>(pdenc);
 }
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -2,12 +2,47 @@
 
 #include "fscrypt_uapi.h"
 
+#include "common/ceph_mutex.h"
+
+#include <map>
+
 
 int fscrypt_calc_hkdf(const char *salt, int salt_len,
                       const char *key, int key_len,
                       char *dest, int dest_len);
 
+
+struct ceph_fscrypt_key_identifier {
+#define FSCRYPT_KEY_IDENTIFIER_LEN 16
+  char raw[FSCRYPT_KEY_IDENTIFIER_LEN];
+
+  int init(const char *k, int klen);
+
+  bool operator<(const struct ceph_fscrypt_key_identifier& r) const;
+};
+
+
 class FSCryptKey {
+  bufferlist key;
+  ceph_fscrypt_key_identifier identifier;
+
 public:
-  int init(const struct fscrypt_key_specifier& key_spec);
+  int init(const char *k, int klen);
+
+  const ceph_fscrypt_key_identifier& get_identifier() const {
+    return identifier;
+  }
+};
+
+using FSCryptKeyRef = std::shared_ptr<FSCryptKey>;
+
+
+class FSCryptKeyStore {
+  ceph::shared_mutex lock = ceph::make_shared_mutex("FSCryptKeyStore");
+  std::map<ceph_fscrypt_key_identifier, FSCryptKeyRef> m;
+public:
+  FSCryptKeyStore() {}
+
+  int create(const char *k, int klen, FSCryptKeyRef& key);
+  int find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyRef& key);
 };

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -46,6 +46,7 @@ public:
 
   int create(const char *k, int klen, FSCryptKeyRef& key);
   int find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyRef& key);
+  int remove(const struct ceph_fscrypt_key_identifier& id);
 };
 
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -3,6 +3,10 @@
 #include "fscrypt_uapi.h"
 
 
+int fscrypt_calc_hkdf(const char *salt, int salt_len,
+                      const char *key, int key_len,
+                      char *dest, int dest_len);
+
 class FSCryptKey {
 public:
   int init(const struct fscrypt_key_specifier& key_spec);

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -16,6 +16,27 @@
 #define HKDF_CONTEXT_KEY_IDENTIFIER 1
 #define HKDF_CONTEXT_PER_FILE_ENC_KEY 2
 
+#define FSCRYPT_BLOCK_SIZE 4096
+#define FSCRYPT_BLOCK_BITS 12
+
+#define FSCRYPT_DATA_ALIGNMENT 16
+
+static inline uint64_t fscrypt_align_ofs(uint64_t ofs) {
+  return (ofs + FSCRYPT_DATA_ALIGNMENT - 1) & ~(FSCRYPT_DATA_ALIGNMENT - 1);
+}
+
+static inline int fscrypt_ofs_in_block(uint64_t pos) {
+  return pos & (FSCRYPT_BLOCK_SIZE - 1);
+}
+
+static inline int fscrypt_block_from_ofs(uint64_t ofs) {
+  return ofs >> FSCRYPT_BLOCK_BITS;
+}
+
+static inline uint64_t fscrypt_block_start(uint64_t ofs) {
+  return ofs & ~(FSCRYPT_BLOCK_SIZE - 1);
+}
+
 static inline std::string fscrypt_hex_str(const void *p, int len)
 {
   if (!p) {

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -53,9 +53,6 @@ static inline std::string fscrypt_hex_str(const void *p, int len)
 
 int fscrypt_fname_unarmor(const char *src, int src_len,
                           char *result, int max_len);
-int fscrypt_decrypt_fname(const uint8_t *enc, int enc_len,
-                          uint8_t *key, uint8_t *iv,
-                          uint8_t *result);
 
 int fscrypt_calc_hkdf(char hkdf_context,
                       const char *nonce, int nonce_len,

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -6,10 +6,39 @@
 
 #include <map>
 
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/core_names.h>
 
 #define FSCRYPT_FILE_NONCE_SIZE 16
 
-int fscrypt_calc_hkdf(const char *salt, int salt_len,
+#define HKDF_CONTEXT_KEY_IDENTIFIER 1
+#define HKDF_CONTEXT_PER_FILE_ENC_KEY 2
+
+static inline std::string fscrypt_hex_str(const void *p, int len)
+{
+  if (!p) {
+    return "<null>";
+  }
+
+  bufferlist bl;
+  bl.append_hole(len);
+  memcpy(bl.c_str(), p, len);
+  std::stringstream ss;
+  bl.hexdump(ss);
+  return ss.str();
+}
+
+int fscrypt_fname_unarmor(const char *src, int src_len,
+                          char *result, int max_len);
+int fscrypt_decrypt_fname(const uint8_t *enc, int enc_len,
+                          uint8_t *key, uint8_t *iv,
+                          uint8_t *result);
+
+int fscrypt_calc_hkdf(char hkdf_context,
+                      const char *nonce, int nonce_len,
+                      const char *salt, int salt_len,
                       const char *key, int key_len,
                       char *dest, int dest_len);
 
@@ -21,9 +50,14 @@ struct ceph_fscrypt_key_identifier {
   int init(const char *k, int klen);
   int init(const struct fscrypt_key_specifier& k);
 
+  void decode(bufferlist::const_iterator& bl) {
+    bl.copy(sizeof(raw), raw);
+  }
+
   bool operator<(const struct ceph_fscrypt_key_identifier& r) const;
 };
 
+std::ostream& operator<<(std::ostream& out, const ceph_fscrypt_key_identifier& kid);
 
 class FSCryptKey {
   bufferlist key;
@@ -32,36 +66,58 @@ class FSCryptKey {
 public:
   int init(const char *k, int klen);
 
+  int calc_hkdf(char ctx_indentifier,
+                const char *nonce, int nonce_len,
+                char *result, int result_len);
+
   const ceph_fscrypt_key_identifier& get_identifier() const {
     return identifier;
   }
+
+  bufferlist& get_key() { return key; }
 };
 
 using FSCryptKeyRef = std::shared_ptr<FSCryptKey>;
+
+#define FSCRYPT_MAX_IV_SIZE 32
+union FSCryptIV {
+  uint8_t raw[FSCRYPT_MAX_IV_SIZE];
+  struct {
+    ceph_le64 block_num;
+    uint8_t nonce[FSCRYPT_FILE_NONCE_SIZE];
+  } u;
+};
 
 struct FSCryptPolicy {
   uint8_t version;
   uint8_t contents_encryption_mode;
   uint8_t filenames_encryption_mode;
   uint8_t flags;
-  uint8_t master_key_identifier[FSCRYPT_KEY_IDENTIFIER_SIZE];
+  ceph_fscrypt_key_identifier master_key_identifier;
 
   virtual ~FSCryptPolicy() {}
 
-  void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
-    decode(version, bl);
-    decode(contents_encryption_mode, bl);
-    decode(filenames_encryption_mode, bl);
-    decode(flags, bl);
+  void decode(bufferlist::const_iterator& env_bl) {
+    uint32_t v;
+
+    ceph::decode(v, env_bl);
+
+    bufferlist _bl;
+    ceph::decode(_bl, env_bl);
+
+    auto bl = _bl.cbegin();
+
+    ceph::decode(version, bl);
+    ceph::decode(contents_encryption_mode, bl);
+    ceph::decode(filenames_encryption_mode, bl);
+    ceph::decode(flags, bl);
 
     uint32_t __reserved;
-    decode(__reserved, bl);
+    ceph::decode(__reserved, bl);
 
-    bl.copy(sizeof(master_key_identifier), (char *)master_key_identifier);
+    master_key_identifier.decode(bl);
 
     decode_extra(bl);
-    DECODE_FINISH(bl);
   }
 
   virtual void decode_extra(bufferlist::const_iterator& bl) {}
@@ -72,7 +128,7 @@ struct FSCryptPolicy {
     dest->filenames_encryption_mode = filenames_encryption_mode;
     dest->flags = flags;
     memset(dest->__reserved, 0, sizeof(dest->__reserved));
-    memcpy(dest->master_key_identifier, master_key_identifier, sizeof(master_key_identifier));
+    memcpy(dest->master_key_identifier, master_key_identifier.raw, sizeof(master_key_identifier.raw));
   }
 };
 
@@ -84,10 +140,38 @@ struct FSCryptContext : public FSCryptPolicy {
   void decode_extra(bufferlist::const_iterator& bl) override {
     bl.copy(sizeof(nonce), (char *)nonce);
   }
+
+  void generate_iv(uint64_t block_num, FSCryptIV& iv) const;
 };
 
 using FSCryptContextRef = std::shared_ptr<FSCryptContext>;
 
+class FSCryptDenc {
+#define FSCRYPT_KEY_SIZE 32 // FIXME
+  char key[FSCRYPT_KEY_SIZE];
+  FSCryptIV iv;
+
+  EVP_CIPHER *cipher;
+  EVP_CIPHER_CTX *cipher_ctx;
+  std::vector<OSSL_PARAM> cipher_params;
+
+  int init(char ctx_identifier,
+           FSCryptContextRef& ctx,
+           FSCryptKeyRef& master_key);
+public:
+  FSCryptDenc();
+  ~FSCryptDenc();
+
+  int init_fname(FSCryptContextRef& ctx,
+                 FSCryptKeyRef& master_key) {
+    return init(HKDF_CONTEXT_PER_FILE_ENC_KEY, ctx, master_key);
+  }
+
+  int decrypt(const char *in_data, int in_len,
+              char *out_data, int out_len);
+};
+
+using FSCryptDencRef = std::shared_ptr<FSCryptDenc>;
 
 class FSCryptKeyStore {
   ceph::shared_mutex lock = ceph::make_shared_mutex("FSCryptKeyStore");
@@ -110,4 +194,6 @@ public:
   FSCryptKeyStore& get_key_store() {
     return key_store;
   }
+
+  FSCryptDencRef get_fname_denc(FSCryptContextRef& ctx);
 };

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -51,6 +51,8 @@ static inline std::string fscrypt_hex_str(const void *p, int len)
   return ss.str();
 }
 
+int fscrypt_fname_armor(const char *src, int src_len,
+                        char *result, int max_len);
 int fscrypt_fname_unarmor(const char *src, int src_len,
                           char *result, int max_len);
 
@@ -194,6 +196,8 @@ public:
   }
 
   int decrypt(const char *in_data, int in_len,
+              char *out_data, int out_len);
+  int encrypt(const char *in_data, int in_len,
               char *out_data, int out_len);
 };
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -46,3 +46,15 @@ public:
   int create(const char *k, int klen, FSCryptKeyRef& key);
   int find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyRef& key);
 };
+
+
+class FSCrypt {
+  FSCryptKeyStore key_store;
+
+public:
+  FSCrypt() {}
+
+  FSCryptKeyStore& get_key_store() {
+    return key_store;
+  }
+};

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -17,6 +17,7 @@ struct ceph_fscrypt_key_identifier {
   char raw[FSCRYPT_KEY_IDENTIFIER_LEN];
 
   int init(const char *k, int klen);
+  int init(const struct fscrypt_key_specifier& k);
 
   bool operator<(const struct ceph_fscrypt_key_identifier& r) const;
 };

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "fscrypt_uapi.h"
+
+
+class FSCryptKey {
+public:
+  int init(const struct fscrypt_key_specifier& key_spec);
+};

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -312,13 +312,15 @@ public:
 using FSCryptKeyHandlerRef = std::shared_ptr<FSCryptKeyHandler>;
 
 class FSCryptKeyStore {
+  CephContext *cct;
+
   ceph::shared_mutex lock = ceph::make_shared_mutex("FSCryptKeyStore");
   int64_t epoch = 0;
   std::map<ceph_fscrypt_key_identifier, FSCryptKeyHandlerRef> m;
 
   int _find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyHandlerRef& key);
 public:
-  FSCryptKeyStore() {}
+  FSCryptKeyStore(CephContext *_cct) : cct(_cct) {}
 
   int create(const char *k, int klen, FSCryptKeyHandlerRef& key);
   int find(const struct ceph_fscrypt_key_identifier& id, FSCryptKeyHandlerRef& key);
@@ -346,7 +348,7 @@ class FSCrypt {
   FSCryptDenc *init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv,
                          std::function<FSCryptDenc *()> gen_denc);
 public:
-  FSCrypt(CephContext *_cct) : cct(_cct) {}
+  FSCrypt(CephContext *_cct) : cct(_cct), key_store(cct) {}
 
   FSCryptContextRef init_ctx(const std::vector<unsigned char>& fscrypt_auth);
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -37,6 +37,10 @@ static inline uint64_t fscrypt_block_start(uint64_t ofs) {
   return ofs & ~(FSCRYPT_BLOCK_SIZE - 1);
 }
 
+static inline uint64_t fscrypt_next_block_start(uint64_t ofs) {
+  return (ofs + FSCRYPT_BLOCK_SIZE - 1) & ~(FSCRYPT_BLOCK_SIZE - 1);
+}
+
 static inline std::string fscrypt_hex_str(const void *p, int len)
 {
   if (!p) {

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -250,6 +250,8 @@ public:
 
   int get_encrypted_fname(const std::string& plain, std::string *encrypted);
   int get_decrypted_fname(const std::string& b64enc, std::string *decrypted);
+
+  int get_decrypted_symlink(const std::string& b64enc, std::string *decrypted);
 };
 
 using FSCryptFNameDencRef = std::shared_ptr<FSCryptFNameDenc>;

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -250,7 +250,9 @@ class FSCryptFDataDenc : public FSCryptDenc {
 public:
   FSCryptFDataDenc();
 
-  int decrypt_bl(uint64_t off, uint64_t len, uint64_t pos, bufferlist *bl);
+  using Segment = std::pair<uint64_t, uint64_t>;
+
+  int decrypt_bl(uint64_t off, uint64_t len, uint64_t pos, const std::vector<Segment>& holes, bufferlist *bl);
   int encrypt_bl(uint64_t off, uint64_t len, bufferlist& bl, bufferlist *encbl);
 };
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -249,7 +249,7 @@ public:
   FSCryptFNameDenc();
 
   int get_encrypted_fname(const std::string& plain, std::string *encrypted);
-  int get_decrypted_fname(const std::string& b64enc, std::string *decrypted);
+  int get_decrypted_fname(const std::string& b64enc, const std::string& alt_name, std::string *decrypted);
 
   int get_encrypted_symlink(const std::string& plain, std::string *encrypted);
   int get_decrypted_symlink(const std::string& b64enc, std::string *decrypted);

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -206,7 +206,12 @@ using FSCryptDencRef = std::shared_ptr<FSCryptDenc>;
 class FSCryptFNameDenc : public FSCryptDenc {
 public:
   FSCryptFNameDenc();
+
+  int get_encrypted_fname(const std::string& plain, std::string *encrypted);
+  int get_decrypted_fname(const std::string& b64enc, std::string *decrypted);
 };
+
+using FSCryptFNameDencRef = std::shared_ptr<FSCryptFNameDenc>;
 
 class FSCryptFDataDenc : public FSCryptDenc {
 public:
@@ -259,8 +264,8 @@ using FSCryptKeyValidatorRef = std::shared_ptr<FSCryptKeyValidator>;
 class FSCrypt {
   FSCryptKeyStore key_store;
 
-  FSCryptDencRef init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv,
-                           std::function<FSCryptDenc *()> gen_denc);
+  FSCryptDenc *init_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv,
+                         std::function<FSCryptDenc *()> gen_denc);
 public:
   FSCrypt() {}
 
@@ -268,6 +273,6 @@ public:
     return key_store;
   }
 
-  FSCryptDencRef get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv, bool calc_key);
+  FSCryptFNameDencRef get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv, bool calc_key);
   FSCryptDencRef get_fdata_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv);
 };

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -74,6 +74,10 @@ struct ceph_fscrypt_key_identifier {
     bl.copy(sizeof(raw), raw);
   }
 
+  void encode(bufferlist& bl) const {
+    bl.append(raw, sizeof(raw));
+  }
+
   bool operator<(const struct ceph_fscrypt_key_identifier& r) const;
 };
 
@@ -142,6 +146,30 @@ struct FSCryptPolicy {
 
   virtual void decode_extra(bufferlist::const_iterator& bl) {}
 
+  void encode(bufferlist& env_bl) const {
+    uint32_t v = 1;
+    ceph::encode(v, env_bl);
+
+    bufferlist bl;
+
+    ceph::encode(version, bl);
+    ceph::encode(contents_encryption_mode, bl);
+    ceph::encode(filenames_encryption_mode, bl);
+    ceph::encode(flags, bl);
+
+    uint32_t __reserved = 0;
+    ceph::encode(__reserved, bl);
+
+    master_key_identifier.encode(bl);
+
+    encode_extra(bl);
+
+    ceph::encode(bl, env_bl);
+
+  }
+
+  virtual void encode_extra(bufferlist& bl) const {}
+
   void convert_to(struct fscrypt_policy_v2 *dest) {
     dest->version = version;
     dest->contents_encryption_mode = contents_encryption_mode;
@@ -161,6 +189,11 @@ struct FSCryptContext : public FSCryptPolicy {
     bl.copy(sizeof(nonce), (char *)nonce);
   }
 
+  void encode_extra(bufferlist& bl) const override {
+    bl.append((char *)nonce, sizeof(nonce));
+  }
+
+  void generate_new_nonce();
   void generate_iv(uint64_t block_num, FSCryptIV& iv) const;
 };
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -216,7 +216,11 @@ using FSCryptFNameDencRef = std::shared_ptr<FSCryptFNameDenc>;
 class FSCryptFDataDenc : public FSCryptDenc {
 public:
   FSCryptFDataDenc();
+
+  int decrypt_bl(uint64_t off, uint64_t len, uint64_t pos, bufferlist *bl);
 };
+
+using FSCryptFDataDencRef = std::shared_ptr<FSCryptFDataDenc>;
 
 class FSCryptKeyHandler {
   ceph::shared_mutex lock = ceph::make_shared_mutex("FSCryptKeyHandler");
@@ -274,5 +278,14 @@ public:
   }
 
   FSCryptFNameDencRef get_fname_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv, bool calc_key);
-  FSCryptDencRef get_fdata_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv);
+  FSCryptFDataDencRef get_fdata_denc(FSCryptContextRef& ctx, FSCryptKeyValidatorRef *kv);
+
+  void prepare_data_read(FSCryptContextRef& ctx,
+                         FSCryptKeyValidatorRef *kv,
+                         uint64_t off,
+                         uint64_t len,
+                         uint64_t file_raw_size,
+                         uint64_t *read_start,
+                         uint64_t *read_len,
+                         FSCryptFDataDencRef *denc);
 };

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -251,6 +251,7 @@ public:
   int get_encrypted_fname(const std::string& plain, std::string *encrypted);
   int get_decrypted_fname(const std::string& b64enc, std::string *decrypted);
 
+  int get_encrypted_symlink(const std::string& plain, std::string *encrypted);
   int get_decrypted_symlink(const std::string& b64enc, std::string *decrypted);
 };
 
@@ -318,6 +319,8 @@ class FSCrypt {
                          std::function<FSCryptDenc *()> gen_denc);
 public:
   FSCrypt() {}
+
+  static FSCryptContextRef init_ctx(const std::vector<unsigned char>& fscrypt_auth);
 
   FSCryptKeyStore& get_key_store() {
     return key_store;

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -121,6 +121,14 @@ struct FSCryptPolicy {
 
   virtual ~FSCryptPolicy() {}
 
+  void init(const struct fscrypt_policy_v2& policy) {
+    version = policy.version;
+    contents_encryption_mode = policy.contents_encryption_mode;
+    filenames_encryption_mode = policy.filenames_encryption_mode;
+    flags = policy.flags;
+    memcpy(master_key_identifier.raw, policy.master_key_identifier, sizeof(master_key_identifier.raw));
+  }
+
   void decode(bufferlist::const_iterator& env_bl) {
     uint32_t v;
 

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -218,6 +218,7 @@ public:
   FSCryptFDataDenc();
 
   int decrypt_bl(uint64_t off, uint64_t len, uint64_t pos, bufferlist *bl);
+  int encrypt_bl(uint64_t off, uint64_t len, bufferlist& bl, bufferlist *encbl);
 };
 
 using FSCryptFDataDencRef = std::shared_ptr<FSCryptFDataDenc>;

--- a/src/client/FSCrypt.h
+++ b/src/client/FSCrypt.h
@@ -248,7 +248,7 @@ class FSCryptFNameDenc : public FSCryptDenc {
 public:
   FSCryptFNameDenc();
 
-  int get_encrypted_fname(const std::string& plain, std::string *encrypted);
+  int get_encrypted_fname(const std::string& plain, std::string *encrypted, std::string *alt_name);
   int get_decrypted_fname(const std::string& b64enc, const std::string& alt_name, std::string *decrypted);
 
   int get_encrypted_symlink(const std::string& plain, std::string *encrypted);

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -813,7 +813,6 @@ void Inode::mark_caps_clean()
 
 FSCryptContextRef Inode::init_fscrypt_ctx()
 {
-lsubdout(client->cct, client, 0) << __func__ << " auth.size()=" << fscrypt_auth.size() << dendl;
   if (fscrypt_auth.size() == 0) {
     return nullptr;
   }

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -841,3 +841,12 @@ uint64_t Inode::effective_size() const
 
   return *(ceph_le64 *)fscrypt_file.data();
 }
+
+void Inode::set_effective_size(uint64_t size)
+{
+  if (fscrypt_file.size() < sizeof(uint64_t)) {
+    fscrypt_file.resize(sizeof(uint64_t));
+  }
+
+  *(ceph_le64 *)fscrypt_file.data() = size;
+}

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -136,7 +136,11 @@ void Inode::make_nosnap_relative_path(filepath& p)
     Dentry *dn = get_first_parent();
     ceph_assert(dn->dir && dn->dir->parent_inode);
     dn->dir->parent_inode->make_nosnap_relative_path(p);
-    p.push_dentry(dn->name);
+    if (dn->enc_name) {
+      p.push_dentry(*dn->enc_name);
+    } else {
+      p.push_dentry(dn->name);
+    }
   } else {
     p = filepath(ino);
   }

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -811,9 +811,9 @@ void Inode::mark_caps_clean()
   dirty_cap_item.remove_myself();
 }
 
-
 FSCryptContextRef Inode::init_fscrypt_ctx()
 {
+lsubdout(client->cct, client, 0) << __func__ << " auth.size()=" << fscrypt_auth.size() << dendl;
   if (fscrypt_auth.size() == 0) {
     return nullptr;
   }
@@ -827,6 +827,7 @@ FSCryptContextRef Inode::init_fscrypt_ctx()
   try {
     ctx->decode(bliter);
   } catch (buffer::error& err) {
+lsubdout(client->cct, client, 0) << __func__ << " " << *this << " failed to decode" << dendl;
     return nullptr;
   }
 

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -832,3 +832,12 @@ lsubdout(client->cct, client, 0) << __func__ << " " << *this << " failed to deco
 
   return ctx;
 }
+
+uint64_t Inode::effective_size() const
+{
+  if (fscrypt_file.size() < sizeof(uint64_t)) {
+    return size;
+  }
+
+  return *(ceph_le64 *)fscrypt_file.data();
+}

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -813,24 +813,7 @@ void Inode::mark_caps_clean()
 
 FSCryptContextRef Inode::init_fscrypt_ctx()
 {
-  if (fscrypt_auth.size() == 0) {
-    return nullptr;
-  }
-
-  FSCryptContextRef ctx = std::make_shared<FSCryptContext>();
-
-  bufferlist bl;
-  bl.append((const char *)fscrypt_auth.data(), fscrypt_auth.size());
-        
-  auto bliter = bl.cbegin();
-  try {
-    ctx->decode(bliter);
-  } catch (buffer::error& err) {
-lsubdout(client->cct, client, 0) << __func__ << " " << *this << " failed to decode" << dendl;
-    return nullptr;
-  }
-
-  return ctx;
+  return FSCrypt::init_ctx(fscrypt_auth);
 }
 
 void Inode::gen_inherited_fscrypt_auth(std::vector<uint8_t> *fsa)

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -815,9 +815,9 @@ void Inode::mark_caps_clean()
   dirty_cap_item.remove_myself();
 }
 
-FSCryptContextRef Inode::init_fscrypt_ctx()
+FSCryptContextRef Inode::init_fscrypt_ctx(FSCrypt *fscrypt)
 {
-  return FSCrypt::init_ctx(fscrypt_auth);
+  return fscrypt->init_ctx(fscrypt_auth);
 }
 
 void Inode::gen_inherited_fscrypt_auth(std::vector<uint8_t> *fsa)

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -812,3 +812,23 @@ void Inode::mark_caps_clean()
 }
 
 
+FSCryptContextRef Inode::init_fscrypt_ctx()
+{
+  if (fscrypt_auth.size() == 0) {
+    return nullptr;
+  }
+
+  FSCryptContextRef ctx = std::make_shared<FSCryptContext>();
+
+  bufferlist bl;
+  bl.append((const char *)fscrypt_auth.data(), fscrypt_auth.size());
+        
+  auto bliter = bl.cbegin();
+  try {
+    ctx->decode(bliter);
+  } catch (buffer::error& err) {
+    return nullptr;
+  }
+
+  return ctx;
+}

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -833,6 +833,24 @@ lsubdout(client->cct, client, 0) << __func__ << " " << *this << " failed to deco
   return ctx;
 }
 
+void Inode::gen_inherited_fscrypt_auth(std::vector<uint8_t> *fsa)
+{
+  if (!fscrypt_ctx) {
+#warning need to make sure that we do not skip entire subtree somehow
+    return;
+  }
+
+  FSCryptContext new_ctx = *fscrypt_ctx;
+
+  new_ctx.generate_new_nonce();
+
+  bufferlist bl;
+  new_ctx.encode(bl);
+
+  fsa->resize(bl.length());
+  memcpy(fsa->data(), bl.c_str(), bl.length());
+}
+
 uint64_t Inode::effective_size() const
 {
   if (fscrypt_file.size() < sizeof(uint64_t)) {

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -254,6 +254,7 @@ struct Inode : RefCountedObject {
   uint64_t  ll_ref = 0;   // separate ref count for ll client
   xlist<Dentry *> dentries; // if i'm linked to a dentry.
   std::string    symlink;  // symlink content, if it's a symlink
+  std::string    symlink_plain;  // decoded symlink (in-memory only)
   std::map<std::string,bufferptr> xattrs;
   std::map<frag_t,int> fragmap;  // known frag -> mds mappings
   std::map<frag_t, std::vector<mds_rank_t>> frag_repmap; // non-auth mds mappings

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -185,6 +185,8 @@ struct Inode : RefCountedObject {
 
   FSCryptContextRef init_fscrypt_ctx();
 
+  void gen_inherited_fscrypt_auth(std::vector<uint8_t> *ctx);
+
   bool is_root()    const { return ino == CEPH_INO_ROOT; }
   bool is_symlink() const { return (mode & S_IFMT) == S_IFLNK; }
   bool is_dir()     const { return (mode & S_IFMT) == S_IFDIR; }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -36,6 +36,7 @@ struct Inode;
 class MetaRequest;
 class filepath;
 class Fh;
+class FSCrypt;
 
 class Cap {
 public:
@@ -183,7 +184,7 @@ struct Inode : RefCountedObject {
     return !!fscrypt_auth.size();
   }
 
-  FSCryptContextRef init_fscrypt_ctx();
+  FSCryptContextRef init_fscrypt_ctx(FSCrypt *fscrypt);
 
   void gen_inherited_fscrypt_auth(std::vector<uint8_t> *ctx);
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -176,6 +176,8 @@ struct Inode : RefCountedObject {
   FSCryptContextRef fscrypt_ctx;
   FSCryptKeyValidatorRef fscrypt_key_validator;
 
+  uint64_t effective_size() const;
+
   bool is_fscrypt_enabled() {
     return !!fscrypt_auth.size();
   }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -177,6 +177,7 @@ struct Inode : RefCountedObject {
   FSCryptKeyValidatorRef fscrypt_key_validator;
 
   uint64_t effective_size() const;
+  void set_effective_size(uint64_t size);
 
   bool is_fscrypt_enabled() {
     return !!fscrypt_auth.size();

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -22,6 +22,12 @@
 #include "UserPerm.h"
 #include "Delegation.h"
 
+#include "FSCrypt.h"
+
+#ifndef S_ENCRYPTED
+#define S_ENCRYPTED (1 << 14)
+#endif
+
 class Client;
 class Dentry;
 class Dir;
@@ -167,14 +173,19 @@ struct Inode : RefCountedObject {
 
   std::vector<uint8_t> fscrypt_auth;
   std::vector<uint8_t> fscrypt_file;
+  FSCryptContextRef fscrypt_ctx;
+
   bool is_fscrypt_enabled() {
     return !!fscrypt_auth.size();
   }
+
+  FSCryptContextRef init_fscrypt_ctx();
 
   bool is_root()    const { return ino == CEPH_INO_ROOT; }
   bool is_symlink() const { return (mode & S_IFMT) == S_IFLNK; }
   bool is_dir()     const { return (mode & S_IFMT) == S_IFDIR; }
   bool is_file()    const { return (mode & S_IFMT) == S_IFREG; }
+  bool is_encrypted() const { return (mode & S_ENCRYPTED) == S_ENCRYPTED; }
 
   bool has_dir_layout() const {
     return layout != file_layout_t();

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -174,6 +174,7 @@ struct Inode : RefCountedObject {
   std::vector<uint8_t> fscrypt_auth;
   std::vector<uint8_t> fscrypt_file;
   FSCryptContextRef fscrypt_ctx;
+  FSCryptKeyValidatorRef fscrypt_key_validator;
 
   bool is_fscrypt_enabled() {
     return !!fscrypt_auth.size();

--- a/src/client/fscrypt_uapi.h
+++ b/src/client/fscrypt_uapi.h
@@ -1,0 +1,215 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/*
+ * fscrypt user API
+ *
+ * These ioctls can be used on filesystems that support fscrypt.  See the
+ * "User API" section of Documentation/filesystems/fscrypt.rst.
+ */
+#ifndef _UAPI_LINUX_FSCRYPT_H
+#define _UAPI_LINUX_FSCRYPT_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+/* Encryption policy flags */
+#define FSCRYPT_POLICY_FLAGS_PAD_4		0x00
+#define FSCRYPT_POLICY_FLAGS_PAD_8		0x01
+#define FSCRYPT_POLICY_FLAGS_PAD_16		0x02
+#define FSCRYPT_POLICY_FLAGS_PAD_32		0x03
+#define FSCRYPT_POLICY_FLAGS_PAD_MASK		0x03
+#define FSCRYPT_POLICY_FLAG_DIRECT_KEY		0x04
+#define FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64	0x08
+#define FSCRYPT_POLICY_FLAG_IV_INO_LBLK_32	0x10
+
+/* Encryption algorithms */
+#define FSCRYPT_MODE_AES_256_XTS		1
+#define FSCRYPT_MODE_AES_256_CTS		4
+#define FSCRYPT_MODE_AES_128_CBC		5
+#define FSCRYPT_MODE_AES_128_CTS		6
+#define FSCRYPT_MODE_SM4_XTS			7
+#define FSCRYPT_MODE_SM4_CTS			8
+#define FSCRYPT_MODE_ADIANTUM			9
+#define FSCRYPT_MODE_AES_256_HCTR2		10
+/* If adding a mode number > 10, update FSCRYPT_MODE_MAX in fscrypt_private.h */
+
+/*
+ * Legacy policy version; ad-hoc KDF and no key verification.
+ * For new encrypted directories, use fscrypt_policy_v2 instead.
+ *
+ * Careful: the .version field for this is actually 0, not 1.
+ */
+#define FSCRYPT_POLICY_V1		0
+#define FSCRYPT_KEY_DESCRIPTOR_SIZE	8
+struct fscrypt_policy_v1 {
+	__u8 version;
+	__u8 contents_encryption_mode;
+	__u8 filenames_encryption_mode;
+	__u8 flags;
+	__u8 master_key_descriptor[FSCRYPT_KEY_DESCRIPTOR_SIZE];
+};
+
+/*
+ * Process-subscribed "logon" key description prefix and payload format.
+ * Deprecated; prefer FS_IOC_ADD_ENCRYPTION_KEY instead.
+ */
+#define FSCRYPT_KEY_DESC_PREFIX		"fscrypt:"
+#define FSCRYPT_KEY_DESC_PREFIX_SIZE	8
+#define FSCRYPT_MAX_KEY_SIZE		64
+struct fscrypt_key {
+	__u32 mode;
+	__u8 raw[FSCRYPT_MAX_KEY_SIZE];
+	__u32 size;
+};
+
+/*
+ * New policy version with HKDF and key verification (recommended).
+ */
+#define FSCRYPT_POLICY_V2		2
+#define FSCRYPT_KEY_IDENTIFIER_SIZE	16
+struct fscrypt_policy_v2 {
+	__u8 version;
+	__u8 contents_encryption_mode;
+	__u8 filenames_encryption_mode;
+	__u8 flags;
+	__u8 __reserved[4];
+	__u8 master_key_identifier[FSCRYPT_KEY_IDENTIFIER_SIZE];
+};
+
+struct fscrypt_policy_arg {
+  union {
+    struct fscrypt_policy_v1 v1;
+    struct fscrypt_policy_v2 v2;
+  } policy;
+}; /* output */
+
+/* Struct passed to FS_IOC_GET_ENCRYPTION_POLICY_EX */
+struct fscrypt_get_policy_ex_arg {
+	__u64 policy_size; /* input/output */
+	union {
+		__u8 version;
+		struct fscrypt_policy_v1 v1;
+		struct fscrypt_policy_v2 v2;
+	} policy; /* output */
+};
+
+/*
+ * v1 policy keys are specified by an arbitrary 8-byte key "descriptor",
+ * matching fscrypt_policy_v1::master_key_descriptor.
+ */
+#define FSCRYPT_KEY_SPEC_TYPE_DESCRIPTOR	1
+
+/*
+ * v2 policy keys are specified by a 16-byte key "identifier" which the kernel
+ * calculates as a cryptographic hash of the key itself,
+ * matching fscrypt_policy_v2::master_key_identifier.
+ */
+#define FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER	2
+
+/*
+ * Specifies a key, either for v1 or v2 policies.  This doesn't contain the
+ * actual key itself; this is just the "name" of the key.
+ */
+struct fscrypt_key_specifier {
+	__u32 type;	/* one of FSCRYPT_KEY_SPEC_TYPE_* */
+	__u32 __reserved;
+	union {
+		__u8 __reserved[32]; /* reserve some extra space */
+		__u8 descriptor[FSCRYPT_KEY_DESCRIPTOR_SIZE];
+		__u8 identifier[FSCRYPT_KEY_IDENTIFIER_SIZE];
+	} u;
+};
+
+/*
+ * Payload of Linux keyring key of type "fscrypt-provisioning", referenced by
+ * fscrypt_add_key_arg::key_id as an alternative to fscrypt_add_key_arg::raw.
+ */
+struct fscrypt_provisioning_key_payload {
+	__u32 type;
+	__u32 __reserved;
+	__u8 raw[];
+};
+
+/* Struct passed to FS_IOC_ADD_ENCRYPTION_KEY */
+struct fscrypt_add_key_arg {
+	struct fscrypt_key_specifier key_spec;
+	__u32 raw_size;
+	__u32 key_id;
+	__u32 __reserved[8];
+	__u8 raw[];
+};
+
+/* Struct passed to FS_IOC_ADD_ENCRYPTION_KEY */
+struct fscrypt_add_key64_arg {
+	struct fscrypt_key_specifier key_spec;
+	__u32 raw_size;
+	__u32 key_id;
+	__u32 __reserved[8];
+	__u8 raw[64];
+};
+
+/* Struct passed to FS_IOC_REMOVE_ENCRYPTION_KEY */
+struct fscrypt_remove_key_arg {
+	struct fscrypt_key_specifier key_spec;
+#define FSCRYPT_KEY_REMOVAL_STATUS_FLAG_FILES_BUSY	0x00000001
+#define FSCRYPT_KEY_REMOVAL_STATUS_FLAG_OTHER_USERS	0x00000002
+	__u32 removal_status_flags;	/* output */
+	__u32 __reserved[5];
+};
+
+/* Struct passed to FS_IOC_GET_ENCRYPTION_KEY_STATUS */
+struct fscrypt_get_key_status_arg {
+	/* input */
+	struct fscrypt_key_specifier key_spec;
+	__u32 __reserved[6];
+
+	/* output */
+#define FSCRYPT_KEY_STATUS_ABSENT		1
+#define FSCRYPT_KEY_STATUS_PRESENT		2
+#define FSCRYPT_KEY_STATUS_INCOMPLETELY_REMOVED	3
+	__u32 status;
+#define FSCRYPT_KEY_STATUS_FLAG_ADDED_BY_SELF   0x00000001
+	__u32 status_flags;
+	__u32 user_count;
+	__u32 __out_reserved[13];
+};
+
+#define FS_IOC_SET_ENCRYPTION_POLICY		_IOR('f', 19, struct fscrypt_policy_v1)
+#define FS_IOC_SET_ENCRYPTION_POLICY_RESTRICTED	_IOWR('f', 19, struct fscrypt_policy_arg)
+#define FS_IOC_GET_ENCRYPTION_PWSALT		_IOW('f', 20, __u8[16])
+#define FS_IOC_GET_ENCRYPTION_POLICY		_IOW('f', 21, struct fscrypt_policy_v1)
+#define FS_IOC_GET_ENCRYPTION_POLICY_EX		_IOWR('f', 22, __u8[9]) /* size + version */
+#define FS_IOC_GET_ENCRYPTION_POLICY_EX_RESTRICTED	_IOWR('f', 22, struct fscrypt_get_policy_ex_arg) /* size + version */
+#define FS_IOC_ADD_ENCRYPTION_KEY		_IOWR('f', 23, struct fscrypt_add_key_arg)
+#define FS_IOC_ADD_ENCRYPTION_KEY64		_IOWR('f', 23, struct fscrypt_add_key64_arg)
+#define FS_IOC_REMOVE_ENCRYPTION_KEY		_IOWR('f', 24, struct fscrypt_remove_key_arg)
+#define FS_IOC_REMOVE_ENCRYPTION_KEY_ALL_USERS	_IOWR('f', 25, struct fscrypt_remove_key_arg)
+#define FS_IOC_GET_ENCRYPTION_KEY_STATUS	_IOWR('f', 26, struct fscrypt_get_key_status_arg)
+#define FS_IOC_GET_ENCRYPTION_NONCE		_IOR('f', 27, __u8[16])
+
+/**********************************************************************/
+
+/* old names; don't add anything new here! */
+#ifndef __KERNEL__
+#define fscrypt_policy			fscrypt_policy_v1
+#define FS_KEY_DESCRIPTOR_SIZE		FSCRYPT_KEY_DESCRIPTOR_SIZE
+#define FS_POLICY_FLAGS_PAD_4		FSCRYPT_POLICY_FLAGS_PAD_4
+#define FS_POLICY_FLAGS_PAD_8		FSCRYPT_POLICY_FLAGS_PAD_8
+#define FS_POLICY_FLAGS_PAD_16		FSCRYPT_POLICY_FLAGS_PAD_16
+#define FS_POLICY_FLAGS_PAD_32		FSCRYPT_POLICY_FLAGS_PAD_32
+#define FS_POLICY_FLAGS_PAD_MASK	FSCRYPT_POLICY_FLAGS_PAD_MASK
+#define FS_POLICY_FLAG_DIRECT_KEY	FSCRYPT_POLICY_FLAG_DIRECT_KEY
+#define FS_POLICY_FLAGS_VALID		0x07	/* contains old flags only */
+#define FS_ENCRYPTION_MODE_INVALID	0	/* never used */
+#define FS_ENCRYPTION_MODE_AES_256_XTS	FSCRYPT_MODE_AES_256_XTS
+#define FS_ENCRYPTION_MODE_AES_256_GCM	2	/* never used */
+#define FS_ENCRYPTION_MODE_AES_256_CBC	3	/* never used */
+#define FS_ENCRYPTION_MODE_AES_256_CTS	FSCRYPT_MODE_AES_256_CTS
+#define FS_ENCRYPTION_MODE_AES_128_CBC	FSCRYPT_MODE_AES_128_CBC
+#define FS_ENCRYPTION_MODE_AES_128_CTS	FSCRYPT_MODE_AES_128_CTS
+#define FS_ENCRYPTION_MODE_ADIANTUM	FSCRYPT_MODE_ADIANTUM
+#define FS_KEY_DESC_PREFIX		FSCRYPT_KEY_DESC_PREFIX
+#define FS_KEY_DESC_PREFIX_SIZE		FSCRYPT_KEY_DESC_PREFIX_SIZE
+#define FS_MAX_KEY_SIZE			FSCRYPT_MAX_KEY_SIZE
+#endif /* !__KERNEL__ */
+
+#endif /* _UAPI_LINUX_FSCRYPT_H */

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1045,6 +1045,40 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
       break;
     }
     break;
+    case FS_IOC_REMOVE_ENCRYPTION_KEY: {
+      if (!in_buf
+          || in_bufsz < sizeof(fscrypt_remove_key_arg)) {
+        fuse_reply_err(req, EFAULT);
+        break;
+      }
+
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_GET_ENCRYPTION_KEY_STATUS ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+
+      auto arg = (fscrypt_remove_key_arg *)in_buf;
+      if (arg->key_spec.type != FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
+        fuse_reply_err(req, ENOTSUP);
+        break;
+      }
+
+      ceph_fscrypt_key_identifier kid;
+      int r = kid.init(arg->key_spec);
+      if (r < 0) {
+        fuse_reply_err(req, -r);
+        break;
+      }
+
+      /* FIXME: handle busy cases */
+      FSCryptKeyRef key;
+      r = cfuse->client->fscrypt->get_key_store().remove(kid);
+      if (r < 0) {
+        fuse_reply_err(req, -r);
+        break;
+      }
+
+      arg->removal_status_flags = 0; /* FIXME */
+      fuse_reply_ioctl(req, 0, arg, sizeof(*arg));
+      break;
+    }
     case FS_IOC_SET_ENCRYPTION_POLICY: {
       if (!in_buf) {
         generic_dout(0) << __FILE__ << ":" << __LINE__ << ": ioctl buffer <none>" << dendl;
@@ -1052,6 +1086,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         break;
       }
       generic_dout(0) << __FILE__ << ":" << __LINE__ << ": ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+
       // fuse_reply_ioctl(req, 0, nullptr, 0);
       fuse_reply_err(req, EINVAL);
       break;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -39,6 +39,7 @@
 #include "Fh.h"
 #include "ioctl.h"
 #include "fscrypt_uapi.h"
+#include "FSCrypt.h"
 #include "common/config.h"
 #include "include/ceph_assert.h"
 #include "include/cephfs/ceph_ll_client.h"
@@ -982,6 +983,18 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         fuse_reply_err(req, ERANGE);
         break;
       }
+
+      FSCryptKey k;
+
+      int r  = k.init((const char *)arg->raw, arg->raw_size);
+      if (r < 0) {
+        generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to calc hkdf: r=" << r << dendl;
+        fuse_reply_err(req, -r);
+      }
+
+      const auto& identifier = k.get_identifier();
+
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": hkdf:\n" << hex_str(identifier.raw, sizeof(identifier.raw)) << dendl;
 
       fuse_reply_ioctl(req, 0, nullptr, 0);
       break;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1004,8 +1004,9 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
 
       int r = key_store.create((const char *)arg->raw, arg->raw_size, kh);
       if (r < 0) {
-        generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to calc hkdf: r=" << r << dendl;
+        generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to create a new key: r=" << r << dendl;
         fuse_reply_err(req, -r);
+        break;
       }
 
       Fh *fh = (Fh*)fi->fh;
@@ -1104,7 +1105,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
 
       /* TODO: return correct info */
       arg->status = (found ? FSCRYPT_KEY_STATUS_PRESENT : FSCRYPT_KEY_STATUS_ABSENT);
-      arg->status_flags = 0;
+      arg->status_flags = (found ? 0x1 : 0); /* FIXME */
       arg->user_count = !!found; /* FIXME */
 
       fuse_reply_ioctl(req, 0, arg, sizeof(*arg));

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -41,6 +41,7 @@
 #include "fscrypt_uapi.h"
 #include "FSCrypt.h"
 #include "Inode.h"
+#include "Dir.h"
 #include "common/config.h"
 #include "include/ceph_assert.h"
 #include "include/cephfs/ceph_ll_client.h"
@@ -999,13 +1000,19 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
 
       auto& key_store = cfuse->client->fscrypt->get_key_store();
 
-      FSCryptKeyRef k;
+      FSCryptKeyHandlerRef kh;
 
-      int r = key_store.create((const char *)arg->raw, arg->raw_size, k);
+      int r = key_store.create((const char *)arg->raw, arg->raw_size, kh);
       if (r < 0) {
         generic_dout(0) << __FILE__ << ":" << __LINE__ << ": failed to calc hkdf: r=" << r << dendl;
         fuse_reply_err(req, -r);
       }
+
+      Fh *fh = (Fh*)fi->fh;
+      Inode *in = fh->inode.get();
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": XXXX ioctl ion=" << in->ino << dendl;
+
+      auto& k = kh->get_key();
 
       const auto& identifier = k->get_identifier();
 
@@ -1038,8 +1045,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
       }
 
       /* FIXME: handle busy cases */
-      FSCryptKeyRef key;
-      r = cfuse->client->fscrypt->get_key_store().remove(kid);
+      r = cfuse->client->fscrypt->get_key_store().invalidate(kid);
       if (r < 0) {
         fuse_reply_err(req, -r);
         break;
@@ -1085,14 +1091,14 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         break;
       }
 
-      FSCryptKeyRef key;
-      r = cfuse->client->fscrypt->get_key_store().find(kid, key);
+      FSCryptKeyHandlerRef kh;
+      r = cfuse->client->fscrypt->get_key_store().find(kid, kh);
       if (r < 0 && r != -ENOENT) {
         fuse_reply_err(req, -r);
         break;
       }
 
-      bool found = (r == 0);
+      bool found = (r == 0 && kh->get_key());
 
       generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_GET_ENCRYPTION_KEY_STATUS found=" << found << dendl;
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -892,16 +892,6 @@ static void fuse_ll_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     fuse_reply_err(req, get_sys_errno(-r));
 }
 
-static string hex_str(const void *p, int len)
-{
-  bufferlist bl;
-  bl.append_hole(len);
-  memcpy(bl.c_str(), p, len);
-  stringstream ss;
-  bl.hexdump(ss);
-  return ss.str();
-}
-
 static void fuse_ll_write(fuse_req_t req, fuse_ino_t ino, const char *buf,
 			   size_t size, off_t off, struct fuse_file_info *fi)
 {
@@ -957,7 +947,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
     case FS_IOC_GET_ENCRYPTION_POLICY_EX: {
       auto arg = (fscrypt_get_policy_ex_arg *)in_buf;
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": in_bufsz=" << in_bufsz << " out_bufsz=" << out_bufsz << " FS_IOC_GET_ENCRYPTION_POLICY_EX buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": in_bufsz=" << in_bufsz << " out_bufsz=" << out_bufsz << " FS_IOC_GET_ENCRYPTION_POLICY_EX buffer:\n" << fscrypt_hex_str(in_buf, in_bufsz) << dendl;
 
       struct fscrypt_get_policy_ex_arg out_arg;
       if (out_bufsz < sizeof(out_arg.policy)) {
@@ -989,16 +979,16 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
 
       auto arg = (fscrypt_add_key_arg *)in_buf;
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": in_bufsz=" << in_bufsz << " ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": in_bufsz=" << in_bufsz << " ioctl buffer:\n" << fscrypt_hex_str(in_buf, in_bufsz) << dendl;
 
       if (arg->key_spec.type != FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
         fuse_reply_err(req, ENOTSUP);
         break;
       }
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": key_spec.type=" << arg->key_spec.type << " key_spec buffer:\n" << hex_str(&arg->key_spec, sizeof(arg->key_spec)) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": key_spec.type=" << arg->key_spec.type << " key_spec buffer:\n" << fscrypt_hex_str(&arg->key_spec, sizeof(arg->key_spec)) << dendl;
       generic_dout(0) << __FILE__ << ":" << __LINE__ << ": raw_size=" << arg->raw_size << " key_id=" << arg->key_id << dendl;
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": raw:\n" << hex_str(arg->raw, arg->raw_size) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": raw:\n" << fscrypt_hex_str(arg->raw, arg->raw_size) << dendl;
 
       if (arg->key_id == 0 &&
           in_bufsz < sizeof(*arg) + arg->raw_size) {
@@ -1019,7 +1009,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
 
       const auto& identifier = k->get_identifier();
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": hkdf:\n" << hex_str(identifier.raw, sizeof(identifier.raw)) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": hkdf:\n" << fscrypt_hex_str(identifier.raw, sizeof(identifier.raw)) << dendl;
 
       fuse_reply_ioctl(req, 0, nullptr, 0);
       break;
@@ -1032,7 +1022,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         break;
       }
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_GET_ENCRYPTION_KEY_STATUS ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_REMOVE_ENCRYPTION_KEY ioctl buffer:\n" << fscrypt_hex_str(in_buf, in_bufsz) << dendl;
 
       auto arg = (fscrypt_remove_key_arg *)in_buf;
       if (arg->key_spec.type != FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
@@ -1065,7 +1055,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         fuse_reply_err(req, EINVAL);
         break;
       }
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": ioctl buffer:\n" << fscrypt_hex_str(in_buf, in_bufsz) << dendl;
 
       // fuse_reply_ioctl(req, 0, nullptr, 0);
       fuse_reply_err(req, EINVAL);
@@ -1080,7 +1070,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
         break;
       }
 
-      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_GET_ENCRYPTION_KEY_STATUS ioctl buffer:\n" << hex_str(in_buf, in_bufsz) << dendl;
+      generic_dout(0) << __FILE__ << ":" << __LINE__ << ": FS_IOC_GET_ENCRYPTION_KEY_STATUS ioctl buffer:\n" << fscrypt_hex_str(in_buf, in_bufsz) << dendl;
 
       auto arg = (fscrypt_get_key_status_arg *)in_buf;
       if (arg->key_spec.type != FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -15,6 +15,7 @@
 #define CEPH_CRYPTO_HMACSHA256_DIGESTSIZE 32
 #define CEPH_CRYPTO_SHA256_DIGESTSIZE 32
 #define CEPH_CRYPTO_SHA512_DIGESTSIZE 64
+#define CEPH_CRYPTO_HMACSHA512_DIGESTSIZE 64
 
 #include <openssl/evp.h>
 #include <openssl/ossl_typ.h>
@@ -187,6 +188,12 @@ namespace TOPNSPC::crypto {
       : HMAC(EVP_sha256(), key, length) {
     }
   };
+
+  struct HMACSHA512 : public HMAC {
+    HMACSHA512 (const unsigned char *key, size_t length)
+      : HMAC(EVP_sha512(), key, length) {
+    }
+  };
 }
 
 
@@ -195,6 +202,7 @@ namespace TOPNSPC::crypto {
   using ssl::SHA1;
   using ssl::SHA512;
 
+  using ssl::HMACSHA512;
   using ssl::HMACSHA256;
   using ssl::HMACSHA1;
 

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -131,6 +131,9 @@ struct ceph_ll_io_info {
   bool syncdataonly;
 };
 
+struct ceph_fscrypt_key_identifier;
+struct fscrypt_policy_v2;
+
 /* setattr mask bits (up to an int in size) */
 #ifndef CEPH_SETATTR_MODE
 #define CEPH_SETATTR_MODE		(1 << 0)
@@ -1893,6 +1896,40 @@ int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd);
  *       for the file
  */
 int ceph_debug_get_file_caps(struct ceph_mount_info *cmount, const char *path);
+
+/**
+ * Add fscrypt encryption key to the in-memory key manager
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param key_data key data
+ * @param key_len key data length
+ * @param kid to hold the returned key identifier
+ * @returns zero on success, other returns a negative error code.
+ */
+int ceph_add_fscrypt_key(struct ceph_mount_info *cmount,
+                         const char *key_data, int key_len,
+                         struct ceph_fscrypt_key_identifier *kid);
+
+/**
+ * Remove fscrypt encryption key from the in-memory key manager
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param kid pointer to the key identifier
+ * @returns zero on success, other returns a negative error code.
+ */
+int ceph_remove_fscrypt_key(struct ceph_mount_info *cmount,
+                            const struct ceph_fscrypt_key_identifier *kid);
+
+/**
+ * Set encryption policy on a directory.
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param fd open directory file descriptor
+ * @param policy pointer to to the fscrypt v2 policy
+ * @returns zero on success, other returns a negative error code.
+ */
+int ceph_set_fscrypt_policy_v2(struct ceph_mount_info *cmount,
+                               int fd, const struct fscrypt_policy_v2 *policy);
 
 /* Low Level */
 struct Inode *ceph_ll_get_inode(struct ceph_mount_info *cmount,

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2312,6 +2312,35 @@ extern "C" void ceph_finish_reclaim(class ceph_mount_info *cmount)
   cmount->get_client()->finish_reclaim();
 }
 
+extern "C" int ceph_add_fscrypt_key(struct ceph_mount_info *cmount,
+                                    const char *key_data, int key_len,
+                                    struct ceph_fscrypt_key_identifier *kid)
+{
+  if (!cmount->is_mounted())
+    return -CEPHFS_ENOTCONN;
+
+  return cmount->get_client()->add_fscrypt_key(key_data, key_len, kid);
+}
+
+extern "C" int ceph_remove_fscrypt_key(struct ceph_mount_info *cmount,
+                                       const struct ceph_fscrypt_key_identifier *kid)
+{
+  if (!cmount->is_mounted())
+    return -CEPHFS_ENOTCONN;
+
+  return cmount->get_client()->remove_fscrypt_key(*kid);
+}
+
+extern "C" int ceph_set_fscrypt_policy_v2(struct ceph_mount_info *cmount,
+                                          int fd, const struct fscrypt_policy_v2 *policy)
+{
+  if (!cmount->is_mounted())
+    return -CEPHFS_ENOTCONN;
+
+  return cmount->get_client()->set_fscrypt_policy_v2(fd, *policy);
+}
+
+
 // This is deprecated, use ceph_ll_register_callbacks2 instead.
 extern "C" void ceph_ll_register_callbacks(class ceph_mount_info *cmount,
 					   struct ceph_client_callback_args *args)

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -80,14 +80,16 @@ class ObjectCacher::C_RetryRead : public Context {
   ObjectSet *oset;
   Context *onfinish;
   ZTracer::Trace trace;
+  std::vector<ObjHole> *holes;
 public:
   C_RetryRead(ObjectCacher *_oc, OSDRead *r, ObjectSet *os, Context *c,
-	      const ZTracer::Trace &trace)
-    : oc(_oc), rd(r), oset(os), onfinish(c), trace(trace) {
+	      const ZTracer::Trace &trace,
+              std::vector<ObjHole> *holes)
+    : oc(_oc), rd(r), oset(os), onfinish(c), trace(trace), holes(holes) {
   }
   void finish(int r) override {
     if (r >= 0) {
-      r = oc->_readx(rd, oset, onfinish, false, &trace);
+      r = oc->_readx(rd, oset, onfinish, false, &trace, holes);
     }
 
     if (r == 0) {
@@ -1383,7 +1385,8 @@ bool ObjectCacher::is_cached(ObjectSet *oset, vector<ObjectExtent>& extents,
  * returns 0 if doing async read
  */
 int ObjectCacher::readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
-			ZTracer::Trace *parent_trace)
+			ZTracer::Trace *parent_trace,
+                        std::vector<ObjHole> *holes)
 {
   ZTracer::Trace trace;
   if (parent_trace != nullptr) {
@@ -1391,7 +1394,7 @@ int ObjectCacher::readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
     trace.event("start");
   }
 
-  int r =_readx(rd, oset, onfinish, true, &trace);
+  int r =_readx(rd, oset, onfinish, true, &trace, holes);
   if (r < 0) {
     trace.event("finish");
   }
@@ -1399,7 +1402,8 @@ int ObjectCacher::readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 }
 
 int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
-			 bool external_call, ZTracer::Trace *trace)
+			 bool external_call, ZTracer::Trace *trace,
+                         std::vector<ObjHole> *holes)
 {
   ceph_assert(trace != nullptr);
   ceph_assert(ceph_mutex_is_locked(lock));
@@ -1464,7 +1468,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  ldout(cct, 10) << "readx  waiting on tid " << o->last_write_tid
 			 << " on " << *o << dendl;
 	  o->waitfor_commit[o->last_write_tid].push_back(
-	    new C_RetryRead(this,rd, oset, onfinish, *trace));
+	    new C_RetryRead(this,rd, oset, onfinish, *trace, holes));
 	  // FIXME: perfcounter!
 	  return 0;
 	}
@@ -1522,7 +1526,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 			   << (std::max(rx_bytes, max_size) - max_size)
 			   << " read bytes" << dendl;
 	    waitfor_read.push_back(new C_RetryRead(this, rd, oset, onfinish,
-						   *trace));
+						   *trace, holes));
 	  }
 
 	  bh_remove(o, bh_it->second);
@@ -1541,7 +1545,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	ldout(cct, 10) << "readx missed, waiting on " << *last->second
 	  << " off " << last->first << dendl;
 	last->second->waitfor_read[last->first].push_back(
-	  new C_RetryRead(this, rd, oset, onfinish, *trace) );
+	  new C_RetryRead(this, rd, oset, onfinish, *trace, holes) );
 
       }
 
@@ -1554,7 +1558,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  ldout(cct, 10) << "readx missed, waiting on " << *bh_it->second
 			 << " off " << bh_it->first << dendl;
 	  bh_it->second->waitfor_read[bh_it->first].push_back(
-	    new C_RetryRead(this, rd, oset, onfinish, *trace) );
+	    new C_RetryRead(this, rd, oset, onfinish, *trace, holes) );
 	}
 	bytes_not_in_cache += bh_it->second->length();
 	success = false;
@@ -1620,6 +1624,9 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  // may get multiple bh's at this stripe_map position
 	  if (bh->is_zero()) {
 	    stripe_map[f_it->first].append_zero(len);
+            if (holes) {
+              holes->push_back(std::make_pair(opos, len));
+            }
 	  } else {
 	    bit.substr_of(bh->bl,
 		opos - bh->start(),

--- a/src/test/client/CMakeLists.txt
+++ b/src/test/client/CMakeLists.txt
@@ -4,6 +4,7 @@ if(${WITH_CEPHFS})
     alternate_name.cc
     ops.cc
     nonblocking.cc
+    fscrypt_conf.cc
     )
   target_link_libraries(ceph_test_client
     client
@@ -15,5 +16,24 @@ if(${WITH_CEPHFS})
     ${CMAKE_DL_LIBS}
     )
   install(TARGETS ceph_test_client
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(ceph_test_client_fscrypt
+    main_fscrypt.cc
+    alternate_name.cc
+    ops.cc
+    nonblocking.cc
+    fscrypt_conf.cc
+    )
+  target_link_libraries(ceph_test_client_fscrypt
+    client
+    global
+    ceph-common
+    cephfs
+    ${UNITTEST_LIBS}
+    ${EXTRALIBS}
+    ${CMAKE_DL_LIBS}
+    )
+  install(TARGETS ceph_test_client_fscrypt
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_CEPHFS})

--- a/src/test/client/TestClient.h
+++ b/src/test/client/TestClient.h
@@ -22,18 +22,30 @@
 #include "osdc/ObjectCacher.h"
 #include "client/MetaRequest.h"
 #include "client/Client.h"
+#include "client/FSCrypt.h"
 #include "messages/MClientReclaim.h"
 #include "messages/MClientSession.h"
 #include "common/async/blocked_completion.h"
+
+#include "fscrypt_conf.h"
 
 #define dout_subsys ceph_subsys_client
 
 namespace bs = boost::system;
 namespace ca = ceph::async;
 
+
+struct fscrypt_env {
+  bool encrypted = false;
+  std::string name;
+  std::string dir;
+  char key[32];
+};
+
 class ClientScaffold : public Client {  
+  fscrypt_env *fse;
 public:
-    ClientScaffold(Messenger *m, MonClient *mc, Objecter *objecter_) : Client(m, mc, objecter_) {}
+    ClientScaffold(Messenger *m, MonClient *mc, Objecter *objecter_, fscrypt_env *fse) : Client(m, mc, objecter_), fse(fse) {}
     virtual ~ClientScaffold()
     { }
     int check_dummy_op(const UserPerm& perms){
@@ -86,6 +98,105 @@ public:
       wait_on_list(waiting_for_reclaim);
       return session->reclaim_state == MetaSession::RECLAIM_FAIL ? true : false;
     }
+
+    bool encrypt(const UserPerm& myperm) {
+      if (!fscrypt_enabled || fse->encrypted) {
+        return false;
+      }
+
+      pid_t mypid = getpid();
+      fse->name = std::string("ceph_test_client_fscrypt.") + stringify(mypid) + "." + stringify(rand());
+      fse->dir = std::string("/") + fse->name;
+
+      int r = mount("/", myperm, true);
+      if (r < 0) {
+        std::clog << __func__ << "(): mount() r=" << r << std::endl;
+        throw std::runtime_error("mount() returned error");
+      }
+
+      r = mkdir(fse->name.c_str(), 0755, myperm);
+      if (r < 0) {
+        std::clog << __func__ << "(): mkdir(" << fse->name << ") r=" << r << std::endl;
+        throw std::runtime_error("get_root() returned error");
+      }
+
+      for (size_t i = 0; i < sizeof(fse->key); ++i) {
+        fse->key[i] = (char)rand();
+      }
+
+      std::string key_fname = fse->name + ".key";
+      int key_fd = open(key_fname.c_str(), O_RDWR|O_CREAT|O_TRUNC, myperm, 0600);
+      if (key_fd < 0) {
+        std::clog << __func__ << "(): open() fd=" << key_fd << std::endl;
+        throw std::runtime_error("open() returned error");
+      }
+
+      r = write(key_fd, fse->key, sizeof(fse->key), 0);
+      if (r < 0) {
+        std::clog << __func__ << "(): write() r=" << r << std::endl;
+        throw std::runtime_error("write() returned error");
+      }
+
+      close(key_fd);
+
+      struct ceph_fscrypt_key_identifier kid;
+
+      r = add_fscrypt_key(fse->key, sizeof(fse->key), &kid);
+      if (r < 0) {
+        std::clog << __func__ << "(): add_fscrypt_key() r=" << r << std::endl;
+        throw std::runtime_error("add_fscrypt_key() returned error");
+      }
+
+      struct fscrypt_policy_v2 policy;
+      policy.version = 2;
+      policy.contents_encryption_mode = FSCRYPT_MODE_AES_256_XTS;
+      policy.filenames_encryption_mode = FSCRYPT_MODE_AES_256_CTS;
+      policy.flags = FSCRYPT_POLICY_FLAGS_PAD_32;
+      memcpy(policy.master_key_identifier, kid.raw, FSCRYPT_KEY_IDENTIFIER_SIZE);
+
+      int fd = open(fse->name.c_str(), O_DIRECTORY, myperm, 0);
+      if (fd < 0) {
+        std::clog << __func__ << "(): open() r=" << r << std::endl;
+        throw std::runtime_error("open() returned error");
+      }
+
+      r = set_fscrypt_policy_v2(fd, policy);
+      if (r < 0) {
+        std::clog << __func__ << "(): set_fscrypt_policy() r=" << r << std::endl;
+        throw std::runtime_error("set_fscrypt_policy() returned error");
+      }
+
+      fse->encrypted = true;
+
+      return true;
+    }
+
+    int do_mount(const std::string &mount_root, const UserPerm& perms,
+                 bool require_mds=false, const std::string &fs_name="") {
+      int r;
+
+      if (fse->dir.empty()) {
+        r = mount(mount_root, perms, require_mds, fs_name);
+      } else {
+        std::string new_root = fse->dir + mount_root;
+
+        r = mount(new_root, perms, require_mds, fs_name);
+      }
+      if (r < 0) {
+        std::clog << __func__ << "() do_mount r=" << r << std::endl;
+        return r;
+      }
+
+      struct ceph_fscrypt_key_identifier kid;
+
+      r = add_fscrypt_key(fse->key, sizeof(fse->key), &kid);
+      if (r < 0) {
+        std::clog << __func__ << "() ceph_mount add_fscrypt_key r=" << r << std::endl;
+        return r;
+      }
+
+      return 0;
+    }
 };
 
 class TestClient : public ::testing::Test {
@@ -93,9 +204,21 @@ public:
     static void SetUpTestSuite() {
       icp.start(g_ceph_context->_conf.get_val<std::uint64_t>("client_asio_thread_count"));
     }
+
     static void TearDownTestSuite() {
       icp.stop();
     }
+
+    bool encrypt() {
+      bool encrypted = client->encrypt(myperm);
+      if (encrypted) {
+        client->unmount();
+        client->shutdown();
+        delete client;
+      }
+      return encrypted;
+    }
+
     void SetUp() override {
       messenger = Messenger::create_client_messenger(g_ceph_context, "client");
       if (messenger->start() != 0) {
@@ -118,9 +241,12 @@ public:
       messenger->add_dispatcher_tail(objecter);
       objecter->start();
 
-      client = new ClientScaffold(messenger, mc, objecter);
-      client->init();
-      client->mount("/", myperm, true);
+      do {
+        client = new ClientScaffold(messenger, mc, objecter, &fse);
+        client->init();
+      } while (encrypt());
+
+      client->do_mount("/", myperm, true);
     }
     void TearDown() override {
       if (client->is_mounted())
@@ -143,6 +269,7 @@ public:
 protected:
     static inline ceph::async::io_context_pool icp;
     static inline UserPerm myperm{0,0};
+    static inline fscrypt_env fse;
     MonClient* mc = nullptr;
     Messenger* messenger = nullptr;
     Objecter* objecter = nullptr;

--- a/src/test/client/fscrypt_conf.cc
+++ b/src/test/client/fscrypt_conf.cc
@@ -1,0 +1,15 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) IBM Corporation 2023
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+bool fscrypt_enabled = false;

--- a/src/test/client/fscrypt_conf.h
+++ b/src/test/client/fscrypt_conf.h
@@ -1,0 +1,17 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) IBM Corporation 2023
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+extern bool fscrypt_enabled;

--- a/src/test/client/main_fscrypt.cc
+++ b/src/test/client/main_fscrypt.cc
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 New Dream Network
+ * Copyright (C) 2016 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+#include "fscrypt_conf.h"
+
+int main(int argc, char **argv)
+{
+  fscrypt_enabled = true;
+
+  auto args = argv_to_vec(argc, argv);
+  [[maybe_unused]] auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -112,12 +112,12 @@ TEST_F(TestClient, LlreadvLlwritev) {
   readfinish.reset(new C_SaferCond("test-nonblocking-readfinish"));
   ssize_t nwritten_a = iov_out_a[0].iov_len + iov_out_a[1].iov_len;
 
-  rc = client->ll_preadv_pwritev(fh, iov_out_a, 2, 100, true, writefinish.get(), nullptr);
+  rc = client->ll_preadv_pwritev(fh, iov_out_a, 2, 5000, true, writefinish.get(), nullptr);
   ASSERT_EQ(0, rc);
   rc = writefinish->wait();
   ASSERT_EQ(nwritten_a, rc);
 
-  rc = client->ll_preadv_pwritev(fh, iov_in_a, 2, 100, false, readfinish.get(), &bl);
+  rc = client->ll_preadv_pwritev(fh, iov_in_a, 2, 5000, false, readfinish.get(), &bl);
   ASSERT_EQ(0, rc);
   rc = readfinish.get()->wait();
   ASSERT_EQ(nwritten_a, rc);
@@ -131,12 +131,12 @@ TEST_F(TestClient, LlreadvLlwritev) {
   readfinish.reset(new C_SaferCond("test-nonblocking-readfinish"));
   ssize_t nwritten_b = iov_out_b[0].iov_len + iov_out_b[1].iov_len;
 
-  rc = client->ll_preadv_pwritev(fh, iov_out_b, 2, 1000, true, writefinish.get(), nullptr, true, false);
+  rc = client->ll_preadv_pwritev(fh, iov_out_b, 2, 4090, true, writefinish.get(), nullptr, true, false);
   ASSERT_EQ(0, rc);
   rc = writefinish->wait();
   ASSERT_EQ(nwritten_b, rc);
 
-  rc = client->ll_preadv_pwritev(fh, iov_in_b, 2, 1000, false, readfinish.get(), &bl);
+  rc = client->ll_preadv_pwritev(fh, iov_in_b, 2, 4090, false, readfinish.get(), &bl);
   ASSERT_EQ(0, rc);
   rc = readfinish.get()->wait();
   ASSERT_EQ(nwritten_b, rc);
@@ -146,6 +146,6 @@ TEST_F(TestClient, LlreadvLlwritev) {
   ASSERT_EQ(0, strncmp((const char*)iov_in_b[1].iov_base, (const char*)iov_out_b[1].iov_base, iov_out_b[1].iov_len));
 
   client->ll_release(fh);
-  ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
+  // ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
 }
 

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -95,4 +95,20 @@ target_link_libraries(ceph_test_libcephfs_lazyio
     )
   install(TARGETS ceph_test_libcephfs_access
     DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(ceph_test_libcephfs_fscrypt
+    fscrypt.cc
+    test.cc
+  )
+  target_link_libraries(ceph_test_libcephfs_fscrypt
+    ceph-common
+    cephfs
+    librados
+    ${UNITTEST_LIBS}
+    ${EXTRALIBS}
+    ${CMAKE_DL_LIBS}
+    )
+  install(TARGETS ceph_test_libcephfs_fscrypt
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 endif(WITH_LIBCEPHFS)

--- a/src/test/libcephfs/fscrypt.cc
+++ b/src/test/libcephfs/fscrypt.cc
@@ -1,0 +1,257 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 New Dream Network
+ * Copyright (C) 2023 IBM Corporation
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "common/ceph_argparse.h"
+#include "include/buffer.h"
+#include "include/stringify.h"
+#include "include/cephfs/libcephfs.h"
+#include "include/fs_types.h"
+#include "include/rados/librados.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <sys/uio.h>
+#include <iostream>
+#include <vector>
+#include "json_spirit/json_spirit.h"
+
+#include "include/fs_types.h"
+
+#include "client/FSCrypt.h"
+
+#ifdef __linux__
+#include <limits.h>
+#include <sys/xattr.h>
+#endif
+
+#include "test.h"
+
+using namespace std;
+
+rados_t cluster;
+
+static string fscrypt_dir;
+
+static char fscrypt_key[32];
+
+
+int do_fscrypt_mount(struct ceph_mount_info *cmount, const char *root)
+{
+  int r;
+
+  if (fscrypt_dir.empty()) {
+    r = ceph_mount(cmount, root);
+  } else {
+    string new_root = fscrypt_dir;
+
+    if (root) {
+      new_root += root;
+    }
+
+    r = ceph_mount(cmount, new_root.c_str());
+  }
+  if (r < 0) {
+    std::clog << __func__ << "() ceph_mount r=" << r << std::endl;
+    return r;
+  }
+
+  struct ceph_fscrypt_key_identifier kid;
+
+  r = ceph_add_fscrypt_key(cmount, fscrypt_key, sizeof(fscrypt_key), &kid);
+  if (r < 0) {
+    std::clog << __func__ << "() ceph_mount add_fscrypt_key r=" << r << std::endl;
+    return r;
+  }
+
+  return 0;
+}
+
+string get_unique_dir_name()
+{
+  pid_t mypid = getpid();
+  return string("ceph_test_libcephfs_fscrypt.") + stringify(mypid) + "." + stringify(rand());
+}
+
+int fscrypt_encrypt(const string& dir_path)
+{
+  struct ceph_mount_info *cmount;
+  int r = ceph_create(&cmount, NULL);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_create() r=" << r << std::endl;
+    return r;
+  }
+
+  r = ceph_conf_read_file(cmount, NULL);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_conf_read_file() r=" << r << std::endl;
+    return r;
+  }
+
+  r = ceph_conf_parse_env(cmount, NULL);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_parse_env() r=" << r << std::endl;
+    return r;
+  }
+
+  r = ceph_mount(cmount, NULL);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_mount() r=" << r << std::endl;
+    return r;
+  }
+
+  Inode *dir, *root;
+  struct ceph_statx stx_dir;
+  struct ceph_statx stx_snap_dir;
+  struct ceph_statx stx_root_snap_dir;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  r = ceph_ll_lookup_root(cmount, &root);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_ll_lookup_root() r=" << r << std::endl;
+    return r;
+  }
+
+  r = ceph_ll_mkdir(cmount, root, dir_path.c_str(), 0755, &dir, &stx_dir, 0, 0, perms);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_ll_mkdir(" << dir_path << ") r=" << r << std::endl;
+    return r;
+  }
+
+  for (int i = 0; i < sizeof(fscrypt_key); ++i) {
+    fscrypt_key[i] = (char)rand();
+  }
+
+  string key_fname = dir_path + ".key";
+  int key_fd = ceph_open(cmount, key_fname.c_str(), O_RDWR|O_CREAT|O_TRUNC, 0600);
+  if (key_fd < 0) {
+    std::clog << __func__ << "(): ceph_open() fd=" << key_fd << std::endl;
+    return key_fd;
+  }
+
+  r = ceph_write(cmount, key_fd, fscrypt_key, sizeof(fscrypt_key), 0);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_write() r=" << r << std::endl;
+    return r;
+  }
+
+  ceph_close(cmount, key_fd);
+
+  struct ceph_fscrypt_key_identifier kid;
+
+  r = ceph_add_fscrypt_key(cmount, fscrypt_key, sizeof(fscrypt_key), &kid);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_add_fscrypt_key() r=" << r << std::endl;
+    return r;
+  }
+
+  struct fscrypt_policy_v2 policy;
+  policy.version = 2;
+  policy.contents_encryption_mode = FSCRYPT_MODE_AES_256_XTS;
+  policy.filenames_encryption_mode = FSCRYPT_MODE_AES_256_CTS;
+  policy.flags = FSCRYPT_POLICY_FLAGS_PAD_32;
+  memcpy(policy.master_key_identifier, kid.raw, FSCRYPT_KEY_IDENTIFIER_SIZE);
+
+  int fd = ceph_open(cmount, dir_path.c_str(), O_DIRECTORY, 0);
+  if (fd < 0) {
+    std::clog << __func__ << "(): ceph_open() r=" << r << std::endl;
+    return fd;
+  }
+
+  r = ceph_set_fscrypt_policy_v2(cmount, fd, &policy);
+  if (r < 0) {
+    std::clog << __func__ << "(): ceph_set_fscrypt_policy() r=" << r << std::endl;
+    return r;
+  }
+
+  ceph_shutdown(cmount);
+
+  return 0;
+}
+
+static int init_fscrypt()
+{
+  string name = get_unique_dir_name();
+  std::clog << __func__ << "(): fscrypt_dir=" << name << std::endl;
+
+  fscrypt_dir = string("/") + name;
+
+  int r = fscrypt_encrypt(name);
+  if (r < 0) {
+    return r;
+  }
+
+  libcephfs_test_set_mount_call(do_fscrypt_mount);
+  std::clog << __func__ << "(): init fscrypt done" << std::endl;
+
+  return 0;
+}
+
+
+static int update_root_mode()
+{
+  struct ceph_mount_info *admin;
+  int r = ceph_create(&admin, NULL);
+  if (r < 0)
+    return r;
+  ceph_conf_read_file(admin, NULL);
+  ceph_conf_parse_env(admin, NULL);
+  ceph_conf_set(admin, "client_permissions", "false");
+  r = ceph_mount(admin, "/");
+  if (r < 0)
+    goto out;
+  r = ceph_chmod(admin, "/", 0777);
+out:
+  ceph_shutdown(admin);
+  return r;
+}
+
+
+int main(int argc, char **argv)
+{
+  int r = update_root_mode();
+  if (r < 0)
+    exit(1);
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  srand(getpid());
+
+  r = rados_create(&cluster, NULL);
+  if (r < 0)
+    exit(1);
+  
+  r = rados_conf_read_file(cluster, NULL);
+  if (r < 0)
+    exit(1);
+
+  rados_conf_parse_env(cluster, NULL);
+  r = rados_connect(cluster);
+  if (r < 0)
+    exit(1);
+
+  r = init_fscrypt();
+  if (r < 0)
+    exit(1);
+
+  r = RUN_ALL_TESTS();
+
+  rados_shutdown(cluster);
+
+  return r;
+}

--- a/src/test/libcephfs/test.h
+++ b/src/test/libcephfs/test.h
@@ -1,0 +1,6 @@
+
+#pragma once
+
+struct ceph_mount_info;
+
+void libcephfs_test_set_mount_call(int (*mount_call)(struct ceph_mount_info *cmount, const char *root));


### PR DESCRIPTION
This implements fscrypt support in libcephfs, and the cephfs userspace client that is interoperable with the cephfs kernel client (see: https://lwn.net/Articles/889912/).

Note that this is still in heavy development.

Currently implemented:
- Key management infrastructure
- Can use [a modified] fscrypt utility [1] with fuse mounted filesystem
- Supports "lock", and "unlock", as well as other required operations
- Listing encrypted directories
- Encrypted files read
- Encrypted files write
- libcephfs control API


TODO:
- ~~Currently cannot select encryption types (uses defaults)~~
- ~~Add libcephfs API to control crypto keys~~
- ~~Long file names support~~
- ~~Cleanly deal with the read caps needed when writing data~~
- read-modify race detection when writing files
- ~~symlinks implementation~~
- ~~snapshots~~
- ~~async API~~
- restrict certain operations to only happen when directory is unlocked (e.g., read file, create snapshots, etc.)
- Probably more filesystem operations coverage (e.g., where there are multiple implementations of different functionalities, etc.)
- testing

We currently only support the default encryption types that the fscrypt control tool sets. The code does handle selection of encryption types dynamically, and gracefully handles the case where it cannot support an encryption type. Since the fscrypt tool does not make it easy to set encryption types, and since libopenssl does not support every type/mode out of the box, we should consider in the future which encryption types we want to support, however this is beyond the scope of this PR.


[1] fscrypt utility is modified due to use of ioctls that are not well formed (a problem with fuse), see https://github.com/yehudasa/fscrypt/tree/wip-ceph-fuse


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
