### PR TITLE
mds: fix deadlock between unlinking and linkmerge

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -108,8 +108,6 @@ ostream& operator<<(ostream& out, const CDentry& dn)
   out << " state=" << dn.get_state();
   if (dn.is_new()) out << "|new";
   if (dn.state_test(CDentry::STATE_BOTTOMLRU)) out << "|bottomlru";
-  if (dn.state_test(CDentry::STATE_UNLINKING)) out << "|unlinking";
-  if (dn.state_test(CDentry::STATE_REINTEGRATING)) out << "|reintegrating";
 
   if (dn.get_num_ref()) {
     out << " |";

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -87,7 +87,6 @@ public:
   static const int STATE_PURGINGPINNED =  (1<<5);
   static const int STATE_BOTTOMLRU =    (1<<6);
   static const int STATE_UNLINKING =    (1<<7);
-  static const int STATE_REINTEGRATING = (1<<8);
   // stray dentry needs notification of releasing reference
   static const int STATE_STRAY =	STATE_NOTIFYREF;
   static const int MASK_STATE_IMPORT_KEPT = STATE_BOTTOMLRU;
@@ -101,9 +100,8 @@ public:
 
   static const unsigned EXPORT_NONCE = 1;
 
-  const static uint64_t WAIT_UNLINK_STATE       = (1<<0);
-  const static uint64_t WAIT_UNLINK_FINISH      = (1<<1);
-  const static uint64_t WAIT_REINTEGRATE_FINISH = (1<<2);
+  const static uint64_t WAIT_UNLINK_STATE  = (1<<0);
+  const static uint64_t WAIT_UNLINK_FINISH = (1<<1);
   uint32_t replica_unlinking_ref = 0;
 
   CDentry(std::string_view n, __u32 h,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -29,7 +29,6 @@
 #include "BatchOp.h"
 #include "MDSCacheObject.h"
 #include "MDSContext.h"
-#include "Mutation.h"
 #include "SimpleLock.h"
 #include "LocalLockC.h"
 #include "ScrubHeader.h"
@@ -86,23 +85,18 @@ public:
   static const int STATE_EVALUATINGSTRAY = (1<<4);
   static const int STATE_PURGINGPINNED =  (1<<5);
   static const int STATE_BOTTOMLRU =    (1<<6);
-  static const int STATE_UNLINKING =    (1<<7);
   // stray dentry needs notification of releasing reference
   static const int STATE_STRAY =	STATE_NOTIFYREF;
   static const int MASK_STATE_IMPORT_KEPT = STATE_BOTTOMLRU;
 
   // -- pins --
-  static const int PIN_INODEPIN =         1;  // linked inode is pinned
-  static const int PIN_FRAGMENTING =     -2;  // containing dir is refragmenting
-  static const int PIN_PURGING =          3;
-  static const int PIN_SCRUBPARENT =      4;
-  static const int PIN_WAITUNLINKSTATE  = 5;
+  static const int PIN_INODEPIN =     1;  // linked inode is pinned
+  static const int PIN_FRAGMENTING = -2;  // containing dir is refragmenting
+  static const int PIN_PURGING =      3;
+  static const int PIN_SCRUBPARENT =  4;
 
   static const unsigned EXPORT_NONCE = 1;
 
-  const static uint64_t WAIT_UNLINK_STATE  = (1<<0);
-  const static uint64_t WAIT_UNLINK_FINISH = (1<<1);
-  uint32_t replica_unlinking_ref = 0;
 
   CDentry(std::string_view n, __u32 h,
           mempool::mds_co::string alternate_name,
@@ -141,7 +135,6 @@ public:
     case PIN_FRAGMENTING: return "fragmenting";
     case PIN_PURGING: return "purging";
     case PIN_SCRUBPARENT: return "scrubparent";
-    case PIN_WAITUNLINKSTATE: return "waitunlinkstate";
     default: return generic_pin_name(p);
     }
   }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -398,8 +398,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const uint64_t WAIT_FROZEN      = (1<<1);
   static const uint64_t WAIT_TRUNC       = (1<<2);
   static const uint64_t WAIT_FLOCK       = (1<<3);
-  static const uint64_t WAIT_UNLINK      = (1<<4);
-
+  
   static const uint64_t WAIT_ANY_MASK	= (uint64_t)(-1);
 
   // misc

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11337,11 +11337,6 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
       }
       ceph_assert(dnl->is_null());
       dn->state_clear(CDentry::STATE_UNLINKING);
-
-      MDSContext::vec finished;
-      dn->take_waiting(CDentry::WAIT_UNLINK_FINISH, finished);
-      mds->queue_waiters(finished);
-
     }
   }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8223,10 +8223,6 @@ void MDCache::dispatch(const cref_t<Message> &m)
   case MSG_MDS_DENTRYUNLINK:
     handle_dentry_unlink(ref_cast<MDentryUnlink>(m));
     break;
-  case MSG_MDS_DENTRYUNLINK_ACK:
-    handle_dentry_unlink_ack(ref_cast<MDentryUnlinkAck>(m));
-    break;
-
 
   case MSG_MDS_FRAGMENTNOTIFY:
     handle_fragment_notify(ref_cast<MMDSFragmentNotify>(m));
@@ -11215,8 +11211,7 @@ void MDCache::handle_dentry_link(const cref_t<MDentryLink> &m)
 
 // UNLINK
 
-void MDCache::send_dentry_unlink(CDentry *dn, CDentry *straydn,
-                                 MDRequestRef& mdr, bool unlinking)
+void MDCache::send_dentry_unlink(CDentry *dn, CDentry *straydn, MDRequestRef& mdr)
 {
   dout(10) << __func__ << " " << *dn << dendl;
   // share unlink news with replicas
@@ -11227,11 +11222,6 @@ void MDCache::send_dentry_unlink(CDentry *dn, CDentry *straydn,
     straydn->list_replicas(replicas);
     CInode *strayin = straydn->get_linkage()->get_inode();
     strayin->encode_snap_blob(snapbl);
-  }
-
-  if (unlinking) {
-    ceph_assert(!straydn);
-    dn->replica_unlinking_ref = 0;
   }
   for (set<mds_rank_t>::iterator it = replicas.begin();
        it != replicas.end();
@@ -11245,21 +11235,12 @@ void MDCache::send_dentry_unlink(CDentry *dn, CDentry *straydn,
 	 rejoin_gather.count(*it)))
       continue;
 
-    auto unlink = make_message<MDentryUnlink>(dn->get_dir()->dirfrag(),
-                                              dn->get_name(), unlinking);
+    auto unlink = make_message<MDentryUnlink>(dn->get_dir()->dirfrag(), dn->get_name());
     if (straydn) {
       encode_replica_stray(straydn, *it, unlink->straybl);
       unlink->snapbl = snapbl;
     }
     mds->send_message_mds(unlink, *it);
-    if (unlinking) {
-      dn->replica_unlinking_ref++;
-      dn->get(CDentry::PIN_WAITUNLINKSTATE);
-    }
-  }
-
-  if (unlinking && dn->replica_unlinking_ref) {
-    dn->add_waiter(CDentry::WAIT_UNLINK_STATE, new C_MDS_RetryRequest(this, mdr));
   }
 }
 
@@ -11268,40 +11249,23 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
   // straydn
   CDentry *straydn = nullptr;
   CInode *strayin = nullptr;
-
   if (m->straybl.length())
     decode_replica_stray(straydn, &strayin, m->straybl, mds_rank_t(m->get_source().num()));
-
-  boost::intrusive_ptr<MDentryUnlinkAck> ack;
-  CDentry::linkage_t *dnl;
-  CDentry *dn;
-  CInode *in;
-  bool hadrealm;
 
   CDir *dir = get_dirfrag(m->get_dirfrag());
   if (!dir) {
     dout(7) << __func__ << " don't have dirfrag " << m->get_dirfrag() << dendl;
-    if (m->is_unlinking())
-      goto ack;
   } else {
-    dn = dir->lookup(m->get_dn());
+    CDentry *dn = dir->lookup(m->get_dn());
     if (!dn) {
       dout(7) << __func__ << " don't have dentry " << *dir << " dn " << m->get_dn() << dendl;
-      if (m->is_unlinking())
-        goto ack;
     } else {
       dout(7) << __func__ << " on " << *dn << dendl;
-
-      if (m->is_unlinking()) {
-        dn->state_set(CDentry::STATE_UNLINKING);
-        goto ack;
-      }
-
-      dnl = dn->get_linkage();
+      CDentry::linkage_t *dnl = dn->get_linkage();
 
       // open inode?
       if (dnl->is_primary()) {
-	in = dnl->get_inode();
+	CInode *in = dnl->get_inode();
 	dn->dir->unlink_inode(dn);
 	ceph_assert(straydn);
 	straydn->dir->link_primary_inode(straydn, in);
@@ -11312,12 +11276,11 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
 	in->first = straydn->first;
 
 	// update subtree map?
-	if (in->is_dir()) {
+	if (in->is_dir()) 
 	  adjust_subtree_after_rename(in, dir, false);
-	}
 
 	if (m->snapbl.length()) {
-	  hadrealm = (in->snaprealm ? true : false);
+	  bool hadrealm = (in->snaprealm ? true : false);
 	  in->decode_snap_blob(m->snapbl);
 	  ceph_assert(in->snaprealm);
 	  if (!hadrealm)
@@ -11328,7 +11291,7 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
 	if (in->is_any_caps() &&
 	    !in->state_test(CInode::STATE_EXPORTINGCAPS))
 	  migrator->export_caps(in);
-
+	
 	straydn = NULL;
       } else {
 	ceph_assert(!straydn);
@@ -11336,7 +11299,6 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
 	dn->dir->unlink_inode(dn);
       }
       ceph_assert(dnl->is_null());
-      dn->state_clear(CDentry::STATE_UNLINKING);
     }
   }
 
@@ -11348,36 +11310,8 @@ void MDCache::handle_dentry_unlink(const cref_t<MDentryUnlink> &m)
     trim_dentry(straydn, ex);
     send_expire_messages(ex);
   }
-  return;
-
-ack:
-  ack = make_message<MDentryUnlinkAck>(m->get_dirfrag(), m->get_dn());
-  mds->send_message(ack, m->get_connection());
 }
 
-void MDCache::handle_dentry_unlink_ack(const cref_t<MDentryUnlinkAck> &m)
-{
-  CDir *dir = get_dirfrag(m->get_dirfrag());
-  if (!dir) {
-    dout(7) << __func__ << " don't have dirfrag " << m->get_dirfrag() << dendl;
-  } else {
-    CDentry *dn = dir->lookup(m->get_dn());
-    if (!dn) {
-      dout(7) << __func__ << " don't have dentry " << *dir << " dn " << m->get_dn() << dendl;
-    } else {
-      dout(7) << __func__ << " on " << *dn << " ref "
-	      << dn->replica_unlinking_ref << " -> "
-	      << dn->replica_unlinking_ref - 1 << dendl;
-      dn->replica_unlinking_ref--;
-      if (!dn->replica_unlinking_ref) {
-        MDSContext::vec finished;
-        dn->take_waiting(CDentry::WAIT_UNLINK_STATE, finished);
-        mds->queue_waiters(finished);
-      }
-      dn->put(CDentry::PIN_WAITUNLINKSTATE);
-    }
-  }
-}
 
 
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -914,7 +914,7 @@ class MDCache {
   void encode_remote_dentry_link(CDentry::linkage_t *dnl, bufferlist& bl);
   void decode_remote_dentry_link(CDir *dir, CDentry *dn, bufferlist::const_iterator& p);
   void send_dentry_link(CDentry *dn, MDRequestRef& mdr);
-  void send_dentry_unlink(CDentry *dn, CDentry *straydn, MDRequestRef& mdr, bool unlinking=false);
+  void send_dentry_unlink(CDentry *dn, CDentry *straydn, MDRequestRef& mdr);
 
   void wait_for_uncommitted_fragment(dirfrag_t dirfrag, MDSContext *c) {
     uncommitted_fragments.at(dirfrag).waiters.push_back(c);
@@ -1157,7 +1157,6 @@ class MDCache {
   void handle_discover_reply(const cref_t<MDiscoverReply> &m);
   void handle_dentry_link(const cref_t<MDentryLink> &m);
   void handle_dentry_unlink(const cref_t<MDentryUnlink> &m);
-  void handle_dentry_unlink_ack(const cref_t<MDentryUnlinkAck> &m);
 
   int dump_cache(std::string_view fn, Formatter *f, double timeout);
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1185,7 +1185,6 @@ bool MDSRank::is_valid_message(const cref_t<Message> &m) {
       type == CEPH_MSG_CLIENT_RECONNECT ||
       type == CEPH_MSG_CLIENT_RECLAIM ||
       type == CEPH_MSG_CLIENT_REQUEST ||
-      type == CEPH_MSG_CLIENT_REPLY ||
       type == MSG_MDS_PEER_REQUEST ||
       type == MSG_MDS_HEARTBEAT ||
       type == MSG_MDS_TABLE_REQUEST ||
@@ -1239,7 +1238,6 @@ void MDSRank::handle_message(const cref_t<Message> &m)
       ALLOW_MESSAGES_FROM(CEPH_ENTITY_TYPE_CLIENT);
       // fall-thru
     case CEPH_MSG_CLIENT_REQUEST:
-    case CEPH_MSG_CLIENT_REPLY:
       server->dispatch(m);
       break;
     case MSG_MDS_PEER_REQUEST:

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -151,29 +151,6 @@ class Finisher;
 class ScrubStack;
 class C_ExecAndReply;
 
-struct MDSMetaRequest {
-private:
-  int _op;
-  CDentry *_dentry;
-  ceph_tid_t _tid;
-public:
-  explicit MDSMetaRequest(int op, CDentry *dn, ceph_tid_t tid) :
-    _op(op), _dentry(dn), _tid(tid) {
-    if (_dentry) {
-      _dentry->get(CDentry::PIN_PURGING);
-    }
-  }
-  ~MDSMetaRequest() {
-    if (_dentry) {
-      _dentry->put(CDentry::PIN_PURGING);
-    }
-  }
-
-  CDentry *get_dentry() { return _dentry; }
-  int get_op() { return _op; }
-  ceph_tid_t get_tid() { return _tid; }
-};
-
 /**
  * The public part of this class's interface is what's exposed to all
  * the various subsystems (server, mdcache, etc), such as pointers
@@ -438,8 +415,6 @@ class MDSRank {
 
     PerfCounters *logger = nullptr, *mlogger = nullptr;
     OpTracker op_tracker;
-
-    std::map<ceph_tid_t, MDSMetaRequest> internal_client_requests;
 
     // The last different state I held before current
     MDSMap::DaemonState last_state = MDSMap::STATE_BOOT;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7260,7 +7260,9 @@ void Server::handle_client_link(MDRequestRef& mdr)
   SnapRealm *target_realm = target_pin->find_snaprealm();
   if (target_pin != dir->inode &&
       target_realm->get_subvolume_ino() !=
-      dir->inode->find_snaprealm()->get_subvolume_ino()) {
+      dir->inode->find_snaprealm()->get_subvolume_ino() &&
+      /* The inode is temporarily located in the stray dir pending reintegration */
+      !target_pin->is_stray()) {
     dout(7) << "target is in different subvolume, failing..." << dendl;
     respond_to_request(mdr, -CEPHFS_EXDEV);
     return;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -31,7 +31,6 @@
 #include "Mutation.h"
 #include "MetricsHandler.h"
 #include "cephfs_features.h"
-#include "MDSContext.h"
 
 #include "msg/Messenger.h"
 
@@ -360,9 +359,6 @@ void Server::dispatch(const cref_t<Message> &m)
     return;
   case CEPH_MSG_CLIENT_REQUEST:
     handle_client_request(ref_cast<MClientRequest>(m));
-    return;
-  case CEPH_MSG_CLIENT_REPLY:
-    handle_client_reply(ref_cast<MClientReply>(m));
     return;
   case CEPH_MSG_CLIENT_RECLAIM:
     handle_client_reclaim(ref_cast<MClientReclaim>(m));
@@ -2326,10 +2322,6 @@ void Server::reply_client_request(MDRequestRef& mdr, const ref_t<MClientReply> &
     mds->send_message_client(reply, session);
   }
 
-  if (client_inst.name.is_mds() && reply->get_op() == CEPH_MDS_OP_RENAME) {
-    mds->send_message(reply, mdr->client_request->get_connection());
-  }
-
   if (req->is_queued_for_replay() &&
       (mdr->has_completed || reply->get_result() < 0)) {
     if (reply->get_result() < 0) {
@@ -2560,38 +2552,6 @@ void Server::handle_client_request(const cref_t<MClientRequest> &req)
 
   dispatch_client_request(mdr);
   return;
-}
-
-void Server::handle_client_reply(const cref_t<MClientReply> &reply)
-{
-  dout(4) << "handle_client_reply " << *reply << dendl;
-
-  ceph_assert(reply->is_safe());
-  ceph_tid_t tid = reply->get_tid();
-
-  if (mds->internal_client_requests.count(tid) == 0) {
-    dout(1) << " no pending request on tid " << tid << dendl;
-    return;
-  }
-
-  auto &req = mds->internal_client_requests.at(tid);
-  CDentry *dn = req.get_dentry();
-
-  switch (reply->get_op()) {
-  case CEPH_MDS_OP_RENAME:
-    if (dn) {
-      dn->state_clear(CDentry::STATE_REINTEGRATING);
-
-      MDSContext::vec finished;
-      dn->take_waiting(CDentry::WAIT_REINTEGRATE_FINISH, finished);
-      mds->queue_waiters(finished);
-    }
-    break;
-  default:
-    dout(5) << " unknown client op " << reply->get_op() << dendl;
-  }
-
-  mds->internal_client_requests.erase(tid);
 }
 
 void Server::handle_osd_map()
@@ -6927,45 +6887,6 @@ void Server::wait_for_pending_unlink(CDentry *dn, MDRequestRef& mdr)
   dn->add_waiter(CDentry::WAIT_UNLINK_FINISH, new C_WaitUnlinkToFinish(mdcache, dn, fin));
 }
 
-struct C_WaitReintegrateToFinish : public MDSContext {
-protected:
-  MDCache *mdcache;
-  CDentry *dn;
-  MDSContext *fin;
-
-  MDSRank *get_mds() override
-  {
-    ceph_assert(mdcache != NULL);
-    return mdcache->mds;
-  }
-
-public:
-  C_WaitReintegrateToFinish(MDCache *m, CDentry *d, MDSContext *f) :
-    mdcache(m), dn(d), fin(f) {}
-  void finish(int r) override {
-    fin->complete(r);
-    dn->put(CDentry::PIN_PURGING);
-  }
-};
-
-bool Server::is_reintegrate_pending(CDentry *dn)
-{
-  CDentry::linkage_t *dnl = dn->get_projected_linkage();
-  if (!dnl->is_null() && dn->state_test(CDentry::STATE_REINTEGRATING)) {
-      return true;
-  }
-  return false;
-}
-
-void Server::wait_for_pending_reintegrate(CDentry *dn, MDRequestRef& mdr)
-{
-  dout(20) << __func__ << " dn " << *dn << dendl;
-  mds->locker->drop_locks(mdr.get());
-  auto fin = new C_MDS_RetryRequest(mdcache, mdr);
-  dn->get(CDentry::PIN_PURGING);
-  dn->add_waiter(CDentry::WAIT_REINTEGRATE_FINISH, new C_WaitReintegrateToFinish(mdcache, dn, fin));
-}
-
 // MKNOD
 
 class C_MDS_mknod_finish : public ServerLogContext {
@@ -8019,11 +7940,6 @@ void Server::handle_client_unlink(MDRequestRef& mdr)
   CDentry *dn = rdlock_path_xlock_dentry(mdr, false, true);
   if (!dn)
     return;
-
-  if (is_reintegrate_pending(dn)) {
-    wait_for_pending_reintegrate(dn, mdr);
-    return;
-  }
 
   // notify replica MDSes the dentry is under unlink
   if (!dn->state_test(CDentry::STATE_UNLINKING)) {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2006,23 +2006,20 @@ void Server::journal_and_reply(MDRequestRef& mdr, CInode *in, CDentry *dn, LogEv
     mdr->pin(dn);
 
   early_reply(mdr, in, dn);
-
+  
   mdr->committing = true;
   submit_mdlog_entry(le, fin, mdr, __func__);
-
+  
   if (mdr->client_request && mdr->client_request->is_queued_for_replay()) {
     if (mds->queue_one_replay()) {
       dout(10) << " queued next replay op" << dendl;
     } else {
       dout(10) << " journaled last replay op" << dendl;
     }
-  } else if (mdr->did_early_reply) {
+  } else if (mdr->did_early_reply)
     mds->locker->drop_rdlocks_for_early_reply(mdr.get());
-    if (dn && dn->is_waiter_for(CDentry::WAIT_UNLINK_FINISH))
-      mdlog->flush();
-  } else {
+  else
     mdlog->flush();
-  }
 }
 
 void Server::submit_mdlog_entry(LogEvent *le, MDSLogContextBase *fin, MDRequestRef& mdr,
@@ -4581,11 +4578,6 @@ void Server::handle_client_openc(MDRequestRef& mdr)
   if (!dn)
     return;
 
-  if (is_unlink_pending(dn)) {
-    wait_for_pending_unlink(dn, mdr);
-    return;
-  }
-
   CDentry::linkage_t *dnl = dn->get_projected_linkage();
   if (!excl && !dnl->is_null()) {
     // it existed.
@@ -6848,44 +6840,6 @@ void Server::handle_client_getvxattr(MDRequestRef& mdr)
 
 // ------------------------------------------------
 
-struct C_WaitUnlinkToFinish : public MDSContext {
-protected:
-  MDCache *mdcache;
-  CDentry *dn;
-  MDSContext *fin;
-
-  MDSRank *get_mds() override
-  {
-    ceph_assert(mdcache != NULL);
-    return mdcache->mds;
-  }
-
-public:
-  C_WaitUnlinkToFinish(MDCache *m, CDentry *d, MDSContext *f) :
-    mdcache(m), dn(d), fin(f) {}
-  void finish(int r) override {
-    fin->complete(r);
-    dn->put(CDentry::PIN_PURGING);
-  }
-};
-
-bool Server::is_unlink_pending(CDentry *dn)
-{
-  CDentry::linkage_t *dnl = dn->get_projected_linkage();
-  if (!dnl->is_null() && dn->state_test(CDentry::STATE_UNLINKING)) {
-      return true;
-  }
-  return false;
-}
-
-void Server::wait_for_pending_unlink(CDentry *dn, MDRequestRef& mdr)
-{
-  mds->locker->drop_locks(mdr.get());
-  auto fin = new C_MDS_RetryRequest(mdcache, mdr);
-  dn->get(CDentry::PIN_PURGING);
-  dn->add_waiter(CDentry::WAIT_UNLINK_FINISH, new C_WaitUnlinkToFinish(mdcache, dn, fin));
-}
-
 // MKNOD
 
 class C_MDS_mknod_finish : public ServerLogContext {
@@ -6951,11 +6905,6 @@ void Server::handle_client_mknod(MDRequestRef& mdr)
   CDentry *dn = rdlock_path_xlock_dentry(mdr, true, false, false, S_ISREG(mode));
   if (!dn)
     return;
-
-  if (is_unlink_pending(dn)) {
-    wait_for_pending_unlink(dn, mdr);
-    return;
-  }
 
   CDir *dir = dn->get_dir();
   CInode *diri = dir->get_inode();
@@ -7054,11 +7003,6 @@ void Server::handle_client_mkdir(MDRequestRef& mdr)
   if (!dn)
     return;
 
-  if (is_unlink_pending(dn)) {
-    wait_for_pending_unlink(dn, mdr);
-    return;
-  }
-
   CDir *dir = dn->get_dir();
   CInode *diri = dir->get_inode();
 
@@ -7152,11 +7096,6 @@ void Server::handle_client_symlink(MDRequestRef& mdr)
   CDentry *dn = rdlock_path_xlock_dentry(mdr, true);
   if (!dn)
     return;
-
-  if (is_unlink_pending(dn)) {
-    wait_for_pending_unlink(dn, mdr);
-    return;
-  }
 
   CDir *dir = dn->get_dir();
   CInode *diri = dir->get_inode();
@@ -7266,11 +7205,6 @@ void Server::handle_client_link(MDRequestRef& mdr)
     }
 
     targeti = ret.second->get_projected_linkage()->get_inode();
-  }
-
-  if (is_unlink_pending(destdn)) {
-    wait_for_pending_unlink(destdn, mdr);
-    return;
   }
 
   ceph_assert(destdn->get_projected_linkage()->is_null());
@@ -7555,17 +7489,11 @@ void Server::_link_remote_finish(MDRequestRef& mdr, bool inc,
   mdr->apply();
 
   MDRequestRef null_ref;
-  if (inc) {
+  if (inc)
     mdcache->send_dentry_link(dn, null_ref);
-  } else {
-    dn->state_clear(CDentry::STATE_UNLINKING);
+  else
     mdcache->send_dentry_unlink(dn, NULL, null_ref);
-
-    MDSContext::vec finished;
-    dn->take_waiting(CDentry::WAIT_UNLINK_FINISH, finished);
-    mdcache->mds->queue_waiters(finished);
-  }
-
+  
   // bump target popularity
   mds->balancer->hit_inode(targeti, META_POP_IWR);
   mds->balancer->hit_dir(dn->get_dir(), META_POP_IWR);
@@ -7935,19 +7863,9 @@ void Server::handle_client_unlink(MDRequestRef& mdr)
 
   if (rmdir)
     mdr->disable_lock_cache();
-
   CDentry *dn = rdlock_path_xlock_dentry(mdr, false, true);
   if (!dn)
     return;
-
-  // notify replica MDSes the dentry is under unlink
-  if (!dn->state_test(CDentry::STATE_UNLINKING)) {
-    dn->state_set(CDentry::STATE_UNLINKING);
-    mdcache->send_dentry_unlink(dn, nullptr, mdr, true);
-    if (dn->replica_unlinking_ref) {
-      return;
-    }
-  }
 
   CDentry::linkage_t *dnl = dn->get_linkage(client, mdr);
   ceph_assert(!dnl->is_null());
@@ -8222,14 +8140,9 @@ void Server::_unlink_local_finish(MDRequestRef& mdr,
   }
 
   mdr->apply();
-
-  dn->state_clear(CDentry::STATE_UNLINKING);
+  
   mdcache->send_dentry_unlink(dn, straydn, mdr);
-
-  MDSContext::vec finished;
-  dn->take_waiting(CDentry::WAIT_UNLINK_FINISH, finished);
-  mdcache->mds->queue_waiters(finished);
-
+  
   if (straydn) {
     // update subtree map?
     if (strayin->is_dir())
@@ -8244,7 +8157,7 @@ void Server::_unlink_local_finish(MDRequestRef& mdr,
 
   // reply
   respond_to_request(mdr, 0);
-
+  
   // removing a new dn?
   dn->get_dir()->try_remove_unlinked_dn(dn);
 
@@ -8699,16 +8612,6 @@ void Server::handle_client_rename(MDRequestRef& mdr)
   auto [destdn, srcdn] = rdlock_two_paths_xlock_destdn(mdr, true);
   if (!destdn)
     return;
-
-  if (is_unlink_pending(destdn)) {
-    wait_for_pending_unlink(destdn, mdr);
-    return;
-  }
-
-  if (is_unlink_pending(srcdn)) {
-    wait_for_pending_unlink(srcdn, mdr);
-    return;
-  }
 
   dout(10) << " destdn " << *destdn << dendl;
   CDir *destdir = destdn->get_dir();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7407,13 +7407,6 @@ void Server::handle_client_link(MDRequestRef& mdr)
   if (target_pin != dir->inode &&
       target_realm->get_subvolume_ino() !=
       dir->inode->find_snaprealm()->get_subvolume_ino()) {
-    if (target_pin->is_stray()) {
-      mds->locker->drop_locks(mdr.get());
-      targeti->add_waiter(CInode::WAIT_UNLINK,
-                          new C_MDS_RetryRequest(mdcache, mdr));
-      mdlog->flush();
-      return;
-    }
     dout(7) << "target is in different subvolume, failing..." << dendl;
     respond_to_request(mdr, -CEPHFS_EXDEV);
     return;
@@ -9223,12 +9216,6 @@ void Server::handle_client_rename(MDRequestRef& mdr)
   C_MDS_rename_finish *fin = new C_MDS_rename_finish(this, mdr, srcdn, destdn, straydn);
 
   journal_and_reply(mdr, srci, destdn, le, fin);
-
-  // trigger to flush mdlog in case reintegrating or migrating the stray dn,
-  // because the link requests maybe waiting.
-  if (srcdn->get_dir()->inode->is_stray()) {
-    mdlog->flush();
-  }
   mds->balancer->maybe_fragment(destdn->get_dir(), false);
 }
 
@@ -9838,14 +9825,6 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
   }
 
   srcdn->get_dir()->unlink_inode(srcdn);
-
-  // After the stray dn being unlinked from the corresponding inode in case of
-  // reintegrate_stray/migrate_stray, just wake up the waitiers.
-  MDSContext::vec finished;
-  in->take_waiting(CInode::WAIT_UNLINK, finished);
-  if (!finished.empty()) {
-    mds->queue_waiters(finished);
-  }
 
   // dest
   if (srcdn_was_remote) {

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -159,7 +159,6 @@ public:
 
   // -- requests --
   void handle_client_request(const cref_t<MClientRequest> &m);
-  void handle_client_reply(const cref_t<MClientReply> &m);
 
   void journal_and_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn,
 			 LogEvent *le, MDSLogContextBase *fin);
@@ -239,9 +238,6 @@ public:
 
   bool is_unlink_pending(CDentry *dn);
   void wait_for_pending_unlink(CDentry *dn, MDRequestRef& mdr);
-
-  bool is_reintegrate_pending(CDentry *dn);
-  void wait_for_pending_reintegrate(CDentry *dn, MDRequestRef& mdr);
 
   // open
   void handle_client_open(MDRequestRef& mdr);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -236,9 +236,6 @@ public:
 
   void handle_client_fsync(MDRequestRef& mdr);
 
-  bool is_unlink_pending(CDentry *dn);
-  void wait_for_pending_unlink(CDentry *dn, MDRequestRef& mdr);
-
   // open
   void handle_client_open(MDRequestRef& mdr);
   void handle_client_openc(MDRequestRef& mdr);  // O_CREAT variant.

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -674,27 +674,19 @@ void StrayManager::reintegrate_stray(CDentry *straydn, CDentry *rdn)
   dout(10) << __func__ << " " << *straydn << " to " << *rdn << dendl;
 
   logger->inc(l_mdc_strays_reintegrated);
-
+  
   // rename it to remote linkage .
   filepath src(straydn->get_name(), straydn->get_dir()->ino());
   filepath dst(rdn->get_name(), rdn->get_dir()->ino());
 
-  ceph_tid_t tid = mds->issue_tid();
-
   auto req = make_message<MClientRequest>(CEPH_MDS_OP_RENAME);
   req->set_filepath(dst);
   req->set_filepath2(src);
-  req->set_tid(tid);
-
-  rdn->state_set(CDentry::STATE_REINTEGRATING);
-  mds->internal_client_requests.emplace(std::piecewise_construct,
-                                        std::make_tuple(tid),
-                                        std::make_tuple(CEPH_MDS_OP_RENAME,
-                                                        rdn, tid));
+  req->set_tid(mds->issue_tid());
 
   mds->send_message_mds(req, rdn->authority().first);
 }
-
+ 
 void StrayManager::migrate_stray(CDentry *dn, mds_rank_t to)
 {
   dout(10) << __func__ << " " << *dn << " to mds." << to << dendl;
@@ -708,17 +700,10 @@ void StrayManager::migrate_stray(CDentry *dn, mds_rank_t to)
   filepath src(dn->get_name(), dirino);
   filepath dst(dn->get_name(), MDS_INO_STRAY(to, MDS_INO_STRAY_INDEX(dirino)));
 
-  ceph_tid_t tid = mds->issue_tid();
-
   auto req = make_message<MClientRequest>(CEPH_MDS_OP_RENAME);
   req->set_filepath(dst);
   req->set_filepath2(src);
-  req->set_tid(tid);
-
-  mds->internal_client_requests.emplace(std::piecewise_construct,
-                                        std::make_tuple(tid),
-                                        std::make_tuple(CEPH_MDS_OP_RENAME,
-                                                        nullptr, tid));
+  req->set_tid(mds->issue_tid());
 
   mds->send_message_mds(req, to);
 }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -280,17 +280,6 @@ void StrayManager::_purge_stray_logged(CDentry *dn, version_t pdv, MutationRef& 
     dir->remove_dentry(dn);
   }
 
-  // Once we are here normally the waiter list are mostly empty
-  // but in corner case that the clients pass a invalidate ino,
-  // which maybe under unlinking, the link caller will add the
-  // request to the waiter list. We need try to wake them up
-  // anyway.
-  MDSContext::vec finished;
-  in->take_waiting(CInode::WAIT_UNLINK, finished);
-  if (!finished.empty()) {
-    mds->queue_waiters(finished);
-  }
-
   // drop inode
   inodeno_t ino = in->ino();
   if (in->is_dirty())

--- a/src/messages/MDentryUnlink.h
+++ b/src/messages/MDentryUnlink.h
@@ -22,17 +22,15 @@
 
 class MDentryUnlink final : public MMDSOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
+  static constexpr int HEAD_VERSION = 1;
   static constexpr int COMPAT_VERSION = 1;
-
+  
   dirfrag_t dirfrag;
   std::string dn;
-  bool unlinking = false;
 
  public:
   dirfrag_t get_dirfrag() const { return dirfrag; }
   const std::string& get_dn() const { return dn; }
-  bool is_unlinking() const { return unlinking; }
 
   ceph::buffer::list straybl;
   ceph::buffer::list snapbl;
@@ -40,9 +38,10 @@ private:
 protected:
   MDentryUnlink() :
     MMDSOp(MSG_MDS_DENTRYUNLINK, HEAD_VERSION, COMPAT_VERSION) { }
-  MDentryUnlink(dirfrag_t df, std::string_view n, bool u=false) :
+  MDentryUnlink(dirfrag_t df, std::string_view n) :
     MMDSOp(MSG_MDS_DENTRYUNLINK, HEAD_VERSION, COMPAT_VERSION),
-    dirfrag(df), dn(n), unlinking(u) {}
+    dirfrag(df),
+    dn(n) {}
   ~MDentryUnlink() final {}
 
 public:
@@ -50,66 +49,19 @@ public:
   void print(std::ostream& o) const override {
     o << "dentry_unlink(" << dirfrag << " " << dn << ")";
   }
-
+  
   void decode_payload() override {
     using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(dn, p);
     decode(straybl, p);
-    if (header.version >= 2)
-      decode(unlinking, p);
   }
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     encode(dirfrag, payload);
     encode(dn, payload);
     encode(straybl, payload);
-    encode(unlinking, payload);
-  }
-private:
-  template<class T, typename... Args>
-  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
-  template<class T, typename... Args>
-  friend MURef<T> crimson::make_message(Args&&... args);
-};
-
-class MDentryUnlinkAck final : public MMDSOp {
-private:
-  static constexpr int HEAD_VERSION = 1;
-  static constexpr int COMPAT_VERSION = 1;
-
-  dirfrag_t dirfrag;
-  std::string dn;
-
- public:
-  dirfrag_t get_dirfrag() const { return dirfrag; }
-  const std::string& get_dn() const { return dn; }
-
-protected:
-  MDentryUnlinkAck() :
-    MMDSOp(MSG_MDS_DENTRYUNLINK_ACK, HEAD_VERSION, COMPAT_VERSION) { }
-  MDentryUnlinkAck(dirfrag_t df, std::string_view n) :
-    MMDSOp(MSG_MDS_DENTRYUNLINK_ACK, HEAD_VERSION, COMPAT_VERSION),
-    dirfrag(df), dn(n) {}
-  ~MDentryUnlinkAck() final {}
-
-public:
-  std::string_view get_type_name() const override { return "dentry_unlink_ack";}
-  void print(std::ostream& o) const override {
-    o << "dentry_unlink_ack(" << dirfrag << " " << dn << ")";
-  }
-
-  void decode_payload() override {
-    using ceph::decode;
-    auto p = payload.cbegin();
-    decode(dirfrag, p);
-    decode(dn, p);
-  }
-  void encode_payload(uint64_t features) override {
-    using ceph::encode;
-    encode(dirfrag, payload);
-    encode(dn, payload);
   }
 private:
   template<class T, typename... Args>

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -831,9 +831,6 @@ Message *decode_message(CephContext *cct,
     break;
 
 
-  case MSG_MDS_DENTRYUNLINK_ACK:
-    m = make_message<MDentryUnlinkAck>();
-    break;
   case MSG_MDS_DENTRYUNLINK:
     m = make_message<MDentryUnlink>();
     break;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -174,7 +174,6 @@
 #define MSG_MDS_OPENINOREPLY       0x210
 #define MSG_MDS_SNAPUPDATE         0x211
 #define MSG_MDS_FRAGMENTNOTIFYACK  0x212
-#define MSG_MDS_DENTRYUNLINK_ACK   0x213
 #define MSG_MDS_LOCK               0x300 // 0x3xx are for locker of mds
 #define MSG_MDS_INODEFILECAPS      0x301
 


### PR DESCRIPTION
In case of one inode have multiple hardlinks, and if an unlink
request removes the primary dentry and just before the linkmerge
is triggered a new unlink request comes. The new unlink request
will need the linkmerge to finish.

We should just wait the linkmerge to finish before handling the
new unlink request for the same inode.

Fixes: https://tracker.ceph.com/issues/58340
Fixes: https://tracker.ceph.com/issues/61818





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
