### PR TITLE
quincy: librbd: avoid object map corruption in snapshots taken under I/O

### DIFF
--- a/qa/suites/krbd/thrash/workloads/krbd_diff_continuous.yaml
+++ b/qa/suites/krbd/thrash/workloads/krbd_diff_continuous.yaml
@@ -1,0 +1,12 @@
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+        - pv
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/diff_continuous.sh
+    env:
+      RBD_DEVICE_TYPE: "krbd"

--- a/qa/suites/rbd/nbd/workloads/rbd_nbd_diff_continuous.yaml
+++ b/qa/suites/rbd/nbd/workloads/rbd_nbd_diff_continuous.yaml
@@ -1,0 +1,14 @@
+overrides:
+  install:
+    ceph:
+      extra_packages:
+        - rbd-nbd
+      extra_system_packages:
+        - pv
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/diff_continuous.sh
+    env:
+      RBD_DEVICE_TYPE: "nbd"

--- a/qa/workunits/rbd/diff_continuous.sh
+++ b/qa/workunits/rbd/diff_continuous.sh
@@ -1,60 +1,106 @@
 #!/usr/bin/env bash
+
 set -ex
+set -o pipefail
 
-max=20
-size=1500
-
-iosize=16384
-iototal=16384000
-iothreads=16
-
-parent=`uuidgen`"-parent"
-src=`uuidgen`"-src";
-dst=`uuidgen`"-dst";
-
-function cleanup() {
-    rbd snap purge $src || :
-    rbd rm $src || :
-    rbd snap purge $dst || :
-    rbd rm $dst || :
-    rbd snap unprotect $parent --snap parent || :
-    rbd snap purge $parent || :
-    rbd rm $parent || :
+function untar_workload() {
+    local i
+    for ((i = 0; i < 10; i++)); do
+        pv -L 10M linux-5.4.tar.gz > "${MOUNT}/linux-5.4.tar.gz"
+        tar -C "${MOUNT}" -xzf "${MOUNT}/linux-5.4.tar.gz"
+        sync "${MOUNT}"
+        rm -rf "${MOUNT}"/linux-5.4*
+    done
 }
-trap cleanup EXIT
 
-# start from a clone
-rbd create $parent --size $size --image-format 2 --stripe-count 8 --stripe-unit 65536
-rbd bench --io-type write $parent --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand
-rbd snap create $parent --snap parent
-rbd snap protect $parent --snap parent
-rbd clone $parent@parent $src --stripe-count 4 --stripe-unit 262144
-rbd create $dst --size $size --image-format 2 --order 19
+function check_object_map() {
+    local spec="$1"
 
-# mirror for a while
-for s in `seq 1 $max`; do
-    rbd snap create $src --snap=snap$s
-    rbd export-diff $src@snap$s - $lastsnap | rbd import-diff - $dst  &
-    rbd bench --io-type write $src --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand  &
-    wait
-    lastsnap="--from-snap snap$s"
+    rbd object-map check "${spec}"
+
+    local flags
+    flags="$(rbd info "${spec}" | grep 'flags: ')"
+    if [[ "${flags}" =~ object\ map\ invalid ]]; then
+        echo "Object map invalid at ${spec}"
+        exit 1
+    fi
+    if [[ "${flags}" =~ fast\ diff\ invalid ]]; then
+        echo "Fast diff invalid at ${spec}"
+        exit 1
+    fi
+}
+
+# RBD_DEVICE_TYPE is intended to be set from yaml, default to krbd
+readonly DEVICE_TYPE="${RBD_DEVICE_TYPE:-krbd}"
+
+BASE_UUID="$(uuidgen)"
+readonly BASE_UUID
+
+readonly SIZE="2G"
+readonly SRC="${BASE_UUID}-src"
+readonly DST="${BASE_UUID}-dst"
+readonly MOUNT="${BASE_UUID}-mnt"
+
+rbd create -s "${SIZE}" --stripe-unit 64K --stripe-count 8 \
+    --image-feature exclusive-lock,object-map,fast-diff "${SRC}"
+rbd create -s "${SIZE}" --object-size 512K "${DST}"
+
+dev="$(sudo rbd device map -t "${DEVICE_TYPE}" "${SRC}")"
+sudo mkfs.ext4 "${dev}"
+mkdir "${MOUNT}"
+sudo mount "${dev}" "${MOUNT}"
+sudo chown "$(whoami)" "${MOUNT}"
+
+# start untar in the background
+wget https://download.ceph.com/qa/linux-5.4.tar.gz
+untar_workload &
+untar_pid=$!
+
+# export initial incremental
+snap_num=1
+rbd snap create "${SRC}@snap${snap_num}"
+rbd export-diff "${SRC}@snap${snap_num}" "${BASE_UUID}@snap${snap_num}.diff"
+
+# keep exporting successive incrementals while untar is running
+while kill -0 "${untar_pid}"; do
+    snap_num=$((snap_num + 1))
+    rbd snap create "${SRC}@snap${snap_num}"
+    sleep $((RANDOM % 4 + 1))
+    rbd export-diff --whole-object --from-snap "snap$((snap_num - 1))" \
+        "${SRC}@snap${snap_num}" "${BASE_UUID}@snap${snap_num}.diff"
 done
 
-#trap "" EXIT
-#exit 0
+sudo umount "${MOUNT}"
+sudo rbd device unmap -t "${DEVICE_TYPE}" "${dev}"
+
+if ! wait "${untar_pid}"; then
+    echo "untar_workload failed"
+    exit 1
+fi
+
+echo "Exported ${snap_num} incrementals"
+if ((snap_num < 30)); then
+    echo "Too few incrementals"
+    exit 1
+fi
 
 # validate
-for s in `seq 1 $max`; do
-    ssum=`rbd export $src@snap$s - | md5sum`
-    dsum=`rbd export $dst@snap$s - | md5sum`
-    if [ "$ssum" != "$dsum" ]; then
-	echo different sum at snap$s
-	exit 1
+for ((i = 1; i <= snap_num; i++)); do
+    rbd import-diff "${BASE_UUID}@snap${i}.diff" "${DST}"
+    src_sum="$(rbd export "${SRC}@snap${i}" - | md5sum | awk '{print $1}')"
+    dst_sum="$(rbd export "${DST}@snap${i}" - | md5sum | awk '{print $1}')"
+    if [[ "${src_sum}" != "${dst_sum}" ]]; then
+        echo "Mismatch at snap${i}: ${src_sum} != ${dst_sum}"
+        exit 1
     fi
+    check_object_map "${SRC}@snap${i}"
+    # FIXME: this reproduces http://tracker.ceph.com/issues/37876
+    # there is no fstrim involved but "rbd import-diff" can produce
+    # write-zeroes requests which turn into discards under the hood
+    # actual: EXISTS, expected: EXISTS_CLEAN inconsistency is harmless
+    # from a data integrity POV and data is validated above regardless,
+    # so just waive it for now
+    #check_object_map "${DST}@snap${i}"
 done
 
-cleanup
-trap "" EXIT
-
 echo OK
-

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -263,8 +263,8 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_write(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, std::move(bl), op_flags, trace);
   req->send();
 }
 
@@ -294,8 +294,8 @@ void Io<I>::aio_discard(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   }
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      off, len, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -326,8 +326,8 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
   }
 
   auto req = io::ImageDispatchSpec::create_write_same(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      off, len, std::move(bl), op_flags, trace);
   req->send();
 }
 
@@ -399,8 +399,8 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
 
       aio_comp->aio_type = io::AIO_TYPE_WRITE;
       auto req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+          {{off, len}}, std::move(bl), op_flags, trace);
       req->send();
       return;
     } else if (prepend_length == 0 && append_length == 0) {
@@ -409,8 +409,8 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       bl.append_zero(data_length);
 
       auto req = io::ImageDispatchSpec::create_write_same(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-        std::move(bl), image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+          off, len, std::move(bl), op_flags, trace);
       req->send();
       return;
     }
@@ -437,9 +437,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto prepend_aio_comp = io::AioCompletion::create_and_start(
         prepend_ctx, &image_ctx, io::AIO_TYPE_WRITE);
       auto prepend_req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
-        {{prepend_offset, prepend_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, prepend_aio_comp,
+          {{prepend_offset, prepend_length}},
+          std::move(bl), op_flags, trace);
       prepend_req->send();
     }
 
@@ -451,9 +451,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
       auto append_aio_comp = io::AioCompletion::create_and_start(
         append_ctx, &image_ctx, io::AIO_TYPE_WRITE);
       auto append_req = io::ImageDispatchSpec::create_write(
-        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
-        {{append_offset, append_length}}, std::move(bl),
-        image_ctx.get_data_io_context(), op_flags, trace);
+          image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, append_aio_comp,
+          {{append_offset, append_length}},
+          std::move(bl), op_flags, trace);
       append_req->send();
     }
 
@@ -464,9 +464,9 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
     auto write_same_aio_comp = io::AioCompletion::create_and_start(
       write_same_ctx, &image_ctx, io::AIO_TYPE_WRITESAME);
     auto req = io::ImageDispatchSpec::create_write_same(
-      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
-      write_same_offset, write_same_length, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+        image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, write_same_aio_comp,
+        write_same_offset, write_same_length,
+        std::move(bl), op_flags, trace);
     req->send();
     return;
   }
@@ -475,8 +475,8 @@ void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
   uint32_t discard_granularity_bytes = 0;
 
   auto req = io::ImageDispatchSpec::create_discard(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
-    discard_granularity_bytes, image_ctx.get_data_io_context(), trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      off, len, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -509,9 +509,9 @@ void Io<I>::aio_compare_and_write(I &image_ctx, io::AioCompletion *aio_comp,
   }
 
   auto req = io::ImageDispatchSpec::create_compare_and_write(
-    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, {{off, len}},
-    std::move(cmp_bl), std::move(bl), mismatch_off,
-    image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
+      {{off, len}}, std::move(cmp_bl), std::move(bl),
+      mismatch_off, op_flags, trace);
   req->send();
 }
 

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -57,7 +57,7 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
   auto req = io::ImageDispatchSpec::create_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
     std::move(image_extents), std::move(bl),
-    image_ctx->get_data_io_context(), fadvise_flags, trace);
+    fadvise_flags, trace);
   req->send();
 }
 
@@ -75,9 +75,8 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
       on_finish, image_ctx, io::AIO_TYPE_DISCARD);
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_discard(
-    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
-    length, discard_granularity_bytes,
-    image_ctx->get_data_io_context(), trace);
+    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
+    offset, length, discard_granularity_bytes, trace);
   req->send();
 }
 
@@ -113,8 +112,8 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
       on_finish, image_ctx, io::AIO_TYPE_WRITESAME);
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write_same(
-    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp, offset,
-    length, std::move(bl), image_ctx->get_data_io_context(),
+    *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
+    offset, length, std::move(bl),
     fadvise_flags, trace);
   req->send();
 }
@@ -136,9 +135,8 @@ void ImageWriteback<I>::aio_compare_and_write(Extents &&image_extents,
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_compare_and_write(
     *image_ctx, io::IMAGE_DISPATCH_LAYER_WRITEBACK_CACHE, aio_comp,
-    std::move(image_extents), std::move(cmp_bl), std::move(bl),
-    mismatch_offset, image_ctx->get_data_io_context(),
-    fadvise_flags, trace);
+    std::move(image_extents), std::move(cmp_bl),
+    std::move(bl), mismatch_offset, fadvise_flags, trace);
   req->send();
 }
 

--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -67,7 +67,7 @@ bool WriteLogImageDispatch<I>::read(
 template <typename I>
 bool WriteLogImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -89,8 +89,7 @@ bool WriteLogImageDispatch<I>::write(
 template <typename I>
 bool WriteLogImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -114,10 +113,9 @@ bool WriteLogImageDispatch<I>::discard(
 
 template <typename I>
 bool WriteLogImageDispatch<I>::write_same(
-    io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    bufferlist &&bl, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -140,10 +138,10 @@ bool WriteLogImageDispatch<I>::write_same(
 
 template <typename I>
 bool WriteLogImageDispatch<I>::compare_and_write(
-    io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    io::AioCompletion* aio_comp, io::Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/cache/WriteLogImageDispatch.h
+++ b/src/librbd/cache/WriteLogImageDispatch.h
@@ -48,30 +48,27 @@ public:
       Context* on_dispatched) override;
     bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -35,10 +35,9 @@ public:
   }
 
   bool write(
-      io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -46,19 +45,17 @@ public:
 
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
   }
 
   bool write_same(
-      io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -67,7 +64,7 @@ public:
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -146,8 +146,7 @@ void FormatRequest<I>::send() {
   ZTracer::Trace trace;
   auto req = io::ImageDispatchSpec::create_write(
           *m_image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
-          {{0, bl.length()}}, std::move(bl),
-          m_image_ctx->get_data_io_context(), 0, trace);
+          {{0, bl.length()}}, std::move(bl), 0, trace);
   req->send();
 }
 

--- a/src/librbd/exclusive_lock/ImageDispatch.cc
+++ b/src/librbd/exclusive_lock/ImageDispatch.cc
@@ -125,7 +125,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -143,9 +143,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -162,7 +161,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -181,7 +180,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/exclusive_lock/ImageDispatch.h
+++ b/src/librbd/exclusive_lock/ImageDispatch.h
@@ -58,27 +58,26 @@ public:
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -55,7 +55,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -73,9 +73,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -92,7 +91,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -110,10 +109,10 @@ bool ImageDispatch<I>::write_same(
 
 template <typename I>
 bool ImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -65,9 +65,8 @@ bool ImageDispatch<I>::write(
   start_in_flight_io(aio_comp);
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  ImageRequest<I>::aio_write(
-    m_image_ctx, aio_comp, std::move(image_extents), std::move(bl),
-    io_context, op_flags, parent_trace);
+  ImageRequest<I>::aio_write(m_image_ctx, aio_comp, std::move(image_extents),
+                             std::move(bl), op_flags, parent_trace);
   return true;
 }
 
@@ -85,9 +84,8 @@ bool ImageDispatch<I>::discard(
   start_in_flight_io(aio_comp);
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  ImageRequest<I>::aio_discard(
-    m_image_ctx, aio_comp, std::move(image_extents), discard_granularity_bytes,
-    io_context, parent_trace);
+  ImageRequest<I>::aio_discard(m_image_ctx, aio_comp, std::move(image_extents),
+                               discard_granularity_bytes, parent_trace);
   return true;
 }
 
@@ -104,9 +102,9 @@ bool ImageDispatch<I>::write_same(
   start_in_flight_io(aio_comp);
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  ImageRequest<I>::aio_writesame(
-    m_image_ctx, aio_comp, std::move(image_extents), std::move(bl),
-    io_context, op_flags, parent_trace);
+  ImageRequest<I>::aio_writesame(m_image_ctx, aio_comp,
+                                 std::move(image_extents), std::move(bl),
+                                 op_flags, parent_trace);
   return true;
 }
 
@@ -124,9 +122,11 @@ bool ImageDispatch<I>::compare_and_write(
   start_in_flight_io(aio_comp);
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  ImageRequest<I>::aio_compare_and_write(
-    m_image_ctx, aio_comp, std::move(image_extents), std::move(cmp_bl),
-    std::move(bl), mismatch_offset, io_context, op_flags, parent_trace);
+  ImageRequest<I>::aio_compare_and_write(m_image_ctx, aio_comp,
+                                         std::move(image_extents),
+                                         std::move(cmp_bl), std::move(bl),
+                                         mismatch_offset, op_flags,
+                                         parent_trace);
   return true;
 }
 

--- a/src/librbd/io/ImageDispatch.h
+++ b/src/librbd/io/ImageDispatch.h
@@ -42,28 +42,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -40,28 +40,27 @@ struct ImageDispatchInterface {
       Context* on_dispatched) = 0;
   virtual bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
   virtual bool flush(

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -139,36 +139,35 @@ public:
   static ImageDispatchSpec* create_discard(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, uint64_t off, uint64_t len,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace) {
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp, {{off, len}},
                                  Discard{discard_granularity_bytes},
-                                 io_context, 0, parent_trace);
+                                 {}, 0, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_write(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace) {
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
-                                 std::move(image_extents), Write{std::move(bl)},
-                                 io_context, op_flags, parent_trace);
+                                 std::move(image_extents),
+                                 Write{std::move(bl)},
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
   static ImageDispatchSpec* create_write_same(
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, uint64_t off, uint64_t len,
-      bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace) {
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
-                                 {{off, len}}, WriteSame{std::move(bl)},
-                                 io_context, op_flags, parent_trace);
+                                 {{off, len}},
+                                 WriteSame{std::move(bl)},
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>
@@ -176,14 +175,14 @@ public:
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace) {
+      int op_flags, const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents),
                                  CompareAndWrite{std::move(cmp_bl),
                                                  std::move(bl),
                                                  mismatch_offset},
-                                 io_context, op_flags, parent_trace);
+                                 {}, op_flags, parent_trace);
   }
 
   template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -52,9 +52,8 @@ struct ImageDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
     return image_dispatch->discard(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents),
-      discard.discard_granularity_bytes, image_dispatch_spec->io_context,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      discard.discard_granularity_bytes, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
@@ -64,33 +63,31 @@ struct ImageDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
     return image_dispatch->write(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents), std::move(write.bl),
-      image_dispatch_spec->io_context, image_dispatch_spec->op_flags,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
   }
 
-  bool  operator()(ImageDispatchSpec::WriteSame& write_same) const {
+  bool operator()(ImageDispatchSpec::WriteSame& write_same) const {
     return image_dispatch->write_same(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents), std::move(write_same.bl),
-      image_dispatch_spec->io_context, image_dispatch_spec->op_flags,
-      image_dispatch_spec->parent_trace, image_dispatch_spec->tid,
-      &image_dispatch_spec->image_dispatch_flags,
+      image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
+      image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,
       &image_dispatch_spec->aio_comp->image_dispatcher_ctx,
       &image_dispatch_spec->dispatcher_ctx);
   }
 
-  bool  operator()(
+  bool operator()(
       ImageDispatchSpec::CompareAndWrite& compare_and_write) const {
     return image_dispatch->compare_and_write(
       image_dispatch_spec->aio_comp,
       std::move(image_dispatch_spec->image_extents),
       std::move(compare_and_write.cmp_bl), std::move(compare_and_write.bl),
-      compare_and_write.mismatch_offset, image_dispatch_spec->io_context,
+      compare_and_write.mismatch_offset,
       image_dispatch_spec->op_flags, image_dispatch_spec->parent_trace,
       image_dispatch_spec->tid, &image_dispatch_spec->image_dispatch_flags,
       &image_dispatch_spec->dispatch_result,

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -239,11 +239,11 @@ void ImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
 
 template <typename I>
 void ImageRequest<I>::aio_write(I *ictx, AioCompletion *c,
-                                Extents &&image_extents, bufferlist &&bl,
-                                IOContext io_context, int op_flags,
+                                Extents &&image_extents,
+                                bufferlist &&bl, int op_flags,
 				const ZTracer::Trace &parent_trace) {
-  ImageWriteRequest<I> req(*ictx, c, std::move(image_extents), std::move(bl),
-                           io_context, op_flags, parent_trace);
+  ImageWriteRequest<I> req(*ictx, c, std::move(image_extents),
+                           std::move(bl), op_flags, parent_trace);
   req.send();
 }
 
@@ -251,11 +251,9 @@ template <typename I>
 void ImageRequest<I>::aio_discard(I *ictx, AioCompletion *c,
                                   Extents &&image_extents,
                                   uint32_t discard_granularity_bytes,
-				  IOContext io_context,
                                   const ZTracer::Trace &parent_trace) {
   ImageDiscardRequest<I> req(*ictx, c, std::move(image_extents),
-                             discard_granularity_bytes, io_context,
-                             parent_trace);
+                             discard_granularity_bytes, parent_trace);
   req.send();
 }
 
@@ -270,12 +268,10 @@ void ImageRequest<I>::aio_flush(I *ictx, AioCompletion *c,
 template <typename I>
 void ImageRequest<I>::aio_writesame(I *ictx, AioCompletion *c,
                                     Extents &&image_extents,
-                                    bufferlist &&bl, IOContext io_context,
-                                    int op_flags,
+                                    bufferlist &&bl, int op_flags,
 				    const ZTracer::Trace &parent_trace) {
   ImageWriteSameRequest<I> req(*ictx, c, std::move(image_extents),
-                               std::move(bl), io_context, op_flags,
-                               parent_trace);
+                               std::move(bl), op_flags, parent_trace);
   req.send();
 }
 
@@ -285,12 +281,11 @@ void ImageRequest<I>::aio_compare_and_write(I *ictx, AioCompletion *c,
                                             bufferlist &&cmp_bl,
                                             bufferlist &&bl,
                                             uint64_t *mismatch_offset,
-                                            IOContext io_context, int op_flags,
+                                            int op_flags,
                                             const ZTracer::Trace &parent_trace) {
   ImageCompareAndWriteRequest<I> req(*ictx, c, std::move(image_extents),
                                      std::move(cmp_bl), std::move(bl),
-                                     mismatch_offset, io_context, op_flags,
-                                     parent_trace);
+                                     mismatch_offset, op_flags, parent_trace);
   req.send();
 }
 
@@ -369,8 +364,8 @@ ImageReadRequest<I>::ImageReadRequest(I &image_ctx, AioCompletion *aio_comp,
 				      int read_flags,
                                       const ZTracer::Trace &parent_trace)
   : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents),
-                    io_context, "read", parent_trace),
-    m_op_flags(op_flags), m_read_flags(read_flags) {
+                    "read", parent_trace),
+    m_io_context(io_context), m_op_flags(op_flags), m_read_flags(read_flags) {
   aio_comp->read_result = std::move(read_result);
 }
 
@@ -382,7 +377,7 @@ void ImageReadRequest<I>::send_request() {
   auto &image_extents = this->m_image_extents;
   if (image_ctx.cache && image_ctx.readahead_max_bytes > 0 &&
       !(m_op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
-    readahead(get_image_ctx(&image_ctx), image_extents, this->m_io_context);
+    readahead(get_image_ctx(&image_ctx), image_extents, m_io_context);
   }
 
   // map image extents to object extents
@@ -412,7 +407,7 @@ void ImageReadRequest<I>::send_request() {
       aio_comp, {{oe.offset, oe.length, std::move(oe.buffer_extents)}});
     auto req = ObjectDispatchSpec::create_read(
       &image_ctx, OBJECT_DISPATCH_LAYER_NONE, oe.object_no,
-      &req_comp->extents, this->m_io_context, m_op_flags, m_read_flags,
+      &req_comp->extents, m_io_context, m_op_flags, m_read_flags,
       this->m_trace, nullptr, req_comp);
     req->send();
   }
@@ -477,7 +472,11 @@ void AbstractImageWriteRequest<I>::send_request() {
       journal_tid = append_journal_event(m_synchronous);
     }
 
-    send_object_requests(object_extents, this->m_io_context, journal_tid);
+    // it's very important that IOContext is captured here instead of
+    // e.g. at the API layer so that an up-to-date snap context is used
+    // when owning the exclusive lock
+    send_object_requests(object_extents, image_ctx.get_data_io_context(),
+                         journal_tid);
   }
 
   update_stats(clip_len);
@@ -841,8 +840,7 @@ ImageListSnapsRequest<I>::ImageListSnapsRequest(
     SnapIds&& snap_ids, int list_snaps_flags, SnapshotDelta* snapshot_delta,
     const ZTracer::Trace& parent_trace)
   : ImageRequest<I>(image_ctx, aio_comp, std::move(image_extents),
-                    image_ctx.get_data_io_context(), "list-snaps",
-                    parent_trace),
+                    "list-snaps", parent_trace),
     m_snap_ids(std::move(snap_ids)), m_list_snaps_flags(list_snaps_flags),
     m_snapshot_delta(snapshot_delta) {
 }

--- a/src/librbd/io/QosImageDispatch.cc
+++ b/src/librbd/io/QosImageDispatch.cc
@@ -144,7 +144,7 @@ bool QosImageDispatch<I>::read(
 template <typename I>
 bool QosImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -167,9 +167,8 @@ bool QosImageDispatch<I>::write(
 template <typename I>
 bool QosImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -191,7 +190,7 @@ bool QosImageDispatch<I>::discard(
 template <typename I>
 bool QosImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -213,10 +212,10 @@ bool QosImageDispatch<I>::write_same(
 
 template <typename I>
 bool QosImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -62,28 +62,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -54,7 +54,7 @@ bool QueueImageDispatch<I>::read(
 template <typename I>
 bool QueueImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -67,8 +67,7 @@ bool QueueImageDispatch<I>::write(
 template <typename I>
 bool QueueImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -81,7 +80,7 @@ bool QueueImageDispatch<I>::discard(
 template <typename I>
 bool QueueImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -93,10 +92,10 @@ bool QueueImageDispatch<I>::write_same(
 
 template <typename I>
 bool QueueImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/QueueImageDispatch.h
+++ b/src/librbd/io/QueueImageDispatch.h
@@ -46,28 +46,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/RefreshImageDispatch.cc
+++ b/src/librbd/io/RefreshImageDispatch.cc
@@ -49,7 +49,7 @@ bool RefreshImageDispatch<I>::read(
 template <typename I>
 bool RefreshImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -67,9 +67,8 @@ bool RefreshImageDispatch<I>::write(
 template <typename I>
 bool RefreshImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -86,7 +85,7 @@ bool RefreshImageDispatch<I>::discard(
 template <typename I>
 bool RefreshImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -103,10 +102,10 @@ bool RefreshImageDispatch<I>::write_same(
 
 template <typename I>
 bool RefreshImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/RefreshImageDispatch.h
+++ b/src/librbd/io/RefreshImageDispatch.h
@@ -42,28 +42,27 @@ public:
       Context* on_dispatched) override;
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/io/WriteBlockImageDispatch.cc
+++ b/src/librbd/io/WriteBlockImageDispatch.cc
@@ -127,7 +127,7 @@ void WriteBlockImageDispatch<I>::wait_on_writes_unblocked(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -140,9 +140,8 @@ bool WriteBlockImageDispatch<I>::write(
 template <typename I>
 bool WriteBlockImageDispatch<I>::discard(
     AioCompletion* aio_comp, Extents &&image_extents,
-    uint32_t discard_granularity_bytes, IOContext io_context,
-    const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -154,7 +153,7 @@ bool WriteBlockImageDispatch<I>::discard(
 template <typename I>
 bool WriteBlockImageDispatch<I>::write_same(
     AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -166,10 +165,10 @@ bool WriteBlockImageDispatch<I>::write_same(
 
 template <typename I>
 bool WriteBlockImageDispatch<I>::compare_and_write(
-    AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-    bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-    int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    AioCompletion* aio_comp, Extents &&image_extents,
+    bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/WriteBlockImageDispatch.h
+++ b/src/librbd/io/WriteBlockImageDispatch.h
@@ -57,28 +57,27 @@ public:
   }
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool flush(

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -356,8 +356,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
   if (!clipped_io(event.offset, aio_comp)) {
     io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp,
                                      {{event.offset, event.length}},
-                                     event.discard_granularity_bytes,
-                                     m_image_ctx.get_data_io_context(), {});
+                                     event.discard_granularity_bytes, {});
   }
 
   if (flush_required) {
@@ -392,7 +391,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
     io::ImageRequest<I>::aio_write(&m_image_ctx, aio_comp,
                                    {{event.offset, event.length}},
                                    std::move(data),
-                                   m_image_ctx.get_data_io_context(), 0, {});
+                                   0, {});
   }
 
   if (flush_required) {
@@ -446,8 +445,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp,
                                        {{event.offset, event.length}},
                                        std::move(data),
-                                       m_image_ctx.get_data_io_context(), 0,
-                                       {});
+                                       0, {});
   }
 
   if (flush_required) {
@@ -481,9 +479,7 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
                                                {{event.offset, event.length}},
                                                std::move(cmp_data),
                                                std::move(write_data),
-                                               nullptr,
-                                               m_image_ctx.get_data_io_context(),
-                                               0, {});
+                                               nullptr, 0, {});
   }
 
   if (flush_required) {

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -52,7 +52,7 @@ bool ImageDispatch<I>::read(
 template <typename I>
 bool ImageDispatch<I>::write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -66,9 +66,8 @@ bool ImageDispatch<I>::write(
 template <typename I>
 bool ImageDispatch<I>::discard(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
-    uint32_t discard_granularity_bytes,
-    IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-    std::atomic<uint32_t>* image_dispatch_flags,
+    uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+    uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
@@ -81,7 +80,7 @@ bool ImageDispatch<I>::discard(
 template <typename I>
 bool ImageDispatch<I>::write_same(
     io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
@@ -96,7 +95,7 @@ template <typename I>
 bool ImageDispatch<I>::compare_and_write(
     io::AioCompletion* aio_comp, io::Extents &&image_extents,
     bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-    IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+    int op_flags, const ZTracer::Trace &parent_trace,
     uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -42,27 +42,26 @@ public:
       Context* on_dispatched) override;
   bool write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool discard(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
-      uint32_t discard_granularity_bytes,
-      IOContext io_context, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool write_same(
       io::AioCompletion* aio_comp, io::Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
   bool compare_and_write(
       io::AioCompletion* aio_comp, io::Extents &&image_extents,
       bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -207,7 +207,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_1(
     mock_image_ctx, aio_comp_1, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_1.send();
@@ -220,7 +220,7 @@ TEST_F(TestMockIoImageRequest, AioWriteModifyTimestamp) {
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write_2(
     mock_image_ctx, aio_comp_2, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write_2.send();
@@ -302,7 +302,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscard) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{16, 63}, {84, 100}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -330,7 +330,7 @@ TEST_F(TestMockIoImageRequest, TailDiscard) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{ictx->layout.object_size - 1024, 1024}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -360,7 +360,7 @@ TEST_F(TestMockIoImageRequest, DiscardGranularity) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -392,7 +392,7 @@ TEST_F(TestMockIoImageRequest, PartialDiscardJournalAppendEnabled) {
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp, {{16, 63}, {84, 100}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -424,8 +424,9 @@ TEST_F(TestMockIoImageRequest, TailDiscardJournalAppendEnabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{ictx->layout.object_size - 1024, 1024}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp,
+    {{ictx->layout.object_size - 1024, 1024}},
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -454,8 +455,8 @@ TEST_F(TestMockIoImageRequest, PruneRequiredDiscardJournalAppendEnabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{96, 31}}, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{96, 31}},
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -484,8 +485,8 @@ TEST_F(TestMockIoImageRequest, LengthModifiedDiscardJournalAppendEnabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{16, 63}}, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{16, 63}},
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -523,7 +524,7 @@ TEST_F(TestMockIoImageRequest, DiscardGranularityJournalAppendEnabled) {
   MockImageDiscardRequest mock_aio_image_discard(
     mock_image_ctx, aio_comp,
     {{16, 63}, {96, 31}, {84, 100}, {ictx->layout.object_size - 33, 33}},
-    ictx->discard_granularity_bytes, mock_image_ctx.get_data_io_context(), {});
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -553,8 +554,7 @@ TEST_F(TestMockIoImageRequest, AioWriteJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteRequest mock_aio_image_write(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();
@@ -582,8 +582,8 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(
-    mock_image_ctx, aio_comp, {{0, 1}}, ictx->discard_granularity_bytes,
-    mock_image_ctx.get_data_io_context(), {});
+    mock_image_ctx, aio_comp, {{0, 1}},
+    ictx->discard_granularity_bytes, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_discard.send();
@@ -641,8 +641,7 @@ TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteSameRequest mock_aio_image_writesame(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl),
-    mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}}, std::move(bl), 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_writesame.send();
@@ -675,8 +674,8 @@ TEST_F(TestMockIoImageRequest, AioCompareAndWriteJournalAppendDisabled) {
   write_bl.append("1");
   uint64_t mismatch_offset;
   MockImageCompareAndWriteRequest mock_aio_image_write(
-    mock_image_ctx, aio_comp, {{0, 1}}, std::move(cmp_bl), std::move(write_bl),
-    &mismatch_offset, mock_image_ctx.get_data_io_context(), 0, {});
+    mock_image_ctx, aio_comp, {{0, 1}},
+    std::move(cmp_bl), std::move(write_bl), &mismatch_offset, 0, {});
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     mock_aio_image_write.send();

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -31,8 +31,8 @@ struct ImageRequest<MockReplayImageCtx> {
   MOCK_METHOD4(aio_write, void(AioCompletion *c, const Extents &image_extents,
                                const bufferlist &bl, int op_flags));
   static void aio_write(MockReplayImageCtx *ictx, AioCompletion *c,
-                        Extents &&image_extents, bufferlist &&bl,
-                        IOContext io_context, int op_flags,
+                        Extents&& image_extents,
+                        bufferlist&& bl, int op_flags,
                         const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_write(c, image_extents, bl, op_flags);
@@ -43,7 +43,6 @@ struct ImageRequest<MockReplayImageCtx> {
   static void aio_discard(MockReplayImageCtx *ictx, AioCompletion *c,
                           Extents&& image_extents,
                           uint32_t discard_granularity_bytes,
-                          IOContext io_context,
                           const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_discard(c, image_extents, discard_granularity_bytes);
@@ -61,8 +60,8 @@ struct ImageRequest<MockReplayImageCtx> {
                                    const bufferlist &bl,
                                    int op_flags));
   static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
-                            Extents&& image_extents, bufferlist &&bl,
-                            IOContext io_context, int op_flags,
+                            Extents&& image_extents,
+                            bufferlist&& bl, int op_flags,
                             const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_writesame(c, image_extents, bl, op_flags);
@@ -73,9 +72,9 @@ struct ImageRequest<MockReplayImageCtx> {
                                            uint64_t *mismatch_offset,
                                            int op_flags));
   static void aio_compare_and_write(MockReplayImageCtx *ictx, AioCompletion *c,
-                                    Extents &&image_extents, bufferlist &&cmp_bl,
-                                    bufferlist &&bl, uint64_t *mismatch_offset,
-                                    IOContext io_context, int op_flags,
+                                    Extents&& image_extents,
+                                    bufferlist&& cmp_bl, bufferlist&& bl,
+                                    uint64_t* mismatch_offset, int op_flags,
                                     const ZTracer::Trace &parent_trace) {
     ceph_assert(s_instance != nullptr);
     s_instance->aio_compare_and_write(c, image_extents, cmp_bl, bl,

--- a/src/test/librbd/mock/io/MockImageDispatch.h
+++ b/src/test/librbd/mock/io/MockImageDispatch.h
@@ -32,7 +32,7 @@ public:
 
   bool write(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -41,9 +41,8 @@ public:
 
   bool discard(
       AioCompletion* aio_comp, Extents &&image_extents,
-      uint32_t discard_granularity_bytes, IOContext io_context,
-      const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      uint32_t discard_granularity_bytes, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;
@@ -51,7 +50,7 @@ public:
 
   bool write_same(
       AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&bl,
-      IOContext io_context, int op_flags, const ZTracer::Trace &parent_trace,
+      int op_flags, const ZTracer::Trace &parent_trace,
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
@@ -59,10 +58,10 @@ public:
   }
 
   bool compare_and_write(
-      AioCompletion* aio_comp, Extents &&image_extents, bufferlist &&cmp_bl,
-      bufferlist &&bl, uint64_t *mismatch_offset, IOContext io_context,
-      int op_flags, const ZTracer::Trace &parent_trace, uint64_t tid,
-      std::atomic<uint32_t>* image_dispatch_flags,
+      AioCompletion* aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
     return false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61752

---

backport of https://github.com/ceph/ceph/pull/52109
parent tracker: https://tracker.ceph.com/issues/61616