### PR TITLE
qa: Fix cbt usage with Crimson

### DIFF
--- a/qa/suites/crimson-rados/perf/workloads/fio_4K_rand_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/fio_4K_rand_read.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/fio_4K_rand_rw.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/fio_4K_rand_rw.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_read.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_rw.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_rw.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_write.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/fio_4M_rand_write.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/radosbench_4K_rand_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/radosbench_4K_rand_read.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/radosbench_4K_seq_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/radosbench_4K_seq_read.yaml
@@ -21,3 +21,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/radosbench_4M_rand_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/radosbench_4M_rand_read.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/radosbench_4M_seq_read.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/radosbench_4M_seq_read.yaml
@@ -21,3 +21,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/radosbench_4M_write.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/radosbench_4M_write.yaml
@@ -21,3 +21,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/sample_fio.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/sample_fio.yaml
@@ -22,3 +22,10 @@ tasks:
           pg_size: 128
           pgp_size: 128
           replication: 3
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/suites/crimson-rados/perf/workloads/sample_radosbench.yaml
+++ b/qa/suites/crimson-rados/perf/workloads/sample_radosbench.yaml
@@ -21,3 +21,10 @@ tasks:
           pg_size: 256
           pgp_size: 256
           replication: 'replicated'
+    monitoring_profiles:
+      perf:
+        nodes:
+          - osds
+        perf_cmd: 'perf'
+        args: 'stat -p {pid} -o {perf_dir}/perf_stat.{pid}'
+        pid_glob: crimson-osd.*.pid

--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -78,7 +78,7 @@ class CBT(Task):
 
         if system_type == 'rpm':
             install_cmd = ['sudo', 'yum', '-y', 'install']
-            cbt_depends = ['python3-yaml', 'python3-lxml', 'librbd-devel', 'pdsh', 'pdsh-rcmd-ssh','linux-tools-generic']
+            cbt_depends = ['python3-yaml', 'python3-lxml', 'librbd-devel', 'pdsh', 'pdsh-rcmd-ssh','perf']
             self.log.info('Installing collectl')
             collectl_location = "https://sourceforge.net/projects/collectl/files/collectl/collectl-4.3.1/collectl-4.3.1.src.tar.gz/download"
             self.first_mon.run(


### PR DESCRIPTION
Centos perf runs are currently failed with (since e174c6e2cf6c90bd130320eb1f251b62d4b4d6c2):
`Error: Unable to find a match: linux-tools-generic`
Replace with yum's version of perf package.

---

Add monitoring_profiles to avoid:
```
2023-07-24T09:37:31.463 INFO:teuthology.orchestra.run.smithi114.stderr:    if 'collectl' not in monitoring_profiles:
2023-07-24T09:37:31.463 INFO:teuthology.orchestra.run.smithi114.stderr:TypeError: argument of type 'NoneType' is not iterable
```

---

Example run with the changes applied:
https://pulpito.ceph.com/matan-2023-07-24_11:05:05-crimson-rados-main-distro-crimson-smithi/
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
