### PR TITLE
pacific: mgr/snap_schedule: catch all exceptions for cli

### DIFF
--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -70,6 +70,8 @@ class Module(MgrModule):
             ret_scheds = self.client.get_snap_schedules(use_fs, path)
         except CephfsConnectionException as e:
             return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         if format == 'json':
             json_report = ','.join([ret_sched.report_json() for ret_sched in ret_scheds])
             return 0, f'[{json_report}]', ''
@@ -90,6 +92,8 @@ class Module(MgrModule):
             self.log.debug(f'recursive is {recursive}')
         except CephfsConnectionException as e:
             return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         if not scheds:
             if format == 'json':
                 output = {} # type: Dict[str,str]
@@ -133,6 +137,8 @@ class Module(MgrModule):
             return -errno.ENOENT, '', str(e)
         except CephfsConnectionException as e:
             return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, suc_msg, ''
 
     @CLIWriteCommand('fs snap-schedule remove')
@@ -150,10 +156,12 @@ class Module(MgrModule):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = path
             self.client.rm_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, 'Schedule removed for path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule retention add')
@@ -173,10 +181,12 @@ class Module(MgrModule):
             self.client.add_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
                                           retention_count)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, 'Retention added to path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule retention remove')
@@ -196,10 +206,12 @@ class Module(MgrModule):
             self.client.rm_retention_spec(use_fs, abs_path,
                                           retention_spec_or_period,
                                           retention_count)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, 'Retention removed from path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule activate')
@@ -217,10 +229,12 @@ class Module(MgrModule):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = path
             self.client.activate_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, 'Schedule activated for path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule deactivate')
@@ -238,8 +252,10 @@ class Module(MgrModule):
                 return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
             abs_path = path
             self.client.deactivate_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
+        except Exception as e:
+            return -errno.EIO, '', str(e)
         return 0, 'Schedule deactivated for path {}'.format(path), ''


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61793

---

backport of https://github.com/ceph/ceph/pull/49295
parent tracker: https://tracker.ceph.com/issues/58195

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh