### PR TITLE
python-common: drive_selection: fix KeyError when osdspec_affinity is not set

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -131,9 +131,10 @@ class DriveSelection(object):
             if not disk.available and disk.ceph_device and disk.lvs:
                 other_osdspec_affinity = ''
                 for lv in disk.lvs:
-                    if lv['osdspec_affinity'] != self.spec.service_id:
-                        other_osdspec_affinity = lv['osdspec_affinity']
-                        break
+                    if 'osdspec_affinity' in lv.keys():
+                        if lv['osdspec_affinity'] != self.spec.service_id:
+                            other_osdspec_affinity = lv['osdspec_affinity']
+                            break
                 if other_osdspec_affinity:
                     logger.debug("{} is already used in spec {}, "
                                  "skipping it.".format(disk.path, other_osdspec_affinity))


### PR DESCRIPTION
When osdspec_affinity is not set, the drive selection code will fail. This can happen when a device has multiple LVs where some of are used by Ceph and at least one LV isn't used by Ceph.

Fixes: https://tracker.ceph.com/issues/58946
