### PR TITLE
doc/radosgw: Improve language and formatting in config-ref.rst

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -79,7 +79,7 @@ workload with a smaller number of buckets but higher number of objects (hundreds
 per bucket you would consider decreasing :confval:`rgw_lc_max_wp_worker` from the default value of 3.
 
 .. note:: When looking to tune either of these specific values please validate the
-       current Cluster performance and Ceph Object Gateway utilization before increasing.
+   current Cluster performance and Ceph Object Gateway utilization before increasing.
 
 Garbage Collection Settings
 ===========================
@@ -97,8 +97,9 @@ To view the queue of objects awaiting garbage collection, execute the following
 
    radosgw-admin gc list
 
-.. note:: specify ``--include-all`` to list all entries, including unexpired
-  
+.. note:: Specify ``--include-all`` to list all entries, including unexpired
+   Garbage Collection objects.
+
 Garbage collection is a background activity that may
 execute continuously or during times of low loads, depending upon how the
 administrator configures the Ceph Object Gateway. By default, the Ceph Object
@@ -121,7 +122,9 @@ configuration parameters.
 
 :Tuning Garbage Collection for Delete Heavy Workloads:
 
-As an initial step towards tuning Ceph Garbage Collection to be more aggressive the following options are suggested to be increased from their default configuration values::
+As an initial step towards tuning Ceph Garbage Collection to be more
+aggressive the following options are suggested to be increased from their
+default configuration values::
 
   rgw_gc_max_concurrent_io = 20
   rgw_gc_max_trim_chunk = 64
@@ -270,7 +273,7 @@ to support future methods of scheduling requests.
 Currently the scheduler defaults to a throttler which throttles the active
 connections to a configured limit. QoS based on mClock is currently in an
 *experimental* phase and not recommended for production yet. Current
-implementation of *dmclock_client* op queue divides RGW Ops on admin, auth
+implementation of *dmclock_client* op queue divides RGW ops on admin, auth
 (swift auth, sts) metadata & data requests.
 
 
@@ -313,15 +316,21 @@ below.
 Topic persistency settings
 ==========================
 
-Topic persistency will persistently push the notification until it succeeds
+Topic persistency will persistently push the notification until it succeeds.
+For more information, see `Bucket Notifications`_.
 
-The default behavior is to push indefinitely as frequently as possible.
-With these settings you can control how long to persistently push and their frequency (or it succeeds before that),
-you can either control by providing maximum time of retention or maximum amount of pushing,
-and you can control the frequency with the sleep duration parameter
+The default behavior is to push indefinitely and as frequently as possible.
+With these settings you can control how long and how often to retry an
+unsuccessful notification. How long to persistently push can be controlled
+by providing maximum time of retention or maximum amount of retries.
+Frequency of persistent push retries can be controlled with the sleep duration
+parameter.
 
-All of these values have default value 0 (persistency retention is indefinite, and as frequently as possible)
+All of these values have default value 0 (persistent retention is indefinite,
+and retried as frequently as possible).
 
 .. confval:: rgw_topic_persistency_time_to_live
 .. confval:: rgw_topic_persistency_max_retries
 .. confval:: rgw_topic_persistency_sleep_duration
+
+.. _Bucket Notifications: ../notifications


### PR DESCRIPTION
The "Topic persistency settings" section includes convoluted and incomplete sentences so attempt to improve the language. The section lacks context so add a link to the relevant documentation about Notifications.  
**note:** I am not sure if this should link to `PubSub Sync Module` or to `Bucket Notifications`!!  
I picked Bucket Notifications but would be interesting to know if that is right.

The "Garbage Collection settings" note includes a sentence that looks incomplete so try to improve the language.

Don't capitalize "Ops" in "RGW Ops" especially when the same sentence talks about "op queue" with lower case "o".

Also improve formatting: indentation of a note and wrap several very long lines.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
