### PR TITLE
[RFC] osd: EC Partial Stripe Reads (Retry of #23138)

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -332,17 +332,39 @@ int ErasureCode::decode_concat(const map<int, bufferlist> &chunks,
 			       bufferlist *decoded)
 {
   set<int> want_to_read;
+  set<int> decode_chunks;
+  bool need_decode = false;
 
   for (unsigned int i = 0; i < get_data_chunk_count(); i++) {
     want_to_read.insert(chunk_index(i));
+  }
+  if (chunks.size() < get_data_chunk_count()) {
+    // for partial_read
+    for (const auto& [key, bl] : chunks) {
+      if (want_to_read.contains(key)) {
+        decode_chunks.insert(key);
+      } else {
+        need_decode = true;
+        break;
+      }
+    }
+    if (!need_decode) {
+      want_to_read.swap(decode_chunks);
+    }
   }
   map<int, bufferlist> decoded_map;
   int r = _decode(want_to_read, chunks, &decoded_map);
   if (r == 0) {
     for (unsigned int i = 0; i < get_data_chunk_count(); i++) {
-      decoded->claim_append(decoded_map[chunk_index(i)]);
+      if (decoded_map.contains(chunk_index(i))) {
+        decoded->claim_append(decoded_map[chunk_index(i)]);
+      }
     }
   }
   return r;
+}
+
+bool ErasureCode::is_systematic() {
+  return true;
 }
 }

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -113,6 +113,8 @@ namespace ceph {
     int decode_concat(const std::map<int, bufferlist> &chunks,
 			      bufferlist *decoded) override;
 
+    virtual bool is_systematic();
+
   protected:
     int parse(const ErasureCodeProfile &profile,
 	      std::ostream *ss);

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -459,6 +459,11 @@ namespace ceph {
      */
     virtual int decode_concat(const std::map<int, bufferlist> &chunks,
 			      bufferlist *decoded) = 0;
+
+    /**
+     * @return **true** if the EC plugin's data placement is systematic.
+     */
+    virtual bool is_systematic() = 0;
   };
 
   typedef std::shared_ptr<ErasureCodeInterface> ErasureCodeInterfaceRef;

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -41,7 +41,6 @@ int ECUtil::decode(
     bufferlist bl;
     int r = ec_impl->decode_concat(chunks, &bl);
     ceph_assert(r == 0);
-    ceph_assert(bl.length() == sinfo.get_stripe_width());
     out->claim_append(bl);
   }
   return 0;

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -66,15 +66,26 @@ public:
   }
   std::pair<uint64_t, uint64_t> aligned_offset_len_to_chunk(
     std::pair<uint64_t, uint64_t> in) const {
+    // we need to align to stripe again to deal with partial chunk read.
+    std::pair<uint64_t, uint64_t> aligned = offset_len_to_stripe_bounds(in);
     return std::make_pair(
-      aligned_logical_offset_to_chunk_offset(in.first),
-      aligned_logical_offset_to_chunk_offset(in.second));
+      aligned_logical_offset_to_chunk_offset(aligned.first),
+      aligned_logical_offset_to_chunk_offset(aligned.second));
   }
   std::pair<uint64_t, uint64_t> offset_len_to_stripe_bounds(
     std::pair<uint64_t, uint64_t> in) const {
     uint64_t off = logical_to_prev_stripe_offset(in.first);
     uint64_t len = logical_to_next_stripe_offset(
       (in.first - off) + in.second);
+    return std::make_pair(off, len);
+  }
+  std::pair<uint64_t, uint64_t> offset_len_to_chunk_bounds(
+    std::pair<uint64_t, uint64_t> in) const {
+    uint64_t off = in.first - (in.first % chunk_size);
+    uint64_t tmp_len = (in.first - off) + in.second;
+    uint64_t len = ((tmp_len % chunk_size) ?
+      (tmp_len - (tmp_len % chunk_size) + chunk_size) :
+      tmp_len);
     return std::make_pair(off, len);
   }
 };

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -196,10 +196,14 @@ TEST(ErasureCodeExample, decode)
   bufferlist usable;
   usable.substr_of(out, 0, in.length());
   EXPECT_TRUE(usable == in);
+  // partial chunk decode
+  map<int, bufferlist> partial_decode;
+  partial_decode[0] = encoded[0];
+  EXPECT_EQ(0, example.decode_concat(partial_decode, &out));
 
   // cannot recover
   map<int, bufferlist> degraded;  
-  degraded[0] = encoded[0];
+  degraded[2] = encoded[2];
   EXPECT_EQ(-ERANGE, example.decode_concat(degraded, &out));
 }
 


### PR DESCRIPTION
This is a re-implementation of PR #23138 rebased on main with a couple of nitpicky changes to make the code a little more clear (to me at least).  Credit goes to Xiaofei Cui [cuixiaofei@sangfor.com.cn](mailto:cuixiaofei@sangfor.com.cn) for the original implementation.

Looking at the original PR's review, it does not appear that we can use the same technique as in https://github.com/ceph/ceph/commit/468ad4b41010488c8d48ef65ccbebfdb4270690f.  We don't have the ReadOp yet.  I'm not sure if @gregsforytwo's idea to query the plugin works, but it's clear we are not doing the efficient thing from the get-go here.

The performance and efficiency benefits for small random reads appears to be quite substantial, especially for large stripe widths.

![FIO 4KB Random Read IOPS (16 Client)](https://github.com/ceph/ceph/assets/1286295/7df0c4c4-5e55-4a67-8e3e-6f7e503ec311)
![FIO 4KB Random Read Cycles_OP (16 Client)](https://github.com/ceph/ceph/assets/1286295/dae135d9-470c-4032-9017-08cd538a90a1)

Edit: _There was previously a bug in the cycles/op calculation due to a change in how the parsing code works (we previous didn't collect perf data on all osds, now we do).  The scale is exactly the same, but the cycles/op numbers were originally over-inflated by a static factor of 6.  The new numbers have been verified to be within about 10% of the expected cycles/op numbers when calculated using aggregate average CPU consumption and IOPS instead of aggregate cycles and ops._

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
