### PR TITLE
qa/suites/crimson-rados: add centos9 to supported distros

### DIFF
--- a/qa/distros/crimson-supported-all-distro/centos_8.yaml
+++ b/qa/distros/crimson-supported-all-distro/centos_8.yaml
@@ -1,0 +1,1 @@
+../all/centos_8.yaml

--- a/qa/distros/crimson-supported-all-distro/centos_latest.yaml
+++ b/qa/distros/crimson-supported-all-distro/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/suites/crimson-rados/basic/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/basic/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/basic/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/basic/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/

--- a/qa/suites/crimson-rados/perf/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/perf/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/perf/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/perf/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/

--- a/qa/suites/crimson-rados/rbd/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/rbd/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/rbd/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/rbd/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/

--- a/qa/suites/crimson-rados/thrash/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/thrash/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/thrash/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/thrash/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/


### PR DESCRIPTION
Following https://github.com/ceph/ceph-build/pull/2154, once Crimson will build successfully on c9 it can be added to the supported distro list.

Verified:
https://pulpito.ceph.com/matan-2023-08-03_13:28:04-crimson-rados-wip-matanb-crimson-only-add-asan-req-distro-crimson-smithi/

Notes: 
* For now a full crimson suite run will include both centos versions. Versions can be filtered out if only one is relevant.
* c9 runs are failing atm. However, these errors are out of the scope of this PR.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
