### PR TITLE
reef: valgrind: update suppression for SyscallParam under call_init

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -184,20 +184,19 @@
    fun:*GetStackTrace*
 }
 {
-   tcmalloc: param points to uninit bytes under call_init (jammy)
+   tcmalloc: param points to uninit bytes under call_init (centos9) or call_init.part.0 (jammy)
    Memcheck:Param
    write(buf)
    fun:syscall
    obj:*libunwind*
-   obj:*libunwind*
-   obj:*libunwind*
+   ...
    obj:*libunwind*
    fun:_ULx86_64_step
    obj:*tcmalloc*
    obj:*tcmalloc*
    obj:*tcmalloc*
    obj:*tcmalloc*
-   fun:call_init.part.0
+   fun:call_init*
 }
 {
 	tcmalloc: string


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62142

---

backport of https://github.com/ceph/ceph/pull/52521
parent tracker: https://tracker.ceph.com/issues/62059

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh