### PR TITLE
rbd-mirror: Handle timeouts within mirroring daemon so that force promote doesn't lead to any stuck ops

### DIFF
--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -441,6 +441,13 @@ options:
   default: false
   services:
   - rbd
+- name: rbd_retry_attempts
+  type: uint
+  level: advanced
+  desc: maximum retries to perform on errors such as timeout or resource busy
+  default: 3
+  services:
+  - rbd
 - name: rbd_mirroring_resync_after_disconnect
   type: bool
   level: advanced

--- a/src/librbd/mirror/snapshot/RemoveImageStateRequest.h
+++ b/src/librbd/mirror/snapshot/RemoveImageStateRequest.h
@@ -51,6 +51,7 @@ private:
 
   ImageCtxT *m_image_ctx;
   uint64_t m_snap_id;
+  uint64_t m_retry_attempts = 0;
   Context *m_on_finish;
 
   bufferlist m_bl;

--- a/src/librbd/operation/SnapshotRemoveRequest.h
+++ b/src/librbd/operation/SnapshotRemoveRequest.h
@@ -83,6 +83,7 @@ private:
   cls::rbd::ChildImageSpecs m_child_images;
   std::string m_snap_name;
   uint64_t m_snap_id;
+  uint64_t m_retry_attempts = 0;
   bool m_trashed_snapshot = false;
   bool m_child_attached = false;
 

--- a/src/tools/rbd_mirror/ClusterWatcher.h
+++ b/src/tools/rbd_mirror/ClusterWatcher.h
@@ -58,6 +58,7 @@ private:
   ServicePools m_service_pools;
   PoolPeers m_pool_peers;
   std::string m_site_name;
+  uint64_t m_retry_attempts = 0;
 
   void read_pool_peers(PoolPeers *pool_peers);
 

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -916,7 +916,7 @@ void LeaderWatcher<I>::handle_notify_heartbeat(int r) {
     return;
   }
 
-  if (r < 0 && r != -ETIMEDOUT) {
+  if (r < 0 && (r != -ETIMEDOUT && r != -EBADMSG)) {
     derr << "error notifying heartbeat: " << cpp_strerror(r)
          <<  ", releasing leader" << dendl;
     release_leader_lock();

--- a/src/tools/rbd_mirror/LeaderWatcher.h
+++ b/src/tools/rbd_mirror/LeaderWatcher.h
@@ -216,6 +216,7 @@ private:
   Context *m_on_finish = nullptr;
   Context *m_on_shut_down_finish = nullptr;
   uint64_t m_acquire_attempts = 0;
+  uint64_t m_retry_attempts = 0;
   int m_ret_val = 0;
   Instances<ImageCtxT> *m_instances = nullptr;
   librbd::managed_lock::Locker m_locker;

--- a/src/tools/rbd_mirror/MirrorStatusUpdater.cc
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.cc
@@ -379,10 +379,16 @@ void MirrorStatusUpdater<I>::handle_update_task(int r) {
 
   m_updating_global_image_ids.clear();
 
+  bool unlock = true;
   if (m_update_requested) {
     m_update_requested = false;
-    queue_update_task(std::move(locker));
-  } else {
+    if (r != -ETIMEDOUT) {
+      queue_update_task(std::move(locker));
+      unlock = false;
+    }
+  }
+
+  if (unlock) {
     locker.unlock();
   }
 

--- a/src/tools/rbd_mirror/RemotePoolPoller.h
+++ b/src/tools/rbd_mirror/RemotePoolPoller.h
@@ -104,6 +104,7 @@ private:
 
   RemotePoolMeta m_remote_pool_meta;
   bool m_updated = false;
+  uint64_t m_retry_attempts = 0;
 
   State m_state = STATE_INITIALIZING;
   Context* m_timer_task = nullptr;


### PR DESCRIPTION
When the primary cluster hits disaster and is not reachable, a force promote on the secondary cluster will lead to stuck in the various components like image replayers, pool replayers, RemotePoolPoller, Cluster watcher, Leader watcher and various others, because these components need some OSD ops which are currently stuck for infinite time as the remote cluster is no longer available.

This tracker ensures that there are no stuck components with in the mirroring daemon. We set timeout option `--rbd-mirror-remote-osd-op-timeout=30` which internally uses OSD's `--rados-osd-op-timeout` with mirroring daemon that sets the OSD op timeout i.e. fix the various components which are not in a position to handle the timeout errors within the mirroring daemon.

Goal:
* rbd-mirror daemon should be in a position to gracefully handle force promote
* rbd-mirror daemon should be in a position to gracefully handle the random timeout errors from OSD's (that might happen because of a sudden spike in the network or overall pressure on the underline node)

Fixes: https://tracker.ceph.com/issues/62163
Needs: https://github.com/ceph/ceph/pull/51540

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
