### PR TITLE
qa/rgw: specify cluster name in 'radosgw-admin gc process'

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -239,7 +239,7 @@ def start_rgw(ctx, config, clients):
                     ],
                 )
             ctx.cluster.only(client).run(args=['sudo', 'rm', '-f', token_path])
-            ctx.cluster.only(client).run(args=['radosgw-admin', 'gc', 'process', '--include-all'])
+            rgwadmin(ctx, client, cmd=['gc', 'process', '--include-all'], check_status=True)
 
 def assign_endpoints(ctx, config, default_cert):
     role_endpoints = {}


### PR DESCRIPTION
we create multiple ceph clusters in the multisite tests, so this command needs to specify the target cluster name

Fixes: https://tracker.ceph.com/issues/61862

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
