### PR TITLE
quincy: doc/mgr/ceph_api: Promptify example commands in index.rst

### DIFF
--- a/doc/mgr/ceph_api/index.rst
+++ b/doc/mgr/ceph_api/index.rst
@@ -41,14 +41,16 @@ So, prior to start consuming the Ceph API, a valid JSON Web Token (JWT) has to
 be obtained, and it may then be reused for subsequent requests. The
 ``/api/auth`` endpoint will provide the valid token:
 
-.. code-block:: sh
+.. prompt:: bash $
 
-  $ curl -X POST "https://example.com:8443/api/auth" \
-    -H  "Accept: application/vnd.ceph.api.v1.0+json" \
-    -H  "Content-Type: application/json" \
-    -d '{"username": <username>, "password": <password>}'
+   curl -X POST "https://example.com:8443/api/auth" \
+   -H  "Accept: application/vnd.ceph.api.v1.0+json" \
+   -H  "Content-Type: application/json" \
+   -d '{"username": <username>, "password": <password>}'
 
-  { "token": "<redacted_token>", ...}
+::
+
+    { "token": "<redacted_token>", ...}
 
 The token obtained must be passed together with every API request in the
 ``Authorization`` HTTP header::
@@ -74,11 +76,11 @@ purpose, Ceph API is built upon the following principles:
 
 An example:
 
-.. code-block:: bash
+.. prompt:: bash $
 
-  $ curl -X GET "https://example.com:8443/api/osd" \
-    -H  "Accept: application/vnd.ceph.api.v1.0+json" \
-    -H  "Authorization: Bearer <token>"
+   curl -X GET "https://example.com:8443/api/osd" \
+   -H  "Accept: application/vnd.ceph.api.v1.0+json" \
+   -H  "Authorization: Bearer <token>"
 
 
 Specification


### PR DESCRIPTION
Use the more modern prompt block instead of
using code blocks for example commands.

Signed-off-by: Ville Ojamo <14869000+bluikko@users.noreply.github.com>
(cherry picked from commit 4f9bd62f374d2f6bf74296d87e5205960464c349)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
