### PR TITLE
ec: initialize lost_chunk in ErasureCodeClay

### DIFF
--- a/src/erasure-code/clay/ErasureCodeClay.cc
+++ b/src/erasure-code/clay/ErasureCodeClay.cc
@@ -507,7 +507,7 @@ int ErasureCodeClay::repair_one_lost_chunk(map<int, bufferlist> &recovered_data,
     }
   }
 
-  int lost_chunk;
+  int lost_chunk = 0;
   int count = 0;
   for ([[maybe_unused]] auto& [node, bl] : recovered_data) {
     lost_chunk = node;


### PR DESCRIPTION
fixes a warning about an uninitialized variable:
```
[346/687] Building CXX object src/erasure-code/clay/CMakeFiles/ec_clay.dir/ErasureCodeClay.cc.o
In file included from /home/cbodley/ceph/src/common/dout.h:21,
                 from /home/cbodley/ceph/src/common/debug.h:18,
                 from /home/cbodley/ceph/src/erasure-code/clay/ErasureCodeClay.cc:22:
home/cbodley/ceph/src/erasure-code/clay/ErasureCodeClay.cc: In member function ‘int ErasureCodeClay::repair_one_lost_chunk(std::map<int, ceph::buffer::v15_2_0::list>&, std::set<int>&, std::map<int, ceph::buffer::v15_2_0::list>&, int, std::vector<std::pair<int, int> >&)’: /home/cbodley/ceph/src/erasure-code/clay/ErasureCodeClay.cc:620:41: warning: ‘lost_chunk’ may be used uninitialized [-Wmaybe-uninitialized]
  620 |             ceph_assert(y == lost_chunk / q);
      |                              ~~~~~~~~~~~^~~
/home/cbodley/ceph/src/include/ceph_assert.h:106:6: note: in definition of macro ‘ceph_assert’
  106 |    ((expr) \
      |      ^~~~
/home/cbodley/ceph/src/erasure-code/clay/ErasureCodeClay.cc:510:7: note: ‘lost_chunk’ was declared here
  510 |   int lost_chunk;
      |       ^~~~~~~~~~
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
