### PR TITLE
quincy: client: correct quota check in Client::_rename()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14036,6 +14036,8 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
     else
       return -CEPHFS_EROFS;
   }
+
+  // don't allow cross-quota renames
   if (cct->_conf.get_val<bool>("client_quota") && fromdir != todir) {
     Inode *fromdir_root =
       fromdir->quota.is_enable() ? fromdir : get_quota_root(fromdir, perm);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59014

---

backport of https://github.com/ceph/ceph/pull/50127
parent tracker: https://tracker.ceph.com/issues/58220

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh