### PR TITLE
common/tracer: remove is_enabled check in add_span methods

### DIFF
--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -60,8 +60,7 @@ jspan Tracer::start_trace(opentelemetry::nostd::string_view trace_name, bool tra
 }
 
 jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan& parent_span) {
-  ceph_assert(cct);
-  if (is_enabled() && parent_span->IsRecording()) {
+  if (parent_span && parent_span->IsRecording()) {
     ceph_assert(tracer);
     opentelemetry::trace::StartSpanOptions span_opts;
     span_opts.parent = parent_span->GetContext();
@@ -72,8 +71,7 @@ jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan&
 }
 
 jspan Tracer::add_span(opentelemetry::nostd::string_view span_name, const jspan_context& parent_ctx) {
-  ceph_assert(cct);
-  if (is_enabled() && parent_ctx.IsValid()) {
+  if (parent_ctx.IsValid()) {
     ceph_assert(tracer);
     opentelemetry::trace::StartSpanOptions span_opts;
     span_opts.parent = parent_ctx;


### PR DESCRIPTION
when tracing is disabled globally, new spans won't be added to existing traces, because of that if condition.
this can happen also if a specific trace was enabled by lua script

so in case tracing is disabled, the tracer will create new spans if it's parent span is not a noop span, regardless of tracer state

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
