### PR TITLE
mds: retry rdlock_path_pin_ref if needs to fwd request to auth

### DIFF
--- a/qa/suites/fs/functional/tasks/fwdauth.yaml
+++ b/qa/suites/fs/functional/tasks/fwdauth.yaml
@@ -1,0 +1,7 @@
+teuthology:
+  postmerge:
+    - if not is_fuse() then reject() end
+- cephfs_test_runner:
+    fail_on_skip: false
+    modules:
+      - tasks.cephfs.test_misc.TestForwardAuth

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1692,6 +1692,7 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
   __u32 hash = 0;
   bool is_hash = false;
   int issued = 0;
+  int rank;
 
   Inode *in = NULL;
   Dentry *de = NULL;
@@ -1700,6 +1701,19 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
     mds = req->resend_mds;
     ldout(cct, 10) << __func__ << " resend_mds specified as mds." << mds << dendl;
     goto out;
+  }
+
+  rank = cct->_conf->client_debug_force_send_request_to_rank;
+  if (unlikely(rank >= 0)) {
+    if (rank >= mdsmap->get_max_mds()) {
+      ldout(cct, 5) << __func__ << " invalid mds rank number " << rank
+                    << ", while there are " << mdsmap->get_max_mds()
+                    << " ranks at most" << dendl;
+    } else {
+      mds = rank;
+      ldout(cct, 10) << __func__ << " force sending requests to mds." << rank << dendl;
+      goto out;
+    }
   }
 
   if (cct->_conf->client_use_random_mds)

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -245,6 +245,14 @@ options:
   fmt_desc: If set to ``true``, clients read data directly from OSDs instead
     of using a local page cache.
   with_legacy: true
+- name: client_debug_force_send_request_to_rank
+  type: int
+  level: dev
+  default: -1
+  services:
+  - mds_client
+  fmt_desc: Set a value of the rank number, clients will always send client requests to this rank.
+  with_legacy: true
 - name: client_debug_inject_tick_delay
   type: secs
   level: dev


### PR DESCRIPTION
In case the _open() is called from _openc() the first
rdlock_path_pin_ref() will do nothing because the _openc() will
set the MutationImpl::PATH_LOCKED flag. And then we need to retry
it.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
