### PR TITLE
 doc/rados/operations: Correct EC min_size recommendation to K+1 in erasure-code.rst

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -236,7 +236,7 @@ mode. As a result, however, pools with lost OSDs but without complete data loss 
 unable to recover and go active without manual intervention to temporarily change
 the ``min_size`` setting.
 
-We recommend that ``min_size`` be ``K+2`` or greater to prevent loss of writes and
+We recommend that ``min_size`` be ``K+1`` or greater to prevent loss of writes and
 loss of data.
 
 


### PR DESCRIPTION
Update the doc to match the reality in the code. I don't know where the recommendation to have min_size = k+2 came from, but for awhile now we've defaulted to K+1. See PR #8008.