### PR TITLE
ceph-dencoder: RBD - Add missing types

### DIFF
--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1132,6 +1132,12 @@ void TrashImageSpec::dump(Formatter *f) const {
   f->dump_unsigned("deferment_end_time", deferment_end_time);
 }
 
+void TrashImageSpec::generate_test_instances(std::list<TrashImageSpec *> &o) {
+  o.push_back(new TrashImageSpec());
+  o.push_back(new TrashImageSpec(TRASH_IMAGE_SOURCE_USER, "trash_image",
+                                 utime_t(123, 456), utime_t(123, 456)));
+}
+
 void MirrorImageMap::encode(bufferlist &bl) const {
   ENCODE_START(1, 1, bl);
   encode(instance_id, bl);

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -877,6 +877,7 @@ struct TrashImageSpec {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& it);
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<TrashImageSpec *> &o);
 
   inline bool operator==(const TrashImageSpec& rhs) const {
     return (source == rhs.source &&

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -29,6 +29,11 @@ void AsyncRequestId::dump(Formatter *f) const {
   f->dump_unsigned("request_id", request_id);
 }
 
+void AsyncRequestId::generate_test_instances(std::list<AsyncRequestId *> &o) {
+  o.push_back(new AsyncRequestId());
+  o.push_back(new AsyncRequestId(ClientId(1, 2), 3));
+}
+
 void AcquiredLockPayload::encode(bufferlist &bl) const {
   using ceph::encode;
   encode(client_id, bl);

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -36,6 +36,7 @@ struct AsyncRequestId {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<AsyncRequestId*>& ls);
 
   inline bool operator<(const AsyncRequestId &rhs) const {
     if (client_id != rhs.client_id) {
@@ -521,9 +522,9 @@ std::ostream &operator<<(std::ostream &out,
 std::ostream &operator<<(std::ostream &out,
                          const AsyncRequestId &request);
 
-WRITE_CLASS_ENCODER(AsyncRequestId);
-WRITE_CLASS_ENCODER(NotifyMessage);
-WRITE_CLASS_ENCODER(ResponseMessage);
+WRITE_CLASS_ENCODER(librbd::watch_notify::AsyncRequestId);
+WRITE_CLASS_ENCODER(librbd::watch_notify::NotifyMessage);
+WRITE_CLASS_ENCODER(librbd::watch_notify::ResponseMessage);
 
 } // namespace watch_notify
 } // namespace librbd

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -675,9 +675,9 @@ struct Listener {
   virtual void handle_resync() = 0;
 };
 
-WRITE_CLASS_ENCODER(EventEntry);
-WRITE_CLASS_ENCODER(ClientData);
-WRITE_CLASS_ENCODER(TagData);
+WRITE_CLASS_ENCODER(librbd::journal::EventEntry);
+WRITE_CLASS_ENCODER(librbd::journal::ClientData);
+WRITE_CLASS_ENCODER(librbd::journal::TagData);
 
 } // namespace journal
 } // namespace librbd

--- a/src/librbd/mirroring_watcher/Types.h
+++ b/src/librbd/mirroring_watcher/Types.h
@@ -89,7 +89,7 @@ struct NotifyMessage {
   static void generate_test_instances(std::list<NotifyMessage *> &o);
 };
 
-WRITE_CLASS_ENCODER(NotifyMessage);
+WRITE_CLASS_ENCODER(librbd::mirroring_watcher::NotifyMessage);
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op);
 

--- a/src/librbd/trash_watcher/Types.h
+++ b/src/librbd/trash_watcher/Types.h
@@ -84,7 +84,7 @@ struct NotifyMessage {
   static void generate_test_instances(std::list<NotifyMessage *> &o);
 };
 
-WRITE_CLASS_ENCODER(NotifyMessage);
+WRITE_CLASS_ENCODER(librbd::trash_watcher::NotifyMessage);
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op);
 

--- a/src/librbd/watcher/Types.cc
+++ b/src/librbd/watcher/Types.cc
@@ -24,6 +24,11 @@ void ClientId::dump(Formatter *f) const {
   f->dump_unsigned("handle", handle);
 }
 
+void ClientId::generate_test_instances(std::list<ClientId *> &o) {
+  o.push_back(new ClientId());
+  o.push_back(new ClientId(123, 456));
+}
+
 void NotifyResponse::encode(bufferlist& bl) const {
   using ceph::encode;
   encode(acks, bl);

--- a/src/librbd/watcher/Types.h
+++ b/src/librbd/watcher/Types.h
@@ -26,6 +26,7 @@ struct ClientId {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<ClientId *> &o);
 
   inline bool is_valid() const {
     return (*this != ClientId());

--- a/src/tools/ceph-dencoder/rbd_types.h
+++ b/src/tools/ceph-dencoder/rbd_types.h
@@ -3,13 +3,18 @@
 TYPE(librbd::journal::EventEntry)
 TYPE(librbd::journal::ClientData)
 TYPE(librbd::journal::TagData)
+
 #include "librbd/mirroring_watcher/Types.h"
 TYPE(librbd::mirroring_watcher::NotifyMessage)
 #include "librbd/trash_watcher/Types.h"
 TYPE(librbd::trash_watcher::NotifyMessage)
 #include "librbd/WatchNotifyTypes.h"
 TYPE_NOCOPY(librbd::watch_notify::NotifyMessage)
+TYPE(librbd::watch_notify::AsyncRequestId)
 TYPE(librbd::watch_notify::ResponseMessage)
+
+#include "librbd/watcher/Types.h"
+TYPE(librbd::watcher::ClientId)
 
 #include "rbd_replay/ActionTypes.h"
 TYPE(rbd_replay::action::Dependency)
@@ -49,4 +54,22 @@ TYPE(cls::rbd::GroupSpec)
 TYPE(cls::rbd::ImageSnapshotSpec)
 TYPE(cls::rbd::SnapshotInfo)
 TYPE(cls::rbd::SnapshotNamespace)
+using namespace cls::rbd;
+TYPE(ParentImageSpec)
+TYPE(ChildImageSpec)
+TYPE(MigrationSpec)
+TYPE(MirrorPeer)
+TYPE(MirrorImage)
+TYPE(MirrorImageMap)
+TYPE(MirrorImageStatus)
+TYPE(MirrorImageSiteStatus)
+TYPE_FEATUREFUL(MirrorImageSiteStatusOnDisk)
+TYPE(GroupImageSpec)
+TYPE(GroupImageStatus)
+TYPE(GroupSnapshot)
+TYPE(GroupSpec)
+TYPE(ImageSnapshotSpec)
+TYPE(SnapshotInfo)
+TYPE(SnapshotNamespace)
+TYPE(TrashImageSpec)
 #endif


### PR DESCRIPTION

Currently, ceph-dencoder lacks certain rbd types, preventing us from accurately checking the ceph corpus for encode-decode mismatches. This pull request aims to address this issue by adding the missing types to ceph-dencoder.

To successfully incorporate these types into ceph-dencoder, we need to introduce the necessary `dump` and `generate_test_instances` functions that was missing in some types. These functions are essential for proper encode and decode of the added types.

This PR will enhance the functionality of ceph-dencoder by including the missing types, enabling a comprehensive analysis of encode-decode consistency. With the addition of these types, we can ensure the robustness and correctness of the ceph corpus.

This update will significantly contribute to improving the overall reliability and accuracy of ceph-dencoder. It allows for a more comprehensive assessment of the encode-decode behavior, leading to enhanced data integrity and stability within the ceph ecosystem.

Fixes: https://tracker.ceph.com/issues/61788





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
