### PR TITLE
rgw/swift: remove redundant moves of object name

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1982,7 +1982,7 @@ void RGWFormPost::init(rgw::sal::Driver* const driver,
                        RGWHandler* const dialect_handler)
 {
   if (!rgw::sal::Object::empty(s->object)) {
-    prefix = std::move(s->object->get_name());
+    prefix = s->object->get_name();
     s->object->set_key(rgw_obj_key());
   }
 
@@ -2555,7 +2555,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_listing_op()
     }
   };
 
-  std::string prefix = std::move(s->object->get_name());
+  std::string prefix = s->object->get_name();
   s->object->set_key(rgw_obj_key());
 
   return new RGWWebsiteListing(std::move(prefix));


### PR DESCRIPTION
resolves a compiler warning:
```
/home/cbodley/ceph/src/rgw/rgw_rest_swift.cc: In member function ‘RGWOp* RGWSwiftWebsiteHandler::get_ws_listing_op()’:
/home/cbodley/ceph/src/rgw/rgw_rest_swift.cc:2558:33: warning: redundant move in initialization [-Wredundant-move]
 2558 |   std::string prefix = std::move(s->object->get_name());
      |                        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/home/cbodley/ceph/src/rgw/rgw_rest_swift.cc:2558:33: note: remove ‘std::move’ call
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
