### PR TITLE
quincy: rgw/crypt: apply rgw_crypt_default_encryption_key by default

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1162,23 +1162,20 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] = std::string(key_id);
         crypt_http_responses["x-amz-server-side-encryption-context"] = std::move(cooked_context);
         return 0;
-      } else if (req_sse == "AES256") {
-        /* SSE-S3: fall through to logic to look for vault or test key */
-      } else {
+      } else if (req_sse != "AES256") {
         ldpp_dout(s, 5) << "ERROR: Invalid value for header x-amz-server-side-encryption"
                          << dendl;
         s->err.message = "Server Side Encryption with KMS managed key requires "
           "HTTP header x-amz-server-side-encryption : aws:kms or AES256";
         return -EINVAL;
       }
-    } else {
-  /*no encryption*/
-      return 0;
-    }
 
-    /* from here on we are only handling SSE-S3 (req_sse=="AES256") */
+      if (s->cct->_conf->rgw_crypt_sse_s3_backend != "vault") {
+        s->err.message = "Request specifies Server Side Encryption "
+            "but server configuration does not support this.";
+        return -EINVAL;
+      }
 
-    if (s->cct->_conf->rgw_crypt_sse_s3_backend == "vault") {
       ldpp_dout(s, 5) << "RGW_ATTR_BUCKET_ENCRYPTION ALGO: "
               <<  req_sse << dendl;
       std::string_view context = "";
@@ -1221,10 +1218,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       crypt_http_responses["x-amz-server-side-encryption"] = "AES256";
 
       return 0;
-    }
-
-    /* SSE-S3 and no backend, check if there is a test key */
-    if (s->cct->_conf->rgw_crypt_default_encryption_key != "") {
+    } else if (s->cct->_conf->rgw_crypt_default_encryption_key != "") {
       std::string master_encryption_key;
       try {
         master_encryption_key = from_base64(s->cct->_conf->rgw_crypt_default_encryption_key);
@@ -1263,10 +1257,8 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
       return 0;
     }
-    s->err.message = "Request specifies Server Side Encryption "
-                     "but server configuration does not support this.";
-    return -EINVAL;
   }
+  return 0;
 }
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62310

---

backport of https://github.com/ceph/ceph/pull/51786
parent tracker: https://tracker.ceph.com/issues/61473

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh