### PR TITLE
test/TestOSDMap: don't use the deprecated std::random_shuffle method

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -2349,7 +2349,9 @@ TEST_F(OSDMapTest, ReadBalanceScore1) {
         float fratio = 1. / (float)replica_count;
         for (int iter = 0 ; iter < 100 ; iter++) {  // run the test 100 times
           // Create random shuffle of OSDs
-          std::random_shuffle (osds.begin(), osds.end());
+          std::random_device seed;
+          std::default_random_engine generator(seed());
+          std::shuffle(osds.begin(), osds.end(), generator);
           for (uint i = 0 ; i < num_osds ; i++) {
             if ((float(i + 1) / float(num_osds)) < fratio) {
               ASSERT_TRUE(osds[i] < num_osds);


### PR DESCRIPTION
test/TestOSDMap: don't use the deprecated std::random_shuffle method

Fixes: https://tracker.ceph.com/issues/62203

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
