### PR TITLE
rgw: add special character support for IAM

### DIFF
--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -52,6 +52,15 @@ bool RGWHandler_REST_IAM::action_exists(const req_state* s)
 RGWOp *RGWHandler_REST_IAM::op_post()
 {
   if (s->info.args.exists("Action")) {
+    boost::char_separator<char> sep("&");
+    string post_body = bl_post_body.c_str();
+    boost::tokenizer<boost::char_separator<char>> tokens(post_body, sep);
+    for (const auto& t : tokens) {
+      auto pos = t.find("=");
+      if (pos != string::npos) {
+        s->info.args.append(t.substr(0,pos), url_decode(t.substr(pos+1, t.size() -1), true));
+      }
+    }
     const std::string action_name = s->info.args.get("Action");
     const auto action_it = op_generators.find(action_name);
     if (action_it != op_generators.end()) {

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -65,7 +65,7 @@ bool RGWRestUserPolicy::validate_input()
     return false;
   }
 
-  std::regex regex_policy_name("[A-Za-z0-9:=,.@-]+");
+  std::regex regex_policy_name("[A-Za-z0-9_+=,.@-]+");
   if (! std::regex_match(policy_name, regex_policy_name)) {
     ldpp_dout(this, 0) << "ERROR: Invalid chars in policy name " << dendl;
     return false;
@@ -91,9 +91,9 @@ uint64_t RGWPutUserPolicy::get_op()
 
 int RGWPutUserPolicy::get_params()
 {
-  policy_name = url_decode(s->info.args.get("PolicyName"), true);
-  user_name = url_decode(s->info.args.get("UserName"), true);
-  policy = url_decode(s->info.args.get("PolicyDocument"), true);
+  policy_name = s->info.args.get("PolicyName");
+  user_name = s->info.args.get("UserName");
+  policy = s->info.args.get("PolicyDocument");
 
   if (policy_name.empty() || user_name.empty() || policy.empty()) {
     ldpp_dout(this, 20) << "ERROR: one of policy name, user name or policy document is empty"

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -201,7 +201,7 @@ bool RGWRole::validate_input(const DoutPrefixProvider* dpp)
     return false;
   }
 
-  std::regex regex_name("[A-Za-z0-9:=,.@-]+");
+  std::regex regex_name("[A-Za-z0-9_+=,.@-]+");
   if (! std::regex_match(info.name, regex_name)) {
     ldpp_dout(dpp, 0) << "ERROR: Invalid chars in name " << dendl;
     return false;


### PR DESCRIPTION
1.In the role-related interface，when the PolicyDocument in json format requested by boto3 has the following spaces, it will be converted into +, and the policy verification will fail, it needs to be converted through url_decode.
`
s3policy = {
     "Version": "2012-10-17",
     "Statement": [{
         "Effect": "Allow",
         "Action": "s3:*",
         "Resource": "*"
     }]
}
client.put_role_policy(
    RoleName='role1',
    PolicyName='policy1',
    PolicyDocument=json.dumps(s3policy)
)
`

2.The support for special characters in the iam names is consistent with that in boto3.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
