### PR TITLE
pacific: rgw: s3 object lock avoids overflow in retention date

### DIFF
--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -56,7 +56,7 @@ ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime)
   if (!rule_exist) {
     return ceph::real_time();
   }
-  int days = get_days();
+  int64_t days = get_days();
   if (days <= 0) {
     days = get_years()*365;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62138

---

backport of https://github.com/ceph/ceph/pull/52056
parent tracker: https://tracker.ceph.com/issues/56993

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh