### PR TITLE
Quincy: osd/scrub: verify SnapMapper consistency

### DIFF
--- a/qa/standalone/scrub/osd-mapper.sh
+++ b/qa/standalone/scrub/osd-mapper.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# -*- mode:text; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+# vim: ts=8 sw=2 smarttab
+#
+# test the handling of a corrupted SnapMapper DB by Scrub
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+source $CEPH_ROOT/qa/standalone/scrub/scrub-helpers.sh
+
+function run() {
+  local dir=$1
+  shift
+
+  export CEPH_MON="127.0.0.1:7144" # git grep '\<7144\>' : there must be only one
+  export CEPH_ARGS
+  CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+  CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+  export -n CEPH_CLI_TEST_DUP_COMMAND
+  local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+  for func in $funcs ; do
+    setup $dir || return 1
+    $func $dir || return 1
+    teardown $dir || return 1
+  done
+}
+
+# one clone & multiple snaps (according to the number of parameters)
+function make_a_clone()
+{
+  #turn off '-x' (but remember previous state)
+  local saved_echo_flag=${-//[^x]/}
+  set +x
+  local pool=$1
+  local obj=$2
+  echo $RANDOM | rados -p $pool put $obj - || return 1
+  shift 2
+  for snap in $@ ; do
+    rados -p $pool mksnap $snap || return 1
+  done
+  if [[ -n "$saved_echo_flag" ]]; then set -x; fi
+}
+
+function TEST_truncated_sna_record() {
+    local dir=$1
+    local -A cluster_conf=(
+        ['osds_num']="3" 
+        ['pgs_in_pool']="4"
+        ['pool_name']="test"
+    )
+
+    local extr_dbg=1
+    (( extr_dbg > 1 )) && echo "Dir: $dir"
+    standard_scrub_cluster $dir cluster_conf
+    ceph tell osd.* config set osd_stats_update_period_not_scrubbing "1"
+    ceph tell osd.* config set osd_stats_update_period_scrubbing "1"
+
+    local osdn=${cluster_conf['osds_num']}
+    local poolid=${cluster_conf['pool_id']}
+    local poolname=${cluster_conf['pool_name']}
+    local objname="objxxx"
+
+    # create an object and clone it
+    make_a_clone $poolname $objname snap01 snap02 || return 1
+    make_a_clone $poolname $objname snap13 || return 1
+    make_a_clone $poolname $objname snap24 snap25 || return 1
+    echo $RANDOM | rados -p $poolname put $objname - || return 1
+
+    #identify the PG and the primary OSD
+    local pgid=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.pgid'`
+    local osd=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.up[0]'`
+    echo "pgid is $pgid (primary: osd.$osd)"
+    # turn on the publishing of test data in the 'scrubber' section of 'pg query' output
+    set_query_debug $pgid
+
+    # verify the existence of these clones
+    (( extr_dbg >= 1 )) && rados --format json-pretty -p $poolname listsnaps $objname
+
+    # scrub the PG
+    ceph pg $pgid deep_scrub || return 1
+
+    # we aren't just waiting for the scrub to terminate, but also for the
+    # logs to be published
+    sleep 3
+    ceph pg dump pgs
+    until grep -a -q -- "event: --^^^^---- ScrubFinished" $dir/osd.$osd.log ; do
+        sleep 0.2
+    done
+
+    ceph pg dump pgs
+    ceph osd set noscrub || return 1
+    ceph osd set nodeep-scrub || return 1
+    sleep 5
+    grep -a -q -v "ERR" $dir/osd.$osd.log || return 1
+
+    # kill the OSDs
+    kill_daemons $dir TERM osd || return 1
+
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/0 dump "p"
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump "p" | grep -a SNA_
+    (( extr_dbg >= 2 )) && grep -a SNA_ /tmp/oo2.dump
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump p 2> /dev/null
+
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+        kvdir=$dir/$sdn
+        echo "corrupting the SnapMapper DB of osd.$sdn (db: $kvdir)"
+        (( extr_dbg >= 3 )) && ceph-kvstore-tool bluestore-kv $kvdir dump "p"
+
+        # truncate the 'mapping' (SNA_) entry corresponding to the snap13 clone
+        KY=`ceph-kvstore-tool bluestore-kv $kvdir dump p 2> /dev/null | grep -a -e 'SNA_[0-9]_0000000000000003_000000000000000' \
+            | awk -e '{print $2;}'`
+        (( extr_dbg >= 1 )) && echo "SNA key: $KY" | cat -v
+
+        tmp_fn1=`mktemp -p /tmp --suffix="_the_val"`
+        (( extr_dbg >= 1 )) && echo "Value dumped in: $tmp_fn1"
+        ceph-kvstore-tool bluestore-kv $kvdir get p "$KY" out $tmp_fn1 2> /dev/null
+        (( extr_dbg >= 2 )) && od -xc $tmp_fn1
+
+        NKY=${KY:0:-30}
+        ceph-kvstore-tool bluestore-kv $kvdir rm "p" "$KY" 2> /dev/null
+        ceph-kvstore-tool bluestore-kv $kvdir set "p" "$NKY" in $tmp_fn1 2> /dev/null
+
+        (( extr_dbg >= 1 )) || rm $tmp_fn1
+    done
+
+    orig_osd_args=" ${cluster_conf['osd_args']}"
+    orig_osd_args=" $(echo $orig_osd_args)"
+    (( extr_dbg >= 2 )) && echo "Copied OSD args: /$orig_osd_args/ /${orig_osd_args:1}/"
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+      CEPH_ARGS="$CEPH_ARGS $orig_osd_args" activate_osd $dir $sdn
+    done
+    sleep 1
+
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+      timeout 60 ceph tell osd.$sdn version
+    done
+
+    # when scrubbing now - we expect the scrub to emit a cluster log ERR message regarding SnapMapper internal inconsistency
+    ceph osd unset nodeep-scrub || return 1
+    ceph osd unset noscrub || return 1
+
+    # what is the primary now?
+    local cur_prim=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.up[0]'`
+    ceph pg dump pgs
+    sleep 2
+    ceph pg $pgid deep_scrub || return 1
+    sleep 5
+    ceph pg dump pgs
+    (( extr_dbg >= 1 )) && grep -a "ERR" $dir/osd.$cur_prim.log
+    grep -a -q "ERR" $dir/osd.$cur_prim.log || return 1
+}
+
+
+
+main osd-mapper "$@"

--- a/qa/standalone/scrub/osd-mapper.sh
+++ b/qa/standalone/scrub/osd-mapper.sh
@@ -100,6 +100,8 @@ function TEST_truncated_sna_record() {
     (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump "p" | grep -a SNA_
     (( extr_dbg >= 2 )) && grep -a SNA_ /tmp/oo2.dump
     (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump p 2> /dev/null
+    local num_sna_b4=`ceph-kvstore-tool bluestore-kv $dir/$osd dump p 2> /dev/null | grep -a -e 'SNA_[0-9]_000000000000000[0-9]_000000000000000' \
+            | awk -e '{print $2;}' | wc -l`
 
     for sdn in $(seq 0 $(expr $osdn - 1))
     do
@@ -137,6 +139,7 @@ function TEST_truncated_sna_record() {
     do
       timeout 60 ceph tell osd.$sdn version
     done
+    rados --format json-pretty -p $poolname listsnaps $objname
 
     # when scrubbing now - we expect the scrub to emit a cluster log ERR message regarding SnapMapper internal inconsistency
     ceph osd unset nodeep-scrub || return 1
@@ -151,8 +154,29 @@ function TEST_truncated_sna_record() {
     ceph pg dump pgs
     (( extr_dbg >= 1 )) && grep -a "ERR" $dir/osd.$cur_prim.log
     grep -a -q "ERR" $dir/osd.$cur_prim.log || return 1
-}
 
+    # but did we fix the snap issue? let's try scrubbing again
+
+    local prev_err_cnt=`grep -a "ERR" $dir/osd.$cur_prim.log | wc -l`
+    echo "prev count: $prev_err_cnt"
+
+    # scrub again. No errors expected this time
+    ceph pg $pgid deep_scrub || return 1
+    sleep 5
+    ceph pg dump pgs
+    (( extr_dbg >= 1 )) && grep -a "ERR" $dir/osd.$cur_prim.log
+    local current_err_cnt=`grep -a "ERR" $dir/osd.$cur_prim.log | wc -l`
+    (( extr_dbg >= 1 )) && echo "current count: $current_err_cnt"
+    (( current_err_cnt == prev_err_cnt )) || return 1
+    kill_daemons $dir TERM osd || return 1
+    kvdir=$dir/$cur_prim
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $kvdir dump p 2> /dev/null | grep -a -e 'SNA_[0-9]_' \
+            | awk -e '{print $2;}'
+    local num_sna_full=`ceph-kvstore-tool bluestore-kv $kvdir dump p 2> /dev/null | grep -a -e 'SNA_[0-9]_000000000000000[0-9]_000000000000000' \
+            | awk -e '{print $2;}' | wc -l`
+    (( num_sna_full == num_sna_b4 )) || return 1
+    return 0
+}
 
 
 main osd-mapper "$@"

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -695,7 +695,7 @@ EOF
     err_strings[19]="log_channel[(]cluster[)] log [[]ERR[]] : scrub [0-9]*[.]0 .*:::obj14:1 : size 1032 != clone_size 1033"
     err_strings[20]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 scrub 20 errors"
     err_strings[21]="log_channel[(]cluster[)] log [[]ERR[]] : scrub [0-9]*[.]0 .*:::obj15:head : can't decode 'snapset' attr "
-    err_strings[22]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 was  r -2...repaired"
+    err_strings[22]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: {1, 2, 3, 4, 5, 6, 7} ...repaired"
 
     for err_string in "${err_strings[@]}"
     do
@@ -1126,7 +1126,7 @@ fi
     # Check replica specific messages
     declare -a rep_err_strings
     osd=$(eval echo \$$which)
-    rep_err_strings[0]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 was  r -2...repaired"
+    rep_err_strings[0]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: {1, 2, 3, 4, 5, 6, 7} ...repaired"
     for err_string in "${rep_err_strings[@]}"
     do
         if ! grep "$err_string" $dir/osd.${osd}.log > /dev/null;

--- a/qa/standalone/scrub/scrub-helpers.sh
+++ b/qa/standalone/scrub/scrub-helpers.sh
@@ -243,7 +243,7 @@ function standard_scrub_cluster() {
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd $ceph_osd_args || return 1
+      run_osd $dir $osd $(echo $ceph_osd_args) || return 1
     done
 
     create_pool $poolname $pg_num $pg_num
@@ -254,6 +254,7 @@ function standard_scrub_cluster() {
     name_n_id=`ceph osd dump | awk '/^pool.*'$poolname'/ { gsub(/'"'"'/," ",$3); print $3," ", $2}'`
     echo "standard_scrub_cluster: $debug_msg: test pool is $name_n_id"
     args['pool_id']="${name_n_id##* }"
+    args['osd_args']=$ceph_osd_args
     if [[ -n "$saved_echo_flag" ]]; then set -x; fi
 }
 

--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -21,6 +21,7 @@
 #include "common/LogEntry.h"
 #include "log/Entry.h"
 #include "log/SubsystemMap.h"
+#include "msg/msg_fmt.h"
 
 
 namespace ceph::logging {

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -15,7 +15,10 @@
 #ifndef CEPH_LOGENTRY_H
 #define CEPH_LOGENTRY_H
 
+#include <fmt/format.h>
+
 #include "include/utime.h"
+#include "msg/msg_fmt.h"
 #include "msg/msg_types.h"
 #include "common/entity_name.h"
 #include "ostream_temp.h"
@@ -190,5 +193,20 @@ inline std::ostream& operator<<(std::ostream& out, const LogEntry& e)
 	     << e.seq << " : "
              << e.channel << " " << e.prio << " " << e.msg;
 }
+
+template <> struct fmt::formatter<EntityName> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const EntityName& e, FormatContext& ctx) {
+    return formatter<std::string_view>::format(e.to_str(), ctx);
+  }
+};
+
+template <> struct fmt::formatter<LogEntry> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const LogEntry& e, FormatContext& ctx) {
+    return fmt::format_to(ctx.out(), "{} {} ({}) {} : {} {} {}",
+			  e.stamp, e.name, e.rank, e.seq, e.channel, e.prio, e.msg);
+  }
+};
 
 #endif

--- a/src/common/hobject_fmt.h
+++ b/src/common/hobject_fmt.h
@@ -6,6 +6,7 @@
  * \file fmtlib formatters for some hobject.h classes
  */
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "common/hobject.h"
 #include "include/types_fmt.h"

--- a/src/include/neorados/RADOS_Decodable.hpp
+++ b/src/include/neorados/RADOS_Decodable.hpp
@@ -24,6 +24,11 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/core.h>
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
 namespace neorados {
 struct Entry {
   std::string nspace;
@@ -103,5 +108,9 @@ struct hash<::neorados::Entry> {
   }
 };
 }
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<neorados::Entry> : ostream_formatter {};
+#endif
 
 #endif // RADOS_DECODABLE_HPP

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -104,8 +104,13 @@ inline namespace v14_2_0 {
   };
   CEPH_RADOS_API std::ostream& operator<<(std::ostream& os, const librados::ObjectCursor& oc);
 
-  class CEPH_RADOS_API NObjectIterator : public std::iterator <std::forward_iterator_tag, ListObject> {
+  class CEPH_RADOS_API NObjectIterator {
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ListObject;
+    using difference_type = std::ptrdiff_t;
+    using pointer = ListObject*;
+    using reference = ListObject&;
     static const NObjectIterator __EndObjectIterator;
     NObjectIterator(): impl(NULL) {}
     ~NObjectIterator();

--- a/src/include/xlist.h
+++ b/src/include/xlist.h
@@ -159,10 +159,15 @@ public:
     remove(_back);
   }
 
-  class iterator: std::iterator<std::forward_iterator_tag, T> {
+  class iterator {
   private:
     item *cur;
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using reference = T&;
     iterator(item *i = 0) : cur(i) {}
     T operator*() { return static_cast<T>(cur->_item); }
     iterator& operator++() {

--- a/src/include/xlist.h
+++ b/src/include/xlist.h
@@ -183,10 +183,16 @@ public:
   iterator begin() { return iterator(_front); }
   iterator end() { return iterator(NULL); }
 
-  class const_iterator: std::iterator<std::forward_iterator_tag, T> {
+  class const_iterator {
   private:
     item *cur;
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const T*;
+    using reference = const T&;
+
     const_iterator(item *i = 0) : cur(i) {}
     const T operator*() { return static_cast<const T>(cur->_item); }
     const_iterator& operator++() {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -298,7 +298,6 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual bool check_failsafe_full() = 0;
 
-     virtual bool pg_is_repair() = 0;
      virtual void inc_osd_stat_repaired() = 0;
      virtual bool pg_is_remote_backfilling() = 0;
      virtual void pg_add_local_num_bytes(int64_t num_bytes) = 0;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -441,9 +441,6 @@ public:
     release_object_locks(manager);
   }
 
-  bool pg_is_repair() override {
-    return is_repair();
-  }
   void inc_osd_stat_repaired() override {
     osd->inc_osd_stat_repaired();
   }

--- a/src/osd/SnapMapReaderI.h
+++ b/src/osd/SnapMapReaderI.h
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file
+ * \brief Defines the interface for the snap-mapper used by the scrubber.
+ */
+#include <set>
+
+#include "common/scrub_types.h"
+#include "include/expected.hpp"
+
+namespace Scrub {
+/*
+ * snaps-related aux structures:
+ * the scrub-backend scans the snaps associated with each scrubbed object, and
+ * fixes corrupted snap-sets.
+ * The actual access to the PG's snap_mapper, and the actual I/O transactions,
+ * are performed by the main PgScrubber object.
+ * the following aux structures are used to facilitate the required exchanges:
+ * - pre-fix snap-sets are accessed by the scrub-backend, and:
+ * - a list of fix-orders (either insert or replace operations) are returned
+ */
+
+struct SnapMapReaderI {
+  struct result_t {
+    enum class code_t { success, backend_error, not_found, inconsistent };
+    code_t code{code_t::success};
+    int backend_error{0};  ///< errno returned by the backend
+  };
+
+  /**
+   *  get SnapMapper's snap-set for a given object
+   *  \returns a set of snaps, or an error code
+   *  \attn: only OBJ_ DB entries are consulted
+   */
+  virtual tl::expected<std::set<snapid_t>, result_t> get_snaps(
+    const hobject_t& hoid) const = 0;
+
+  /**
+   *  get SnapMapper's snap-set for a given object.
+   *  The snaps gleaned from the OBJ_ entry are verified against the
+   *  mapping ('SNA_') entries.
+   *  A mismatch between both sets of entries will result in an error.
+   *  \returns a set of snaps, or an error code.
+   */
+  virtual tl::expected<std::set<snapid_t>, result_t>
+  get_snaps_check_consistency(const hobject_t& hoid) const = 0;
+
+  virtual ~SnapMapReaderI() = default;
+};
+
+}  // namespace Scrub
+
+enum class snap_mapper_op_t {
+  add,
+  update,
+  overwrite,  //< the mapper's data is internally inconsistent. Similar
+	      //<  to an 'update' operation, but the logs are different.
+};
+
+struct snap_mapper_fix_t {
+  snap_mapper_op_t op;
+  hobject_t hoid;
+  std::set<snapid_t> snaps;
+  std::set<snapid_t> wrong_snaps;  // only collected & returned for logging sake
+};

--- a/src/osd/SnapMapReaderI.h
+++ b/src/osd/SnapMapReaderI.h
@@ -51,8 +51,6 @@ struct SnapMapReaderI {
   virtual ~SnapMapReaderI() = default;
 };
 
-}  // namespace Scrub
-
 enum class snap_mapper_op_t {
   add,
   update,
@@ -66,3 +64,5 @@ struct snap_mapper_fix_t {
   std::set<snapid_t> snaps;
   std::set<snapid_t> wrong_snaps;  // only collected & returned for logging sake
 };
+
+}  // namespace Scrub

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -32,7 +32,6 @@ using std::set;
 using std::string;
 using std::vector;
 
-using ceph::bufferlist;
 using ceph::decode;
 using ceph::encode;
 using ceph::timespan_str;
@@ -81,14 +80,14 @@ const char *SnapMapper::PURGED_SNAP_PREFIX = "PSN_";
 
 int OSDriver::get_keys(
   const std::set<std::string> &keys,
-  std::map<std::string, bufferlist> *out)
+  std::map<std::string, ceph::buffer::list> *out)
 {
   return os->omap_get_values(ch, hoid, keys, out);
 }
 
 int OSDriver::get_next(
   const std::string &key,
-  pair<std::string, bufferlist> *next)
+  pair<std::string, ceph::buffer::list> *next)
 {
   ObjectMap::ObjectMapIterator iter =
     os->get_omap_iterator(ch, hoid);
@@ -128,20 +127,20 @@ std::string SnapMapper::to_raw_key(snapid_t snap, const hobject_t &clone) const
   return get_prefix(clone.pool, snap) + shard_prefix + clone.to_str();
 }
 
-pair<string, bufferlist> SnapMapper::to_raw(
+pair<string, ceph::buffer::list> SnapMapper::to_raw(
   const pair<snapid_t, hobject_t> &in) const
 {
-  bufferlist bl;
+  ceph::buffer::list bl;
   encode(Mapping(in), bl);
   return make_pair(to_raw_key(in), bl);
 }
 
 pair<snapid_t, hobject_t> SnapMapper::from_raw(
-  const pair<std::string, bufferlist> &image)
+  const pair<std::string, ceph::buffer::list> &image)
 {
   using ceph::decode;
   Mapping map;
-  bufferlist bl(image.second);
+  ceph::buffer::list bl(image.second);
   auto bp = bl.cbegin();
   decode(map, bp);
   return make_pair(map.snap, map.hoid);
@@ -167,7 +166,7 @@ string SnapMapper::to_object_key(const hobject_t &hoid) const
   return OBJECT_PREFIX + shard_prefix + hoid.to_str();
 }
 
-void SnapMapper::object_snaps::encode(bufferlist &bl) const
+void SnapMapper::object_snaps::encode(ceph::buffer::list &bl) const
 {
   ENCODE_START(1, 1, bl);
   encode(oid, bl);
@@ -175,7 +174,7 @@ void SnapMapper::object_snaps::encode(bufferlist &bl) const
   ENCODE_FINISH(bl);
 }
 
-void SnapMapper::object_snaps::decode(bufferlist::const_iterator &bl)
+void SnapMapper::object_snaps::decode(ceph::buffer::list::const_iterator &bl)
 {
   DECODE_START(1, bl);
   decode(oid, bl);
@@ -234,7 +233,7 @@ SnapMapper::get_snaps_common(const hobject_t &oid) const
   dout(20) << fmt::format("{}: key string: {} oid:{}", __func__, keys, oid)
 	   << dendl;
 
-  map<string, bufferlist> got;
+  map<string, ceph::buffer::list> got;
   int r = backend.get_keys(keys, &got);
   if (r < 0) {
     dout(10) << __func__ << " " << oid << " got err " << r << dendl;
@@ -290,8 +289,8 @@ SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
   // we have the clone oid and the set of snaps relevant to this clone.
   // Let's construct all expected SNA_ key, then fetch them.
 
-  map<string, bufferlist> kvmap;
   auto mapping_keys = to_raw_keys(hoid, *obj_snaps);
+  map<string, ceph::buffer::list> kvmap;
   auto r = backend.get_keys(mapping_keys, &kvmap);
   if (r < 0) {
     dout(10) << fmt::format(
@@ -333,7 +332,7 @@ SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
 
 void SnapMapper::clear_snaps(
   const hobject_t &oid,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   dout(20) << __func__ << " " << oid << dendl;
   ceph_assert(check(oid));
@@ -350,11 +349,11 @@ void SnapMapper::clear_snaps(
 void SnapMapper::set_snaps(
   const hobject_t &oid,
   const object_snaps &in,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   ceph_assert(check(oid));
-  map<string, bufferlist> to_set;
-  bufferlist bl;
+  map<string, ceph::buffer::list> to_set;
+  ceph::buffer::list bl;
   encode(in, bl);
   to_set[to_object_key(oid)] = bl;
   dout(20) << __func__ << " " << oid << " " << in.snaps << dendl;
@@ -370,7 +369,7 @@ int SnapMapper::update_snaps(
   const hobject_t &oid,
   const set<snapid_t> &new_snaps,
   const set<snapid_t> *old_snaps_check,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   dout(20) << __func__ << " " << oid << " " << new_snaps
 	   << " was " << (old_snaps_check ? *old_snaps_check : set<snapid_t>())
@@ -410,7 +409,7 @@ int SnapMapper::update_snaps(
 void SnapMapper::add_oid(
   const hobject_t &oid,
   const set<snapid_t>& snaps,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   dout(20) << __func__ << " " << oid << " " << snaps << dendl;
   ceph_assert(!snaps.empty());
@@ -429,7 +428,7 @@ void SnapMapper::add_oid(
   object_snaps _snaps(oid, snaps);
   set_snaps(oid, _snaps, t);
 
-  map<string, bufferlist> to_add;
+  map<string, ceph::buffer::list> to_add;
   for (set<snapid_t>::iterator i = snaps.begin();
        i != snaps.end();
        ++i) {
@@ -463,7 +462,7 @@ int SnapMapper::get_next_objects_to_trim(
     string prefix(get_prefix(pool, snap) + *i);
     string pos = prefix;
     while (out->size() < max) {
-      pair<string, bufferlist> next;
+      pair<string, ceph::buffer::list> next;
       r = backend.get_next(pos, &next);
       dout(20) << __func__ << " get_next(" << pos << ") returns " << r
 	       << " " << next << dendl;
@@ -497,7 +496,7 @@ int SnapMapper::get_next_objects_to_trim(
 
 int SnapMapper::remove_oid(
   const hobject_t &oid,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   dout(20) << __func__ << " " << oid << dendl;
   ceph_assert(check(oid));
@@ -506,7 +505,7 @@ int SnapMapper::remove_oid(
 
 int SnapMapper::_remove_oid(
   const hobject_t &oid,
-  MapCacher::Transaction<std::string, bufferlist> *t)
+  MapCacher::Transaction<std::string, ceph::buffer::list> *t)
 {
   dout(20) << __func__ << " " << oid << dendl;
   object_snaps out;
@@ -557,7 +556,7 @@ string SnapMapper::make_purged_snap_key(int64_t pool, snapid_t last)
 }
 
 void SnapMapper::make_purged_snap_key_value(
-  int64_t pool, snapid_t begin, snapid_t end, map<string,bufferlist> *m)
+  int64_t pool, snapid_t begin, snapid_t end, map<string,ceph::buffer::list> *m)
 {
   string k = make_purged_snap_key(pool, end - 1);
   auto& v = (*m)[k];
@@ -588,7 +587,7 @@ int SnapMapper::_lookup_purged_snap(
 	     << it->key() << "'" << dendl;
     return -ENOENT;
   }
-  bufferlist v = it->value();
+  ceph::buffer::list v = it->value();
   auto p = v.cbegin();
   int64_t gotpool;
   decode(gotpool, p);
@@ -611,7 +610,7 @@ void SnapMapper::record_purged_snaps(
   map<epoch_t,mempool::osdmap::map<int64_t,snap_interval_set_t>> purged_snaps)
 {
   dout(10) << __func__ << " purged_snaps " << purged_snaps << dendl;
-  map<string,bufferlist> m;
+  map<string,ceph::buffer::list> m;
   set<string> rm;
   for (auto& [epoch, bypool] : purged_snaps) {
     // index by (pool, snap)
@@ -670,7 +669,7 @@ bool SnapMapper::Scrubber::_parse_p()
     pool = -1;
     return false;
   }
-  bufferlist v = psit->value();
+  ceph::buffer::list v = psit->value();
   auto p = v.cbegin();
   ceph::decode(pool, p);
   ceph::decode(begin, p);
@@ -813,7 +812,7 @@ bool SnapMapper::is_legacy_mapping(const string &to_test)
  */
 std::string SnapMapper::convert_legacy_key(
   const std::string& old_key,
-  const bufferlist& value)
+  const ceph::buffer::list& value)
 {
   auto old = from_raw(make_pair(old_key, value));
   std::string object_suffix = old_key.substr(
@@ -839,7 +838,7 @@ int SnapMapper::convert_legacy(
   auto start = ceph::mono_clock::now();
 
   iter->upper_bound(SnapMapper::LEGACY_MAPPING_PREFIX);
-  map<string,bufferlist> to_set;
+  map<string,ceph::buffer::list> to_set;
   while (iter->valid()) {
     bool valid = SnapMapper::is_legacy_mapping(iter->key());
     if (valid) {

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -14,6 +14,12 @@
 
 #include "SnapMapper.h"
 
+#include <fmt/printf.h>
+#include <fmt/ranges.h>
+
+#include "osd/osd_types_fmt.h"
+#include "SnapMapReaderI.h"
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
@@ -30,6 +36,9 @@ using ceph::bufferlist;
 using ceph::decode;
 using ceph::encode;
 using ceph::timespan_str;
+using result_t = Scrub::SnapMapReaderI::result_t;
+using code_t = Scrub::SnapMapReaderI::result_t::code_t;
+
 
 const string SnapMapper::LEGACY_MAPPING_PREFIX = "MAP_";
 const string SnapMapper::MAPPING_PREFIX = "SNA_";
@@ -109,19 +118,22 @@ string SnapMapper::get_prefix(int64_t pool, snapid_t snap)
 }
 
 string SnapMapper::to_raw_key(
-  const pair<snapid_t, hobject_t> &in)
+  const pair<snapid_t, hobject_t> &in) const
 {
   return get_prefix(in.second.pool, in.first) + shard_prefix + in.second.to_str();
 }
 
+std::string SnapMapper::to_raw_key(snapid_t snap, const hobject_t &clone) const
+{
+  return get_prefix(clone.pool, snap) + shard_prefix + clone.to_str();
+}
+
 pair<string, bufferlist> SnapMapper::to_raw(
-  const pair<snapid_t, hobject_t> &in)
+  const pair<snapid_t, hobject_t> &in) const
 {
   bufferlist bl;
   encode(Mapping(in), bl);
-  return make_pair(
-    to_raw_key(in),
-    bl);
+  return make_pair(to_raw_key(in), bl);
 }
 
 pair<snapid_t, hobject_t> SnapMapper::from_raw(
@@ -135,12 +147,22 @@ pair<snapid_t, hobject_t> SnapMapper::from_raw(
   return make_pair(map.snap, map.hoid);
 }
 
+std::pair<snapid_t, hobject_t> SnapMapper::from_raw(
+  const ceph::buffer::list &image)
+{
+  using ceph::decode;
+  Mapping map;
+  auto bp = image.cbegin();
+  decode(map, bp);
+  return make_pair(map.snap, map.hoid);
+}
+
 bool SnapMapper::is_mapping(const string &to_test)
 {
   return to_test.substr(0, MAPPING_PREFIX.size()) == MAPPING_PREFIX;
 }
 
-string SnapMapper::to_object_key(const hobject_t &hoid)
+string SnapMapper::to_object_key(const hobject_t &hoid) const
 {
   return OBJECT_PREFIX + shard_prefix + hoid.to_str();
 }
@@ -172,35 +194,141 @@ bool SnapMapper::check(const hobject_t &hoid) const
   return false;
 }
 
-int SnapMapper::get_snaps(
-  const hobject_t &oid,
-  object_snaps *out)
+int SnapMapper::get_snaps(const hobject_t &oid, object_snaps *out) const
+{
+  auto snaps = get_snaps_common(oid);
+  if (snaps) {
+    *out = *snaps;
+    return 0;
+  }
+  switch (auto e = snaps.error(); e.code) {
+    case code_t::backend_error:
+      return e.backend_error;
+    case code_t::not_found:
+      return -ENOENT;
+    case code_t::inconsistent:
+      // As this is a legacy interface, we cannot surprise the user with
+      // a new error code here.
+      return -ENOENT;
+    default:
+      // Can't happen. Just to keep the compiler happy.
+      ceph_abort("get_snaps_common() returned invalid error code");
+  }
+}
+
+tl::expected<std::set<snapid_t>, Scrub::SnapMapReaderI::result_t>
+SnapMapper::get_snaps(const hobject_t &oid) const
+{
+  auto snaps = get_snaps_common(oid);
+  if (snaps) {
+    return snaps->snaps;
+  }
+  return tl::unexpected(snaps.error());
+}
+
+tl::expected<SnapMapper::object_snaps, Scrub::SnapMapReaderI::result_t>
+SnapMapper::get_snaps_common(const hobject_t &oid) const
 {
   ceph_assert(check(oid));
-  set<string> keys;
+  set<string> keys{to_object_key(oid)};
+  dout(20) << fmt::format("{}: key string: {} oid:{}", __func__, keys, oid)
+	   << dendl;
+
   map<string, bufferlist> got;
-  keys.insert(to_object_key(oid));
   int r = backend.get_keys(keys, &got);
   if (r < 0) {
-    dout(20) << __func__ << " " << oid << " got err " << r << dendl;
-    return r;
+    dout(10) << __func__ << " " << oid << " got err " << r << dendl;
+    return tl::unexpected(result_t{code_t::backend_error, r});
   }
   if (got.empty()) {
-    dout(20) << __func__ << " " << oid << " got.empty()" << dendl;
-    return -ENOENT;
+    dout(10) << __func__ << " " << oid << " got.empty()" << dendl;
+    return tl::unexpected(result_t{code_t::not_found, -ENOENT});
   }
-  if (out) {
-    auto bp = got.begin()->second.cbegin();
-    decode(*out, bp);
-    dout(20) << __func__ << " " << oid << " " << out->snaps << dendl;
-    if (out->snaps.empty()) {
-      dout(1) << __func__ << " " << oid << " empty snapset" << dendl;
-      ceph_assert(!cct->_conf->osd_debug_verify_snaps);
+
+  object_snaps out;
+  auto bp = got.begin()->second.cbegin();
+  try {
+    decode(out, bp);
+  } catch (...) {
+    dout(1) << __func__ << ": " << oid << " decode failed" << dendl;
+    return tl::unexpected(result_t{code_t::backend_error, -EIO});
+  }
+
+  dout(20) << __func__ << " " << oid << " " << out.snaps << dendl;
+  if (out.snaps.empty()) {
+    dout(1) << __func__ << " " << oid << " empty snapset" << dendl;
+    ceph_assert(!cct->_conf->osd_debug_verify_snaps);
+  }
+  return out;
+}
+
+std::set<std::string> SnapMapper::to_raw_keys(
+  const hobject_t &clone,
+  const std::set<snapid_t> &snaps) const
+{
+  std::set<std::string> keys;
+  for (auto snap : snaps) {
+    keys.insert(to_raw_key(snap, clone));
+  }
+  dout(20) << fmt::format(
+		"{}: clone:{} snaps:{} -> keys: {}", __func__, clone, snaps,
+		keys)
+	   << dendl;
+  return keys;
+}
+
+tl::expected<std::set<snapid_t>, result_t>
+SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
+{
+  // derive the set of snaps from the 'OBJ_' entry
+  auto obj_snaps = get_snaps(hoid);
+  if (!obj_snaps) {
+    return obj_snaps;
+  }
+
+  // make sure we have the expected set of SNA_ entries:
+  // we have the clone oid and the set of snaps relevant to this clone.
+  // Let's construct all expected SNA_ key, then fetch them.
+
+  map<string, bufferlist> kvmap;
+  auto mapping_keys = to_raw_keys(hoid, *obj_snaps);
+  auto r = backend.get_keys(mapping_keys, &kvmap);
+  if (r < 0) {
+    dout(10) << fmt::format(
+		  "{}: backend error ({}) for cobject {}", __func__, r, hoid)
+	     << dendl;
+    // that's a backend error, but for the SNA_ entries. Let's treat it as an
+    // internal consistency error (although a backend error would have made
+    // sense too).
+    return tl::unexpected(result_t{code_t::inconsistent, r});
+  }
+
+  std::set<snapid_t> snaps_from_mapping;
+  for (auto &[k, v] : kvmap) {
+    dout(20) << __func__ << " " << hoid << " " << k << dendl;
+    // extract the object ID from the value fetched for an SNA mapping key
+    auto [sn, obj] = SnapMapper::from_raw(v);
+    if (obj != hoid) {
+      dout(1) << fmt::format(
+		   "{}: unexpected object ID {} for key{} (expected {})",
+		   __func__, obj, k, hoid)
+	      << dendl;
+      return tl::unexpected(result_t{code_t::inconsistent});
     }
-  } else {
-    dout(20) << __func__ << " " << oid << " (out == NULL)" << dendl;
+    snaps_from_mapping.insert(sn);
   }
-  return 0;
+
+  if (snaps_from_mapping != *obj_snaps) {
+    dout(10) << fmt::format(
+		  "{}: hoid:{} -> mapper internal inconsistency ({} vs {})",
+		  __func__, hoid, *obj_snaps, snaps_from_mapping)
+	     << dendl;
+    return tl::unexpected(result_t{code_t::inconsistent});
+  }
+  dout(10) << fmt::format(
+		"{}: snaps for {}: {}", __func__, hoid, snaps_from_mapping)
+	   << dendl;
+  return obj_snaps;
 }
 
 void SnapMapper::clear_snaps(
@@ -327,6 +455,8 @@ int SnapMapper::get_next_objects_to_trim(
   // trim the snaptrim queue
   ceph_assert(max > 0);
   int r = 0;
+
+  /// \todo cache the prefixes-set in update_bits()
   for (set<string>::iterator i = prefixes.begin();
        i != prefixes.end() && out->size() < max && r == 0;
        ++i) {
@@ -403,7 +533,7 @@ int SnapMapper::_remove_oid(
 
 int SnapMapper::get_snaps(
   const hobject_t &oid,
-  std::set<snapid_t> *snaps)
+  std::set<snapid_t> *snaps) const
 {
   ceph_assert(check(oid));
   object_snaps out;

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -15,18 +15,19 @@
 #ifndef SNAPMAPPER_H
 #define SNAPMAPPER_H
 
-#include <string>
-#include <set>
-#include <utility>
 #include <cstring>
+#include <set>
+#include <string>
+#include <utility>
 
-#include "common/map_cacher.hpp"
 #include "common/hobject.h"
+#include "common/map_cacher.hpp"
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "include/object.h"
 #include "os/ObjectStore.h"
 #include "osd/OSDMap.h"
+#include "osd/SnapMapReaderI.h"
 
 class OSDriver : public MapCacher::StoreDriver<std::string, ceph::buffer::list> {
   ObjectStore *os;
@@ -61,6 +62,11 @@ public:
 
   OSTransaction get_transaction(
     ObjectStore::Transaction *t) {
+    return OSTransaction(ch->cid, hoid, t);
+  }
+
+  OSTransaction get_transaction(
+    ObjectStore::Transaction *t) const {
     return OSTransaction(ch->cid, hoid, t);
   }
 
@@ -99,7 +105,7 @@ public:
  * snap will sort together, and so that all objects in a pg for a
  * particular snap will group under up to 8 prefixes.
  */
-class SnapMapper {
+class SnapMapper : public Scrub::SnapMapReaderI {
   friend class MapperVerifier;
 public:
   CephContext* cct;
@@ -213,8 +219,9 @@ private:
     snapid_t end, std::map<std::string,ceph::buffer::list> *m);
   static std::string make_purged_snap_key(int64_t pool, snapid_t last);
 
-
-  MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
+  // note: marked 'mutable', as functions as a cache and used in some 'const'
+  // functions.
+  mutable MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
 
   static std::string get_legacy_prefix(snapid_t snap);
   std::string to_legacy_raw_key(
@@ -223,19 +230,28 @@ private:
 
   static std::string get_prefix(int64_t pool, snapid_t snap);
   std::string to_raw_key(
-    const std::pair<snapid_t, hobject_t> &to_map);
+    const std::pair<snapid_t, hobject_t> &to_map) const;
+
+  std::string to_raw_key(snapid_t snap, const hobject_t& clone) const;
 
   std::pair<std::string, ceph::buffer::list> to_raw(
-    const std::pair<snapid_t, hobject_t> &to_map);
+    const std::pair<snapid_t, hobject_t> &to_map) const;
 
   static bool is_mapping(const std::string &to_test);
 
   static std::pair<snapid_t, hobject_t> from_raw(
     const std::pair<std::string, ceph::buffer::list> &image);
 
-  std::string to_object_key(const hobject_t &hoid);
+  static std::pair<snapid_t, hobject_t> from_raw(
+    const ceph::buffer::list& image);
 
-  int get_snaps(const hobject_t &oid, object_snaps *out);
+  std::string to_object_key(const hobject_t &hoid) const;
+
+  int get_snaps(const hobject_t &oid, object_snaps *out) const;
+
+  std::set<std::string> to_raw_keys(
+    const hobject_t &clone,
+    const std::set<snapid_t> &snaps) const;
 
   void set_snaps(
     const hobject_t &oid,
@@ -254,7 +270,11 @@ private:
     MapCacher::Transaction<std::string, ceph::buffer::list> *t ///< [out] transaction
     );
 
-public:
+  /// Get snaps (as an 'object_snaps' object) for oid
+  tl::expected<object_snaps, SnapMapReaderI::result_t> get_snaps_common(
+    const hobject_t &hoid) const;
+
+ public:
   static std::string make_shard_prefix(shard_id_t shard) {
     if (shard == shard_id_t::NO_SHARD)
       return std::string();
@@ -330,7 +350,20 @@ public:
   int get_snaps(
     const hobject_t &oid,     ///< [in] oid to get snaps for
     std::set<snapid_t> *snaps ///< [out] snaps
-    ); ///< @return error, -ENOENT if oid is not recorded
+    ) const; ///< @return error, -ENOENT if oid is not recorded
+
+  /// Get snaps for oid - alternative interface
+  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t> get_snaps(
+    const hobject_t &hoid) const final;
+
+  /**
+   * get_snaps_check_consistency
+   *
+   * Returns snaps for hoid as in get_snaps(), but additionally validates the
+   * snap->hobject_t mappings ('SNA_' entries).
+   */
+  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t>
+  get_snaps_check_consistency(const hobject_t &hoid) const final;
 };
 WRITE_CLASS_ENCODER(SnapMapper::object_snaps)
 WRITE_CLASS_ENCODER(SnapMapper::Mapping)

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -61,11 +61,6 @@ public:
   };
 
   OSTransaction get_transaction(
-    ObjectStore::Transaction *t) {
-    return OSTransaction(ch->cid, hoid, t);
-  }
-
-  OSTransaction get_transaction(
     ObjectStore::Transaction *t) const {
     return OSTransaction(ch->cid, hoid, t);
   }

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -106,7 +106,8 @@ public:
  * particular snap will group under up to 8 prefixes.
  */
 class SnapMapper : public Scrub::SnapMapReaderI {
-  friend class MapperVerifier;
+  friend class MapperVerifier; // unit-test support
+  friend class DirectMapper; // unit-test support
 public:
   CephContext* cct;
   struct object_snaps {

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -57,7 +57,7 @@ struct fmt::formatter<chunk_info_t> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const chunk_info_t& ci, FormatContext& ctx)
+  auto format(const chunk_info_t& ci, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(), "(len: {} oid: {} offset: {} flags: {})",
 			  ci.length, ci.oid, ci.offset,
@@ -169,7 +169,7 @@ struct fmt::formatter<pg_info_t> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const pg_info_t& pgi, FormatContext& ctx)
+  auto format(const pg_info_t& pgi, FormatContext& ctx) const
   {
     fmt::format_to(ctx.out(), "{}({}", pgi.pgid, (pgi.dne() ? " DNE" : ""));
     if (pgi.is_empty()) {
@@ -211,7 +211,7 @@ struct fmt::formatter<SnapSet> {
   }
 
   template <typename FormatContext>
-  auto format(const SnapSet& snps, FormatContext& ctx)
+  auto format(const SnapSet& snps, FormatContext& ctx) const
   {
     if (verbose) {
       // similar to SnapSet::dump()
@@ -265,7 +265,7 @@ struct fmt::formatter<ScrubMap::object> {
 
   ///\todo: consider passing the 'D" flag to control snapset dump
   template <typename FormatContext>
-  auto format(const ScrubMap::object& so, FormatContext& ctx)
+  auto format(const ScrubMap::object& so, FormatContext& ctx) const
   {
     fmt::format_to(ctx.out(),
 		   "so{{ sz:{} dd:{} od:{} ",
@@ -308,7 +308,7 @@ struct fmt::formatter<ScrubMap> {
   }
 
   template <typename FormatContext>
-  auto format(const ScrubMap& smap, FormatContext& ctx)
+  auto format(const ScrubMap& smap, FormatContext& ctx) const
   {
     fmt::format_to(ctx.out(),
 		   "smap{{ valid:{} incr-since:{} #:{}",

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1318,12 +1318,15 @@ int PgScrubber::build_scrub_map_chunk(
 }
 
 /*
- * Process:
  * Building a map of objects suitable for snapshot validation.
- * The data in m_cleaned_meta_map is the left over partial items that need to
- * be completed before they can be processed.
  *
- * Snapshots in maps precede the head object, which is why we are scanning backwards.
+ * We are moving all "full" clone sets, i.e. the head and (preceding it, as
+ * snapshots precede the head entry) the clone entries, into 'for_meta_scrub'.
+ * That collection, not containing partial items, will be scrubbed by
+ * scrub_snapshot_metadata().
+ *
+ * What's left in m_cleaned_meta_map is the leftover partial items that need to
+ * be completed before they can be processed.
  */
 ScrubMap PgScrubber::clean_meta_map()
 {

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -976,8 +976,81 @@ void PgScrubber::on_replica_init()
   ++m_sessions_counter;
 }
 
-void PgScrubber::_scan_snaps(ScrubMap& smap)
+void PgScrubber::apply_snap_mapper_fixes(
+    const std::vector<snap_mapper_fix_t>& fix_list)
 {
+  dout(15) << __func__ << " " << fix_list.size() << " fixes" << dendl;
+
+  if (fix_list.empty()) {
+    return;
+  }
+
+  ObjectStore::Transaction t;
+  OSDriver::OSTransaction t_drv(m_pg->osdriver.get_transaction(&t));
+
+  for (auto& [fix_op, hoid, snaps, bogus_snaps] : fix_list) {
+
+    if (fix_op != snap_mapper_op_t::add) {
+
+      // must remove the existing snap-set before inserting the correct one
+      if (auto r = m_pg->snap_mapper.remove_oid(hoid, &t_drv); r < 0) {
+
+	derr << __func__ << ": remove_oid returned " << cpp_strerror(r)
+	     << dendl;
+	if (fix_op == snap_mapper_op_t::update) {
+	  // for inconsistent snapmapper objects (i.e. for
+	  // snap_mapper_op_t::inconsistent), we don't fret if we can't remove
+	  // the old entries
+	  ceph_abort();
+	}
+      }
+
+      m_osds->clog->error() << fmt::format(
+	  "osd.{} found snap mapper error on pg {} oid {} snaps in mapper: {}, "
+	  "oi: "
+	  "{} ...repaired",
+	  m_pg_whoami, m_pg_id, hoid, bogus_snaps, snaps);
+
+    } else {
+
+      m_osds->clog->error() << fmt::format(
+	  "osd.{} found snap mapper error on pg {} oid {} snaps missing in "
+	  "mapper, should be: {} ...repaired",
+	  m_pg_whoami, m_pg_id, hoid, snaps);
+    }
+
+    // now - insert the correct snap-set
+    m_pg->snap_mapper.add_oid(hoid, snaps, &t_drv);
+  }
+
+  // wait for repair to apply to avoid confusing other bits of the system.
+  {
+    dout(15) << __func__ << " wait on repair!" << dendl;
+
+    ceph::condition_variable my_cond;
+    ceph::mutex my_lock = ceph::make_mutex("PG::_scan_snaps my_lock");
+    int e = 0;
+    bool done{false};
+
+    t.register_on_applied_sync(new C_SafeCond(my_lock, my_cond, &done, &e));
+
+    if (e = m_pg->osd->store->queue_transaction(m_pg->ch, std::move(t));
+	e != 0) {
+      derr << __func__ << ": queue_transaction got " << cpp_strerror(e)
+	   << dendl;
+    } else {
+      std::unique_lock l{my_lock};
+      my_cond.wait(l, [&done] { return done; });
+      ceph_assert(m_pg->osd->store);  // RRR why?
+    }
+    dout(15) << __func__ << " wait on repair - done" << dendl;
+  }
+}
+
+
+std::vector<snap_mapper_fix_t> PgScrubber::_scan_snaps(ScrubMap& smap)
+{
+  std::vector<snap_mapper_fix_t> out_orders;
   hobject_t head;
   SnapSet snapset;
 
@@ -1013,66 +1086,116 @@ void PgScrubber::_scan_snaps(ScrubMap& smap)
     if (hoid.snap < CEPH_MAXSNAP) {
       // check and if necessary fix snap_mapper
       if (hoid.get_head() != head) {
-	derr << __func__ << " no head for " << hoid << " (have " << head << ")" << dendl;
+	derr << __func__ << " no head for " << hoid << " (have " << head << ")"
+	     << dendl;
 	continue;
       }
       set<snapid_t> obj_snaps;
       auto p = snapset.clone_snaps.find(hoid.snap);
       if (p == snapset.clone_snaps.end()) {
-	derr << __func__ << " no clone_snaps for " << hoid << " in " << snapset << dendl;
+	derr << __func__ << " no clone_snaps for " << hoid << " in " << snapset
+	     << dendl;
 	continue;
       }
-      obj_snaps.insert(p->second.begin(), p->second.end());
-      set<snapid_t> cur_snaps;
-      int r = m_pg->snap_mapper.get_snaps(hoid, &cur_snaps);
-      if (r != 0 && r != -ENOENT) {
-	derr << __func__ << ": get_snaps returned " << cpp_strerror(r) << dendl;
-	ceph_abort();
-      }
-      if (r == -ENOENT || cur_snaps != obj_snaps) {
-	ObjectStore::Transaction t;
-	OSDriver::OSTransaction _t(m_pg->osdriver.get_transaction(&t));
-	if (r == 0) {
-	  r = m_pg->snap_mapper.remove_oid(hoid, &_t);
-	  if (r != 0) {
-	    derr << __func__ << ": remove_oid returned " << cpp_strerror(r) << dendl;
-	    ceph_abort();
-	  }
-	  m_pg->osd->clog->error()
-	    << "osd." << m_pg->osd->whoami << " found snap mapper error on pg "
-	    << m_pg->info.pgid << " oid " << hoid << " snaps in mapper: " << cur_snaps
-	    << ", oi: " << obj_snaps << "...repaired";
-	} else {
-	  m_pg->osd->clog->error()
-	    << "osd." << m_pg->osd->whoami << " found snap mapper error on pg "
-	    << m_pg->info.pgid << " oid " << hoid << " snaps missing in mapper"
-	    << ", should be: " << obj_snaps << " was " << cur_snaps << " r " << r
-	    << "...repaired";
+
+      /// \todo document why guaranteed to have initialized 'head' at this point
+
+      if (hoid.snap < CEPH_MAXSNAP) {
+
+	if (hoid.get_head() != head) {
+	  derr << __func__ << " no head for " << hoid << " (have " << head
+	       << ")" << dendl;
+	  continue;
 	}
-	m_pg->snap_mapper.add_oid(hoid, obj_snaps, &_t);
 
-	// wait for repair to apply to avoid confusing other bits of the system.
-	{
-	  dout(15) << __func__ << " wait on repair!" << dendl;
-
-	  ceph::condition_variable my_cond;
-	  ceph::mutex my_lock = ceph::make_mutex("PG::_scan_snaps my_lock");
-	  int e = 0;
-	  bool done;
-
-	  t.register_on_applied_sync(new C_SafeCond(my_lock, my_cond, &done, &e));
-
-	  e = m_pg->osd->store->queue_transaction(m_pg->ch, std::move(t));
-	  if (e != 0) {
-	    derr << __func__ << ": queue_transaction got " << cpp_strerror(e) << dendl;
-	  } else {
-	    std::unique_lock l{my_lock};
-	    my_cond.wait(l, [&done] { return done; });
-	  }
+	// the 'hoid' is a clone hoid at this point. The 'snapset' below was taken
+	// from the corresponding head hoid.
+	auto maybe_fix_order = scan_object_snaps(hoid, snapset, m_pg->snap_mapper);
+	if (maybe_fix_order) {
+	  out_orders.push_back(std::move(*maybe_fix_order));
 	}
       }
     }
   }
+
+  dout(15) << __func__ << " " << out_orders.size() << " fix orders" << dendl;
+  return out_orders;
+}
+
+std::optional<snap_mapper_fix_t> PgScrubber::scan_object_snaps(
+  const hobject_t& hoid,
+  const SnapSet& snapset,
+  SnapMapReaderI& snaps_getter)
+{
+  using result_t = Scrub::SnapMapReaderI::result_t;
+
+  auto p = snapset.clone_snaps.find(hoid.snap);
+  if (p == snapset.clone_snaps.end()) {
+    derr << __func__ << " no clone_snaps for " << hoid << " in " << snapset
+         << dendl;
+    return std::nullopt;
+  }
+  set<snapid_t> obj_snaps{p->second.begin(), p->second.end()};
+
+  // validate both that the mapper contains the correct snaps for the object
+  // and that it is internally consistent.
+  // possible outcomes:
+  //
+  // Error scenarios:
+  // - SnapMapper index of object snaps does not match that stored in head
+  //   object snapset attribute:
+  //    we should delete the snapmapper entry and re-add it.
+  // - no mapping found for the object's snaps:
+  //    we should add the missing mapper entries.
+  // - the snapmapper set for this object is internally inconsistent (e.g.
+  //    the OBJ_ entries do not match the SNA_ entries). We remove
+  //    whatever entries are there, and redo the DB content for this object.
+  //
+  // And
+  // There is the "happy path": cur_snaps == obj_snaps. Nothing to do there.
+
+  auto cur_snaps = snaps_getter.get_snaps_check_consistency(hoid);
+  if (!cur_snaps) {
+    switch (auto e = cur_snaps.error(); e.code) {
+      case result_t::code_t::backend_error:
+	derr << __func__ << ": get_snaps returned "
+	     << cpp_strerror(e.backend_error) << " for " << hoid << dendl;
+	ceph_abort();
+      case result_t::code_t::not_found:
+	dout(10) << __func__ << ": no snaps for " << hoid << ". Adding."
+		 << dendl;
+	return snap_mapper_fix_t{snap_mapper_op_t::add, hoid, obj_snaps, {}};
+      case result_t::code_t::inconsistent:
+	dout(10) << __func__ << ": inconsistent snapmapper data for " << hoid
+		 << ". Recreating." << dendl;
+	return snap_mapper_fix_t{
+	  snap_mapper_op_t::overwrite, hoid, obj_snaps, {}};
+      default:
+	dout(10) << __func__ << ": error (" << cpp_strerror(e.backend_error)
+		 << ") fetching snapmapper data for " << hoid << ". Recreating."
+		 << dendl;
+	return snap_mapper_fix_t{
+	  snap_mapper_op_t::overwrite, hoid, obj_snaps, {}};
+    }
+    __builtin_unreachable();
+  }
+
+  if (*cur_snaps == obj_snaps) {
+    dout(20) << fmt::format(
+		  "{}: {}: snapset match SnapMapper's ({})", __func__, hoid,
+		  obj_snaps)
+	     << dendl;
+    return std::nullopt;
+  }
+
+  // add this object to the list of snapsets that needs fixing. Note
+  // that we also collect the existing (bogus) list, for logging purposes
+  dout(20) << fmt::format(
+		"{}: obj {}: was: {} updating to: {}", __func__, hoid,
+		*cur_snaps, obj_snaps)
+	   << dendl;
+  return snap_mapper_fix_t{
+    snap_mapper_op_t::update, hoid, obj_snaps, *cur_snaps};
 }
 
 int PgScrubber::build_primary_map_chunk()
@@ -1114,7 +1237,8 @@ int PgScrubber::build_replica_map_chunk()
       m_cleaned_meta_map.clear_from(m_start);
       m_cleaned_meta_map.insert(replica_scrubmap);
       auto for_meta_scrub = clean_meta_map();
-      _scan_snaps(for_meta_scrub);
+      auto required_fixes = _scan_snaps(for_meta_scrub);
+      apply_snap_mapper_fixes(required_fixes);
 
       // the local map has been created. Send it to the primary.
       // Note: once the message reaches the Primary, it may ask us for another
@@ -1448,7 +1572,10 @@ void PgScrubber::scrub_compare_maps()
   scrub_snapshot_metadata(for_meta_scrub, missing_digest);
 
   // Called here on the primary can use an authoritative map if it isn't the primary
-  _scan_snaps(for_meta_scrub);
+  auto required_fixes = _scan_snaps(for_meta_scrub);
+
+  // actuate snap-mapper changes:
+  apply_snap_mapper_fixes(required_fixes);
 
   if (!m_store->empty()) {
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -977,7 +977,7 @@ void PgScrubber::on_replica_init()
 }
 
 void PgScrubber::apply_snap_mapper_fixes(
-    const std::vector<snap_mapper_fix_t>& fix_list)
+    const std::vector<Scrub::snap_mapper_fix_t>& fix_list)
 {
   dout(15) << __func__ << " " << fix_list.size() << " fixes" << dendl;
 
@@ -1048,9 +1048,9 @@ void PgScrubber::apply_snap_mapper_fixes(
 }
 
 
-std::vector<snap_mapper_fix_t> PgScrubber::_scan_snaps(ScrubMap& smap)
+std::vector<Scrub::snap_mapper_fix_t> PgScrubber::_scan_snaps(ScrubMap& smap)
 {
-  std::vector<snap_mapper_fix_t> out_orders;
+  std::vector<Scrub::snap_mapper_fix_t> out_orders;
   hobject_t head;
   SnapSet snapset;
 
@@ -1122,7 +1122,7 @@ std::vector<snap_mapper_fix_t> PgScrubber::_scan_snaps(ScrubMap& smap)
   return out_orders;
 }
 
-std::optional<snap_mapper_fix_t> PgScrubber::scan_object_snaps(
+std::optional<Scrub::snap_mapper_fix_t> PgScrubber::scan_object_snaps(
   const hobject_t& hoid,
   const SnapSet& snapset,
   SnapMapReaderI& snaps_getter)
@@ -1164,17 +1164,17 @@ std::optional<snap_mapper_fix_t> PgScrubber::scan_object_snaps(
       case result_t::code_t::not_found:
 	dout(10) << __func__ << ": no snaps for " << hoid << ". Adding."
 		 << dendl;
-	return snap_mapper_fix_t{snap_mapper_op_t::add, hoid, obj_snaps, {}};
+	return Scrub::snap_mapper_fix_t{snap_mapper_op_t::add, hoid, obj_snaps, {}};
       case result_t::code_t::inconsistent:
 	dout(10) << __func__ << ": inconsistent snapmapper data for " << hoid
 		 << ". Recreating." << dendl;
-	return snap_mapper_fix_t{
+	return Scrub::snap_mapper_fix_t{
 	  snap_mapper_op_t::overwrite, hoid, obj_snaps, {}};
       default:
 	dout(10) << __func__ << ": error (" << cpp_strerror(e.backend_error)
 		 << ") fetching snapmapper data for " << hoid << ". Recreating."
 		 << dendl;
-	return snap_mapper_fix_t{
+	return Scrub::snap_mapper_fix_t{
 	  snap_mapper_op_t::overwrite, hoid, obj_snaps, {}};
     }
     __builtin_unreachable();
@@ -1194,7 +1194,7 @@ std::optional<snap_mapper_fix_t> PgScrubber::scan_object_snaps(
 		"{}: obj {}: was: {} updating to: {}", __func__, hoid,
 		*cur_snaps, obj_snaps)
 	   << dendl;
-  return snap_mapper_fix_t{
+  return Scrub::snap_mapper_fix_t{
     snap_mapper_op_t::update, hoid, obj_snaps, *cur_snaps};
 }
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -16,6 +16,7 @@
 #include "ScrubStore.h"
 #include "scrub_machine_lstnr.h"
 #include "osd/scrubber_common.h"
+#include "osd/SnapMapReaderI.h"
 #include "osd_scrub_sched.h"
 
 class Callback;
@@ -488,7 +489,15 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
 
   void requeue_waiting() const { m_pg->requeue_ops(m_pg->waiting_for_scrub); }
 
-  void _scan_snaps(ScrubMap& smap);
+  [[nodiscard]] std::vector<snap_mapper_fix_t> _scan_snaps(ScrubMap& smap);
+
+  [[nodiscard]] std::optional<snap_mapper_fix_t> scan_object_snaps(
+      const hobject_t& hoid,
+      const SnapSet& snapset,
+      Scrub::SnapMapReaderI& snaps_getter);
+
+  void apply_snap_mapper_fixes(
+      const std::vector<snap_mapper_fix_t>& fix_list);
 
   ScrubMap clean_meta_map();
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -38,10 +38,8 @@ struct BuildMap;
  *  sorting) is better than boost::small_vec. And for std::vector: no need to pre-reserve.
  */
 class ReplicaReservations {
-  using OrigSet = decltype(std::declval<PG>().get_actingset());
-
   PG* m_pg;
-  OrigSet m_acting_set;
+  std::set<pg_shard_t> m_acting_set;
   OSDService* m_osds;
   std::vector<pg_shard_t> m_waited_for_peers;
   std::vector<pg_shard_t> m_reserved_peers;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -489,15 +489,15 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
 
   void requeue_waiting() const { m_pg->requeue_ops(m_pg->waiting_for_scrub); }
 
-  [[nodiscard]] std::vector<snap_mapper_fix_t> _scan_snaps(ScrubMap& smap);
+  [[nodiscard]] std::vector<Scrub::snap_mapper_fix_t> _scan_snaps(ScrubMap& smap);
 
-  [[nodiscard]] std::optional<snap_mapper_fix_t> scan_object_snaps(
+  [[nodiscard]] std::optional<Scrub::snap_mapper_fix_t> scan_object_snaps(
       const hobject_t& hoid,
       const SnapSet& snapset,
       Scrub::SnapMapReaderI& snaps_getter);
 
   void apply_snap_mapper_fixes(
-      const std::vector<snap_mapper_fix_t>& fix_list);
+      const std::vector<Scrub::snap_mapper_fix_t>& fix_list);
 
   ScrubMap clean_meta_map();
 

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -8,6 +8,7 @@
 
 #include "include/buffer.h"
 #include "common/map_cacher.hpp"
+#include "osd/osd_types_fmt.h"
 #include "osd/SnapMapper.h"
 #include "common/Cond.h"
 
@@ -683,3 +684,162 @@ TEST_F(SnapMapperTest, LegacyKeyConvertion) {
     ASSERT_EQ(converted_key, new_key);
 }
 
+/**
+ * 'DirectMapper' provides simple, controlled, interface to the underlying
+ * SnapMapper.
+ */
+class DirectMapper {
+public:
+  std::unique_ptr<PausyAsyncMap> driver{make_unique<PausyAsyncMap>()};
+  std::unique_ptr<SnapMapper> mapper;
+  uint32_t mask;
+  uint32_t bits;
+  ceph::mutex lock = ceph::make_mutex("lock");
+
+  DirectMapper(
+    uint32_t mask,
+    uint32_t bits)
+   : mapper(new SnapMapper(g_ceph_context, driver.get(), mask, bits, 0, shard_id_t(1))), 
+             mask(mask), bits(bits) {}
+
+  hobject_t random_hobject() {
+    return hobject_t(
+      random_string(1+(rand() % 16)),
+      random_string(1+(rand() % 16)),
+      snapid_t(rand() % 1000),
+      (rand() & ((~0)<<bits)) | (mask & ~((~0)<<bits)),
+      0, random_string(rand() % 16));
+  }
+
+  void create_object(const hobject_t& obj, const set<snapid_t> &snaps) {
+    std::lock_guard l{lock};
+      PausyAsyncMap::Transaction t;
+      mapper->add_oid(obj, snaps, &t);
+      driver->submit(&t);
+  }
+
+  std::pair<std::string, ceph::buffer::list> to_raw(
+    const std::pair<snapid_t, hobject_t> &to_map) {
+    return mapper->to_raw(to_map);
+  }
+
+  std::string to_legacy_raw_key(
+    const std::pair<snapid_t, hobject_t> &to_map) {
+    return mapper->to_legacy_raw_key(to_map);
+  }
+
+  std::string to_raw_key(
+    const std::pair<snapid_t, hobject_t> &to_map) {
+    return mapper->to_raw_key(to_map);
+  }
+
+  void shorten_mapping_key(snapid_t snap, const hobject_t &clone)
+  {
+    // calculate the relevant key
+    std::string k = mapper->to_raw_key(snap, clone);
+
+    // find the value for this key
+    map<string, bufferlist> kvmap;
+    auto r = mapper->backend.get_keys(set{k}, &kvmap);
+    ASSERT_GE(r, 0);
+
+    // replace the key with its shortened version
+    PausyAsyncMap::Transaction t;
+    mapper->backend.remove_keys(set{k}, &t);
+    auto short_k = k.substr(0, 10);
+    mapper->backend.set_keys(map<string, bufferlist>{{short_k, kvmap[k]}}, &t);
+    driver->submit(&t);
+    driver->flush();
+  }
+};
+
+class DirectMapperTest : public ::testing::Test {
+ public:
+  // ctor & initialization
+  DirectMapperTest() = default;
+  ~DirectMapperTest() = default;
+  void SetUp() override;
+  void TearDown() override;
+
+ protected:
+  std::unique_ptr<DirectMapper> direct;
+};
+
+void DirectMapperTest::SetUp()
+{
+  direct = std::make_unique<DirectMapper>(0, 0);
+}
+
+void DirectMapperTest::TearDown()
+{
+  direct->driver->stop();
+  direct->mapper.reset();
+  direct->driver.reset();
+}
+
+
+TEST_F(DirectMapperTest, BasciObject)
+{
+  auto obj = direct->random_hobject();
+  set<snapid_t> snaps{100, 200};
+  direct->create_object(obj, snaps);
+
+  // verify that the OBJ_ & SNA_ entries are there
+  auto osn1 = direct->mapper->get_snaps(obj);
+  ASSERT_EQ(snaps, osn1);
+  auto vsn1 = direct->mapper->get_snaps_check_consistency(obj);
+  ASSERT_EQ(snaps, vsn1);
+}
+
+TEST_F(DirectMapperTest, CorruptedSnaRecord)
+{
+  object_t base_name{"obj"};
+  std::string key{"key"};
+
+  hobject_t head{base_name, key, CEPH_NOSNAP, 0x17, 0, ""};
+  hobject_t cln1{base_name, key, 10, 0x17, 0, ""};
+  hobject_t cln2{base_name, key, 20, 0x17, 0, ""}; // the oldest version
+  set<snapid_t> head_snaps{400, 500};
+  set<snapid_t> cln1_snaps{300};
+  set<snapid_t> cln2_snaps{100, 200};
+
+  PausyAsyncMap::Transaction t;
+  direct->mapper->add_oid(head, head_snaps, &t);
+  direct->mapper->add_oid(cln1, cln1_snaps, &t);
+  direct->mapper->add_oid(cln2, cln2_snaps, &t);
+  direct->driver->submit(&t);
+  direct->driver->flush();
+
+  // verify that the OBJ_ & SNA_ entries are there
+  {
+    auto osn1 = direct->mapper->get_snaps(cln1);
+    EXPECT_EQ(cln1_snaps, osn1);
+    auto osn2 = direct->mapper->get_snaps(cln2);
+    EXPECT_EQ(cln2_snaps, osn2);
+    auto osnh = direct->mapper->get_snaps(head);
+    EXPECT_EQ(head_snaps, osnh);
+  }
+  {
+    auto vsn1 = direct->mapper->get_snaps_check_consistency(cln1);
+    EXPECT_EQ(cln1_snaps, vsn1);
+    auto vsn2 = direct->mapper->get_snaps_check_consistency(cln2);
+    EXPECT_EQ(cln2_snaps, vsn2);
+    auto vsnh = direct->mapper->get_snaps_check_consistency(head);
+    EXPECT_EQ(head_snaps, vsnh);
+  }
+
+  // corrupt the SNA_ entry for cln1
+  direct->shorten_mapping_key(300, cln1);
+  {
+    auto vsnh = direct->mapper->get_snaps_check_consistency(head);
+    EXPECT_EQ(head_snaps, vsnh);
+    auto vsn1 = direct->mapper->get_snaps(cln1);
+    EXPECT_EQ(cln1_snaps, vsn1);
+    auto osn1 = direct->mapper->get_snaps_check_consistency(cln1);
+    EXPECT_NE(cln1_snaps, osn1);
+    auto vsn2 = direct->mapper->get_snaps_check_consistency(cln2);
+    EXPECT_EQ(cln2_snaps, vsn2);
+  }
+}
+
+///\todo test the case of a corrupted OBJ_ entry

--- a/src/tools/neorados.cc
+++ b/src/tools/neorados.cc
@@ -293,6 +293,10 @@ const std::array commands = {
 	  "remove OBJECT in POOL"sv }
 };
 
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<boost::program_options::options_description> : ostream_formatter {};
+#endif // FMT_VERSION
+
 int main(int argc, char* argv[])
 {
   const std::string_view prog(argv[0]);


### PR DESCRIPTION
Whenever the scrubber accesses the SnapMapper for the snaps of a specific
clone, the mapper will now verify that the snaps have the required
mapping DB entries (the 'SNA_' keys).

A backport of https://github.com/ceph/ceph/pull/47388
Backport tracker: https://tracker.ceph.com/issues/59537

Note: contains cherry-picked fixes to compilation issues
(from PRs by Adam Emerson & Kefu)

Signed-off-by: Ronen Friedman [rfriedma@redhat.com](mailto:rfriedma@redhat.com)
