### PR TITLE
rgw: rgwx-skip-decrypt also skips decompression of encrypted objects

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3402,8 +3402,12 @@ public:
         try_etag_verify = false;
       }
 
+      // if the object is both compressed and encrypted, it was transferred
+      // in its encrypted+compressed form. we need to preserve the original
+      // RGW_ATTR_COMPRESSION instead of falling back to default compression
+      // settings
       auto iter = src_attrs.find(RGW_ATTR_COMPRESSION);
-      if (iter != src_attrs.end()) {
+      if (iter != src_attrs.end() && !encrypted) {
         const bufferlist bl = std::move(iter->second);
         src_attrs.erase(iter); // don't preserve source compression info
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2200,8 +2200,9 @@ void RGWGetObj::execute(optional_yield y)
   gc_invalidate_time = ceph_clock_now();
   gc_invalidate_time += (s->cct->_conf->rgw_gc_obj_min_wait / 2);
 
-  bool need_decompress;
-  int64_t ofs_x, end_x;
+  bool need_decompress = false;
+  int64_t ofs_x = 0, end_x = 0;
+  bool encrypted = false;
 
   RGWGetObj_CB cb(this);
   RGWGetObj_Filter* filter = (RGWGetObj_Filter *)&cb;
@@ -2301,11 +2302,17 @@ void RGWGetObj::execute(optional_yield y)
     ldpp_dout(this, 0) << "ERROR: failed to decode compression info, cannot decompress" << dendl;
     goto done_err;
   }
-  if (need_decompress) {
-      s->obj_size = cs_info.orig_size;
-      s->object->set_obj_size(cs_info.orig_size);
-      decompress.emplace(s->cct, &cs_info, partial_content, filter);
-      filter = &*decompress;
+
+  // where encryption and compression are combined, compression was applied to
+  // the data before encryption. if the system header rgwx-skip-decrypt is
+  // present, we have to skip the decompression filter too
+  encrypted = attrs.count(RGW_ATTR_CRYPT_MODE);
+
+  if (need_decompress && (!encrypted || !skip_decrypt)) {
+    s->obj_size = cs_info.orig_size;
+    s->object->set_obj_size(cs_info.orig_size);
+    decompress.emplace(s->cct, &cs_info, partial_content, filter);
+    filter = &*decompress;
   }
 
   attr_iter = attrs.find(RGW_ATTR_OBJ_REPLICATION_TRACE);


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/46188 added support for combining encryption and compression at the same time, but multisite does not replicate these objects correctly. the decompression filter cannot run without the decryption filter, because it's the unencrypted data that gets compressed. encrypted objects are replicated in their encrypted form, so we preserve their initial compression attribute instead of trying to de/recompress

Fixes: https://tracker.ceph.com/issues/57905

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
