### PR TITLE
build: Force removal of overly new ceph-libboost packages

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -165,8 +165,34 @@ function install_pkg_on_ubuntu {
     fi
 }
 
+boost_ver=1.75
+
+function clean_boost_on_ubuntu {
+    echo 'About to clean_boost_on_ubuntu. Continue?'
+    #read -r
+    local ver=$boost_ver
+    local installed_ver
+    installed_ver=$(apt -qq list --installed 'ceph-libboost*-dev' 2> /dev/null \
+			| grep -e 'libboost[0-9].[0-9]\+-dev' \
+			| cut -d ' ' -f 2 \
+			| cut -d '.' -f1,2)
+    ls /etc/apt/sources.list.d
+    $SUDO rm -f "/etc/apt/sources.list.d/ceph-libboost${installed_ver}.list"
+    $SUDO rm -f "/etc/apt/sources.list.d/ceph-libboost.list"
+    $SUDO rm -f "/etc/apt/sources.list.d/libboost.list"
+    $SUDO apt-get update -y
+    apt -qq list --installed 'ceph-libboost*-dev' 2> /dev/null | \
+	grep -F -v "$boost_ver" | \
+	cut -f 1 -d / | \
+	xargs "$SUDO" apt-get -y remove
+    echo 'Finished clean_boost_on_ubuntu. Continue?'
+    #read -r
+}
+
 function install_boost_on_ubuntu {
-    local ver=1.75
+    echo 'About to install_boost_on_ubuntu. Continue?'
+    #read -r
+    local ver=$boost_ver
     local installed_ver=$(apt -qq list --installed ceph-libboost*-dev 2>/dev/null |
                               grep -e 'libboost[0-9].[0-9]\+-dev' |
                               cut -d' ' -f2 |
@@ -203,6 +229,8 @@ function install_boost_on_ubuntu {
 	ceph-libboost-test$ver-dev \
 	ceph-libboost-thread$ver-dev \
 	ceph-libboost-timer$ver-dev
+    echo 'Finished install_boost_on_ubuntu. Continue?'
+    #read -r
 }
 
 function install_libzbd_on_ubuntu {
@@ -299,6 +327,8 @@ else
         $SUDO apt-get install -y devscripts equivs
         $SUDO apt-get install -y dpkg-dev
         ensure_python3_sphinx_on_ubuntu
+	clean_boost_on_ubuntu
+	echo "Hi, my version is $VERSION!"
         case "$VERSION" in
             *Bionic*)
                 ensure_decent_gcc_on_ubuntu 9 bionic


### PR DESCRIPTION
To force removal of overly new libboost packages when building with system boost.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
