### PR TITLE
osd/OSD: Simplify trim_maps

### DIFF
--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -291,6 +291,12 @@ public:
   Transaction(const Transaction& other) = default;
   Transaction& operator=(const Transaction& other) = default;
 
+  Transaction claim_and_reset() {
+    auto ret = Transaction();
+    std::swap(*this, ret);
+    return ret;
+  }
+
   // expose object_index for FileStore::Op's benefit
   const std::map<ghobject_t, uint32_t>& get_object_index() const {
     return object_index;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7948,6 +7948,9 @@ void OSD::osdmap_subscribe(version_t epoch, bool force_request)
 void OSD::trim_maps(epoch_t oldest, bool skip_maps)
 {
   epoch_t min = std::min(oldest, service.map_cache.cached_key_lower_bound());
+  dout(20) <<  __func__ << ": min=" << min << " oldest_map="
+           << superblock.oldest_map << " skip_maps=" << skip_maps
+           << dendl;
   if (min <= superblock.oldest_map)
     return;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1685,7 +1685,7 @@ protected:
 
   void handle_osd_map(class MOSDMap *m);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
-  void trim_maps(epoch_t oldest, int nreceived, bool skip_maps);
+  void trim_maps(epoch_t oldest, bool skip_maps);
   void note_down_osd(int osd);
   void note_up_osd(int osd);
   friend struct C_OnMapCommit;


### PR DESCRIPTION
 Simplification/rewrite of `trim_maps()` as part of Crimson's counterpart implementation.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
