### PR TITLE
mount.fuse.ceph: strip the 'nofail' option from those that fuse will see

### DIFF
--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -39,8 +39,11 @@ def ceph_options_compat(device):
     return [ 'ceph.' + opt for opt in device.split(',') ]
 
 def fs_options(opts, ceph_opts):
-    # strip out noauto and _netdev options; libfuse doesn't like it
-    strip_opts = ['defaults', 'noauto', '_netdev']
+    # - strip out noauto and _netdev options; libfuse doesn't like it
+    # - nofail option is also not recognized by libfuse.
+    #   Starting with fuse 3.2.2 the option is also ignored by mount.fuse, see
+    #   https://github.com/libfuse/libfuse/commit/a83cd72f641671b71b8268b1765e449cae071f3e
+    strip_opts = ['defaults', 'noauto', '_netdev', 'nofail']
     return ','.join(list(set(opts) - set(ceph_opts) - set(strip_opts)))
 
 def main(arguments):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/58394

The research of this problem has shown that stripping the option from the list that is sent to libfuse is the correct approach.

[libfuse](https://github.com/libfuse/libfuse) themselves took this route in their fix of the problem in https://github.com/libfuse/libfuse/commit/a83cd72f641671b71b8268b1765e449cae071f3e.

The kernel mainly uses the option to decide how to treat errors during the boot process or mount -a. While I can't say whether some file systems overload this option with internal functionality, it's not used by the libfuse.

More info:
https://github.com/ceph/ceph/pull/26992
https://github.com/systemd/systemd/issues/5032
https://access.redhat.com/discussions/4976921
https://furorteutonicus.eu/2013-08-29-nofail-and-nobootwait-mount-options-in-fstab-prevent-boot-problems
https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-unionfilesystems/issues/36
https://linux.die.net/man/8/mount

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
