### PR TITLE
ci: run make-check as GH Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,81 @@
+name: Build and Test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  install-dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro-name: centos
+            distro-release: stream8
+            distro-image: quay.io/centos/centos:stream8
+            cache_package_path: |
+              /var/lib/dnf
+              /var/cache/dnf
+            cache_package_hashfiles: |
+              ceph.spec.in
+          #- distro-name: centos
+          #  distro-release: stream9
+          #- ubuntu:20.04
+          #- ubuntu:22.04
+    container:
+      image: ${{ matrix.distro-image }}
+      options: --user root
+      env:
+        BASH_ENV: ./run-make-check.sh
+        SHELLOPTS: xtrace
+        FOR_MAKE_CHECK: 1
+        DNF_INSTALL_OPTIONS: >-
+          --setopt=install_weak_deps=False
+          --setopt=keepcache=True
+          --setopt=fastestmirror=True
+          --nodocs
+    defaults:
+      run:
+        shell: bash
+    env:
+      CACHE_PACKAGE_HASHFILES: |
+        install-deps.sh
+        run-make-check.sh
+        do_cmake.sh
+        src/script/run-make.sh
+        src/script/lib-build.sh
+    name: "${{ matrix.distro-name }}:${{ matrix.distro-release }}"
+    timeout-minutes: 120
+    steps:
+      - run: |
+          dnf install -y $DNF_INSTALL_OPTIONS git-core
+      - run: export
+      - run: set
+      - name: Restore package cache
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Restore ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.distro-name }}-${{ matrix.distro-release }}-${{ github.ref_name }}
+          restore-keys: |
+            packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.cache_package_path }}
+          key: packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-${{ hashFiles(env.CACHE_PACKAGE_HASHFILES, matrix.cache_package_hashfiles) }}
+          restore-keys: |
+            packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-
+      - run: prepare
+      - run: ccache -s
+      - run: configure
+      - run: build vstart
+      - name: Test
+        run: |
+          build tests
+          cd build
+          run

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -43,7 +43,7 @@ function run() {
     fi
 
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
-    if in_jenkins; then
+    if in_ci; then
         if ! ctest $CHECK_MAKEOPTS --no-compress-output --output-on-failure --test-output-size-failed 1024000 -T Test; then
             # do not return failure, as the jenkins publisher will take care of this
             rm -fr ${TMPDIR:-/tmp}/ceph-asok.*
@@ -72,7 +72,7 @@ function main() {
     # uses run-make.sh to install-deps
     FOR_MAKE_CHECK=1 prepare
     configure "$@"
-    in_jenkins && echo "CI_DEBUG: Running 'build tests'"
+    in_ci && echo "CI_DEBUG: Running 'build tests'"
     build tests
     echo "make check: successful build on $(git rev-parse HEAD)"
     FOR_MAKE_CHECK=1 run

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -22,12 +22,12 @@
 # shellcheck disable=SC2034
 _SOURCED_LIB_BUILD=1
 
-function in_jenkins() {
-    [ -n "$JENKINS_HOME" ]
+function in_ci() {
+    [ -n "$JENKINS_HOME" -o -n "$CI" ]
 }
 
 function ci_debug() {
-    if in_jenkins || [ "${FORCE_CI_DEBUG}" ]; then
+    if in_ci || [ "${FORCE_CI_DEBUG}" ]; then
         echo "CI_DEBUG: $*"
     fi
 }


### PR DESCRIPTION
## Jenkins `make check` Feature parity

- [ ] Base OS
	- [ ] Ubuntu 20.04
	- [ ] Ubuntu 22.04
	- [x] CentOS 8
	- [ ] CentOS 9
- [x] Timestamps
- [x] Timeout: [per job](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) and [per-task timeouts](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes).
- [x] Log & Artifact retention (15 days in Jenkins, [90 days in Github Actions](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization))
- [ ] Abort previous build on new build
- [x] Trigger phrases (not needed, jobs can be directly retriggered from Github)
- [ ] JUnit-like reporting
- [ ] Failure cause analysis
- [x] Parameters ([inputs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs))
- [ ] Runtime (Jenkins is ~42 mins, Github is ...)
- [ ] Optimizations
	- [ ] Parallelize
	- [ ] ccache
	- [ ] cache git
	- [x] cache OS packages (dnf): `install-deps.sh` went from 30min-1 hour (🤯) to 3 mins.
	- [x] cache pip packages: reduced `install-deps.sh` from the above 5-8 mins to 4.
	- [ ] Check-out with submodules.
	- [ ] `DNF_INSTALL_OPTIONS = --setopt fastestmirror=true` 
	- [ ] cache npm packages

## Issues
- [ ] `install-deps.sh` doesn't fail when a single command fails (despite the `set -e` flag). [Example](https://github.com/ceph/ceph/actions/runs/5695180308/job/15437800096?pr=52677#step:5:3873). 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
