### PR TITLE
[POC] mgr/dashboard: make orch APIs generally available

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/daemon.py
+++ b/src/pybind/mgr/dashboard/controllers/daemon.py
@@ -2,10 +2,12 @@
 
 from typing import Optional
 
+from orchestrator_api import OrchClient, OrchFeature
+
+from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.exception import handle_orchestrator_error
-from ..services.orchestrator import OrchClient, OrchFeature
 from . import APIDoc, APIRouter, RESTController
 from ._version import APIVersion
 from .orchestrator import raise_if_no_orchestrator
@@ -28,6 +30,6 @@ class Daemon(RESTController):
         if container_image == '' and action != 'redeploy':
             container_image = None
 
-        orch = OrchClient.instance()
+        orch = OrchClient(mgr).instance(mgr)
         res = orch.daemons.action(action=action, daemon_name=daemon_name, image=container_image)
         return res

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -2,9 +2,10 @@
 
 from functools import wraps
 
+from orchestrator_api import OrchClient
+
 from .. import mgr
 from ..exceptions import DashboardException
-from ..services.orchestrator import OrchClient
 from . import APIDoc, Endpoint, EndpointDoc, ReadPermission, RESTController, UIRouter
 
 STATUS_SCHEMA = {
@@ -17,7 +18,7 @@ def raise_if_no_orchestrator(features=None):
     def inner(method):
         @wraps(method)
         def _inner(self, *args, **kwargs):
-            orch = OrchClient.instance()
+            orch = OrchClient(mgr).instance(mgr)
             if not orch.available():
                 raise DashboardException(code='orchestrator_status_unavailable',  # pragma: no cover
                                          msg='Orchestrator is unavailable',
@@ -45,7 +46,7 @@ class Orchestrator(RESTController):
     @EndpointDoc("Display Orchestrator Status",
                  responses={200: STATUS_SCHEMA})
     def status(self):
-        return OrchClient.instance().status()
+        return OrchClient(mgr).instance(mgr).status()
 
     @Endpoint()
     def get_name(self):

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -9,6 +9,7 @@ from typing import NamedTuple, Optional, no_type_check
 
 import cherrypy
 import rbd
+from orchestrator_api import OrchClient
 
 from .. import mgr
 from ..controllers.pool import RBDPool
@@ -16,7 +17,6 @@ from ..controllers.service import Service
 from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.exception import handle_rados_error, handle_rbd_error, serialize_dashboard_exception
-from ..services.orchestrator import OrchClient
 from ..services.rbd import rbd_call
 from ..tools import ViewCache
 from . import APIDoc, APIRouter, BaseController, CreatePermission, Endpoint, \
@@ -643,7 +643,7 @@ class RbdMirroringStatus(BaseController):
     @ReadPermission
     def status(self):
         status = {'available': True, 'message': None}
-        orch_status = OrchClient.instance().status()
+        orch_status = OrchClient(mgr).instance(mgr).status()
 
         # if the orch is not available we can't create the service
         # using dashboard.

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import cherrypy
+from orchestrator_api import OrchClient
 
 from .. import mgr
 from ..exceptions import DashboardException
@@ -12,7 +13,6 @@ from ..rest_client import RequestException
 from ..security import Permission, Scope
 from ..services.auth import AuthManager, JwtManager
 from ..services.ceph_service import CephService
-from ..services.orchestrator import OrchClient
 from ..services.rgw_client import NoRgwDaemonsException, RgwClient
 from ..tools import json_str_to_object, str_to_bool
 from . import APIDoc, APIRouter, BaseController, CreatePermission, \
@@ -119,7 +119,7 @@ class RgwStatus(BaseController):
             instance = RgwClient.admin_instance(daemon_name=daemon_name)
             result = instance.migrate_to_multisite(realm_name, zonegroup_name, zone_name,
                                                    zonegroup_endpoints, zone_endpoints, user)
-            orch = OrchClient.instance()
+            orch = OrchClient(mgr).instance(mgr)
             daemons = orch.services.list_daemons(service_name='rgw')
             for daemon in daemons:
                 orch.daemons.action(action='reload', daemon_name=daemon.daemon_id)

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -8,4 +8,8 @@ rstcheck==3.3.1
 autopep8==1.5.7
 pyfakefs==4.5.0
 isort==5.5.3
+<<<<<<< Updated upstream
 jsonschema~=4.0
+=======
+jsonschema
+>>>>>>> Stashed changes

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,4 +1,8 @@
 pytest-cov
 pytest-instafail
 pyfakefs==4.5.0
+<<<<<<< Updated upstream
 jsonschema~=4.0
+=======
+jsonschema
+>>>>>>> Stashed changes

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -361,7 +361,7 @@ def patch_orch(available: bool, missing_features: Optional[List[str]] = None,
                hosts: Optional[List[HostSpec]] = None,
                inventory: Optional[List[dict]] = None,
                daemons: Optional[List[DaemonDescription]] = None):
-    with mock.patch('dashboard.controllers.orchestrator.OrchClient.instance') as instance:
+    with mock.patch('orchestrator_api.OrchClient.instance') as instance:
         fake_client = mock.Mock()
         fake_client.available.return_value = available
         fake_client.get_missing_features.return_value = missing_features

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -11,6 +11,7 @@ except ImportError:
     import unittest.mock as mock
 
 from mgr_module import ERROR_MSG_NO_INPUT_FILE
+from orchestrator_api import OrchClient
 
 from .. import mgr
 from ..controllers.iscsi import Iscsi, IscsiTarget, IscsiUi
@@ -18,7 +19,6 @@ from ..exceptions import DashboardException
 from ..rest_client import RequestException
 from ..services.exception import handle_request_error
 from ..services.iscsi_client import IscsiClient
-from ..services.orchestrator import OrchClient
 from ..tests import CLICommandTestMixin, CmdException, ControllerTestCase, KVStoreMockMixin
 from ..tools import NotificationQueue, TaskManager
 
@@ -81,7 +81,7 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
     def setup_server(cls):
         NotificationQueue.start_queue()
         TaskManager.init()
-        OrchClient.instance().available = lambda: False
+        OrchClient(mgr).instance(mgr).available = lambda: False
         mgr.rados.side_effect = None
         cls.setup_controllers([Iscsi, IscsiTarget])
 

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -2,10 +2,11 @@ import inspect
 import unittest
 from unittest import mock
 
+# from .. import mgr
 from orchestrator import Orchestrator as OrchestratorBase
+from orchestrator_api import OrchFeature
 
 from ..controllers.orchestrator import Orchestrator
-from ..services.orchestrator import OrchFeature
 from ..tests import ControllerTestCase
 
 
@@ -17,7 +18,7 @@ class OrchestratorControllerTest(ControllerTestCase):
     def setup_server(cls):
         cls.setup_controllers([Orchestrator])
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_status_get(self, instance):
         status = {'available': False, 'description': ''}
 

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -317,7 +317,7 @@ class OsdTest(ControllerTestCase):
         res = self.json_body()
         self.assertIn(data['data']['svc_id'], res['detail'])
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_osd_create_with_drive_groups(self, instance):
         # without orchestrator service
         fake_client = mock.Mock()
@@ -342,7 +342,7 @@ class OsdTest(ControllerTestCase):
                                    data_devices=DeviceSelection(rotational=True))]
         fake_client.osds.create.assert_called_with(dg_specs)
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_osd_create_with_invalid_drive_groups(self, instance):
         # without orchestrator service
         fake_client = mock.Mock()
@@ -407,7 +407,7 @@ class OsdTest(ControllerTestCase):
         res = self.json_body()
         return res
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_deployment_options(self, instance):
         fake_client = mock.Mock()
         instance.return_value = fake_client
@@ -434,7 +434,7 @@ class OsdTest(ControllerTestCase):
         self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
         self.assertEqual(res['recommended_option'], None)
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_deployment_options_throughput(self, instance):
         fake_client = mock.Mock()
         instance.return_value = fake_client
@@ -454,7 +454,7 @@ class OsdTest(ControllerTestCase):
         self.assertFalse(res['options'][OsdDeploymentOptions.IOPS]['available'])
         assert res['recommended_option'] == OsdDeploymentOptions.THROUGHPUT
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_deployment_options_with_hdds_and_nvmes(self, instance):
         fake_client = mock.Mock()
         instance.return_value = fake_client
@@ -474,7 +474,7 @@ class OsdTest(ControllerTestCase):
         self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])
         assert res['recommended_option'] == OsdDeploymentOptions.COST_CAPACITY
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_deployment_options_iops(self, instance):
         fake_client = mock.Mock()
         instance.return_value = fake_client

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -302,7 +302,7 @@ class RbdMirroringStatusControllerTest(ControllerTestCase):
     def setup_server(cls):
         cls.setup_controllers([RbdMirroringStatus, Orchestrator])
 
-    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    @mock.patch('orchestrator_api.OrchClient.instance')
     def test_status(self, instance):
         status = {'available': False, 'description': ''}
         fake_client = mock.Mock()


### PR DESCRIPTION
Currently there's no way to access methods of a dashboard service from other mgr module, for instance if you try to use orchestrator service in Prometheus module it'll an throw error 
`AttributeError: global manager module instance not initialized`
This is happening because in the dashboard we store the mgrmodule instance in a singleton when loading `dashboard/__init__.py`. 

The purpose of this PR is to expose the orchestrator service outside of dashboard module and make it generally available to use for all mgr modules. 
There's already a need to use orch services in prometheus module to get the correct instance id for `rgw_metadata` metrics, to use `daemon_id` coming from daemons list API, instead of relying on `mgr.list_servers()` when there's a 
orchestrator available.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
