### PR TITLE
[RFC] crimson: understand performance impacts by skipping mempool in raw 

### DIFF
--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -46,32 +46,32 @@ inline namespace v15_2_0 {
 
     explicit raw(unsigned l, int mempool=mempool::mempool_buffer_anon)
       : data(nullptr), len(l), nref(0), mempool(mempool) {
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
     }
     raw(char *c, unsigned l, int mempool=mempool::mempool_buffer_anon)
       : data(c), len(l), nref(0), mempool(mempool) {
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
     }
     virtual ~raw() {
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
-	-1, -(int)len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
+	// -1, -(int)len);
     }
 
     void _set_len(unsigned l) {
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
-	-1, -(int)len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
+	// -1, -(int)len);
       len = l;
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
     }
 
     void reassign_to_mempool(int pool) {
       if (pool == mempool) {
 	return;
       }
-      mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
-	-1, -(int)len);
+      // mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(
+	// -1, -(int)len);
       mempool = pool;
-      mempool::get_pool(mempool::pool_index_t(pool)).adjust_count(1, len);
+      // mempool::get_pool(mempool::pool_index_t(pool)).adjust_count(1, len);
     }
 
     void try_assign_to_mempool(int pool) {


### PR DESCRIPTION
![msgr-iops-cpus](https://github.com/ceph/ceph/assets/7736006/d87fefc0-cf5f-4f56-8f53-10b599b436a2)

The above results are using `perf_crimson_msgr (client mode)` to pressurize `perf_crimson_msgr (server mode)` or `perf_async_msgr` to understand apple-to-apple performance by CPU cores used.

Initially, both **crimson** and **async** msgr have similar performance curve, but further analysis shows they have different bottlenecks:
* Async msgr is mostly blocked by its locks at 16 CPUs;
* Crimson msgr is mostly blocked by some mempool counters in raw buffer at 16 CPUs;

Async msgr should share the same infrastructure about the buffer and mempool, but its immediate bottleneck is not there, which implies that its scaling issue might be synthetic.

For crimson msgr, if comment out the mempool counters in this PR, the CPU scaling problem is relaxed greatly, see the curve of **crimson-poc**.

In short:
* Both crimson and async msgr implements similar features, and their single-core performance looks similar when there is no racing;
* When goes to multiple cores, a single point of shared resource in the hot path can make crimson scale bad, with the end-to-end result approaches classic;

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
