### PR TITLE
quincy: build: Remove ceph-libboost* packages in install-deps

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -343,6 +343,27 @@ else
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu focal
                 $with_zbd && install_libzbd_on_ubuntu focal
                 ;;
+            *Jammy*)
+                [ ! $NO_BOOST_PKGS ] && \
+		    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+			  libboost-atomic-dev \
+			  libboost-chrono-dev \
+			  libboost-container-dev \
+			  libboost-context-dev \
+			  libboost-coroutine-dev \
+			  libboost-date-time-dev \
+			  libboost-filesystem-dev \
+			  libboost-iostreams-dev \
+			  libboost-program-options-dev \
+			  libboost-python-dev \
+			  libboost-random-dev \
+			  libboost-regex-dev \
+			  libboost-system-dev \
+			  libboost-test-dev \
+			  libboost-thread-dev \
+			  libboost-timer-dev \
+			  gcc
+                ;;
             *)
                 $SUDO apt-get install -y gcc
                 ;;

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -165,44 +165,75 @@ function install_pkg_on_ubuntu {
     fi
 }
 
+boost_ver=1.75
+
+function clean_boost_on_ubuntu {
+    # Find currently installed version. If there are multiple
+    # versions, they end up newline separated
+    local installed_ver=$(apt -qq list --installed ceph-libboost*-dev 2>/dev/null |
+                              cut -d' ' -f2 |
+                              cut -d'.' -f1,2 |
+			      sort -u)
+    # If installed_ver contains whitespace, we can't really count on it,
+    # but otherwise, bail out if the version installed is the version
+    # we want.
+    if test -n "$installed_ver" &&
+	    echo -n "$installed_ver" | tr '[:space:]' ' ' | grep -v -q ' '; then
+	if echo "$installed_ver" | grep -q "^$boost_ver"; then
+	    return
+        fi
+    fi
+
+    # Historical packages
+    $SUDO rm -f /etc/apt/sources.list.d/ceph-libboost*.list
+    # Currently used
+    $SUDO rm -f /etc/apt/sources.list.d/libboost.list
+    # Refresh package list so things aren't in the available list.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update -y || true
+    # Remove all ceph-libboost packages. We have an early return if
+    # the desired version is already (and the only) version installed,
+    # so no need to spare it.
+    if test -n "$installed_ver"; then
+	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y --fix-missing remove "ceph-libboost*"
+    fi
+}
+
 function install_boost_on_ubuntu {
-    local ver=1.75
+    # Once we get to this point, clean_boost_on_ubuntu() should ensure
+    # that there is no more than one installed version.
     local installed_ver=$(apt -qq list --installed ceph-libboost*-dev 2>/dev/null |
                               grep -e 'libboost[0-9].[0-9]\+-dev' |
                               cut -d' ' -f2 |
                               cut -d'.' -f1,2)
     if test -n "$installed_ver"; then
-        if echo "$installed_ver" | grep -q "^$ver"; then
+        if echo "$installed_ver" | grep -q "^$boost_ver"; then
             return
-        else
-            $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove "ceph-libboost.*${installed_ver}.*"
-            $SUDO rm -f /etc/apt/sources.list.d/ceph-libboost${installed_ver}.list
         fi
     fi
     local codename=$1
     local project=libboost
     local sha1=7aba8a1882670522ee1d1ee1bba0ea170b292dec
     install_pkg_on_ubuntu \
-	$project \
-	$sha1 \
-	$codename \
-	check \
-	ceph-libboost-atomic$ver-dev \
-	ceph-libboost-chrono$ver-dev \
-	ceph-libboost-container$ver-dev \
-	ceph-libboost-context$ver-dev \
-	ceph-libboost-coroutine$ver-dev \
-	ceph-libboost-date-time$ver-dev \
-	ceph-libboost-filesystem$ver-dev \
-	ceph-libboost-iostreams$ver-dev \
-	ceph-libboost-program-options$ver-dev \
-	ceph-libboost-python$ver-dev \
-	ceph-libboost-random$ver-dev \
-	ceph-libboost-regex$ver-dev \
-	ceph-libboost-system$ver-dev \
-	ceph-libboost-test$ver-dev \
-	ceph-libboost-thread$ver-dev \
-	ceph-libboost-timer$ver-dev
+        $project \
+        $sha1 \
+        $codename \
+        check \
+        ceph-libboost-atomic${boost_ver}-dev \
+        ceph-libboost-chrono${boost_ver}-dev \
+        ceph-libboost-container${boost_ver}-dev \
+        ceph-libboost-context${boost_ver}-dev \
+        ceph-libboost-coroutine${boost_ver}-dev \
+        ceph-libboost-date-time${boost_ver}-dev \
+        ceph-libboost-filesystem${boost_ver}-dev \
+        ceph-libboost-iostreams${boost_ver}-dev \
+        ceph-libboost-program-options${boost_ver}-dev \
+        ceph-libboost-python${boost_ver}-dev \
+        ceph-libboost-random${boost_ver}-dev \
+        ceph-libboost-regex${boost_ver}-dev \
+        ceph-libboost-system${boost_ver}-dev \
+        ceph-libboost-test${boost_ver}-dev \
+        ceph-libboost-thread${boost_ver}-dev \
+        ceph-libboost-timer${boost_ver}-dev
 }
 
 function install_libzbd_on_ubuntu {
@@ -296,6 +327,9 @@ else
     case "$ID" in
     debian|ubuntu|devuan|elementary|softiron)
         echo "Using apt-get to install dependencies"
+	# Put this before any other invocation of apt so it can clean
+	# up in a broken case.
+        clean_boost_on_ubuntu
         $SUDO apt-get install -y devscripts equivs
         $SUDO apt-get install -y dpkg-dev
         ensure_python3_sphinx_on_ubuntu

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -90,9 +90,9 @@ def with_cephadm_module(module_options=None, store=None):
     :param module_options: Set opts as if they were set before module.__init__ is called
     :param store: Set the store before module.__init__ is called
     """
-    with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option),\
+    with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option), \
             mock.patch("cephadm.services.osd.RemoveUtil._run_mon_cmd"), \
-            mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex),\
+            mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex), \
             mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
             mock.patch("cephadm.module.CephadmOrchestrator.remote"), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._request_agent_acks"), \

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -92,11 +92,11 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
             cephadm_module.set_container_image('global', 'from_image')
             cephadm_module.use_repo_digest = use_repo_digest
             with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*', count=2)),
-                              CephadmOrchestrator.apply_mgr, '', status_running=True),\
+                              CephadmOrchestrator.apply_mgr, '', status_running=True), \
                 mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name",
-                           return_value='foo'),\
+                           return_value='foo'), \
                 mock.patch("cephadm.module.CephadmOrchestrator.version",
-                           new_callable=mock.PropertyMock) as version_mock,\
+                           new_callable=mock.PropertyMock) as version_mock, \
                 mock.patch("cephadm.module.CephadmOrchestrator.get",
                            return_value={
                                # capture fields in both mon and osd maps

--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from prettytable import PrettyTable
 import re
 from threading import Event, Lock
-from typing import cast, Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Tuple, TypeVar,\
+from typing import cast, Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Tuple, TypeVar, \
     Union, TYPE_CHECKING
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62102

---

backport of https://github.com/ceph/ceph/pull/52559 + a quincy-only patch
parent tracker: https://tracker.ceph.com/issues/62097