### PR TITLE
   mgr/volumes: Fix pending_subvolume_deletions in volume info

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -649,6 +649,22 @@ class TestVolumes(TestVolumesHelper):
         self.assertEqual(vol_info["used_size"], 0,
                          "Size should be zero when volumes directory is empty")
 
+    def test_volume_info_pending_subvol_deletions(self):
+        """
+        Tests the pending_subvolume_deletions in 'fs volume info' command
+        """
+        subvolname = self._generate_random_subvolume_name()
+        # create subvolume
+        self._fs_cmd("subvolume", "create", self.volname, subvolname, "--mode=777")
+        # create 3K files of 0.1MB
+        self._do_subvolume_io(subvolname, number_of_files=3000, file_size=0.1)
+        # Delete the subvolume
+        self._fs_cmd("subvolume", "rm", self.volname, subvolname)
+        # get volume metadata
+        vol_info = json.loads(self._get_volume_info(self.volname))
+        self.assertNotEqual(vol_info['pending_subvolume_deletions'], 0,
+                            "pending_subvolume_deletions should be 1")
+
     def test_volume_info_without_subvolumegroup(self):
         """
         Tests the 'fs volume info' command without subvolume group

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -68,11 +68,12 @@ def volume_exists(mgr, fs_name):
             return True
     return False
 
-def listdir(fs, dirpath, filter_entries=None):
+def listdir(fs, dirpath, filter_entries=None, filter_files=True):
     """
-    Get the directory names (only dirs) for a given path
+    Get the directory entries for a given path. List only dirs if 'filter_files' is True.
+    Don't list the entries passed in 'filter_entries'
     """
-    dirs = []
+    entries = []
     if filter_entries is None:
         filter_entries = [b".", b".."]
     else:
@@ -81,12 +82,15 @@ def listdir(fs, dirpath, filter_entries=None):
         with fs.opendir(dirpath) as dir_handle:
             d = fs.readdir(dir_handle)
             while d:
-                if (d.d_name not in filter_entries) and d.is_dir():
-                    dirs.append(d.d_name)
+                if (d.d_name not in filter_entries):
+                    if not filter_files:
+                        entries.append(d.d_name)
+                    elif d.is_dir():
+                        entries.append(d.d_name)
                 d = fs.readdir(dir_handle)
     except cephfs.Error as e:
         raise VolumeException(-e.args[0], e.args[1])
-    return dirs
+    return entries
 
 
 def has_subdir(fs, dirpath, filter_entries=None):

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -11,7 +11,7 @@ import orchestrator
 from .lock import GlobalLock
 from ..exception import VolumeException
 from ..fs_util import create_pool, remove_pool, rename_pool, create_filesystem, \
-    remove_filesystem, rename_filesystem, create_mds, volume_exists
+    remove_filesystem, rename_filesystem, create_mds, volume_exists, listdir
 from .trash import Trash
 from mgr_util import open_filesystem, CephfsConnectionException
 
@@ -244,15 +244,15 @@ def list_volumes(mgr):
     return result
 
 
-def get_pending_subvol_deletions_count(path):
+def get_pending_subvol_deletions_count(fs, path):
     """
     Get the number of pending subvolumes deletions.
     """
     trashdir = os.path.join(path, Trash.GROUP_NAME)
     try:
-        num_pending_subvol_del = len(os.listdir(trashdir))
-    except OSError as e:
-        if e.errno == errno.ENOENT:
+        num_pending_subvol_del = len(listdir(fs, trashdir, filter_entries=None, filter_files=False))
+    except VolumeException as ve:
+        if ve.errno == -errno.ENOENT:
             num_pending_subvol_del = 0
 
     return {'pending_subvolume_deletions': num_pending_subvol_del}

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -152,7 +152,7 @@ class VolumeClient(CephfsClient["Module"]):
                                          cephfs.AT_SYMLINK_NOFOLLOW)
 
                     usedbytes = st['size']
-                    vol_info_dict = get_pending_subvol_deletions_count(path)
+                    vol_info_dict = get_pending_subvol_deletions_count(fs_handle, path)
                     if human_readable:
                         vol_info_dict['used_size'] = mgr_util.format_bytes(int(usedbytes), 5)
                     else:


### PR DESCRIPTION
Problem:
     The pending_subvolume_deletions field in 'fs volume info' output is
    always zero
    
Cause:
     The 'os.listdir' being used to list the trash directory didn't have
    subvolume basdir context. Hence it was always failing with ENOENT.
    
Fix:
     Modify the fs_util's listdir function to list the files as well and use it.
    
Signed-off-by: Kotresh HR <khiremat@redhat.com>
Fixes: https://tracker.ceph.com/issues/62278



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
