### PR TITLE
pacific: os/bluestore: cumulative bluefs backport

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -906,6 +906,7 @@ OPTION(objectstore_blackhole, OPT_BOOL)
 
 OPTION(bluefs_alloc_size, OPT_U64)
 OPTION(bluefs_shared_alloc_size, OPT_U64)
+OPTION(bluefs_failed_shared_alloc_cooldown, OPT_DOUBLE)
 OPTION(bluefs_max_prefetch, OPT_U64)
 OPTION(bluefs_min_log_runway, OPT_U64)  // alloc when we get this low
 OPTION(bluefs_max_log_runway, OPT_U64)  // alloc this much at a time

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4278,6 +4278,18 @@ std::vector<Option> get_global_options() {
     .set_default(64_K)
     .set_description("Allocation unit size for primary/shared device"),
 
+    Option("bluefs_failed_shared_alloc_cooldown", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(600)
+    .set_description(
+        "Duration(in seconds) until the next attempt to use "
+        "'bluefs_shared_alloc_size' after facing ENOSPC failure.")
+    .set_long_description(
+        "Cooldown period(in seconds) when BlueFS uses shared/slow device "
+        "allocation size instead of 'bluefs_shared_alloc_size' one after facing "
+        "recoverable (via fallback to smaller chunk size) ENOSPC failure. Intended "
+        "primarily to avoid repetitive unsuccessful allocations which might be "
+        " expensive."),
+
     Option("bluefs_max_prefetch", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_M)
     .set_description(""),

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -464,7 +464,7 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : nodes.file_map) {
@@ -517,13 +517,13 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   ceph_assert(log.seq_live == 1);
   log.t.seq = 1;
   log.t.op_init();
-  flush_and_sync_log();
+  _flush_and_sync_log_LD();
 
   // write supers
   super.log_fnode = log_file->fnode;
   super.memorized_layout = layout;
   _write_super(BDEV_DB);
-  flush_bdev();
+  _flush_bdev();
 
   // clean up
   super = bluefs_super_t();
@@ -867,7 +867,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    rewrite_log_and_layout_sync(false,
+    _rewrite_log_and_layout_sync_LN_LD(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -875,7 +875,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    rewrite_log_and_layout_sync(false,
+    _rewrite_log_and_layout_sync_LN_LD(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -1090,7 +1090,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
       int r = _read(log_reader, read_pos, super.block_size,
 		    &bl, NULL);
       if (r != (int)super.block_size && cct->_conf->bluefs_replay_recovery) {
-	r += do_replay_recovery_read(log_reader, pos, read_pos + r, super.block_size - r, &bl);
+	r += _do_replay_recovery_read(log_reader, pos, read_pos + r, super.block_size - r, &bl);
       }
       assert(r == (int)super.block_size);
       read_pos += r;
@@ -1150,7 +1150,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                  << ", which is past eof" << dendl;
 	if (cct->_conf->bluefs_replay_recovery) {
 	  //try to search for more data
-	  r += do_replay_recovery_read(log_reader, pos, read_pos + r, more - r, &t);
+	  r += _do_replay_recovery_read(log_reader, pos, read_pos + r, more - r, &t);
 	  if (r < (int)more) {
 	    //in normal mode we must read r==more, for recovery it is too strict
 	    break;
@@ -1719,7 +1719,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  rewrite_log_and_layout_sync(
+  _rewrite_log_and_layout_sync_LN_LD(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1854,7 +1854,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  rewrite_log_and_layout_sync(
+  _rewrite_log_and_layout_sync_LN_LD(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1879,7 +1879,7 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
   }
 }
 
-void BlueFS::_drop_link(FileRef file)
+void BlueFS::_drop_link_D(FileRef file)
 {
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
@@ -2150,9 +2150,9 @@ void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
   }
 }
 
-uint64_t BlueFS::estimate_log_size()
+uint64_t BlueFS::_estimate_log_size_N()
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
@@ -2166,14 +2166,14 @@ void BlueFS::compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      compact_log_sync();
+      _compact_log_sync_LN_LD();
     } else {
-      compact_log_async();
+      _compact_log_async_LD_NF_D();
     }
   }
 }
 
-bool BlueFS::should_start_compact_log()
+bool BlueFS::_should_start_compact_log_L_N()
 {
   if (log_is_compacting.load() == true) {
     // compaction is already running
@@ -2181,10 +2181,10 @@ bool BlueFS::should_start_compact_log()
   }
   uint64_t current;
   {
-    std::lock_guard dirl(log.lock);
+    std::lock_guard ll(log.lock);
     current = log.writer->file->fnode.size;
   }
-  uint64_t expected = estimate_log_size();
+  uint64_t expected = _estimate_log_size_N();
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
@@ -2197,10 +2197,10 @@ bool BlueFS::should_start_compact_log()
   return true;
 }
 
-void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
+void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
 					int flags)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
 
   t->seq = 1;
   t->uuid = super.uuid;
@@ -2248,12 +2248,12 @@ void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::compact_log_sync()
+void BlueFS::_compact_log_sync_LN_LD()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
     vselector->select_prefer_bdev(log.writer->file->vselector_hint);
-  rewrite_log_and_layout_sync(true,
+  _rewrite_log_and_layout_sync_LN_LD(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2262,7 +2262,7 @@ void BlueFS::compact_log_sync()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
+void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 					 int super_dev,
 					 int log_dev,
 					 int log_dev_new,
@@ -2288,7 +2288,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  compact_log_dump_metadata(&t, flags);
+  _compact_log_dump_metadata_N(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log.seq_live << dendl;
   t.op_jump_seq(log.seq_live);
@@ -2334,11 +2334,11 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(log.writer, &completed_ios);
-    wait_for_aio(log.writer);
+    _wait_for_aio(log.writer);
     completed_ios.clear();
   }
 #endif
-  flush_bdev();
+  _flush_bdev();
 
   super.memorized_layout = layout;
   super.log_fnode = log_file->fnode;
@@ -2353,7 +2353,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   ++super.version;
   _write_super(super_dev);
-  flush_bdev();
+  _flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
   std::lock_guard dl(dirty.lock);
@@ -2385,7 +2385,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
  * 8. Release the old log space.  Clean up.
  */
 
-void BlueFS::compact_log_async()
+void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 {
   dout(10) << __func__ << dendl;
   // only one compaction allowed at one time
@@ -2441,8 +2441,8 @@ void BlueFS::compact_log_async()
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
-  flush_bdev();
-  _flush_and_sync_log_jump(old_log_jump_to, runway);
+  _flush_bdev();
+  _flush_and_sync_log_jump_D(old_log_jump_to, runway);
 
   log.lock.unlock();
   // out of jump section - now log can be used to write to
@@ -2452,7 +2452,7 @@ void BlueFS::compact_log_async()
   //this needs files lock
   //what will happen, if a file is modified *twice* before we stream it to log?
   //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
-  compact_log_dump_metadata(&t, 0);
+  _compact_log_dump_metadata_N(&t, 0);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2483,6 +2483,7 @@ void BlueFS::compact_log_async()
   new_log_writer = _create_writer(new_log);
 
   new_log_writer->append(bl);
+  new_log->lock.lock();
   new_log_writer->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
@@ -2491,6 +2492,7 @@ void BlueFS::compact_log_async()
   // 4. wait
   _flush_bdev(new_log_writer);
   new_log_writer->lock.unlock();
+  new_log->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -2545,7 +2547,7 @@ void BlueFS::compact_log_async()
   ++super.version;
   _write_super(BDEV_DB);
 
-  flush_bdev();
+  _flush_bdev();
 
   old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
   ceph_assert(old_forbidden == true);
@@ -2718,9 +2720,9 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 }
 
 // Clears dirty.files up to (including) seq_stable.
-void BlueFS::_clear_dirty_set_stable(uint64_t seq)
+void BlueFS::_clear_dirty_set_stable_D(uint64_t seq)
 {
-  std::lock_guard lg(dirty.lock);
+  std::lock_guard dl(dirty.lock);
 
   // clean dirty files
   if (seq > dirty.seq_stable) {
@@ -2778,9 +2780,8 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
   }
 }
 
-int BlueFS::flush_and_sync_log(uint64_t want_seq)
+int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
 {
-  // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
     log.lock.lock();
@@ -2819,7 +2820,7 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
   //now log.lock is no longer needed
   log.lock.unlock();
 
-  _clear_dirty_set_stable(seq);
+  _clear_dirty_set_stable_D(seq);
   _release_pending_allocations(to_release);
 
   _update_logger_stats();
@@ -2827,7 +2828,7 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
 }
 
 // Flushes log and immediately adjusts log_writer pos.
-int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
+int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
 				     int64_t available_runway)
 {
   ceph_assert(ceph_mutex_is_locked(log.lock));
@@ -2852,7 +2853,7 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 
   _flush_bdev(log.writer);
 
-  _clear_dirty_set_stable(seq);
+  _clear_dirty_set_stable_D(seq);
   _release_pending_allocations(to_release);
 
   _update_logger_stats();
@@ -2902,7 +2903,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   return bl;
 }
 
-int BlueFS::_signal_dirty_to_log(FileWriter *h)
+int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   std::lock_guard dl(dirty.lock);
@@ -2936,12 +2937,12 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   return 0;
 }
 
-void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+void BlueFS::flush_range/*WF*/(FileWriter *h, uint64_t offset, uint64_t length) {
   std::unique_lock hl(h->lock);
-  _flush_range(h, offset, length);
+  _flush_range_F(h, offset, length);
 }
 
-int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
+int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
@@ -3000,8 +3001,10 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
-  //ceph_assert(ceph_mutex_is_locked(h->lock));
-  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  if (h->file->fnode.ino != 1) {
+    ceph_assert(ceph_mutex_is_locked(h->lock));
+    ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  }
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -3091,7 +3094,7 @@ void BlueFS::_claim_completed_aios(FileWriter *h, list<aio_t> *ls)
   dout(10) << __func__ << " got " << ls->size() << " aios" << dendl;
 }
 
-void BlueFS::wait_for_aio(FileWriter *h)
+void BlueFS::_wait_for_aio(FileWriter *h)
 {
   // NOTE: this is safe to call without a lock, as long as our reference is
   // stable.
@@ -3109,7 +3112,7 @@ void BlueFS::wait_for_aio(FileWriter *h)
 #endif
 
 
-void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush/*_WFL_WFN*/(FileWriter *h, const char* buf, size_t len)
 {
   std::unique_lock hl(h->lock);
   size_t max_size = 1ull << 30; // cap to 1GB
@@ -3125,10 +3128,10 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
     }
     if (need_flush) {
       bool flushed = false;
-      int r = _flush(h, true, &flushed);
+      int r = _flush_F(h, true, &flushed);
       ceph_assert(r == 0);
       if (r == 0 && flushed) {
-	maybe_compact_log();
+	_maybe_compact_log_LN_NF_LD_D();
       }
       // make sure we've made any progress with flush hence the
       // loop doesn't iterate forever
@@ -3141,14 +3144,14 @@ void BlueFS::flush(FileWriter *h, bool force)
 {
   std::unique_lock hl(h->lock);
   bool flushed = false;
-  int r = _flush(h, force, &flushed);
+  int r = _flush_F(h, force, &flushed);
   ceph_assert(r == 0);
   if (r == 0 && flushed) {
-    maybe_compact_log();
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
-int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
+int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
@@ -3172,7 +3175,7 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
            << std::hex << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
   ceph_assert(h->pos <= h->file->fnode.size);
-  int r = _flush_range(h, offset, length);
+  int r = _flush_range_F(h, offset, length);
   if (flushed) {
     *flushed = true;
   }
@@ -3187,8 +3190,7 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 // smart enough to discover it on its own.
 int BlueFS::_flush_special(FileWriter *h)
 {
-  //ceph_assert(ceph_mutex_is_locked(h->lock));
-  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  ceph_assert(h->file->fnode.ino <= 1);
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
@@ -3219,7 +3221,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
     ceph_abort_msg("actually this shouldn't happen");
   }
   if (h->get_buffer_length()) {
-    int r = _flush(h, true);
+    int r = _flush_F(h, true);
     if (r < 0)
       return r;
   }
@@ -3243,28 +3245,36 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
 int BlueFS::fsync(FileWriter *h)
 {
   std::unique_lock hl(h->lock);
-  dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
-  int r = _flush(h, true);
-  if (r < 0)
-     return r;
-  if (h->file->is_dirty) {
-    _signal_dirty_to_log(h);
-    h->file->is_dirty = false;
+  uint64_t old_dirty_seq = 0;
+  {
+    dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
+    int r = _flush_F(h, true);
+    if (r < 0)
+      return r;
+    _flush_bdev(h);
+    if (h->file->is_dirty) {
+      _signal_dirty_to_log_D(h);
+      h->file->is_dirty = false;
+    }
+    {
+      std::lock_guard dl(dirty.lock);
+      if (dirty.seq_stable < h->file->dirty_seq) {
+	old_dirty_seq = h->file->dirty_seq;
+	dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
+		 << ") on " << h->file->fnode << ", flushing log" << dendl;
+      }
+    }
   }
-  uint64_t old_dirty_seq = h->file->dirty_seq;
-
-  _flush_bdev(h);
-
   if (old_dirty_seq) {
     uint64_t s = log.seq_live; // AKAK !!! locks!
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
-    flush_and_sync_log(old_dirty_seq);
+    _flush_and_sync_log_LD(old_dirty_seq);
     // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
 		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
-  maybe_compact_log();
+  _maybe_compact_log_LN_NF_LD_D();
   return 0;
 }
 
@@ -3282,14 +3292,14 @@ void BlueFS::_flush_bdev(FileWriter *h)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);
-    wait_for_aio(h);
+    _wait_for_aio(h);
     completed_ios.clear();
   }
 #endif
-  flush_bdev(flush_devs);
+  _flush_bdev(flush_devs);
 }
 
-void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
+void BlueFS::_flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
 {
   // NOTE: this is safe to call without a lock.
   dout(20) << __func__ << dendl;
@@ -3299,7 +3309,7 @@ void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
   }
 }
 
-void BlueFS::flush_bdev()
+void BlueFS::_flush_bdev()
 {
   // NOTE: this is safe to call without a lock.
   dout(20) << __func__ << dendl;
@@ -3460,24 +3470,24 @@ void BlueFS::sync_metadata(bool avoid_compact)
     lgeneric_subdout(cct, bluefs, 10) << __func__;
     start = ceph_clock_now();
     *_dout <<  dendl;
-    flush_bdev(); // FIXME?
-    flush_and_sync_log();
+    _flush_bdev(); // FIXME?
+    _flush_and_sync_log_LD();
     dout(10) << __func__ << " done in " << (ceph_clock_now() - start) << dendl;
   }
 
   if (!avoid_compact) {
-    maybe_compact_log();
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
-void BlueFS::maybe_compact_log()
+void BlueFS::_maybe_compact_log_LN_NF_LD_D()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
-      should_start_compact_log()) {
+      _should_start_compact_log_L_N()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      compact_log_sync();
+      _compact_log_sync_LN_LD();
     } else {
-      compact_log_async();
+      _compact_log_async_LD_NF_D();
     }
   }
 }
@@ -3488,7 +3498,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
@@ -3635,7 +3645,7 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
@@ -3664,8 +3674,8 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(old_dirname);
@@ -3696,7 +3706,7 @@ int BlueFS::rename(
 	     << " already exists, unlinking" << dendl;
     ceph_assert(q->second != file);
     log.t.op_dir_unlink(new_dirname, new_filename);
-    _drop_link(q->second);
+    _drop_link_D(q->second);
   }
 
   dout(10) << __func__ << " " << new_dirname << "/" << new_filename << " "
@@ -3712,8 +3722,8 @@ int BlueFS::rename(
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p != nodes.dir_map.end()) {
@@ -3727,8 +3737,8 @@ int BlueFS::mkdir(std::string_view dirname)
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   auto p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3747,7 +3757,7 @@ int BlueFS::rmdir(std::string_view dirname)
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   bool exists = p != nodes.dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
@@ -3757,7 +3767,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3785,7 +3795,8 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3805,7 +3816,6 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
-    std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);
     log.t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
@@ -3824,7 +3834,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3838,7 +3848,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
@@ -3866,8 +3876,8 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3889,7 +3899,7 @@ int BlueFS::unlink(std::string_view dirname, std::string_view filename)
   }
   dir->file_map.erase(string{filename});
   log.t.op_dir_unlink(dirname, filename);
-  _drop_link(file);
+  _drop_link_D(file);
   return 0;
 }
 
@@ -3912,7 +3922,7 @@ bool BlueFS::wal_is_rotational()
   When we find it, we decode following bytes as extent.
   We read that whole extent and then check if merged with existing log part gives a proper bluefs transaction.
  */
-int BlueFS::do_replay_recovery_read(FileReader *log_reader,
+int BlueFS::_do_replay_recovery_read(FileReader *log_reader,
 				    size_t replay_pos,
 				    size_t read_offset,
 				    size_t read_len,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3624,6 +3624,7 @@ int BlueFS::_allocate_without_fallback(uint8_t id, uint64_t len,
          << ", allocator type " << alloc[id]->get_type()
          << ", capacity 0x" << alloc[id]->get_capacity()
          << ", block size 0x" << alloc[id]->get_block_size()
+         << ", alloc size 0x" << alloc_size[id]
          << ", free 0x" << alloc[id]->get_free()
          << ", fragmentation " << alloc[id]->get_fragmentation()
          << ", allocated 0x" << (alloc_len > 0 ? alloc_len : 0)
@@ -3670,6 +3671,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
               << ", allocator type " << alloc[id]->get_type()
               << ", capacity 0x" << alloc[id]->get_capacity()
               << ", block size 0x" << alloc[id]->get_block_size()
+              << ", alloc size 0x" << alloc_size[id]
               << ", free 0x" << alloc[id]->get_free()
               << ", fragmentation " << alloc[id]->get_fragmentation()
               << ", allocated 0x" << (alloc_len > 0 ? alloc_len : 0)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -148,7 +148,7 @@ private:
       out.append(ss);
     } else if (command == "bluefs files list") {
       const char* devnames[3] = {"wal","db","slow"};
-      std::lock_guard l(bluefs->lock);
+      std::lock_guard l(bluefs->dirs_lock);
       f->open_array_section("files");
       for (auto &d : bluefs->dir_map) {
         std::string dir = d.first;
@@ -310,6 +310,7 @@ void BlueFS::_shutdown_logger()
   delete logger;
 }
 
+//AK - TODO - locking needed but not certain
 void BlueFS::_update_logger_stats()
 {
   // we must be holding the lock
@@ -392,7 +393,6 @@ void BlueFS::handle_discard(unsigned id, interval_set<uint64_t>& to_release)
 
 uint64_t BlueFS::get_used()
 {
-  std::lock_guard l(lock);
   uint64_t used = 0;
   for (unsigned id = 0; id < MAX_BDEV; ++id) {
     used += _get_used(id);
@@ -418,7 +418,6 @@ uint64_t BlueFS::get_used(unsigned id)
 {
   ceph_assert(id < alloc.size());
   ceph_assert(alloc[id]);
-  std::lock_guard l(lock);
   return _get_used(id);
 }
 
@@ -431,13 +430,11 @@ uint64_t BlueFS::_get_total(unsigned id) const
 
 uint64_t BlueFS::get_total(unsigned id)
 {
-  std::lock_guard l(lock);
   return _get_total(id);
 }
 
 uint64_t BlueFS::get_free(unsigned id)
 {
-  std::lock_guard l(lock);
   ceph_assert(id < alloc.size());
   return alloc[id]->get_free();
 }
@@ -467,7 +464,7 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : file_map) {
@@ -482,7 +479,6 @@ int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 
 int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 {
-  std::unique_lock l(lock);
   dout(1) << __func__
 	  << " osd_uuid " << osd_uuid
 	  << dendl;
@@ -519,7 +515,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // initial txn
   log_t.op_init();
-  _flush_and_sync_log(l);
+  flush_and_sync_log();
 
   // write supers
   super.log_fnode = log_file->fnode;
@@ -869,7 +865,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -877,7 +873,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -908,7 +904,6 @@ void BlueFS::get_devices(set<string> *ls)
 
 int BlueFS::fsck()
 {
-  std::lock_guard l(lock);
   dout(1) << __func__ << dendl;
   // hrm, i think we check everything on mount...
   return 0;
@@ -1712,7 +1707,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1847,7 +1842,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1877,12 +1872,16 @@ void BlueFS::_drop_link(FileRef file)
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
   ceph_assert(file->refs > 0);
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   --file->refs;
   if (file->refs == 0) {
     dout(20) << __func__ << " destroying " << file->fnode << dendl;
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
     log_t.op_file_remove(file->fnode.ino);
+
+    std::lock_guard dl(dirty_lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
@@ -1890,6 +1889,7 @@ void BlueFS::_drop_link(FileRef file)
     file->deleted = true;
 
     if (file->dirty_seq) {
+      // retract request to serialize changes
       ceph_assert(file->dirty_seq > log_seq_stable);
       ceph_assert(dirty_files.count(file->dirty_seq));
       auto it = dirty_files[file->dirty_seq].iterator_to(*file);
@@ -2116,8 +2116,9 @@ int64_t BlueFS::_read(
   return ret;
 }
 
-void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
+void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 {
+  std::lock_guard l(f->lock);
   dout(10) << __func__ << " file " << f->fnode
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
            << dendl;
@@ -2137,8 +2138,9 @@ void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
   }
 }
 
-uint64_t BlueFS::_estimate_log_size()
+uint64_t BlueFS::estimate_log_size()
 {
+  std::lock_guard dirl(dirs_lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
@@ -2150,37 +2152,44 @@ uint64_t BlueFS::_estimate_log_size()
 
 void BlueFS::compact_log()
 {
-  std::unique_lock<ceph::mutex> l(lock);
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
 
-bool BlueFS::_should_compact_log()
+bool BlueFS::should_start_compact_log()
 {
-  uint64_t current = log_writer->file->fnode.size;
-  uint64_t expected = _estimate_log_size();
+  if (log_is_compacting.load() == true) {
+    // compaction is already running
+    return false;
+  }
+  uint64_t current;
+  {
+    std::lock_guard dirl(log_lock);
+    current = log_writer->file->fnode.size;
+  }
+  uint64_t expected = estimate_log_size();
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
 	   << " ratio " << ratio
-	   << (new_log ? " (async compaction in progress)" : "")
 	   << dendl;
-  if (new_log ||
-      current < cct->_conf->bluefs_log_compact_min_size ||
+  if (current < cct->_conf->bluefs_log_compact_min_size ||
       ratio < cct->_conf->bluefs_log_compact_min_ratio) {
     return false;
   }
   return true;
 }
 
-void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
+void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
 					int flags)
 {
+  std::lock_guard dirl(dirs_lock);
+
   t->seq = 1;
   t->uuid = super.uuid;
   dout(20) << __func__ << " op_init" << dendl;
@@ -2190,7 +2199,7 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
-
+    //AK - TODO - touching fnode - need to lock
     for(auto& e : file_ref->fnode.extents) {
       auto bdev = e.bdev;
       auto bdev_new = bdev;
@@ -2227,12 +2236,12 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::_compact_log_sync()
+void BlueFS::compact_log_sync()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
     vselector->select_prefer_bdev(log_writer->file->vselector_hint);
-  _rewrite_log_and_layout_sync(true,
+  rewrite_log_and_layout_sync(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2241,13 +2250,16 @@ void BlueFS::_compact_log_sync()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
-					  int super_dev,
-					  int log_dev,
-					  int log_dev_new,
-					  int flags,
-					  std::optional<bluefs_layout_t> layout)
+void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
+					 int super_dev,
+					 int log_dev,
+					 int log_dev_new,
+					 int flags,
+					 std::optional<bluefs_layout_t> layout)
 {
+  //ceph_assert(ceph_mutex_is_notlocked(log_lock));
+  std::lock_guard ll(log_lock);
+
   File *log_file = log_writer->file.get();
 
   // clear out log (be careful who calls us!!!)
@@ -2259,7 +2271,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  _compact_log_dump_metadata(&t, flags);
+  compact_log_dump_metadata(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log_seq << dendl;
   t.op_jump_seq(log_seq);
@@ -2327,6 +2339,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
   flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
+  std::lock_guard dl(dirty_lock);
   for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
@@ -2354,29 +2367,42 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
  *
  * 8. Release the old log space.  Clean up.
  */
-void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::compact_log_async()
 {
   dout(10) << __func__ << dendl;
-  File *log_file = log_writer->file.get();
-  ceph_assert(!new_log);
-  ceph_assert(!new_log_writer);
-
-  // create a new log [writer] so that we know compaction is in progress
-  // (see _should_compact_log)
-  new_log = ceph::make_ref<File>();
-  new_log->fnode.ino = 0;   // so that _flush_range won't try to log the fnode
-
-  // 0. wait for any racing flushes to complete.  (We do not want to block
-  // in _flush_sync_log with jump_to set or else a racing thread might flush
-  // our entries and our jump_to update won't be correct.)
-  while (log_flushing) {
-    dout(10) << __func__ << " log is currently flushing, waiting" << dendl;
-    log_cond.wait(l);
+  // only one compaction allowed at one time
+  bool old_is_comp = std::atomic_exchange(&log_is_compacting, true);
+  if (old_is_comp) {
+    dout(10) << __func__ << " ongoing" <<dendl;
+    return;
   }
+
+  log_lock.lock();
+  File *log_file = log_writer->file.get();
+  FileWriter *new_log_writer = nullptr;
+  FileRef new_log = nullptr;
+  uint64_t new_log_jump_to = 0;
+  uint64_t old_log_jump_to = 0;
+
+  new_log = ceph::make_ref<File>();
+  new_log->fnode.ino = 0;   // we use _flush_special to avoid log of the fnode
+
+  // Part 1.
+  // Prepare current log for jumping into it.
+  // 1. Allocate extent
+  // 2. Update op to log
+  // 3. Jump op to log
+  // During that, no one else can write to log, otherwise we risk jumping backwards.
+  // We need to sync log, because we are injecting discontinuity, and writer is not prepared for that.
+
+  //signal _maybe_extend_log that expansion of log is temporary inacceptable
+  bool old_forbidden = atomic_exchange(&log_forbidden_to_expand, true);
+  ceph_assert(old_forbidden == false);
 
   vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
 
-  // 1. allocate new log space and jump to it.
+  // 1.1 allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
   uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
@@ -2391,21 +2417,24 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log_t.op_file_update(log_file->fnode);
-  log_t.op_jump(log_seq, old_log_jump_to);
+  log_t.op_file_update(log_file->fnode); // 1.2
+  log_t.op_jump(log_seq, old_log_jump_to); // 1.3
 
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
   flush_bdev();
-
   _flush_and_sync_log_jump(old_log_jump_to, runway);
+
+  log_lock.unlock();
+  // out of jump section - now log can be used to write to
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  //avoid record two times in log_t and _compact_log_dump_metadata.
-  log_t.clear();
-  _compact_log_dump_metadata(&t, 0);
+  //this needs files lock
+  //what will happen, if a file is modified *twice* before we stream it to log?
+  //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
+  compact_log_dump_metadata(&t, 0);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2423,7 +2452,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ceph_assert(r == 0);
 
   // we might have some more ops in log_t due to _allocate call
-  t.claim_ops(log_t);
+  // t.claim_ops(log_t); no we no longer track allocations in log
 
   bufferlist bl;
   encode(t, bl);
@@ -2433,15 +2462,16 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 	   << std::dec << dendl;
 
   new_log_writer = _create_writer(new_log);
-  new_log_writer->append(bl);
 
+  new_log_writer->append(bl);
+  new_log_writer->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
-  _flush_bdev_safely(new_log_writer);
-
+  _flush_bdev(new_log_writer);
+  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -2496,29 +2526,42 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ++super.version;
   _write_super(BDEV_DB);
 
-  lock.unlock();
   flush_bdev();
-  lock.lock();
+
+  old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
+  ceph_assert(old_forbidden == true);
+  //to wake up if someone was in need of expanding log
+  log_cond.notify_all();
 
   // 7. release old space
   dout(10) << __func__ << " release old log extents " << old_extents << dendl;
-  for (auto& r : old_extents) {
-    pending_release[r.bdev].insert(r.offset, r.length);
+  {
+    std::lock_guard dl(dirty_lock);
+    for (auto& r : old_extents) {
+      pending_release[r.bdev].insert(r.offset, r.length);
+    }
   }
 
   // delete the new log, remove from the dirty files list
   _close_writer(new_log_writer);
+  // flush_special does not dirty files
+  /*
   if (new_log->dirty_seq) {
+    std::lock_guard dl(dirty_lock);
     ceph_assert(dirty_files.count(new_log->dirty_seq));
     auto it = dirty_files[new_log->dirty_seq].iterator_to(*new_log);
     dirty_files[new_log->dirty_seq].erase(it);
   }
+  */
   new_log_writer = nullptr;
   new_log = nullptr;
   log_cond.notify_all();
 
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
   logger->inc(l_bluefs_log_compactions);
+
+  old_is_comp = atomic_exchange(&log_is_compacting, false);
+  ceph_assert(old_is_comp);
 }
 
 void BlueFS::_pad_bl(bufferlist& bl)
@@ -2531,10 +2574,26 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
+/**
+ * Adds file modifications from `dirty_files` to bluefs transactions
+ * already stored in `log_t`. Writes them to disk and waits until are stable.
+ * Guarantees that file modifications with `want_seq` are already stable on disk.
+ * In addition may insert jump forward transaction to log write position `jump_to`.
+ *
+ * it should lock ability to:
+ * 1) add to log_t
+ * 2) modify dirty_files
+ * 3) add to pending_release
+ *
+ * pending_release and log_t go with same lock
+ */
+
 // Adds to log_t file modifications mentioned in `dirty_files`.
 // Note: some bluefs ops may have already been stored in log_t transaction.
 uint64_t BlueFS::_consume_dirty()
 {
+  ceph_assert(ceph_mutex_is_locked(dirty_lock));
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   //acquire new seq
   // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
@@ -2557,6 +2616,7 @@ uint64_t BlueFS::_consume_dirty()
 // Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
 int64_t BlueFS::_maybe_extend_log()
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
@@ -2579,7 +2639,7 @@ int64_t BlueFS::_maybe_extend_log()
      * - re-run compaction with more runway for old log
      * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
      */
-    if (new_log_writer) {
+    if (log_forbidden_to_expand.load() == true) {
       return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
@@ -2596,6 +2656,7 @@ int64_t BlueFS::_maybe_extend_log()
 
 void BlueFS::_flush_and_sync_log_core(int64_t runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
@@ -2625,6 +2686,8 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 // Clears dirty_files up to (including) seq_stable.
 void BlueFS::_clear_dirty_set_stable(uint64_t seq)
 {
+  std::lock_guard lg(dirty_lock);
+
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
@@ -2681,33 +2744,46 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
   }
 }
 
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			       uint64_t want_seq)
+int BlueFS::flush_and_sync_log(uint64_t want_seq)
 {
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    return 0;
-  }
+  // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
+    log_lock.lock();
+    dirty_lock.lock();
+    if (want_seq && want_seq <= log_seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	       << log_seq_stable << ", done" << dendl;
+      dirty_lock.unlock();
+      log_lock.unlock();
+      return 0;
+    }
+
     available_runway = _maybe_extend_log();
     if (available_runway == -EWOULDBLOCK) {
-      while (new_log_writer) {
-	dout(10) << __func__ << " waiting for async compaction" << dendl;
-	log_cond.wait(l);
+      // we are in need of adding runway, but we are during log-switch from compaction
+      dirty_lock.unlock();
+      //instead log_lock_unlock() do move ownership
+      std::unique_lock<ceph::mutex> ll(log_lock, std::adopt_lock);
+      while (log_forbidden_to_expand.load()) {
+	log_cond.wait(ll);
       }
+    } else {
+      ceph_assert(available_runway >= 0);
     }
-  } while (available_runway == -EWOULDBLOCK);
+  } while (available_runway < 0);
 
   ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
 
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
+  dirty_lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
+  //now log_lock is no longer needed
+  log_lock.unlock();
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2720,11 +2796,16 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 				     int64_t available_runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   ceph_assert(jump_to);
+  // we synchronize writing to log, by lock to log_lock
+
+  dirty_lock.lock();
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-
+  dirty_lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
@@ -2734,7 +2815,7 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
   log_writer->file->fnode.size = jump_to;
   vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
 
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2749,6 +2830,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   const unsigned length,
   const bluefs_super_t& super)
 {
+  ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino == 1);
   ceph::bufferlist bl;
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
@@ -2787,6 +2869,8 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 
 int BlueFS::_signal_dirty_to_log(FileWriter *h)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
+  std::lock_guard dl(dirty_lock);
   if (h->file->deleted) {
     dout(10) << __func__ << "  deleted, no-op" << dendl;
     return 0;
@@ -2817,8 +2901,14 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   return 0;
 }
 
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+  std::unique_lock hl(h->lock);
+  _flush_range(h, offset, length);
+}
+
 int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
@@ -2841,13 +2931,13 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
              << std::hex << offset << "~" << length << std::dec
              << dendl;
   }
+  std::lock_guard file_lock(h->file->lock);
   ceph_assert(offset <= h->file->fnode.size);
 
   uint64_t allocated = h->file->fnode.get_allocated();
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode);
   // do not bother to dirty the file if we are overwriting
   // previously allocated extents.
-
   if (allocated < offset + length) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
@@ -2868,12 +2958,15 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     h->file->fnode.size = offset + length;
     h->file->is_dirty = true;
   }
+
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
   return _flush_data(h, offset, length, buffered);
 }
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -2980,18 +3073,49 @@ void BlueFS::wait_for_aio(FileWriter *h)
 }
 #endif
 
-int BlueFS::_flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
 {
+  std::unique_lock hl(h->lock);
+  size_t max_size = 1ull << 30; // cap to 1GB
+  while (len > 0) {
+    bool need_flush = true;
+    auto l0 = h->get_buffer_length();
+    if (l0 < max_size) {
+      size_t l = std::min(len, max_size - l0);
+      h->append(buf, l);
+      buf += l;
+      len -= l;
+      need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
+    }
+    if (need_flush) {
+      bool flushed = false;
+      int r = _flush(h, true, &flushed);
+      ceph_assert(r == 0);
+      if (r == 0 && flushed) {
+	maybe_compact_log();
+      }
+      // make sure we've made any progress with flush hence the
+      // loop doesn't iterate forever
+      ceph_assert(h->get_buffer_length() < max_size);
+    }
+  }
+}
+
+void BlueFS::flush(FileWriter *h, bool force)
+{
+  std::unique_lock hl(h->lock);
   bool flushed = false;
   int r = _flush(h, force, &flushed);
+  ceph_assert(r == 0);
   if (r == 0 && flushed) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
-  return r;
 }
 
 int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   if (flushed) {
@@ -3028,6 +3152,8 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 // smart enough to discover it on its own.
 int BlueFS::_flush_special(FileWriter *h)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
@@ -3037,8 +3163,9 @@ int BlueFS::_flush_special(FileWriter *h)
   return _flush_data(h, offset, length, false);
 }
 
-int BlueFS::_truncate(FileWriter *h, uint64_t offset)
+int BlueFS::truncate(FileWriter *h, uint64_t offset)
 {
+  std::lock_guard hl(h->lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << std::dec
            << " file " << h->file->fnode << dendl;
   if (h->file->deleted) {
@@ -3068,17 +3195,19 @@ int BlueFS::_truncate(FileWriter *h, uint64_t offset)
     ceph_abort_msg("truncate up not supported");
   }
   ceph_assert(h->file->fnode.size >= offset);
-  _flush_bdev_safely(h);
+  _flush_bdev(h);
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
   h->file->fnode.size = offset;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
 
+  std::lock_guard ll(log_lock);
   log_t.op_file_update_inc(h->file->fnode);
   return 0;
 }
 
-int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
+int BlueFS::fsync(FileWriter *h)
 {
+  std::unique_lock hl(h->lock);
   dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
   int r = _flush(h, true);
   if (r < 0)
@@ -3089,39 +3218,40 @@ int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
   }
   uint64_t old_dirty_seq = h->file->dirty_seq;
 
-  _flush_bdev_safely(h);
+  _flush_bdev(h);
 
   if (old_dirty_seq) {
     uint64_t s = log_seq;
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
-    _flush_and_sync_log(l, old_dirty_seq);
+    flush_and_sync_log(old_dirty_seq);
+    // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-	   h->file->dirty_seq > s);    // or redirtied by someone else
+		h->file->dirty_seq > s);    // or redirtied by someone else
   }
+  maybe_compact_log();
   return 0;
 }
 
-void BlueFS::_flush_bdev_safely(FileWriter *h)
+// be careful - either h->file->lock or log_lock must be taken
+void BlueFS::_flush_bdev(FileWriter *h)
 {
+  if (h->file->fnode.ino != 1) {
+    ceph_assert(ceph_mutex_is_locked(h->lock));
+  } else {
+    ceph_assert(ceph_mutex_is_locked(log_lock));
+  }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);
-    lock.unlock();
     wait_for_aio(h);
     completed_ios.clear();
-    flush_bdev(flush_devs);
-    lock.lock();
-  } else
-#endif
-  {
-    lock.unlock();
-    flush_bdev(flush_devs);
-    lock.lock();
   }
+#endif
+  flush_bdev(flush_devs);
 }
 
 void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
@@ -3253,8 +3383,9 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   return 0;
 }
 
-int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
+int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
   if (f->deleted) {
@@ -3273,6 +3404,7 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update_inc(f->fnode);
   }
   return 0;
@@ -3280,8 +3412,13 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
 
 void BlueFS::sync_metadata(bool avoid_compact)
 {
-  std::unique_lock l(lock);
-  if (log_t.empty() && dirty_files.empty()) {
+  bool can_skip_flush;
+  {
+    std::lock_guard ll(log_lock);
+    std::lock_guard dl(dirty_lock);
+    can_skip_flush = log_t.empty() && dirty_files.empty();
+  }
+  if (can_skip_flush) {
     dout(10) << __func__ << " - no pending log events" << dendl;
   } else {
     utime_t start;
@@ -3289,23 +3426,23 @@ void BlueFS::sync_metadata(bool avoid_compact)
     start = ceph_clock_now();
     *_dout <<  dendl;
     flush_bdev(); // FIXME?
-    _flush_and_sync_log(l);
+    flush_and_sync_log();
     dout(10) << __func__ << " done in " << (ceph_clock_now() - start) << dendl;
   }
 
   if (!avoid_compact) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
 }
 
-void BlueFS::_maybe_compact_log(std::unique_lock<ceph::mutex>& l)
+void BlueFS::maybe_compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
-      _should_compact_log()) {
+      should_start_compact_log()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
@@ -3316,7 +3453,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   DirRef dir;
@@ -3378,11 +3515,12 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
-
-  log_t.op_file_update(file->fnode);
-  if (create)
-    log_t.op_dir_link(dirname, filename, file->fnode.ino);
-
+  {
+    std::lock_guard ll(log_lock);
+    log_t.op_file_update(file->fnode);
+    if (create)
+      log_t.op_dir_link(dirname, filename, file->fnode.ino);
+  }
   *h = _create_writer(file);
 
   if (boost::algorithm::ends_with(filename, ".log")) {
@@ -3412,7 +3550,7 @@ BlueFS::FileWriter *BlueFS::_create_writer(FileRef f)
   return w;
 }
 
-void BlueFS::_close_writer(FileWriter *h)
+void BlueFS::_drain_writer(FileWriter *h)
 {
   dout(10) << __func__ << " " << h << " type " << h->writer_type << dendl;
   //h->buffer.reassign_to_mempool(mempool::mempool_bluefs_file_writer);
@@ -3428,18 +3566,31 @@ void BlueFS::_close_writer(FileWriter *h)
   if (h->file->fnode.size >= (1ull << 30)) {
     dout(10) << __func__ << " file is unexpectedly large:" << h->file->fnode << dendl;
   }
+}
+
+void BlueFS::_close_writer(FileWriter *h)
+{
+  _drain_writer(h);
+  delete h;
+}
+void BlueFS::close_writer(FileWriter *h)
+{
+  {
+    std::lock_guard l(h->lock);
+    _drain_writer(h);
+  }
   delete h;
 }
 
 uint64_t BlueFS::debug_get_dirty_seq(FileWriter *h)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->file->dirty_seq;
 }
 
 bool BlueFS::debug_get_is_dev_dirty(FileWriter *h, uint8_t dev)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->dirty_devs[dev];
 }
 
@@ -3449,7 +3600,7 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
@@ -3478,7 +3629,8 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(old_dirname);
@@ -3525,7 +3677,8 @@ int BlueFS::rename(
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p != dir_map.end()) {
@@ -3539,7 +3692,8 @@ int BlueFS::mkdir(std::string_view dirname)
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   auto p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3558,7 +3712,7 @@ int BlueFS::rmdir(std::string_view dirname)
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   bool exists = p != dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
@@ -3568,7 +3722,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3596,7 +3750,7 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3616,6 +3770,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update(file->fnode);
     log_t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
@@ -3634,7 +3789,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3648,7 +3803,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
@@ -3676,7 +3831,8 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2511,16 +2511,16 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   new_log_writer = _create_writer(new_log);
 
   new_log_writer->append(bl);
-  new_log->lock.lock();
   new_log_writer->lock.lock();
+  new_log->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
   _flush_bdev(new_log_writer);
-  new_log_writer->lock.unlock();
   new_log->lock.unlock();
+  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -3268,9 +3268,9 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
 
 int BlueFS::fsync(FileWriter *h)
 {
-  std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
   {
+    std::unique_lock hl(h->lock);
     dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
     int r = _flush_F(h, true);
     if (r < 0)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2176,13 +2176,13 @@ uint64_t BlueFS::_estimate_log_size_N()
   return round_up_to(size, super.block_size);
 }
 
-void BlueFS::compact_log()
+void BlueFS::compact_log()/*_LNF_LD_NF_D*/
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
       _compact_log_sync_LNF_LD();
     } else {
-      _compact_log_async_LD_NF_D();
+      _compact_log_async_LD_LNF_D();
     }
   }
 }
@@ -2435,7 +2435,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
  * 8. Release the old log space.  Clean up.
  */
 
-void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
+void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
 {
   dout(10) << __func__ << dendl;
   // only one compaction allowed at one time
@@ -2968,7 +2968,8 @@ int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
   return 0;
 }
 
-void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length)/*_WF*/
+{
   std::unique_lock hl(h->lock);
   _flush_range_F(h, offset, length);
 }
@@ -3143,7 +3144,7 @@ void BlueFS::_wait_for_aio(FileWriter *h)
 }
 #endif
 
-void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_LNF_NF_LD_D*/
 {
   bool flushed_sum = false;
   {
@@ -3175,7 +3176,7 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
   }
 }
 
-void BlueFS::flush(FileWriter *h, bool force)
+void BlueFS::flush(FileWriter *h, bool force)/*_WF_LNF_NF_LD_D*/
 {
   bool flushed = false;
   int r;
@@ -3241,7 +3242,7 @@ uint64_t BlueFS::_flush_special(FileWriter *h)
   return new_data;
 }
 
-int BlueFS::truncate(FileWriter *h, uint64_t offset)
+int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
 {
   std::lock_guard hl(h->lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << std::dec
@@ -3283,7 +3284,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
   return 0;
 }
 
-int BlueFS::fsync(FileWriter *h)
+int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
 {
   std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
@@ -3463,7 +3464,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   return 0;
 }
 
-int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
+int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)/*_LF*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard fl(f->lock);
@@ -3491,7 +3492,7 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
   return 0;
 }
 
-void BlueFS::sync_metadata(bool avoid_compact)
+void BlueFS::sync_metadata(bool avoid_compact)/*_LNF_NF_LD_D*/
 {
   bool can_skip_flush;
   {
@@ -3523,7 +3524,7 @@ void BlueFS::_maybe_compact_log_LNF_NF_LD_D()
     if (cct->_conf->bluefs_compact_log_sync) {
       _compact_log_sync_LNF_LD();
     } else {
-      _compact_log_async_LD_NF_D();
+      _compact_log_async_LD_LNF_D();
     }
   }
 }
@@ -3532,7 +3533,7 @@ int BlueFS::open_for_write(
   std::string_view dirname,
   std::string_view filename,
   FileWriter **h,
-  bool overwrite)
+  bool overwrite)/*_N_LD*/
 {
   FileRef file;
   bool create = false;
@@ -3686,7 +3687,7 @@ int BlueFS::open_for_read(
   std::string_view dirname,
   std::string_view filename,
   FileReader **h,
-  bool random)
+  bool random)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
@@ -3715,7 +3716,7 @@ int BlueFS::open_for_read(
 
 int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
-  std::string_view new_dirname, std::string_view new_filename)
+  std::string_view new_dirname, std::string_view new_filename)/*_LND*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3763,7 +3764,7 @@ int BlueFS::rename(
   return 0;
 }
 
-int BlueFS::mkdir(std::string_view dirname)
+int BlueFS::mkdir(std::string_view dirname)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3778,7 +3779,7 @@ int BlueFS::mkdir(std::string_view dirname)
   return 0;
 }
 
-int BlueFS::rmdir(std::string_view dirname)
+int BlueFS::rmdir(std::string_view dirname)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3798,7 +3799,7 @@ int BlueFS::rmdir(std::string_view dirname)
   return 0;
 }
 
-bool BlueFS::dir_exists(std::string_view dirname)
+bool BlueFS::dir_exists(std::string_view dirname)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
@@ -3808,7 +3809,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 }
 
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
-		 uint64_t *size, utime_t *mtime)
+		 uint64_t *size, utime_t *mtime)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
@@ -3836,7 +3837,7 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 }
 
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
-		      FileLock **plock)
+		      FileLock **plock)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3876,7 +3877,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
   return 0;
 }
 
-int BlueFS::unlock_file(FileLock *fl)
+int BlueFS::unlock_file(FileLock *fl)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
@@ -3886,7 +3887,7 @@ int BlueFS::unlock_file(FileLock *fl)
   return 0;
 }
 
-int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
+int BlueFS::readdir(std::string_view dirname, vector<string> *ls)/*_N*/
 {
   // dirname may contain a trailing /
   if (!dirname.empty() && dirname.back() == '/') {
@@ -3918,7 +3919,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   return 0;
 }
 
-int BlueFS::unlink(std::string_view dirname, std::string_view filename)
+int BlueFS::unlink(std::string_view dirname, std::string_view filename)/*_LND*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -842,13 +842,13 @@ void BlueFS::umount(bool avoid_compact)
 
   _close_writer(log.writer);
   log.writer = NULL;
+  log.t.clear();
 
   vselector.reset(nullptr);
   _stop_alloc();
   nodes.file_map.clear();
   nodes.dir_map.clear();
   super = bluefs_super_t();
-  log.t.clear();
   _shutdown_logger();
 }
 
@@ -863,7 +863,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    _rewrite_log_and_layout_sync_LN_LD(false,
+    _rewrite_log_and_layout_sync_LNF_LD(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -871,7 +871,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    _rewrite_log_and_layout_sync_LN_LD(false,
+    _rewrite_log_and_layout_sync_LNF_LD(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -1713,7 +1713,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  _rewrite_log_and_layout_sync_LN_LD(
+  _rewrite_log_and_layout_sync_LNF_LD(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1848,7 +1848,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  _rewrite_log_and_layout_sync_LN_LD(
+  _rewrite_log_and_layout_sync_LNF_LD(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1875,6 +1875,14 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
   }
 }
 
+
+/**
+To modify fnode both FileWriter::lock and File::lock must be obtained.
+The special case is when we modify bluefs log (ino 1) or
+we are compacting log (ino 0).
+
+In any case it is enough to hold File::lock to be sure fnode will not be modified.
+*/
 struct lock_fnode_print {
   BlueFS::FileRef file;
   lock_fnode_print(BlueFS::FileRef file) : file(file) {};
@@ -1891,6 +1899,7 @@ void BlueFS::_drop_link_D(FileRef file)
 	   << " on " << lock_fnode_print(file) << dendl;
   ceph_assert(file->refs > 0);
   ceph_assert(ceph_mutex_is_locked(log.lock));
+  ceph_assert(ceph_mutex_is_locked(nodes.lock));
 
   --file->refs;
   if (file->refs == 0) {
@@ -2136,7 +2145,7 @@ int64_t BlueFS::_read(
 void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 {
   std::lock_guard l(f->lock);
-  dout(10) << __func__ << " file " << lock_fnode_print(f)
+  dout(10) << __func__ << " file " << f->fnode
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
            << dendl;
   if (offset & ~super.block_mask()) {
@@ -2171,7 +2180,7 @@ void BlueFS::compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync_LN_LD();
+      _compact_log_sync_LNF_LD();
     } else {
       _compact_log_async_LD_NF_D();
     }
@@ -2202,7 +2211,7 @@ bool BlueFS::_should_start_compact_log_L_N()
   return true;
 }
 
-void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
+void BlueFS::_compact_log_dump_metadata_NF(bluefs_transaction_t *t,
 					int flags)
 {
   std::lock_guard nl(nodes.lock);
@@ -2287,12 +2296,16 @@ void BlueFS::_compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::_compact_log_sync_LN_LD()
+void BlueFS::_compact_log_sync_LNF_LD()
 {
   dout(10) << __func__ << dendl;
-  auto prefer_bdev =
-    vselector->select_prefer_bdev(log.writer->file->vselector_hint);
-  _rewrite_log_and_layout_sync_LN_LD(true,
+  uint8_t prefer_bdev;
+  {
+    std::lock_guard ll(log.lock);
+    prefer_bdev =
+      vselector->select_prefer_bdev(log.writer->file->vselector_hint);
+  }
+  _rewrite_log_and_layout_sync_LNF_LD(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2301,7 +2314,7 @@ void BlueFS::_compact_log_sync_LN_LD()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
+void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
 					 int super_dev,
 					 int log_dev,
 					 int log_dev_new,
@@ -2326,7 +2339,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  _compact_log_dump_metadata_N(&t, flags);
+  _compact_log_dump_metadata_NF(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log.seq_live << dendl;
   t.op_jump_seq(log.seq_live);
@@ -2507,9 +2520,6 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
                     &new_log->fnode);
   ceph_assert(r == 0);
 
-  // we might have some more ops in log_t due to _allocate call
-  // t.claim_ops(log_t); no we no longer track allocations in log
-
   bufferlist bl;
   encode(t, bl);
   _pad_bl(bl);
@@ -2624,19 +2634,6 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
-/**
- * Adds file modifications from `dirty.files` to bluefs transactions
- * already stored in `log.t`. Writes them to disk and waits until are stable.
- * Guarantees that file modifications with `want_seq` are already stable on disk.
- * In addition may insert jump forward transaction to log write position `jump_to`.
- *
- * it should lock ability to:
- * 1) add to log.t
- * 2) modify dirty.files
- * 3) add to pending_release
- *
- * pending_release and log.t go with same lock
- */
 
 // Returns log seq that was live before advance.
 uint64_t BlueFS::_log_advance_seq()
@@ -2971,7 +2968,7 @@ int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
   return 0;
 }
 
-void BlueFS::flush_range/*WF*/(FileWriter *h, uint64_t offset, uint64_t length) {
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
   std::unique_lock hl(h->lock);
   _flush_range_F(h, offset, length);
 }
@@ -3174,7 +3171,7 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
     }
   }
   if (flushed_sum) {
-    _maybe_compact_log_LN_NF_LD_D();
+    _maybe_compact_log_LNF_NF_LD_D();
   }
 }
 
@@ -3188,7 +3185,7 @@ void BlueFS::flush(FileWriter *h, bool force)
     ceph_assert(r == 0);
   }
   if (r == 0 && flushed) {
-    _maybe_compact_log_LN_NF_LD_D();
+    _maybe_compact_log_LNF_NF_LD_D();
   }
 }
 
@@ -3312,7 +3309,7 @@ int BlueFS::fsync(FileWriter *h)
   if (old_dirty_seq) {
     _flush_and_sync_log_LD(old_dirty_seq);
   }
-  _maybe_compact_log_LN_NF_LD_D();
+  _maybe_compact_log_LNF_NF_LD_D();
   return 0;
 }
 
@@ -3515,16 +3512,16 @@ void BlueFS::sync_metadata(bool avoid_compact)
   }
 
   if (!avoid_compact) {
-    _maybe_compact_log_LN_NF_LD_D();
+    _maybe_compact_log_LNF_NF_LD_D();
   }
 }
 
-void BlueFS::_maybe_compact_log_LN_NF_LD_D()
+void BlueFS::_maybe_compact_log_LNF_NF_LD_D()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
       _should_start_compact_log_L_N()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync_LN_LD();
+      _compact_log_sync_LNF_LD();
     } else {
       _compact_log_async_LD_NF_D();
     }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2299,7 +2299,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   log_writer = _create_writer(log_file);
   log_writer->append(bl);
-  r = _flush(log_writer, true);
+  r = _flush_special(log_writer);
   ceph_assert(r == 0);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
@@ -2436,7 +2436,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   new_log_writer->append(bl);
 
   // 3. flush
-  r = _flush(new_log_writer, true);
+  r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
@@ -2618,7 +2618,7 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
   log_t.clear();
   log_t.seq = 0;  // just so debug output is less confusing
 
-  int r = _flush(log_writer, true);
+  int r = _flush_special(log_writer);
   ceph_assert(r == 0);
 }
 
@@ -2829,11 +2829,8 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 
   ceph_assert(h->file->num_readers.load() == 0);
 
-  bool buffered;
-  if (h->file->fnode.ino == 1)
-    buffered = false;
-  else
-    buffered = cct->_conf->bluefs_buffered_io;
+  bool buffered = cct->_conf->bluefs_buffered_io;
+  ceph_assert(h->file->fnode.ino > 1);
 
   if (offset + length <= h->pos)
     return 0;
@@ -2854,7 +2851,6 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   if (allocated < offset + length) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
-    ceph_assert(h->file->fnode.ino != 1);
     int r = _allocate(vselector->select_prefer_bdev(h->file->vselector_hint),
 		      offset + length - allocated,
 		      &h->file->fnode);
@@ -2870,15 +2866,14 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   }
   if (h->file->fnode.size < offset + length) {
     h->file->fnode.size = offset + length;
-    if (h->file->fnode.ino > 1) {
-      // we do not need to dirty the log file (or it's compacting
-      // replacement) when the file size changes because replay is
-      // smart enough to discover it on its own.
-      h->file->is_dirty = true;
-    }
+    h->file->is_dirty = true;
   }
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
+  return _flush_data(h, offset, length, buffered);
+}
 
+int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
+{
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -3023,6 +3018,23 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
     *flushed = true;
   }
   return r;
+}
+
+// Flush for bluefs special files.
+// Does not add extents to h.
+// Does not mark h as dirty.
+// we do not need to dirty the log file (or it's compacting
+// replacement) when the file size changes because replay is
+// smart enough to discover it on its own.
+int BlueFS::_flush_special(FileWriter *h)
+{
+  uint64_t length = h->get_buffer_length();
+  uint64_t offset = h->pos;
+  ceph_assert(length + offset <= h->file->fnode.get_allocated());
+  if (h->file->fnode.size < offset + length) {
+    h->file->fnode.size = offset + length;
+  }
+  return _flush_data(h, offset, length, false);
 }
 
 int BlueFS::_truncate(FileWriter *h, uint64_t offset)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2378,6 +2378,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // 1. allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
+  uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
            << " need 0x" << (old_log_jump_to + cct->_conf->bluefs_max_log_runway) << std::dec << dendl;
   int r = _allocate(vselector->select_prefer_bdev(log_file->vselector_hint),
@@ -2393,9 +2394,12 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   log_t.op_file_update(log_file->fnode);
   log_t.op_jump(log_seq, old_log_jump_to);
 
-  flush_bdev();  // FIXME?
+  // we need to flush all bdev because we will be streaming all dirty files to log
+  // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
+  // then flush_bdev() will not be necessary
+  flush_bdev();
 
-  _flush_and_sync_log(l, 0, old_log_jump_to);
+  _flush_and_sync_log_jump(old_log_jump_to, runway);
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
@@ -2527,38 +2531,17 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
-
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-				uint64_t want_seq,
-				uint64_t jump_to)
+// Adds to log_t file modifications mentioned in `dirty_files`.
+// Note: some bluefs ops may have already been stored in log_t transaction.
+uint64_t BlueFS::_consume_dirty()
 {
-  while (log_flushing) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " log is currently flushing, waiting" << dendl;
-    ceph_assert(!jump_to);
-    log_cond.wait(l);
-  }
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-  if (log_t.empty() && dirty_files.empty()) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " " << log_t << " not dirty, dirty_files empty, no-op" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
-
+  //acquire new seq
+  // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
-  ceph_assert(want_seq == 0 || want_seq <= seq);
   log_t.uuid = super.uuid;
 
   // log dirty files
+  // we just incremented log_seq. It is now illegal to add to dirty_files[log_seq]
   auto lsi = dirty_files.find(seq);
   if (lsi != dirty_files.end()) {
     dout(20) << __func__ << " " << lsi->second.size() << " dirty_files" << dendl;
@@ -2567,21 +2550,37 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       log_t.op_file_update_inc(f.fnode);
     }
   }
+  return seq;
+}
 
-  dout(10) << __func__ << " " << log_t << dendl;
-  ceph_assert(!log_t.empty());
-
+// Extends log if its free space is smaller then bluefs_min_log_runway.
+// Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
+int64_t BlueFS::_maybe_extend_log()
+{
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
     log_writer->get_effective_write_pos();
-  bool just_expanded_log = false;
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
-    while (new_log_writer) {
-      dout(10) << __func__ << " waiting for async compaction" << dendl;
-      log_cond.wait(l);
+    /*
+     * Usually, when we are low on space in log, we just allocate new extent,
+     * put update op(log) to log and we are fine.
+     * Problem - it interferes with log compaction:
+     * New log produced in compaction will include - as last op - jump into some offset (anchor) of current log.
+     * It is assumed that log region (anchor - end) will contain all changes made by bluefs since
+     * full state capture into new log.
+     * Putting log update into (anchor - end) region is illegal, because any update there must be compatible with
+     * both logs, but old log is different then new log.
+     *
+     * Possible solutions:
+     * - stall extending log until we finish compacting and switch log (CURRENT)
+     * - re-run compaction with more runway for old log
+     * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
+     */
+    if (new_log_writer) {
+      return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     int r = _allocate(
@@ -2591,8 +2590,13 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
     ceph_assert(r == 0);
     vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     log_t.op_file_update_inc(log_writer->file->fnode);
-    just_expanded_log = true;
   }
+  return runway;
+}
+
+void BlueFS::_flush_and_sync_log_core(int64_t runway)
+{
+  dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
   bl.reserve(super.block_size);
@@ -2604,38 +2608,29 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 
   logger->inc(l_bluefs_logged_bytes, bl.length());
 
-  if (just_expanded_log) {
+  if (true) {
     ceph_assert(bl.length() <= runway); // if we write this, we will have an unrecoverable data loss
+                                        // transaction will not fit extents before growth -> data loss on _replay
   }
 
   log_writer->append(bl);
 
   log_t.clear();
   log_t.seq = 0;  // just so debug output is less confusing
-  log_flushing = true;
 
   int r = _flush(log_writer, true);
   ceph_assert(r == 0);
+}
 
-  if (jump_to) {
-    dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	     << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-    log_writer->pos = jump_to;
-    vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-    log_writer->file->fnode.size = jump_to;
-    vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-  }
-
-  _flush_bdev_safely(log_writer);
-
-  log_flushing = false;
-  log_cond.notify_all();
-
+// Clears dirty_files up to (including) seq_stable.
+void BlueFS::_clear_dirty_set_stable(uint64_t seq)
+{
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
     dout(20) << __func__ << " log_seq_stable " << log_seq_stable << dendl;
 
+    // undirty all files that were already streamed to log
     auto p = dirty_files.begin();
     while (p != dirty_files.end()) {
       if (p->first > log_seq_stable) {
@@ -2661,7 +2656,10 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
              << " already >= out seq " << seq
              << ", we lost a race against another log flush, done" << dendl;
   }
+}
 
+void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
+{
   for (unsigned i = 0; i < to_release.size(); ++i) {
     if (!to_release[i].empty()) {
       /* OK, now we have the guarantee alloc[i] won't be null. */
@@ -2681,9 +2679,67 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       }
     }
   }
+}
+
+int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
+			       uint64_t want_seq)
+{
+  if (want_seq && want_seq <= log_seq_stable) {
+    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	     << log_seq_stable << ", done" << dendl;
+    return 0;
+  }
+  int64_t available_runway;
+  do {
+    available_runway = _maybe_extend_log();
+    if (available_runway == -EWOULDBLOCK) {
+      while (new_log_writer) {
+	dout(10) << __func__ << " waiting for async compaction" << dendl;
+	log_cond.wait(l);
+      }
+    }
+  } while (available_runway == -EWOULDBLOCK);
+
+  ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
+
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
 
   _update_logger_stats();
+  return 0;
+}
 
+// Flushes log and immediately adjusts log_writer pos.
+int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
+				     int64_t available_runway)
+{
+  ceph_assert(jump_to);
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+
+  dout(10) << __func__ << " jumping log offset from 0x" << std::hex
+	   << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
+  log_writer->pos = jump_to;
+  vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+  log_writer->file->fnode.size = jump_to;
+  vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
+
+  _update_logger_stats();
   return 0;
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1191,7 +1191,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
     }
 
     auto p = t.op_bl.cbegin();
+    auto pos0 = pos;
     while (!p.end()) {
+      pos = pos0 + p.get_off();
       __u8 op;
       decode(op, p);
       switch (op) {
@@ -2013,7 +2015,9 @@ int64_t BlueFS::_read_random(
       buf->pos += r;
     }
   }
-  dout(20) << __func__ << " got " << ret << dendl;
+  dout(20) << __func__ << std::hex
+           << " got 0x" << ret
+           << std::dec  << dendl;
   --h->file->num_reading;
   return ret;
 }
@@ -2137,7 +2141,9 @@ int64_t BlueFS::_read(
     buf->pos += r;
   }
 
-  dout(20) << __func__ << " got " << ret << dendl;
+  dout(20) << __func__ << std::hex
+           << " got 0x" << ret
+           << std::dec  << dendl;
   ceph_assert(!outbl || (int)outbl->length() == ret);
   --h->file->num_reading;
   return ret;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3448,6 +3448,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
 
 int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard ll(log.lock);
   std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
@@ -3467,7 +3468,7 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
-    std::lock_guard ll(log.lock);
+
     log.t.op_file_update_inc(f->fnode);
   }
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -490,7 +490,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   _init_alloc();
   _init_logger();
 
-  super.version = 1;
+  super.version = 0;
   super.block_size = bdev[BDEV_DB]->get_block_size();
   super.osd_uuid = osd_uuid;
   super.uuid.generate_random();
@@ -909,6 +909,7 @@ int BlueFS::fsck()
 
 int BlueFS::_write_super(int dev)
 {
+  ++super.version;
   // build superblock
   bufferlist bl;
   encode(super, bl);
@@ -2366,7 +2367,6 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
   }
   dout(10) << __func__ << " writing super, log fnode: " << super.log_fnode << dendl;
 
-  ++super.version;
   _write_super(super_dev);
   _flush_bdev();
 
@@ -2514,7 +2514,6 @@ void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
   new_log->fnode.size = 0;
   new_log->fnode.mtime = ceph_clock_now();
   super.log_fnode = new_log->fnode;
-  ++super.version;
   _write_super(BDEV_DB);
   _flush_bdev();
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3516,7 +3516,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard nl(nodes.lock);
+  std::unique_lock nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
@@ -3578,6 +3578,7 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
+  nl.unlock();
   {
     std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2360,8 +2360,8 @@ void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 
   log.writer = _create_writer(log_file);
   log.writer->append(bl);
-  r = _flush_special(log.writer);
-  ceph_assert(r == 0);
+  uint64_t new_data = _flush_special(log.writer);
+  vselector->add_usage(log_file->vselector_hint, new_data);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
@@ -2518,8 +2518,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   new_log_writer->lock.lock();
   new_log->lock.lock();
   // 3. flush
-  r = _flush_special(new_log_writer);
-  ceph_assert(r == 0);
+  _flush_special(new_log_writer);
 
   // 4. wait
   _flush_bdev(new_log_writer);
@@ -2738,8 +2737,8 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
   log.t.clear();
   log.t.seq = log.seq_live;
 
-  int r = _flush_special(log.writer);
-  ceph_assert(r == 0);
+  uint64_t new_data = _flush_special(log.writer);
+  vselector->add_usage(log.writer->file->vselector_hint, new_data);
 }
 
 // Clears dirty.files up to (including) seq_stable.
@@ -3217,18 +3216,19 @@ int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
 // we do not need to dirty the log file (or it's compacting
 // replacement) when the file size changes because replay is
 // smart enough to discover it on its own.
-int BlueFS::_flush_special(FileWriter *h)
+uint64_t BlueFS::_flush_special(FileWriter *h)
 {
   ceph_assert(h->file->fnode.ino <= 1);
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
+  uint64_t new_data = 0;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
   if (h->file->fnode.size < offset + length) {
-    vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
+    new_data = offset + length - h->file->fnode.size;
     h->file->fnode.size = offset + length;
-    vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
   }
-  return _flush_data(h, offset, length, false);
+  _flush_data(h, offset, length, false);
+  return new_data;
 }
 
 int BlueFS::truncate(FileWriter *h, uint64_t offset)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -189,9 +189,9 @@ BlueFS::BlueFS(CephContext* cct)
     ioc(MAX_BDEV),
     block_reserved(MAX_BDEV),
     alloc(MAX_BDEV),
-    alloc_size(MAX_BDEV, 0),
-    pending_release(MAX_BDEV)
+    alloc_size(MAX_BDEV, 0)
 {
+  dirty.pending_release.resize(MAX_BDEV);
   discard_cb[BDEV_WAL] = wal_discard_cb;
   discard_cb[BDEV_DB] = db_discard_cb;
   discard_cb[BDEV_SLOW] = slow_discard_cb;
@@ -1904,7 +1904,7 @@ void BlueFS::_drop_link_D(FileRef file)
 
     std::lock_guard dl(dirty.lock);
     for (auto& r : file->fnode.extents) {
-      pending_release[r.bdev].insert(r.offset, r.length);
+      dirty.pending_release[r.bdev].insert(r.offset, r.length);
     }
     if (file->dirty_seq > dirty.seq_stable) {
       // retract request to serialize changes
@@ -2395,7 +2395,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
   std::lock_guard dl(dirty.lock);
   for (auto& r : old_fnode.extents) {
-    pending_release[r.bdev].insert(r.offset, r.length);
+    dirty.pending_release[r.bdev].insert(r.offset, r.length);
   }
 }
 
@@ -2597,7 +2597,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   {
     std::lock_guard dl(dirty.lock);
     for (auto& r : old_extents) {
-      pending_release[r.bdev].insert(r.offset, r.length);
+      dirty.pending_release[r.bdev].insert(r.offset, r.length);
     }
   }
 
@@ -2843,8 +2843,8 @@ int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
   ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
   uint64_t seq =_log_advance_seq();
   _consume_dirty(seq);
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
+  vector<interval_set<uint64_t>> to_release(dirty.pending_release.size());
+  to_release.swap(dirty.pending_release);
   dirty.lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
@@ -2872,8 +2872,8 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
   dirty.lock.lock();
   uint64_t seq =_log_advance_seq();
   _consume_dirty(seq);
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
+  vector<interval_set<uint64_t>> to_release(dirty.pending_release.size());
+  to_release.swap(dirty.pending_release);
   dirty.lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
@@ -3537,6 +3537,11 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
+  FileRef file;
+  bool create = false;
+  bool truncate = false;
+  mempool::bluefs::vector<bluefs_extent_t> pending_release_extents;
+  {
   std::unique_lock nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
@@ -3550,9 +3555,6 @@ int BlueFS::open_for_write(
     dir = p->second;
   }
 
-  FileRef file;
-  bool create = false;
-  bool truncate = false;
   map<string,FileRef>::iterator q = dir->file_map.find(filename);
   if (q == dir->file_map.end()) {
     if (overwrite) {
@@ -3581,9 +3583,7 @@ int BlueFS::open_for_write(
 	       << " already exists, truncate + overwrite" << dendl;
       vselector->sub_usage(file->vselector_hint, file->fnode);
       file->fnode.size = 0;
-      for (auto& p : file->fnode.extents) {
-	pending_release[p.bdev].insert(p.offset, p.length);
-      }
+      pending_release_extents.swap(file->fnode.extents);
       truncate = true;
 
       file->fnode.clear_extents();
@@ -3600,12 +3600,17 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
-  nl.unlock();
+  }
   {
     std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);
     if (create)
       log.t.op_dir_link(dirname, filename, file->fnode.ino);
+
+    std::lock_guard dl(dirty.lock);
+    for (auto& p : pending_release_extents) {
+      dirty.pending_release[p.bdev].insert(p.offset, p.length);
+    }
   }
   *h = _create_writer(file);
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2355,6 +2355,9 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
   }
 #endif
   _flush_bdev();
+  ++log.seq_live;
+  dirty.seq_live = log.seq_live;
+  log.t.seq = log.seq_live;
 
   super.memorized_layout = layout;
   super.log_fnode = log_file->fnode;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -442,6 +442,9 @@ private:
   };
   void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
+  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					  uint64_t capture_before_seq);
+
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -437,9 +437,8 @@ private:
     RENAME_DB2SLOW = 8,
   };
   void _compact_log_dump_metadata_NF(bluefs_transaction_t *t,
-				 int flags);
-  void _compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
-					   uint64_t capture_before_seq);
+				 int flags,
+				 uint64_t capture_before_seq);
 
   void _compact_log_sync_LNF_LD();
   void _compact_log_async_LD_LNF_D();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -50,6 +50,8 @@ enum {
   l_bluefs_read_bytes,
   l_bluefs_read_prefetch_count,
   l_bluefs_read_prefetch_bytes,
+  l_bluefs_compaction_lat,
+  l_bluefs_compaction_lock_lat,
   l_bluefs_read_zeros_candidate,
   l_bluefs_read_zeros_errors,
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -698,13 +698,13 @@ public:
  * Column represents last lock taken.
  * Row represents next lock taken.
  *
- *     <        | L | D | N | F | W
+ *     >        | W | L | D | N | F
  * -------------|---|---|---|---|---
- * log        L |     <   <         
- * dirty      D |                   
- * nodes      N |             <     
- * File       F |                  
- * FileWriter W | <   <       <      
+ * FileWriter W |   | > | > |   | >
+ * log        L |       | > | > | >
+ * dirty      D |           |   | >
+ * nodes      N |               | >
+ * File       F |
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.
  */

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -336,6 +336,11 @@ private:
     uint64_t seq_live = 1;   //seq that is ongoing and dirty files will be written to
     // map of dirty files, files of same dirty_seq are grouped into list.
     std::map<uint64_t, dirty_file_list_t> files;
+    std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
+    // TODO: it should be examined what makes pending_release immune to
+    // eras in a way similar to dirty_files. Hints:
+    // 1) we have actually only 2 eras: log_seq and log_seq+1
+    // 2) we usually not remove extents from files. And when we do, we force log-syncing.
   } dirty;
 
   ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
@@ -354,11 +359,6 @@ private:
   std::vector<uint64_t> block_reserved;            ///< starting reserve extent per device
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
-  std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
-  // TODO: it should be examined what makes pending_release immune to
-  // eras in a way similar to dirty_files. Hints:
-  // 1) we have actually only 2 eras: log_seq and log_seq+1
-  // 2) we usually not remove extents from files. And when we do, we force log-syncing.
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -379,6 +379,7 @@ private:
   inline bool is_shared_alloc(unsigned id) const {
     return id == shared_alloc_id;
   }
+  std::atomic<int64_t> cooldown_deadline = 0;
 
   class SocketHook;
   SocketHook* asok_hook = nullptr;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -408,7 +408,7 @@ private:
   int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
   int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
-  int _flush_special(FileWriter *h);
+  uint64_t _flush_special(FileWriter *h);
   int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -398,9 +398,18 @@ private:
   void wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
+  int64_t _maybe_extend_log();
+  void _extend_log();
+  uint64_t _consume_dirty();
+  void _clear_dirty_set_stable(uint64_t seq_stable);
+  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+
+  void _flush_and_sync_log_core(int64_t available_runway);
+  int _flush_and_sync_log_jump(uint64_t jump_to,
+			       int64_t available_runway);
   int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			  uint64_t want_seq = 0,
-			  uint64_t jump_to = 0);
+			  uint64_t want_seq = 0);
+
   uint64_t _estimate_log_size();
   bool _should_compact_log();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -400,7 +400,7 @@ private:
   int _allocate(uint8_t bdev, uint64_t len,
 		bluefs_fnode_t* node);
   int _allocate_without_fallback(uint8_t id, uint64_t len,
-				 PExtentVector* extents);
+				 bluefs_fnode_t* node);
 
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log_D(FileWriter *h);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -436,15 +436,15 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
+  void _compact_log_dump_metadata_NF(bluefs_transaction_t *t,
 				 int flags);
   void _compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
 					   uint64_t capture_before_seq);
 
-  void _compact_log_sync_LN_LD();
+  void _compact_log_sync_LNF_LD();
   void _compact_log_async_LD_NF_D();
 
-  void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -575,7 +575,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void _maybe_compact_log_LN_NF_LD_D();
+  void _maybe_compact_log_LNF_NF_LD_D();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -317,6 +317,8 @@ private:
     l_bluefs_max_bytes_wal,
     l_bluefs_max_bytes_db,
     l_bluefs_max_bytes_slow,
+    l_bluefs_max_bytes_wal,
+    l_bluefs_max_bytes_db,
   };
 
   // cache
@@ -406,10 +408,9 @@ private:
   const char* get_device_name(unsigned id);
   int _allocate(uint8_t bdev, uint64_t len,
                 uint64_t alloc_unit,
-		bluefs_fnode_t* node);
-  int _allocate_without_fallback(uint8_t id, uint64_t len,
-				 uint64_t alloc_unit,
-				 bluefs_fnode_t* node);
+		bluefs_fnode_t* node,
+                size_t alloc_attempts = 0,
+                bool permit_dev_fallback = true);
 
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log_D(FileWriter *h);
@@ -458,7 +459,7 @@ private:
   void _compact_log_sync_LNF_LD();
   void _compact_log_async_LD_LNF_D();
 
-  void _rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync_LNF_LD(bool permit_dev_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -52,9 +52,10 @@ enum {
   l_bluefs_read_prefetch_bytes,
   l_bluefs_compaction_lat,
   l_bluefs_compaction_lock_lat,
+  l_bluefs_alloc_shared_dev_fallbacks,
+  l_bluefs_alloc_shared_size_fallbacks,
   l_bluefs_read_zeros_candidate,
   l_bluefs_read_zeros_errors,
-
   l_bluefs_last,
 };
 
@@ -79,16 +80,19 @@ public:
 struct bluefs_shared_alloc_context_t {
   bool need_init = false;
   Allocator* a = nullptr;
+  uint64_t alloc_unit = 0;
 
   std::atomic<uint64_t> bluefs_used = 0;
 
-  void set(Allocator* _a) {
+  void set(Allocator* _a, uint64_t _au) {
     a = _a;
+    alloc_unit = _au;
     need_init = true;
     bluefs_used = 0;
   }
   void reset() {
     a = nullptr;
+    alloc_unit = 0;
   }
 };
 
@@ -401,8 +405,10 @@ private:
   }
   const char* get_device_name(unsigned id);
   int _allocate(uint8_t bdev, uint64_t len,
+                uint64_t alloc_unit,
 		bluefs_fnode_t* node);
   int _allocate_without_fallback(uint8_t id, uint64_t len,
+				 uint64_t alloc_unit,
 				 bluefs_fnode_t* node);
 
   /* signal replay log to include h->file in nearest log flush */
@@ -488,6 +494,7 @@ private:
     const char* op_name);
   int _verify_alloc_granularity(
     __u8 id, uint64_t offset, uint64_t length,
+    uint64_t alloc_unit,
     const char *op);
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -706,8 +706,8 @@ public:
  * log        L |     <   <         
  * dirty      D |                   
  * nodes      N |             <     
- * File       F | <                 
- * FileWriter W | <  <        <      
+ * File       F |                  
+ * FileWriter W | <   <       <      
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.
  */

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -429,6 +429,10 @@ private:
   int _flush_and_sync_log_LD(uint64_t want_seq = 0);
 
   uint64_t _estimate_transaction_size(bluefs_transaction_t* t);
+  uint64_t _make_initial_transaction(uint64_t start_seq,
+                                     bluefs_fnode_t& fnode,
+                                     uint64_t expected_final_size,
+                                     bufferlist* out);
   uint64_t _estimate_log_size_N();
   bool _should_start_compact_log_L_N();
 
@@ -438,9 +442,10 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata_NF(bluefs_transaction_t *t,
-				 int flags,
-				 uint64_t capture_before_seq);
+  void _compact_log_dump_metadata_NF(uint64_t start_seq,
+                                     bluefs_transaction_t *t,
+				     int flags,
+				     uint64_t capture_before_seq);
 
   void _compact_log_sync_LNF_LD();
   void _compact_log_async_LD_LNF_D();
@@ -454,7 +459,7 @@ private:
 
   //void _aio_finish(void *priv);
 
-  void _flush_bdev(FileWriter *h);
+  void _flush_bdev(FileWriter *h, bool check_mutex_locked = true);
   void _flush_bdev();  // this is safe to call without a lock
   void _flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -389,8 +389,10 @@ private:
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log(FileWriter *h);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
   int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
   int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_special(FileWriter *h);
   int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
 
 #ifdef HAVE_LIBAIO

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -384,7 +384,8 @@ private:
   void _init_alloc();
   void _stop_alloc();
 
-  void _pad_bl(ceph::buffer::list& bl);  ///< pad ceph::buffer::list to block size w/ zeros
+  ///< pad ceph::buffer::list to max(block size, pad_size) w/ zeros
+  void _pad_bl(ceph::buffer::list& bl, uint64_t pad_size = 0);
 
   uint64_t _get_used(unsigned id) const;
   uint64_t _get_total(unsigned id) const;
@@ -427,6 +428,7 @@ private:
 			       int64_t available_runway);
   int _flush_and_sync_log_LD(uint64_t want_seq = 0);
 
+  uint64_t _estimate_transaction_size(bluefs_transaction_t* t);
   uint64_t _estimate_log_size_N();
   bool _should_start_compact_log_L_N();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -304,9 +304,6 @@ public:
   };
 
 private:
-  ceph::mutex log_lock = ceph::make_mutex("BlueFS::log_lock");
-  ceph::mutex dirs_lock = ceph::make_mutex("BlueFS::dirs_lock");
-  ceph::mutex dirty_lock = ceph::make_mutex("BlueFS::dirty_lock");
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -325,7 +325,6 @@ private:
 
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
-    //uint64_t seq_stable = 0; //seq that is now stable on disk    AK - consider also mirroring this
     uint64_t seq_live = 1;   //seq that log is currently writing to; mirrors dirty.seq_live
     FileWriter *writer = 0;
     bluefs_transaction_t t;
@@ -439,8 +438,8 @@ private:
   };
   void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
-  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
-					  uint64_t capture_before_seq);
+  void _compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					   uint64_t capture_before_seq);
 
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5391,9 +5391,11 @@ int BlueStore::_create_alloc()
     alloc_size = _zoned_piggyback_device_parameters_onto(alloc_size);
   }
 
-  shared_alloc.set(Allocator::create(cct, cct->_conf->bluestore_allocator,
-    bdev->get_size(),
-    alloc_size, "block"));
+  shared_alloc.set(
+    Allocator::create(cct, cct->_conf->bluestore_allocator,
+      bdev->get_size(),
+      alloc_size, "block"),
+    alloc_size);
 
   if (!shared_alloc.a) {
     lderr(cct) << __func__ << "Failed to create allocator:: "
@@ -5401,6 +5403,7 @@ int BlueStore::_create_alloc()
       << dendl;
     return -EINVAL;
   }
+
   return 0;
 }
 

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -167,7 +167,6 @@ bluefs_fnode_delta_t* bluefs_fnode_t::make_delta(bluefs_fnode_delta_t* delta) {
       delta->extents.push_back(*p);
       ++p;
     }
-    reset_delta();
   }
   return delta;
 }

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -62,7 +62,7 @@ struct bluefs_fnode_t {
   uint64_t ino;
   uint64_t size;
   utime_t mtime;
-  uint8_t __unused__; // was prefer_bdev
+  uint8_t __unused__ = 0; // was prefer_bdev
   mempool::bluefs::vector<bluefs_extent_t> extents;
 
   // precalculated logical offsets for extents vector entries
@@ -72,7 +72,15 @@ struct bluefs_fnode_t {
   uint64_t allocated;
   uint64_t allocated_commited;
 
-  bluefs_fnode_t() : ino(0), size(0), __unused__(0), allocated(0), allocated_commited(0) {}
+  bluefs_fnode_t() : ino(0), size(0), allocated(0), allocated_commited(0) {}
+  bluefs_fnode_t(uint64_t _ino, uint64_t _size, utime_t _mtime) :
+    ino(_ino), size(_size), mtime(_mtime), allocated(0), allocated_commited(0) {}
+  bluefs_fnode_t(const bluefs_fnode_t& other) :
+    ino(other.ino), size(other.size), mtime(other.mtime),
+    allocated(other.allocated),
+    allocated_commited(other.allocated_commited) {
+    clone_extents(other);
+  }
 
   uint64_t get_allocated() const {
     return allocated;
@@ -111,7 +119,6 @@ struct bluefs_fnode_t {
     denc(v.extents, p);
     DENC_FINISH(p);
   }
-
   void reset_delta() {
     allocated_commited = allocated;
   }

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -149,6 +149,12 @@ struct bluefs_fnode_t {
     extents.erase(it);
   }
   
+  void swap(bluefs_fnode_t& other) {
+    std::swap(ino, other.ino);
+    std::swap(size, other.size);
+    std::swap(mtime, other.mtime);
+    swap_extents(other);
+  }
   void swap_extents(bluefs_fnode_t& other) {
     other.extents.swap(extents);
     other.extents_index.swap(extents_index);
@@ -290,9 +296,10 @@ struct bluefs_transaction_t {
   void op_file_update_inc(bluefs_fnode_t& file) {
     using ceph::encode;
     bluefs_fnode_delta_t delta;
-    file.make_delta(&delta); //also resets delta to zero
+    file.make_delta(&delta);
     encode((__u8)OP_FILE_UPDATE_INC, op_bl);
     encode(delta, op_bl);
+    file.reset_delta();
   }
   void op_file_remove(uint64_t ino) {
     using ceph::encode;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -115,6 +115,11 @@ struct bluefs_fnode_t {
   void reset_delta() {
     allocated_commited = allocated;
   }
+  void clone_extents(const bluefs_fnode_t& fnode) {
+    for (const auto& p : fnode.extents) {
+      append_extent(p);
+    }
+  }
   void claim_extents(mempool::bluefs::vector<bluefs_extent_t>& extents) {
     for (const auto& p : extents) {
       append_extent(p);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -232,7 +232,7 @@ TEST(BlueFS, very_large_write) {
     delete h;
     ASSERT_EQ(0, fs.open_for_read("dir", "bigfile", &h));
     ASSERT_EQ(h->file->fnode.size, total_written);
-    unique_ptr<char> huge_buf(new char[h->file->fnode.size]);
+    auto huge_buf = std::make_unique<char[]>(h->file->fnode.size);
     auto l = h->file->fnode.size;
     int64_t r = fs.read(h, 0, l, NULL, huge_buf.get());
     ASSERT_EQ(r, l);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -10,13 +10,14 @@
 #include <random>
 #include <thread>
 #include <stack>
+#include <gtest/gtest.h>
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
 #include "include/stringify.h"
 #include "include/scope_guard.h"
 #include "common/errno.h"
-#include <gtest/gtest.h>
 
+#include "os/bluestore/Allocator.h"
 #include "os/bluestore/BlueFS.h"
 
 std::unique_ptr<char[]> gen_buffer(uint64_t size)
@@ -991,6 +992,225 @@ TEST(BlueFS, test_update_ino1_delta_after_replay) {
   // remount and check log can replay safe?
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+  fs.umount();
+}
+
+TEST(BlueFS, test_shared_alloc) {
+  uint64_t size = 1048576 * 128;
+  TempBdev bdev_slow{size};
+  uint64_t size_db = 1048576 * 8;
+  TempBdev bdev_db{size_db};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_shared_alloc_size", "1048576");
+
+  bluefs_shared_alloc_context_t shared_alloc;
+  uint64_t shared_alloc_unit = 4096;
+  shared_alloc.set(
+    Allocator::create(g_ceph_context, g_ceph_context->_conf->bluefs_allocator,
+                      size, shared_alloc_unit, "test shared allocator"),
+    shared_alloc_unit);
+  shared_alloc.a->init_add_free(0, size);
+
+  BlueFS fs(g_ceph_context);
+  // DB device is fully utilized
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_db.path, false, size_db - 0x1000));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false, 0,
+                                   &shared_alloc));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+  {
+    for (int i=0; i<10; i++) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       ASSERT_EQ(0, fs.mkdir(dir));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          BlueFS::FileWriter *h;
+          ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+          ASSERT_NE(nullptr, h);
+          auto sg = make_scope_guard([&fs, h] { fs.close_writer(h); });
+          bufferlist bl;
+          std::unique_ptr<char[]> buf = gen_buffer(4096);
+	  bufferptr bp = buffer::claim_char(4096, buf.get());
+	  bl.push_back(bp);
+          h->append(bl.c_str(), bl.length());
+          fs.fsync(h);
+       }
+    }
+  }
+  {
+    for (int i=0; i<10; i+=2) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          fs.unlink(dir, file);
+	  fs.sync_metadata(false);
+       }
+       ASSERT_EQ(0, fs.rmdir(dir));
+       fs.sync_metadata(false);
+    }
+  }
+  fs.compact_log();
+  auto *logger = fs.get_perf_counters();
+  ASSERT_NE(logger->get(l_bluefs_alloc_shared_dev_fallbacks), 0);
+  auto num_files = logger->get(l_bluefs_num_files);
+  fs.umount();
+  fs.mount();
+  ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
+  fs.umount();
+}
+
+TEST(BlueFS, test_shared_alloc_sparse) {
+  uint64_t size = 1048576 * 128 * 2;
+  uint64_t main_unit = 4096;
+  uint64_t bluefs_alloc_unit = 1048576;
+  TempBdev bdev_slow{size};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_shared_alloc_size",
+    stringify(bluefs_alloc_unit).c_str());
+
+  bluefs_shared_alloc_context_t shared_alloc;
+  shared_alloc.set(
+    Allocator::create(g_ceph_context, g_ceph_context->_conf->bluefs_allocator,
+                      size, main_unit, "test shared allocator"),
+    main_unit);
+  // prepare sparse free space but let's have a continuous chunk at
+  // the beginning to fit initial log's fnode into superblock,
+  // we don't have any tricks to deal with sparse allocations
+  // (and hence long fnode) at mkfs
+  shared_alloc.a->init_add_free(bluefs_alloc_unit, 4 * bluefs_alloc_unit);
+  for(uint64_t i = 5 * bluefs_alloc_unit; i < size; i += 2 * main_unit) {
+    shared_alloc.a->init_add_free(i, main_unit);
+  }
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_slow.path, false, 0,
+                                   &shared_alloc));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+  {
+    for (int i=0; i<10; i++) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       ASSERT_EQ(0, fs.mkdir(dir));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          BlueFS::FileWriter *h;
+          ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+          ASSERT_NE(nullptr, h);
+          auto sg = make_scope_guard([&fs, h] { fs.close_writer(h); });
+          bufferlist bl;
+          std::unique_ptr<char[]> buf = gen_buffer(4096);
+	  bufferptr bp = buffer::claim_char(4096, buf.get());
+	  bl.push_back(bp);
+          h->append(bl.c_str(), bl.length());
+          fs.fsync(h);
+       }
+    }
+  }
+  {
+    for (int i=0; i<10; i+=2) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          fs.unlink(dir, file);
+	  fs.sync_metadata(false);
+       }
+       ASSERT_EQ(0, fs.rmdir(dir));
+       fs.sync_metadata(false);
+    }
+  }
+  fs.compact_log();
+  auto *logger = fs.get_perf_counters();
+  ASSERT_NE(logger->get(l_bluefs_alloc_shared_size_fallbacks), 0);
+  auto num_files = logger->get(l_bluefs_num_files);
+  fs.umount();
+
+  fs.mount();
+  ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
+  fs.umount();
+}
+
+TEST(BlueFS, test_4k_shared_alloc) {
+  uint64_t size = 1048576 * 128 * 2;
+  uint64_t main_unit = 4096;
+  uint64_t bluefs_alloc_unit = main_unit;
+  TempBdev bdev_slow{size};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_shared_alloc_size",
+    stringify(bluefs_alloc_unit).c_str());
+
+  bluefs_shared_alloc_context_t shared_alloc;
+  shared_alloc.set(
+    Allocator::create(g_ceph_context, g_ceph_context->_conf->bluefs_allocator,
+                      size, main_unit, "test shared allocator"),
+    main_unit);
+  shared_alloc.a->init_add_free(bluefs_alloc_unit, size - bluefs_alloc_unit);
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_slow.path, false, 0,
+                                   &shared_alloc));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
+  {
+    for (int i=0; i<10; i++) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       ASSERT_EQ(0, fs.mkdir(dir));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          BlueFS::FileWriter *h;
+          ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+          ASSERT_NE(nullptr, h);
+          auto sg = make_scope_guard([&fs, h] { fs.close_writer(h); });
+          bufferlist bl;
+          std::unique_ptr<char[]> buf = gen_buffer(4096);
+	  bufferptr bp = buffer::claim_char(4096, buf.get());
+	  bl.push_back(bp);
+          h->append(bl.c_str(), bl.length());
+          fs.fsync(h);
+       }
+    }
+  }
+  {
+    for (int i=0; i<10; i+=2) {
+       string dir = "dir.";
+       dir.append(to_string(i));
+       for (int j=0; j<10; j++) {
+          string file = "file.";
+	  file.append(to_string(j));
+          fs.unlink(dir, file);
+	  fs.sync_metadata(false);
+       }
+       ASSERT_EQ(0, fs.rmdir(dir));
+       fs.sync_metadata(false);
+    }
+  }
+  fs.compact_log();
+  auto *logger = fs.get_perf_counters();
+  ASSERT_EQ(logger->get(l_bluefs_alloc_shared_dev_fallbacks), 0);
+  ASSERT_EQ(logger->get(l_bluefs_alloc_shared_size_fallbacks), 0);
+  auto num_files = logger->get(l_bluefs_num_files);
+  fs.umount();
+
+  fs.mount();
+  ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
   fs.umount();
 }
 


### PR DESCRIPTION
This includes:
- os/bluestore: BlueFS fine grain locking
(https://github.com/ceph/ceph/pull/43794)
- os/bluestore/bluefs: Fix improper vselector tracking in _flush_special()
https://github.com/ceph/ceph/pull/44955
- os/bluestore: enable 4K allocation unit for BlueFS
 https://github.com/ceph/ceph/pull/48854
- os/bluestore/bluefs: Fix sync compaction
https://github.com/ceph/ceph/pull/44913/commits/4fd98ce0359d6c3a36f08a3d87a78c3f0b65018d

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
