### PR TITLE
pacific: python-common/drive_selection: lower log level of limit policy message

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -71,7 +71,7 @@ class DriveSelection(object):
         limit = device_filter.limit or 0
 
         if limit > 0 and (len_devices + self.existing_daemons >= limit):
-            logger.info("Refuse to add {} due to limit policy of <{}>".format(
+            logger.debug("Refuse to add {} due to limit policy of <{}>".format(
                 disk_path, limit))
             return True
         return False


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61683

---

backport of https://github.com/ceph/ceph/pull/51924
parent tracker: https://tracker.ceph.com/issues/61592

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh