### PR TITLE
rgw: remove useless op ret assign

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2270,11 +2270,10 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params(optional_yield y)
                      << max_num
                      << " rules, request website routing rules num: "
                      << routing_rules_num << dendl;
-    op_ret = -ERR_INVALID_WEBSITE_ROUTING_RULES_ERROR;
     s->err.message = std::to_string(routing_rules_num) +" routing rules provided, the number of routing rules in a website configuration is limited to "
                      + std::to_string(max_num)
                      + ".";
-    return -ERR_INVALID_REQUEST;
+    return -ERR_INVALID_WEBSITE_ROUTING_RULES_ERROR;
   }
 
   return 0;
@@ -3716,10 +3715,9 @@ int RGWPutCORS_ObjStore_S3::get_params(optional_yield y)
                      << max_num
                      << " rules, request cors rules num: "
                      << cors_rules_num << dendl;
-    op_ret = -ERR_INVALID_CORS_RULES_ERROR;
     s->err.message = "The number of CORS rules should not exceed allowed limit of "
                      + std::to_string(max_num) + " rules.";
-    return -ERR_INVALID_REQUEST;
+    return -ERR_INVALID_CORS_RULES_ERROR;
   }
 
   // forward bucket cors requests to meta master zone


### PR DESCRIPTION
in op rgwsetbucketwebsite_objstore_s3 and rgwputcors_objstore_s3 get_param trys to assign op_ret which will be overwritten by return value.
 use this to be assigned value as the return value will result in a same http response because in rgw_common rgw_http_s3_errors will translate them into the same.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
