### PR TITLE
osd: qualify fmt::format_to() for gcc13

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -669,7 +669,7 @@ struct fmt::formatter<ceph::osd::scheduler::OpSchedulerItem> {
 	    ? fmt::format(" reserved_pushes {}", opsi.get_reserved_pushes())
 	    : "";
 
-    return format_to(
+    return fmt::format_to(
 	ctx.out(), "OpSchedulerItem({} {} class_id {} prio {}{} cost {} e{}{})",
 	opsi.get_ordering_token(), opsi.qitem->print(),
 	static_cast<class_t>(opsi.get_scheduler_class()), opsi.get_priority(),


### PR DESCRIPTION
```
/home/cbodley/ceph/src/osd/scheduler/OpSchedulerItem.h:672:21: error: call of overloaded ‘format_to(fmt::v9::basic_format_context<fmt::v9::appender, char>::it erator, const char [59], const spg_t&, std::string, class_t, unsigned int, const std::__cxx11::basic_string<char>&, int, epoch_t, const std::__cxx11::basic_st ring<char>&)’ is ambiguous
  672 |     return format_to(
      |            ~~~~~~~~~^
  673 |         ctx.out(), "OpSchedulerItem({} {} class_id {} prio {}{} cost {} e{}{})",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  674 |         opsi.get_ordering_token(), opsi.qitem->print(),
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  675 |         static_cast<class_t>(opsi.get_scheduler_class()), opsi.get_priority(),
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  676 |         qos_cost, opsi.get_cost(), opsi.get_map_epoch(), pushes);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/cbodley/ceph/src/fmt/include/fmt/core.h:3233:17: note: candidate: ‘OutputIt fmt::v9::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt =
 appender; T = {const spg_t&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned char, unsigned int, const std::__cxx11
::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, unsigned int, const std::__cxx11::basic_string<char, std::char_traits<char>, std::a
llocator<char> >&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format
_string<char, const spg_t&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned char, unsigned int, const std::__cxx11::
basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, unsigned int, const std::__cxx11::basic_string<char, std::char_traits<char>, std::all
ocator<char> >&>]’
 3233 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
/usr/include/c++/13/format:3745:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v9::appender; _Args =
{const spg_t&, __cxx11::basic_string<char, char_traits<char>, allocator<char> >, unsigned char, unsigned int, const __cxx11::basic_string<char, char_traits<ch
ar>, allocator<char> >&, int, unsigned int, const __cxx11::basic_string<char, char_traits<char>, allocator<char> >&}; format_string<_Args ...> = basic_format_
string<char, const spg_t&, __cxx11::basic_string<char, char_traits<char>, allocator<char> >, unsigned char, unsigned int, const __cxx11::basic_string<char, ch
ar_traits<char>, allocator<char> >&, int, unsigned int, const __cxx11::basic_string<char, char_traits<char>, allocator<char> >&>]’
 3745 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
```
Fixes: https://tracker.ceph.com/issues/61975

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
