### PR TITLE
quincy: mgr/dashboard: disable promote on mirroring not enabled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -214,14 +214,22 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
       icon: Icons.edit,
       click: () => this.actionPrimary(true),
       name: this.actionLabels.PROMOTE,
-      visible: () => this.selection.first() != null && !this.selection.first().primary
+      visible: () => this.selection.first() != null && !this.selection.first().primary,
+      disable: () =>
+        this.selection.first().mirror_mode === 'Disabled'
+          ? 'Mirroring needs to be enabled on the image to perform this action'
+          : ''
     };
     const demoteAction: CdTableAction = {
       permission: 'update',
       icon: Icons.edit,
       click: () => this.actionPrimary(false),
       name: this.actionLabels.DEMOTE,
-      visible: () => this.selection.first() != null && this.selection.first().primary
+      visible: () => this.selection.first() != null && this.selection.first().primary,
+      disable: () =>
+        this.selection.first().mirror_mode === 'Disabled'
+          ? 'Mirroring needs to be enabled on the image to perform this action'
+          : ''
     };
     this.tableActions = [
       addAction,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62018

---

backport of https://github.com/ceph/ceph/pull/51831
parent tracker: https://tracker.ceph.com/issues/61507

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh