### PR TITLE
osd/scrub: reduce calls to on_scrub_schedule_input_change()

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2564,16 +2564,20 @@ void PG::handle_advance_map(
     rctx);
 }
 
-void PG::handle_activate_map(PeeringCtx &rctx)
+void PG::handle_activate_map(PeeringCtx &rctx, epoch_t range_starts_at)
 {
-  dout(10) << __func__ << ": " << get_osdmap()->get_epoch()
-	   << dendl;
+  dout(10) << fmt::format("{}: epoch range: {}..{}", __func__, range_starts_at,
+                          get_osdmap()->get_epoch())
+           << dendl;
   recovery_state.activate_map(rctx);
-
   requeue_map_waiters();
 
-  // pool options affecting scrub may have changed
-  on_scrub_schedule_input_change();
+  // If pool.info changed during this sequence of map updates, invoke
+  // on_scrub_schedule_input_change() as pool.info contains scrub scheduling
+  // parameters.
+  if (pool.info.last_change >= range_starts_at) {
+    on_scrub_schedule_input_change();
+  }
 }
 
 void PG::handle_initialize(PeeringCtx &rctx)

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -682,7 +682,14 @@ public:
     std::vector<int>& newup, int up_primary,
     std::vector<int>& newacting, int acting_primary,
     PeeringCtx &rctx);
-  void handle_activate_map(PeeringCtx &rctx);
+
+  /**
+   *  \note: handle_activate_map() is not guaranteed to be called for
+   *  each epoch in sequence. Thus we supply it with the full range of
+   *  epochs that were skipped.
+   */
+  void handle_activate_map(PeeringCtx &rctx, epoch_t range_starts_at);
+
   void handle_initialize(PeeringCtx &rxcx);
   void handle_query_state(ceph::Formatter *f);
 


### PR DESCRIPTION
PG::handle_activate_map() modified to accept the range of epochs since its last invocation.
A possible scrub-related parameters change will only be handled if the latest pool info
change was within that time range.

