### PR TITLE
doc: Add a Ceph Foundation footer to docs.ceph.com

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -22,4 +22,10 @@
 {%- endif %}
 
   {{ super() }}
+
+<div id="support-the-ceph-foundation" class="admonition note">
+  <p class="first admonition-title">Brought to you by the Ceph Foundation</p>
+  <p class="last">The Ceph Documentation is a community resource funded and hosted by the non-profit <a href="https://ceph.io/en/foundation/">Ceph Foundation</a>. If you would like to support this and our other efforts, please consider <a href="https://ceph.io/en/foundation/join/">joining now</a>.</p>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
Add an info box to the footer of every docs page inviting visitors to support the Ceph Foundation.