### PR TITLE
mds: add ceph.dir.bal.mask vxattr for MDS Balancer

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -337,7 +337,7 @@ class CephFSTestCase(CephTestCase):
 
     def _get_subtrees(self, status=None, rank=None, path=None):
         if path is None:
-            path = "/"
+            path = "/"  # everything below root but not root
         try:
             with contextutil.safe_while(sleep=1, tries=3) as proceed:
                 while proceed():
@@ -351,7 +351,16 @@ class CephFSTestCase(CephTestCase):
                                 subtrees += s
                         else:
                             subtrees = self.fs.rank_asok(["get", "subtrees"], status=status, rank=rank)
-                        subtrees = filter(lambda s: s['dir']['path'].startswith(path), subtrees)
+                        def match(s):
+                            if path == "" and s['dir']['path'] == "":
+                                return True
+                            elif path == "" and s['dir']['path'].startswith("/"):
+                                return True
+                            elif path != "" and s['dir']['path'].startswith(path):
+                                return True
+                            else:
+                                return False
+                        subtrees = filter(match, subtrees)
                         return list(subtrees)
                     except CommandFailedError as e:
                         # Sometimes we get transient errors
@@ -363,6 +372,8 @@ class CephFSTestCase(CephTestCase):
             raise RuntimeError(f"could not get subtree state from rank {rank}") from e
 
     def _wait_subtrees(self, test, status=None, rank=None, timeout=30, sleep=2, action=None, path=None):
+        log.info(f'_wait_subtrees test={test} status={status} rank={rank} timeout={timeout} '
+                 f'sleep={sleep} action={action} path={path}')
         test = sorted(test)
         try:
             with contextutil.safe_while(sleep=sleep, tries=timeout//sleep) as proceed:
@@ -418,6 +429,16 @@ class CephFSTestCase(CephTestCase):
                         return subtrees
         except contextutil.MaxWhileTries as e:
             raise RuntimeError("rank {0} failed to reach desired subtree state".format(rank)) from e
+
+    def _wait_xattrs(self, mount, path, key, exp):
+        try:
+            with contextutil.safe_while(sleep=5, tries=20) as proceed:
+                while proceed():
+                    value = mount.getfattr(path, key)
+                    if value == exp:
+                        return value
+        except contextutil.MaxWhileTries as e:
+            raise RuntimeError("client failed to get desired value with key {0}".format(key)) from e
 
     def create_client(self, client_id, moncap=None, osdcap=None, mdscap=None):
         if not (moncap or osdcap or mdscap):

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -668,6 +668,9 @@ class FilesystemBase(MDSClusterBase):
     def set_bal_rank_mask(self, bal_rank_mask):
         self.set_var("bal_rank_mask", bal_rank_mask)
 
+    def set_balance_automate(self, yes):
+        self.set_var("balance_automate", yes)
+
     def set_refuse_client_session(self, yes):
         self.set_var("refuse_client_session", yes)
 

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -814,3 +814,366 @@ class TestKillExports(CephFSTestCase):
 
             # failed if buggy
             self.mount_a.ls()
+
+class TestBalMask(CephFSTestCase):
+    MDSS_REQUIRED = 3
+
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+
+        self.fs.set_max_mds(self.MDSS_REQUIRED)
+        self.status = self.fs.wait_for_daemons()
+        if self.fs.get_var("max_mds") < 3:
+            self.skipTest("Require three MDSes")
+        self.fs.set_balance_automate(True)
+        self.mount_a.run_shell_payload("mkdir -p 1/a")
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_set_to_only_invalid_value_for_subdir(self):
+        """
+        That passing invalid values leads to a command failure.
+        """
+        MAX_MDS = 256
+        invalid_values = list(map(str, [-2,MAX_MDS, MAX_MDS+1]))
+        for value in invalid_values:
+            try:
+                self.mount_a.setfattr("1", "ceph.dir.bal.mask", value)
+            except CommandFailedError as e:
+                self.assertEqual(e.exitstatus, 1)
+
+    def test_set_to_mix_invalid_value_for_subdir(self):
+        """
+        That combining valid and invalid values results in a command failure.
+        """
+        MAX_MDS = 256
+        valid_values = list(map(str, [0, 1]))
+        invalid_values = list(map(str, [-2, MAX_MDS, MAX_MDS+1]))
+        invalid_values = [f'{pair[1]},{pair[1]}' for pair in zip(invalid_values, valid_values)]
+        for value in invalid_values:
+            try:
+                self.mount_a.setfattr("1", "ceph.dir.bal.mask", value)
+            except CommandFailedError as e:
+                self.assertEqual(e.exitstatus, 1)
+
+    def test_distribute_directory_to_multiple_ranks(self):
+        """
+        That bal.mask distributes a directory to multiple ranks.
+        """
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1,2")
+        for i in range(10):
+            self.mount_a.run_shell_payload(f"mkdir -p 1/{i}")
+            self.mount_a.create_n_files(f"1/{i}/file", 100, sync=True)
+
+        time.sleep(15)
+
+        subtrees = self._get_subtrees(status=self.status, rank='all', path="/1")
+        hit_ranks = set([s['auth_first'] for s in subtrees])
+        self.assertEqual(set([1,2]), hit_ranks)
+
+    def test_set_to_single_valid_value_for_subdir(self):
+        """
+        That vaild value is passed.
+        """
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+    def test_set_to_multiple_valid_values_for_subdir(self):
+        """
+        That multiple vaild values are passed.
+        The root of the subtree is moved to the lowest rank
+        among multiple rank values.
+        """
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "0,1")
+        self._wait_subtrees([('/1', 0)], status=self.status)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1,2")
+        self._wait_subtrees([('/1', 1)], status=self.status)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "0,2")
+        self._wait_subtrees([('/1', 0)], status=self.status)
+
+    def test_set_to_invalid_value_for_root(self):
+        """
+        That the root directory must always include rank 0.
+        Otherwise, it will result in a command failure.
+        """
+
+        try:
+            self.mount_a.setfattr("", "ceph.dir.bal.mask", "1")
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, 1)
+
+        try:
+            self.mount_a.setfattr("", "ceph.dir.bal.mask", "2")
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, 1)
+
+        try:
+            self.mount_a.setfattr("", "ceph.dir.bal.mask", "1,2")
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, 1)
+
+    def test_set_to_valid_value_for_root(self):
+        """
+        That the root directory must always include rank 0.
+        """
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0,1")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0,2")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0,1,2")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+
+    def test_override_ceph_fs_set_bal_rank_mask(self):
+        """
+        That ceph.dir.bal.mask overrides mdsmap's bal_rank_mask.
+        The bal_rank_mask is originally set to 0x1, which confines all workloads to rank 0.
+        By overriding it with ceph.dir.bal.mask at 0,1, you can now examine sub-trees like /1 on rank 1.
+        """
+        bal_rank_mask = '0x1'
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0,1")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        found = False
+        for i in range(10):
+            self.mount_a.create_n_files("1/file", 100, sync=True)
+            self.mount_a.create_n_files("file", 100, sync=True)
+
+            try:
+                self._wait_subtrees([('/1', 1)], status=self.status, timeout=10)
+                found = True
+                break
+            except:
+                pass
+
+        self.assertEqual(found, True)
+
+    def test_rank_mask_override_pin(self):
+        """
+        That ceph.dir.bal.mask overrides ceph.dir.pin.
+        """
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+        self.mount_a.setfattr("1/a", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 1), ('/1/a', 2)], status=self.status, rank=2)
+
+    def test_pin_override_rank_mask_simple(self):
+        """
+        That ceph.dir.pin overrides ceph.dir.bal.mask.
+        """
+        self.mount_a.run_shell(["touch", "1/a/file"])
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+        self.mount_a.setfattr("1/a", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 1),('/1/a', 2)], status=self.status, rank=2)
+
+    def test_pin_override_rank_mask_mix(self):
+        """
+        That ceph.dir.pin overrides ceph.dir.bal.mask in the same directory.
+        ceph.dir.pin has higher priority.
+        """
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+        self.mount_a.setfattr("1", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status, rank=2)
+
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status, rank=2)
+
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
+        self._wait_subtrees([('/1', 2)], status=self.status, rank=2)
+
+    def test_ephemeral_pin_overried_rank_mask(self):
+        """
+        That ephemeral pin overrides ceph.dir.bal.mask
+        """
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status, rank=2)
+        self.mount_a.create_n_files("1/file", 100, sync=True)
+        time.sleep(10)
+
+        self.config_set('mds', 'mds_export_ephemeral_distributed', True)
+        self.mount_a.setfattr("1", "ceph.dir.pin.distributed", "1")
+        self.mount_a.create_n_files("1/file", 100, sync=True)
+        subtrees = self._wait_distributed_subtrees(3 * 2, status=self.status, rank="all")
+        for s in subtrees:
+            path = s['dir']['path']
+            if path == '/1':
+                self.assertTrue(s['distributed_ephemeral_pin'])
+                self.assertEqual(s['bal_rank_mask'], "2")
+
+    def test_ephemeral_random_overried_rank_mask(self):
+        """
+        that ephemeral random overrides ceph.dir.bal.mask.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        count = 10
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        for i in range(count):
+            self.mount_a.create_n_files("1/file", 10, sync=True)
+        self._wait_subtrees([('/1', 2)], status=self.status, rank=2)
+
+        self.mount_a.setfattr("1", "ceph.dir.pin.random", "1.0")
+        # timing issue
+        # Sometimes, there might be a delay in the synchronization of export_ephemeral_random_pin.
+        time.sleep(10)
+        for i in range(count):
+            self.mount_a.run_shell_payload(f"mkdir -p 1/{i}")
+            self.mount_a.create_n_files(f"1/{i}/file", 10, sync=True)
+
+        self._wait_random_subtrees(count, status=self.status, rank="all")
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        for i in range(count):
+            self.mount_a.create_n_files("1/file", 10, sync=True)
+
+        self._wait_random_subtrees(count, status=self.status, rank="all")
+
+    def test_unset_rank_mask(self):
+        """
+        That ceph.dir.bal.mask is unset with -1.
+        """
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        value = self.mount_a.getfattr("1", "ceph.dir.bal.mask")
+        self.assertEqual(value, "2")
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "-1")
+        value = self.mount_a.getfattr("1", "ceph.dir.bal.mask")
+        self.assertEqual(value, None)
+
+    def test_unset_rank_mask_under_nested_root(self):
+        """
+        That ceph.dir.bal.mask is unset under root directory.
+        """
+
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        value = self.mount_a.getfattr("1", "ceph.dir.bal.mask")
+        self.assertEqual(value, "2")
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "-1")
+        value = self.mount_a.getfattr("1", "ceph.dir.bal.mask")
+        self.assertEqual(value, None)
+
+        """
+        After the ceph.dir.bal.mask value of /1 is unset,
+        the /1 subtree is merged with the / root .
+
+        """
+        self.mount_a.setfattr(".", "ceph.dir.bal.mask", "0")
+        self._wait_subtrees([('', 0)], status=self.status, path='')
+
+    def test_unset_rank_mask_under_nested_parent(self):
+        """
+        That ceph.dir.bal.mask is unset under nested directory.
+        """
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/a", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 1), ('/1/a', 2)], status=self.status, rank=2)
+
+        self.mount_a.setfattr("1/a", "ceph.dir.bal.mask", "-1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+    def test_mds_failover(self):
+        """
+        That MDS failover does not affect the ceph.dir.bal.mask.
+        """
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        self._wait_xattrs(self.mount_a, "1", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+        for i in range(5):
+            self.fs.rank_fail(rank=2)
+            self.status = self.fs.wait_for_daemons()
+
+            value = self.mount_a.getfattr("1", "ceph.dir.bal.mask")
+            self.assertEqual(value, "2")
+            self._wait_subtrees([('/1', 2)], status=self.status)
+
+    def test_mds_shrink(self):
+        """
+        That ceph.dir.bal.mask is sustained during reducing MDS.
+        """
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_xattrs(self.mount_a, "1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status)
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+        self._wait_subtrees([('/1', 1)], status=self.status)
+
+    def test_mds_shrink_and_grow(self):
+        """
+        That ceph.dir.bal.mask is sustained during reducing and growing MDS.
+        """
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "2")
+        self._wait_xattrs(self.mount_a, "1", "ceph.dir.bal.mask", "2")
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+        self._wait_subtrees([('/1', 0)], status=self.status)
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+        self._wait_subtrees([('/1', 2)], status=self.status)
+
+    def test_mds_grow(self):
+        """
+        That ceph.dir.bal.mask is sustained during growing MDS.
+        """
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.setfattr("1", "ceph.dir.bal.mask", "1")
+        self._wait_xattrs(self.mount_a, "1", "ceph.dir.bal.mask", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, timeout=600)
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+        self._wait_subtrees([('/1', 1)], status=self.status, timeout=600)

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -73,6 +73,7 @@ typedef int32_t mds_rank_t;
 constexpr mds_rank_t MDS_RANK_NONE		= -1;
 constexpr mds_rank_t MDS_RANK_EPHEMERAL_DIST	= -2;
 constexpr mds_rank_t MDS_RANK_EPHEMERAL_RAND	= -3;
+constexpr mds_rank_t MDS_RANK_MASK              = -4;
 
 struct scatter_info_t {
   version_t version = 0;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2885,6 +2885,12 @@ mds_rank_t CDir::get_export_pin(bool inherit) const
   return export_pin;
 }
 
+std::string CDir::get_rank_mask(bool inherit) const
+{
+  CInode *in = inode->get_rank_mask_inode(inherit);
+  return in->get_bal_rank_mask_from_xattrs();
+}
+
 bool CDir::is_exportable(mds_rank_t dest) const
 {
   mds_rank_t export_pin = get_export_pin();

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -517,6 +517,7 @@ public:
 
   // -- import/export --
   mds_rank_t get_export_pin(bool inherit=true) const;
+  std::string get_rank_mask(bool inherit=true) const;
   bool is_exportable(mds_rank_t dest) const;
 
   void encode_export(ceph::buffer::list& bl);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -512,6 +512,9 @@ CInode::projected_inode CInode::project_inode(const MutationRef& mut,
 void CInode::pop_and_dirty_projected_inode(LogSegmentRef const& ls, const MutationRef& mut)
 {
   ceph_assert(!projected_nodes.empty());
+
+  bool bal_rank_mask_updated = get_bal_rank_mask_from_xattrs(true) != get_bal_rank_mask_from_xattrs(false);
+
   auto front = std::move(projected_nodes.front());
   dout(15) << __func__ << " v" << front.inode->version << dendl;
 
@@ -537,7 +540,7 @@ void CInode::pop_and_dirty_projected_inode(LogSegmentRef const& ls, const Mutati
   if (get_inode()->is_backtrace_updated())
     mark_dirty_parent(ls, pool_updated);
 
-  if (pin_updated)
+  if (pin_updated || bal_rank_mask_updated)
     maybe_export_pin(true);
 }
 
@@ -2179,6 +2182,8 @@ void CInode::encode_lock_ixattr(bufferlist& bl)
 
 void CInode::decode_lock_ixattr(bufferlist::const_iterator& p)
 {
+  std::string prev_bal_rank_mask = get_bal_rank_mask_from_xattrs(false);
+
   ceph_assert(!is_auth());
   auto _inode = allocate_inode(*get_inode());
   DECODE_START(2, p);
@@ -2193,6 +2198,9 @@ void CInode::decode_lock_ixattr(bufferlist::const_iterator& p)
   }
   DECODE_FINISH(p);
   reset_inode(std::move(_inode));
+
+  std::string bal_rank_mask = get_bal_rank_mask_from_xattrs(false);
+  maybe_export_pin(prev_bal_rank_mask != bal_rank_mask);
 }
 
 void CInode::encode_lock_isnap(bufferlist& bl)
@@ -5543,6 +5551,8 @@ void CInode::queue_export_pin(mds_rank_t export_pin)
     target = export_pin;
   else if (export_pin == MDS_RANK_EPHEMERAL_RAND)
     target = mdcache->hash_into_rank_bucket(ino());
+  else if (export_pin == MDS_RANK_MASK)
+    target = MDS_RANK_MASK;
   else
     target = MDS_RANK_NONE;
 
@@ -5597,8 +5607,18 @@ void CInode::maybe_export_pin(bool update)
   dout(15) << __func__ << " update=" << update << " " << *this << dendl;
 
   mds_rank_t export_pin = get_export_pin(false);
-  if (export_pin == MDS_RANK_NONE && !update)
+  if (export_pin == MDS_RANK_NONE && !update) {
     return;
+  }
+
+  if (export_pin == MDS_RANK_NONE) {
+    CInode *in = get_rank_mask_inode(false);
+    std::string bal_rank_mask = in->get_bal_rank_mask_from_xattrs();
+    if (bal_rank_mask.size() == 0 && !update) {
+     return;
+    }
+    export_pin = MDS_RANK_MASK;
+  }
 
   check_pin_policy(export_pin);
   queue_export_pin(export_pin);
@@ -5693,6 +5713,59 @@ void CInode::setxattr_ephemeral_dist(bool val)
 {
   ceph_assert(is_dir());
   _get_projected_inode()->set_ephemeral_distributed_pin(val);
+}
+
+std::string CInode::get_bal_rank_mask_from_xattrs(bool projected_node)
+{
+  const auto& pxattrs = (projected_node && !projected_nodes.empty())
+                        ? projected_nodes.front().xattrs : get_xattrs();
+  if (pxattrs) {
+    auto it = pxattrs->find("ceph.dir.bal.mask");
+    if (it != pxattrs->end()) {
+        std::string val(it->second.c_str(), it->second.length());
+        return val;
+    }
+  }
+  return "";
+}
+
+CInode *CInode::get_rank_mask_inode(bool inherit)
+{
+  if (!mdcache->get_bal_export_pin())
+    return this;
+
+  CInode *in = this;
+  const CDir *dir = nullptr;
+  std::string bal_rank_mask;
+
+  while (true) {
+    if (in->is_system()) {
+      break;
+    }
+
+    const CDentry *pdn = in->get_parent_dn();
+    if (!pdn) {
+      break;
+    }
+
+    if (in->get_inode()->nlink == 0) {
+      // ignore export pin for unlinked directory
+      break;
+    }
+
+    bal_rank_mask = in->get_bal_rank_mask_from_xattrs();
+    if (bal_rank_mask.size()) {
+      break;
+    }
+
+    if (!inherit) {
+      break;
+    }
+    dir = pdn->get_dir();
+    in = dir->inode;
+  }
+
+  return in;
 }
 
 void CInode::set_export_pin(mds_rank_t rank)

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1015,6 +1015,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   charmap_md_t<mempool::mds_co::pool_allocator> const* get_charmap() const;
 
+  CInode *get_rank_mask_inode(bool inherit=true);
   mds_rank_t get_export_pin(bool inherit=true) const;
   void check_pin_policy(mds_rank_t target);
   void set_export_pin(mds_rank_t rank);
@@ -1032,6 +1033,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   double get_ephemeral_rand() const;
   void maybe_ephemeral_rand(double threshold=-1.0);
   void setxattr_ephemeral_rand(double prob=0.0);
+  std::string get_bal_rank_mask_from_xattrs(bool projected_node=true);
   bool is_ephemeral_rand() const {
     return state_test(STATE_RANDEPHEMERALPIN);
   }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -35,6 +35,8 @@
 #include <vector>
 #include <map>
 
+#include <boost/tokenizer.hpp>
+
 using namespace std;
 
 #include "common/config.h"
@@ -142,7 +144,50 @@ void MDBalancer::handle_conf_change(const std::set<std::string>& changed, const 
 
 bool MDBalancer::test_rank_mask(mds_rank_t rank)
 {
-  return mds->mdsmap->get_bal_rank_mask_bitset().test(rank);
+  return bal_rank_mask_bitset.test(rank);
+}
+
+void MDBalancer::handle_rank_mask(void)
+{
+  dout(20) << " start " << dendl;
+  mds->mdsmap->update_num_mdss_in_rank_mask_bitset();
+  std::vector<CDir*> authsubs = mds->mdcache->get_auth_subtrees();
+  for (auto &cd : authsubs) {
+    if (cd->inode->is_system() || cd->inode->is_root()) {
+      continue;
+    }
+
+    mds_rank_t export_pin = cd->inode->get_export_pin(false);
+    dout(7) << "export_pin " << export_pin << " " << cd->get_path() << dendl;
+
+    if (export_pin != MDS_RANK_NONE && export_pin != MDS_RANK_MASK)
+      continue;
+
+    max_mds_bitset_t rank_mask_bitset;
+    int r = get_rank_mask_bitset(cd, rank_mask_bitset);
+    if (r != 0) {
+      continue;
+    }
+
+    dout(7) << "rank_mask_bitset " << bitmask_to_str(rank_mask_bitset) << " " << cd->get_path() << dendl;
+    ceph_assert(rank_mask_bitset.count());
+
+    mds_rank_t target = -1;
+    for (mds_rank_t mds_rank = 0; mds_rank < mds->mdsmap->get_max_mds(); mds_rank++) {
+      if (rank_mask_bitset.test(mds_rank)) {
+        target = mds_rank;
+        break;
+      }
+    }
+
+    if (rank_mask_bitset.test(cd->authority().first) == false && 
+        target != mds->get_nodeid() && 
+        target >= 0 && 
+        target < mds->mdsmap->get_max_mds()) { 
+      dout(7) << "try to export nicely " << cd->get_path() << " auth " << cd->authority().first << " to " << target << " mask " << bitmask_to_str(rank_mask_bitset) << dendl;
+      mds->mdcache->migrator->export_dir_nicely(cd, target);
+    } 
+  }
 }
 
 void MDBalancer::handle_export_pins(void)
@@ -159,6 +204,12 @@ void MDBalancer::handle_export_pins(void)
     ceph_assert(in->is_dir());
 
     mds_rank_t export_pin = in->get_export_pin(false);
+    if (export_pin == MDS_RANK_NONE) {
+      CInode *pin = in->get_rank_mask_inode(false);
+      std::string bal_rank_mask = pin->get_bal_rank_mask_from_xattrs();
+      if (bal_rank_mask.size())
+        export_pin = MDS_RANK_MASK;
+    }
     in->check_pin_policy(export_pin);
 
     if (export_pin >= max_mds) {
@@ -171,7 +222,6 @@ void MDBalancer::handle_export_pins(void)
       continue;
     }
 
-    dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
     unsigned min_frag_bits = 0;
     mds_rank_t target = MDS_RANK_NONE;
     if (export_pin >= 0)
@@ -180,6 +230,10 @@ void MDBalancer::handle_export_pins(void)
       target = mdcache->hash_into_rank_bucket(in->ino());
     else if (export_pin == MDS_RANK_EPHEMERAL_DIST)
       min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+    else if (export_pin == MDS_RANK_MASK)
+      target = MDS_RANK_MASK;
+
+    dout(20) << " executing export_pin=" << export_pin << " on " << *in << " target " << target << dendl;
 
     bool remove = true;
     for (auto&& dir : in->get_dirfrags()) {
@@ -209,7 +263,7 @@ void MDBalancer::handle_export_pins(void)
 	  dir->state_clear(CDir::STATE_AUXSUBTREE);
 	  mds->mdcache->try_subtree_merge(dir);
 	}
-      } else if (target == mds->get_nodeid()) {
+      } else if (target == mds->get_nodeid() || target == MDS_RANK_MASK) {
         if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
           ceph_assert(dir->is_subtree_root());
         } else if (dir->state_test(CDir::STATE_CREATING) ||
@@ -260,6 +314,8 @@ void MDBalancer::handle_export_pins(void)
       export_pin = mdcache->hash_into_rank_bucket(cd->ino(), cd->get_frag());
     } else if (export_pin == MDS_RANK_EPHEMERAL_RAND) {
       export_pin = mdcache->hash_into_rank_bucket(cd->ino());
+    } else if (export_pin == MDS_RANK_MASK) {
+      export_pin = MDS_RANK_MASK;
     }
 
     if (print_auth_subtrees)
@@ -279,6 +335,7 @@ void MDBalancer::tick()
 
   if (bal_export_pin) {
     handle_export_pins();
+    handle_rank_mask();
   }
 
   // sample?
@@ -503,6 +560,85 @@ void MDBalancer::send_heartbeat()
   }
 }
 
+int MDBalancer::rank_mask_list_str_to_bitset(CInode *cur, std::string& rank_mask_list_str, max_mds_bitset_t& rank_mask_bitset, std::ostream& ss)
+{
+  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  boost::char_separator<char> sep{","};
+  tokenizer tokens{rank_mask_list_str, sep};
+  bool rank0_involved = false;
+  max_mds_bitset_t temp_mask_bitset;
+
+  if (std::distance(tokens.begin(), tokens.end()) == 0) {
+      ss << "bad vxattr value, unable to parse string";
+      return -EINVAL;
+  }
+
+  for (const auto &token : tokens) {
+    try {
+      mds_rank_t rank = std::stoi(token);
+      if (cur->is_root() && rank == 0)
+        rank0_involved = true;
+
+      if (rank < 0 || rank >= MAX_MDS) {
+        ss << "bad vxattr value, unable to parse string";
+        return -EINVAL;
+      }
+      temp_mask_bitset.set(rank);
+    } catch (const std::invalid_argument& e) {
+      ss << "bad vxattr value, unable to parse string";
+      return -EINVAL;
+    }
+  }
+
+  if (cur->is_root() and rank0_involved == false) {
+    ss << "bad vxattr value, rank0 must be set for root dir";
+    return -EINVAL;
+  }
+
+  if (temp_mask_bitset.count() == 0) {
+      ss << "at least one rank must be set";
+      return -EINVAL;
+  }
+
+  rank_mask_bitset = temp_mask_bitset;
+  return 0;
+}
+
+int MDBalancer::get_rank_mask_bitset(CDir *dir, max_mds_bitset_t& rank_mask_bitset, bool inherit)
+{
+  CInode *in = dir->inode->get_rank_mask_inode(inherit);
+  std::string bal_rank_mask = in->get_bal_rank_mask_from_xattrs();
+  int r;
+
+  if (in->is_root() && bal_rank_mask.size() == 0) {
+    rank_mask_bitset = mds->mdsmap->get_bal_rank_mask_bitset();
+    dout(10) << " bal_rank_mask is obtained from mdsmap " << mds->mdsmap->get_num_mdss_in_rank_mask_bitset() << 
+      " " <<
+      mds->mdsmap->get_bal_rank_mask() << dendl;
+    if (rank_mask_bitset.count() == 0) {
+      dout(10) << "at least one rank must be set" << dendl;
+      r = -EINVAL;
+    } else {
+      r = 0;
+    }
+  } else {
+    dout(7) << dir->get_path() << " " << bal_rank_mask << dendl;
+    CachedStackStringStream css;
+    r = rank_mask_list_str_to_bitset(dir->get_inode(), bal_rank_mask, rank_mask_bitset, *css);
+    dout(10) << css->str() << dendl;
+  }
+  return r;
+}
+
+std::string MDBalancer::bitmask_to_str(max_mds_bitset_t& bitmask)
+{
+    std::string mask_str = bitmask.to_string();
+    std::reverse(mask_str.begin(), mask_str.end());
+    mask_str.resize(mds->mdsmap->get_max_mds());
+    std::reverse(mask_str.begin(), mask_str.end());
+    return mask_str;
+}
+
 void MDBalancer::handle_heartbeat(const cref_t<MHeartbeat> &m)
 {
   mds_rank_t who = mds_rank_t(m->get_source().num());
@@ -547,20 +683,49 @@ void MDBalancer::handle_heartbeat(const cref_t<MHeartbeat> &m)
     }
   }
 
-  {
-    auto em = mds_load.emplace(std::piecewise_construct, std::forward_as_tuple(who), std::forward_as_tuple(m->get_load()));
-    if (!em.second) {
-      em.first->second = m->get_load();
-    }
-  }
-  mds_import_map[who] = m->get_import_map();
-
   mds->mdsmap->update_num_mdss_in_rank_mask_bitset();
 
-  if (mds->mdsmap->get_num_mdss_in_rank_mask_bitset() > 0)
+  max_mds_bitset_t my_bal_rank_mask_bitset;
+  std::vector<CDir*> authsubs = mds->mdcache->get_auth_subtrees();
+  int overlap_count = 0;
+  for (auto &cd : authsubs) {
+    max_mds_bitset_t temp_bitset;
+    int r = get_rank_mask_bitset(cd, temp_bitset);
+    if (r != 0)
+      continue;
+
+    dout(10) << " authsubtree bitset mask "<< bitmask_to_str(temp_bitset) << " bit count " << temp_bitset.count() << " auth " << cd->authority().first << " " << cd->get_path() << dendl;
+
+    if (temp_bitset.test(mds->get_nodeid())) {
+      my_bal_rank_mask_bitset |= temp_bitset;
+      overlap_count++;
+      if (overlap_count > 1)
+        dout(10) << " rank_mask overlap subdir " << *cd << dendl;
+    }
+  }
+
+  if (overlap_count > 1) {
+    dout(10) << " bal_rank_mask of multiple subdirectories overlap with the value: " << overlap_count << dendl;
+  }
+
+  bal_rank_mask_bitset = my_bal_rank_mask_bitset;
+  num_mdss_in_rank_mask_bitset = bal_rank_mask_bitset.count();
+
+  if (bal_rank_mask_bitset.test(who)) {
+    {
+        auto em = mds_load.emplace(std::piecewise_construct, std::forward_as_tuple(who), std::forward_as_tuple(m->get_load()));
+        if (!em.second) {
+          em.first->second = m->get_load();
+        }
+    }
+    mds_import_map[who] = m->get_import_map();
+  }
+
+  if (num_mdss_in_rank_mask_bitset)
   {
     unsigned cluster_size = mds->get_mds_map()->get_num_in_mds();
-    if (mds_load.size() == cluster_size) {
+    cluster_size = std::min(cluster_size, num_mdss_in_rank_mask_bitset);
+    if (mds_load.size() == cluster_size && cluster_size > 1) {
       // let's go!
       //export_empties();  // no!
 
@@ -574,6 +739,8 @@ void MDBalancer::handle_heartbeat(const cref_t<MHeartbeat> &m)
       }
       prep_rebalance(m->get_beat());
     }
+  } else {
+    dout(10) << "Nothing to do because rank mask bitset is cleared "<< bitmask_to_str(bal_rank_mask_bitset) << dendl;
   }
 }
 
@@ -789,6 +956,9 @@ void MDBalancer::prep_rebalance(int beat)
     double total_load = 0.0;
     multimap<double,mds_rank_t> load_map;
     for (mds_rank_t i=mds_rank_t(0); i < mds_rank_t(cluster_size); i++) {
+      if (test_rank_mask(i) == false) {
+        continue;
+      }
       mds_load_t& load = mds_load.at(i);
 
       double l = load.mds_load(bal_mode) * load_fac;
@@ -807,7 +977,7 @@ void MDBalancer::prep_rebalance(int beat)
     }
 
     // target load
-    target_load = total_load / (double)mds->mdsmap->get_num_mdss_in_rank_mask_bitset();
+    target_load = total_load / (double)num_mdss_in_rank_mask_bitset;
     dout(7) << "my load " << my_load
 	    << "   target " << target_load
 	    << "   total " << total_load
@@ -846,7 +1016,7 @@ void MDBalancer::prep_rebalance(int beat)
     for (multimap<double,mds_rank_t>::iterator it = load_map.begin();
 	 it != load_map.end();
 	 ++it) {
-      if (it->first < target_load && test_rank_mask(it->second)) {
+      if (it->first < target_load) {
 	dout(15) << "   mds." << it->second << " is importer" << dendl;
 	importers.insert(pair<double,mds_rank_t>(it->first,it->second));
 	importer_set.insert(it->second);
@@ -880,6 +1050,9 @@ void MDBalancer::prep_rebalance(int beat)
 	for (map<mds_rank_t, float>::iterator im = mds_import_map[ex->second].begin();
 	     im != mds_import_map[ex->second].end();
 	     ++im) {
+          if (!test_rank_mask(im->first)) {
+            continue;
+          }
 	  double maxim = get_maxim(state, im->first, target_load);
 	  if (maxim <= .001) continue;
 	  try_match(state, ex->second, maxex, im->first, maxim);
@@ -971,8 +1144,6 @@ int MDBalancer::mantle_prep_rebalance()
   return 0;
 }
 
-
-
 void MDBalancer::try_rebalance(balance_state_t& state)
 {
   if (g_conf()->mds_thrash_exports) {
@@ -989,10 +1160,20 @@ void MDBalancer::try_rebalance(balance_state_t& state)
     CInode *diri = dir->get_inode();
     if (diri->is_mdsdir())
       continue;
-    if (diri->get_export_pin(false) != MDS_RANK_NONE)
+    mds_rank_t export_pin = diri->get_export_pin(false);
+    if (export_pin != MDS_RANK_NONE && export_pin != MDS_RANK_MASK)
       continue;
     if (dir->is_freezing() || dir->is_frozen())
       continue;  // export pbly already in progress
+
+    max_mds_bitset_t rank_mask_bitset;
+    int r = get_rank_mask_bitset(dir, rank_mask_bitset);
+    if (r != 0)
+      continue;
+
+    if (!rank_mask_bitset.test(mds->get_nodeid())) {
+      continue;
+    }
 
     mds_rank_t from = diri->authority().first;
     double pop = dir->pop_auth_subtree.meta_load();

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -57,6 +57,7 @@ public:
   void tick();
 
   void handle_export_pins(void);
+  void handle_rank_mask(void);
 
   void subtract_export(CDir *ex);
   void add_import(CDir *im);
@@ -82,6 +83,10 @@ public:
   void handle_mds_failure(mds_rank_t who);
 
   int dump_loads(Formatter *f, int64_t depth = -1) const;
+  int get_rank_mask_bitset(CDir *dir, max_mds_bitset_t& rank_mask_bitset, bool inherit=true);
+  std::string bitmask_to_str(max_mds_bitset_t& bitmask);
+  void print_auth_subtrees(std::vector<CDir*> authsubs);
+  int rank_mask_list_str_to_bitset(CInode *cur, std::string& rank_mask_list_str, max_mds_bitset_t& rank_mask_bitset, std::ostream& ss);
 
   bool get_bal_export_pin() const {
     return bal_export_pin;
@@ -191,5 +196,9 @@ private:
   // per-epoch state
   double my_load = 0;
   double target_load = 0;
+
+  // rank mask
+  max_mds_bitset_t bal_rank_mask_bitset;
+  uint32_t num_mdss_in_rank_mask_bitset;
 };
 #endif

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -188,6 +188,7 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   export_ephemeral_distributed_config =  g_conf().get_val<bool>("mds_export_ephemeral_distributed");
   export_ephemeral_random_config =  g_conf().get_val<bool>("mds_export_ephemeral_random");
   export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
+  bal_export_pin = g_conf().get_val<bool>("mds_bal_export_pin");
 
   symlink_recovery = g_conf().get_val<bool>("mds_symlink_recovery");
   kill_dirfrag_at = static_cast<enum dirfrag_killpoint>(g_conf().get_val<int64_t>("mds_kill_dirfrag_at"));
@@ -243,6 +244,9 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
   }
   if (changed.count("mds_export_ephemeral_random_max")) {
     export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
+  }
+  if (changed.count("mds_bal_export_pin")) {
+    bal_export_pin = g_conf().get_val<bool>("mds_bal_export_pin");
   }
 
   if (changed.count("mds_kill_dirfrag_at")) {
@@ -1041,12 +1045,23 @@ void MDCache::try_subtree_merge(CDir *dir)
   auto oldbounds = subtrees.at(dir);
 
   set<CInode*> to_eval;
-  // try merge at my root
-  try_subtree_merge_at(dir, &to_eval);
+
+  max_mds_bitset_t rank_mask_bitset;
+  int r = mds->balancer->get_rank_mask_bitset(dir, rank_mask_bitset, false);
+  if (r != 0) {
+    // try merge at my root
+    try_subtree_merge_at(dir, &to_eval);
+  }
 
   // try merge at my old bounds
-  for (auto bound : oldbounds)
+  for (auto bound : oldbounds) {
+    rank_mask_bitset.reset();
+    int r = mds->balancer->get_rank_mask_bitset(bound, rank_mask_bitset, false);
+    if (r == 0 && rank_mask_bitset.count()) {
+      continue;
+    }
     try_subtree_merge_at(bound, &to_eval);
+  }
 
   if (!(mds->is_any_replay() || mds->is_resolve())) {
     for(auto in : to_eval)
@@ -1071,8 +1086,15 @@ void MDCache::try_subtree_merge_at(CDir *dir, set<CInode*> *to_eval, bool adjust
   if (!dir->inode->is_base())
     parent = get_subtree_root(dir->get_parent_dir());
   
+  max_mds_bitset_t rank_mask_bitset;
+  int r = mds->balancer->get_rank_mask_bitset(dir, rank_mask_bitset, false);
+  bool has_mask = false;
+  if (r == 0 && rank_mask_bitset.count()) {
+    has_mask = true;
+  }
+
   if (parent != dir &&				// we have a parent,
-      parent->dir_auth == dir->dir_auth) {	// auth matches,
+      parent->dir_auth == dir->dir_auth && has_mask == false) {	// auth matches,
     // merge with parent.
     dout(10) << "  subtree merge at " << *dir << dendl;
     dir->set_dir_auth(CDIR_AUTH_DEFAULT);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -268,6 +268,10 @@ class MDCache {
     return use_global_snaprealm_seq;
   }
 
+  bool get_bal_export_pin(void) const {
+    return bal_export_pin;
+  }
+
   /**
    * Call this when you know that a CDentry is ready to be passed
    * on to StrayManager (i.e. this is a stray you've just created)
@@ -1583,6 +1587,7 @@ private:
   bool export_ephemeral_distributed_config;
   bool export_ephemeral_random_config;
   unsigned export_ephemeral_dist_frag_bits;
+  bool bal_export_pin;
 
   // Stores the symlink target on the file object's head
   bool symlink_recovery;

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -1344,7 +1344,7 @@ void MDSMap::set_min_compat_client(ceph_release_t version)
   required_client_features = feature_bitset_t(bits);
 }
 
-const std::bitset<MAX_MDS>& MDSMap::get_bal_rank_mask_bitset() const {
+const max_mds_bitset_t& MDSMap::get_bal_rank_mask_bitset() const {
   return bal_rank_mask_bitset;
 }
 
@@ -1375,7 +1375,7 @@ void MDSMap::update_num_mdss_in_rank_mask_bitset()
 
     r = hex2bin(bal_rank_mask, bin_string, MAX_MDS, *css);
     if (r == 0) {
-      auto _mds_bal_mask_bitset = std::bitset<MAX_MDS>(bin_string);
+      auto _mds_bal_mask_bitset = max_mds_bitset_t(bin_string);
       bal_rank_mask_bitset = _mds_bal_mask_bitset;
       num_mdss_in_rank_mask_bitset = _mds_bal_mask_bitset.count();
     } else {
@@ -1384,14 +1384,16 @@ void MDSMap::update_num_mdss_in_rank_mask_bitset()
   }
 
   if (r == -EINVAL) {
+    bal_rank_mask_bitset.reset();
     if (check_special_bal_rank_mask(bal_rank_mask, BAL_RANK_MASK_TYPE_NONE)) {
       dout(10) << "Balancer is disabled with bal_rank_mask " << bal_rank_mask << dendl;
-      bal_rank_mask_bitset.reset();
       num_mdss_in_rank_mask_bitset = 0;
     } else {
       dout(10) << "Balancer distributes mds workloads to all ranks as bal_rank_mask is empty or invalid" << dendl;
-      bal_rank_mask_bitset.set();
-      num_mdss_in_rank_mask_bitset = get_max_mds();
+      for (mds_rank_t mds_rank = 0; mds_rank < get_max_mds(); mds_rank++) {
+        bal_rank_mask_bitset.set(mds_rank);
+      }
+      num_mdss_in_rank_mask_bitset = bal_rank_mask_bitset.count();
     }
   }
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -298,11 +298,12 @@ public:
   const std::string get_balancer() const { return balancer; }
   void set_balancer(std::string val) { balancer.assign(val); }
 
-  const std::bitset<MAX_MDS>& get_bal_rank_mask_bitset() const;
+  const max_mds_bitset_t& get_bal_rank_mask_bitset() const;
   void set_bal_rank_mask(std::string val);
   unsigned get_num_mdss_in_rank_mask_bitset() const { return num_mdss_in_rank_mask_bitset; }
   void update_num_mdss_in_rank_mask_bitset();
   int hex2bin(std::string hex_string, std::string &bin_string, unsigned int max_bits, std::ostream& ss) const;
+  std::string get_bal_rank_mask() const { return bal_rank_mask; }
 
   typedef enum
   {
@@ -628,7 +629,7 @@ protected:
   std::string balancer;    /* The name/version of the mantle balancer (i.e. the rados obj name) */
 
   std::string bal_rank_mask = "-1";
-  std::bitset<MAX_MDS> bal_rank_mask_bitset;
+  max_mds_bitset_t bal_rank_mask_bitset;
   uint32_t num_mdss_in_rank_mask_bitset;
 
   std::set<mds_rank_t> in;              // currently defined cluster

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3283,6 +3283,7 @@ void MDSRank::command_get_subtrees(Formatter *f)
 	f->dump_int("export_pin", export_pin >= 0 ? export_pin : -1);
 	f->dump_bool("distributed_ephemeral_pin", export_pin == MDS_RANK_EPHEMERAL_DIST);
 	f->dump_bool("random_ephemeral_pin", export_pin == MDS_RANK_EPHEMERAL_RAND);
+	f->dump_string("bal_rank_mask", dir->inode->get_bal_rank_mask_from_xattrs());
       }
       f->dump_int("export_pin_target", dir->get_export_pin(false));
       f->open_object_section("dir");

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -27,6 +27,7 @@
 #include <boost/config/warning_disable.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "MDSRank.h"
 #include "Locker.h"
@@ -6877,6 +6878,13 @@ const Server::XattrHandler Server::xattr_handlers[] = {
     setxattr: &Server::mirror_info_setxattr_handler,
     removexattr: &Server::mirror_info_removexattr_handler
   },
+  {
+    xattr_name: "ceph.dir.bal.mask",
+    description: "balancer mask xattr handler",
+    validate: &Server::bal_rank_mask_xattr_validate,
+    setxattr: &Server::bal_rank_mask_setxattr_handler,
+    removexattr: &Server::default_removexattr_handler
+  },
 };
 
 const Server::XattrHandler* Server::get_xattr_or_default_handler(std::string_view xattr_name) {
@@ -7043,6 +7051,39 @@ void Server::mirror_info_removexattr_handler(CInode *cur, InodeStoreBase::xattr_
                                              const XattrOp &xattr_op) {
   xattr_rm(xattrs, Server::MirrorXattrInfo::CLUSTER_ID);
   xattr_rm(xattrs, Server::MirrorXattrInfo::FS_ID);
+}
+
+int Server::bal_rank_mask_xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_ptr xattrs,
+                                       XattrOp *xattr_op) {
+  int r = xattr_validate(cur, xattrs, xattr_op->xattr_name, xattr_op->op, xattr_op->flags);
+  if (r < 0)
+    return r;
+
+  if (xattr_op->op == CEPH_MDS_OP_RMXATTR) {
+    return 0;
+  }
+
+  std::string value = xattr_op->xattr_value.to_str();
+  if (value == "-1")
+    return 0;
+
+  CachedStackStringStream css;
+  max_mds_bitset_t rank_mask_bitset;
+  r = mds->balancer->rank_mask_list_str_to_bitset(cur, value, rank_mask_bitset, *css);
+  if (r != 0) {
+    dout(10) << __func__ << " invalid value " << css->str() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+void Server::bal_rank_mask_setxattr_handler(CInode *cur, InodeStoreBase::xattr_map_ptr xattrs,
+                                      const XattrOp &xattr_op) {
+  if (xattr_op.xattr_value.to_str() != "-1")
+    xattr_set(xattrs, xattr_op.xattr_name, xattr_op.xattr_value);
+  else
+    xattr_rm(xattrs, xattr_op.xattr_name);
 }
 
 void Server::handle_client_setxattr(const MDRequestRef& mdr)

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -491,6 +491,10 @@ private:
                                     const XattrOp &xattr_op);
   void mirror_info_removexattr_handler(CInode *cur, xattr_map_ptr xattrs,
                                        const XattrOp &xattr_op);
+  int bal_rank_mask_xattr_validate(CInode *cur, const xattr_map_const_ptr xattrs,
+                                   XattrOp *xattr_op);
+  void bal_rank_mask_setxattr_handler(CInode *cur, xattr_map_ptr xattrs,
+                                      const XattrOp &xattr_op);
 
   static bool is_ceph_vxattr(std::string_view xattr_name) {
     return xattr_name.rfind("ceph.dir.layout", 0) == 0 ||
@@ -548,7 +552,8 @@ private:
     }
 
     return xattr_name == "ceph.mirror.info" ||
-           xattr_name == "ceph.mirror.dirty_snap_id";
+           xattr_name == "ceph.mirror.dirty_snap_id" ||
+           xattr_name == "ceph.dir.bal.mask";
   }
 
   void reply_client_request(const MDRequestRef& mdr, const ref_t<MClientReply> &reply);

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -419,7 +419,8 @@ void EMetaBlob::add_dir_context(CDir *dir, int mode)
 		!dir->is_ambiguous_dir_auth() &&
 		!dir->state_test(CDir::STATE_EXPORTBOUND) &&
 		!dir->state_test(CDir::STATE_AUXSUBTREE) &&
-		!diri->state_test(CInode::STATE_AMBIGUOUSAUTH)) {
+		!diri->state_test(CInode::STATE_AMBIGUOUSAUTH) && 
+                dir->get_rank_mask(false).size() == 0) {
 	      dout(0) << "EMetaBlob::add_dir_context unexpected subtree " << *dir << dendl;
 	      ceph_abort();
 	    }

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -136,6 +136,8 @@ std::ostream& operator<<(std::ostream &out, const vinodeno_t &vino);
 
 typedef uint32_t damage_flags_t;
 
+typedef std::bitset<MAX_MDS> max_mds_bitset_t;
+
 template<template<typename> class Allocator>
 using alloc_string = std::basic_string<char,std::char_traits<char>,Allocator<char>>;
 


### PR DESCRIPTION
tracker: https://tracker.ceph.com/issues/61777

**Introduction**
This PR introduces the ceph.dir.bal.mask vxattr, which is an option to rebalance a subtree within specific active MDSs. Similar to the CPU mask, this feature enables load balancing of specific directories across multiple MDS ranks. It is especially useful for fine-tuning and improving performance in various scenarios. Previously, the bal_rank_mask in https://github.com/ceph/ceph/pull/43284 supports isolating unpinned subtrees under the root directory ('/') to a specific MDS rank. However, with this new option vxattr, it becomes possible to isolate specific subdirectories to designated MDS ranks. By introducing the ceph.dir.bal.mask vxattr, this PR empowers Ceph administrators with enhanced control and flexibility for optimizing performance and fine-tuning their deployments.

**Use Cases**
The first is when it is difficult to pin a subdir to one MDS rank. The /home/images directory exists. There are /0 to /99 directories under it, and 10 million image files are stored in each directory. In this case, it is difficult to pin the entire images directory to one MDS rank. Also, pinning the huge 100 directories manually or using ephemeral pinning is not an easy task. Therefore, efficient resource management is possible by using ceph.dir.bal.mask.

Second, when there are several large directories such as /home/images, performance can be optimized by distributing them to different MDS rank groups using ceph.dir.bal.mask. Since the existing mdsmap’s bal_rank_mask isolated the entire ‘/’ directory to specific ranks, it can affect performance due to each other's migration overhead. For example, mdsmap’s bal_rank_mask is set to 0xf and /home/images and /home/backups large directories exist. If the load on /home/images instantaneously increases, metadata distribution occurs across ranks 0 to 3. Thus, users of /home/backups may be affected by noisy neighbors unnecessarily. If the two directories are set to MDS rank 0-1 (ceph.dir.bal.mask 0x3) and 2-3 (ceph.dir.bal.mask 0xC) respectively, the effect on each other can be minimized. Like this, it can be used efficiently for various directories.

**How to use**
```
# / root is distributed within MDS rank 0 to 3
# it overrides mdsmap bal_rank_mask value
setfattr -n ceph.dir.bal.mask -v 0x0f /

# /home/images subdir is distributed within MDS rank 1 and 2
setfattr -n ceph.dir.bal.mask -v 0x06 /home/images

# /home/images subdir is distributed within MDS rank 3 and 4
setfattr -n ceph.dir.bal.mask -v 0x18 /home/backups

# remove values and they will obey parent the value or mdsmap bal_rank_mask
setfattr -n ceph.dir.bal.mask -v -1 /home/images
setfattr -n ceph.dir.bal.mask -v -1 /home/backups

# /home/images is placed only on MDS rank1 (similar to ceph.dir.dir)
setfattr -n ceph.dir.bal.mask -v 0x02 /home/images
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
