### PR TITLE
pacific: mon/MDSMonitor: do not propose on error in prepare_update

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -554,7 +554,7 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
     } catch (const bad_cmd_get& e) {
       bufferlist bl;
       mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
-      return true;
+      return false; /* nothing to propose */
     }
 
   case MSG_MDS_OFFLOAD_TARGETS:
@@ -564,7 +564,7 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
     ceph_abort();
   }
 
-  return true;
+  return false; /* nothing to propose! */
 }
 
 bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
@@ -864,6 +864,7 @@ null:
 bool MDSMonitor::prepare_offload_targets(MonOpRequestRef op)
 {
   auto &pending = get_pending_fsmap_writeable();
+  bool propose = false;
 
   op->mark_mdsmon_event(__func__);
   auto m = op->get_req<MMDSLoadTargets>();
@@ -871,11 +872,12 @@ bool MDSMonitor::prepare_offload_targets(MonOpRequestRef op)
   if (pending.gid_has_rank(gid)) {
     dout(10) << "prepare_offload_targets " << gid << " " << m->targets << dendl;
     pending.update_export_targets(gid, m->targets);
+    propose = true;
   } else {
     dout(10) << "prepare_offload_targets " << gid << " not in map" << dendl;
   }
   mon.no_reply(op);
-  return true;
+  return propose;
 }
 
 bool MDSMonitor::should_propose(double& delay)
@@ -1345,7 +1347,7 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon.reply_command(op, -EINVAL, rs, rdata, get_last_committed());
-    return true;
+    return false;
   }
 
   string prefix;
@@ -1355,7 +1357,7 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
   MonSession *session = op->get_session();
   if (!session) {
     mon.reply_command(op, -EACCES, "access denied", rdata, get_last_committed());
-    return true;
+    return false;
   }
 
   auto &pending = get_pending_fsmap_writeable();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61414

---

backport of https://github.com/ceph/ceph/pull/50501
parent tracker: https://tracker.ceph.com/issues/58971

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh