### PR TITLE
quincy: test/cli-integration/rbd: iSCSI REST API responses aren't pretty-printed anymore

### DIFF
--- a/src/test/cli-integration/rbd/rest_api_create.t
+++ b/src/test/cli-integration/rbd/rest_api_create.t
@@ -1,25 +1,19 @@
 Create a datapool/block1 disk
 =============================
   $ sudo curl --user admin:admin -d mode=create -d size=300M -X PUT http://127.0.0.1:5000/api/disk/datapool/block1 -s
-  {
-    "message": "disk create/update successful"
-  }
+  {"message":"disk create/update successful"}
 
 Create the target IQN
 =====================
   $ sudo curl --user admin:admin -X PUT http://127.0.0.1:5000/api/target/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw -s
-  {
-    "message": "Target defined successfully"
-  }
+  {"message":"Target defined successfully"}
 
 Create the first gateway
 ========================
   $ HOST=`python3 -c "import socket; print(socket.getfqdn())"`
   > IP=`hostname -i | awk '{print $1}'`
   > sudo curl --user admin:admin -d ip_address=$IP -X PUT http://127.0.0.1:5000/api/gateway/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/$HOST -s
-  {
-    "message": "Gateway creation successful"
-  }
+  {"message":"Gateway creation successful"}
 
 Create the second gateway
 ========================
@@ -32,27 +26,19 @@ Create the second gateway
   >   HOST=`python3 -c "import socket; print(socket.getfqdn('$IP'))"`
   >   sudo curl --user admin:admin -d ip_address=$IP -X PUT http://127.0.0.1:5000/api/gateway/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/$HOST -s
   > fi
-  {
-    "message": "Gateway creation successful"
-  }
+  {"message":"Gateway creation successful"}
 
 Attach the disk
 ===============
   $ sudo curl --user admin:admin -d disk=datapool/block1 -X PUT http://127.0.0.1:5000/api/targetlun/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw -s
-  {
-    "message": "Target LUN mapping updated successfully"
-  }
+  {"message":"Target LUN mapping updated successfully"}
 
 Create a host
 =============
   $ sudo curl --user admin:admin -X PUT http://127.0.0.1:5000/api/client/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/iqn.1994-05.com.redhat:client -s
-  {
-    "message": "client create/update successful"
-  }
+  {"message":"client create/update successful"}
 
 Map the LUN
 ===========
   $ sudo curl --user admin:admin -d disk=datapool/block1 -X PUT http://127.0.0.1:5000/api/clientlun/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/iqn.1994-05.com.redhat:client -s
-  {
-    "message": "client masking update successful"
-  }
+  {"message":"client masking update successful"}

--- a/src/test/cli-integration/rbd/rest_api_delete.t
+++ b/src/test/cli-integration/rbd/rest_api_delete.t
@@ -1,27 +1,19 @@
 Delete the host
 ===============
   $ sudo curl --user admin:admin -X DELETE http://127.0.0.1:5000/api/client/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/iqn.1994-05.com.redhat:client -s
-  {
-    "message": "client delete successful"
-  }
+  {"message":"client delete successful"}
 
 Delete the iscsi-targets disk
 =============================
   $ sudo curl --user admin:admin -d disk=datapool/block1 -X DELETE http://127.0.0.1:5000/api/targetlun/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw -s
-  {
-    "message": "Target LUN mapping updated successfully"
-  }
+  {"message":"Target LUN mapping updated successfully"}
 
 Delete the target IQN
 =====================
   $ sudo curl --user admin:admin -X DELETE http://127.0.0.1:5000/api/target/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw -s
-  {
-    "message": "Target deleted."
-  }
+  {"message":"Target deleted."}
 
 Delete the disks
 ================
   $ sudo curl --user admin:admin -X DELETE http://127.0.0.1:5000/api/disk/datapool/block1 -s
-  {
-    "message": "disk map deletion successful"
-  }
+  {"message":"disk map deletion successful"}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57388

---

backport of https://github.com/ceph/ceph/pull/47881
parent tracker: https://tracker.ceph.com/issues/57343