### PR TITLE
cmake: install() the neorados tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT WIN32)
       neorados.cc)
   add_executable(neorados ${neorados_srcs})
   target_link_libraries(neorados libneorados spawn fmt::fmt ${CMAKE_DL_LIBS})
-  #install(TARGETS neorados DESTINATION bin)
+  install(TARGETS neorados DESTINATION bin)
 endif()
 
 if(WITH_TESTS)


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
