### PR TITLE
reef: rgw: rgwx-skip-decrypt also skips decompression of encrypted objects

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -77,7 +77,11 @@
   map and unmap images in namespaces using the `image-spec` syntax since then
   but the corresponding option available in most other commands was missing.
 * RGW: Compression is now supported for objects uploaded with Server-Side Encryption.
-  When both are enabled, compression is applied before encryption.
+  When both are enabled, compression is applied before encryption. Earlier releases
+  of multisite do not replicate such objects correctly, so all zones must upgrade to
+  Reef before enabling the `compress-encrypted` zonegroup feature: see
+  https://docs.ceph.com/en/reef/radosgw/multisite/#zone-features and note the
+  security considerations.
 * RGW: the "pubsub" functionality for storing bucket notifications inside Ceph
   is removed. Together with it, the "pubsub" zone should not be used anymore.
   The REST operations, as well as radosgw-admin commands for manipulating

--- a/doc/radosgw/compression.rst
+++ b/doc/radosgw/compression.rst
@@ -7,6 +7,9 @@ Compression
 The Ceph Object Gateway supports server-side compression of uploaded objects,
 using any of Ceph's existing compression plugins.
 
+.. note:: The Reef release added a :ref:`feature_compress_encrypted` zonegroup
+   feature to enable compression with `Server-Side Encryption`_.
+
 
 Configuration
 =============
@@ -84,4 +87,5 @@ The ``size_utilized`` and ``size_kb_utilized`` fields represent the total
 size of compressed data, in bytes and kilobytes respectively.
 
 
+.. _`Server-Side Encryption`: ../encryption
 .. _`Multisite Configuration`: ../multisite

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1574,11 +1574,13 @@ On creation of new zones and zonegroups, all known features are supported/enable
 Supported Features
 ------------------
 
-+---------------------------+---------+----------+
-| Feature                   | Release | Default  |
-+===========================+=========+==========+
-| :ref:`feature_resharding` | Reef    | Enabled  |
-+---------------------------+---------+----------+
++-----------------------------------+---------+----------+
+| Feature                           | Release | Default  |
++===================================+=========+==========+
+| :ref:`feature_resharding`         | Reef    | Enabled  |
++-----------------------------------+---------+----------+
+| :ref:`feature_compress_encrypted` | Reef    | Disabled |
++-----------------------------------+---------+----------+
 
 .. _feature_resharding:
 
@@ -1596,6 +1598,21 @@ of its RGWs and OSDs have upgraded.
 .. note:: Dynamic resharding is not supported in multisite deployments prior to
    the Reef release.
 
+
+.. _feature_compress_encrypted:
+
+compress-encrypted
+~~~~~~~~~~~~~~~~~~
+
+This feature enables support for combining `Server-Side Encryption`_ and
+`Compression`_ on the same object. Object data gets compressed before encryption.
+Prior to Reef, multisite would not replicate such objects correctly, so all zones
+must upgrade to Reef or later before enabling.
+
+.. warning:: The compression ratio may leak information about the encrypted data,
+   and allow attackers to distinguish whether two same-sized objects might contain
+   the same data. Due to these security considerations, this feature is disabled
+   by default.
 
 Commands
 --------
@@ -1644,3 +1661,5 @@ On any cluster in the realm:
 
 .. _`Pools`: ../pools
 .. _`Sync Policy Config`: ../multisite-sync-policy
+.. _`Server-Side Encryption`: ../encryption
+.. _`Compression`: ../compression

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1582,7 +1582,7 @@ Supported Features
 
 .. _feature_resharding:
 
-Resharding
+resharding
 ~~~~~~~~~~
 
 This feature allows buckets to be resharded in a multisite configuration

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1574,11 +1574,11 @@ On creation of new zones and zonegroups, all known features are supported/enable
 Supported Features
 ------------------
 
-+---------------------------+---------+
-| Feature                   | Release |
-+===========================+=========+
-| :ref:`feature_resharding` | Reef    |
-+---------------------------+---------+
++---------------------------+---------+----------+
+| Feature                   | Release | Default  |
++===========================+=========+==========+
+| :ref:`feature_resharding` | Reef    | Enabled  |
++---------------------------+---------+----------+
 
 .. _feature_resharding:
 

--- a/src/rgw/driver/json_config/store.cc
+++ b/src/rgw/driver/json_config/store.cc
@@ -149,7 +149,8 @@ void sanity_check_config(const DoutPrefixProvider* dpp, DecodedConfig& config)
       throw std::system_error(-r, std::system_category());
     }
 
-    config.zonegroup.enabled_features = std::move(enable_features);
+    config.zonegroup.enabled_features.insert(rgw::zone_features::enabled.begin(),
+                                             rgw::zone_features::enabled.end());
   }
 
   // insert the default placement target if it doesn't exist

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3393,8 +3393,12 @@ public:
         try_etag_verify = false;
       }
 
+      // if the object is both compressed and encrypted, it was transferred
+      // in its encrypted+compressed form. we need to preserve the original
+      // RGW_ATTR_COMPRESSION instead of falling back to default compression
+      // settings
       auto iter = src_attrs.find(RGW_ATTR_COMPRESSION);
-      if (iter != src_attrs.end()) {
+      if (iter != src_attrs.end() && !encrypted) {
         const bufferlist bl = std::move(iter->second);
         src_attrs.erase(iter); // don't preserve source compression info
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3377,6 +3377,7 @@ public:
 
 
   int process_attrs(void) {
+    bool encrypted = false;
     if (extra_data_bl.length()) {
       JSONParser jp;
       if (!jp.parse(extra_data_bl.c_str(), extra_data_bl.length())) {
@@ -3385,6 +3386,12 @@ public:
       }
 
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
+
+      encrypted = src_attrs.count(RGW_ATTR_CRYPT_MODE);
+      if (encrypted) {
+        // we won't have access to the decrypted data for checksumming
+        try_etag_verify = false;
+      }
 
       auto iter = src_attrs.find(RGW_ATTR_COMPRESSION);
       if (iter != src_attrs.end()) {
@@ -3428,8 +3435,8 @@ public:
       return ret;
     }
 
-    if (plugin && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
-      //do not compress if object is encrypted
+    // do not compress if object is encrypted
+    if (plugin && !encrypted) {
       compressor = boost::in_place(cct, plugin, filter);
       // add a filter that buffers data so we don't try to compress tiny blocks.
       // libcurl reads in 16k at a time, and we need at least 64k to get a good
@@ -3439,12 +3446,7 @@ public:
       filter = &*buffering;
     }
 
-    /*
-     * Presently we don't support ETag based verification if encryption is
-     * requested. We can enable simultaneous support once we have a mechanism
-     * to know the sequence in which the filters must be applied.
-     */
-    if (try_etag_verify && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
+    if (try_etag_verify) {
       ret = rgw::putobj::create_etag_verifier(dpp, cct, filter, manifest_bl,
                                               compression_info,
                                               etag_verifier);

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -88,6 +88,9 @@ public:
   virtual int get_zone_by_id(const std::string& id, std::unique_ptr<Zone>* zone) override;
   virtual int get_zone_by_name(const std::string& name, std::unique_ptr<Zone>* zone) override;
   virtual int list_zones(std::list<std::string>& zone_ids) override;
+  bool supports(std::string_view feature) const override {
+    return group.supports(feature);
+  }
   virtual std::unique_ptr<ZoneGroup> clone() override {
     return std::make_unique<RadosZoneGroup>(store, group);
   }

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -81,10 +81,12 @@ int RGWZoneGroup::create_default(const DoutPrefixProvider *dpp, optional_yield y
   default_zone.id = zone_params.get_id();
   master_zone = default_zone.id;
 
-  // enable all supported features
-  enabled_features.insert(rgw::zone_features::supported.begin(),
-                          rgw::zone_features::supported.end());
-  default_zone.supported_features = enabled_features;
+  // initialize supported zone features
+  default_zone.supported_features.insert(rgw::zone_features::supported.begin(),
+                                         rgw::zone_features::supported.end());
+  // enable default zonegroup features
+  enabled_features.insert(rgw::zone_features::enabled.begin(),
+                          rgw::zone_features::enabled.end());
   
   r = create(dpp, y);
   if (r < 0 && r != -EEXIST) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5150,9 +5150,9 @@ int main(int argc, const char **argv)
         zonegroup.api_name = (api_name.empty() ? zonegroup_name : api_name);
 
         zonegroup.enabled_features = enable_features;
-        if (zonegroup.enabled_features.empty()) { // enable all features by default
-          zonegroup.enabled_features.insert(rgw::zone_features::supported.begin(),
-                                            rgw::zone_features::supported.end());
+        if (zonegroup.enabled_features.empty()) { // enable features by default
+          zonegroup.enabled_features.insert(rgw::zone_features::enabled.begin(),
+                                            rgw::zone_features::enabled.end());
         }
         for (const auto& feature : disable_features) {
           auto i = zonegroup.enabled_features.find(feature);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4182,7 +4182,11 @@ void RGWPutObj::execute(optional_yield y)
     if (encrypt != nullptr) {
       filter = &*encrypt;
     }
-    if (compression_type != "none") {
+    // a zonegroup feature is required to combine compression and encryption
+    const rgw::sal::ZoneGroup& zonegroup = driver->get_zone()->get_zonegroup();
+    const bool compress_encrypted = zonegroup.supports(rgw::zone_features::compress_encrypted);
+    if (compression_type != "none" &&
+        (encrypt == nullptr || compress_encrypted)) {
       plugin = get_compressor_plugin(s, compression_type);
       if (!plugin) {
         ldpp_dout(this, 1) << "Cannot load plugin for compression type "

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2199,8 +2199,9 @@ void RGWGetObj::execute(optional_yield y)
   gc_invalidate_time = ceph_clock_now();
   gc_invalidate_time += (s->cct->_conf->rgw_gc_obj_min_wait / 2);
 
-  bool need_decompress;
-  int64_t ofs_x, end_x;
+  bool need_decompress = false;
+  int64_t ofs_x = 0, end_x = 0;
+  bool encrypted = false;
 
   RGWGetObj_CB cb(this);
   RGWGetObj_Filter* filter = (RGWGetObj_Filter *)&cb;
@@ -2303,11 +2304,17 @@ void RGWGetObj::execute(optional_yield y)
     ldpp_dout(this, 0) << "ERROR: failed to decode compression info, cannot decompress" << dendl;
     goto done_err;
   }
-  if (need_decompress) {
-      s->obj_size = cs_info.orig_size;
-      s->object->set_obj_size(cs_info.orig_size);
-      decompress.emplace(s->cct, &cs_info, partial_content, filter);
-      filter = &*decompress;
+
+  // where encryption and compression are combined, compression was applied to
+  // the data before encryption. if the system header rgwx-skip-decrypt is
+  // present, we have to skip the decompression filter too
+  encrypted = attrs.count(RGW_ATTR_CRYPT_MODE);
+
+  if (need_decompress && (!encrypted || !skip_decrypt)) {
+    s->obj_size = cs_info.orig_size;
+    s->object->set_obj_size(cs_info.orig_size);
+    decompress.emplace(s->cct, &cs_info, partial_content, filter);
+    filter = &*decompress;
   }
 
   attr_iter = attrs.find(RGW_ATTR_OBJ_REPLICATION_TRACE);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1500,6 +1500,8 @@ public:
   virtual int get_zone_by_name(const std::string& name, std::unique_ptr<Zone>* zone) = 0;
   /** List zones in zone group by ID */
   virtual int list_zones(std::list<std::string>& zone_ids) = 0;
+  /// Return true if the given feature is enabled in the zonegroup.
+  virtual bool supports(std::string_view feature) const = 0;
   /** Clone a copy of this zonegroup. */
   virtual std::unique_ptr<ZoneGroup> clone() = 0;
 };

--- a/src/rgw/rgw_sal_daos.h
+++ b/src/rgw/rgw_sal_daos.h
@@ -431,6 +431,9 @@ class DaosZoneGroup : public StoreZoneGroup {
   virtual int get_zone_count() const override { return group.zones.size(); }
   virtual int get_placement_tier(const rgw_placement_rule& rule,
                                  std::unique_ptr<PlacementTier>* tier);
+  bool supports(std::string_view feature) const override {
+    return group.supports(feature);
+  }
   virtual std::unique_ptr<ZoneGroup> clone() override {
     return std::make_unique<DaosZoneGroup>(store, group);
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -300,6 +300,9 @@ protected:
       zone_ids.clear();
       return 0;
     }
+    bool supports(std::string_view feature) const override {
+      return group->supports(feature);
+    }
     virtual std::unique_ptr<ZoneGroup> clone() override {
       std::unique_ptr<RGWZoneGroup>zg = std::make_unique<RGWZoneGroup>(*group.get());
       return std::make_unique<DBZoneGroup>(store, std::move(zg));

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -83,6 +83,9 @@ public:
   virtual int get_zone_by_name(const std::string& name, std::unique_ptr<Zone>* zone) override;
   virtual int list_zones(std::list<std::string>& zone_ids) override
     { return next->list_zones(zone_ids); }
+  bool supports(std::string_view feature) const override {
+    return next->supports(feature);
+  }
   virtual std::unique_ptr<ZoneGroup> clone() override {
     std::unique_ptr<ZoneGroup> nzg = next->clone();
     return std::make_unique<FilterZoneGroup>(std::move(nzg));

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -471,6 +471,9 @@ public:
     return 0;
   }
   const RGWZoneGroup& get_group() { return group; }
+  bool supports(std::string_view feature) const override {
+    return group.supports(features);
+  }
   virtual std::unique_ptr<ZoneGroup> clone() override {
     return std::make_unique<MotrZoneGroup>(store, group);
   }

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -14,10 +14,12 @@ namespace rgw::zone_features {
 
 // zone feature names
 inline constexpr std::string_view resharding = "resharding";
+inline constexpr std::string_view compress_encrypted = "compress-encrypted";
 
 // static list of features supported by this release
 inline constexpr std::initializer_list<std::string_view> supported = {
   resharding,
+  compress_encrypted,
 };
 
 inline constexpr bool supports(std::string_view feature) {

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -29,6 +29,11 @@ inline constexpr bool supports(std::string_view feature) {
   return false;
 }
 
+// static list of features enabled by default on new zonegroups
+inline constexpr std::initializer_list<std::string_view> enabled = {
+  resharding,
+};
+
 
 // enable string_view overloads for find() contains() etc
 struct feature_less : std::less<std::string_view> {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61888

---

backport of https://github.com/ceph/ceph/pull/52247
parent tracker: https://tracker.ceph.com/issues/57905

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh