### PR TITLE
osd/scrub: fixing & improving ReservationTimeout handler messages

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -2480,9 +2480,13 @@ template<typename T>
 concept HasDoFormatTo = requires(T x, std::back_insert_iterator<fmt::memory_buffer> out) {
   { x.do_format_to(out, true) } -> std::same_as<decltype(out)>;
 };
-template <HasDoFormatTo T> struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+namespace fmt {
+// placed in the fmt namespace due to an ADL bug in g++ < 12
+// (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92944).
+template <HasDoFormatTo T> struct formatter<T> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const T& staged_iterator, FormatContext& ctx) {
     return staged_iterator.do_format_to(ctx.out(), true);
   }
 };
+}

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -591,9 +591,14 @@ MURef<T> make_message(Args&&... args) {
 }
 }
 
+namespace fmt {
+// placed in the fmt namespace due to an ADL bug in g++ < 12
+// (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92944).
+// Specifically - gcc pre-12 can't handle two templated specializations of
+// the formatter if in two different namespaces.
 template <std::derived_from<Message> M>
-struct fmt::formatter<M> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+struct formatter<M> {
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
   template <typename FormatContext>
   auto format(const M& m, FormatContext& ctx) const {
     std::ostringstream oss;
@@ -605,5 +610,6 @@ struct fmt::formatter<M> {
     }
   }
 };
+}  // namespace fmt
 
 #endif

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -144,16 +144,11 @@ sc::result ReservingReplicas::react(const ReservationTimeout&)
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
   dout(10) << "ReservingReplicas::react(const ReservationTimeout&)" << dendl;
 
-  dout(10)
-    << "PgScrubber: " << scrbr->get_spgid()
-    << " timeout on reserving replicas (since " << entered_at
-    << ")" << dendl;
-  scrbr->get_clog()->warn()
-    << "osd." << scrbr->get_whoami()
-    << " PgScrubber: " << scrbr->get_spgid()
-    << " timeout on reserving replicsa (since " << entered_at
-    << ")";
-
+  const auto msg = fmt::format(
+      "PgScrubber: {} timeout on reserving replicas (since {})",
+      scrbr->get_spgid(), entered_at);
+  dout(5) << msg << dendl;
+  scrbr->get_clog()->warn() << "osd." << scrbr->get_whoami() << " " << msg;
   scrbr->on_replica_reservation_timeout();
   return discard_event();
 }


### PR DESCRIPTION

Note: the use of the 'fmt' namespace is required due to a bug in gcc versions pre gcc-12.
