### PR TITLE
pacific: mgr/dashboard: allow PUT in CORS

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -263,7 +263,7 @@ class CherryPyConfig(object):
                 resp_head['Access-Control-Allow-Origin'] = req_header_origin_url
             ac_method = req_head.get('Access-Control-Request-Method', None)
 
-            allowed_methods = ['GET', 'POST']
+            allowed_methods = ['GET', 'POST', 'PUT']
             allowed_headers = [
                 'Content-Type',
                 'Authorization',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62237

---

backport of https://github.com/ceph/ceph/pull/52622
parent tracker: https://tracker.ceph.com/issues/62222

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh