### PR TITLE
test/osd: Use shuffle instead of random_shuffle

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -2349,7 +2349,7 @@ TEST_F(OSDMapTest, ReadBalanceScore1) {
         float fratio = 1. / (float)replica_count;
         for (int iter = 0 ; iter < 100 ; iter++) {  // run the test 100 times
           // Create random shuffle of OSDs
-          std::random_shuffle (osds.begin(), osds.end());
+          std::shuffle (osds.begin(), osds.end(), std::default_random_engine{});
           for (uint i = 0 ; i < num_osds ; i++) {
             if ((float(i + 1) / float(num_osds)) < fratio) {
               ASSERT_TRUE(osds[i] < num_osds);


### PR DESCRIPTION
This commit replaces std::random_shuffle with
std::shuffle.

The make check failed due to jenkins build failure :
```
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestOSDMap.cc:2352:16: error: 'random_shuffle<__gnu_cxx::__normal_iterator<unsigned int *, std::vector<unsigned int>>>' is deprecated: use 'std::shuffle' instead [-Werror,-Wdeprecated-declarations]
          std::random_shuffle (osds.begin(), osds.end());
               ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:4539:5: note: 'random_shuffle<__gnu_cxx::__normal_iterator<unsigned int *, std::vector<unsigned int>>>' has been explicitly marked deprecated here
    _GLIBCXX14_DEPRECATED_SUGGEST("std::shuffle")
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:112:45: note: expanded from macro '_GLIBCXX14_DEPRECATED_SUGGEST'
                                            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:96:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
  __attribute__ ((__deprecated__ ("use '" ALT "' instead")))
                  ^
1 error generated.
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
