### PR TITLE
rgw/lua: add entity name to rgw_luarocks_location

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3709,7 +3709,7 @@ options:
   type: str
   level: advanced
   desc: Directory where luarocks install packages from allowlist
-  default: @rgw_luarocks_location@
+  default: /tmp/rgw_luarocks/$name
   services:
   - rgw
   flags:

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -550,11 +550,7 @@ void rgw::AppMain::init_lua()
 {
   rgw::sal::Driver* driver = env.driver;
   int r{0};
-  std::string path = g_conf().get_val<std::string>("rgw_luarocks_location");
-  if (!path.empty()) {
-    path += "/" + g_conf()->name.to_str();
-  }
-  env.lua.luarocks_path = path;
+  const std::string path = g_conf().get_val<std::string>("rgw_luarocks_location");
 
 #ifdef WITH_RADOSGW_LUA_PACKAGES
   rgw::lua::packages_t failed_packages;
@@ -577,8 +573,7 @@ void rgw::AppMain::init_lua()
   env.lua.manager = env.driver->get_lua_manager();
 
   if (driver->get_name() == "rados") { /* Supported for only RadosStore */
-    lua_background = std::make_unique<
-      rgw::lua::Background>(driver, dpp->get_cct(), path);
+    lua_background = std::make_unique<rgw::lua::Background>(driver, dpp->get_cct());
     lua_background->start();
     env.lua.background = lua_background.get();
   }

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -58,13 +58,11 @@ int RGWTable::increment_by(lua_State* L) {
 
 Background::Background(rgw::sal::Driver* driver,
     CephContext* cct,
-      const std::string& luarocks_path,
       int execute_interval) :
     execute_interval(execute_interval),
     dp(cct, dout_subsys, "lua background: "),
     lua_manager(driver->get_lua_manager()),
-    cct(cct),
-    luarocks_path(luarocks_path) {}
+    cct(cct) {}
 
 void Background::shutdown(){
   stopped = true;
@@ -129,7 +127,8 @@ void Background::run() {
   lua_State* const L = luaL_newstate();
   rgw::lua::lua_state_guard lguard(L);
   open_standard_libs(L);
-  set_package_path(L, luarocks_path);
+  const std::string path = cct->_conf.get_val<std::string>("rgw_luarocks_location");
+  set_package_path(L, path);
   create_debug_action(L, cct);
   create_background_metatable(L);
   const DoutPrefixProvider* const dpp = &dp;

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -151,7 +151,6 @@ private:
   const DoutPrefix dp;
   std::unique_ptr<rgw::sal::LuaManager> lua_manager; 
   CephContext* const cct;
-  const std::string luarocks_path;
   std::thread runner;
   mutable std::mutex table_mutex;
   std::mutex cond_mutex;
@@ -167,7 +166,6 @@ protected:
 public:
   Background(rgw::sal::Driver* driver,
       CephContext* cct,
-      const std::string& luarocks_path,
       int execute_interval = INIT_EXECUTE_INTERVAL);
 
     virtual ~Background() = default;

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -821,7 +821,8 @@ int execute(
   lua_state_guard lguard(L);
 
   open_standard_libs(L);
-  set_package_path(L, s->penv.lua.luarocks_path);
+  const std::string path = s->cct->_conf.get_val<std::string>("rgw_luarocks_location");
+  set_package_path(L, path);
 
   create_debug_action(L, s->cct);  
   

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -32,7 +32,6 @@ namespace rgw::flight {
 #endif
 
 struct RGWLuaProcessEnv {
-  std::string luarocks_path;
   rgw::lua::Background* background = nullptr;
   std::unique_ptr<rgw::sal::LuaManager> manager;
 };

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1782,7 +1782,7 @@ do_rgw()
             --log-file=${CEPH_OUT_DIR}/radosgw.${current_port}.log \
             --admin-socket=${CEPH_OUT_DIR}/radosgw.${current_port}.asok \
             --pid-file=${CEPH_OUT_DIR}/radosgw.${current_port}.pid \
-            --rgw_luarocks_location=${CEPH_OUT_DIR}/luarocks \
+            --rgw_luarocks_location=${CEPH_OUT_DIR}/radosgw.${current_port}.luarocks \
             ${RGWDEBUG} \
             -n ${rgw_name} \
             "--rgw_frontends=${rgw_frontend} port=${current_port}${CEPH_RGW_HTTPS}${flight_conf:+,arrow_flight}"


### PR DESCRIPTION
use the ceph.conf substitution variable to add the entity name to the luarocks path. this avoids fudging with the path on rgw startup and storing `luarocks_path` as a separate variable. users just query the config variable directly

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
