### PR TITLE
os/bluestore: Fix bluefs_test

### DIFF
--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1179,6 +1179,7 @@ TEST(BlueFS, test_shared_alloc) {
   auto num_files = logger->get(l_bluefs_num_files);
   fs.umount();
   fs.mount();
+  logger = fs.get_perf_counters();
   ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
   fs.umount();
 }
@@ -1256,6 +1257,7 @@ TEST(BlueFS, test_shared_alloc_sparse) {
   fs.umount();
 
   fs.mount();
+  logger = fs.get_perf_counters();
   ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
   fs.umount();
 }
@@ -1327,6 +1329,7 @@ TEST(BlueFS, test_4k_shared_alloc) {
   fs.umount();
 
   fs.mount();
+  logger = fs.get_perf_counters();
   ASSERT_EQ(num_files, logger->get(l_bluefs_num_files));
   fs.umount();
 }


### PR DESCRIPTION
Re-load logger.
bluefs.umount() destroys logger. One needs to reload it after bluefs.mount().

This has been detected by valgrind memcheck tool.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
