### PR TITLE
reef: mon/ConfigMonitor: update crush_location from osd entity

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -920,6 +920,7 @@ bool ConfigMonitor::refresh_config(MonSession *s)
 
   string device_class;
   if (s->name.is_osd()) {
+    osdmap.crush->get_full_location(s->entity_name.to_str(), &crush_location);
     const char *c = osdmap.crush->get_item_class(s->name.num());
     if (c) {
       device_class = c;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62029

---

backport of https://github.com/ceph/ceph/pull/52088
parent tracker: https://tracker.ceph.com/issues/48750

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh