### PR TITLE
pacific: mds: allow all types of mds caps

### DIFF
--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -101,30 +101,17 @@ private:
 struct MDSCapMatch {
   static const int64_t MDS_AUTH_UID_ANY = -1;
 
-  MDSCapMatch() : uid(MDS_AUTH_UID_ANY), fs_name(std::string()) {}
+  MDSCapMatch() {}
 
-  MDSCapMatch(int64_t uid_, std::vector<gid_t>& gids_) :
-    uid(uid_), gids(gids_), fs_name(std::string()) {}
+  MDSCapMatch(const std::string& fsname_, const std::string& path_,
+	      bool root_squash_, int64_t uid_=MDS_AUTH_UID_ANY,
+	      const std::vector<gid_t>& gids_={}) {
+    fs_name = std::move(fsname_);
+    path = std::move(path_);
+    root_squash = root_squash_;
+    uid = (uid_ == 0) ? -1 : uid_;
+    gids = gids_;
 
-  explicit MDSCapMatch(const std::string &path_)
-    : uid(MDS_AUTH_UID_ANY), path(path_), fs_name(std::string()) {
-    normalize_path();
-  }
-
-  explicit MDSCapMatch(std::string path, std::string fs_name) :
-    uid(MDS_AUTH_UID_ANY), path(std::move(path)), fs_name(std::move(fs_name))
-  {
-    normalize_path();
-  }
-
-  explicit MDSCapMatch(std::string path, std::string fs_name, bool root_squash_) :
-    uid(MDS_AUTH_UID_ANY), path(std::move(path)), fs_name(std::move(fs_name)), root_squash(root_squash_)
-  {
-    normalize_path();
-  }
-
-  MDSCapMatch(const std::string& path_, int64_t uid_, std::vector<gid_t>& gids_)
-    : uid(uid_), gids(gids_), path(path_), fs_name(std::string()) {
     normalize_path();
   }
 
@@ -149,7 +136,8 @@ struct MDSCapMatch {
    */
   bool match_path(std::string_view target_path) const;
 
-  int64_t uid;       // Require UID to be equal to this, if !=MDS_AUTH_UID_ANY
+  // Require UID to be equal to this, if !=MDS_AUTH_UID_ANY
+  int64_t uid = MDS_AUTH_UID_ANY;
   std::vector<gid_t> gids;  // Use these GIDs
   std::string path;  // Require path to be child of this (may be "" or "/" for any)
   std::string fs_name;

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -24,7 +24,14 @@ using std::cout;
 
 entity_addr_t addr;
 
-const char *parse_good[] = {
+string fsnamecap = "fsname=a";
+string pathcap = "path=/dir1";
+string rscap = "root_squash";
+string uidcap = "uid=1000";
+string gidscap = "gids=1000,1001,1002";
+
+
+vector<string> parse_good = {
   "allow rw uid=1 gids=1",
   "allow * path=\"/foo\"",
   "allow * path=/foo",
@@ -35,8 +42,6 @@ const char *parse_good[] = {
   "allow *",
   "allow r",
   "allow rw",
-  "allow rw uid=1 gids=1,2,3",
-  "allow rw path=/foo uid=1 gids=1,2,3",
   "allow r, allow rw path=/foo",
   "allow r, allow * uid=1",
   "allow r ,allow * uid=1",
@@ -46,17 +51,50 @@ const char *parse_good[] = {
   "allow r uid=1 gids=1,2,3, allow * uid=2",
   "allow r network 1.2.3.4/8",
   "allow rw path=/foo uid=1 gids=1,2,3 network 2.3.4.5/16",
-  "allow r root_squash",
-  "allow rw path=/foo root_squash",
-  "allow rw fsname=a root_squash",
-  "allow rw fsname=a path=/foo root_squash",
-  "allow rw fsname=a root_squash, allow rwp fsname=a path=/volumes",
-  0
+
+  // Following are all types of MDS caps, or in other words, all
+  // (mathematical) combinations of fsnamecap, pathcap, rscap, uidcap, and
+  // gidscaps.
+  "allow rw " + fsnamecap,
+  "allow rw " + pathcap,
+  "allow rw " + rscap,
+  "allow rw " + uidcap,
+  "allow rw " + gidscap,
+
+  "allow rw " + fsnamecap + " " + pathcap,
+  "allow rw " + fsnamecap + " " + rscap,
+  "allow rw " + fsnamecap + " " + uidcap,
+  "allow rw " + fsnamecap + " " + gidscap,
+  "allow rw " + pathcap + " " + rscap,
+  "allow rw " + pathcap + " " + uidcap,
+  "allow rw " + pathcap + " " + gidscap,
+  "allow rw " + rscap + " " + uidcap,
+  "allow rw " + rscap + " " + gidscap,
+  "allow rw " + uidcap + " " + gidscap,
+
+  "allow rw " + fsnamecap + " " + pathcap + " " + rscap,
+  "allow rw " + fsnamecap + " " + pathcap + " " + uidcap,
+  "allow rw " + fsnamecap + " " + pathcap + " " + gidscap,
+  "allow rw " + fsnamecap + " " + rscap + " " + uidcap,
+  "allow rw " + fsnamecap + " " + rscap + " " + gidscap,
+  "allow rw " + fsnamecap + " " + uidcap + " " + gidscap,
+  "allow rw " + pathcap + " " + rscap + " " + uidcap,
+  "allow rw " + pathcap + " " + rscap + " " + gidscap,
+  "allow rw " + pathcap + " " + uidcap + " " + gidscap,
+  "allow rw " + rscap + " " + uidcap + " " + gidscap,
+
+  "allow rw " + fsnamecap + " " + pathcap + " " + rscap + " " + uidcap,
+  "allow rw " + fsnamecap + " " + pathcap + " " + rscap + " " + gidscap,
+  "allow rw " + fsnamecap + " " + pathcap + " " + uidcap + " " + gidscap,
+  "allow rw " + fsnamecap + " " + rscap + " " + uidcap + " " + gidscap,
+  "allow rw " + pathcap + " " + rscap + " " + uidcap + " " + gidscap,
+
+  "allow rw " + fsnamecap + " " + pathcap + " " + rscap + " " + uidcap +
+  " " + gidscap
 };
 
 TEST(MDSAuthCaps, ParseGood) {
-  for (int i=0; parse_good[i]; i++) {
-    string str = parse_good[i];
+  for (auto str : parse_good) {
     MDSAuthCaps cap;
     std::cout << "Testing good input: '" << str << "'" << std::endl;
     ASSERT_TRUE(cap.parse(str, &cout));
@@ -86,8 +124,6 @@ const char *parse_bad[] = {
   "allow namespace=foo",
   "allow rwx auid 123 namespace asdf",
   "allow wwx pool ''",
-  "allow rw gids=1",
-  "allow rw gids=1,2,3",
   "allow rw uid=123 gids=asdf",
   "allow rw uid=123 gids=1,2,asdf",
   0
@@ -99,6 +135,8 @@ TEST(MDSAuthCaps, ParseBad) {
     MDSAuthCaps cap;
     std::cout << "Testing bad input: '" << str << "'" << std::endl;
     ASSERT_FALSE(cap.parse(str, &cout));
+    // error message from parse() doesn't have newline char at the end of it
+    std::cout << std::endl;
   }
 }
 

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -101,6 +101,32 @@ TEST(MDSAuthCaps, ParseGood) {
   }
 }
 
+TEST(MDSAuthCaps, ParseDumpReparseCaps) {
+  for (auto str : parse_good) {
+    MDSAuthCaps cap1;
+    ASSERT_TRUE(cap1.parse(str, &cout));
+
+    std::cout << "Testing by parsing caps, dumping to string, reparsing "
+		 "string and then redumping and checking strings from "
+		 "first and second dumps: '" << str << "'" << std::endl;
+    // Convert cap object to string, reparse and check if converting again
+    // gives same string as before.
+    MDSAuthCaps cap2;
+    std::ostringstream cap1_ostream;
+    cap1_ostream << cap1;
+    string cap1_str = cap1_ostream.str();
+    // Removing "MDSAuthCaps[" from cap1_str
+    cap1_str.replace(0, 12, "");
+    // Removing "]" from cap1_str
+    cap1_str.replace(cap1_str.length() - 1, 1, "");
+    ASSERT_TRUE(cap2.parse(cap1_str, &cout));
+
+    std::ostringstream cap2_ostream;
+    cap2_ostream << cap2;
+    ASSERT_TRUE(cap1_ostream.str().compare(cap2_ostream.str()) == 0);
+  }
+}
+
 const char *parse_bad[] = {
   "allow r poolfoo",
   "allow r w",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62028

---

backport of https://github.com/ceph/ceph/pull/51317
parent tracker: https://tracker.ceph.com/issues/59388

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh