### PR TITLE
qa/cephfs: add sleep to test_cephfs_shell.py to avoid race

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -839,7 +839,7 @@ class TestDF(TestCephFSShell):
         s = 'df test' * 14145016
         o = self.get_cephfs_shell_cmd_output("put - dumpfile", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
-        sleep(20)
+        sleep(10)
         self.validate_df("dumpfile")
 
 

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -839,6 +839,7 @@ class TestDF(TestCephFSShell):
         s = 'df test' * 14145016
         o = self.get_cephfs_shell_cmd_output("put - dumpfile", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
+        sleep(20)
         self.validate_df("dumpfile")
 
 


### PR DESCRIPTION
There probably is some kind of race condition due to which issue
described in tracker ticket https://tracker.ceph.com/issues/47292 only
reproduces sometimes. This has been the case in tests for "du" command
in cephfs-shell before. Since a sleep was added to those tests, the
error never reproduced again,

Let's add a sleep to this test to. Hopefully, this issue will stop
reproducing altogether.

Maybe Fixes: https://tracker.ceph.com/issues/47292






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>