### PR TITLE
mgr: fix flake8 compliants

### DIFF
--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -90,9 +90,9 @@ def with_cephadm_module(module_options=None, store=None):
     :param module_options: Set opts as if they were set before module.__init__ is called
     :param store: Set the store before module.__init__ is called
     """
-    with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option),\
+    with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option), \
             mock.patch("cephadm.services.osd.RemoveUtil._run_mon_cmd"), \
-            mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex),\
+            mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex), \
             mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
             mock.patch("cephadm.module.CephadmOrchestrator.remote"), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._request_agent_acks"), \

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -92,11 +92,11 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
             cephadm_module.set_container_image('global', 'from_image')
             cephadm_module.use_repo_digest = use_repo_digest
             with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*', count=2)),
-                              CephadmOrchestrator.apply_mgr, '', status_running=True),\
+                              CephadmOrchestrator.apply_mgr, '', status_running=True), \
                 mock.patch("cephadm.module.CephadmOrchestrator.lookup_release_name",
-                           return_value='foo'),\
+                           return_value='foo'), \
                 mock.patch("cephadm.module.CephadmOrchestrator.version",
-                           new_callable=mock.PropertyMock) as version_mock,\
+                           new_callable=mock.PropertyMock) as version_mock, \
                 mock.patch("cephadm.module.CephadmOrchestrator.get",
                            return_value={
                                # capture fields in both mon and osd maps

--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from prettytable import PrettyTable
 import re
 from threading import Event, Lock
-from typing import cast, Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Tuple, TypeVar,\
+from typing import cast, Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Tuple, TypeVar, \
     Union, TYPE_CHECKING
 
 


### PR DESCRIPTION
[mgr tox ](https://jenkins.ceph.com/job/ceph-pull-requests/119232/consoleFull#15343907506733401c-e9d0-4737-9832-6594c5da0afa) is failing because of flake8 issues.

A new [flake8](https://pypi.org/project/flake8/6.1.0/#history) has been released over the weekend which also uses a newly updated [pyflakes](https://pypi.org/project/pyflakes/#history), and that is now strict on some rules. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
