### PR TITLE
rgw: Fix potential null dereference in rgw/driver/dbstore/sqlite/statement.cc

### DIFF
--- a/src/rgw/driver/dbstore/sqlite/statement.cc
+++ b/src/rgw/driver/dbstore/sqlite/statement.cc
@@ -118,10 +118,10 @@ void eval0(const DoutPrefixProvider* dpp, const stmt_execution& stmt)
   if (ec != sqlite::errc::done) {
     const char* errmsg = ::sqlite3_errmsg(db);
     ldpp_dout(dpp, 20) << "evaluation failed: " << errmsg
-        << " (" << ec << ")\nstatement: " << sql.get() << dendl;
+        << " (" << ec << ")\nstatement: " << (sql ? sql.get() : "") << dendl;
     throw sqlite::error(errmsg, ec);
   }
-  ldpp_dout(dpp, 20) << "evaluation succeeded: " << sql.get() << dendl;
+  ldpp_dout(dpp, 20) << "evaluation succeeded: " << (sql ? sql.get() : "") << dendl;
 }
 
 void eval1(const DoutPrefixProvider* dpp, const stmt_execution& stmt)
@@ -137,10 +137,10 @@ void eval1(const DoutPrefixProvider* dpp, const stmt_execution& stmt)
     sqlite3* db = ::sqlite3_db_handle(stmt.get());
     const char* errmsg = ::sqlite3_errmsg(db);
     ldpp_dout(dpp, 1) << "evaluation failed: " << errmsg << " (" << ec
-        << ")\nstatement: " << sql.get() << dendl;
+        << ")\nstatement: " << (sql ? sql.get() : "") << dendl;
     throw sqlite::error(errmsg, ec);
   }
-  ldpp_dout(dpp, 20) << "evaluation succeeded: " << sql.get() << dendl;
+  ldpp_dout(dpp, 20) << "evaluation succeeded: " << (sql ? sql.get() : "") << dendl;
 }
 
 int column_int(const stmt_execution& stmt, int column)
@@ -181,14 +181,14 @@ auto read_text_rows(const DoutPrefixProvider* dpp,
       sqlite3* db = ::sqlite3_db_handle(stmt.get());
       const char* errmsg = ::sqlite3_errmsg(db);
       ldpp_dout(dpp, 1) << "evaluation failed: " << errmsg << " (" << ec
-          << ")\nstatement: " << sql.get() << dendl;
+          << ")\nstatement: " << (sql ? sql.get() : "") << dendl;
       throw sqlite::error(errmsg, ec);
     }
     entries[count] = column_text(stmt, 0);
     ++count;
   }
   ldpp_dout(dpp, 20) << "statement evaluation produced " << count
-      << " results: " << sql.get() << dendl;
+      << " results: " << (sql ? sql.get() : "") << dendl;
 
   return entries.first(count);
 }


### PR DESCRIPTION

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
