### PR TITLE
os/bluestore: Change contract for BlueStore's Allocator interface

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -49,6 +49,13 @@ public:
 
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
+  /*
+    Releases disk regions.
+    It is required that prior to invoking it the regions were marked as taken.
+    The caller is relinquishing ownership back to the allocator.
+
+    Note: the allocator must assert if any part of any region was already free.
+  */
   virtual void release(const interval_set<uint64_t>& release_set) = 0;
   void release(const PExtentVector& release_set);
 
@@ -56,7 +63,21 @@ public:
   virtual void foreach(
     std::function<void(uint64_t offset, uint64_t length)> notify) = 0;
 
+  /*
+    Used during allocator initialization.
+    init_add_free tells that specific region is free.
+
+    Note: the allocator must assert if any part of the region was already free.
+   */
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;
+  /*
+    Used during allocator initialization.
+    init_rm_free tells that specific region is allocated.
+
+    Note: the allocator must assert if any part of the region was already allocated.
+    init_rm_free() is similiar to release(), but will never be called from
+    concurrent threads; it does not have to maintain internal execution exclusion.
+   */
   virtual void init_rm_free(uint64_t offset, uint64_t length) = 0;
 
   virtual uint64_t get_free() = 0;

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -105,6 +105,12 @@ void AvlAllocator::_add_to_tree(uint64_t start, uint64_t size)
     rs_before = std::prev(rs_after);
   }
 
+  // It is illegal if region before is in collision with new region
+  ceph_assert(rs_before == range_tree.end() || rs_before->end <= start);
+  // It is illegal if region after is in collision with new region
+  // the below assertion seems to be necessary, but in fact it only check upper_bound()
+  ceph_assert(rs_after == range_tree.end() || end <= rs_after->start);
+
   bool merge_before = (rs_before != range_tree.end() && rs_before->end == start);
   bool merge_after = (rs_after != range_tree.end() && rs_after->start == end);
 

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -75,6 +75,12 @@ void BtreeAllocator::_add_to_tree(uint64_t start, uint64_t size)
     rs_before = std::prev(rs_after);
   }
 
+  // It is illegal if region before is in collision with new region
+  ceph_assert(rs_before == range_tree.end() || rs_before->second <= start);
+  // It is illegal if region after is in collision with new region
+  // the below assertion seems to be necessary, but in fact it only check upper_bound()
+  ceph_assert(rs_after == range_tree.end() || end <= rs_after->first);
+
   bool merge_before = (rs_before != range_tree.end() && rs_before->second == start);
   bool merge_after = (rs_after != range_tree.end() && rs_after->first == end);
 

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -53,7 +53,6 @@ if(WITH_BLUESTORE)
 
   add_executable(unittest_alloc
     Allocator_test.cc
-    $<TARGET_OBJECTS:unit-main>
     )
   add_ceph_unittest(unittest_alloc)
   target_link_libraries(unittest_alloc os global)


### PR DESCRIPTION
New contract on Allocator interface requires that functions:
- release()
- init_add_free()
- init_rm_free() assert critically when undelying state does not align with request. That is, releasing of something already free is illegal and marking-allocate something that is already allocated is illegal.

A comprehensive unit test is added to require ASSERT_DEATH in offending cases.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
