### PR TITLE
reef: qa/rgw: pacific upgrade disables centos9

### DIFF
--- a/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_8.stream.yaml
+++ b/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/pacific/distro$/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62247

---

backport of https://github.com/ceph/ceph/pull/52603
parent tracker: https://tracker.ceph.com/issues/62135

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh