### PR TITLE
rgw/d3n: implement non-yielding d3n cache op

### DIFF
--- a/qa/suites/rgw/verify/datacache/rgw-datacache.yaml
+++ b/qa/suites/rgw/verify/datacache/rgw-datacache.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     conf:
-      client:
+      client.0:
         rgw d3n l1 local datacache enabled: true
         rgw enable ops log: true
         rgw d3n l1 datacache persistent path: /tmp/rgw_datacache/

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -74,6 +74,7 @@ set(librgw_common_srcs
   rgw_compression.cc
   rgw_cors.cc
   rgw_cors_s3.cc
+  rgw_d3n_cacherequest.cc
   rgw_env.cc
   rgw_es_query.cc
   rgw_formats.cc

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/errno.h"
 #include "rgw_acl_s3.h"
 #include "rgw_tag_s3.h"
 

--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-#include "rgw_rados.h"
+#include <aio.h>
 #include <curl/curl.h>
 
 #include "rgw_common.h"
+#include "rgw_rados.h"
 
 #include <unistd.h>
 #include <signal.h>
 #include "include/Context.h"
 #include "include/lru.h"
-#include "rgw_d3n_cacherequest.h"
 
 
 /*D3nDataCache*/
@@ -240,7 +240,7 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
     if (d->rgwrados->d3n_data_cache->get(oid, len)) {
       // Read From Cache
       ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): READ FROM CACHE: oid=" << read_obj.oid << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << ", len=" << len << dendl;
-      auto completed = d->aio->get(ref.obj, rgw::Aio::d3n_cache_op(dpp, d->yield, read_ofs, len, d->rgwrados->d3n_data_cache->cache_location), cost, id);
+      auto completed = d->aio->get(ref.obj, rgw::d3n::cache_read_op(dpp, d->yield, read_ofs, len, d->rgwrados->d3n_data_cache->cache_location), cost, id);
       r = d->flush(std::move(completed));
       if (r < 0) {
         lsubdout(g_ceph_context, rgw, 0) << "D3nDataCache: " << __func__ << "(): Error: failed to drain/flush, r= " << r << dendl;

--- a/src/rgw/driver/rados/rgw_period.cc
+++ b/src/rgw/driver/rados/rgw_period.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/errno.h"
 #include "rgw_sync.h"
 
 #include "services/svc_zone.h"

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/errno.h"
 #include "rgw_sync.h"
 #include "rgw_rest_conn.h"
 #include "rgw_cr_rados.h"

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/errno.h"
 #include "rgw_zone.h"
 #include "rgw_realm_watcher.h"
 #include "rgw_sal_config.h"

--- a/src/rgw/driver/rados/sync_fairness.cc
+++ b/src/rgw/driver/rados/sync_fairness.cc
@@ -18,6 +18,7 @@
 #include <boost/container/flat_map.hpp>
 #include "include/encoding.h"
 #include "include/rados/librados.hpp"
+#include "common/errno.h"
 #include "rgw_sal_rados.h"
 #include "rgw_cr_rados.h"
 #include "sync_fairness.h"

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -18,7 +18,6 @@
 #include "librados/librados_asio.h"
 
 #include "rgw_aio.h"
-#include "rgw_d3n_cacherequest.h"
 
 namespace rgw {
 
@@ -101,18 +100,6 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
     };
 }
 
-
-Aio::OpFunc d3n_cache_aio_abstract(const DoutPrefixProvider *dpp, optional_yield y, off_t read_ofs, off_t read_len, std::string& cache_location) {
-  return [dpp, y, read_ofs, read_len, cache_location] (Aio* aio, AioResult& r) mutable {
-    // d3n data cache requires yield context (rgw_beast_enable_async=true)
-    ceph_assert(y);
-    auto c = std::make_unique<D3nL1CacheRequest>();
-    lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: d3n_cache_aio_abstract(): libaio Read From Cache, oid=" << r.obj.oid << dendl;
-    c->file_aio_read_abstract(dpp, y.get_io_context(), y.get_yield_context(), cache_location, read_ofs, read_len, aio, r);
-  };
-}
-
-
 template <typename Op>
 Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, optional_yield y) {
   static_assert(std::is_base_of_v<librados::ObjectOperation, std::decay_t<Op>>);
@@ -136,11 +123,6 @@ Aio::OpFunc Aio::librados_op(librados::IoCtx ctx,
                              librados::ObjectWriteOperation&& op,
                              optional_yield y) {
   return aio_abstract(std::move(ctx), std::move(op), y);
-}
-
-Aio::OpFunc Aio::d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
-                              off_t read_ofs, off_t read_len, std::string& cache_location) {
-  return d3n_cache_aio_abstract(dpp, y, read_ofs, read_len, cache_location);
 }
 
 } // namespace rgw

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -97,8 +97,6 @@ class Aio {
   static OpFunc librados_op(librados::IoCtx ctx,
                             librados::ObjectWriteOperation&& op,
                             optional_yield y);
-  static OpFunc d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
-                             off_t read_ofs, off_t read_len, std::string& location);
 };
 
 } // namespace rgw

--- a/src/rgw/rgw_d3n_cacherequest.cc
+++ b/src/rgw/rgw_d3n_cacherequest.cc
@@ -13,92 +13,104 @@ namespace rgw::d3n {
 
 // unique_ptr with custom deleter for struct aiocb
 struct libaio_aiocb_deleter {
-  void operator()(struct aiocb* c) {
-    if(c->aio_fildes > 0) {
-      if( ::close(c->aio_fildes) != 0) {
-        lsubdout(g_ceph_context, rgw_datacache, 2) << "D3nDataCache: " << __func__ << "(): Error - can't close file, errno=" << -errno << dendl;
-      }
+  void operator()(aiocb* c) {
+    if (c->aio_fildes > 0) {
+      TEMP_FAILURE_RETRY(::close(c->aio_fildes));
     }
     delete c;
   }
 };
-
 using unique_aio_cb_ptr = std::unique_ptr<struct aiocb, libaio_aiocb_deleter>;
 
-using aio_notify_fn = void(*)(union sigval); // sigevent::sigev_notify_function
-
-struct AsyncFileReadOp {
-  bufferlist result;
+// aio state stored in AioResult::user_data
+struct state {
+  Aio* aio = nullptr;
   unique_aio_cb_ptr aio_cb;
 
-  int init_async_read(const DoutPrefixProvider *dpp, const std::string& location,
-                      off_t read_ofs, off_t read_len, aio_notify_fn notify_cb,
-                      void* arg)
-  {
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
-    aio_cb.reset(new struct aiocb);
-    memset(aio_cb.get(), 0, sizeof(struct aiocb));
-    aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(location.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
-    if(aio_cb->aio_fildes < 0) {
-      int err = errno;
-      ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << location << " : " << cpp_strerror(err) << dendl;
-      return -err;
-    }
-    if (g_conf()->rgw_d3n_l1_fadvise != POSIX_FADV_NORMAL)
-      posix_fadvise(aio_cb->aio_fildes, 0, 0, g_conf()->rgw_d3n_l1_fadvise);
-
-    bufferptr bp(read_len);
-    aio_cb->aio_buf = bp.c_str();
-    result.append(std::move(bp));
-
-    aio_cb->aio_nbytes = read_len;
-    aio_cb->aio_offset = read_ofs;
-    aio_cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
-    aio_cb->aio_sigevent.sigev_notify_function = notify_cb;
-    aio_cb->aio_sigevent.sigev_notify_attributes = nullptr;
-    aio_cb->aio_sigevent.sigev_value.sival_ptr = arg;
-
-    return 0;
-  }
+  explicit state(Aio* aio) : aio(aio) {}
 };
+static_assert(sizeof(AioResult::user_data) >= sizeof(state));
 
-using Signature = void(boost::system::error_code, bufferlist);
-using Completion = ceph::async::Completion<Signature, AsyncFileReadOp>;
+static void on_complete(AioResult& r)
+{
+  auto s = reinterpret_cast<state*>(&r.user_data);
+  Aio* aio = s->aio;
+  // manually destroy the state that was constructed with placement new
+  s->~state();
+  aio->put(r);
+}
 
+
+// for sigevent::sigev_notify_function
+using aio_notify_fn = void(*)(union sigval);
+
+static int init_async_read(const DoutPrefixProvider *dpp, aiocb* aio_cb,
+                           const std::string& path, off_t ofs, off_t len,
+                           void* buffer, aio_notify_fn notify_cb, void* arg)
+{
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << path << dendl;
+  aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(path.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
+  if (aio_cb->aio_fildes < 0) {
+    int err = errno;
+    ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << path << " : " << cpp_strerror(err) << dendl;
+    return -err;
+  }
+  if (g_conf()->rgw_d3n_l1_fadvise != POSIX_FADV_NORMAL)
+    posix_fadvise(aio_cb->aio_fildes, 0, 0, g_conf()->rgw_d3n_l1_fadvise);
+
+  aio_cb->aio_buf = buffer;
+  aio_cb->aio_nbytes = len;
+  aio_cb->aio_offset = ofs;
+  aio_cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
+  aio_cb->aio_sigevent.sigev_notify_function = notify_cb;
+  aio_cb->aio_sigevent.sigev_notify_attributes = nullptr;
+  aio_cb->aio_sigevent.sigev_value.sival_ptr = arg;
+
+  return 0;
+}
+
+
+// yielding completion
+
+using Signature = void(boost::system::error_code);
+using Completion = ceph::async::Completion<Signature, state*>;
+
+// aio_notify_fn for yield_context overload
 static void on_notify_yield(sigval sigval)
 {
   lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: " << __func__ << "()" << dendl;
   auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
-  auto op = std::move(p->user_data);
-  const int ret = -aio_error(op.aio_cb.get());
+  const int ret = -::aio_error(p->user_data->aio_cb.get());
   boost::system::error_code ec;
   if (ret < 0) {
     ec.assign(-ret, boost::system::system_category());
   }
 
-  ceph::async::dispatch(std::move(p), ec, std::move(op.result));
+  ceph::async::dispatch(std::move(p), ec);
 }
 
 template <typename ExecutionContext, typename CompletionToken>
 static auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx,
-                       const std::string& location, off_t ofs, off_t len,
-                       CompletionToken&& token)
+                       const std::string& path, off_t ofs, off_t len,
+                       AioResult& r, void* buffer, CompletionToken&& token)
 {
+  auto s = reinterpret_cast<state*>(&r.user_data);
+
   boost::asio::async_completion<CompletionToken, Signature> init(token);
   auto p = Completion::create(ctx.get_executor(),
-                              std::move(init.completion_handler));
-  auto& op = p->user_data;
+                              std::move(init.completion_handler), s);
 
-  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
-  int ret = op.init_async_read(dpp, location, ofs, len,
-                               on_notify_yield, p.get());
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << path << dendl;
+  int ret = init_async_read(dpp, s->aio_cb.get(), path, ofs, len,
+                            buffer, on_notify_yield, p.get());
   if(0 == ret) {
-    ret = ::aio_read(op.aio_cb.get());
+    ret = ::aio_read(s->aio_cb.get());
   }
   ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
-  if(ret < 0) {
+  if (ret < 0) {
     auto ec = boost::system::error_code{-ret, boost::system::system_category()};
-    ceph::async::post(std::move(p), ec, bufferlist{});
+    r.data.clear();
+    ceph::async::post(std::move(p), ec);
   } else {
     // coverity[leaked_storage:SUPPRESS]
     (void)p.release();
@@ -107,39 +119,83 @@ static auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx,
 }
 
 struct d3n_libaio_handler {
-  Aio* throttle = nullptr;
   AioResult& r;
   // read callback
-  void operator()(boost::system::error_code ec, bufferlist bl) const {
+  void operator()(boost::system::error_code ec) const {
     r.result = -ec.value();
-    r.data = std::move(bl);
-    throttle->put(r);
+    on_complete(r);
   }
 };
 
 static void cache_read(const DoutPrefixProvider *dpp,
                        boost::asio::io_context& context, yield_context yield,
-                       const std::string& dir, off_t ofs, off_t len,
-                       Aio* aio, AioResult& r)
+                       const std::string& path, off_t ofs, off_t len,
+                       void* buffer, AioResult& r)
 {
   using namespace boost::asio;
   async_completion<yield_context, void()> init(yield);
   auto ex = get_associated_executor(init.completion_handler);
 
-  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << r.obj.oid << dendl;
-  async_read(dpp, context, dir+"/"+url_encode(r.obj.oid, true), ofs, len,
-             bind_executor(ex, d3n_libaio_handler{aio, r}));
+  async_read(dpp, context, path, ofs, len, r, buffer,
+             bind_executor(ex, d3n_libaio_handler{r}));
 }
+
+
+// non-yielding completion
+
+static void on_notify(sigval sigval)
+{
+  auto& r = *(static_cast<AioResult*>(sigval.sival_ptr));
+  auto s = reinterpret_cast<state*>(&r.user_data);
+  r.result = -::aio_error(s->aio_cb.get());
+  on_complete(r);
+}
+
+static void cache_read(const DoutPrefixProvider *dpp, const std::string& path,
+                       off_t ofs, off_t len, void* buffer, AioResult& r)
+{
+  auto s = reinterpret_cast<state*>(&r.user_data);
+
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << path << dendl;
+  int ret = init_async_read(dpp, s->aio_cb.get(), path, ofs, len,
+                            buffer, on_notify, &r);
+  if (0 == ret) {
+    ret = ::aio_read(s->aio_cb.get());
+  }
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
+  if (ret < 0) {
+    r.result = -::aio_error(s->aio_cb.get());
+    r.data.clear();
+    on_complete(r);
+  }
+}
+
 
 Aio::OpFunc cache_read_op(const DoutPrefixProvider *dpp, optional_yield y,
                           off_t ofs, off_t len, const std::string& cache_dir)
 {
   return [dpp, y, ofs, len, cache_dir] (Aio* aio, AioResult& r) mutable {
-    // d3n data cache requires yield context (rgw_beast_enable_async=true)
-    ceph_assert(y);
+    // use placement new to construct the aio state inside of user_data
+    auto s = new (&r.user_data) state(aio);
+
+    // allocate/zero the aiocb
+    s->aio_cb.reset(new aiocb);
+    memset(s->aio_cb.get(), 0, sizeof(aiocb));
+
+    // preallocate the data buffer and manage its lifetime in AioResult::data
+    bufferptr bp(len);
+    void* buffer = bp.c_str();
+    r.data.append(std::move(bp));
+
+    std::string path = cache_dir+"/"+url_encode(r.obj.oid, true);
+
     lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: d3n_cache_aio_abstract(): libaio Read From Cache, oid=" << r.obj.oid << dendl;
-    cache_read(dpp, y.get_io_context(), y.get_yield_context(),
-               cache_dir, ofs, len, aio, r);
+    if (y) {
+      cache_read(dpp, y.get_io_context(), y.get_yield_context(),
+                 path, ofs, len, buffer, r);
+    } else {
+      cache_read(dpp, path, ofs, len, buffer, r);
+    }
   };
 }
 

--- a/src/rgw/rgw_d3n_cacherequest.cc
+++ b/src/rgw/rgw_d3n_cacherequest.cc
@@ -1,0 +1,146 @@
+#include "rgw_d3n_cacherequest.h"
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <aio.h>
+
+#include "common/async/completion.h"
+#include "common/error_code.h"
+#include "common/errno.h"
+
+
+namespace rgw::d3n {
+
+// unique_ptr with custom deleter for struct aiocb
+struct libaio_aiocb_deleter {
+  void operator()(struct aiocb* c) {
+    if(c->aio_fildes > 0) {
+      if( ::close(c->aio_fildes) != 0) {
+        lsubdout(g_ceph_context, rgw_datacache, 2) << "D3nDataCache: " << __func__ << "(): Error - can't close file, errno=" << -errno << dendl;
+      }
+    }
+    delete c;
+  }
+};
+
+using unique_aio_cb_ptr = std::unique_ptr<struct aiocb, libaio_aiocb_deleter>;
+
+using aio_notify_fn = void(*)(union sigval); // sigevent::sigev_notify_function
+
+struct AsyncFileReadOp {
+  bufferlist result;
+  unique_aio_cb_ptr aio_cb;
+
+  int init_async_read(const DoutPrefixProvider *dpp, const std::string& location,
+                      off_t read_ofs, off_t read_len, aio_notify_fn notify_cb,
+                      void* arg)
+  {
+    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
+    aio_cb.reset(new struct aiocb);
+    memset(aio_cb.get(), 0, sizeof(struct aiocb));
+    aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(location.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
+    if(aio_cb->aio_fildes < 0) {
+      int err = errno;
+      ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << location << " : " << cpp_strerror(err) << dendl;
+      return -err;
+    }
+    if (g_conf()->rgw_d3n_l1_fadvise != POSIX_FADV_NORMAL)
+      posix_fadvise(aio_cb->aio_fildes, 0, 0, g_conf()->rgw_d3n_l1_fadvise);
+
+    bufferptr bp(read_len);
+    aio_cb->aio_buf = bp.c_str();
+    result.append(std::move(bp));
+
+    aio_cb->aio_nbytes = read_len;
+    aio_cb->aio_offset = read_ofs;
+    aio_cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
+    aio_cb->aio_sigevent.sigev_notify_function = notify_cb;
+    aio_cb->aio_sigevent.sigev_notify_attributes = nullptr;
+    aio_cb->aio_sigevent.sigev_value.sival_ptr = arg;
+
+    return 0;
+  }
+};
+
+using Signature = void(boost::system::error_code, bufferlist);
+using Completion = ceph::async::Completion<Signature, AsyncFileReadOp>;
+
+static void on_notify_yield(sigval sigval)
+{
+  lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: " << __func__ << "()" << dendl;
+  auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
+  auto op = std::move(p->user_data);
+  const int ret = -aio_error(op.aio_cb.get());
+  boost::system::error_code ec;
+  if (ret < 0) {
+    ec.assign(-ret, boost::system::system_category());
+  }
+
+  ceph::async::dispatch(std::move(p), ec, std::move(op.result));
+}
+
+template <typename ExecutionContext, typename CompletionToken>
+static auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx,
+                       const std::string& location, off_t ofs, off_t len,
+                       CompletionToken&& token)
+{
+  boost::asio::async_completion<CompletionToken, Signature> init(token);
+  auto p = Completion::create(ctx.get_executor(),
+                              std::move(init.completion_handler));
+  auto& op = p->user_data;
+
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
+  int ret = op.init_async_read(dpp, location, ofs, len,
+                               on_notify_yield, p.get());
+  if(0 == ret) {
+    ret = ::aio_read(op.aio_cb.get());
+  }
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
+  if(ret < 0) {
+    auto ec = boost::system::error_code{-ret, boost::system::system_category()};
+    ceph::async::post(std::move(p), ec, bufferlist{});
+  } else {
+    // coverity[leaked_storage:SUPPRESS]
+    (void)p.release();
+  }
+  return init.result.get();
+}
+
+struct d3n_libaio_handler {
+  Aio* throttle = nullptr;
+  AioResult& r;
+  // read callback
+  void operator()(boost::system::error_code ec, bufferlist bl) const {
+    r.result = -ec.value();
+    r.data = std::move(bl);
+    throttle->put(r);
+  }
+};
+
+static void cache_read(const DoutPrefixProvider *dpp,
+                       boost::asio::io_context& context, yield_context yield,
+                       const std::string& dir, off_t ofs, off_t len,
+                       Aio* aio, AioResult& r)
+{
+  using namespace boost::asio;
+  async_completion<yield_context, void()> init(yield);
+  auto ex = get_associated_executor(init.completion_handler);
+
+  ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << r.obj.oid << dendl;
+  async_read(dpp, context, dir+"/"+url_encode(r.obj.oid, true), ofs, len,
+             bind_executor(ex, d3n_libaio_handler{aio, r}));
+}
+
+Aio::OpFunc cache_read_op(const DoutPrefixProvider *dpp, optional_yield y,
+                          off_t ofs, off_t len, const std::string& cache_dir)
+{
+  return [dpp, y, ofs, len, cache_dir] (Aio* aio, AioResult& r) mutable {
+    // d3n data cache requires yield context (rgw_beast_enable_async=true)
+    ceph_assert(y);
+    lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: d3n_cache_aio_abstract(): libaio Read From Cache, oid=" << r.obj.oid << dendl;
+    cache_read(dpp, y.get_io_context(), y.get_yield_context(),
+               cache_dir, ofs, len, aio, r);
+  };
+}
+
+} // namespace rgw::d3n

--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -3,143 +3,23 @@
 
 #pragma once
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <aio.h>
+#include <mutex>
 
-#include "include/rados/librados.hpp"
-#include "include/Context.h"
-#include "common/async/completion.h"
-
-#include <errno.h>
-#include "common/error_code.h"
-#include "common/errno.h"
+#include <common/async/yield_context.h>
+#include <common/dout.h>
 
 #include "rgw_aio.h"
-#include "rgw_cache.h"
 
 
 struct D3nGetObjData {
   std::mutex d3n_lock;
 };
 
-struct D3nL1CacheRequest {
-  ~D3nL1CacheRequest() {
-    lsubdout(g_ceph_context, rgw_datacache, 30) << "D3nDataCache: " << __func__ << "(): Read From Cache, complete" << dendl;
-  }
+// TODO: move under src/rgw/driver/d3n/
+namespace rgw::d3n {
 
-  // unique_ptr with custom deleter for struct aiocb
-  struct libaio_aiocb_deleter {
-    void operator()(struct aiocb* c) {
-      if(c->aio_fildes > 0) {
-        if( ::close(c->aio_fildes) != 0) {
-          lsubdout(g_ceph_context, rgw_datacache, 2) << "D3nDataCache: " << __func__ << "(): Error - can't close file, errno=" << -errno << dendl;
-        }
-      }
-      delete c;
-    }
-  };
+// async cache read operation
+Aio::OpFunc cache_read_op(const DoutPrefixProvider* dpp, optional_yield y,
+                          off_t ofs, off_t len, const std::string& cache_dir);
 
-  using unique_aio_cb_ptr = std::unique_ptr<struct aiocb, libaio_aiocb_deleter>;
-
-  struct AsyncFileReadOp {
-    bufferlist result;
-    unique_aio_cb_ptr aio_cb;
-    using Signature = void(boost::system::error_code, bufferlist);
-    using Completion = ceph::async::Completion<Signature, AsyncFileReadOp>;
-
-    int init_async_read(const DoutPrefixProvider *dpp, const std::string& location, off_t read_ofs, off_t read_len, void* arg) {
-      ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
-      aio_cb.reset(new struct aiocb);
-      memset(aio_cb.get(), 0, sizeof(struct aiocb));
-      aio_cb->aio_fildes = TEMP_FAILURE_RETRY(::open(location.c_str(), O_RDONLY|O_CLOEXEC|O_BINARY));
-      if(aio_cb->aio_fildes < 0) {
-        int err = errno;
-        ldpp_dout(dpp, 1) << "ERROR: D3nDataCache: " << __func__ << "(): can't open " << location << " : " << cpp_strerror(err) << dendl;
-        return -err;
-      }
-      if (g_conf()->rgw_d3n_l1_fadvise != POSIX_FADV_NORMAL)
-        posix_fadvise(aio_cb->aio_fildes, 0, 0, g_conf()->rgw_d3n_l1_fadvise);
-
-      bufferptr bp(read_len);
-      aio_cb->aio_buf = bp.c_str();
-      result.append(std::move(bp));
-
-      aio_cb->aio_nbytes = read_len;
-      aio_cb->aio_offset = read_ofs;
-      aio_cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
-      aio_cb->aio_sigevent.sigev_notify_function = libaio_cb_aio_dispatch;
-      aio_cb->aio_sigevent.sigev_notify_attributes = nullptr;
-      aio_cb->aio_sigevent.sigev_value.sival_ptr = arg;
-
-      return 0;
-    }
-
-    static void libaio_cb_aio_dispatch(sigval sigval) {
-      lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: " << __func__ << "()" << dendl;
-      auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
-      auto op = std::move(p->user_data);
-      const int ret = -aio_error(op.aio_cb.get());
-      boost::system::error_code ec;
-      if (ret < 0) {
-          ec.assign(-ret, boost::system::system_category());
-      }
-
-      ceph::async::dispatch(std::move(p), ec, std::move(op.result));
-    }
-
-    template <typename Executor1, typename CompletionHandler>
-    static auto create(const Executor1& ex1, CompletionHandler&& handler) {
-      auto p = Completion::create(ex1, std::move(handler));
-      return p;
-    }
-  };
-
-  template <typename ExecutionContext, typename CompletionToken>
-  auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& location,
-                  off_t read_ofs, off_t read_len, CompletionToken&& token) {
-    using Op = AsyncFileReadOp;
-    using Signature = typename Op::Signature;
-    boost::asio::async_completion<CompletionToken, Signature> init(token);
-    auto p = Op::create(ctx.get_executor(), init.completion_handler);
-    auto& op = p->user_data;
-
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
-    int ret = op.init_async_read(dpp, location, read_ofs, read_len, p.get());
-    if(0 == ret) {
-      ret = ::aio_read(op.aio_cb.get());
-    }
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
-    if(ret < 0) {
-      auto ec = boost::system::error_code{-ret, boost::system::system_category()};
-      ceph::async::post(std::move(p), ec, bufferlist{});
-    } else {
-      // coverity[leaked_storage:SUPPRESS]
-      (void)p.release();
-    }
-    return init.result.get();
-  }
-
-  struct d3n_libaio_handler {
-    rgw::Aio* throttle = nullptr;
-    rgw::AioResult& r;
-    // read callback
-    void operator()(boost::system::error_code ec, bufferlist bl) const {
-      r.result = -ec.value();
-      r.data = std::move(bl);
-      throttle->put(r);
-    }
-  };
-
-  void file_aio_read_abstract(const DoutPrefixProvider *dpp, boost::asio::io_context& context, yield_context yield,
-                              std::string& cache_location, off_t read_ofs, off_t read_len,
-                              rgw::Aio* aio, rgw::AioResult& r) {
-    using namespace boost::asio;
-    async_completion<yield_context, void()> init(yield);
-    auto ex = get_associated_executor(init.completion_handler);
-
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << r.obj.oid << dendl;
-    async_read(dpp, context, cache_location+"/"+url_encode(r.obj.oid, true), read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
-  }
-
-};
+} // namespace rgw::d3n

--- a/src/rgw/rgw_period.cc
+++ b/src/rgw/rgw_period.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/errno.h"
 #include "rgw_sync.h"
 
 using namespace std;

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -337,8 +337,6 @@ DriverManager::Config DriverManager::get_config(bool admin, CephContext* cct)
       if (g_conf().get_val<Option::size_t>("rgw_max_chunk_size") !=
 	  g_conf().get_val<Option::size_t>("rgw_obj_stripe_size")) {
 	lsubdout(cct, rgw_datacache, 0) << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires that the chunk_size equals stripe_size)" << dendl;
-      } else if (!g_conf().get_val<bool>("rgw_beast_enable_async")) {
-	lsubdout(cct, rgw_datacache, 0) << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires yield context - rgw_beast_enable_async=true)" << dendl;
       } else {
 	cfg.store_name = "d3n";
       }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -4,6 +4,7 @@
 #include "rgw_sal_rados.h"
 
 #include "include/types.h"
+#include "common/errno.h"
 #include "rgw_user.h"
 
 // until everything is moved from rgw_common


### PR DESCRIPTION
adds a simple `cache_read()` overload that uses a `on_notify()` callback to issue the aio completion. this is similar to the yielding version, except that it doesn't run on an executor. libaio will invoke this callback directly, and we'll rely on BlockingAioThrottle to handle the thread-safety
    
add a `struct state` to keep track of the `aiocb`. as with the librados implementation, we use placement new to store this in `AioResult::user_data`
    
instead of storing a `bufferlist result` separately, preallocate the buffer directly into `AioResult::data`; in case of errors, this buffer is cleared before returning


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
