### PR TITLE
mgr/cephadm: ceph orch add fails when ipv6 address is surrounded by square brackets.

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -19,6 +19,7 @@ from ceph.deployment.inventory import Device  # noqa: F401; pylint: disable=unus
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, OSDMethod
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, service_spec_allow_invalid_from_json, TracingSpec
 from ceph.deployment.hostspec import SpecValidationError
+from ceph.deployment.utils import unwrap_ipv6
 from ceph.utils import datetime_now
 
 from mgr_util import to_pretty_timedelta, format_bytes
@@ -465,6 +466,9 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         # split multiple labels passed in with --labels=label1,label2
         if labels and len(labels) == 1:
             labels = labels[0].split(',')
+
+        if addr is not None:
+            addr = unwrap_ipv6(addr)
 
         s = HostSpec(hostname=hostname, addr=addr, labels=labels, status=_status)
 


### PR DESCRIPTION
When calling "ceph orch add host1 [ipv6], it fails as the ipv6 address surrounded by [] is not recognized.

Fixes: https://tracker.ceph.com/issues/61885
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2153448

