### PR TITLE
pacific: pybind/mgr/devicehealth: do not crash if db not ready

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -4,7 +4,7 @@ Device health monitoring
 
 import errno
 import json
-from mgr_module import MgrModule, CommandResult, CLICommand, Option, NotifyType
+from mgr_module import MgrModule, CommandResult, CLICommand, Option, NotifyType, MgrDBNotReady
 import operator
 import rados
 from threading import Event
@@ -720,7 +720,10 @@ class Module(MgrModule):
             return -1, '', 'unable to invoke diskprediction local or remote plugin'
 
     def get_recent_device_metrics(self, devid: str, min_sample: str) -> Dict[str, Dict[str, Any]]:
-        return self._get_device_metrics(devid, min_sample=min_sample)
+        try:
+            return self._get_device_metrics(devid, min_sample=min_sample)
+        except MgrDBNotReady:
+            return dict()
 
     def get_time_format(self) -> str:
         return TIME_FORMAT


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61835

---

backport of https://github.com/ceph/ceph/pull/51858
parent tracker: https://tracker.ceph.com/issues/56239

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh