### PR TITLE
pacific: qa: pass arg as list to fix test case failure

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -22,7 +22,7 @@ class TestNFS(MgrTestCase):
         return self._cmd("nfs", *args)
 
     def _nfs_complete_cmd(self, cmd):
-        return self.mgr_cluster.mon_manager.run_cluster_cmd(args=f"nfs {cmd}",
+        return self.mgr_cluster.mon_manager.run_cluster_cmd(args=["nfs"] + cmd,
                                                             stdout=StringIO(),
                                                             stderr=StringIO(),
                                                             check_status=False)
@@ -150,8 +150,8 @@ class TestNFS(MgrTestCase):
                 try:
                     # Disable any running nfs ganesha daemon
                     self._check_nfs_server_status()
-                    cluster_create = self._nfs_complete_cmd(
-                        f'cluster create {self.cluster_id}')
+                    cmd = ["cluster", "create", self.cluster_id]
+                    cluster_create = self._nfs_complete_cmd(cmd)
                     if cluster_create.stderr and 'cluster already exists' \
                             in cluster_create.stderr.getvalue():
                         self._test_delete_cluster()


### PR DESCRIPTION
Pacific branch's run_cluster_cmd() code can't split string into a list, and
because backporting is too tricky as a lot of qa code doesn't reach pacific, it
would be tedious to backport the PRs that enabled passing string as arg to
run_cluster_cmd() in ceph_manager.py. For complete details please checkout
note #13 in the tracker attached below

Fixes: https://tracker.ceph.com/issues/61732





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
