### PR TITLE
qa/distros: disable ceph/el9 copr workaround for missing python deps

### DIFF
--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,9 +1,2 @@
 os_type: centos
 os_version: "9.stream"
-
-# enable the ceph/el9 copr for python packages that aren't in epel9 yet
-# see https://tracker.ceph.com/issues/58832
-overrides:
-  install:
-    ceph:
-      enable_coprs: [ceph/el9]


### PR DESCRIPTION
This reverts commit c9e873cc52336ddb62ab52d6cfd91eb799ca7ef0.

this "ceph/el9" copr repository contains the python dependencies that hadn't yet made it to epel9. it was used in the meantime as a workaround for centos9 testing in teuthology, but we need to verify that all packages are available through epel9

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
