### PR TITLE
ceph-dencoder: MDS - Add missing types

### DIFF
--- a/src/include/cephfs/metrics/Types.h
+++ b/src/include/cephfs/metrics/Types.h
@@ -688,6 +688,10 @@ public:
     apply_visitor(DumpPayloadVisitor(f), payload);
   }
 
+  static void generate_test_instances(std::list<ClientMetricMessage*>& ls) {
+    ls.push_back(new ClientMetricMessage(CapInfoPayload(1, 2, 3)));
+  }
+
   void print(std::ostream *out) const {
     apply_visitor(PrintPayloadVisitor(out), payload);
   }

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -226,7 +226,6 @@ struct vinodeno_t {
     ls.push_back(new vinodeno_t);
     ls.push_back(new vinodeno_t(1, 2));
   }
-
   inodeno_t ino;
   snapid_t snapid;
 };
@@ -371,7 +370,6 @@ public:
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<inline_data_t*>& ls);
-
   version_t version = 1;
 
 private:

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -73,14 +73,8 @@ void Capability::Export::dump(ceph::Formatter *f) const
 
 void Capability::Export::generate_test_instances(std::list<Capability::Export*>& ls)
 {
-  ls.push_back(new Export);
-  ls.push_back(new Export);
-  ls.back()->wanted = 1;
-  ls.back()->issued = 2;
-  ls.back()->pending = 3;
-  ls.back()->client_follows = 4;
-  ls.back()->mseq = 5;
-  ls.back()->last_issue_stamp = utime_t(6, 7);
+  ls.push_back(new Export());
+  ls.push_back(new Export(1, 2, 3, 4, 5, 6, 7, utime_t(8, 9), 10));
 }
 
 void Capability::Import::encode(ceph::buffer::list &bl) const
@@ -108,6 +102,11 @@ void Capability::Import::dump(ceph::Formatter *f) const
   f->dump_unsigned("migrate_seq", mseq);
 }
 
+void Capability::Import::generate_test_instances(std::list<Capability::Import*>& ls)
+{
+  ls.push_back(new Import());
+  ls.push_back(new Import(1, 2, 3));
+}
 /*
  * Capability::revoke_info
  */

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -100,6 +100,7 @@ public:
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator &p);
     void dump(ceph::Formatter *f) const;
+    static void generate_test_instances(std::list<Import*>& ls);
 
     int64_t cap_id = 0;
     ceph_seq_t issue_seq = 0;

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -115,6 +115,14 @@ void MirrorInfo::dump(ceph::Formatter *f) const {
   f->close_section(); // peers
 }
 
+void MirrorInfo::generate_test_instances(std::list<MirrorInfo*>& ls) {
+  ls.push_back(new MirrorInfo());
+  ls.push_back(new MirrorInfo());
+  ls.back()->mirrored = true;
+  ls.back()->peers.insert(Peer());
+  ls.back()->peers.insert(Peer());
+}
+
 void MirrorInfo::print(std::ostream& out) const {
   out << "[peers=" << peers << "]" << std::endl;
 }

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -168,6 +168,7 @@ struct MirrorInfo {
   Peers peers;
 
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<MirrorInfo*>& ls);
   void print(std::ostream& out) const;
 
   void encode(ceph::buffer::list &bl) const;

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -99,6 +99,17 @@ void PurgeItem::decode(bufferlist::const_iterator &p)
   DECODE_FINISH(p);
 }
 
+void PurgeItem::generate_test_instances(std::list<PurgeItem*>& ls) {
+  ls.push_back(new PurgeItem());
+  ls.push_back(new PurgeItem());
+  ls.back()->action = PurgeItem::PURGE_FILE;
+  ls.back()->ino = 1;
+  ls.back()->size = 2;
+  ls.back()->layout = file_layout_t();
+  ls.back()->old_pools = {1, 2};
+  ls.back()->snapc = SnapContext();
+  ls.back()->stamp = utime_t(3, 4);
+}
 // if Objecter has any slow requests, take that as a hint and
 // slow down our rate of purging
 PurgeQueue::PurgeQueue(

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -61,6 +61,7 @@ public:
     fragtree.dump(f);
     f->close_section();
   }
+  static void generate_test_instances(std::list<PurgeItem*>& ls);
 
   std::string_view get_type_str() const;
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -574,7 +574,6 @@ public:
   }
 
   static void generate_test_instances(std::list<SessionMapStore*>& ls);
-
   void reset_state()
   {
     session_map.clear();

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -43,6 +43,13 @@ void SimpleLock::dump(ceph::Formatter *f) const {
   f->close_section();
 }
 
+void SimpleLock::generate_test_instances(std::list<SimpleLock*>& ls) {
+  ls.push_back(new SimpleLock);
+  ls.push_back(new SimpleLock);
+  ls.back()->set_state(LOCK_SYNC);
+}
+
+
 int SimpleLock::get_wait_shift() const {
   switch (get_type()) {
     case CEPH_LOCK_DN:       return 0;

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -175,6 +175,12 @@ public:
     }
   }
 
+  //for dencoder only
+  SimpleLock() :
+    type(nullptr),
+    parent(nullptr)
+  {}
+
   SimpleLock(MDSCacheObject *o, const LockType *lt) :
     type(lt),
     parent(o)
@@ -199,8 +205,8 @@ public:
 
   // parent
   MDSCacheObject *get_parent() { return parent; }
-  int get_type() const { return type->type; }
-  const sm_t* get_sm() const { return type->sm; }
+  int get_type() const { return (type != nullptr) ? type->type : 0; }
+  const sm_t* get_sm() const { return (type != nullptr) ? type->sm : nullptr; }
 
   int get_cap_shift() const;
   int get_cap_mask() const;
@@ -493,6 +499,7 @@ public:
       encode(empty_gather_set, bl);
     ENCODE_FINISH(bl);
   }
+  
   void decode(ceph::buffer::list::const_iterator& p) {
     DECODE_START(2, p);
     decode(state, p);
@@ -588,6 +595,7 @@ public:
    * to formatter, or nothing if is_sync_and_unlocked.
    */
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<SimpleLock*>& ls);
 
   virtual void print(std::ostream& out) const {
     out << "(";

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -37,6 +37,50 @@ ceph_lock_state_t::~ceph_lock_state_t()
   }
 }
 
+void ceph_lock_state_t::dump(ceph::Formatter *f) const {
+  f->dump_int("type", type);
+  f->dump_int("held_locks", held_locks.size());
+  for (auto &p : held_locks) {
+    f->open_object_section("lock");
+    f->dump_int("start", p.second.start);
+    f->dump_int("length", p.second.length);
+    f->dump_int("client", p.second.client);
+    f->dump_int("owner", p.second.owner);
+    f->dump_int("pid", p.second.pid);
+    f->dump_int("type", p.second.type);
+    f->close_section();
+  }
+  f->dump_int("waiting_locks", waiting_locks.size());
+  for (auto &p : waiting_locks) {
+    f->open_object_section("lock");
+    f->dump_int("start", p.second.start);
+    f->dump_int("length", p.second.length);
+    f->dump_int("client", p.second.client);
+    f->dump_int("owner", p.second.owner);
+    f->dump_int("pid", p.second.pid);
+    f->dump_int("type", p.second.type);
+    f->close_section();
+  }
+  f->dump_int("client_held_lock_counts", client_held_lock_counts.size());
+  for (auto &p : client_held_lock_counts) {
+    f->open_object_section("client");
+    f->dump_int("client_id", p.first.v);
+    f->dump_int("count", p.second);
+    f->close_section();
+  }
+  f->dump_int("client_waiting_lock_counts", client_waiting_lock_counts.size());
+}
+
+
+void ceph_lock_state_t::generate_test_instances(std::list<ceph_lock_state_t*>& ls) {
+  ls.push_back(new ceph_lock_state_t(NULL, 0));
+  ls.push_back(new ceph_lock_state_t(NULL, 1));
+  ls.back()->held_locks.insert(std::make_pair(1, ceph_filelock()));
+  ls.back()->waiting_locks.insert(std::make_pair(1, ceph_filelock()));
+  ls.back()->client_held_lock_counts.insert(std::make_pair(1, 1));
+  ls.back()->client_waiting_lock_counts.insert(std::make_pair(1, 1));
+}
+
 bool ceph_lock_state_t::is_waiting(const ceph_filelock &fl) const
 {
   auto p = waiting_locks.find(fl.start);

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -71,6 +71,7 @@ inline bool operator!=(const ceph_filelock& l, const ceph_filelock& r) {
 class ceph_lock_state_t {
 public:
   explicit ceph_lock_state_t(CephContext *cct_, int type_) : cct(cct_), type(type_) {}
+  ceph_lock_state_t() : cct(NULL), type(0) {}
   ~ceph_lock_state_t();
   /**
    * Check if a lock is on the waiting_locks list.
@@ -132,6 +133,8 @@ public:
     decode(held_locks, bl);
     decode(client_held_lock_counts, bl);
   }
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<ceph_lock_state_t*>& ls);
   bool empty() const {
     return held_locks.empty() && waiting_locks.empty() &&
 	   client_held_lock_counts.empty() &&

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -504,6 +504,15 @@ void feature_bitset_t::dump(Formatter *f) const {
   f->dump_string("feature_bits", css->strv());
 }
 
+void feature_bitset_t::generate_test_instances(std::list<feature_bitset_t*>& ls)
+{
+  ls.push_back(new feature_bitset_t());
+  ls.push_back(new feature_bitset_t());
+  ls.back()->_vec.push_back(1);
+  ls.back()->_vec.push_back(2);
+  ls.back()->_vec.push_back(3);
+}
+
 void feature_bitset_t::print(ostream& out) const
 {
   std::ios_base::fmtflags f(out.flags());
@@ -538,6 +547,13 @@ void metric_spec_t::decode(bufferlist::const_iterator &p) {
 
 void metric_spec_t::dump(Formatter *f) const {
   f->dump_object("metric_flags", metric_flags);
+}
+
+void metric_spec_t::generate_test_instances(std::list<metric_spec_t*>& ls)
+{
+  ls.push_back(new metric_spec_t());
+  ls.push_back(new metric_spec_t());
+  ls.back()->metric_flags = 1;
 }
 
 void metric_spec_t::print(ostream& out) const
@@ -575,6 +591,16 @@ void client_metadata_t::dump(Formatter *f) const
   f->dump_object("metric_spec", metric_spec);
   for (const auto& [name, val] : kv_map)
     f->dump_string(name.c_str(), val);
+}
+
+void client_metadata_t::generate_test_instances(std::list<client_metadata_t*>& ls)
+{
+  ls.push_back(new client_metadata_t());
+  ls.push_back(new client_metadata_t());
+  ls.back()->kv_map["key1"] = "val1";
+  ls.back()->kv_map["key2"] = "val2";
+  ls.back()->features = 0x12345678;
+  ls.back()->metric_spec.metric_flags = 0x12345678;
 }
 
 /*

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -348,6 +348,7 @@ public:
   void decode(ceph::buffer::list::const_iterator &p);
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
+  static void generate_test_instances(std::list<feature_bitset_t*>& ls);
 private:
   std::vector<block_type> _vec;
 };
@@ -384,6 +385,7 @@ struct metric_spec_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<metric_spec_t*>& ls);
   void print(std::ostream& out) const;
 
   // set of metrics that a client is capable of forwarding
@@ -430,6 +432,7 @@ struct client_metadata_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<client_metadata_t*>& ls);
 
   kv_map_t kv_map;
   feature_bitset_t features;
@@ -631,7 +634,10 @@ struct metareqid_t {
   void print(std::ostream& out) const {
     out << name << ":" << tid;
   }
-
+  static void generate_test_instances(std::list<metareqid_t*>& ls) {
+    ls.push_back(new metareqid_t);
+    ls.push_back(new metareqid_t(entity_name_t::CLIENT(123), 456));
+  }
   entity_name_t name;
   uint64_t tid = 0;
 };
@@ -782,6 +788,15 @@ struct dirfrag_t {
     using ceph::decode;
     decode(ino, bl);
     decode(frag, bl);
+  }
+  void dump(ceph::Formatter *f) const {
+    f->dump_unsigned("ino", ino);
+    f->dump_unsigned("frag", frag);
+  }
+  static void generate_test_instances(std::list<dirfrag_t*>& ls) {
+    ls.push_back(new dirfrag_t);
+    ls.push_back(new dirfrag_t(1, frag_t()));
+    ls.push_back(new dirfrag_t(2, frag_t(3)));
   }
 
   inodeno_t ino = 0;

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -151,6 +151,25 @@ struct MDSHealthMetric
     DECODE_FINISH(bl);
   }
 
+  void dump(ceph::Formatter *f) const {
+    f->dump_string("type", mds_metric_name(type));
+    f->dump_stream("sev") << sev;
+    f->dump_string("message", message);
+    f->open_object_section("metadata");
+    for (auto& i : metadata) {
+      f->dump_string(i.first.c_str(), i.second);
+    }
+    f->close_section();
+  }
+
+  static void generate_test_instances(std::list<MDSHealthMetric*>& ls) {
+    ls.push_back(new MDSHealthMetric());
+    ls.back()->type = MDS_HEALTH_CACHE_OVERSIZED;
+    ls.push_back(new MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN, "MDS is behind on trimming"));
+    ls.back()->metadata["mds"] = "a";
+    ls.back()->metadata["num"] = "1";
+  }
+
   bool operator==(MDSHealthMetric const &other) const
   {
     return (type == other.type && sev == other.sev && message == other.message);
@@ -181,6 +200,23 @@ struct MDSHealth
     DECODE_START(1, bl);
     decode(metrics, bl);
     DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const {
+    f->open_array_section("metrics");
+    for (auto& i : metrics) {
+      f->open_object_section("metric");
+      i.dump(f);
+      f->close_section();
+    }
+    f->close_section();
+  }
+
+  static void generate_test_instances(std::list<MDSHealth*>& ls) {
+    ls.push_back(new MDSHealth);
+    ls.push_back(new MDSHealth);
+    ls.back()->metrics.push_back(MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN,
+             "MDS is behind on trimming"));
   }
 
   bool operator==(MDSHealth const &other) const

--- a/src/mgr/DaemonHealthMetric.h
+++ b/src/mgr/DaemonHealthMetric.h
@@ -7,6 +7,7 @@
 #include <ostream>
 #include "common/Formatter.h"
 #include "include/denc.h"
+#include "common/Formatter.h"
 
 enum class daemon_metric : uint8_t {
   SLOW_OPS,

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -7,6 +7,8 @@
 #include "common/ceph_json.h"
 #include "include/denc.h"
 #include "include/stringify.h"
+#include "common/Formatter.h"
+
 #include "mgr/Types.h"
 
 #include <regex>
@@ -70,7 +72,6 @@ struct OSDPerfMetricSubKeyDescriptor {
     denc(v.regex_str, p);
     DENC_FINISH(p);
   }
-
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("type", static_cast<uint8_t>(type));
     f->dump_string("regex", regex_str);

--- a/src/tools/ceph-dencoder/mds_types.h
+++ b/src/tools/ceph-dencoder/mds_types.h
@@ -10,13 +10,22 @@ TYPE(SnapInfo)
 TYPE(snaplink_t)
 TYPE(sr_t)
 
-#include "mds/mdstypes.h"
+#include "mds/SimpleLock.h"
+TYPE_NOCOPY(SimpleLock)
+
+#include "mds/PurgeQueue.h"
+TYPE(PurgeItem)
+
+#include "mds/Anchor.h"
+TYPE(Anchor)
+
 #include "include/cephfs/types.h"
 TYPE(frag_info_t)
 TYPE(nest_info_t)
 TYPE(quota_info_t)
 TYPE(client_writeable_range_t)
 TYPE_FEATUREFUL(inode_t<std::allocator>)
+//TYPE(inode_t<std::allocator>)
 TYPE_FEATUREFUL(old_inode_t<std::allocator>)
 TYPE(fnode_t)
 TYPE(old_rstat_t)
@@ -31,6 +40,10 @@ TYPE(mds_load_t)
 TYPE(MDSCacheObjectInfo)
 TYPE(inode_backtrace_t)
 TYPE(inode_backpointer_t)
+TYPE(vinodeno_t)
+
+#include "include/cephfs/metrics/Types.h"
+TYPE(ClientMetricMessage)
 
 #include "mds/CInode.h"
 TYPE_FEATUREFUL(InodeStore)
@@ -40,12 +53,18 @@ TYPE_FEATUREFUL(InodeStoreBare)
 TYPE_FEATUREFUL(MDSMap)
 TYPE_FEATUREFUL(MDSMap::mds_info_t)
 
+#include "mds/flock.h"
+TYPE(ceph_lock_state_t)
+
 #include "mds/FSMap.h"
 //TYPE_FEATUREFUL(Filesystem)
 TYPE_FEATUREFUL(FSMap)
+TYPE(MirrorInfo)
 
 #include "mds/Capability.h"
 TYPE_NOCOPY(Capability)
+TYPE(Capability::Export)
+TYPE(Capability::Import)
 
 #include "mds/inode_backtrace.h"
 TYPE(inode_backpointer_t)
@@ -54,8 +73,11 @@ TYPE(inode_backtrace_t)
 #include "mds/InoTable.h"
 TYPE(InoTable)
 
+#include "mds/SessionMap.h"
+//TYPE_FEATUREFUL(SessionMapStore)
+
 #include "mds/SnapServer.h"
-TYPE_STRAYDATA(SnapServer)
+TYPE_FEATUREFUL(SnapServer)
 
 #include "mds/events/ECommitted.h"
 TYPE_FEATUREFUL_NOCOPY(ECommitted)
@@ -109,4 +131,22 @@ TYPE_FEATUREFUL_NOCOPY(ETableServer)
 
 #include "mds/events/EUpdate.h"
 TYPE_FEATUREFUL_NOCOPY(EUpdate)
+
+#include "mgr/MetricTypes.h"
+TYPE(MDSMetricPayload)
+TYPE(MetricReportMessage)
+TYPE(MDSConfigPayload)
+
+#include "mds/mdstypes.h"
+TYPE(metareqid_t)
+TYPE(feature_bitset_t)
+TYPE(dirfrag_t)
+TYPE(client_metadata_t)
+TYPE(MDSPerfMetricReport)
+TYPE(metric_spec_t)
+
+#include "messages/MMDSBeacon.h"
+TYPE(MDSHealthMetric)
+TYPE(MDSHealth)
+
 #endif // WITH_CEPHFS


### PR DESCRIPTION
…code-decode comparison

Currently, ceph-dencoder lacks certain mds types, preventing us from accurately checking the ceph corpus for encode-decode mismatches. This pull request aims to address this issue by adding the missing types to ceph-dencoder.

To successfully incorporate these types into ceph-dencoder, we need to introduce the necessary `dump` and `generate_test_instances` functions that was missing in some types. These functions are essential for proper encode and decode of the added types.

This PR will enhance the functionality of ceph-dencoder by including the missing types, enabling a comprehensive analysis of encode-decode consistency. With the addition of these types, we can ensure the robustness and correctness of the ceph corpus.

This update will significantly contribute to improving the overall reliability and accuracy of ceph-dencoder. It allows for a more comprehensive assessment of the encode-decode behavior, leading to enhanced data integrity and stability within the ceph ecosystem.

Fixes: https://tracker.ceph.com/issues/61788





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
