### PR TITLE
ceph-dencoder: RGW - Add missing types

### DIFF
--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -27,6 +27,23 @@ struct cls_log_add_op {
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter* f) const {
+    encode_json("entries", entries, f);
+    encode_json("monotonic_inc", monotonic_inc, f);
+  }
+
+  static void generate_test_instances(std::list<cls_log_add_op *>& l) {
+    l.push_back(new cls_log_add_op);
+    l.push_back(new cls_log_add_op);
+    l.back()->entries.push_back(cls_log_entry());
+    l.back()->entries.push_back(cls_log_entry());
+    l.back()->entries.back().section = "section";
+    l.back()->entries.back().name = "name";
+    l.back()->entries.back().timestamp = utime_t(1, 2);
+    l.back()->entries.back().data.append("data");
+    l.back()->entries.back().id = "id";
+  }
 };
 WRITE_CLASS_ENCODER(cls_log_add_op)
 

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -527,6 +527,17 @@ struct rgw_cls_obj_remove_op {
     decode(keep_attr_prefixes, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    encode_json("keep_attr_prefixes", keep_attr_prefixes, f);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_obj_remove_op*>& o) {
+    o.push_back(new rgw_cls_obj_remove_op);
+    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes1");
+    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes2");
+    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes3");
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_remove_op)
 
@@ -543,6 +554,15 @@ struct rgw_cls_obj_store_pg_ver_op {
     DECODE_START(1, bl);
     decode(attr, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("attr", attr);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_obj_store_pg_ver_op*>& o) {
+    o.push_back(new rgw_cls_obj_store_pg_ver_op);
+    o.back()->attr = "attr";
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_store_pg_ver_op)
@@ -565,6 +585,17 @@ struct rgw_cls_obj_check_attrs_prefix {
     decode(check_prefix, bl);
     decode(fail_if_exist, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("check_prefix", check_prefix);
+    f->dump_bool("fail_if_exist", fail_if_exist);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_obj_check_attrs_prefix*>& o) {
+    o.push_back(new rgw_cls_obj_check_attrs_prefix);
+    o.back()->check_prefix = "prefix";
+    o.back()->fail_if_exist = true;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_check_attrs_prefix)
@@ -619,6 +650,15 @@ struct rgw_cls_usage_log_add_op {
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("info", info);
+    f->dump_string("user", user.to_str());
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_usage_log_add_op*>& o) {
+    o.push_back(new rgw_cls_usage_log_add_op);
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_add_op)
 
@@ -643,6 +683,19 @@ struct rgw_cls_bi_get_op {
     type = (BIIndexType)c;
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_stream("key") << key;
+    f->dump_int("type", (int)type);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_bi_get_op*>& o) {
+    o.push_back(new rgw_cls_bi_get_op);
+    o.push_back(new rgw_cls_bi_get_op);
+    o.back()->key.name = "key";
+    o.back()->key.instance = "instance";
+    o.back()->type = BIIndexType::Plain;
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_get_op)
 
@@ -662,6 +715,15 @@ struct rgw_cls_bi_get_ret {
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("entry", entry.idx);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_bi_get_ret*>& o) {
+    o.push_back(new rgw_cls_bi_get_ret);
+    o.back()->entry.idx = "entry";
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_get_ret)
 
@@ -680,6 +742,16 @@ struct rgw_cls_bi_put_op {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("entry", entry.idx);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_bi_put_op*>& o) {
+    o.push_back(new rgw_cls_bi_put_op);
+    o.push_back(new rgw_cls_bi_put_op);
+    o.back()->entry.idx = "entry";
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_op)
@@ -706,6 +778,20 @@ struct rgw_cls_bi_list_op {
     decode(marker, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("max", max);
+    f->dump_string("name_filter", name_filter);
+    f->dump_string("marker", marker);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_bi_list_op*>& o) {
+    o.push_back(new rgw_cls_bi_list_op);
+    o.push_back(new rgw_cls_bi_list_op);
+    o.back()->max = 100;
+    o.back()->name_filter = "name_filter";
+    o.back()->marker = "marker";
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_list_op)
 
@@ -727,6 +813,20 @@ struct rgw_cls_bi_list_ret {
     decode(entries, bl);
     decode(is_truncated, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_bool("is_truncated", is_truncated);
+    encode_json("entries", entries, f);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_bi_list_ret*>& o) {
+    o.push_back(new rgw_cls_bi_list_ret);
+    o.push_back(new rgw_cls_bi_list_ret);
+    o.back()->entries.push_back(rgw_cls_bi_entry());
+    o.back()->entries.push_back(rgw_cls_bi_entry());
+    o.back()->entries.back().idx = "entry";
+    o.back()->is_truncated = true;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_list_ret)
@@ -763,6 +863,25 @@ struct rgw_cls_usage_log_read_op {
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("start_epoch", start_epoch);
+    f->dump_unsigned("end_epoch", end_epoch);
+    f->dump_string("owner", owner);
+    f->dump_string("bucket", bucket);
+    f->dump_string("iter", iter);
+    f->dump_unsigned("max_entries", max_entries);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_usage_log_read_op*>& o) {
+    o.push_back(new rgw_cls_usage_log_read_op);
+    o.back()->start_epoch = 1;
+    o.back()->end_epoch = 2;
+    o.back()->owner = "owner";
+    o.back()->bucket = "bucket";
+    o.back()->iter = "iter";
+    o.back()->max_entries = 100;
+  }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_op)
 
@@ -785,6 +904,24 @@ struct rgw_cls_usage_log_read_ret {
     decode(truncated, bl);
     decode(next_iter, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_bool("truncated", truncated);
+    f->dump_string("next_iter", next_iter);
+    encode_json("usage", usage, f);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_usage_log_read_ret*>& o) {
+    o.push_back(new rgw_cls_usage_log_read_ret);
+    o.back()->next_iter = "123";
+    o.back()->truncated = true;
+    o.back()->usage.clear();
+    o.push_back(new rgw_cls_usage_log_read_ret);
+    o.back()->usage[rgw_user_bucket("user1", "bucket1")] = rgw_usage_log_entry();
+    o.back()->usage[rgw_user_bucket("user2", "bucket2")] = rgw_usage_log_entry();
+    o.back()->truncated = true;
+    o.back()->next_iter = "next_iter";
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_ret)
@@ -813,6 +950,22 @@ struct rgw_cls_usage_log_trim_op {
       decode(bucket, bl);
     }
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("start_epoch", start_epoch);
+    f->dump_unsigned("end_epoch", end_epoch);
+    f->dump_string("user", user);
+    f->dump_string("bucket", bucket);
+  }
+
+  static void generate_test_instances(std::list<rgw_cls_usage_log_trim_op*>& ls) {
+    rgw_cls_usage_log_trim_op *m = new rgw_cls_usage_log_trim_op;
+    m->start_epoch = 1;
+    m->end_epoch = 2;
+    m->user = "user";
+    m->bucket = "bucket";
+    ls.push_back(m);
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_trim_op)
@@ -1173,6 +1326,20 @@ struct cls_rgw_lc_set_entry_op {
       decode(entry, bl);
     }
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("bucket", entry.bucket);
+    f->dump_int("start_time", entry.start_time);
+    f->dump_int("status", entry.status);
+  }
+
+  static void generate_test_instances(std::list<cls_rgw_lc_set_entry_op*>& ls) {
+    ls.push_back(new cls_rgw_lc_set_entry_op);
+    ls.push_back(new cls_rgw_lc_set_entry_op);
+    ls.back()->entry.bucket = "foo";
+    ls.back()->entry.start_time = 123;
+    ls.back()->entry.status = 456;
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_set_entry_op)

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -56,6 +56,20 @@ void rgw_zone_set_entry::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("entry", s, obj);
   from_str(s);
 }
+void rgw_zone_set::dump(Formatter *f) const
+{
+  encode_json("entries", entries, f);
+}
+
+void rgw_zone_set::generate_test_instances(list<rgw_zone_set*>& o)
+{
+  o.push_back(new rgw_zone_set);
+  o.push_back(new rgw_zone_set);
+  std::optional<string> loc_key = "loc_key";
+  o.back()->insert("zone1", loc_key);
+  o.back()->insert("zone2", loc_key);
+  o.back()->insert("zone3", loc_key);
+}
 
 void rgw_zone_set::insert(const string& zone, std::optional<string> location_key)
 {

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -72,7 +72,8 @@ struct rgw_zone_set {
     /* no DECODE_START, DECODE_END for backward compatibility */
     ceph::decode(entries, bl);
   }
-
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_zone_set*>& o);
   void insert(const std::string& zone, std::optional<std::string> location_key);
   bool exists(const std::string& zone, std::optional<std::string> location_key) const;
 };

--- a/src/cls/rgw_gc/cls_rgw_gc_ops.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_ops.h
@@ -25,6 +25,16 @@ struct cls_rgw_gc_queue_init_op {
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("size", size);
+    f->dump_unsigned("num_deferred_entries", num_deferred_entries);
+  }
+
+  static void generate_test_instances(std::list<cls_rgw_gc_queue_init_op*>& o) {
+    o.push_back(new cls_rgw_gc_queue_init_op);
+    o.back()->size = 1024;
+    o.back()->num_deferred_entries = 512;
+  }
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_queue_init_op)
 

--- a/src/cls/rgw_gc/cls_rgw_gc_types.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_types.h
@@ -30,5 +30,22 @@ struct cls_rgw_gc_urgent_data
     decode(num_xattr_urgent_entries, bl);
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter *f) const {
+    f->open_object_section("urgent_data_map");
+    for (auto& i : urgent_data_map) {
+      f->dump_string(i.first.c_str(), i.first);
+    }
+    f->close_section();
+    f->dump_unsigned("num_urgent_data_entries", num_urgent_data_entries);
+    f->dump_unsigned("num_head_urgent_entries", num_head_urgent_entries);
+    f->dump_unsigned("num_xattr_urgent_entries", num_xattr_urgent_entries);
+  }
+  static void generate_test_instances(std::list<cls_rgw_gc_urgent_data*>& o) {
+    o.push_back(new cls_rgw_gc_urgent_data);
+    o.push_back(new cls_rgw_gc_urgent_data);
+    o.back()->num_urgent_data_entries = 1024;
+    o.back()->num_head_urgent_entries = 512;
+    o.back()->num_xattr_urgent_entries = 512;
+  }
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_urgent_data)

--- a/src/rgw/driver/rados/rgw_obj_manifest.cc
+++ b/src/rgw/driver/rados/rgw_obj_manifest.cc
@@ -346,6 +346,18 @@ void RGWObjManifestRule::dump(Formatter *f) const
   encode_json("override_prefix", override_prefix, f);
 }
 
+void RGWObjManifestRule::generate_test_instances(std::list<RGWObjManifestRule*>& o)
+{
+  RGWObjManifestRule *r = new RGWObjManifestRule;
+  r->start_part_num = 0;
+  r->start_ofs = 0;
+  r->part_size = 512 * 1024;
+  r->stripe_max_size = 512 * 1024 * 1024;
+  r->override_prefix = "override_prefix";
+  o.push_back(r);
+  o.push_back(new RGWObjManifestRule);
+}
+
 void rgw_obj_select::dump(Formatter *f) const
 {
   f->dump_string("placement_rule", placement_rule.to_str());
@@ -359,6 +371,20 @@ void RGWObjTier::dump(Formatter *f) const
   encode_json("name", name, f);
   encode_json("tier_placement", tier_placement, f);
   encode_json("is_multipart_upload", is_multipart_upload, f);
+}
+
+void RGWObjTier::generate_test_instances(std::list<RGWObjTier*>& o)
+{
+  RGWObjTier *t = new RGWObjTier;
+  t->name = "name";
+  std::list<RGWZoneGroupPlacementTier *> tiers;
+  RGWZoneGroupPlacementTier::generate_test_instances(tiers);
+  for (auto iter = tiers.begin(); iter != tiers.end(); ++iter) {
+    t->tier_placement = *(*iter);
+  }
+  t->is_multipart_upload = true;
+  o.push_back(t);
+  o.push_back(new RGWObjTier);
 }
 
 // returns true on success, false on failure

--- a/src/rgw/driver/rados/rgw_obj_manifest.h
+++ b/src/rgw/driver/rados/rgw_obj_manifest.h
@@ -154,6 +154,7 @@ struct RGWObjManifestRule {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWObjManifestRule*>& o);
 };
 WRITE_CLASS_ENCODER(RGWObjManifestRule)
 
@@ -180,6 +181,7 @@ struct RGWObjTier {
       DECODE_FINISH(bl);
     }
     void dump(Formatter *f) const;
+    static void generate_test_instances(std::list<RGWObjTier*>& o);
 };
 WRITE_CLASS_ENCODER(RGWObjTier)
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10081,3 +10081,9 @@ void RGWOLHPendingInfo::dump(Formatter *f) const
   encode_json("time", ut, f);
 }
 
+void RGWOLHPendingInfo::generate_test_instances(list<RGWOLHPendingInfo*>& o)
+{
+  auto it = new RGWOLHPendingInfo;
+  it->time = ceph::real_clock::zero();
+  o.push_back(it);
+}

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -131,6 +131,7 @@ struct RGWOLHPendingInfo {
   }
 
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWOLHPendingInfo*>& o);
 };
 WRITE_CLASS_ENCODER(RGWOLHPendingInfo)
 

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -51,6 +51,14 @@ struct RGWUID
     decode(s, bl);
     user_id.from_str(s);
   }
+  void dump(Formatter *f) const {
+    f->dump_string("user_id", user_id.to_str());
+  }
+  static void generate_test_instances(std::list<RGWUID*>& o) {
+    o.push_back(new RGWUID);
+    o.push_back(new RGWUID);
+    o.back()->user_id.from_str("test:tester");
+  }
 };
 WRITE_CLASS_ENCODER(RGWUID)
 

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -1502,3 +1502,10 @@ void RGWNameToId::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("obj_id", obj_id, obj);
 }
 
+void RGWNameToId::generate_test_instances(list<RGWNameToId*>& o) {
+  RGWNameToId *n = new RGWNameToId;
+  n->obj_id = "id";
+  o.push_back(n);
+  o.push_back(new RGWNameToId);
+}
+

--- a/src/rgw/rgw_acl_types.h
+++ b/src/rgw/rgw_acl_types.h
@@ -127,7 +127,7 @@ public:
   bool is_valid_cap_type(const std::string& tp);
   void dump(Formatter *f) const;
   void dump(Formatter *f, const char *name) const;
-
+  static void generate_test_instances(std::list<RGWUserCaps*>& o);
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(RGWUserCaps)

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -74,6 +74,15 @@ struct rgw_zone_id {
     ceph::decode(id, bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("id", id);
+  }
+
+  static void generate_test_instances(std::list<rgw_zone_id*>& o) {
+    o.push_back(new rgw_zone_id);
+    o.push_back(new rgw_zone_id("id"));
+  }
+
   void clear() {
     id.clear();
   }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2023,6 +2023,15 @@ void RGWUserCaps::dump(Formatter *f) const
   dump(f, "caps");
 }
 
+void RGWUserCaps::generate_test_instances(list<RGWUserCaps*>& o)
+{
+  o.push_back(new RGWUserCaps);
+  RGWUserCaps *caps = new RGWUserCaps;
+  caps->add_cap("read");
+  caps->add_cap("write");
+  o.push_back(caps);
+}
+
 void RGWUserCaps::dump(Formatter *f, const char *name) const
 {
   f->open_array_section(name);
@@ -2148,6 +2157,16 @@ void rgw_raw_obj::decode_from_rgw_obj(bufferlist::const_iterator& bl)
 
   get_obj_bucket_and_oid_loc(old_obj, oid, loc);
   pool = old_obj.get_explicit_data_pool();
+}
+
+void rgw_raw_obj::generate_test_instances(std::list<rgw_raw_obj*>& o)
+{
+  rgw_raw_obj *r = new rgw_raw_obj;
+  r->oid = "foo";
+  r->loc = "bar";
+  r->pool.name = "baz";
+  r->pool.ns = "ns";
+  o.push_back(r);
 }
 
 static struct rgw_name_to_flag op_type_mapping[] = { {"*",  RGW_OP_TYPE_ALL},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1368,6 +1368,17 @@ struct multipart_upload_info
     decode(dest_placement, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(Formatter *f) const {
+    dest_placement.dump(f);
+  }
+
+  static void generate_test_instances(std::list<multipart_upload_info*>& o) {
+    o.push_back(new multipart_upload_info);
+    o.push_back(new multipart_upload_info);
+    o.back()->dest_placement.name = "dest_placement";
+    o.back()->dest_placement.storage_class = "dest_storage_class";
+  }
 };
 WRITE_CLASS_ENCODER(multipart_upload_info)
 

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -234,3 +234,14 @@ void RGWCompressionInfo::dump(Formatter *f) const
   ::encode_json("blocks", blocks, f);
 }
 
+void RGWCompressionInfo::generate_test_instances(list<RGWCompressionInfo*>& o)
+{
+  RGWCompressionInfo *i = new RGWCompressionInfo;
+  i->compression_type = "type";
+  i->orig_size = 1024;
+  i->blocks.push_back(compression_block());
+  i->blocks.back().old_ofs = 0;
+  i->blocks.back().new_ofs = 0;
+  i->blocks.back().len = 1024;
+  o.push_back(i);
+}

--- a/src/rgw/rgw_compression_types.h
+++ b/src/rgw/rgw_compression_types.h
@@ -71,6 +71,7 @@ struct RGWCompressionInfo {
      DECODE_FINISH(bl);
   } 
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWCompressionInfo*>& o);
 };
 WRITE_CLASS_ENCODER(RGWCompressionInfo)
 

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -23,6 +23,7 @@
 #include "include/types.h"
 #include "common/debug.h"
 #include "include/str_list.h"
+#include "common/ceph_json.h"
 #include "common/Formatter.h"
 
 #include "rgw_cors.h"
@@ -40,6 +41,17 @@ void RGWCORSRule::dump_origins() {
   }
 }
 
+void RGWCORSRule::dump(Formatter *f) const
+{
+  f->open_object_section("CORSRule");
+  f->dump_string("ID", id);
+  f->dump_unsigned("MaxAgeSeconds", max_age);
+  f->dump_unsigned("AllowedMethod", allowed_methods);
+  encode_json("AllowedOrigin", allowed_origins, f);
+  encode_json("AllowedHeader", allowed_hdrs, f);
+  encode_json("ExposeHeader", exposable_hdrs, f);
+}
+
 void RGWCORSRule::erase_origin_if_present(string& origin, bool *rule_empty) {
   set<string>::iterator it = allowed_origins.find(origin);
   if (!rule_empty)
@@ -51,6 +63,20 @@ void RGWCORSRule::erase_origin_if_present(string& origin, bool *rule_empty) {
     allowed_origins.erase(it);
     *rule_empty = (allowed_origins.empty());
   }
+}
+
+void RGWCORSRule::generate_test_instances(list<RGWCORSRule*>& o)
+{
+  o.push_back(new RGWCORSRule);
+  o.push_back(new RGWCORSRule);
+  o.back()->id = "test";
+  o.back()->max_age = 100;
+  o.back()->allowed_methods = RGW_CORS_GET | RGW_CORS_PUT;
+  o.back()->allowed_origins.insert("http://origin1");
+  o.back()->allowed_origins.insert("http://origin2");
+  o.back()->allowed_hdrs.insert("accept-encoding");
+  o.back()->allowed_hdrs.insert("accept-language");
+  o.back()->exposable_hdrs.push_back("x-rgw-something");
 }
 
 /*

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -80,6 +80,7 @@ public:
     decode(exposable_hdrs, bl);
     DECODE_FINISH(bl);
   }
+  static void generate_test_instances(std::list<RGWCORSRule*>& o);
   bool has_wildcard_origin();
   bool is_origin_present(const char *o);
   void format_exp_headers(std::string& s);

--- a/src/rgw/rgw_obj_types.h
+++ b/src/rgw/rgw_obj_types.h
@@ -475,6 +475,7 @@ struct rgw_raw_obj {
   }
 
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_raw_obj*>& o);
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_raw_obj)

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -17,6 +17,15 @@ void DefaultRetention::decode_xml(XMLObj *obj) {
   }
 }
 
+void DefaultRetention::dump(Formatter *f) const {
+  f->dump_string("mode", mode);
+  if (days > 0) {
+    f->dump_int("days", days);
+  } else {
+    f->dump_int("years", years);
+  }
+}
+
 void DefaultRetention::dump_xml(Formatter *f) const {
   encode_xml("Mode", mode, f);
   if (days > 0) {
@@ -32,6 +41,17 @@ void ObjectLockRule::decode_xml(XMLObj *obj) {
 
 void ObjectLockRule::dump_xml(Formatter *f) const {
   encode_xml("DefaultRetention", defaultRetention, f);
+}
+
+void ObjectLockRule::dump(Formatter *f) const {
+  f->open_object_section("default_retention");
+  defaultRetention.dump(f);
+  f->close_section();
+}
+
+void ObjectLockRule::generate_test_instances(std::list<ObjectLockRule*>& o) {
+  ObjectLockRule *obj = new ObjectLockRule;
+  o.push_back(obj);
 }
 
 void RGWObjectLock::decode_xml(XMLObj *obj) {
@@ -54,6 +74,16 @@ void RGWObjectLock::dump_xml(Formatter *f) const {
   }
 }
 
+void RGWObjectLock::dump(Formatter *f) const {
+  f->dump_bool("enabled", enabled);
+  f->dump_bool("rule_exist", rule_exist);
+  if (rule_exist) {
+    f->open_object_section("rule");
+    rule.dump(f);
+    f->close_section();
+  }
+}
+
 ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime) const {
   if (!rule_exist) {
     return ceph::real_time();
@@ -62,6 +92,17 @@ ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime)
     return mtime + std::chrono::days(days);
   }
   return mtime + std::chrono::years(get_years());
+}
+
+void RGWObjectLock::generate_test_instances(list<RGWObjectLock*>& o) {
+  RGWObjectLock *obj = new RGWObjectLock;
+  obj->enabled = true;
+  obj->rule_exist = true;
+  o.push_back(obj);
+  obj = new RGWObjectLock;
+  obj->enabled = false;
+  obj->rule_exist = false;
+  o.push_back(obj);
 }
 
 void RGWObjectRetention::decode_xml(XMLObj *obj) {

--- a/src/rgw/rgw_object_lock.h
+++ b/src/rgw/rgw_object_lock.h
@@ -45,7 +45,7 @@ public:
     decode(years, bl);
     DECODE_FINISH(bl);
   }
-
+  void dump(Formatter *f) const;
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
 };
@@ -82,6 +82,8 @@ public:
 
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<ObjectLockRule*>& o);
 };
 WRITE_CLASS_ENCODER(ObjectLockRule)
 
@@ -141,6 +143,8 @@ public:
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
   ceph::real_time get_lock_until_date(const ceph::real_time& mtime) const;
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWObjectLock*>& o);
 };
 WRITE_CLASS_ENCODER(RGWObjectLock)
 

--- a/src/rgw/rgw_placement_types.h
+++ b/src/rgw/rgw_placement_types.h
@@ -89,6 +89,16 @@ struct rgw_placement_rule {
     from_str(s);
   }
 
+  void dump(Formatter *f) const {
+    f->dump_string("name", name);
+    f->dump_string("storage_class", get_storage_class());
+  }
+
+  static void generate_test_instances(std::list<rgw_placement_rule*>& o) {
+    o.push_back(new rgw_placement_rule);
+    o.push_back(new rgw_placement_rule("name", "storage_class"));
+  }
+
   std::string to_str() const {
     if (standard_storage_class()) {
       return name;

--- a/src/rgw/rgw_pool_types.h
+++ b/src/rgw/rgw_pool_types.h
@@ -90,6 +90,16 @@ struct rgw_pool {
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("name", name);
+    f->dump_string("ns", ns);
+  }
+
+  static void generate_test_instances(std::list<rgw_pool*>& o) {
+    o.push_back(new rgw_pool);
+    o.push_back(new rgw_pool("pool", "ns"));
+  }
+
   rgw_pool& operator=(const rgw_pool&) = default;
 
   bool operator==(const rgw_pool& p) const {

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1032,6 +1032,16 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_objects", max_objects);
 }
 
+void RGWQuotaInfo::generate_test_instances(std::list<RGWQuotaInfo*>& o)
+{
+  o.push_back(new RGWQuotaInfo);
+  o.push_back(new RGWQuotaInfo);
+  o.back()->enabled = true;
+  o.back()->check_on_raw = true;
+  o.back()->max_size = 1024;
+  o.back()->max_objects = 1;
+}
+
 void RGWQuotaInfo::decode_json(JSONObj *obj)
 {
   if (false == JSONDecoder::decode_json("max_size", max_size, obj)) {

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -75,7 +75,7 @@ public:
   }
 
   void dump(Formatter *f) const;
-
+  static void generate_test_instances(std::list<RGWQuotaInfo*>& o);
   void decode_json(JSONObj *obj);
 
 };

--- a/src/rgw/rgw_sync_policy.cc
+++ b/src/rgw/rgw_sync_policy.cc
@@ -774,6 +774,12 @@ void rgw_sync_policy_info::dump(Formatter *f) const
   }
 }
 
+void rgw_sync_policy_info::generate_test_instances(list<rgw_sync_policy_info*>& o)
+{
+  rgw_sync_policy_info *info = new rgw_sync_policy_info;
+  o.push_back(info);
+}
+
 void rgw_sync_policy_info::decode_json(JSONObj *obj)
 {
   vector<rgw_sync_policy_group> groups_vec;

--- a/src/rgw/rgw_sync_policy.h
+++ b/src/rgw/rgw_sync_policy.h
@@ -667,6 +667,7 @@ struct rgw_sync_policy_info {
   }
 
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_sync_policy_info*>& o);
   void decode_json(JSONObj *obj);
 
   bool empty() const {

--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -65,3 +65,12 @@ void RGWObjTags::dump(Formatter *f) const
   f->close_section();
 }
 
+void RGWObjTags::generate_test_instances(std::list<RGWObjTags*>& o)
+{
+  RGWObjTags *r = new RGWObjTags;
+  r->add_tag("key1","val1");
+  r->add_tag("key2","val2");
+  o.push_back(r);
+  o.push_back(new RGWObjTags);
+}
+

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -36,6 +36,7 @@ protected:
   }
 
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWObjTags*>& o);
   void add_tag(const std::string& key, const std::string& val="");
   void emplace_tag(std::string&& key, std::string&& val);
   int check_and_add_tag(const std::string& key, const std::string& val="");

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -770,6 +770,17 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
    * rather not clutter the output */
 }
 
+void RGWZonePlacementInfo::generate_test_instances(list<RGWZonePlacementInfo*>& o)
+{
+  o.push_back(new RGWZonePlacementInfo);
+  o.push_back(new RGWZonePlacementInfo);
+  o.back()->index_pool = rgw_pool("rgw.buckets.index");
+  
+  o.back()->data_extra_pool = rgw_pool("rgw.buckets.non-ec");
+  o.back()->index_type = rgw::BucketIndexType::Normal;
+  o.back()->inline_data = false;
+}
+
 void RGWZonePlacementInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("index_pool", index_pool, obj);
@@ -860,6 +871,11 @@ void RGWZoneStorageClasses::dump(Formatter *f) const
   }
 }
 
+void RGWZoneStorageClasses::generate_test_instances(list<RGWZoneStorageClasses*>& o)
+{
+  o.push_back(new RGWZoneStorageClasses);
+}
+
 void RGWZoneStorageClasses::decode_json(JSONObj *obj)
 {
   JSONFormattable f;
@@ -913,6 +929,14 @@ void RGWZoneStorageClass::dump(Formatter *f) const
   if (compression_type) {
     encode_json("compression_type", compression_type.get(), f);
   }
+}
+
+void RGWZoneStorageClass::generate_test_instances(list<RGWZoneStorageClass*>& o)
+{
+  o.push_back(new RGWZoneStorageClass);
+  o.push_back(new RGWZoneStorageClass);
+  o.back()->data_pool = rgw_pool("pool1");
+  o.back()->compression_type = "zlib";
 }
 
 void RGWZoneStorageClass::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -79,6 +79,7 @@ struct RGWNameToId {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWNameToId*>& o);
 };
 WRITE_CLASS_ENCODER(RGWNameToId)
 
@@ -122,6 +123,7 @@ struct RGWZoneStorageClass {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWZoneStorageClass*>& o);
 };
 WRITE_CLASS_ENCODER(RGWZoneStorageClass)
 
@@ -209,6 +211,7 @@ public:
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWZoneStorageClasses*>& o);
 };
 WRITE_CLASS_ENCODER(RGWZoneStorageClasses)
 
@@ -305,6 +308,7 @@ struct RGWZonePlacementInfo {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWZonePlacementInfo*>& o);
 
 };
 WRITE_CLASS_ENCODER(RGWZonePlacementInfo)
@@ -574,6 +578,12 @@ struct RGWZoneGroupPlacementTier {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWZoneGroupPlacementTier*>& o) {
+    o.push_back(new RGWZoneGroupPlacementTier);
+    o.push_back(new RGWZoneGroupPlacementTier);
+    o.back()->tier_type = "cloud-s3";
+    o.back()->storage_class = "STANDARD";
+  }
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTier)
 
@@ -621,5 +631,16 @@ struct RGWZoneGroupPlacementTarget {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<RGWZoneGroupPlacementTarget*>& o) {
+    o.push_back(new RGWZoneGroupPlacementTarget);
+    o.back()->storage_classes.insert("STANDARD");
+    o.push_back(new RGWZoneGroupPlacementTarget);
+    o.back()->name = "target";
+    o.back()->tags.insert("tag1");
+    o.back()->tags.insert("tag2");
+    o.back()->storage_classes.insert("STANDARD_IA");
+    o.back()->tier_targets["cloud-s3"].tier_type = "cloud-s3";
+    o.back()->tier_targets["cloud-s3"].storage_class = "STANDARD";
+  }
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -5,6 +5,7 @@ TYPE(RGWOLHInfo)
 TYPE(RGWObjManifestPart)
 TYPE(RGWObjManifest)
 TYPE(objexp_hint_entry)
+TYPE(RGWOLHPendingInfo)
 
 #include "rgw_zone.h"
 TYPE(RGWZoneParams)
@@ -13,6 +14,7 @@ TYPE(RGWZoneGroup)
 TYPE(RGWRealm)
 TYPE(RGWPeriod)
 TYPE(RGWPeriodLatestEpochInfo)
+TYPE(RGWNameToId)
 
 #include "rgw_acl.h"
 TYPE(ACLPermission)
@@ -33,6 +35,9 @@ TYPE(RGWLifecycleConfiguration)
 #include "cls/log/cls_log_types.h"
 TYPE(cls_log_entry)
 
+#include "cls/log/cls_log_ops.h"
+TYPE(cls_log_add_op)
+
 #include "cls/rgw/cls_rgw_types.h"
 TYPE(rgw_bucket_pending_info)
 TYPE(rgw_bucket_dir_entry_meta)
@@ -51,6 +56,7 @@ TYPE(rgw_usage_data)
 TYPE(rgw_usage_log_info)
 TYPE(rgw_user_bucket)
 TYPE(cls_rgw_lc_entry)
+TYPE(rgw_zone_set)
 
 #include "cls/rgw/cls_rgw_ops.h"
 TYPE(cls_rgw_lc_get_entry_ret)
@@ -86,6 +92,28 @@ TYPE(cls_rgw_reshard_remove_op)
 TYPE(cls_rgw_set_bucket_resharding_op)
 TYPE(cls_rgw_clear_bucket_resharding_op)
 TYPE(cls_rgw_lc_obj_head)
+TYPE(rgw_cls_bi_get_op)
+TYPE(rgw_cls_bi_get_ret)
+TYPE(rgw_cls_bi_list_op)
+TYPE(rgw_cls_bi_list_ret)
+TYPE(rgw_cls_bi_put_op)
+TYPE(rgw_cls_obj_check_attrs_prefix)
+TYPE(rgw_cls_obj_remove_op)
+TYPE(rgw_cls_obj_store_pg_ver_op)
+TYPE(rgw_cls_usage_log_add_op)
+TYPE(rgw_cls_usage_log_read_op)
+TYPE(rgw_cls_usage_log_read_ret)
+TYPE(rgw_cls_usage_log_trim_op)
+TYPE(cls_rgw_guard_bucket_resharding_op)
+TYPE(cls_rgw_lc_set_entry_op)
+
+#include "cls/rgw_gc/cls_rgw_gc_ops.h"
+TYPE(cls_rgw_gc_queue_init_op)
+#include "cls/rgw_gc/cls_rgw_gc_types.h"
+TYPE(cls_rgw_gc_urgent_data)
+
+
+
 
 #include "cls/rgw/cls_rgw_client.h"
 TYPE(rgw_bi_log_entry)
@@ -112,6 +140,14 @@ TYPE(cls::journal::ObjectPosition)
 TYPE(cls::journal::ObjectSetPosition)
 TYPE(cls::journal::Client)
 TYPE(cls::journal::Tag)
+using namespace cls::journal;
+TYPE(ObjectSetPosition)
+TYPE(ObjectPosition)
+TYPE(Tag)
+TYPE(Client)
+
+#include "cls/version/cls_version_types.h"
+TYPE(obj_version)
 
 #include "rgw_common.h"
 TYPE(RGWAccessKey)
@@ -121,6 +157,9 @@ TYPE(rgw_bucket)
 TYPE(RGWBucketInfo)
 TYPE(RGWBucketEnt)
 TYPE(rgw_obj)
+TYPE(RGWBucketEntryPoint)
+TYPE(multipart_upload_info)
+
 
 #include "rgw_log.h"
 TYPE(rgw_log_entry)
@@ -146,5 +185,55 @@ TYPE(rgw_data_sync_status)
 
 #include "rgw_bucket_encryption.h"
 TYPE(RGWBucketEncryptionConfig)
+
+#include "rgw_compression_types.h"
+TYPE(RGWCompressionInfo)
+
+#include "rgw_cors.h"
+TYPE(RGWCORSRule)
+
+#include "rgw_object_lock.h"
+TYPE(RGWObjectLock)
+TYPE(ObjectLockRule)
+
+
+#include "rgw_obj_types.h"
+TYPE(rgw_obj_index_key)
+TYPE(rgw_raw_obj)
+
+#include "rgw_obj_manifest.h"
+TYPE(RGWObjManifestRule)
+TYPE(RGWObjTier)
+
+#include "rgw_tag.h"
+TYPE(RGWObjTags)
+
+#include "rgw_placement_types.h"
+TYPE(rgw_placement_rule)
+
+#include "rgw_pool_types.h"
+TYPE(rgw_pool)
+
+#include "rgw_quota_types.h"
+TYPE(RGWQuotaInfo)
+
+
+#include "rgw_sync_policy.h"
+TYPE(rgw_sync_policy_info)
+
+#include "rgw_basic_types.h"
+TYPE(rgw_zone_id)
+TYPE(RGWZoneStorageClass)
+TYPE(RGWZoneStorageClasses)
+TYPE(RGWZonePlacementInfo)
+TYPE(RGWZoneGroupPlacementTarget)
+TYPE(RGWUserCaps)
+
+
+#include "rgw_user.h"
+TYPE(RGWUID)
+
+#include "rgw_user_types.h"
+TYPE(rgw_user)
 
 #endif


### PR DESCRIPTION
Currently, ceph-dencoder lacks certain rgw types, preventing us from accurately checking the ceph corpus for encode-decode mismatches. This pull request aims to address this issue by adding the missing types to ceph-dencoder.

To successfully incorporate these types into ceph-dencoder, we need to introduce the necessary `dump` and `generate_test_instances` functions that was missing in some types. These functions are essential for proper encode and decode of the added types.

This PR will enhance the functionality of ceph-dencoder by including the missing types, enabling a comprehensive analysis of encode-decode consistency. With the addition of these types, we can ensure the robustness and correctness of the ceph corpus.

This update will significantly contribute to improving the overall reliability and accuracy of ceph-dencoder. It allows for a more comprehensive assessment of the encode-decode behavior, leading to enhanced data integrity and stability within the ceph ecosystem.

Fixes: https://tracker.ceph.com/issues/61788





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
