### PR TITLE
rgw: rename request traces and change for tags

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -383,11 +383,8 @@ int process_request(const RGWProcessEnv& penv,
       goto done;
     }
 
-
-    const auto trace_name = std::string(op->name()) + " " + s->trans_id;
-    s->trace = tracing::rgw::tracer.start_trace(trace_name, s->trace_enabled);
-    s->trace->SetAttribute(tracing::rgw::OP, op->name());
-    s->trace->SetAttribute(tracing::rgw::TYPE, tracing::rgw::REQUEST);
+    s->trace = tracing::rgw::tracer.start_trace(op->name(), s->trace_enabled);
+    s->trace->SetAttribute(tracing::rgw::TRANS_ID, s->trans_id);
 
     ret = rgw_process_authenticated(handler, op, req, s, yield, driver);
     if (ret < 0) {
@@ -402,7 +399,9 @@ int process_request(const RGWProcessEnv& penv,
 done:
   if (op) {
     if (s->trace) {
-      s->trace->SetAttribute(tracing::rgw::RETURN, op->get_ret());
+      s->trace->SetAttribute(tracing::rgw::OP_RESULT, op->get_ret());
+      s->trace->SetAttribute(tracing::rgw::HOST_ID, driver->get_host_id());
+
       if (!rgw::sal::User::empty(s->user)) {
         s->trace->SetAttribute(tracing::rgw::USER_ID, s->user->get_id().id);
       }

--- a/src/rgw/rgw_tracer.h
+++ b/src/rgw/rgw_tracer.h
@@ -8,15 +8,15 @@
 namespace tracing {
 namespace rgw {
 
-const auto OP = "op";
+
 const auto BUCKET_NAME = "bucket_name";
 const auto USER_ID = "user_id";
 const auto OBJECT_NAME = "object_name";
-const auto RETURN = "return";
+const auto OP_RESULT = "op_result";
 const auto UPLOAD_ID = "upload_id";
-const auto TYPE = "type";
-const auto REQUEST = "request";
 const auto MULTIPART = "multipart_upload ";
+const auto TRANS_ID = "trans_id";
+const auto HOST_ID = "host_id";
 
 extern tracing::Tracer tracer;
 


### PR DESCRIPTION
when we have a lot of traces, for example on multisite configuration we have traces for list_meta_logs and list_data_changes and it become too verbose to have trans id as the trace name, the filtering in the jaeger gui becomes a mess,
so we will have the trans_id as tag, so ops of same type will be named the op name only for cleaner usage.

the tag 'return' is ambigious. the actual name should be 'op_result' so we can distinguish between http return code and op return value.

the tag 'type' doesn't add extra information, so it removed.

s well, add host_id as tag for the request trace.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
