### PR TITLE
pybind: drop GIL during library callouts

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1169,7 +1169,8 @@ cdef class LibCephFS(object):
         cdef:
             char* _path = path
             char* _name = name
-        ret = ceph_rmsnap(self.cluster, _path, _name)
+        with nogil:
+            ret = ceph_rmsnap(self.cluster, _path, _name)
         if ret < 0:
             raise make_ex(ret, "rmsnap error")
         return 0
@@ -1188,7 +1189,8 @@ cdef class LibCephFS(object):
         cdef:
             char* _path = path
             snap_info info
-        ret = ceph_get_snap_info(self.cluster, _path, &info)
+        with nogil:
+            ret = ceph_get_snap_info(self.cluster, _path, &info)
         if ret < 0:
             raise make_ex(ret, "snap_info error")
         md = {}
@@ -1353,7 +1355,8 @@ cdef class LibCephFS(object):
         self.require_state("mounted")
         path = cstr(path, 'path')
         cdef char* _path = path
-        ret = ceph_rmdir(self.cluster, _path)
+        with nogil:
+            ret = ceph_rmdir(self.cluster, _path)
         if ret < 0:
             raise make_ex(ret, "error in rmdir {}".format(path.decode('utf-8')))
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -1397,8 +1397,10 @@ class RBD(object):
             char *_client_name = client_name
         try:
             _uuid = <char *>realloc_chk(_uuid, _uuid_max_length)
-            ret = rbd_mirror_peer_site_add(_ioctx, _uuid, _uuid_max_length,
-                                           _direction, _site_name, _client_name)
+            with nogil:
+                ret = rbd_mirror_peer_site_add(_ioctx, _uuid, _uuid_max_length,
+                                               _direction, _site_name,
+                                               _client_name)
             if ret != 0:
                 raise make_ex(ret, 'error adding mirror peer')
             return decode_cstr(_uuid)
@@ -3132,7 +3134,11 @@ cdef class Image(object):
 
         :returns: int - the pool id
         """
-        return rbd_get_data_pool_id(self.image)
+        with nogil:
+            ret = rbd_get_data_pool_id(self.image)
+        if ret < 0:
+            raise make_ex(ret, 'error getting data pool id for image %s' % self.name)
+        return ret
 
     @requires_not_closed
     def get_parent_image_spec(self):

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -13,7 +13,8 @@ import sys
 from datetime import datetime, timedelta
 from nose import with_setup, SkipTest
 from nose.plugins.attrib import attr
-from nose.tools import eq_ as eq, assert_raises, assert_not_equal
+from nose.tools import (eq_ as eq, assert_raises, assert_not_equal,
+                        assert_greater_equal)
 from rados import (Rados,
                    LIBRADOS_OP_FLAG_FADVISE_DONTNEED,
                    LIBRADOS_OP_FLAG_FADVISE_NOCACHE,
@@ -606,6 +607,9 @@ class TestImage(object):
 
     def test_block_name_prefix(self):
         assert_not_equal(b'', self.image.block_name_prefix())
+
+    def test_data_pool_id(self):
+        assert_greater_equal(self.image.data_pool_id(), 0)
 
     def test_create_timestamp(self):
         timestamp = self.image.create_timestamp()


### PR DESCRIPTION
This has disastorous consequences including the possibility of deadlock. In the best case, you have the rmdir holding the GIL until the MDS responds!

Fixes: https://tracker.ceph.com/issues/61869





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
