### PR TITLE
MDSAuthCaps: minor improvements

### DIFF
--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -33,6 +33,7 @@
 using std::ostream;
 using std::string;
 using std::vector;
+using std::string_view;
 namespace qi = boost::spirit::qi;
 namespace ascii = boost::spirit::ascii;
 namespace phoenix = boost::phoenix;
@@ -142,7 +143,7 @@ void MDSCapMatch::normalize_path()
   // drop ..
 }
 
-bool MDSCapMatch::match(std::string_view target_path,
+bool MDSCapMatch::match(string_view target_path,
 			const int caller_uid,
 			const int caller_gid,
 			const vector<uint64_t> *caller_gid_list) const
@@ -174,7 +175,7 @@ bool MDSCapMatch::match(std::string_view target_path,
   return true;
 }
 
-bool MDSCapMatch::match_path(std::string_view target_path) const
+bool MDSCapMatch::match_path(string_view target_path) const
 {
   if (path.length()) {
     if (target_path.find(path) != 0)
@@ -200,7 +201,7 @@ void MDSCapGrant::parse_network()
  * Is the client *potentially* able to access this path?  Actual
  * permission will depend on uids/modes in the full is_capable.
  */
-bool MDSAuthCaps::path_capable(std::string_view inode_path) const
+bool MDSAuthCaps::path_capable(string_view inode_path) const
 {
   for (const auto &i : grants) {
     if (i.match.match_path(inode_path)) {
@@ -218,7 +219,7 @@ bool MDSAuthCaps::path_capable(std::string_view inode_path) const
  * This is true if any of the 'grant' clauses in the capability match the
  * requested path + op.
  */
-bool MDSAuthCaps::is_capable(std::string_view inode_path,
+bool MDSAuthCaps::is_capable(string_view inode_path,
 			     uid_t inode_uid, gid_t inode_gid,
 			     unsigned inode_mode,
 			     uid_t caller_uid, gid_t caller_gid,
@@ -338,7 +339,7 @@ void MDSAuthCaps::set_allow_all()
 				 {}));
 }
 
-bool MDSAuthCaps::parse(std::string_view str, ostream *err)
+bool MDSAuthCaps::parse(string_view str, ostream *err)
 {
   // Special case for legacy caps
   if (str == "allow") {

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -79,11 +79,11 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
 	     (uid >> gidlist)[_val = phoenix::construct<MDSCapMatch>(_1, _2)] |
 	     (path >> uid >> gidlist)[_val = phoenix::construct<MDSCapMatch>(_1, _2, _3)] |
              (fs_name >> path)[_val = phoenix::construct<MDSCapMatch>(_2, _1)] |
-             (fs_name >> root_squash)[_val = phoenix::construct<MDSCapMatch>(std::string(), _1, _2)] |
-             (path >> root_squash)[_val = phoenix::construct<MDSCapMatch>(_1, std::string(), _2)] |
+             (fs_name >> root_squash)[_val = phoenix::construct<MDSCapMatch>(string(), _1, _2)] |
+             (path >> root_squash)[_val = phoenix::construct<MDSCapMatch>(_1, string(), _2)] |
              (path)[_val = phoenix::construct<MDSCapMatch>(_1)] |
-             (root_squash)[_val = phoenix::construct<MDSCapMatch>(std::string(), std::string(), _1)] |
-             (fs_name)[_val = phoenix::construct<MDSCapMatch>(std::string(),
+             (root_squash)[_val = phoenix::construct<MDSCapMatch>(string(), string(), _1)] |
+             (fs_name)[_val = phoenix::construct<MDSCapMatch>(string(),
 							      _1)]);
 
     // capspec = * | r[w][f][p][s]
@@ -123,11 +123,11 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
   qi::rule<Iterator, bool()> root_squash;
   qi::rule<Iterator, MDSCapSpec()> capspec;
   qi::rule<Iterator, uint32_t()> uid;
-  qi::rule<Iterator, std::vector<uint32_t>() > uintlist;
-  qi::rule<Iterator, std::vector<uint32_t>() > gidlist;
+  qi::rule<Iterator, vector<uint32_t>() > uintlist;
+  qi::rule<Iterator, vector<uint32_t>() > gidlist;
   qi::rule<Iterator, MDSCapMatch()> match;
   qi::rule<Iterator, MDSCapGrant()> grant;
-  qi::rule<Iterator, std::vector<MDSCapGrant>()> grants;
+  qi::rule<Iterator, vector<MDSCapGrant>()> grants;
   qi::rule<Iterator, MDSAuthCaps()> mdscaps;
 };
 
@@ -366,7 +366,7 @@ bool MDSAuthCaps::parse(string_view str, ostream *err)
 
     if (err)
       *err << "mds capability parse failed, stopped at '"
-	   << std::string(iter, end)
+	   << string(iter, end)
            << "' of '" << str << "'";
     return false; 
   }


### PR DESCRIPTION
1. Since std::string and std::vector has been imported into MDSAuthCaps's
   namespace, write "string" and "vector" instead of "std::string" and
   "std::vector" to use them.

2. Import std::string_view into MDSAuthCaps's namespace and write
   "string_view" instead of "std::string_view" to use it.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>