### PR TITLE
pacific: mds: use variable g_ceph_context directly in MDSAuthCaps

### DIFF
--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -227,15 +227,14 @@ bool MDSAuthCaps::is_capable(std::string_view inode_path,
 			     uid_t new_uid, gid_t new_gid,
 			     const entity_addr_t& addr) const
 {
-  if (cct)
-    ldout(cct, 10) << __func__ << " inode(path /" << inode_path
-		   << " owner " << inode_uid << ":" << inode_gid
-		   << " mode 0" << std::oct << inode_mode << std::dec
-		   << ") by caller " << caller_uid << ":" << caller_gid
+  ldout(g_ceph_context, 10) << __func__ << " inode(path /" << inode_path
+		 << " owner " << inode_uid << ":" << inode_gid
+		 << " mode 0" << std::oct << inode_mode << std::dec
+		 << ") by caller " << caller_uid << ":" << caller_gid
 // << "[" << caller_gid_list << "]";
-		   << " mask " << mask
-		   << " new " << new_uid << ":" << new_gid
-		   << " cap: " << *this << dendl;
+		 << " mask " << mask
+		 << " new " << new_uid << ":" << new_gid
+		 << " cap: " << *this << dendl;
 
   for (const auto& grant : grants) {
     if (grant.network.size() &&
@@ -339,7 +338,7 @@ void MDSAuthCaps::set_allow_all()
 				 {}));
 }
 
-bool MDSAuthCaps::parse(CephContext *c, std::string_view str, ostream *err)
+bool MDSAuthCaps::parse(std::string_view str, ostream *err)
 {
   // Special case for legacy caps
   if (str == "allow") {
@@ -354,7 +353,6 @@ bool MDSAuthCaps::parse(CephContext *c, std::string_view str, ostream *err)
   MDSCapParser<decltype(iter)> g;
 
   bool r = qi::phrase_parse(iter, end, g, ascii::space, *this);
-  cct = c;  // set after parser self-assignment
   if (r && iter == end) {
     for (auto& grant : grants) {
       std::sort(grant.match.gids.begin(), grant.match.gids.end());

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -183,9 +183,8 @@ class MDSAuthCaps
 {
 public:
   MDSAuthCaps() = default;
-  explicit MDSAuthCaps(CephContext *cct_) : cct(cct_) {}
 
-  // this ctor is used by spirit/phoenix; doesn't need cct.
+  // this ctor is used by spirit/phoenix
   explicit MDSAuthCaps(const std::vector<MDSCapGrant>& grants_) : grants(grants_) {}
 
   void clear() {
@@ -193,7 +192,7 @@ public:
   }
 
   void set_allow_all();
-  bool parse(CephContext *cct, std::string_view str, std::ostream *err);
+  bool parse(std::string_view str, std::ostream *err);
 
   bool allow_all() const;
   bool is_capable(std::string_view inode_path,
@@ -226,7 +225,6 @@ public:
 
   friend std::ostream &operator<<(std::ostream &out, const MDSAuthCaps &cap);
 private:
-  CephContext *cct = nullptr;
   std::vector<MDSCapGrant> grants;
 };
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1060,7 +1060,7 @@ bool MDSDaemon::parse_caps(const AuthCapsInfo& info, MDSAuthCaps& caps)
 
     dout(10) << __func__ << ": parsing auth_cap_str='" << auth_cap_str << "'" << dendl;
     CachedStackStringStream cs;
-    if (caps.parse(g_ceph_context, auth_cap_str, cs.get())) {
+    if (caps.parse(auth_cap_str, cs.get())) {
       return true;
     } else {
       dout(1) << __func__ << ": auth cap parse error: " << cs->strv() << " parsing '" << auth_cap_str << "'" << dendl;

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1307,7 +1307,7 @@ bool AuthMonitor::valid_caps(
     }
   } else if (type == "mds") {
     MDSAuthCaps mdscap;
-    if (!mdscap.parse(g_ceph_context, caps, out)) {
+    if (!mdscap.parse(caps, out)) {
       return false;
     }
   } else {

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -59,7 +59,7 @@ TEST(MDSAuthCaps, ParseGood) {
     string str = parse_good[i];
     MDSAuthCaps cap;
     std::cout << "Testing good input: '" << str << "'" << std::endl;
-    ASSERT_TRUE(cap.parse(g_ceph_context, str, &cout));
+    ASSERT_TRUE(cap.parse(str, &cout));
   }
 }
 
@@ -98,7 +98,7 @@ TEST(MDSAuthCaps, ParseBad) {
     string str = parse_bad[i];
     MDSAuthCaps cap;
     std::cout << "Testing bad input: '" << str << "'" << std::endl;
-    ASSERT_FALSE(cap.parse(g_ceph_context, str, &cout));
+    ASSERT_FALSE(cap.parse(str, &cout));
   }
 }
 
@@ -106,26 +106,26 @@ TEST(MDSAuthCaps, AllowAll) {
   MDSAuthCaps cap;
   ASSERT_FALSE(cap.allow_all());
 
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow r", NULL));
+  ASSERT_TRUE(cap.parse("allow r", NULL));
   ASSERT_FALSE(cap.allow_all());
   cap = MDSAuthCaps();
 
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow rw", NULL));
+  ASSERT_TRUE(cap.parse("allow rw", NULL));
   ASSERT_FALSE(cap.allow_all());
   cap = MDSAuthCaps();
 
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow", NULL));
+  ASSERT_TRUE(cap.parse("allow", NULL));
   ASSERT_FALSE(cap.allow_all());
   cap = MDSAuthCaps();
 
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow *", NULL));
+  ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
   ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
-  MDSAuthCaps cap(g_ceph_context);
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow * uid=10", NULL));
+  MDSAuthCaps cap;
+  ASSERT_TRUE(cap.parse("allow * uid=10", NULL));
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
@@ -137,8 +137,8 @@ TEST(MDSAuthCaps, AllowUid) {
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
-  MDSAuthCaps cap(g_ceph_context);
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow * uid=10 gids=10,11,12; allow * uid=12 gids=12,10", NULL));
+  MDSAuthCaps cap;
+  ASSERT_TRUE(cap.parse("allow * uid=10 gids=10,11,12; allow * uid=12 gids=12,10", NULL));
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
@@ -208,7 +208,7 @@ TEST(MDSAuthCaps, AllowUidGid) {
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow * path=/sandbox", NULL));
+  ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
   ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
   ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
@@ -218,7 +218,7 @@ TEST(MDSAuthCaps, AllowPath) {
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
-  ASSERT_TRUE(unquo_cap.parse(g_ceph_context, "allow * path=/sandbox-._foo", NULL));
+  ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
   ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
   ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
@@ -229,7 +229,7 @@ TEST(MDSAuthCaps, AllowPathChars) {
 
 TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
-  ASSERT_TRUE(quo_cap.parse(g_ceph_context, "allow * path=\"/sandbox-._foo\"", NULL));
+  ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
   ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
   ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
@@ -239,7 +239,7 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
-  ASSERT_TRUE(rs_cap.parse(g_ceph_context, "allow rw root_squash, allow rw path=/sandbox", NULL));
+  ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
   ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
   ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
   ASSERT_FALSE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
@@ -293,7 +293,7 @@ TEST(MDSAuthCaps, OutputParsed) {
   for (size_t i = 0; i < num_tests; ++i) {
     MDSAuthCaps cap;
     std::cout << "Testing input '" << test_values[i].input << "'" << std::endl;
-    ASSERT_TRUE(cap.parse(g_ceph_context, test_values[i].input, &cout));
+    ASSERT_TRUE(cap.parse(test_values[i].input, &cout));
     ASSERT_EQ(test_values[i].output, stringify(cap));
   }
 }
@@ -305,7 +305,7 @@ TEST(MDSAuthCaps, network) {
   c.parse("192.167.2.3");
 
   MDSAuthCaps cap;
-  ASSERT_TRUE(cap.parse(g_ceph_context, "allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
+  ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
   ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
   ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62337

---

backport of https://github.com/ceph/ceph/pull/50874
parent tracker: https://tracker.ceph.com/issues/62334

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh