### PR TITLE
reef: valgrind: replace suppression for EVP_DecryptFinal_ex

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -678,6 +678,19 @@
 }
 
 # "Conditional jump or move depends on uninitialised value(s)" in OpenSSL
+# https://github.com/openssl/openssl/issues/19719
+{
+  uninitialized value in gcm_cipher_internal
+  Memcheck:Cond
+  ...
+  fun:gcm_cipher_internal
+  ...
+  fun:ossl_gcm_stream_final
+  fun:EVP_DecryptFinal_ex
+  ...
+}
+
+# "Conditional jump or move depends on uninitialised value(s)" in OpenSSL
 # while using aes-128-gcm with AES-NI enabled. Not observed while running
 # with `OPENSSL_ia32cap="~0x200000200000000"`.
 {

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -689,31 +689,3 @@
   fun:EVP_DecryptFinal_ex
   ...
 }
-
-# "Conditional jump or move depends on uninitialised value(s)" in OpenSSL
-# while using aes-128-gcm with AES-NI enabled. Not observed while running
-# with `OPENSSL_ia32cap="~0x200000200000000"`.
-{
-   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 1
-   Memcheck:Cond
-   ...
-   fun:EVP_DecryptFinal_ex
-   fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v*4listEj
-   fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v*8ptr_nodeENS4_8disposerEEi
-   fun:_ZN10ProtocolV216run_continuationER2CtIS_E
-   ...
-   fun:_ZN15AsyncConnection7processEv
-   fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   ...
-}
-
-{
-   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 2
-   Memcheck:Cond
-   fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v*4listEj
-   fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v*8ptr_nodeENS4_8disposerEEi
-   fun:_ZN10ProtocolV216run_continuationER2CtIS_E
-   ...
-   fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   ...
-}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62106

---

backport of https://github.com/ceph/ceph/pull/52491
parent tracker: https://tracker.ceph.com/issues/61566

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh