### PR TITLE
reef: qa/distros: add centos stream 9 as supported distro

### DIFF
--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,0 +1,2 @@
+os_type: centos
+os_version: "9.stream"

--- a/qa/distros/all/centos_latest.yaml
+++ b/qa/distros/all/centos_latest.yaml
@@ -1,0 +1,1 @@
+centos_9.stream.yaml

--- a/qa/distros/supported-random-distro$/centos_latest.yaml
+++ b/qa/distros/supported-random-distro$/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/distros/supported/centos_8.stream.yaml
+++ b/qa/distros/supported/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+../all/centos_8.stream.yaml

--- a/qa/distros/supported/centos_latest.yaml
+++ b/qa/distros/supported/centos_latest.yaml
@@ -1,1 +1,1 @@
-../all/centos_8.yaml
+../all/centos_latest.yaml


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/50441 which didn't have a tracker issue. omits the final commit [qa/distos: centos9 enables ceph/el9 copr](https://github.com/ceph/ceph/pull/50441/commits/c9e873cc52336ddb62ab52d6cfd91eb799ca7ef0) whose revert is being tested on main in https://github.com/ceph/ceph/pull/52549

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
