### PR TITLE
qa/rgw: disable 'rgw lc debug interval' in most suites

### DIFF
--- a/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
+++ b/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
@@ -52,6 +52,7 @@ tasks:
       storage classes: LUKEWARM, FROZEN
       extra_attrs: ["cloud_transition"]
       lc_debug_interval: 10
+      lifecycle_tests: True
       cloudtier_tests: True
     #client.2:
       #force-branch: ceph-master

--- a/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
@@ -7,5 +7,5 @@ tasks:
     client.0:
       rgw_server: client.0
       storage classes: LUKEWARM, FROZEN
-      extra_attrs: ["lifecycle"]
       lc_debug_interval: 10
+      lifecycle_tests: True

--- a/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/lifecycle/tasks/rgw_s3tests.yaml
@@ -9,12 +9,3 @@ tasks:
       storage classes: LUKEWARM, FROZEN
       extra_attrs: ["lifecycle"]
       lc_debug_interval: 10
-overrides:
-  ceph:
-    conf:
-      client:
-        debug rgw: 20
-        rgw lc debug interval: 10
-        storage classes: LUKEWARM, FROZEN
-  rgw:
-    storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -10,3 +10,5 @@ overrides:
         rgw crypt require ssl: false
   rgw:
     storage classes: LUKEWARM, FROZEN
+  s3tests:
+    storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -13,8 +13,3 @@ tasks:
       default-branch: ceph-master
       rgw_server: client.0
       stages: check
-overrides:
-  ceph:
-    conf:
-      client:
-        rgw lc debug interval: 10

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -6,8 +6,3 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-overrides:
-  ceph:
-    conf:
-      client:
-        rgw lc debug interval: 10

--- a/qa/suites/rgw/notifications/overrides.yaml
+++ b/qa/suites/rgw/notifications/overrides.yaml
@@ -10,3 +10,5 @@ overrides:
         rgw crypt require ssl: false
   rgw:
     storage classes: LUKEWARM, FROZEN
+  s3tests:
+    storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/notifications/tasks/0-install.yaml
+++ b/qa/suites/rgw/notifications/tasks/0-install.yaml
@@ -11,5 +11,3 @@ overrides:
       global:
         osd_min_pg_log_entries: 10
         osd_max_pg_log_entries: 10
-      client:
-        rgw lc debug interval: 10

--- a/qa/suites/rgw/sts/overrides.yaml
+++ b/qa/suites/rgw/sts/overrides.yaml
@@ -16,3 +16,5 @@ overrides:
         rgw s3 auth use sts: true
   rgw:
     storage classes: LUKEWARM, FROZEN
+  s3tests:
+    storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -7,7 +7,6 @@ overrides:
   ceph:
     conf:
       client:
-        rgw lc debug interval: 10
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false

--- a/qa/suites/rgw/verify/0-install.yaml
+++ b/qa/suites/rgw/verify/0-install.yaml
@@ -16,5 +16,3 @@ overrides:
       global:
         osd_min_pg_log_entries: 10
         osd_max_pg_log_entries: 10
-      client:
-        rgw lc debug interval: 10

--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -12,3 +12,5 @@ overrides:
   rgw:
     compression type: random
     storage classes: LUKEWARM, FROZEN
+  s3tests:
+    storage classes: LUKEWARM, FROZEN

--- a/qa/suites/rgw/website/overrides.yaml
+++ b/qa/suites/rgw/website/overrides.yaml
@@ -13,8 +13,6 @@ overrides:
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
         rgw enable static website: True
-      client.0:
-        rgw lc debug interval: 10
       client.1:
         rgw enable apis: s3website
     rgw:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -377,7 +377,11 @@ def run_tests(ctx, config):
             args += ['REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt']
         else:
             args += ['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']
-        attrs = ["not fails_on_rgw", "not lifecycle_expiration"]
+        attrs = ["not fails_on_rgw"]
+        if not client_config.get('lifecycle_tests'):
+            attrs += ['not lifecycle_expiration', 'not lifecycle_transition']
+        if not client_config.get('cloudtier_tests'):
+            attrs += ['not cloud_transition']
         if not client_config.get('sts_tests', False):
             attrs += ["not test_of_sts"]
         if not client_config.get('webidentity_tests', False):


### PR DESCRIPTION
this has a performance cost, and the teuthology environment can already be sluggish. if lifecycle expiration/transition testing was limited to the rgw/lifecycle and rgw/cloud-transition suites, the others would probably run significantly faster

Fixes: https://tracker.ceph.com/issues/61859

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
