### PR TITLE
reef:  mds: session ls command appears twice in command listing

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -483,6 +483,29 @@ class TestMisc(CephFSTestCase):
                 return
         self.assertTrue(False, "Failed to dump in-memory logs during missed internal heartbeat")
 
+    def _session_client_ls(self, cmd):
+        mount_a_client_id = self.mount_a.get_global_id()
+        info = self.fs.rank_asok(cmd)
+        mount_a_mountpoint = self.mount_a.mountpoint
+        mount_b_mountpoint = self.mount_b.mountpoint
+        self.assertIsNotNone(info)
+        for i in range(0, len(info)):
+            self.assertIn(info[i]["client_metadata"]["mount_point"], 
+                             [mount_a_mountpoint, mount_b_mountpoint])        
+        info = self.fs.rank_asok(cmd + [f"id={mount_a_client_id}"])
+        self.assertEqual(len(info), 1)
+        self.assertEqual(info[0]["id"], mount_a_client_id)
+        self.assertEqual(info[0]["client_metadata"]["mount_point"], mount_a_mountpoint)
+        info = self.fs.rank_asok(cmd + ['--cap_dump'])
+        for i in range(0, len(info)):
+            self.assertIn("caps", info[i])
+
+    def test_session_ls(self):
+        self._session_client_ls(['session', 'ls'])
+
+    def test_client_ls(self):
+        self._session_client_ls(['client', 'ls'])
+        
 class TestCacheDrop(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -376,10 +376,6 @@ void MDSDaemon::set_up_admin_socket()
 				     asok_hook,
 				     "Evict a client session by id");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("session ls name=cap_dump,type=CephBool,req=false",
-				     asok_hook,
-				     "Enumerate connected CephFS clients");
-  ceph_assert(r == 0);
   r = admin_socket->register_command("session config "
 				     "name=client_id,type=CephInt,req=true "
 				     "name=option,type=CephString,req=true "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61987

---

backport of https://github.com/ceph/ceph/pull/51959
parent tracker: https://tracker.ceph.com/issues/61444

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh