### PR TITLE
valgrind: remove stale openssl suppressions

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -662,31 +662,3 @@
   fun:_dl_init
   ...
 }
-
-# "Conditional jump or move depends on uninitialised value(s)" in OpenSSL
-# while using aes-128-gcm with AES-NI enabled. Not observed while running
-# with `OPENSSL_ia32cap="~0x200000200000000"`.
-{
-   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 1
-   Memcheck:Cond
-   ...
-   fun:EVP_DecryptFinal_ex
-   fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v*4listEj
-   fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v*8ptr_nodeENS4_8disposerEEi
-   fun:_ZN10ProtocolV216run_continuationER2CtIS_E
-   ...
-   fun:_ZN15AsyncConnection7processEv
-   fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   ...
-}
-
-{
-   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 2
-   Memcheck:Cond
-   fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v*4listEj
-   fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v*8ptr_nodeENS4_8disposerEEi
-   fun:_ZN10ProtocolV216run_continuationER2CtIS_E
-   ...
-   fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   ...
-}


### PR DESCRIPTION
years ago in commit fe97a000990632dbe9734e0d3a96df627f104f7a, the signature of `authenticated_decrypt_update_final()` changed and this suppression no longer matches its mangled form:
```diff
-  fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v*4listEj
+  fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalERNS_6buffer7v15_2_04listE
```
the fact that we didn't notice must mean that we don't need the suppressions anymore

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
