### PR TITLE
rgw: RGWOp_ZoneConfig_Get doesn't require RadosStore

### DIFF
--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -14,22 +14,9 @@
  */
 
 #include "common/ceph_json.h"
-#include "common/strtol.h"
-#include "rgw_rest.h"
 #include "rgw_op.h"
-#include "rgw_rados.h"
-#include "rgw_rest_s3.h"
 #include "rgw_process_env.h"
 #include "rgw_rest_config.h"
-#include "rgw_client_io.h"
-#include "rgw_sal_rados.h"
-#include "common/errno.h"
-#include "include/ceph_assert.h"
-
-#include "services/svc_zone.h"
-
-#define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_rgw
 
 using namespace std;
 

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -19,6 +19,7 @@
 #include "rgw_op.h"
 #include "rgw_rados.h"
 #include "rgw_rest_s3.h"
+#include "rgw_process_env.h"
 #include "rgw_rest_config.h"
 #include "rgw_client_io.h"
 #include "rgw_sal_rados.h"
@@ -33,7 +34,7 @@
 using namespace std;
 
 void RGWOp_ZoneConfig_Get::send_response() {
-  const RGWZoneParams& zone_params = static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_params();
+  const RGWZoneParams& zone_params = s->penv.site->get_zone_params();
 
   set_req_state_err(s, op_ret);
   dump_errno(s);


### PR DESCRIPTION
`RGWOp_ZoneConfig_Get` API used by ragweed crashes when `RadosStore` isn't the top-level store. this caused crashes when testing the D3N filter in https://github.com/ceph/ceph/pull/50198


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
