### PR TITLE
quincy: mds: Fix the linkmerge assert check

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -9528,7 +9528,7 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
   // primary+remote link merge?
   bool linkmerge = (srcdnl->get_inode() == oldin);
   if (linkmerge)
-    ceph_assert(srcdnl->is_primary() || destdnl->is_remote());
+    ceph_assert(srcdnl->is_primary() && destdnl->is_remote());
 
   bool new_in_snaprealm = false;
   bool new_oldin_snaprealm = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62241

---

backport of https://github.com/ceph/ceph/pull/51934
parent tracker: https://tracker.ceph.com/issues/61879

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh