### PR TITLE
doc/rgw: several response headers are supported

### DIFF
--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -91,13 +91,7 @@ The following common request header fields are not supported:
 +----------------------------+------------+
 | Name                       | Type       |
 +============================+============+
-| **Server**                 | Response   |
-+----------------------------+------------+
-| **x-amz-delete-marker**    | Response   |
-+----------------------------+------------+
 | **x-amz-id-2**             | Response   |
-+----------------------------+------------+
-| **x-amz-version-id**       | Response   |
 +----------------------------+------------+
 
 .. _Amazon S3 API: http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html


### PR DESCRIPTION
Server, delete-marker, and version-id have been supported since pacific at least

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
