### PR TITLE
quincy: doc/radosgw: edit "Basic Workflow" in s3select.rst

### DIFF
--- a/doc/radosgw/s3select.rst
+++ b/doc/radosgw/s3select.rst
@@ -28,30 +28,29 @@ possible to save a lot of network and CPU(serialization / deserialization).
 Basic workflow
 --------------
     
-S3-select query is sent to RGW via `AWS-CLI
+S3 Select queries are sent to RGW via `AWS-CLI
 <https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html>`_
 
-It passes the authentication and permission process as an incoming message
-(POST). **RGWSelectObj_ObjStore_S3::send_response_data** is the “entry point”,
-it handles each fetched chunk according to input object-key.
-**send_response_data** is first handling the input query, it extracts the query
-and other CLI parameters.
+S3 Select passes the authentication and permission parameters as an incoming
+message (POST). ``RGWSelectObj_ObjStore_S3::send_response_data`` is the entry
+point and handles each fetched chunk according to the object key that was
+input.  ``send_response_data`` is the first to handle the input query: it
+extracts the query and other CLI parameters.
    
-Per each new fetched chunk (~4m), RGW executes an s3-select query on it. The
-current implementation supports CSV objects and since chunks are randomly
-“cutting” the CSV rows in the middle, those broken-lines (first or last per
-chunk) are skipped while processing the query.   Those “broken” lines are
-stored and later merged with the next broken-line (belong to the next chunk),
-and finally processed.
-   
-Per each processed chunk an output message is formatted according to `AWS
+RGW executes an S3 Select query on each new fetched chunk (up to 4 MB). The
+current implementation supports CSV objects. CSV rows are sometimes "cut" in
+the middle by the limits of the chunks, and those broken-lines (the first or
+last per chunk) are skipped while processing the query. Such broken lines are
+stored and later merged with the next broken line (which belongs to the next
+chunk), and only then processed.
+
+For each processed chunk, an output message is formatted according to `aws
 specification
-<https://docs.aws.amazon.com/AmazonS3/latest/API/archive-RESTObjectSELECTContent.html#archive-RESTObjectSELECTContent-responses>`_
-and sent back to the client.  RGW supports the following response:
+<https://docs.aws.amazon.com/amazons3/latest/api/archive-restobjectselectcontent.html#archive-restobjectselectcontent-responses>`_
+and sent back to the client. RGW supports the following response:
 ``{:event-type,records} {:content-type,application/octet-stream}
-{:message-type,event}``.  For aggregation queries the last chunk should be
-identified as the end of input, following that the s3-select-engine initiates
-end-of-process and produces an aggregated result.  
+{:message-type,event}``. For aggregation queries, the last chunk should be
+identified as the end of input. 
 
         
 Basic functionalities


### PR DESCRIPTION
Edit the "Basic Workflow" section in doc/radosgw/s3select.rst.

Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 4d2c09b683421552cfb4df7f467f2d9a6c9c7c26)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
