### PR TITLE
build: bump gcc version to 12 for debian bookworm

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DESTDIR=$(CURDIR)/debian/tmp
 
 include /usr/share/dpkg/default.mk
 
-extraopts += -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
+extraopts += -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
 ifneq (,$(findstring WITH_STATIC_LIBSTDCXX,$(CEPH_EXTRA_CMAKE_ARGS)))
   # dh_auto_build sets LDFLAGS with `dpkg-buildflags --get LDFLAGS` on ubuntu,
   # which makes the application aborts when the shared library throws

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -418,7 +418,7 @@ else
                 $with_zbd && install_libzbd_on_ubuntu bionic
                 ;;
             *Focal*)
-                ensure_decent_gcc_on_ubuntu 11 focal
+                ensure_decent_gcc_on_ubuntu 12 focal
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu focal
                 $with_zbd && install_libzbd_on_ubuntu focal
                 ;;

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -423,6 +423,7 @@ else
                 $with_zbd && install_libzbd_on_ubuntu focal
                 ;;
             *Jammy*)
+                ensure_decent_gcc_on_ubuntu 12 jammy
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu jammy
                 $SUDO apt-get install -y gcc
                 ;;


### PR DESCRIPTION
debian/rules had pinned the gcc version to 11, but bookworm only has 12. raise the pin to gcc-12, and enable the toolchain ppa to make that available for ubuntu jammy

Fixes: https://tracker.ceph.com/issues/61845

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
