### PR TITLE
build: globally set FMT_USE_TZSET=0 for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if(WIN32)
   # https://github.com/msys2/MINGW-packages/issues/3319
   add_definitions(
     -D_WIN32_WINNT=${WIN32_WINNT}
+    -DFMT_USE_TZSET=0
     -DBOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN
     -DBOOST_THREAD_V2_SHARED_MUTEX
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -337,8 +337,6 @@ else()
   add_subdirectory(fmt)
   set(BUILD_SHARED_LIBS ${old_BUILD_SHARED_LIBS})
   unset(old_BUILD_SHARED_LIBS)
-  target_compile_definitions(fmt PUBLIC
-    $<$<BOOL:${WIN32}>:FMT_USE_TZSET=0>)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/fmt/include")
 endif()
 


### PR DESCRIPTION
We're currently setting FMT_USE_TZSET=0 when building libfmt in order to avoid the _tzset function, which is unavailable under Mingw:
https://github.com/ceph/ceph/commit/aa5769ecf1d80fc9824280d2e90fd4c61a0e7769

The issue is that it still gets used by fmt/chrono.h, which is why we'll add this definition to the top level cmake file.

Note that the Windows build is currently failing as a result of a recent change: https://github.com/ceph/ceph/pull/52590

```
  In file included from ceph/src/common/ceph_time.h:22,
                   from ceph/src/include/encoding.h:31,
                   from ceph/src/include/uuid.h:9,
                   from ceph/src/include/types.h:21,
                   from ceph/src/crush/CrushWrapper.h:14,
                   from ceph/src/crush/CrushCompiler.h:7,
                   from ceph/src/crush/CrushCompiler.cc:4:
  ceph/src/fmt/include/fmt/chrono.h: In lambda function:
  ceph/src/fmt/include/fmt/chrono.h:953:5: error: ‘_tzset’ was
  not declared in this scope; did you mean ‘tzset’?
    953 |     _tzset();
        |     ^~~~~~
        |     tzset
```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
