### PR TITLE
pacific: mds: update mdlog perf counters during replay

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1419,6 +1419,7 @@ void MDLog::_replay_thread()
       le->_segment->num_events++;
       le->_segment->end = journaler->get_read_pos();
       num_events++;
+      logger->set(l_mdl_ev, num_events);
 
       {
         std::lock_guard l(mds->mds_lock);
@@ -1431,6 +1432,8 @@ void MDLog::_replay_thread()
     }
 
     logger->set(l_mdl_rdpos, pos);
+    logger->set(l_mdl_expos, journaler->get_expire_pos());
+    logger->set(l_mdl_wrpos, journaler->get_write_pos());
   }
 
   // done!


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62190

---

backport of https://github.com/ceph/ceph/pull/52275
parent tracker: https://tracker.ceph.com/issues/61864

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh