### PR TITLE
reef: test/TestOSDMap: don't use the deprecated std::random_shuffle method

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -2349,7 +2349,9 @@ TEST_F(OSDMapTest, ReadBalanceScore1) {
         float fratio = 1. / (float)replica_count;
         for (int iter = 0 ; iter < 100 ; iter++) {  // run the test 100 times
           // Create random shuffle of OSDs
-          std::random_shuffle (osds.begin(), osds.end());
+          std::random_device seed;
+          std::default_random_engine generator(seed());
+          std::shuffle(osds.begin(), osds.end(), generator);
           for (uint i = 0 ; i < num_osds ; i++) {
             if ((float(i + 1) / float(num_osds)) < fratio) {
               ASSERT_TRUE(osds[i] < num_osds);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62275

---

backport of https://github.com/ceph/ceph/pull/52675
parent tracker: https://tracker.ceph.com/issues/62203

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh