### PR TITLE
script: discover_compiler() tries newer clangs for 'make check'

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -669,7 +669,7 @@ struct fmt::formatter<ceph::osd::scheduler::OpSchedulerItem> {
 	    ? fmt::format(" reserved_pushes {}", opsi.get_reserved_pushes())
 	    : "";
 
-    return fmt::format_to(
+    return format_to(
 	ctx.out(), "OpSchedulerItem({} {} class_id {} prio {}{} cost {} e{}{})",
 	opsi.get_ordering_token(), opsi.qitem->print(),
 	static_cast<class_t>(opsi.get_scheduler_class()), opsi.get_priority(),

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -64,7 +64,7 @@ function discover_compiler() {
     local cxx_compiler=g++
     local c_compiler=gcc
     # ubuntu/debian ci builds prefer clang
-    for i in {14..10}; do
+    for i in {19..10}; do
         if type -t "clang-$i" > /dev/null; then
             cxx_compiler="clang++-$i"
             c_compiler="clang-$i"


### PR DESCRIPTION
trying to see if we can get a newer clang version for 'make check' that could catch build regressions like the one fixed in https://github.com/ceph/ceph/pull/52417

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
