### PR TITLE
mgr/status: fix kb_used and kb_avail display as byte unit

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -336,8 +336,8 @@ class Module(MgrModule):
                 stats = osd_stats[osd_id]
                 assert metadata
                 hostname = metadata['hostname']
-                kb_used = stats['kb_used'] * 1024
-                kb_avail = stats['kb_avail'] * 1024
+                kb_used = stats['kb_used']
+                kb_avail = stats['kb_avail']
 
             wr_ops_rate = (self.get_rate("osd", osd_id.__str__(), "osd.op_w") +
                            self.get_rate("osd", osd_id.__str__(), "osd.op_rw"))
@@ -345,8 +345,8 @@ class Module(MgrModule):
             rd_ops_rate = self.get_rate("osd", osd_id.__str__(), "osd.op_r")
             rd_byte_rate = self.get_rate("osd", osd_id.__str__(), "osd.op_out_bytes")
             osd_table.add_row([osd_id, hostname,
-                               mgr_util.format_bytes(kb_used, 5),
-                               mgr_util.format_bytes(kb_avail, 5),
+                               mgr_util.format_bytes(kb_used * 1024, 5),
+                               mgr_util.format_bytes(kb_avail * 1024, 5),
                                mgr_util.format_dimless(wr_ops_rate, 5),
                                mgr_util.format_bytes(wr_byte_rate, 5),
                                mgr_util.format_dimless(rd_ops_rate, 5),


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62385

Command `ceph osd status --format json` shows `kb used` and `kb available` as byte unit, fix it.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
