### PR TITLE
qa/tasks/test_nfs: have TestNFS inherit from CephFSTestCase

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -6,6 +6,7 @@ import logging
 from io import BytesIO, StringIO
 
 from tasks.mgr.mgr_test_case import MgrTestCase
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology import contextutil
 from teuthology.exceptions import CommandFailedError
 
@@ -14,7 +15,7 @@ log = logging.getLogger(__name__)
 NFS_POOL_NAME = '.nfs'  # should match mgr_module.py
 
 # TODO Add test for cluster update when ganesha can be deployed on multiple ports.
-class TestNFS(MgrTestCase):
+class TestNFS(MgrTestCase, CephFSTestCase):
     def _cmd(self, *args):
         return self.get_ceph_cmd_stdout(args)
 


### PR DESCRIPTION
The TestNFS was recently updated to use run_ceph_cmd but doesn't actually have access to it, resulting in
```
====================================================================== 
ERROR: test_cluster_info (tasks.cephfs.test_nfs.TestNFS) 
---------------------------------------------------------------------- 
Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_ceph-c_4ae2a76aad461f2c9f6a1456c25df23ec97a5b2f/qa/tasks/cephfs/test_nfs.py", line 578, in test_cluster_info
    self._test_create_cluster()
  File "/home/teuthworker/src/git.ceph.com_ceph-c_4ae2a76aad461f2c9f6a1456c25df23ec97a5b2f/qa/tasks/cephfs/test_nfs.py", line 156, in _test_create_cluster
    cluster_create = self._nfs_complete_cmd(
  File "/home/teuthworker/src/git.ceph.com_ceph-c_4ae2a76aad461f2c9f6a1456c25df23ec97a5b2f/qa/tasks/cephfs/test_nfs.py", line 25, in _nfs_complete_cmd
    return self.run_ceph_cmd(args=f"nfs {cmd}", stdout=StringIO(),
AttributeError: 'TestNFS' object has no attribute 'run_ceph_cmd'

----------------------------------------------------------------------
```
The function we need is specified in the new RunCephCmd class, so I think inheriting from there should fix this.

Fixes: https://tracker.ceph.com/issues/62084

The run_ceph_cmd function was added in https://github.com/ceph/ceph/pull/50569



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
