### PR TITLE
reef: mgr/snap_schedule: allow retention spec 'n' to be user defined

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -171,6 +171,11 @@
     https://docs.ceph.com/en/reef/rados/configuration/mclock-config-ref/
 * CEPHFS: After recovering a Ceph File System post following the disaster recovery
   procedure, the recovered files under `lost+found` directory can now be deleted.
+    https://docs.ceph.com/en/latest/rados/configuration/mclock-config-ref/
+* mgr/snap_schedule: The snap-schedule mgr module now retains one less snapshot
+  than the number mentioned against the config tunable `mds_max_snaps_per_dir`
+  so that a new snapshot can be created and retained during the next schedule
+  run.
 
 >=17.2.1
 

--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -162,6 +162,11 @@ Examples::
    snapshot creation is accounted for in the "created_count" field, which is a
    cumulative count of the total number of snapshots created so far.
 
+.. note: The maximum number of snapshots to retain per directory is limited by the
+   config tunable `mds_max_snaps_per_dir`. This tunable defaults to 100.
+   To ensure a new snapshot can be created, one snapshot less than this will be
+   retained. So by default, a maximum of 99 snapshots will be retained.
+
 Active and inactive schedules
 -----------------------------
 Snapshot schedules can be added for a path that doesn't exist yet in the

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -372,6 +372,9 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         snap_stats['fs_count'] = fs_count
         snap_stats['db_count'] = db_count
 
+        log.debug(f'fs_count: {fs_count}')
+        log.debug(f'db_count: {db_count}')
+
         return snap_stats
 
     def verify_snap_stats(self, dir_path):
@@ -476,6 +479,42 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
 
         # remove snapshot schedule
         self.fs_snap_schedule_cmd('remove', path="/bad-path")
+
+    def test_snap_schedule_for_number_of_snaps_retention(self):
+        """
+        Test that number of snaps retained are as per user spec.
+        """
+        total_snaps = 55
+        test_dir = '/' + TestSnapSchedules.TEST_DIRECTORY
+
+        self.mount_a.run_shell(['mkdir', '-p', test_dir[1:]])
+
+        # set a schedule on the dir
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('retention', 'add', path=test_dir,
+                                  retention_spec_or_period=f'{total_snaps}n')
+        exec_time = time.time()
+
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+
+        # verify snapshot schedule
+        self.verify_schedule(test_dir, ['1M'])
+
+        # we wait for total_snaps snaps to be taken
+        wait_time = timo_1 + total_snaps * 60 + 15
+        time.sleep(wait_time)
+
+        snap_stats = self.get_snap_stats(test_dir)
+        self.assertTrue(snap_stats['fs_count'] == total_snaps)
+        self.assertTrue(snap_stats['db_count'] >= total_snaps)
+
+        # remove snapshot schedule
+        self.fs_snap_schedule_cmd('remove', path=test_dir)
+
+        # remove all scheduled snapshots
+        self.remove_snapshots(test_dir[1:])
+
+        self.mount_a.run_shell(['rmdir', test_dir[1:]])
 
 
 class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -112,8 +112,8 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
                                    f'{period_count}{period}'))
                         break
     if len(keep) > max_snaps_to_retain:
-        log.info((f'Would keep more then {max_snaps_to_retain}, '
-                  'pruning keep set'))
+        log.info(f'Pruning keep set; would retain first {max_snaps_to_retain}'
+                 f' out of {len(keep)} snaps')
         keep = keep[:max_snaps_to_retain]
     return candidates - set(keep)
 

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -19,7 +19,6 @@ from .schedule import Schedule
 import traceback
 
 
-MAX_SNAPS_PER_PATH = 50
 SNAP_SCHEDULE_NAMESPACE = 'cephfs-snap-schedule'
 SNAP_DB_PREFIX = 'snap_db'
 # increment this every time the db schema changes and provide upgrade code
@@ -72,7 +71,8 @@ def updates_schedule_db(func: FuncT) -> FuncT:
 
 
 def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
-                  retention: Dict[str, int]) -> Set:
+                  retention: Dict[str, int],
+                  max_snaps_to_retain: int) -> Set:
     PRUNING_PATTERNS = OrderedDict([
         # n is for keep last n snapshots, uses the snapshot name timestamp
         # format for lowest granularity
@@ -88,8 +88,8 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
     ])
     keep = []
     if not retention:
-        log.info(f'no retention set, assuming n: {MAX_SNAPS_PER_PATH}')
-        retention = {'n': MAX_SNAPS_PER_PATH}
+        log.info(f'no retention set, assuming n: {max_snaps_to_retain}')
+        retention = {'n': max_snaps_to_retain}
     for period, date_pattern in PRUNING_PATTERNS.items():
         log.debug(f'compiling keep set for period {period}')
         period_count = retention.get(period, 0)
@@ -111,10 +111,10 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
                         log.debug(('found enough snapshots for '
                                    f'{period_count}{period}'))
                         break
-    if len(keep) > MAX_SNAPS_PER_PATH:
-        log.info((f'Would keep more then {MAX_SNAPS_PER_PATH}, '
+    if len(keep) > max_snaps_to_retain:
+        log.info((f'Would keep more then {max_snaps_to_retain}, '
                   'pruning keep set'))
-        keep = keep[:MAX_SNAPS_PER_PATH]
+        keep = keep[:max_snaps_to_retain]
     return candidates - set(keep)
 
 def snap_name_to_timestamp(scheduled_snap_name: str) -> str:
@@ -324,6 +324,7 @@ class SnapSchedClient(CephfsClient):
             path = sched.path
             prune_candidates = set()
             time = datetime.now(timezone.utc)
+            mds_max_snaps_per_dir = self.mgr.get_ceph_option('mds_max_snaps_per_dir')
             with open_filesystem(self, sched.fs) as fs_handle:
                 snap_dir = self.mgr.rados.conf_get('client_snapdir')
                 with fs_handle.opendir(f'{path}/{snap_dir}') as d_handle:
@@ -337,7 +338,9 @@ class SnapSchedClient(CephfsClient):
                         else:
                             log.debug(f'skipping dir entry {dir_.d_name}')
                         dir_ = fs_handle.readdir(d_handle)
-                to_prune = get_prune_set(prune_candidates, ret)
+                # Limit ourselves to one snapshot less than allowed by config to allow for
+                # snapshot creation before pruning
+                to_prune = get_prune_set(prune_candidates, ret, mds_max_snaps_per_dir - 1)
                 for k in to_prune:
                     dirname = k[0].d_name.decode('utf-8')
                     log.debug(f'rmdir on {dirname}')

--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule_client.py
@@ -15,7 +15,7 @@ class TestScheduleClient(object):
             fake_dir.d_name = f'scheduled-{ts.strftime(SNAPSHOT_TS_FORMAT)}'
             candidates.add((fake_dir, ts))
         ret = {}
-        prune_set = get_prune_set(candidates, ret)
+        prune_set = get_prune_set(candidates, ret, 99)
         assert prune_set == set(), 'candidates are pruned despite empty retention'
 
     def test_get_prune_set_two_retention_specs(self):
@@ -33,5 +33,5 @@ class TestScheduleClient(object):
             candidates.add((fake_dir, ts))
         # should keep 8 snapshots
         ret = {'h': 6, 'd': 2}
-        prune_set = get_prune_set(candidates, ret)
+        prune_set = get_prune_set(candidates, ret, 99)
         assert len(prune_set) == len(candidates) - 8, 'wrong size of prune set'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61990

---

backport of https://github.com/ceph/ceph/pull/51278
parent tracker: https://tracker.ceph.com/issues/59582

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh