### PR TITLE
doc/man/radosgw: use underscores in configuration var names

### DIFF
--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -155,9 +155,9 @@ tcp and through unix domain socket:
 	[client.radosgw.gateway]
 	host = {hostname}
 	keyring = /etc/ceph/ceph.client.radosgw.keyring
-	rgw socket path = /var/run/ceph/ceph.radosgw.gateway.fastcgi.sock
-	log file = /var/log/ceph/client.radosgw.gateway.log
-	rgw print continue = false
+	rgw_socket_path = /var/run/ceph/ceph.radosgw.gateway.fastcgi.sock
+	log_file = /var/log/ceph/client.radosgw.gateway.log
+	rgw_print_continue = false
 
 #. Add the following content in the gateway configuration file:
 

--- a/doc/man/8/radosgw.rst
+++ b/doc/man/8/radosgw.rst
@@ -100,10 +100,10 @@ tcp and through unix domain socket:
 	[client.radosgw.gateway]
 	host = {hostname}
 	keyring = /etc/ceph/ceph.client.radosgw.keyring
-	rgw socket path = ""
-	log file = /var/log/ceph/client.radosgw.gateway.log
-	rgw frontends = fastcgi socket_port=9000 socket_host=0.0.0.0
-	rgw print continue = false
+	rgw_socket_path = ""
+	log_file = /var/log/ceph/client.radosgw.gateway.log
+	rgw_frontends = fastcgi socket_port=9000 socket_host=0.0.0.0
+	rgw_print_continue = false
 
 #. Add the following content in the gateway configuration file:
 
@@ -223,11 +223,11 @@ which case it is accounted under the operating user.
 Following is an example configuration::
 
         [client.radosgw.gateway]
-            rgw enable usage log = true
-            rgw usage log tick interval = 30
-            rgw usage log flush threshold = 1024
-            rgw usage max shards = 32
-            rgw usage max user shards = 1
+            rgw_enable_usage_log = true
+            rgw_usage_log_tick_interval = 30
+            rgw_usage_log_flush_threshold = 1024
+            rgw_usage_max_shards = 32
+            rgw_usage_max_user_shards = 1
 
 
 The total number of shards determines how many total objects hold the


### PR DESCRIPTION
Most of the documentation already uses underscores instead of spaces in configuration variable names.

Update radosgw(8) man page to follow, changing spaces into underscores.

The radosgw configuration reference in https://docs.ceph.com/en/latest/radosgw/config-ref/ has already been updated to use underscores instead of spaces. But radosgw(8) man page still uses examples with spaces instead of underscores in `ceph.conf` config var names.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
