### PR TITLE
pacific: qa/cephfs: add 'rhel' to family of RH OS in xfstest_dev.py

### DIFF
--- a/qa/tasks/cephfs/test_acls.py
+++ b/qa/tasks/cephfs/test_acls.py
@@ -1,9 +1,9 @@
-import logging
+from logging import getLogger
 
 from io import BytesIO
 from tasks.cephfs.xfstests_dev import XFSTestsDev
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 class TestACLs(XFSTestsDev):
 

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -1,8 +1,10 @@
 from io import BytesIO
-import logging
+from logging import getLogger
+
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
-logger = logging.getLogger(__name__)
+
+logger = getLogger(__name__)
 
 
 # TODO: add code to run non-ACL tests too.

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -90,11 +90,12 @@ class XFSTestsDev(CephFSTestCase):
         distro = distro.lower()
         major_ver_num = int(version.split('.')[0]) # only keep major release
                                                    # number
+        log.info(f'distro and version detected is "{distro}" and "{version}".')
 
         # we keep fedora here so that right deps are installed when this test
         # is run locally by a dev.
         if distro in ('redhatenterpriseserver', 'redhatenterprise', 'fedora',
-                      'centos'):
+                      'centos', 'centosstream', 'rhel'):
             deps = """acl attr automake bc dbench dump e2fsprogs fio \
             gawk gcc indent libtool lvm2 make psmisc quota sed \
             xfsdump xfsprogs \

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
 
-logger = getLogger(__name__)
+log = getLogger(__name__)
 
 
 # TODO: add code to run non-ACL tests too.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58992

---

backport of https://github.com/ceph/ceph/pull/50142
parent tracker: https://tracker.ceph.com/issues/58726

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh