### PR TITLE
quincy: tools/osdmaptool: fix possible segfaults when there are down osds

### DIFF
--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -693,9 +693,10 @@ skip_upmap:
 
 	for (unsigned i=0; i<osds.size(); i++) {
 	  //cout << " rep " << i << " on " << osds[i] << std::endl;
-	  count[osds[i]]++;
+          if (osds[i] != CRUSH_ITEM_NONE)
+            count[osds[i]]++;
 	}
-	if (osds.size())
+	if (osds.size() && osds[0] != CRUSH_ITEM_NONE)
 	  first_count[osds[0]]++;
 	if (primary >= 0)
 	  primary_count[primary]++;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61823

---

backport of https://github.com/ceph/ceph/pull/43345
parent tracker: https://tracker.ceph.com/issues/48505

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh