### PR TITLE
qa/rgw: run s3tests against keystone ec2

### DIFF
--- a/qa/suites/rgw/tempest/0-install.yaml
+++ b/qa/suites/rgw/tempest/0-install.yaml
@@ -11,5 +11,4 @@ tasks:
           description: Swift Service
 - rgw:
     client.0:
-      frontend_prefix: /swift
       use-keystone-role: client.0

--- a/qa/suites/rgw/tempest/0-install.yaml
+++ b/qa/suites/rgw/tempest/0-install.yaml
@@ -1,0 +1,15 @@
+tasks:
+- install:
+- ceph:
+- tox: [ client.0 ]
+- keystone:
+    client.0:
+      force-branch: stable/2023.1
+      services:
+        - name: swift
+          type: object-store
+          description: Swift Service
+- rgw:
+    client.0:
+      frontend_prefix: /swift
+      use-keystone-role: client.0

--- a/qa/suites/rgw/tempest/overrides.yaml
+++ b/qa/suites/rgw/tempest/overrides.yaml
@@ -1,7 +1,21 @@
 overrides:
   ceph:
     conf:
+      global:
+        osd_min_pg_log_entries: 10
+        osd_max_pg_log_entries: 10
       client:
         setuser: ceph
         setgroup: ceph
         debug rgw: 20
+        rgw keystone api version: 3
+        rgw keystone accepted roles: admin,member
+        rgw keystone implicit tenants: true
+        rgw keystone accepted admin roles: admin
+        rgw swift enforce content length: true
+        rgw swift account in url: true
+        rgw swift versioning enabled: true
+        rgw keystone admin domain: Default
+        rgw keystone admin user: admin
+        rgw keystone admin password: ADMIN
+        rgw keystone admin project: admin

--- a/qa/suites/rgw/tempest/s3tests-branch.yaml
+++ b/qa/suites/rgw/tempest/s3tests-branch.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/s3tests-branch.yaml

--- a/qa/suites/rgw/tempest/tasks/s3tests.yaml
+++ b/qa/suites/rgw/tempest/tasks/s3tests.yaml
@@ -1,0 +1,35 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw s3 auth use keystone: true
+        rgw crypt s3 kms backend: testing
+        rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl: false
+  keystone:
+    client.0:
+      projects:
+        - name: s3tests
+          description: s3tests project
+      users:
+        - name: s3tests-main
+          password: SECRET
+          project: s3tests
+      ec2 credentials:
+        - project: s3tests
+          user: s3tests-main
+      roles: [ name: member ]
+      role-mappings:
+        - name: member
+          user: s3tests-main
+          project: s3tests
+
+tasks:
+- s3tests:
+    client.0:
+      rgw_server: client.0
+      keystone users:
+        s3 main:
+          client: client.0
+          project: s3tests
+          user: s3tests-main

--- a/qa/suites/rgw/tempest/tasks/tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/tempest.yaml
@@ -1,3 +1,9 @@
+overrides:
+  rgw:
+    client.0:
+      # tempest tests expect the swift api at the root
+      frontend_prefix: /swift
+
 tasks:
 - tempest:
     client.0:

--- a/qa/suites/rgw/tempest/tasks/tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/tempest.yaml
@@ -1,18 +1,4 @@
 tasks:
-- install:
-- ceph:
-- tox: [ client.0 ]
-- keystone:
-    client.0:
-      force-branch: stable/2023.1
-      services:
-        - name: swift
-          type: object-store
-          description: Swift Service
-- rgw:
-    client.0:
-      frontend_prefix: /swift
-      use-keystone-role: client.0
 - tempest:
     client.0:
       sha1: 34.1.0
@@ -51,22 +37,3 @@ tasks:
         - .*test_object_expiry.ObjectExpiryTest.test_get_object_after_expiry_time
         - .*test_object_expiry.ObjectExpiryTest.test_get_object_at_expiry_time
         - .*test_account_services.AccountTest.test_list_no_account_metadata
-
-overrides:
-  ceph:
-    conf:
-      global:
-        osd_min_pg_log_entries: 10
-        osd_max_pg_log_entries: 10
-      client:
-        rgw keystone api version: 3
-        rgw keystone accepted roles: admin,member
-        rgw keystone implicit tenants: true
-        rgw keystone accepted admin roles: admin
-        rgw swift enforce content length: true
-        rgw swift account in url: true
-        rgw swift versioning enabled: true
-        rgw keystone admin domain: Default
-        rgw keystone admin user: admin
-        rgw keystone admin password: ADMIN
-        rgw keystone admin project: admin

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -326,25 +326,26 @@ def dict_to_args(specials, items):
     args.extend(arg for arg in special_vals.values() if arg)
     return args
 
+def os_auth_args(host, port):
+    return [
+        '--os-username', 'admin',
+        '--os-password', 'ADMIN',
+        '--os-user-domain-id', 'default',
+        '--os-project-name', 'admin',
+        '--os-project-domain-id', 'default',
+        '--os-identity-api-version', '3',
+        '--os-auth-url', 'http://{host}:{port}/v3'.format(host=host, port=port),
+    ]
+
 def run_section_cmds(ctx, cclient, section_cmd, specials,
                      section_config_list):
     public_host, public_port = ctx.keystone.public_endpoints[cclient]
-
-    auth_section = [
-        ( 'os-username', 'admin' ),
-        ( 'os-password', 'ADMIN' ),
-        ( 'os-user-domain-id', 'default' ),
-        ( 'os-project-name', 'admin' ),
-        ( 'os-project-domain-id', 'default' ),
-        ( 'os-identity-api-version', '3' ),
-        ( 'os-auth-url', 'http://{host}:{port}/v3'.format(host=public_host,
-                                                          port=public_port) ),
-    ]
+    auth_args = os_auth_args(public_host, public_port)
 
     for section_item in section_config_list:
         run_in_keystone_venv(ctx, cclient,
-            [ 'openstack' ] + section_cmd.split() +
-            dict_to_args(specials, auth_section + list(section_item.items())) +
+            [ 'openstack' ] + section_cmd.split() + auth_args +
+            dict_to_args(specials, list(section_item.items())) +
             [ '--debug' ])
 
 def create_endpoint(ctx, cclient, service, url, adminurl=None):

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -463,6 +463,8 @@ def task(ctx, config):
         config = all_clients
     if isinstance(config, list):
         config = dict.fromkeys(config)
+    overrides = ctx.config.get('overrides', {})
+    teuthology.deep_merge(config, overrides.get('keystone', {}))
 
     log.debug('Keystone config is %s', config)
 

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -387,6 +387,8 @@ def fill_keystone(ctx, config):
                          cconfig.get('projects', []))
         run_section_cmds(ctx, cclient, 'user create --or-show', 'name',
                          cconfig.get('users', []))
+        run_section_cmds(ctx, cclient, 'ec2 credentials create', '',
+                         cconfig.get('ec2 credentials', []))
         run_section_cmds(ctx, cclient, 'role create --or-show', 'name',
                          cconfig.get('roles', []))
         run_section_cmds(ctx, cclient, 'role add', 'name',
@@ -441,6 +443,9 @@ def task(ctx, config):
               - name: custom
                 password: SECRET
                 project: custom
+            ec2 credentials:
+              - project: custom
+                user: custom
             roles: [ name: custom ]
             role-mappings:
               - name: custom


### PR DESCRIPTION
allow keystone task's yaml to create ec2 credentials for its users
allow s3test task's yaml to point at keystone users instead of creating a local user with radosgw-admin
add an s3test task to the rgw/tempest suite

Fixes: https://tracker.ceph.com/issues/59424

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
