### PR TITLE
cephadm.py: Don't install recommended apps on Debian/Ubuntu

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -8367,7 +8367,7 @@ class Apt(Packager):
 
     def install(self, ls: List[str]) -> None:
         logger.info('Installing packages %s...' % ls)
-        call_throws(self.ctx, ['apt-get', 'install', '-y'] + ls)
+        call_throws(self.ctx, ['apt-get', 'install', '-y', '--no-install-recommends'] + ls)
 
     def update(self) -> None:
         logger.info('Updating package list...')


### PR DESCRIPTION
While installing Ceph 17 (but double checked with later versions) even though docekr is already installed, when installing `cephadm` via the python script, Ubuntu automatically installs podman since its a recommended app of `cephadm`.  This complicates things if you already have CNI (like kubernetes) installed as it conflicts.  When installing manually, adding `--no-install-recommends` worked great.  This PR adds that to the script since the script already does checking for Podman or Docker.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
