### PR TITLE
test/libcephfs: update delegation test assertions

### DIFF
--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -186,9 +186,9 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   std::thread breaker1(open_breaker_func, tcmount, filename, O_RDWR, &opened);
 
   wait_for_atomic_bool(recalled);
-  ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker1.join();
+  ASSERT_EQ(opened.load(), true);
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
   ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
 
@@ -201,9 +201,9 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker2(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
   wait_for_atomic_bool(recalled);
-  ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker2.join();
+  ASSERT_EQ(opened.load(), true);
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
   ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
 
@@ -222,9 +222,9 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   std::thread breaker4(open_breaker_func, tcmount, filename, O_WRONLY, &opened);
   wait_for_atomic_bool(recalled);
   usleep(1000);
-  ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker4.join();
+  ASSERT_EQ(opened.load(), true);
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
   ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
 
@@ -389,10 +389,10 @@ TEST(LibCephFS, RecalledGetattr) {
     ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
   } while (!recalled.load());
-  ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount2, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, nullptr), 0);
   breaker1.join();
+  ASSERT_EQ(opened.load(), true);
   ASSERT_EQ(ceph_ll_close(cmount2, fh), 0);
   ceph_unmount(cmount2);
   ceph_release(cmount2);


### PR DESCRIPTION
Some of the libcephfs tests ensure that the delegations are recalled as a result of certain open requests.

The issue is that we're expecting the "opened" flag to be false after the delegation gets recalled, which is racy.

```
  /home/ubuntu/ceph/src/test/libcephfs/deleg.cc:392: Failure
  Expected equality of these values:
    opened.load()
      Which is: true
    false
```

We'll update those checks, asserting that "opened" is true after the delegation breaker thread returns.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
