### PR TITLE
rgw: add coverity annotations and asserts for null dereferences

### DIFF
--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -177,6 +177,8 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
     if (r < 0)
       return r;
 
+    // astate can be modified by append_atomic_test
+    // coverity[check_after_deref:SUPPRESS]
     if (astate &&
         obj_ofs < astate->data.length()) {
       unsigned chunk_len = std::min((uint64_t)astate->data.length() - obj_ofs, (uint64_t)len);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6491,6 +6491,8 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end,
     if (r < 0)
       return r;
 
+    // astate can be modified by append_atomic_test
+    // coverity[check_after_deref:SUPPRESS]
     if (astate && astate->prefetch_data) {
       if (!ofs && astate->data.length() >= len) {
         bl = astate->data;
@@ -6606,6 +6608,8 @@ int RGWRados::get_obj_iterate_cb(const DoutPrefixProvider *dpp,
     if (r < 0)
       return r;
 
+    // astate can be modified by append_atomic_test
+    // coverity[check_after_deref:SUPPRESS]
     if (astate &&
         obj_ofs < astate->data.length()) {
       unsigned chunk_len = std::min((uint64_t)astate->data.length() - obj_ofs, (uint64_t)len);

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -81,13 +81,14 @@ int RGWBackoffControlCR::operate(const DoutPrefixProvider *dpp) {
     // retry the operation until it succeeds
     while (true) {
       yield {
-	std::lock_guard l{lock};
+        std::lock_guard l{lock};
         cr = alloc_cr();
         cr->get();
         call(cr);
       }
       {
-	std::lock_guard l{lock};
+        std::lock_guard l{lock};
+        // coverity[var_deref_model:SUPPRESS]
         cr->put();
         cr = NULL;
       }

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -383,6 +383,7 @@ namespace rgw {
 	/* implies !rgw_fh, so also !LOCKED */
 	return -ENOENT;
       }
+      assert(rgw_fh);
 
       if (bs.num_entries > 1) {
 	unref(bkt_fh); /* return stat_bucket ref */
@@ -449,6 +450,7 @@ namespace rgw {
 
     /* ENOENT when raced with other s3 gateway */
     if (! rc || rc == -ENOENT) {
+      // coverity[var_deref_op:SUPPRESS]
       rgw_fh->flags |= RGWFileHandle::FLAG_DELETED;
       fh_cache.remove(rgw_fh->fh.fh_hk.object, rgw_fh,
 		      RGWFileHandle::FHCache::FLAG_LOCK);

--- a/src/rgw/rgw_kmip_client_impl.cc
+++ b/src/rgw/rgw_kmip_client_impl.cc
@@ -243,11 +243,7 @@ RGWKmipHandleBuilder::build() const
 
   failed = 0;
 Done:
-  if (!failed)
-    ;
-  else if (!r)
-    ;
-  else {
+  if(failed && r) {
     kmip_free_handle_stuff(r);
     delete r;
     r = 0;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4292,7 +4292,10 @@ void RGWPutObj::execute(optional_yield y)
 
   if (compressor && compressor->is_compressed()) {
     bufferlist tmp;
-    RGWCompressionInfo cs_info;
+    RGWCompressionInfo cs_info;      
+    assert(plugin != nullptr);  
+    // plugin exists when the compressor does
+    // coverity[dereference:SUPPRESS]
     cs_info.compression_type = plugin->get_type_name();
     cs_info.orig_size = s->obj_size;
     cs_info.compressor_message = compressor->get_compressor_message();
@@ -4632,6 +4635,9 @@ void RGWPostObj::execute(optional_yield y)
     if (compressor && compressor->is_compressed()) {
       ceph::bufferlist tmp;
       RGWCompressionInfo cs_info;
+      assert(plugin != nullptr);
+      // plugin exists when the compressor does
+      // coverity[dereference:SUPPRESS]
       cs_info.compression_type = plugin->get_type_name();
       cs_info.orig_size = s->obj_size;
       cs_info.compressor_message = compressor->get_compressor_message();
@@ -7757,6 +7763,9 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   if (compressor && compressor->is_compressed()) {
     ceph::bufferlist tmp;
     RGWCompressionInfo cs_info;
+    assert(plugin != nullptr);
+    // plugin exists when the compressor does
+    // coverity[dereference:SUPPRESS]
     cs_info.compression_type = plugin->get_type_name();
     cs_info.orig_size = size;
     cs_info.compressor_message = compressor->get_compressor_message();


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
