### PR TITLE
mgr/dashboard: empty grafana panels for performance of daemons 

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -157,7 +158,6 @@ void DaemonMetricCollector::dump_asok_metrics() {
             labels.insert(multisite_labels_and_name.first.begin(), multisite_labels_and_name.first.end());
             counter_name = multisite_labels_and_name.second;
           }
-          labels.insert({"ceph_daemon", quote(daemon_name)});
           auto perf_values = counters_values.at(counter_name_init);
           dump_asok_metric(counter_group, perf_values, counter_name, labels);
         }
@@ -291,6 +291,14 @@ DaemonMetricCollector::get_labels_and_metric_name(std::string daemon_name,
   std::string new_metric_name;
   labels_t labels;
   new_metric_name = metric_name;
+  const std::string ceph_daemon_prefix = "ceph-";
+  const std::string ceph_client_prefix = "client.";
+  if (daemon_name.rfind(ceph_daemon_prefix, 0) == 0) {
+    daemon_name = daemon_name.substr(ceph_daemon_prefix.size());
+  }
+  if (daemon_name.rfind(ceph_client_prefix, 0) == 0) {
+    daemon_name = daemon_name.substr(ceph_client_prefix.size());
+  }
   // In vstart cluster socket files for rgw are stored as radosgw.<instance_id>.asok
   if (daemon_name.find("radosgw") != std::string::npos) {
     std::size_t pos = daemon_name.find_last_of('.');
@@ -298,11 +306,17 @@ DaemonMetricCollector::get_labels_and_metric_name(std::string daemon_name,
     labels["instance_id"] = quote(tmp);
   }
   else if (daemon_name.find("rgw") != std::string::npos) {
-    std::string tmp = daemon_name.substr(16, std::string::npos);
-    std::string::size_type pos = tmp.find('.');
-    labels["instance_id"] = quote("rgw." + tmp.substr(0, pos));
+    // fetch intance_id for e.g. "okbvtv" from daemon_name=rgw.foo.ceph-node-00.okbvtv 
+    size_t pos = daemon_name.find_last_of(".");
+    std::string instance_id = "";
+    if (pos != std::string::npos) {
+       instance_id = daemon_name.substr(pos+1);
+    }
+    labels["instance_id"] = quote(instance_id);
+  } else {
+    labels.insert({"ceph_daemon", quote(daemon_name)});
   }
-  else if (daemon_name.find("rbd-mirror") != std::string::npos) {
+  if (daemon_name.find("rbd-mirror") != std::string::npos) {
     std::regex re(
         "^rbd_mirror_image_([^/]+)/(?:(?:([^/]+)/"
         ")?)(.*)\\.(replay(?:_bytes|_latency)?)$");

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -34,6 +34,8 @@ class DaemonMetricCollector {
 public:
   void main();
   std::string get_metrics();
+  std::pair<labels_t, std::string>
+  get_labels_and_metric_name(std::string daemon_name, std::string metric_name);
 
 private:
   std::map<std::string, AdminSocketClient> clients;
@@ -47,8 +49,6 @@ private:
   void dump_asok_metric(boost::json::object perf_info,
                         boost::json::value perf_values, std::string name,
                         labels_t labels);
-  std::pair<labels_t, std::string>
-  get_labels_and_metric_name(std::string daemon_name, std::string metric_name);
   std::pair<labels_t, std::string> add_fixed_name_metrics(std::string metric_name);
   void get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
   std::string asok_request(AdminSocketClient &asok, std::string command, std::string daemon_name);

--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -38,6 +38,8 @@ cypress_run () {
 
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
 
+kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'
+
 # check if the prometheus daemon is running
 # before starting the e2e tests
 
@@ -52,8 +54,6 @@ kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-alertmanager-ap
 kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-prometheus-api-host http://192.168.100.100:9095"'
 kcli ssh -u root ceph-node-00 'cephadm shell "ceph dashboard set-grafana-api-url https://192.168.100.100:3000"'
 kcli ssh -u root ceph-node-00 'cephadm shell "ceph orch apply node-exporter --placement 'count:2'"'
-
-kcli ssh -u root ceph-node-00 'cephadm shell "ceph config set mgr mgr/prometheus/exclude_perf_counters false"'
 
 cypress_run ["cypress/e2e/orchestrator/workflow/*.feature","cypress/e2e/orchestrator/workflow/*-spec.ts"]
 cypress_run "cypress/e2e/orchestrator/grafana/*.feature"

--- a/src/test/exporter/CMakeLists.txt
+++ b/src/test/exporter/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(unittest_exporter
   test_exporter.cc
   "${CMAKE_SOURCE_DIR}/src/exporter/util.cc"
+  "${CMAKE_SOURCE_DIR}/src/exporter/DaemonMetricCollector.cc"
   )
 
 target_link_libraries(unittest_exporter


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61792
Signed-off-by: avanthakkar <avanjohn@gmail.com>

Before:
```
# TYPE ceph_osd_numpg gauge
 ceph_osd_numpg{ceph_daemon="ceph-osd.0"} 113
 ceph_osd_numpg{ceph_daemon="ceph-osd.1"} 113
 ceph_osd_numpg{ceph_daemon="ceph-osd.2"} 113
```
After: 
/metrics output(removed `ceph-` prefix from ceph_daemon label): 
```# HELP ceph_osd_numpg Placement groups
# TYPE ceph_osd_numpg gauge
ceph_osd_numpg{ceph_daemon="osd.0"} 113
ceph_osd_numpg{ceph_daemon="osd.1"} 113
ceph_osd_numpg{ceph_daemon="osd.2"} 113
```
Also the changes fixes the instance_id used for `rgw_metadata` metrics, when orch is available and matches with the one coming from ceph-exporter.

**Fixes the OSD grafana panels:**

![Screenshot from 2023-07-01 15-04-31](https://github.com/ceph/ceph/assets/23611106/12b2de95-4bd6-49b0-b083-78ad28e36dc9)

![Screenshot from 2023-07-01 15-03-08](https://github.com/ceph/ceph/assets/23611106/a8fbbeb9-0193-434c-a4a3-5ff3bd40a999)


**Fixes the RGW grafana panels:**
- RGW Overview: 
![Screenshot from 2023-07-07 00-04-31](https://github.com/ceph/ceph/assets/23611106/967d8eea-e908-437f-8539-5bedf3f39ccd)

- RGW instance details:
![Screenshot from 2023-07-07 00-05-22](https://github.com/ceph/ceph/assets/23611106/ce639d1d-334e-4396-93eb-8640dae82b6c)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
