### PR TITLE
cephx: initializing two member variables in the ctors

### DIFF
--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -379,7 +379,7 @@ struct CephXServiceTicketInfo {
 WRITE_CLASS_ENCODER(CephXServiceTicketInfo)
 
 struct CephXAuthorizeChallenge : public AuthAuthorizerChallenge {
-  uint64_t server_challenge;
+  uint64_t server_challenge = 0;
   void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
@@ -396,7 +396,7 @@ struct CephXAuthorizeChallenge : public AuthAuthorizerChallenge {
 WRITE_CLASS_ENCODER(CephXAuthorizeChallenge)
 
 struct CephXAuthorize {
-  uint64_t nonce;
+  uint64_t nonce = 0;
   bool have_challenge = false;
   uint64_t server_challenge_plus_one = 0;
   void encode(ceph::buffer::list& bl) const {


### PR DESCRIPTION
Eliminating compiler warnings.

.../ceph/src/auth/cephx/CephxProtocol.cc: In member function ‘virtual bool CephXAuthorizer::add_challenge(ceph::common::CephContext*, const ceph::bufferlist&)’:
.../ceph/src/auth/cephx/CephxProtocol.cc:595:57: warning: ‘ch.CephXAuthorizeChallenge::server_challenge’ may be used uninitialized [-Wmaybe-uninitialized]
  595 |     msg.server_challenge_plus_one = ch.server_challenge + 1;
      |                                     ~~~~~~~~~~~~~~~~~~~~^~~
.../ceph/src/auth/cephx/CephxProtocol.cc:587:29: note: ‘ch.CephXAuthorizeChallenge::server_challenge’ was declared here
  587 |     CephXAuthorizeChallenge ch;
      |                             ^~
.../ceph/src/auth/cephx/CephxProtocol.cc: In function ‘bool cephx_verify_authorizer(ceph::common::CephContext*, const KeyStore&, ceph::buffer::v15_2_0::list::const_iterator&, size_t, CephXServiceTicketInfo&, std::unique_ptr<AuthAuthorizerChallenge>*, std::string*, ceph::bufferlist*)’:
.../ceph/src/auth/cephx/CephxProtocol.cc:524:41: warning: ‘auth_msg.CephXAuthorize::nonce’ may be used uninitialized [-Wmaybe-uninitialized]
  524 |   reply.nonce_plus_one = auth_msg.nonce + 1;
      |                          ~~~~~~~~~~~~~~~^~~
.../ceph/src/auth/cephx/CephxProtocol.cc:487:18: note: ‘auth_msg.CephXAuthorize::nonce’ was declared here
  487 |   CephXAuthorize auth_msg;
      |                  ^~~~~~~~

