### PR TITLE
qa/s3tests: filter on 'sts_tests' and 'webidentity_tests'

### DIFF
--- a/qa/suites/rgw/sts/overrides.yaml
+++ b/qa/suites/rgw/sts/overrides.yaml
@@ -1,6 +1,9 @@
 overrides:
   ceph:
     conf:
+      global:
+        osd_min_pg_log_entries: 10
+        osd_max_pg_log_entries: 10
       client:
         setuser: ceph
         setgroup: ceph
@@ -8,5 +11,8 @@ overrides:
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
+        rgw lc debug interval: 10
+        rgw sts key: abcdefghijklmnop
+        rgw s3 auth use sts: true
   rgw:
     storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/sts/tasks/0-install.yaml
+++ b/qa/suites/rgw/sts/tasks/0-install.yaml
@@ -4,12 +4,3 @@ tasks:
 - openssl_keys:
 - rgw:
     client.0:
-
-overrides:
-  ceph:
-    conf:
-      global:
-        osd_min_pg_log_entries: 10
-        osd_max_pg_log_entries: 10
-      client:
-        rgw lc debug interval: 10

--- a/qa/suites/rgw/sts/tasks/1-keycloak.yaml
+++ b/qa/suites/rgw/sts/tasks/1-keycloak.yaml
@@ -1,0 +1,5 @@
+tasks:
+- tox: [ client.0 ]
+- keycloak:
+    client.0:
+      keycloak_version: 11.0.0

--- a/qa/suites/rgw/sts/tasks/2-s3tests.yaml
+++ b/qa/suites/rgw/sts/tasks/2-s3tests.yaml
@@ -1,8 +1,4 @@
 tasks:
-- tox: [ client.0 ]
-- keycloak:
-    client.0:
-      keycloak_version: 11.0.0
 - s3tests:
     client.0:
       sts_tests: True

--- a/qa/suites/rgw/sts/tasks/first.yaml
+++ b/qa/suites/rgw/sts/tasks/first.yaml
@@ -8,9 +8,3 @@ tasks:
       sts_tests: True
       webidentity_tests: True
       rgw_server: client.0
-overrides:
-  ceph:
-    conf:
-      client:
-              rgw sts key: abcdefghijklmnop
-              rgw s3 auth use sts: true

--- a/qa/suites/rgw/sts/tasks/first.yaml
+++ b/qa/suites/rgw/sts/tasks/first.yaml
@@ -6,8 +6,8 @@ tasks:
 - s3tests:
     client.0:
       sts_tests: True
+      webidentity_tests: True
       rgw_server: client.0
-      extra_attrs: ['webidentity_test']
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -3,9 +3,3 @@ tasks:
     client.0:
       sts_tests: True
       rgw_server: client.0
-overrides:
-  ceph:
-    conf:
-      client:
-              rgw sts key: abcdefghijklmnop
-              rgw s3 auth use sts: true

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -1,5 +1,0 @@
-tasks:
-- s3tests:
-    client.0:
-      sts_tests: True
-      rgw_server: client.0

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -2,7 +2,6 @@ tasks:
 - s3tests:
     client.0:
       sts_tests: True
-      extra_attrs: ["test_of_sts"]
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -377,7 +377,11 @@ def run_tests(ctx, config):
             args += ['REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt']
         else:
             args += ['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']
-        attrs = ["not fails_on_rgw", "not lifecycle_expiration", "not test_of_sts", "not webidentity_test"]
+        attrs = ["not fails_on_rgw", "not lifecycle_expiration"]
+        if not client_config.get('sts_tests', False):
+            attrs += ["not test_of_sts"]
+        if not client_config.get('webidentity_tests', False):
+            attrs += ["not webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['not fails_with_subdomain']
         if not client_config.get('with-sse-s3'):


### PR DESCRIPTION
qa/tasks/s3tests.py was adding `not test_of_sts` and `not webidentity_test` by default, and the rgw/sts suites were adding those attrs back in `extra_attrs`

when `extra_attrs` was changed to be additive in https://github.com/ceph/ceph/pull/52156, this started causing `InvocationError` failures

instead of using `extra_attrs` to control these filters, qa/tasks/s3tests.py now uses the `sts_tests` and `webidentity_tests` flags from the sts yaml files to control whether or the `not test_of_sts`/`not webidentity_test` attrs are added to the pytest command line

Fixes: https://tracker.ceph.com/issues/61838

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
