### PR TITLE
crush/CrushLocation: remove useless flag

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -45,9 +45,6 @@ int CrushLocation::update_from_hook()
   if (cct->_conf->crush_location_hook.length() == 0)
     return 0;
  
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
-  ceph_abort_msg("crimson does not support crush_location_hook, it must stay empty");
-#else
   if (0 != access(cct->_conf->crush_location_hook.c_str(), R_OK)) {
     lderr(cct) << "the user define crush location hook: " << cct->_conf->crush_location_hook
                << " may not exist or can not access it" << dendl;
@@ -95,7 +92,6 @@ int CrushLocation::update_from_hook()
   bl.begin().copy(bl.length(), out);
   out.erase(out.find_last_not_of(" \n\r\t")+1);
   return _parse(out);
-#endif // WITH_SEASTAR && !WITH_ALIEN
 }
 
 int CrushLocation::init_on_startup()

--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <vector>
+#include <boost/algorithm/string/trim.hpp>
 
 #include "CrushLocation.h"
 #include "CrushWrapper.h"
@@ -90,7 +91,7 @@ int CrushLocation::update_from_hook()
 
   std::string out;
   bl.begin().copy(bl.length(), out);
-  out.erase(out.find_last_not_of(" \n\r\t")+1);
+  boost::algorithm::trim_right_if(out, boost::algorithm::is_any_of(" \n\r\t"));
   return _parse(out);
 }
 


### PR DESCRIPTION

In pr ‘https://github.com/ceph/ceph/pull/51352’, we have
crimson/crush/CrushLocation.cc, there is no need crimson
releated code in crush/CrushLocation.cc, so just remove.

Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
