### PR TITLE
rgw: typecast long long to int when passing length to format string

### DIFF
--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -167,10 +167,11 @@ void RGWFormatter_Plain::dump_format_va(std::string_view name, const char *ns, b
     eol = "";
   wrote_something = true;
 
-  if (use_kv && !entry.is_array)
-    write_data("%s%.*s: %s", eol, name.size(), name.data(), buf);
-  else
+  if (use_kv && !entry.is_array) {
+    write_data("%s%.*s: %s", eol, static_cast<int>(name.size()), name.data(), buf);
+  } else {
     write_data("%s%s", eol, buf);
+  }
 }
 
 int RGWFormatter_Plain::get_len() const
@@ -277,10 +278,11 @@ void RGWFormatter_Plain::dump_value_int(std::string_view name, const char *fmt, 
     eol = "";
   wrote_something = true;
 
-  if (use_kv && !entry.is_array)
-    write_data("%s%.*s: %s", eol, name.size(), name.data(), buf);
-  else
+  if (use_kv && !entry.is_array) {
+    write_data("%s%.*s: %s", eol, static_cast<int>(name.size()), name.data(), buf);
+  } else {
     write_data("%s%s", eol, buf);
+  }
 
 }
 


### PR DESCRIPTION
The %.s format string is used to specify a string along with the length to be printed. The length is expected to be of type int, but we internally use long for some lengths. This is safe though, since these string are expected to be very small anyway.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
