### PR TITLE
Add missing bcrypt dependency for ceph-mgr-modules-core.requires

### DIFF
--- a/debian/ceph-mgr-modules-core.requires
+++ b/debian/ceph-mgr-modules-core.requires
@@ -5,3 +5,4 @@ werkzeug
 requests
 pkg-resources
 python-dateutil
+bcrypt


### PR DESCRIPTION
ceph mgr modules failed to start after upgrading from quincy to reef with the error:
 Module 'status' has failed dependency: No module named 'bcrypt'

Add bcrypt as dependency.

Signed-off-by: Markus Schade <markus.schade@gmail.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests


