### PR TITLE
cephadm: refactor code to make use of DaemonIdentity type

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1887,7 +1887,7 @@ def get_unit_name(fsid, daemon_type, daemon_id=None):
     # type: (str, str, Optional[Union[int, str]]) -> str
     # accept either name or type + id
     if daemon_id is not None:
-        return 'ceph-%s@%s.%s' % (fsid, daemon_type, daemon_id)
+        return DaemonIdentity(fsid, daemon_type, daemon_id).unit_name
     else:
         return 'ceph-%s@%s' % (fsid, daemon_type)
 
@@ -5803,9 +5803,8 @@ def get_deployment_type(ctx: CephadmContext, daemon_type: str, daemon_id: str) -
     deployment_type: DeploymentType = DeploymentType.DEFAULT
     if ctx.reconfig:
         deployment_type = DeploymentType.RECONFIG
-    unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
-    (_, state, _) = check_unit(ctx, unit_name)
     ident = DaemonIdentity(ctx.fsid, daemon_type, daemon_id)
+    (_, state, _) = check_unit(ctx, ident.unit_name)
     if state == 'running' or is_container_running(ctx, CephContainer.for_daemon(ctx, ident, 'bash')):
         # if reconfig was set, that takes priority over redeploy. If
         # this is considered a fresh deployment at this stage,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3114,7 +3114,7 @@ def deploy_daemon_units(
                 ctx, f, ident, osd_fsid, data_dir, uid, gid
             )
         elif daemon_type == CephIscsi.daemon_type:
-            _write_iscsi_unit_run_commands(ctx, f, daemon_type, str(daemon_id), fsid, data_dir)
+            _write_iscsi_unit_run_commands(ctx, f, ident, data_dir)
         init_containers = init_containers or []
         if init_containers:
             _write_init_container_cmds_clean(ctx, f, init_containers[0])
@@ -3250,10 +3250,10 @@ def _write_osd_unit_run_commands(
 
 
 def _write_iscsi_unit_run_commands(
-    ctx: CephadmContext, f: IO, daemon_type: str, daemon_id: str, fsid: str, data_dir: str
+    ctx: CephadmContext, f: IO, ident: 'DaemonIdentity', data_dir: str
 ) -> None:
     f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=True)) + '\n')
-    ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
+    ceph_iscsi = CephIscsi.init(ctx, ident.fsid, ident.daemon_id)
     tcmu_container = ceph_iscsi.get_tcmu_runner_container()
     _write_container_cmd_to_bash(ctx, f, tcmu_container, 'iscsi tcmu-runner container', background=True)
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3144,7 +3144,7 @@ def deploy_daemon_units(
         _write_stop_actions(ctx, cast(TextIO, f), container, timeout)
         if daemon_type == 'osd':
             assert osd_fsid
-            _write_osd_unit_poststop_commands(ctx, f, daemon_type, str(daemon_id), fsid, osd_fsid)
+            _write_osd_unit_poststop_commands(ctx, f, ident, osd_fsid)
         elif daemon_type == CephIscsi.daemon_type:
             _write_iscsi_unit_poststop_commands(ctx, f, daemon_type, str(daemon_id), fsid, data_dir)
 
@@ -3259,19 +3259,17 @@ def _write_iscsi_unit_run_commands(
 
 
 def _write_osd_unit_poststop_commands(
-    ctx: CephadmContext, f: IO, daemon_type: str, daemon_id: str, fsid: str, osd_fsid: str
+    ctx: CephadmContext, f: IO, ident: 'DaemonIdentity', osd_fsid: str
 ) -> None:
-    ident = DaemonIdentity(fsid, daemon_type, daemon_id)
     poststop = get_ceph_volume_container(
         ctx,
         args=[
             'lvm', 'deactivate',
-            str(daemon_id), osd_fsid,
+            ident.daemon_id, osd_fsid,
         ],
         volume_mounts=get_container_mounts(ctx, ident),
         bind_mounts=get_container_binds(ctx, ident),
-        cname='ceph-%s-%s.%s-deactivate' % (fsid, daemon_type,
-                                            daemon_id),
+        cname='ceph-%s-%s.%s-deactivate' % (ident.fsid, ident.daemon_type, ident.daemon_id),
     )
     _write_container_cmd_to_bash(ctx, f, poststop, 'deactivate osd')
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1883,13 +1883,21 @@ def move_files(ctx, src, dst, uid=None, gid=None):
             os.chown(dst_file, uid, gid)
 
 
-def get_unit_name(fsid, daemon_type, daemon_id=None):
-    # type: (str, str, Optional[Union[int, str]]) -> str
-    # accept either name or type + id
-    if daemon_id is not None:
-        return DaemonIdentity(fsid, daemon_type, daemon_id).unit_name
-    else:
-        return 'ceph-%s@%s' % (fsid, daemon_type)
+def get_unit_name(
+    fsid: str, daemon_type: str, daemon_id: Union[str, int]
+) -> str:
+    """Return the name of the systemd unit given an fsid, a daemon_type,
+    and the daemon_id.
+    """
+    # TODO: fully replace get_unit_name with DaemonIdentity instances
+    return DaemonIdentity(fsid, daemon_type, daemon_id).unit_name
+
+
+def get_unit_name_by_instance(fsid: str, instance: str) -> str:
+    """Return the name of the systemd unit given an fsid and the name
+    of the instance (the stuff after the @-sign and before the file extension).
+    """
+    return 'ceph-%s@%s' % (fsid, instance)
 
 
 def get_unit_name_by_daemon_name(ctx: CephadmContext, fsid: str, name: str) -> str:
@@ -7251,7 +7259,7 @@ def _rm_cluster(ctx: CephadmContext, keep_logs: bool, zap_osds: bool) -> None:
             continue
         if d['style'] != 'cephadm:v1':
             continue
-        disable_systemd_service(get_unit_name(ctx.fsid, d['name']))
+        disable_systemd_service(get_unit_name_by_instance(ctx.fsid, d['name']))
 
     # cluster units
     for unit_name in ['ceph-%s.target' % ctx.fsid]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5970,17 +5970,16 @@ def _common_deploy(ctx: CephadmContext) -> None:
 
     # Get and check ports explicitly required to be opened
     endpoints = fetch_tcp_ports(ctx)
-    _dispatch_deploy(ctx, ident.daemon_type, ident.daemon_id, endpoints, deployment_type)
+    _dispatch_deploy(ctx, ident, endpoints, deployment_type)
 
 
 def _dispatch_deploy(
     ctx: CephadmContext,
-    daemon_type: str,
-    daemon_id: str,
+    ident: 'DaemonIdentity',
     daemon_endpoints: List[EndPoint],
     deployment_type: DeploymentType,
 ) -> None:
-    ident = DaemonIdentity(ctx.fsid, daemon_type, daemon_id)
+    daemon_type = ident.daemon_type
     if daemon_type in Ceph.daemons:
         config, keyring = get_config_and_keyring(ctx)
         uid, gid = extract_uid_gid(ctx)
@@ -6104,7 +6103,7 @@ def _dispatch_deploy(
             endpoints=daemon_endpoints,
         )
     elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(ctx, ctx.fsid, daemon_id)
+        haproxy = HAproxy.init(ctx, ident.fsid, ident.daemon_id)
         uid, gid = haproxy.extract_uid_gid_haproxy()
         c = get_deployment_container(ctx, ident)
         deploy_daemon(
@@ -6118,7 +6117,7 @@ def _dispatch_deploy(
         )
 
     elif daemon_type == Keepalived.daemon_type:
-        keepalived = Keepalived.init(ctx, ctx.fsid, daemon_id)
+        keepalived = Keepalived.init(ctx, ident.fsid, ident.daemon_id)
         uid, gid = keepalived.extract_uid_gid_keepalived()
         c = get_deployment_container(ctx, ident)
         deploy_daemon(
@@ -6132,7 +6131,7 @@ def _dispatch_deploy(
         )
 
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(ctx, ctx.fsid, daemon_id)
+        cc = CustomContainer.init(ctx, ident.fsid, ident.daemon_id)
         # only check ports if this is a fresh deployment
         if deployment_type == DeploymentType.DEFAULT:
             daemon_endpoints.extend([EndPoint('0.0.0.0', p) for p in cc.ports])
@@ -6171,7 +6170,7 @@ def _dispatch_deploy(
         )
 
     elif daemon_type == SNMPGateway.daemon_type:
-        sc = SNMPGateway.init(ctx, ctx.fsid, daemon_id)
+        sc = SNMPGateway.init(ctx, ident.fsid, ident.daemon_id)
         c = get_deployment_container(ctx, ident)
         deploy_daemon(
             ctx,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -135,7 +135,7 @@ from cephadmlib.net_utils import (
     wrap_ipv6,
 )
 from cephadmlib.locking import FileLock
-from cephadmlib.daemon_identity import DaemonIdentity
+from cephadmlib.daemon_identity import DaemonIdentity, DaemonSubIdentity
 from cephadmlib.packagers import create_packager, Packager
 from cephadmlib.logging import cephadm_init_logging
 
@@ -3969,7 +3969,7 @@ class InitContainer(BasicContainer):
             }
         return cls(
             ctx,
-            identity=primary.identity._replace(subcomponent='init'),
+            identity=DaemonSubIdentity.from_parent(primary.identity, 'init'),
             image=opts.get('image', primary.image),
             entrypoint=opts.get('entrypoint', primary.entrypoint),
             # note: args is not inherited from primary container

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2247,15 +2247,22 @@ def create_daemon_dirs(
         sg = SNMPGateway.init(ctx, fsid, ident.daemon_id)
         sg.create_daemon_conf()
 
-    _write_custom_conf_files(ctx, daemon_type, ident.daemon_id, fsid, uid, gid)
+    _write_custom_conf_files(ctx, ident, uid, gid)
 
 
-def _write_custom_conf_files(ctx: CephadmContext, daemon_type: str, daemon_id: str, fsid: str, uid: int, gid: int) -> None:
+def _write_custom_conf_files(
+    ctx: CephadmContext, ident: 'DaemonIdentity', uid: int, gid: int
+) -> None:
     # mostly making this its own function to make unit testing easier
     ccfiles = fetch_custom_config_files(ctx)
     if not ccfiles:
         return
-    custom_config_dir = os.path.join(ctx.data_dir, fsid, 'custom_config_files', f'{daemon_type}.{daemon_id}')
+    custom_config_dir = os.path.join(
+        ctx.data_dir,
+        ident.fsid,
+        'custom_config_files',
+        f'{ident.daemon_type}.{ident.daemon_id}',
+    )
     if not os.path.exists(custom_config_dir):
         makedirs(custom_config_dir, uid, gid, 0o755)
     mandatory_keys = ['mount_path', 'content']
@@ -2266,7 +2273,7 @@ def _write_custom_conf_files(ctx: CephadmContext, daemon_type: str, daemon_id: s
                 f.write(ccf['content'])
             # temporary workaround to make custom config files work for tcmu-runner
             # container we deploy with iscsi until iscsi is refactored
-            if daemon_type == 'iscsi':
+            if ident.daemon_type == 'iscsi':
                 tcmu_config_dir = custom_config_dir + '.tcmu'
                 if not os.path.exists(tcmu_config_dir):
                     makedirs(tcmu_config_dir, uid, gid, 0o755)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3146,7 +3146,7 @@ def deploy_daemon_units(
             assert osd_fsid
             _write_osd_unit_poststop_commands(ctx, f, ident, osd_fsid)
         elif daemon_type == CephIscsi.daemon_type:
-            _write_iscsi_unit_poststop_commands(ctx, f, daemon_type, str(daemon_id), fsid, data_dir)
+            _write_iscsi_unit_poststop_commands(ctx, f, ident, data_dir)
 
     # post-stop command(s)
     with write_new(data_dir + '/unit.stop') as f:
@@ -3275,15 +3275,15 @@ def _write_osd_unit_poststop_commands(
 
 
 def _write_iscsi_unit_poststop_commands(
-    ctx: CephadmContext, f: IO, daemon_type: str, daemon_id: str, fsid: str, data_dir: str
+    ctx: CephadmContext, f: IO, ident: 'DaemonIdentity', data_dir: str
 ) -> None:
     # make sure we also stop the tcmu container
     runtime_dir = '/run'
-    ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
+    ceph_iscsi = CephIscsi.init(ctx, ident.fsid, ident.daemon_id)
     tcmu_container = ceph_iscsi.get_tcmu_runner_container()
     f.write('! ' + ' '.join(tcmu_container.stop_cmd()) + '\n')
-    f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-pid' % (fsid, daemon_type, str(daemon_id) + '.tcmu') + '\n')
-    f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-cid' % (fsid, daemon_type, str(daemon_id) + '.tcmu') + '\n')
+    f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-pid' % (ident.fsid, ident.daemon_type, ident.daemon_id + '.tcmu') + '\n')
+    f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-cid' % (ident.fsid, ident.daemon_type, ident.daemon_id + '.tcmu') + '\n')
     f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=False)) + '\n')
 
 

--- a/src/cephadm/cephadmlib/daemon_identity.py
+++ b/src/cephadm/cephadmlib/daemon_identity.py
@@ -89,6 +89,14 @@ class DaemonSubIdentity(DaemonIdentity):
         return name.replace('.', '-')
 
     @property
+    def unit_name(self) -> str:
+        # NB: This is a minor hack because a subcomponent may be running as part
+        # of the same unit as the primary. However, to fix a bug with iscsi
+        # this is a quick and dirty workaround for distinguishing the two types
+        # when generating --cidfile and --conmon-pidfile values.
+        return f'ceph-{self.fsid}@{self.daemon_type}.{self.daemon_id}.{self.subcomponent}'
+
+    @property
     def legacy_container_name(self) -> str:
         raise ValueError(
             'legacy_container_name not valid for DaemonSubIdentity'

--- a/src/cephadm/cephadmlib/daemon_identity.py
+++ b/src/cephadm/cephadmlib/daemon_identity.py
@@ -1,6 +1,8 @@
 # deamon_identity.py - classes for identifying daemons & services
 
-from typing import Union, Optional
+import re
+
+from typing import Union
 
 from .context import CephadmContext
 
@@ -11,12 +13,10 @@ class DaemonIdentity:
         fsid: str,
         daemon_type: str,
         daemon_id: Union[int, str],
-        subcomponent: str = '',
     ) -> None:
         self._fsid = fsid
         self._daemon_type = daemon_type
         self._daemon_id = str(daemon_id)
-        self._subcomponent = subcomponent
 
     @property
     def fsid(self) -> str:
@@ -31,38 +31,13 @@ class DaemonIdentity:
         return self._daemon_id
 
     @property
-    def subcomponent(self) -> str:
-        return self._subcomponent
-
-    @property
     def legacy_container_name(self) -> str:
         return 'ceph-%s-%s.%s' % (self.fsid, self.daemon_type, self.daemon_id)
 
     @property
     def container_name(self) -> str:
         name = f'ceph-{self.fsid}-{self.daemon_type}-{self.daemon_id}'
-        if self.subcomponent:
-            name = f'{name}-{self.subcomponent}'
         return name.replace('.', '-')
-
-    def _replace(
-        self,
-        *,
-        fsid: Optional[str] = None,
-        daemon_type: Optional[str] = None,
-        daemon_id: Union[None, int, str] = None,
-        subcomponent: Optional[str] = None,
-    ) -> 'DaemonIdentity':
-        return self.__class__(
-            fsid=self.fsid if fsid is None else fsid,
-            daemon_type=(
-                self.daemon_type if daemon_type is None else daemon_type
-            ),
-            daemon_id=self.daemon_id if daemon_id is None else daemon_id,
-            subcomponent=(
-                self.subcomponent if subcomponent is None else subcomponent
-            ),
-        )
 
     @classmethod
     def from_name(cls, fsid: str, name: str) -> 'DaemonIdentity':
@@ -72,3 +47,45 @@ class DaemonIdentity:
     @classmethod
     def from_context(cls, ctx: 'CephadmContext') -> 'DaemonIdentity':
         return cls.from_name(ctx.fsid, ctx.name)
+
+
+class DaemonSubIdentity(DaemonIdentity):
+    def __init__(
+        self,
+        fsid: str,
+        daemon_type: str,
+        daemon_id: Union[int, str],
+        subcomponent: str = '',
+    ) -> None:
+        super().__init__(fsid, daemon_type, daemon_id)
+        self._subcomponent = subcomponent
+        if not re.match('^[a-zA-Z0-9]{1,15}$', self._subcomponent):
+            raise ValueError(
+                f'invalid subcomponent; invalid characters: {subcomponent!r}'
+            )
+
+    @property
+    def subcomponent(self) -> str:
+        return self._subcomponent
+
+    @property
+    def container_name(self) -> str:
+        name = f'ceph-{self.fsid}-{self.daemon_type}-{self.daemon_id}-{self.subcomponent}'
+        return name.replace('.', '-')
+
+    @property
+    def legacy_container_name(self) -> str:
+        raise ValueError(
+            'legacy_container_name not valid for DaemonSubIdentity'
+        )
+
+    @classmethod
+    def from_parent(
+        cls, parent: 'DaemonIdentity', subcomponent: str
+    ) -> 'DaemonSubIdentity':
+        return cls(
+            parent.fsid,
+            parent.daemon_type,
+            parent.daemon_id,
+            subcomponent,
+        )

--- a/src/cephadm/cephadmlib/daemon_identity.py
+++ b/src/cephadm/cephadmlib/daemon_identity.py
@@ -17,6 +17,9 @@ class DaemonIdentity:
         self._fsid = fsid
         self._daemon_type = daemon_type
         self._daemon_id = str(daemon_id)
+        assert self._fsid
+        assert self._daemon_type
+        assert self._daemon_id
 
     @property
     def fsid(self) -> str:

--- a/src/cephadm/cephadmlib/daemon_identity.py
+++ b/src/cephadm/cephadmlib/daemon_identity.py
@@ -39,6 +39,10 @@ class DaemonIdentity:
         name = f'ceph-{self.fsid}-{self.daemon_type}-{self.daemon_id}'
         return name.replace('.', '-')
 
+    @property
+    def unit_name(self) -> str:
+        return f'ceph-{self.fsid}@{self.daemon_type}.{self.daemon_id}'
+
     @classmethod
     def from_name(cls, fsid: str, name: str) -> 'DaemonIdentity':
         daemon_type, daemon_id = name.split('.', 1)

--- a/src/cephadm/cephadmlib/daemon_identity.py
+++ b/src/cephadm/cephadmlib/daemon_identity.py
@@ -34,6 +34,10 @@ class DaemonIdentity:
         return self._daemon_id
 
     @property
+    def daemon_name(self) -> str:
+        return f'{self.daemon_type}.{self.daemon_id}'
+
+    @property
     def legacy_container_name(self) -> str:
         return 'ceph-%s-%s.%s' % (self.fsid, self.daemon_type, self.daemon_id)
 
@@ -74,6 +78,10 @@ class DaemonSubIdentity(DaemonIdentity):
     @property
     def subcomponent(self) -> str:
         return self._subcomponent
+
+    @property
+    def daemon_name(self) -> str:
+        return f'{self.daemon_type}.{self.daemon_id}.{self.subcomponent}'
 
     @property
     def container_name(self) -> str:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1739,9 +1739,9 @@ class TestIscsi:
             ctx.config_json = json.dumps(config_json)
             ctx.fsid = fsid
             _cephadm.get_parm.return_value = config_json
-            c = _cephadm.get_container(ctx, fsid, 'iscsi', 'daemon_id')
 
             ident = _cephadm.DaemonIdentity(fsid, 'iscsi', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.make_data_dir(ctx, ident)
             _cephadm.deploy_daemon_units(
                 ctx,
@@ -1774,7 +1774,9 @@ if ! grep -qs /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id
         fsid = '9b9d7609-f4d5-4aba-94c8-effa764d96c9'
         with with_cephadm_ctx(['--image=ceph/ceph'], list_networks={}) as ctx:
             ctx.fsid = fsid
-            c = _cephadm.get_container(ctx, fsid, 'iscsi', 'something')
+            c = _cephadm.get_container(
+                ctx, _cephadm.DaemonIdentity(fsid, 'iscsi', 'something')
+            )
             assert c.cname == 'ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi-something'
             assert c.old_cname == 'ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi.something'
 
@@ -2278,9 +2280,9 @@ class TestSNMPGateway:
             ctx.fsid = fsid
             ctx.tcp_ports = '9464'
             _cephadm.get_parm.return_value = self.V2c_config
-            c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
             ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.make_data_dir(ctx, ident)
 
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
@@ -2307,9 +2309,9 @@ class TestSNMPGateway:
             ctx.fsid = fsid
             ctx.tcp_ports = '9465'
             _cephadm.get_parm.return_value = self.V3_no_priv_config
-            c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
             ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.make_data_dir(ctx, ident)
 
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
@@ -2336,9 +2338,9 @@ class TestSNMPGateway:
             ctx.fsid = fsid
             ctx.tcp_ports = '9464'
             _cephadm.get_parm.return_value = self.V3_priv_config
-            c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
             ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.make_data_dir(ctx, ident)
 
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
@@ -2367,7 +2369,10 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.no_destination_config
 
             with pytest.raises(Exception) as e:
-                c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
+                c = _cephadm.get_container(
+                    ctx,
+                    _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id'),
+                )
             assert str(e.value) == "config is missing destination attribute(<ip>:<port>) of the target SNMP listener"
 
     def test_unit_run_bad_version(self, cephadm_fs):
@@ -2380,7 +2385,10 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.bad_version_config
 
             with pytest.raises(Exception) as e:
-                c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
+                c = _cephadm.get_container(
+                    ctx,
+                    _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id'),
+                )
             assert str(e.value) == 'not a valid snmp version: V1'
 
 class TestNetworkValidation:
@@ -2548,8 +2556,8 @@ class TestJaeger:
             import json
             ctx.config_json = json.dumps(self.single_es_node_conf)
             ctx.fsid = fsid
-            c = _cephadm.get_container(ctx, fsid, 'jaeger-collector', 'daemon_id')
             ident = _cephadm.DaemonIdentity(fsid, 'jaeger-collector', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
@@ -2568,8 +2576,8 @@ class TestJaeger:
             import json
             ctx.config_json = json.dumps(self.multiple_es_nodes_conf)
             ctx.fsid = fsid
-            c = _cephadm.get_container(ctx, fsid, 'jaeger-collector', 'daemon_id')
             ident = _cephadm.DaemonIdentity(fsid, 'jaeger-collector', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
@@ -2588,8 +2596,8 @@ class TestJaeger:
             import json
             ctx.config_json = json.dumps(self.agent_conf)
             ctx.fsid = fsid
-            c = _cephadm.get_container(ctx, fsid, 'jaeger-agent', 'daemon_id')
             ident = _cephadm.DaemonIdentity(fsid, 'jaeger-agent', 'daemon_id')
+            c = _cephadm.get_container(ctx, ident)
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1220,7 +1220,9 @@ class TestMonitoring(object):
         daemon_type = 'prometheus'
         daemon_id = 'home'
         fsid = 'aaf5a720-13fe-4a3b-82b9-2d99b7fd9704'
-        args = _cephadm.get_daemon_args(ctx, fsid, daemon_type, daemon_id)
+        args = _cephadm.get_daemon_args(
+            ctx, _cephadm.DaemonIdentity(fsid, daemon_type, daemon_id)
+        )
         assert any([x.startswith('--web.external-url=http://') for x in args])
 
     @mock.patch('cephadm.call')

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -341,9 +341,11 @@ class TestCephAdm(object):
         ]
         _get_container.return_value = _cephadm.CephContainer.for_daemon(
             ctx,
-            fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
-            daemon_type='grafana',
-            daemon_id='host1',
+            ident=_cephadm.DaemonIdentity(
+                fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
+                daemon_type='grafana',
+                daemon_id='host1',
+            ),
             entrypoint='',
             args=[],
             container_args=[],
@@ -396,9 +398,11 @@ class TestCephAdm(object):
 
         _get_deployment_container.return_value = _cephadm.CephContainer.for_daemon(
             ctx,
-            fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
-            daemon_type='mon',
-            daemon_id='test',
+            ident=_cephadm.DaemonIdentity(
+                fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
+                daemon_type='mon',
+                daemon_id='test',
+            ),
             entrypoint='',
             args=[],
             container_args=[],

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1741,15 +1741,12 @@ class TestIscsi:
             _cephadm.get_parm.return_value = config_json
             c = _cephadm.get_container(ctx, fsid, 'iscsi', 'daemon_id')
 
-            _cephadm.make_data_dir(
-                ctx, _cephadm.DaemonIdentity(fsid, 'iscsi', 'daemon_id')
-            )
+            ident = _cephadm.DaemonIdentity(fsid, 'iscsi', 'daemon_id')
+            _cephadm.make_data_dir(ctx, ident)
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'iscsi',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2293,10 +2290,8 @@ class TestSNMPGateway:
 
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'snmp-gateway',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2324,10 +2319,8 @@ class TestSNMPGateway:
 
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'snmp-gateway',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2355,10 +2348,8 @@ class TestSNMPGateway:
 
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'snmp-gateway',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2562,10 +2553,8 @@ class TestJaeger:
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'jaeger-collector',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2584,10 +2573,8 @@ class TestJaeger:
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'jaeger-collector',
-                'daemon_id',
                 c,
                 True, True
             )
@@ -2606,10 +2593,8 @@ class TestJaeger:
             _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
-                fsid,
+                ident,
                 0, 0,
-                'jaeger-agent',
-                'daemon_id',
                 c,
                 True, True
             )

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -414,7 +414,7 @@ class TestCephAdm(object):
             host_network=True,
         )
 
-        def _crush_location_checker(ctx, fsid, daemon_type, daemon_id, container, uid, gid, **kwargs):
+        def _crush_location_checker(ctx, ident, container, uid, gid, **kwargs):
             print(container.args)
             raise Exception(' '.join(container.args))
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1250,14 +1250,14 @@ class TestMonitoring(object):
             }
         })
 
-        _cephadm.create_daemon_dirs(ctx,
-                              fsid,
-                              daemon_type,
-                              daemon_id,
-                              uid,
-                              gid,
-                              config=None,
-                              keyring=None)
+        _cephadm.create_daemon_dirs(
+            ctx,
+            _cephadm.DaemonIdentity(fsid, daemon_type, daemon_id),
+            uid,
+            gid,
+            config=None,
+            keyring=None,
+        )
 
         prefix = '{data_dir}/{fsid}/{daemon_type}.{daemon_id}'.format(
             data_dir=ctx.data_dir,
@@ -1280,14 +1280,14 @@ class TestMonitoring(object):
         # assert uid/gid after redeploy
         new_uid = uid+1
         new_gid = gid+1
-        _cephadm.create_daemon_dirs(ctx,
-                              fsid,
-                              daemon_type,
-                              daemon_id,
-                              new_uid,
-                              new_gid,
-                              config=None,
-                              keyring=None)
+        _cephadm.create_daemon_dirs(
+            ctx,
+            _cephadm.DaemonIdentity(fsid, daemon_type, daemon_id),
+            new_uid,
+            new_gid,
+            config=None,
+            keyring=None,
+        )
         for file,content in expected.items():
             file = os.path.join(prefix, file)
             assert os.stat(file).st_uid == new_uid
@@ -2279,11 +2279,10 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V2c_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(
-                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
-            )
+            ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(ctx, ident)
 
-            _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:
                 conf = f.read().rstrip()
                 assert conf == 'SNMP_NOTIFIER_COMMUNITY=public'
@@ -2311,11 +2310,10 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V3_no_priv_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(
-                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
-            )
+            ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(ctx, ident)
 
-            _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:
                 conf = f.read()
                 assert conf == 'SNMP_NOTIFIER_AUTH_USERNAME=myuser\nSNMP_NOTIFIER_AUTH_PASSWORD=mypassword\n'
@@ -2343,11 +2341,10 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V3_priv_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(
-                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
-            )
+            ident = _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(ctx, ident)
 
-            _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:
                 conf = f.read()
                 assert conf == 'SNMP_NOTIFIER_AUTH_USERNAME=myuser\nSNMP_NOTIFIER_AUTH_PASSWORD=mypassword\nSNMP_NOTIFIER_PRIV_PASSWORD=mysecret\n'
@@ -2557,7 +2554,8 @@ class TestJaeger:
             ctx.config_json = json.dumps(self.single_es_node_conf)
             ctx.fsid = fsid
             c = _cephadm.get_container(ctx, fsid, 'jaeger-collector', 'daemon_id')
-            _cephadm.create_daemon_dirs(ctx, fsid, 'jaeger-collector', 'daemon_id', 0, 0)
+            ident = _cephadm.DaemonIdentity(fsid, 'jaeger-collector', 'daemon_id')
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
                 fsid,
@@ -2578,7 +2576,8 @@ class TestJaeger:
             ctx.config_json = json.dumps(self.multiple_es_nodes_conf)
             ctx.fsid = fsid
             c = _cephadm.get_container(ctx, fsid, 'jaeger-collector', 'daemon_id')
-            _cephadm.create_daemon_dirs(ctx, fsid, 'jaeger-collector', 'daemon_id', 0, 0)
+            ident = _cephadm.DaemonIdentity(fsid, 'jaeger-collector', 'daemon_id')
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
                 fsid,
@@ -2599,7 +2598,8 @@ class TestJaeger:
             ctx.config_json = json.dumps(self.agent_conf)
             ctx.fsid = fsid
             c = _cephadm.get_container(ctx, fsid, 'jaeger-agent', 'daemon_id')
-            _cephadm.create_daemon_dirs(ctx, fsid, 'jaeger-agent', 'daemon_id', 0, 0)
+            ident = _cephadm.DaemonIdentity(fsid, 'jaeger-agent', 'daemon_id')
+            _cephadm.create_daemon_dirs(ctx, ident, 0, 0)
             _cephadm.deploy_daemon_units(
                 ctx,
                 fsid,

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1737,7 +1737,9 @@ class TestIscsi:
             _cephadm.get_parm.return_value = config_json
             c = _cephadm.get_container(ctx, fsid, 'iscsi', 'daemon_id')
 
-            _cephadm.make_data_dir(ctx, fsid, 'iscsi', 'daemon_id')
+            _cephadm.make_data_dir(
+                ctx, _cephadm.DaemonIdentity(fsid, 'iscsi', 'daemon_id')
+            )
             _cephadm.deploy_daemon_units(
                 ctx,
                 fsid,
@@ -2277,7 +2279,9 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V2c_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(ctx, fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(
+                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            )
 
             _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:
@@ -2307,7 +2311,9 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V3_no_priv_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(ctx, fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(
+                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            )
 
             _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:
@@ -2337,7 +2343,9 @@ class TestSNMPGateway:
             _cephadm.get_parm.return_value = self.V3_priv_config
             c = _cephadm.get_container(ctx, fsid, 'snmp-gateway', 'daemon_id')
 
-            _cephadm.make_data_dir(ctx, fsid, 'snmp-gateway', 'daemon_id')
+            _cephadm.make_data_dir(
+                ctx, _cephadm.DaemonIdentity(fsid, 'snmp-gateway', 'daemon_id')
+            )
 
             _cephadm.create_daemon_dirs(ctx, fsid, 'snmp-gateway', 'daemon_id', 0, 0)
             with open(f'/var/lib/ceph/{fsid}/snmp-gateway.daemon_id/snmp-gateway.conf', 'r') as f:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -339,13 +339,14 @@ class TestCephAdm(object):
                 'content': 'this\nis\na\nstring',
             }
         ]
+        ident = _cephadm.DaemonIdentity(
+            fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
+            daemon_type='grafana',
+            daemon_id='host1',
+        )
         _get_container.return_value = _cephadm.CephContainer.for_daemon(
             ctx,
-            ident=_cephadm.DaemonIdentity(
-                fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
-                daemon_type='grafana',
-                daemon_id='host1',
-            ),
+            ident=ident,
             entrypoint='',
             args=[],
             container_args=[],
@@ -356,10 +357,7 @@ class TestCephAdm(object):
             ptrace=False,
             host_network=True,
         )
-        c = _cephadm.get_deployment_container(ctx,
-                                    '9b9d7609-f4d5-4aba-94c8-effa764d96c9',
-                                    'grafana',
-                                    'host1',)
+        c = _cephadm.get_deployment_container(ctx, ident)
 
         assert '--pids-limit=12345' in c.container_args
         assert '--something' in c.container_args

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -446,7 +446,9 @@ class TestCephAdm(object):
                 'mount_path': '/etc/no-content.conf',
             },
         ]
-        _cephadm._write_custom_conf_files(ctx, 'mon', 'host1', 'fsid', 0, 0)
+        _cephadm._write_custom_conf_files(
+            ctx, _cephadm.DaemonIdentity('fsid', 'mon', 'host1'), 0, 0
+        )
         with open(os.path.join(_cephadm.DATA_DIR, 'fsid', 'custom_config_files', 'mon.host1', 'testing.str'), 'r') as f:
             assert 'this\nis\na\nstring' == f.read()
         with open(os.path.join(_cephadm.DATA_DIR, 'fsid', 'custom_config_files', 'mon.host1', 'testing.conf'), 'r') as f:


### PR DESCRIPTION
Depends on #52178

Throughout cephadm a familiar pattern occurred: a function would have (at least) arguments of `fsid`, `daemon_type`, and `daemon_id`, not always in that order or exactly that naming but typically so.

In other words the code was generally expecting a triple of these values. This PR builds upon the work that added init_containers and the new `DaemonIdentity` type. DaemonIdentity is essentially this triple elevated to a type and with methods and attributes for commonly needed conversions (to a unit name for example).

I'll admit that this PR is pretty tedious and doesn't seem to do much. There's a lot of plumbing this new type in various places. You might be skeptical of the payoff of this work. In future work, we'll better make use of these types and also add additional helpful methods/attributes. But the scope of this PR is just to make use of DaemonIdentity, not make DaemonIdentity more useful. That said I do think there are benefits to correctness and type checking when you have a well defined type. DaemonIdentity uses the property decorator to implement `.fsid`, `.daemon_type`, and `.daemon_id` making the type quasi-read-only so that an error occurs if one tries to assign a new value to one of the properties.

Some functions make heavy use of all or one of `fsid`, `daemon_type`, and `daemon_id` in the body of the function. In many cases I simply assigned the DaemonIdentity property to a local variable (like `daemon_type = ident.daemon_type`) so as to avoid an unpleasant level of churn. But in cases where there were not a lot I used the DaemonIdentity value.property directly. When and where I chose to do this was somewhat subjective.

The code for adoption and list_units scares me. I only changed those where they needed to change. I otherwise left them alone because I don't know how to test them well enough yet.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Relies on existing tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
