### PR TITLE
dashboard: regression, make install fails w/dashboard disabled

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -15,9 +15,11 @@ if(WITH_MGR_DASHBOARD_FRONTEND)
     add_tox_test(mgr-dashboard-openapi TOX_ENVS openapi-check)
   endif()
 else()
-  # prebuilt
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/frontend/dist
-    DESTINATION ${CEPH_INSTALL_DATADIR}/mgr/dashboard/frontend)
-  install(FILES frontend/package.json
-    DESTINATION ${CEPH_INSTALL_DATADIR}/mgr/dashboard/frontend)
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/frontend/dist)
+    # prebuilt
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/frontend/dist
+      DESTINATION ${CEPH_INSTALL_DATADIR}/mgr/dashboard/frontend)
+    install(FILES frontend/package.json
+      DESTINATION ${CEPH_INSTALL_DATADIR}/mgr/dashboard/frontend)
+  endif()
 endif()


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
