### PR TITLE
quincy: tools/cephfs: add basic detection/cleanup tool for dentry first damage

### DIFF
--- a/qa/workunits/fs/damage/test-first-damage.sh
+++ b/qa/workunits/fs/damage/test-first-damage.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -ex
+
+FIRST_DAMAGE="first-damage.sh"
+FS=cephfs
+METADATA_POOL=cephfs_meta
+
+function usage {
+  printf '%s: [--fs=<fs_name>] [--metadata-pool=<pool>] [--first-damage=</path/to/first-damage.sh>]\n'
+  exit 1
+}
+
+
+function create {
+  mkdir dir
+  DIR_INODE=$(stat -c '%i' dir)
+  touch dir/a
+  mkdir dir/.snap/1
+  mkdir dir/.snap/2
+  # two snaps
+  rm dir/a
+  mkdir dir/.snap/3
+  # not present in HEAD
+  touch dir/a
+  mkdir dir/.snap/4
+  # one snap
+  rm dir/a
+  touch dir/a
+  mkdir dir/.snap/5
+  # unlink then create
+  rm dir/a
+  touch dir/a
+  # unlink then create, HEAD not snapped
+  ls dir/.snap/*/
+}
+
+function flush {
+  ceph tell mds."$FS":0 flush journal
+}
+
+function damage {
+  local IS=$(printf '%llx.%08llx' "$DIR_INODE" 0)
+  local LS=$(ceph tell mds."$FS":0 dump snaps | jq .last_created)
+
+  local T=$(mktemp -p /tmp)
+
+  # nuke snap 1 version of "a"
+  rados --pool="$METADATA_POOL" getomapval "$IS" a_$(printf %x $((LS-4))) "$T"
+  printf '\xff\xff\xff\xf0' | dd of="$T" count=4 bs=1
+  rados --pool="$METADATA_POOL" setomapval "$IS" a_$(printf %x $((LS-4))) --input-file="$T"
+
+  # nuke snap 4 version of "a"
+  rados --pool="$METADATA_POOL" getomapval "$IS" a_$(printf %x $((LS-1))) "$T"
+  printf '\xff\xff\xff\xff' | dd of="$T" count=4 bs=1
+  rados --pool="$METADATA_POOL" setomapval "$IS" a_$(printf %x $((LS-1))) --input-file="$T"
+
+  rm -f "$T"
+}
+
+function recover {
+  # drop client cache -- approx. umount without unmounting for test
+  echo 3 | sudo tee /proc/sys/vm/drop_caches
+  flush
+  ceph fs fail "$FS"
+  sleep 5
+  cephfs-journal-tool --rank="$FS":0 event recover_dentries summary
+  cephfs-journal-tool --rank="$FS":0 journal reset
+  $FIRST_DAMAGE "$METADATA_POOL"
+  $FIRST_DAMAGE --remove "$METADATA_POOL"
+  ceph fs set "$FS" joinable true
+}
+
+function check {
+  stat dir || exit 1
+  for i in `seq 1 5`; do
+    stat dir/.snap/$i || exit 2
+  done
+  stat dir/.snap/2/a || exit 3
+  stat dir/.snap/5/a || exit 4
+  if stat dir/.snap/1/a; then
+    echo should be gone
+    exit 5
+  fi
+  if stat dir/.snap/3/a; then
+    echo should not ever exist
+    exit 6
+  fi
+  if stat dir/.snap/4/a; then
+    echo should be gone
+    exit 7
+  fi
+}
+
+function cleanup {
+  rmdir dir/.snap/*
+  rm -rf dir
+}
+
+function main {
+  eval set -- $(getopt --name "$0" --options '' --longoptions 'help,fs:,metadata-pool:,first-damage:' -- "$@")
+
+  while [ "$#" -gt 0 ]; do
+      echo "$*"
+      echo "$1"
+      case "$1" in
+          -h|--help)
+              usage
+              ;;
+          --fs)
+              FS="$2"
+              shift 2
+              ;;
+          --metadata-pool)
+              METADATA_POOL="$2"
+              shift 2
+              ;;
+          --first-damage)
+              FIRST_DAMAGE="$2"
+              shift 2
+              ;;
+          --)
+              shift
+              break
+              ;;
+          *)
+              usage
+              ;;
+      esac
+  done
+
+  create
+
+  # flush dentries/inodes to omap
+  (cd / && flush)
+
+  (cd / && damage)
+
+  (cd / && recover)
+
+  check
+
+  cleanup
+}
+
+main "$@"

--- a/src/tools/cephfs/first-damage.sh
+++ b/src/tools/cephfs/first-damage.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Ceph - scalable distributed file system
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 2.1, as published by the Free Software
+# Foundation.  See file COPYING.
+
+# Suggested recovery sequence (for single MDS cluster):
+#
+# 1) Unmount all clients.
+#
+# 2) Flush the journal (if possible):
+#
+#    ceph tell mds.<fs_name>:0 flush journal
+#
+# 3) Fail the file system:
+#
+#    ceph fs fail <fs_name>
+#
+# 4a) Recover dentries from the journal. This will be a no-op if the MDS flushed the journal successfully:
+#
+#    cephfs-journal-tool --rank=<fs_name>:0 event recover_dentries summary
+#
+# 4b) If all good so far, reset the journal:
+#
+#    cephfs-journal-tool --rank=<fs_name>:0 journal reset
+#
+# 5) Run this tool to see list of damaged dentries:
+#
+#    first-damage.sh <pool>
+#
+# 6) Optionally, remove them:
+#
+#    first-damage.sh --remove <pool>
+#
+# This has the effect of removing that dentry from the snapshot or HEAD
+# (current hierarchy).  Note: the inode's linkage will be lost. The inode may
+# be recoverable in lost+found during a future data scan recovery.
+
+set -ex
+
+function usage {
+  printf '%s: [--remove] <metadata pool> [newest snapid]\n' "$0"
+  printf '  remove CephFS metadata dentries with invalid first snapshot'
+  exit 1
+}
+
+function mrados {
+  rados --pool="$METADATA_POOL" "$@"
+}
+
+function traverse {
+  local T=$(mktemp -p /tmp MDS_TRAVERSAL.XXXXXX)
+  mrados ls | grep -E '[[:xdigit:]]{8,}\.[[:xdigit:]]+' > "$T"
+  while read obj; do
+    local O=$(mktemp -p /tmp "$obj".XXXXXX)
+    for dnk in $(mrados listomapkeys "$obj"); do
+      mrados getomapval "$obj" "$dnk" "$O"
+      local first=$(dd if="$O" bs=1 count=4 | od --endian=little -An -t u8)
+      if [ "$first" -gt "$NEXT_SNAP" ]; then
+        printf 'found "%s:%s" first (0x%x) > NEXT_SNAP (0x%x)\n' "$obj" "$dnk" "$first" "$NEXT_SNAP"
+        if [ "$REMOVE" -ne 0 ]; then
+          printf 'removing "%s:%s"\n' "$obj" "$dnk"
+          mrados rmomapkey "$obj" "$dnk"
+        fi
+      fi
+    done
+    rm "$O"
+  done < "$T"
+}
+
+function main {
+    eval set -- $(getopt --name "$0" --options 'r' --longoptions 'help,remove' -- "$@")
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                usage
+                ;;
+            --remove)
+                REMOVE=1
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+        esac
+    done
+
+  if [ -z "$1" ]; then
+    usage
+  fi
+  METADATA_POOL="$1"
+  NEXT_SNAP="$2"
+
+  if [ -z "$NEXT_SNAP" ]; then
+    SNAPTABLE=$(mktemp -p /tmp MDS_SNAPTABLE.XXXXXX)
+    rados --pool="$METADATA_POOL" get mds_snaptable "$SNAPTABLE"
+    # skip "version" of MDSTable payload
+    V=$(dd if="$SNAPTABLE" bs=1 count=1 skip=8 | od --endian=little -An -t u1)
+    if [ "$V" -ne 5 ]; then
+      printf 'incompatible snaptable\n'
+      exit 2
+    fi
+    # skip version,struct_v,compat_v,length
+    NEXT_SNAP=$((1 + $(dd if="$SNAPTABLE" bs=1 count=8 skip=14 | od --endian=little -An -t u8)))
+    printf 'found latest snap: %d\n' "$NEXT_SNAP"
+  fi
+
+  traverse
+}
+
+main "$@"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59303

---

backport of https://github.com/ceph/ceph/pull/47542
parent tracker: https://tracker.ceph.com/issues/56140

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh