### PR TITLE
ceph-volume: fix list command failing on volumes sharing the same name

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -153,7 +153,8 @@ class List(object):
         elif arg[0] == '/':
             lv = api.get_lvs_from_path(arg)
         else:
-            lv = [api.get_single_lv(filters={'lv_name': arg.split('/')[1]})]
+            vg_name, lv_name = arg.split('/')
+            lv = [api.get_single_lv(filters={'lv_name': lv_name, 'vg_name': vg_name})]
 
         report = self.create_report(lv)
 


### PR DESCRIPTION
Given a system with the following disk setup:

    nvme1n1               259:0    0   1.8T  0 disk
    └─group1-volume       253:1    0   1.8T  0 lvm
    nvme0n1               259:0    0   1.8T  0 disk
    └─group2-volume       253:2    0   1.8T  0 lvm

That is, two disks; the first one with a vg named "group1", and in that vg an lv named "volume"; and the second one with a vg named "group2" and in that vg an lv named "volume".

`ceph-volume lvm list group1/volume` would fail with the following error:

    $ ceph-volume lvm list group1/volume
    -->  RuntimeError: Filters {'lv_name': 'volume'} matched more than 1 LV present on this host.

... even though there should be no ambiguity. The command contains both the vg name and the lv name, yet the filter that was used only considered lv_name for some reason.

This caused a lot of confusion as it caused rook-ceph to fail to provision OSDs on a machine with a similar setup, because rook was calling `ceph-volume lvm list --format=json vg/lv`, and getting a nonzero exit status.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
