### PR TITLE
ceph-dencoder: COMMON - Add missing types

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -511,6 +511,23 @@ void CryptoKey::decode(bufferlist::const_iterator& bl)
     throw ceph::buffer::malformed_input("malformed secret");
 }
 
+void CryptoKey::dump(Formatter *f) const
+{
+  f->dump_int("type", type);
+  f->dump_stream("created") << created;
+  f->dump_int("secret.length", secret.length());
+}
+
+void CryptoKey::generate_test_instances(std::list<CryptoKey*>& ls)
+{
+  ls.push_back(new CryptoKey);
+  ls.push_back(new CryptoKey);
+  ls.back()->type = CEPH_CRYPTO_AES;
+  ls.back()->set_secret(
+    CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
+  ls.back()->created = utime_t(123, 456);
+}
+
 int CryptoKey::set_secret(int type, const bufferptr& s, utime_t c)
 {
   int r = _set_secret(type, s);

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -111,6 +111,8 @@ public:
 
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<CryptoKey*>& ls);
 
   void clear() {
     *this = CryptoKey();

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -257,6 +257,16 @@ std::map<EntityName,CryptoKey> KeyServer::get_used_pending_keys()
   return ret;
 }
 
+void KeyServer::dump(Formatter *f) const
+{
+  f->dump_object("data", data);
+}
+
+void KeyServer::generate_test_instances(std::list<KeyServer*>& ls)
+{
+  ls.push_back(new KeyServer(nullptr, nullptr));
+}
+
 bool KeyServer::generate_secret(CryptoKey& secret)
 {
   bufferptr bp;

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -3,12 +3,13 @@
 
 #pragma once
 
+#include "common/ceph_json.h"
 #include "include/types.h"
 #include "cls_2pc_queue_types.h"
 
 struct cls_2pc_queue_reserve_op {
   uint64_t size;
-  uint32_t entries;
+  uint32_t entries{0};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -22,6 +23,19 @@ struct cls_2pc_queue_reserve_op {
     decode(size, bl);
     decode(entries, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("size", size);
+    f->dump_unsigned("entries", entries);
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_queue_reserve_op*>& ls) {
+    ls.push_back(new cls_2pc_queue_reserve_op);
+    ls.back()->size = 0;
+    ls.push_back(new cls_2pc_queue_reserve_op);
+    ls.back()->size = 123;
+    ls.back()->entries = 456;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_op)
@@ -39,6 +53,15 @@ struct cls_2pc_queue_reserve_ret {
     DECODE_START(1, bl);
     decode(id, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("id", id);
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_queue_reserve_ret*>& ls) {
+    ls.push_back(new cls_2pc_queue_reserve_ret);
+    ls.back()->id = 123;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_ret)
@@ -61,6 +84,19 @@ struct cls_2pc_queue_commit_op {
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("id", id);
+    encode_json("bl_data_vec", bl_data_vec, f);
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_queue_commit_op*>& ls) {
+    ls.push_back(new cls_2pc_queue_commit_op);
+    ls.back()->id = 123;
+    ls.back()->bl_data_vec.push_back(ceph::buffer::list());
+    ls.back()->bl_data_vec.back().append("foo");
+    ls.back()->bl_data_vec.push_back(ceph::buffer::list());
+    ls.back()->bl_data_vec.back().append("bar");
+  }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_commit_op)
 
@@ -77,6 +113,13 @@ struct cls_2pc_queue_abort_op {
     DECODE_START(1, bl);
     decode(id, bl);
     DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("id", id);
+  }
+  static void generate_test_instances(std::list<cls_2pc_queue_abort_op*>& ls) {
+    ls.push_back(new cls_2pc_queue_abort_op);
+    ls.back()->id = 1;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_abort_op)
@@ -96,6 +139,14 @@ struct cls_2pc_queue_expire_op {
     decode(stale_time, bl);
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_stream("stale_time") << stale_time;
+  }
+  static void generate_test_instances(std::list<cls_2pc_queue_expire_op*>& ls) {
+    ls.push_back(new cls_2pc_queue_expire_op);
+    ls.push_back(new cls_2pc_queue_expire_op);
+    ls.back()->stale_time = ceph::coarse_real_time::min();
+  }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_expire_op)
 
@@ -112,6 +163,23 @@ struct cls_2pc_queue_reservations_ret {
     DECODE_START(1, bl);
     decode(reservations, bl);
     DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->open_array_section("reservations");
+    for (const auto& i : reservations) {
+      f->open_object_section("reservation");
+      f->dump_unsigned("id", i.first);
+      i.second.dump(f);
+      f->close_section();
+    }
+    f->close_section();
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_queue_reservations_ret*>& ls) {
+    ls.push_back(new cls_2pc_queue_reservations_ret);
+    ls.push_back(new cls_2pc_queue_reservations_ret);
+    ls.back()->reservations[1] = cls_2pc_reservation();
+    ls.back()->reservations[2] = cls_2pc_reservation();
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reservations_ret)

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -34,6 +34,19 @@ struct cls_2pc_reservation
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("size", size);
+    f->dump_stream("timestamp") << timestamp;
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_reservation*>& ls) {
+    ls.push_back(new cls_2pc_reservation);
+    ls.back()->size = 0;
+    ls.push_back(new cls_2pc_reservation);
+    ls.back()->size = 123;
+    ls.back()->timestamp = ceph::coarse_real_clock::zero();
+  }
 };
 WRITE_CLASS_ENCODER(cls_2pc_reservation)
 
@@ -67,6 +80,29 @@ struct cls_2pc_urgent_data
       decode(committed_entries, bl);
     }
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("reserved_size", reserved_size);
+    f->dump_unsigned("last_id", last_id);
+    f->open_array_section("reservations");
+    for (const auto& [id, res] : reservations) {
+      f->open_object_section("reservation");
+      f->dump_unsigned("id", id);
+      res.dump(f);
+      f->close_section();
+    }
+    f->close_section();
+    f->dump_bool("has_xattrs", has_xattrs);
+  }
+
+  static void generate_test_instances(std::list<cls_2pc_urgent_data*>& ls) {
+    ls.push_back(new cls_2pc_urgent_data);
+    ls.push_back(new cls_2pc_urgent_data);
+    ls.back()->reserved_size = 123;
+    ls.back()->last_id = 456;
+    ls.back()->reservations.emplace(789, cls_2pc_reservation(1, ceph::coarse_real_clock::zero(), 2));
+    ls.back()->has_xattrs = true;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_urgent_data)

--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -145,6 +145,12 @@ struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
     }
     f->close_section();
   }
+  static void generate_test_instances(std::list<chunk_refs_by_object_t*>& ls) {
+    ls.push_back(new chunk_refs_by_object_t());
+    ls.push_back(new chunk_refs_by_object_t());
+    ls.back()->by_object.insert(hobject_t(sobject_t("foo", CEPH_NOSNAP)));
+    ls.back()->by_object.insert(hobject_t(sobject_t("bar", CEPH_NOSNAP)));
+  }
 };
 WRITE_CLASS_ENCODER(chunk_refs_by_object_t)
 
@@ -385,6 +391,11 @@ struct chunk_refs_count_t : public chunk_refs_t::refs_t {
   void dump(Formatter *f) const override {
     f->dump_string("type", "count");
     f->dump_unsigned("count", total);
+  }
+  static void generate_test_instances(std::list<chunk_refs_count_t*>& o) {
+    o.push_back(new chunk_refs_count_t);
+    o.push_back(new chunk_refs_count_t);
+    o.back()->total = 123;
   }
 };
 WRITE_CLASS_ENCODER(chunk_refs_count_t)

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -67,6 +67,31 @@ struct create_meta
     decode(exclusive, bl);
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("id", id);
+    f->dump_object("version", version.value_or(objv()));
+    f->dump_string("pool_name", pool.name);
+    f->dump_string("pool_ns", pool.ns);
+    f->dump_string("oid_prefix", oid_prefix.value_or(""));
+    f->dump_unsigned("max_part_size", max_part_size);
+    f->dump_unsigned("max_entry_size", max_entry_size);
+    f->dump_bool("exclusive", exclusive);
+  }
+  static void generate_test_instances(std::list<create_meta*>& o) {
+    o.push_back(new create_meta);
+    o.push_back(new create_meta);
+    o.back()->id = "id";
+    objv v1;
+    v1.instance = "inst1";
+    v1.ver = 1;
+    o.back()->version = v1;
+    o.back()->pool.name = "pool";
+    o.back()->pool.ns = "ns";
+    o.back()->oid_prefix = "prefix";
+    o.back()->max_part_size = 1024;
+    o.back()->max_entry_size = 1024;
+    o.back()->exclusive = true;
+  }
 };
 WRITE_CLASS_ENCODER(create_meta)
 
@@ -83,6 +108,17 @@ struct get_meta
     DECODE_START(1, bl);
     decode(version, bl);
     DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("version", version.value_or(objv()));
+  }
+  static void generate_test_instances(std::list<get_meta*>& o) {
+    o.push_back(new get_meta);
+    o.push_back(new get_meta);
+    objv v1;
+    v1.instance = "inst1";
+    v1.ver = 1;
+    o.back()->version = v1;
   }
 };
 WRITE_CLASS_ENCODER(get_meta)
@@ -107,6 +143,18 @@ struct get_meta_reply
     decode(part_header_size, bl);
     decode(part_entry_overhead, bl);
     DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("info", info);
+    f->dump_unsigned("part_header_size", part_header_size);
+    f->dump_unsigned("part_entry_overhead", part_entry_overhead);
+  }
+  static void generate_test_instances(std::list<get_meta_reply*>& o) {
+    o.push_back(new get_meta_reply);
+    o.push_back(new get_meta_reply);
+    o.back()->info = fifo::info();
+    o.back()->part_header_size = 1024;
+    o.back()->part_entry_overhead = 1024;
   }
 };
 WRITE_CLASS_ENCODER(get_meta_reply)

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_CLS_LOG_OPS_H
 #define CEPH_CLS_LOG_OPS_H
 
+#include "common/ceph_json.h"
 #include "cls_log_types.h"
 
 struct cls_log_add_op {
@@ -73,6 +74,21 @@ struct cls_log_list_op {
     decode(max_entries, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter* f) const {
+    f->dump_stream("from_time") << from_time;
+    f->dump_string("marker", marker);
+    f->dump_stream("to_time") << to_time;
+    f->dump_int("max_entries", max_entries);
+  }
+  static void generate_test_instances(std::list<cls_log_list_op*>& ls) {
+    ls.push_back(new cls_log_list_op);
+    ls.push_back(new cls_log_list_op);
+    ls.back()->from_time = utime_t(1, 2);
+    ls.back()->marker = "marker";
+    ls.back()->to_time = utime_t(3, 4);
+    ls.back()->max_entries = 5;
+  }
 };
 WRITE_CLASS_ENCODER(cls_log_list_op)
 
@@ -97,6 +113,25 @@ struct cls_log_list_ret {
     decode(marker, bl);
     decode(truncated, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter* f) const {
+    encode_json("entries", entries, f);
+    f->dump_string("marker", marker);
+    f->dump_bool("truncated", truncated);
+  }
+  static void generate_test_instances(std::list<cls_log_list_ret*>& ls) {
+    ls.push_back(new cls_log_list_ret);
+    ls.push_back(new cls_log_list_ret);
+    ls.back()->entries.push_back(cls_log_entry());
+    ls.back()->entries.push_back(cls_log_entry());
+    ls.back()->entries.back().section = "section";
+    ls.back()->entries.back().name = "name";
+    ls.back()->entries.back().timestamp = utime_t(1, 2);
+    ls.back()->entries.back().data.append("data");
+    ls.back()->entries.back().id = "id";
+    ls.back()->marker = "marker";
+    ls.back()->truncated = true;
   }
 };
 WRITE_CLASS_ENCODER(cls_log_list_ret)
@@ -133,6 +168,20 @@ struct cls_log_trim_op {
     }
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter* f) const {
+    f->dump_stream("from_time") << from_time;
+    f->dump_stream("to_time") << to_time;
+    f->dump_string("from_marker", from_marker);
+    f->dump_string("to_marker", to_marker);
+  }
+  static void generate_test_instances(std::list<cls_log_trim_op*>& ls) {
+    ls.push_back(new cls_log_trim_op);
+    ls.push_back(new cls_log_trim_op);
+    ls.back()->from_time = utime_t(1, 2);
+    ls.back()->to_time = utime_t(3, 4);
+    ls.back()->from_marker = "from_marker";
+    ls.back()->to_marker = "to_marker";
+  }
 };
 WRITE_CLASS_ENCODER(cls_log_trim_op)
 
@@ -149,6 +198,13 @@ struct cls_log_info_op {
     DECODE_START(1, bl);
     // currently empty request
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter* f) const {
+  }
+
+  static void generate_test_instances(std::list<cls_log_info_op*>& ls) {
+    ls.push_back(new cls_log_info_op);
   }
 };
 WRITE_CLASS_ENCODER(cls_log_info_op)

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -92,6 +92,16 @@ struct cls_log_header {
     decode(max_time, bl);
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter* f) const {
+    f->dump_string("max_marker", max_marker);
+    f->dump_stream("max_time") << max_time;
+  }
+  static void generate_test_instances(std::list<cls_log_header*>& o) {
+    o.push_back(new cls_log_header);
+    o.push_back(new cls_log_header);
+    o.back()->max_marker = "test_marker";
+    o.back()->max_time = utime_t();
+  }
 };
 inline bool operator ==(const cls_log_header& lhs, const cls_log_header& rhs) {
   return (lhs.max_marker == rhs.max_marker &&

--- a/src/cls/queue/cls_queue_ops.h
+++ b/src/cls/queue/cls_queue_ops.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_CLS_QUEUE_OPS_H
 #define CEPH_CLS_QUEUE_OPS_H
 
+#include "common/ceph_json.h"
 #include "cls/queue/cls_queue_types.h"
 
 struct cls_queue_init_op {
@@ -29,6 +30,19 @@ struct cls_queue_init_op {
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("queue_size", queue_size);
+    f->dump_unsigned("max_urgent_data_size", max_urgent_data_size);
+    f->dump_unsigned("urgent_data_len", bl_urgent_data.length());
+  }
+
+  static void generate_test_instances(std::list<cls_queue_init_op*>& o) {
+    o.push_back(new cls_queue_init_op);
+    o.push_back(new cls_queue_init_op);
+    o.back()->queue_size = 1024;
+    o.back()->max_urgent_data_size = 1024;
+    o.back()->bl_urgent_data.append(std::string_view("data"));
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_init_op)
 
@@ -47,12 +61,23 @@ struct cls_queue_enqueue_op {
     DECODE_START(1, bl);
     decode(bl_data_vec, bl);
     DECODE_FINISH(bl);
-  } 
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("data_vec_len", bl_data_vec.size());
+  }
+
+  static void generate_test_instances(std::list<cls_queue_enqueue_op*>& o) {
+    o.push_back(new cls_queue_enqueue_op);
+    o.push_back(new cls_queue_enqueue_op);
+    o.back()->bl_data_vec.push_back(ceph::buffer::list());
+    o.back()->bl_data_vec.back().append(std::string_view("data"));
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_enqueue_op)
 
 struct cls_queue_list_op {
-  uint64_t max;
+  uint64_t max{0};
   std::string start_marker;
 
   cls_queue_list_op() {}
@@ -69,6 +94,18 @@ struct cls_queue_list_op {
     decode(max, bl);
     decode(start_marker, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("max", max);
+    f->dump_string("start_marker", start_marker);
+  }
+
+  static void generate_test_instances(std::list<cls_queue_list_op*>& o) {
+    o.push_back(new cls_queue_list_op);
+    o.push_back(new cls_queue_list_op);
+    o.back()->max = 123;
+    o.back()->start_marker = "foo";
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_list_op)
@@ -95,6 +132,22 @@ struct cls_queue_list_ret {
     decode(entries, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_bool("is_truncated", is_truncated);
+    f->dump_string("next_marker", next_marker);
+    encode_json("entries", entries, f);
+  }
+
+  static void generate_test_instances(std::list<cls_queue_list_ret*>& o) {
+    o.push_back(new cls_queue_list_ret);
+    o.back()->is_truncated = true;
+    o.back()->next_marker = "foo";
+    o.back()->entries.push_back(cls_queue_entry());
+    o.back()->entries.push_back(cls_queue_entry());
+    o.back()->entries.back().marker = "id";
+    o.back()->entries.back().data.append(std::string_view("data"));
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_list_ret)
 
@@ -114,6 +167,15 @@ struct cls_queue_remove_op {
     decode(end_marker, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("end_marker", end_marker);
+  }
+  static void generate_test_instances(std::list<cls_queue_remove_op*>& o) {
+    o.push_back(new cls_queue_remove_op);
+    o.push_back(new cls_queue_remove_op);
+    o.back()->end_marker = "foo";
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_remove_op)
 
@@ -132,6 +194,14 @@ struct cls_queue_get_capacity_ret {
     DECODE_START(1, bl);
     decode(queue_capacity, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("queue_capacity", queue_capacity);
+  }
+  static void generate_test_instances(std::list<cls_queue_get_capacity_ret*>& o) {
+    o.push_back(new cls_queue_get_capacity_ret);
+    o.back()->queue_capacity = 123;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_get_capacity_ret)

--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -34,6 +34,17 @@ struct cls_queue_entry
     decode(marker, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("marker", marker);
+    f->dump_unsigned("data_len", data.length());
+  }
+  static void generate_test_instances(std::list<cls_queue_entry*>& o) {
+    o.push_back(new cls_queue_entry);
+    o.push_back(new cls_queue_entry);
+    o.back()->data.append(std::string_view("data"));
+    o.back()->marker = "marker";
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_entry)
 
@@ -80,7 +91,16 @@ struct cls_queue_marker
     }
     return 0;
   }
-
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("offset", offset);
+    f->dump_unsigned("gen", gen);
+  }
+  static void generate_test_instances(std::list<cls_queue_marker*>& o) {
+    o.push_back(new cls_queue_marker);
+    o.push_back(new cls_queue_marker);
+    o.back()->offset = 1024;
+    o.back()->gen = 0;
+  }
 };
 WRITE_CLASS_ENCODER(cls_queue_marker)
 
@@ -113,6 +133,27 @@ struct cls_queue_head
     decode(max_urgent_data_size, bl);
     decode(bl_urgent_data, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("max_head_size", max_head_size);
+    f->dump_unsigned("queue_size", queue_size);
+    f->dump_unsigned("max_urgent_data_size", max_urgent_data_size);
+    f->dump_unsigned("front_offset", front.offset);
+    f->dump_unsigned("front_gen", front.gen);
+    f->dump_unsigned("tail_offset", tail.offset);
+    f->dump_unsigned("tail_gen", tail.gen);
+  }
+  static void generate_test_instances(std::list<cls_queue_head*>& o) {
+    o.push_back(new cls_queue_head);
+    o.push_back(new cls_queue_head);
+    o.back()->max_head_size = 1024;
+    o.back()->front.offset = 1024;
+    o.back()->front.gen = 0;
+    o.back()->tail.offset = 1024;
+    o.back()->tail.gen = 0;
+    o.back()->queue_size = 1024;
+    o.back()->max_urgent_data_size = 0;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_head)

--- a/src/cls/timeindex/cls_timeindex_ops.h
+++ b/src/cls/timeindex/cls_timeindex_ops.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_CLS_TIMEINDEX_OPS_H
 #define CEPH_CLS_TIMEINDEX_OPS_H
 
+#include "common/ceph_json.h"
 #include "cls_timeindex_types.h"
 
 struct cls_timeindex_add_op {
@@ -51,6 +52,26 @@ struct cls_timeindex_list_op {
     decode(max_entries, bl);
     DECODE_FINISH(bl);
   }
+
+   void dump(ceph::Formatter *f) const {
+    f->open_object_section("from_time");
+    from_time.dump(f);
+    f->close_section();
+    f->dump_string("marker", marker);
+    f->open_object_section("to_time");
+    to_time.dump(f);
+    f->close_section();
+    f->dump_int("max_entries", max_entries);
+  }
+
+  static void generate_test_instances(std::list<cls_timeindex_list_op*>& o) {
+    o.push_back(new cls_timeindex_list_op);
+    o.push_back(new cls_timeindex_list_op);
+    o.back()->from_time = utime_t(1, 2);
+    o.back()->marker = "marker";
+    o.back()->to_time = utime_t(3, 4);
+    o.back()->max_entries = 5;
+  }
 };
 WRITE_CLASS_ENCODER(cls_timeindex_list_op)
 
@@ -75,6 +96,23 @@ struct cls_timeindex_list_ret {
     decode(marker, bl);
     decode(truncated, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    encode_json("entries", entries, f);
+    f->dump_string("marker", marker);
+    f->dump_bool("truncated", truncated);
+  }
+
+  static void generate_test_instances(std::list<cls_timeindex_list_ret*>& o) {
+    o.push_back(new cls_timeindex_list_ret);
+    o.push_back(new cls_timeindex_list_ret);
+    o.back()->entries.push_back(cls_timeindex_entry());
+    o.back()->entries.back().key_ts = utime_t(1, 2);
+    o.back()->entries.back().key_ext = "key_ext";
+    o.back()->entries.back().value.append("value");
+    o.back()->marker = "marker";
+    o.back()->truncated = true;
   }
 };
 WRITE_CLASS_ENCODER(cls_timeindex_list_ret)

--- a/src/cls/timeindex/cls_timeindex_types.h
+++ b/src/cls/timeindex/cls_timeindex_types.h
@@ -4,9 +4,9 @@
 #ifndef CEPH_CLS_TIMEINDEX_TYPES_H
 #define CEPH_CLS_TIMEINDEX_TYPES_H
 
+#include "common/Formatter.h"
 #include "include/encoding.h"
 #include "include/types.h"
-
 #include "include/utime.h"
 
 class JSONObj;

--- a/src/cls/version/cls_version_ops.h
+++ b/src/cls/version/cls_version_ops.h
@@ -5,6 +5,7 @@
 #define CEPH_CLS_VERSION_OPS_H
 
 #include "cls_version_types.h"
+#include "common/ceph_json.h"
 
 struct cls_version_set_op {
   obj_version objv;
@@ -21,6 +22,17 @@ struct cls_version_set_op {
     DECODE_START(1, bl);
     decode(objv, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("objv", objv);
+  }
+
+  static void generate_test_instances(std::list<cls_version_set_op*>& o) {
+    o.push_back(new cls_version_set_op);
+    o.push_back(new cls_version_set_op);
+    o.back()->objv.ver = 123;
+    o.back()->objv.tag = "foo";
   }
 };
 WRITE_CLASS_ENCODER(cls_version_set_op)
@@ -44,6 +56,22 @@ struct cls_version_inc_op {
     decode(conds, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("objv", objv);
+    encode_json("conds", conds, f);
+  }
+
+  static void generate_test_instances(std::list<cls_version_inc_op*>& o) {
+    o.push_back(new cls_version_inc_op);
+    o.push_back(new cls_version_inc_op);
+    o.back()->objv.ver = 123;
+    o.back()->objv.tag = "foo";
+    o.back()->conds.push_back(obj_version_cond());
+    o.back()->conds.back().ver.ver = 123;
+    o.back()->conds.back().ver.tag = "foo";
+    o.back()->conds.back().cond = VER_COND_GE;
+  }
 };
 WRITE_CLASS_ENCODER(cls_version_inc_op)
 
@@ -66,6 +94,22 @@ struct cls_version_check_op {
     decode(conds, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("objv", objv);
+    encode_json("conds", conds, f);
+  }
+
+  static void generate_test_instances(std::list<cls_version_check_op*>& o) {
+    o.push_back(new cls_version_check_op);
+    o.push_back(new cls_version_check_op);
+    o.back()->objv.ver = 123;
+    o.back()->objv.tag = "foo";
+    o.back()->conds.push_back(obj_version_cond());
+    o.back()->conds.back().ver.ver = 123;
+    o.back()->conds.back().ver.tag = "foo";
+    o.back()->conds.back().cond = VER_COND_GE;
+  }
 };
 WRITE_CLASS_ENCODER(cls_version_check_op)
 
@@ -84,6 +128,17 @@ struct cls_version_read_ret {
     DECODE_START(1, bl);
     decode(objv, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("objv", objv);
+  }
+
+  static void generate_test_instances(std::list<cls_version_read_ret*>& o) {
+    o.push_back(new cls_version_read_ret);
+    o.push_back(new cls_version_read_ret);
+    o.back()->objv.ver = 123;
+    o.back()->objv.tag = "foo";
   }
 };
 WRITE_CLASS_ENCODER(cls_version_read_ret)

--- a/src/cls/version/cls_version_types.cc
+++ b/src/cls/version/cls_version_types.cc
@@ -6,12 +6,6 @@
 #include "common/ceph_json.h"
 
 
-void obj_version::dump(ceph::Formatter *f) const
-{
-  f->dump_int("ver", ver);
-  f->dump_string("tag", tag);
-}
-
 void obj_version::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("ver", ver, obj);

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -53,7 +53,11 @@ struct obj_version {
             tag.compare(v.tag) == 0);
   }
 
-  void dump(ceph::Formatter *f) const;
+  void dump(ceph::Formatter *f) const {
+    f->dump_int("ver", ver);
+    f->dump_string("tag", tag);
+  }
+
   void decode_json(JSONObj *obj);
   static void generate_test_instances(std::list<obj_version*>& o);
 };
@@ -91,6 +95,18 @@ struct obj_version_cond {
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_object("ver", ver);
+    f->dump_unsigned("cond", cond);
+  }
+
+  static void generate_test_instances(std::list<obj_version_cond*>& o) {
+    o.push_back(new obj_version_cond);
+    o.push_back(new obj_version_cond);
+    o.back()->ver.ver = 1;
+    o.back()->ver.tag = "foo";
+    o.back()->cond = VER_COND_EQ;
+  }
 };
 WRITE_CLASS_ENCODER(obj_version_cond)
 

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -836,6 +836,61 @@ public:
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    switch (type) {
+      case FMT_VALUE:
+        if (value.quoted) {
+          f->dump_string("value", value.str);
+        } else {
+          f->dump_format_unquoted("value", "%s", value.str.c_str());
+        }
+        break;
+      case FMT_ARRAY:
+        f->open_array_section("array");
+        for (auto& i : arr) {
+          i.dump(f);
+        }
+        f->close_section();
+        break;
+      case FMT_OBJ:
+        f->open_object_section("object");
+        for (auto& i : obj) {
+          f->dump_object(i.first.c_str(), i.second);
+        }
+        f->close_section();
+        break;
+      default:
+        break;
+    }
+  }
+  static void generate_test_instances(std::list<JSONFormattable*>& o) {
+    o.push_back(new JSONFormattable);
+    o.push_back(new JSONFormattable);
+    o.back()->set_type(FMT_VALUE);
+    o.back()->value.str = "foo";
+    o.back()->value.quoted = true;
+    o.push_back(new JSONFormattable);
+    o.back()->set_type(FMT_VALUE);
+    o.back()->value.str = "foo";
+    o.back()->value.quoted = false;
+    o.push_back(new JSONFormattable);
+    o.back()->set_type(FMT_ARRAY);
+    o.back()->arr.push_back(JSONFormattable());
+    o.back()->arr.back().set_type(FMT_VALUE);
+    o.back()->arr.back().value.str = "foo";
+    o.back()->arr.back().value.quoted = true;
+    o.back()->arr.push_back(JSONFormattable());
+    o.back()->arr.back().set_type(FMT_VALUE);
+    o.back()->arr.back().value.str = "bar";
+    o.back()->arr.back().value.quoted = true;
+    o.push_back(new JSONFormattable);
+    o.back()->set_type(FMT_OBJ);
+    o.back()->obj["foo"] = JSONFormattable();
+    o.back()->obj["foo"].set_type(FMT_VALUE);
+    o.back()->obj["foo"].value.str = "bar";
+    o.back()->obj["foo"].value.quoted = true;
+  }
+
   const std::string& val() const {
     return value.str;
   }

--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -29,21 +29,30 @@ const std::array<EntityName::str_to_entity_type_t, 6> EntityName::STR_TO_ENTITY_
   { CEPH_ENTITY_TYPE_CLIENT, "client" },
 }};
 
-const std::string& EntityName::
-to_str() const
-{
+void EntityName::dump(ceph::Formatter *f) const {
+  f->dump_int("type", type);
+  f->dump_string("id", id);
+}
+
+void EntityName::generate_test_instances(std::list<EntityName*>& ls) {
+  ls.push_back(new EntityName);
+  ls.push_back(new EntityName);
+  ls.back()->set_type(CEPH_ENTITY_TYPE_OSD);
+  ls.back()->set_id("0");
+  ls.push_back(new EntityName);
+  ls.back()->set_type(CEPH_ENTITY_TYPE_MDS);
+  ls.back()->set_id("a");
+}
+
+const std::string& EntityName::to_str() const {
   return type_id;
 }
 
-const char* EntityName::
-to_cstr() const
-{
+const char* EntityName::to_cstr() const {
   return type_id.c_str();
 }
 
-bool EntityName::
-from_str(std::string_view s)
-{
+bool EntityName::from_str(std::string_view s) {
   size_t pos = s.find('.');
 
   if (pos == string::npos)
@@ -56,9 +65,7 @@ from_str(std::string_view s)
   return true;
 }
 
-void EntityName::
-set(uint32_t type_, std::string_view id_)
-{
+void EntityName::set(uint32_t type_, std::string_view id_) {
   type = type_;
   id = id_;
 
@@ -71,9 +78,7 @@ set(uint32_t type_, std::string_view id_)
   }
 }
 
-int EntityName::
-set(std::string_view type_, std::string_view id_)
-{
+int EntityName::set(std::string_view type_, std::string_view id_) {
   uint32_t t = str_to_ceph_entity_type(type_);
   if (t == CEPH_ENTITY_TYPE_ANY)
     return -EINVAL;
@@ -81,9 +86,7 @@ set(std::string_view type_, std::string_view id_)
   return 0;
 }
 
-void EntityName::
-set_type(uint32_t type_)
-{
+void EntityName::set_type(uint32_t type_) {
   set(type_, id);
 }
 
@@ -93,9 +96,7 @@ set_type(std::string_view type_)
   return set(type_, id);
 }
 
-void EntityName::
-set_id(std::string_view id_)
-{
+void EntityName::set_id(std::string_view id_) {
   set(type, id_);
 }
 
@@ -106,33 +107,23 @@ void EntityName::set_name(entity_name_t n)
   set(n.type(), s);
 }
 
-const char* EntityName::
-get_type_str() const
-{
+const char* EntityName::get_type_str() const {
   return ceph_entity_type_name(type);
 }
 
-std::string_view EntityName::
-get_type_name() const
-{
+std::string_view EntityName::get_type_name() const {
   return ceph_entity_type_name(type);
 }
 
-const std::string &EntityName::
-get_id() const
-{
+const std::string &EntityName::get_id() const {
   return id;
 }
 
-bool EntityName::
-has_default_id() const
-{
+bool EntityName::has_default_id() const {
   return (id == "admin");
 }
 
-std::string EntityName::
-get_valid_types_as_str()
-{
+std::string EntityName::get_valid_types_as_str() {
   std::ostringstream out;
   size_t i;
   for (i = 0; i < STR_TO_ENTITY_TYPE.size(); ++i) {

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -41,7 +41,8 @@ struct EntityName
     decode(id_, bl);
     set(type_, id_);
   }
-
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<EntityName*>& ls);
   const std::string& to_str() const;
   const char *to_cstr() const;
   bool from_str(std::string_view s);

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -349,6 +349,8 @@ public:
   }
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<inline_data_t*>& ls);
 
   version_t version = 1;
 

--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -159,6 +159,15 @@ public:
     ceph::decode_raw(v, p);
     _enc = v;
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("value", value());
+    f->dump_unsigned("bits", bits());
+  }
+  static void generate_test_instances(std::list<frag_t*>& ls) {
+    ls.push_back(new frag_t);
+    ls.push_back(new frag_t(10, 2));
+    ls.push_back(new frag_t(11, 3));
+  }
   bool operator<(const frag_t& b) const
   {
     if (value() != b.value())
@@ -524,6 +533,11 @@ public:
       f->close_section(); // split
     }
     f->close_section(); // splits
+  }
+
+  static void generate_test_instances(std::list<fragtree_t*>& ls) {
+    ls.push_back(new fragtree_t);
+    ls.push_back(new fragtree_t);
   }
 };
 WRITE_CLASS_ENCODER(fragtree_t)

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -75,6 +75,13 @@ struct inodeno_t {
     using ceph::decode;
     decode(val, p);
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("val", val);
+  }
+  static void generate_test_instances(std::list<inodeno_t*>& ls) {
+    ls.push_back(new inodeno_t(1));
+    ls.push_back(new inodeno_t(123456789));
+  }
 } __attribute__ ((__may_alias__));
 WRITE_CLASS_ENCODER(inodeno_t)
 

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -25,6 +25,7 @@
 
 #include "include/rados.h"
 #include "include/unordered_map.h"
+#include "common/Formatter.h"
 
 #include "hash.h"
 #include "encoding.h"
@@ -57,6 +58,15 @@ struct object_t {
   void decode(ceph::buffer::list::const_iterator &bl) {
     using ceph::decode;
     decode(name, bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("name", name);
+  }
+
+  static void generate_test_instances(std::list<object_t*>& o) {
+    o.push_back(new object_t);
+    o.push_back(new object_t("myobject"));
   }
 };
 WRITE_CLASS_ENCODER(object_t)
@@ -169,6 +179,14 @@ struct sobject_t {
     using ceph::decode;
     decode(oid, bl);
     decode(snap, bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_stream("oid") << oid;
+    f->dump_stream("snap") << snap;
+  }
+  static void generate_test_instances(std::list<sobject_t*>& o) {
+    o.push_back(new sobject_t);
+    o.push_back(new sobject_t(object_t("myobject"), 123));
   }
 };
 WRITE_CLASS_ENCODER(sobject_t)

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -371,6 +371,14 @@ struct client_t {
     using ceph::decode;
     decode(v, bl);
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_int("id", v);
+  }
+  static void generate_test_instances(std::list<client_t*>& ls) {
+    ls.push_back(new client_t);
+    ls.push_back(new client_t(1));
+    ls.push_back(new client_t(123));
+  }
 };
 WRITE_CLASS_ENCODER(client_t)
 
@@ -517,7 +525,13 @@ struct shard_id_t {
     using ceph::decode;
     decode(id, bl);
   }
-
+  void dump(ceph::Formatter *f) const {
+    f->dump_int("id", id);
+  }
+  static void generate_test_instances(std::list<shard_id_t*>& ls) {
+    ls.push_back(new shard_id_t(1));
+    ls.push_back(new shard_id_t(2));
+  }
   bool operator==(const shard_id_t&) const = default;
   auto operator<=>(const shard_id_t&) const = default;
 };
@@ -561,6 +575,13 @@ struct errorcode32_t {
     decode(code, bl);
     code = ceph_to_hostos_errno(code);
   }
+  void dump(ceph::Formatter *f) const {
+    f->dump_int("code", code);
+  }
+  static void generate_test_instances(std::list<errorcode32_t*>& ls) {
+    ls.push_back(new errorcode32_t(1));
+    ls.push_back(new errorcode32_t(2));
+  }
 };
 WRITE_CLASS_ENCODER(errorcode32_t)
 
@@ -601,6 +622,16 @@ struct sha_digest_t {
     std::array<unsigned char, SIZE> tmparr;
     decode(tmparr, bl);
     memcpy(v, tmparr.data(), SIZE);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("sha1", to_str());
+  }
+  static void generate_test_instances(std::list<sha_digest_t*>& ls) {
+    ls.push_back(new sha_digest_t);
+    ls.push_back(new sha_digest_t);
+    ls.back()->v[0] = 1;
+    ls.push_back(new sha_digest_t);
+    ls.back()->v[0] = 2;
   }
 };
 

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -284,6 +284,21 @@ void inline_data_t::decode(bufferlist::const_iterator &p)
     free_data();
 }
 
+void inline_data_t::dump(Formatter *f) const
+{
+  f->dump_unsigned("version", version);
+  f->dump_unsigned("length", length());
+}
+
+void inline_data_t::generate_test_instances(std::list<inline_data_t*>& ls)
+{
+  ls.push_back(new inline_data_t);
+  ls.push_back(new inline_data_t);
+  bufferlist bl;
+  bl.append("inline data");
+  ls.back()->set_data(bl);
+}
+
 
 /*
  * fnode_t

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -291,7 +291,7 @@ struct InodeStat {
 };
 
 struct openc_response_t {
-  _inodeno_t			created_ino;
+  _inodeno_t			created_ino{0};
   interval_set<inodeno_t>	delegated_inos;
 
 public:
@@ -308,6 +308,16 @@ public:
     decode(created_ino, p);
     decode(delegated_inos, p);
     DECODE_FINISH(p);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("created_ino", created_ino);
+    f->dump_stream("delegated_inos") << delegated_inos;
+  }
+  static void generate_test_instances(std::list<openc_response_t*>& ls) {
+    ls.push_back(new openc_response_t);
+    ls.push_back(new openc_response_t);
+    ls.back()->created_ino = 1;
+    ls.back()->delegated_inos.insert(1, 10);
   }
 } __attribute__ ((__may_alias__));
 WRITE_CLASS_ENCODER(openc_response_t)

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -60,6 +60,17 @@ struct SnapPayload {
     decode(metadata, iter);
     DECODE_FINISH(iter);
   }
+  void dump(ceph::Formatter *f) const {
+    for (const auto &i : metadata) {
+      f->dump_string(i.first.c_str(), i.second);
+    }
+  }
+  static void generate_test_instances(std::list<SnapPayload *> &o) {
+    o.push_back(new SnapPayload);
+    o.push_back(new SnapPayload);
+    o.back()->metadata["key1"] = "val1";
+    o.back()->metadata["key2"] = "val2";
+  }
 };
 
 WRITE_CLASS_ENCODER(SnapPayload)
@@ -94,6 +105,26 @@ public:
       using ceph::decode;
       decode(item, bl);
       ceph::decode_nohead(item.dname_len, dname, bl);
+    }
+
+    void dump(ceph::Formatter *f) const {
+      f->dump_string("dname", dname);
+      f->dump_unsigned("ino", item.ino);
+      f->dump_unsigned("cap_id", item.cap_id);
+      f->dump_unsigned("caps", item.caps);
+      f->dump_unsigned("wanted", item.wanted);
+      f->dump_unsigned("seq", item.seq);
+      f->dump_unsigned("issue_seq", item.issue_seq);
+      f->dump_unsigned("mseq", item.mseq);
+      f->dump_unsigned("dname_seq", item.dname_seq);
+      f->dump_unsigned("dname_len", item.dname_len);
+    }
+
+    static void generate_test_instances(std::list<Release*>& ls) {
+      ls.push_back(new Release);
+      ls.push_back(new Release);
+      ls.back()->item.dname_len = 4;
+      ls.back()->dname = "test";
     }
   };
   mutable std::vector<Release> releases; /* XXX HACK! */

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -63,6 +63,17 @@ public:
       decode(nestlock, bl);
       decode(dftlock, bl);
     }
+    void dump(ceph::Formatter *f) const {
+      f->dump_int("nonce", nonce);
+      f->dump_int("caps_wanted", caps_wanted);
+      f->dump_int("filelock", filelock);
+      f->dump_int("nestlock", nestlock);
+      f->dump_int("dftlock", dftlock);
+    }
+    static void generate_test_instances(std::list<inode_strong*>& ls) {
+      ls.push_back(new inode_strong);
+      ls.push_back(new inode_strong(1, 2, 3, 4, 5));
+    }
   };
   WRITE_CLASS_ENCODER(inode_strong)
 
@@ -80,6 +91,14 @@ public:
       using ceph::decode;
       decode(nonce, bl);
       decode(dir_rep, bl);
+    }
+    static void generate_test_instances(std::list<dirfrag_strong*>& ls) {
+      ls.push_back(new dirfrag_strong);
+      ls.push_back(new dirfrag_strong(1, 2));
+    }
+    void dump(ceph::Formatter *f) const {
+      f->dump_unsigned("nonce", nonce);
+      f->dump_unsigned("dir_rep", dir_rep);
     }
   };
   WRITE_CLASS_ENCODER(dirfrag_strong)
@@ -117,6 +136,19 @@ public:
       decode(nonce, bl);
       decode(lock, bl);
       decode(alternate_name, bl);
+    }
+    static void generate_test_instances(std::list<dn_strong*>& ls) {
+      ls.push_back(new dn_strong);
+      ls.push_back(new dn_strong(1, "alternate_name", 2, 3, 4, 5, 6));
+    }
+    void dump(ceph::Formatter *f) const {
+      f->dump_unsigned("first", first);
+      f->dump_string("alternate_name", alternate_name);
+      f->dump_unsigned("ino", ino);
+      f->dump_unsigned("remote_ino", remote_ino);
+      f->dump_unsigned("remote_d_type", remote_d_type);
+      f->dump_unsigned("nonce", nonce);
+      f->dump_unsigned("lock", lock);
     }
   };
   WRITE_CLASS_ENCODER(dn_strong)

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -74,6 +74,27 @@ public:
     }
     DECODE_FINISH(p);
   }
+
+  void dump(ceph::Formatter *f) const
+  {
+    f->dump_string("path", path);
+    f->dump_string("description", description);
+    f->dump_string("nick", nick);
+    f->dump_int("type", type);
+    f->dump_int("priority", priority);
+    f->dump_int("unit", unit);
+  }
+  static void generate_test_instances(std::list<PerfCounterType*>& ls)
+  {
+    ls.push_back(new PerfCounterType);
+    ls.push_back(new PerfCounterType);
+    ls.back()->path = "mycounter";
+    ls.back()->description = "mycounter description";
+    ls.back()->nick = "mycounter nick";
+    ls.back()->type = PERFCOUNTER_COUNTER;
+    ls.back()->priority = PerfCountersBuilder::PRIO_CRITICAL;
+    ls.back()->unit = UNIT_BYTES;
+  }
 };
 WRITE_CLASS_ENCODER(PerfCounterType)
 

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1087,6 +1087,15 @@ void bluestore_onode_t::shard_info::dump(Formatter *f) const
   f->dump_unsigned("bytes", bytes);
 }
 
+void bluestore_onode_t::shard_info::generate_test_instances(
+  list<shard_info*>& o)
+{
+  o.push_back(new shard_info);
+  o.push_back(new shard_info);
+  o.back()->offset = 123;
+  o.back()->bytes = 456;
+}
+
 ostream& operator<<(ostream& out, const bluestore_onode_t::shard_info& si)
 {
   return out << std::hex << "0x" << si.offset << "(0x" << si.bytes << " bytes"

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -954,6 +954,7 @@ struct bluestore_onode_t {
       denc_varint(v.bytes, p);
     }
     void dump(ceph::Formatter *f) const;
+    static void generate_test_instances(std::list<shard_info*>& ls);
   };
   std::vector<shard_info> extent_map_shards; ///< extent std::map shards (if any)
 

--- a/src/tools/ceph-dencoder/common_types.h
+++ b/src/tools/ceph-dencoder/common_types.h
@@ -23,12 +23,29 @@ TYPE(filepath)
 
 #include "include/fs_types.h"
 TYPE_FEATUREFUL(file_layout_t)
+TYPE(inodeno_t)
 
 #include "include/util.h"
 TYPE(ceph_data_stats)
 
+#include "include/object.h"
+TYPE(object_t)
+TYPE(sobject_t)
+
+#include "include/frag.h"
+TYPE(fragtree_t)
+TYPE(frag_t)
+
+#include "include/types.h"
+TYPE(shard_id_t)
+TYPE(inline_data_t)
+TYPE(sha256_digest_t)
+TYPE(errorcode32_t)
+TYPE(client_t)
+
 #include "common/bit_vector.hpp"
 TYPE(BitVector<2>)
+TYPE(ceph::BitVector<2>)
 
 #include "common/bloom_filter.hpp"
 TYPE(bloom_filter)
@@ -36,6 +53,9 @@ TYPE(compressible_bloom_filter)
 
 #include "common/DecayCounter.h"
 TYPE(DecayCounter)
+
+#include "common/entity_name.h"
+TYPE(EntityName)
 
 #include "common/histogram.h"
 TYPE(pow2_hist_t)
@@ -71,11 +91,17 @@ TYPE(cls_cas_chunk_put_ref_op)
 
 #include "cls/cas/cls_cas_internal.h"
 TYPE(chunk_refs_t)
+TYPE(chunk_refs_count_t)
+TYPE(chunk_refs_by_object_t)
 
 #include "cls/lock/cls_lock_types.h"
 TYPE(rados::cls::lock::locker_id_t)
 TYPE_FEATUREFUL(rados::cls::lock::locker_info_t)
 TYPE_FEATUREFUL(rados::cls::lock::lock_info_t)
+using namespace rados::cls::lock;
+TYPE(locker_id_t)
+TYPE_FEATUREFUL(locker_info_t)
+TYPE_FEATUREFUL(lock_info_t)
 
 #include "cls/lock/cls_lock_ops.h"
 TYPE(cls_lock_lock_op)
@@ -97,6 +123,64 @@ TYPE(obj_refcount)
 
 #include "cls/timeindex/cls_timeindex_types.h"
 TYPE(cls_timeindex_entry)
+
+#include "cls/timeindex/cls_timeindex_ops.h"
+TYPE(cls_timeindex_list_op)
+TYPE(cls_timeindex_list_ret)
+
+#include "cls/queue/cls_queue_types.h"
+TYPE(cls_queue_entry)
+TYPE(cls_queue_marker)
+TYPE(cls_queue_head)
+
+#include "cls/queue/cls_queue_ops.h"
+TYPE(cls_queue_get_capacity_ret)
+TYPE(cls_queue_remove_op)
+TYPE(cls_queue_enqueue_op)
+TYPE(cls_queue_list_op)
+TYPE(cls_queue_list_ret)
+TYPE(cls_queue_init_op)
+
+#include "cls/2pc_queue/cls_2pc_queue_ops.h"
+TYPE(cls_2pc_queue_abort_op)
+TYPE(cls_2pc_queue_commit_op)
+TYPE(cls_2pc_queue_expire_op)
+TYPE_NONDETERMINISTIC(cls_2pc_queue_reservations_ret)
+TYPE(cls_2pc_queue_reserve_op)
+TYPE(cls_2pc_queue_reserve_ret)
+TYPE(cls_queue_init_op)
+
+#include "cls/2pc_queue/cls_2pc_queue_types.h"
+TYPE(cls_2pc_reservation)
+TYPE_NONDETERMINISTIC(cls_2pc_urgent_data)
+
+#include "cls/log/cls_log_types.h"
+TYPE(cls_log_header)
+
+#include "cls/log/cls_log_ops.h"
+TYPE(cls_log_info_op)
+TYPE(cls_log_list_op)
+TYPE(cls_log_list_ret)
+TYPE(cls_log_trim_op)
+
+#include "cls/version/cls_version_ops.h"
+TYPE(cls_version_check_op)
+TYPE(cls_version_read_ret)
+TYPE(cls_version_inc_op)
+TYPE(cls_version_set_op)
+
+
+#include "cls/fifo/cls_fifo_ops.h"
+using namespace rados::cls::fifo::op;
+TYPE(create_meta)
+TYPE(get_meta)
+TYPE(get_meta_reply)
+
+#include "cls/fifo/cls_fifo_types.h"
+using namespace rados::cls::fifo;
+TYPE(data_params)
+TYPE(objv)
+TYPE(info)
 
 #include "journal/Entry.h"
 TYPE(journal::Entry)
@@ -125,9 +209,12 @@ MESSAGE(MClientReconnect)
 
 #include "messages/MClientReply.h"
 MESSAGE(MClientReply)
+TYPE(openc_response_t)
 
 #include "messages/MClientRequest.h"
 MESSAGE(MClientRequest)
+TYPE(SnapPayload)
+TYPE(MClientRequest::Release)
 
 #include "messages/MClientRequestForward.h"
 MESSAGE(MClientRequestForward)
@@ -251,6 +338,9 @@ MESSAGE(MMDSBeacon)
 
 #include "messages/MMDSCacheRejoin.h"
 MESSAGE(MMDSCacheRejoin)
+TYPE(MMDSCacheRejoin::dirfrag_strong)
+TYPE(MMDSCacheRejoin::dn_strong)
+TYPE(MMDSCacheRejoin::inode_strong)
 
 #include "messages/MMDSFindIno.h"
 MESSAGE(MMDSFindIno)
@@ -265,10 +355,14 @@ MESSAGE(MMDSFragmentNotify)
 MESSAGE(MMDSLoadTargets)
 
 #include "messages/MMDSMap.h"
-MESSAGE(MMDSMap)
+MESSAGE(MMDSMap) 
+
+#include "messages/MMgrBeacon.h"
+MESSAGE(MMgrBeacon)
 
 #include "messages/MMgrReport.h"
 MESSAGE(MMgrReport)
+TYPE(PerfCounterType)
 
 #include "messages/MMDSResolve.h"
 MESSAGE(MMDSResolve)
@@ -320,6 +414,9 @@ MESSAGE(MMonGetVersionReply)
 
 #include "messages/MMonGlobalID.h"
 MESSAGE(MMonGlobalID)
+
+#include "messages/MMonHealth.h"
+MESSAGE(MMonHealth)
 
 #include "messages/MMonJoin.h"
 MESSAGE(MMonJoin)
@@ -452,3 +549,74 @@ MESSAGE(MWatchNotify)
 
 #include "messages/MMgrUpdate.h" 
 MESSAGE(MMgrUpdate)
+
+#include "messages/MOSDECSubOpRead.h"
+MESSAGE(MOSDECSubOpRead)
+
+#include "messages/MOSDECSubOpReadReply.h"
+MESSAGE(MOSDECSubOpReadReply)
+
+#include "messages/MOSDECSubOpWrite.h"
+MESSAGE(MOSDECSubOpWrite)
+
+#include "messages/MOSDECSubOpWriteReply.h"
+MESSAGE(MOSDECSubOpWriteReply)
+
+#include "messages/MOSDMarkMeDown.h"
+MESSAGE(MOSDMarkMeDown)
+
+#include "messages/MOSDPGCreated.h"
+MESSAGE(MOSDPGCreated)
+
+#include "messages/MOSDPGPush.h"
+MESSAGE(MOSDPGPush)
+
+#include "messages/MOSDPGPushReply.h"
+MESSAGE(MOSDPGPushReply)
+
+#include "messages/MOSDPGUpdateLogMissing.h"
+MESSAGE(MOSDPGUpdateLogMissing)
+
+#include "messages/MOSDPGUpdateLogMissingReply.h"
+MESSAGE(MOSDPGUpdateLogMissingReply)
+
+#include "messages/MOSDRepOp.h"
+MESSAGE(MOSDRepOp)
+
+#include "messages/MOSDRepOpReply.h"
+MESSAGE(MOSDRepOpReply)
+
+#include "messages/MRecoveryReserve.h"
+MESSAGE(MRecoveryReserve)
+
+
+#include "auth/cephx/CephxProtocol.h"
+TYPE(CephXAuthenticate)
+TYPE(CephXAuthorize)
+TYPE(CephXAuthorizeChallenge)
+TYPE(CephXAuthorizeReply)
+TYPE(CephXChallengeBlob)
+TYPE(CephXRequestHeader)
+TYPE(CephXResponseHeader)
+TYPE(CephXServerChallenge)
+TYPE(CephXServiceTicket)
+TYPE(CephXServiceTicketInfo)
+TYPE(CephXServiceTicketRequest)
+TYPE(CephXTicketBlob)
+
+#include "auth/cephx/CephxKeyServer.h"
+TYPE(KeyServerData)
+TYPE(KeyServerData::Incremental)
+
+#include "auth/Auth.h"
+TYPE(RotatingSecrets)
+TYPE(ExpiringCryptoKey)
+TYPE(AuthCapsInfo)
+TYPE(AuthTicket)
+TYPE(EntityAuth)
+
+#include "auth/Crypto.h"
+TYPE(CryptoKey)
+
+#include "common/ceph_json.h"
+TYPE(JSONFormattable)


### PR DESCRIPTION
Currently, ceph-dencoder lacks certain common types, preventing us from accurately checking the ceph corpus for encode-decode mismatches. This pull request aims to address this issue by adding the missing types to ceph-dencoder.

To successfully incorporate these types into ceph-dencoder, we need to introduce the necessary dump and generate_test_instances functions that was missing in some types. These functions are essential for proper encode and decode of the added types.

This PR will enhance the functionality of ceph-dencoder by including the missing types, enabling a comprehensive analysis of encode-decode consistency. With the addition of these types, we can ensure the robustness and correctness of the ceph corpus.

This update will significantly contribute to improving the overall reliability and accuracy of ceph-dencoder. It allows for a more comprehensive assessment of the encode-decode behavior, leading to enhanced data integrity and stability within the ceph ecosystem.

Fixes: https://tracker.ceph.com/issues/61788





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
