### PR TITLE
rgw/multisite: disable mdlog async notifications

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2412,7 +2412,7 @@ options:
   long_desc: Length of time (in milliseconds) in which the master zone aggregates
     all the metadata changes that occurred, before sending notifications to all the
     other zones.
-  default: 200
+  default: 0
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/driver/rados/rgw_metadata.cc
+++ b/src/rgw/driver/rados/rgw_metadata.cc
@@ -198,6 +198,10 @@ int RGWMetadataLog::unlock(const DoutPrefixProvider *dpp, int shard_id, string& 
 
 void RGWMetadataLog::mark_modified(int shard_id)
 {
+  if (!cct->_conf->rgw_md_notify_interval_msec) {
+    return;
+  }
+
   lock.get_read();
   if (modified_shards.find(shard_id) != modified_shards.end()) {
     lock.unlock();

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1208,9 +1208,11 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp, optional_yield y)
   }
 
   if (svc.zone->is_meta_master()) {
-    auto md_log = svc.mdlog->get_log(current_period.get_id());
-    meta_notifier = new RGWMetaNotifier(this, md_log);
-    meta_notifier->start();
+    if (cct->_conf->rgw_md_notify_interval_msec) {
+      auto md_log = svc.mdlog->get_log(current_period.get_id());
+      meta_notifier = new RGWMetaNotifier(this, md_log);
+      meta_notifier->start();
+    }
   }
 
   /* init it anyway, might run sync through radosgw-admin explicitly */


### PR DESCRIPTION
With async notifications enabled, zones would excessively poll master zone to clone metadata log preventing the 20 second sleep interval between the RGWCloneMetaLogCoroutine() calls. This pr disables mdlog async notifications. They are not required for a successful metadata sync.

https://tracker.ceph.com/issues/61743



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
