### PR TITLE
qa/rgw: pacific upgrade disables centos9

### DIFF
--- a/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_8.stream.yaml
+++ b/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION
we don't build centos 9 packages for pacific, so the pacific upgrade suite was failing with errors like:

> Failed to fetch package version from https://shaman.ceph.com/api/search/?status=ready&project=ceph&flavor=default&distros=centos%2F9%2Fx86_64&ref=pacific

Fixes: https://tracker.ceph.com/issues/62135

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
