### PR TITLE
quincy:  mon: fix iterator mishandling in PGMap::apply_incremental

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1212,10 +1212,12 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
       stat_osd_sub(t->first, t->second);
       osd_stat.erase(t);
     }
-    for (auto i = pool_statfs.begin();  i != pool_statfs.end(); ++i) {
+    for (auto i = pool_statfs.begin();  i != pool_statfs.end();) {
       if (i->first.second == *p) {
 	pg_pool_sum[i->first.first].sub(i->second);
-	pool_statfs.erase(i);
+	i = pool_statfs.erase(i);
+      } else {
+        ++i;
       }
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62092

---

backport of https://github.com/ceph/ceph/pull/49480
parent tracker: https://tracker.ceph.com/issues/58303

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh