### PR TITLE
reef: ceph_volume: support encrypted volumes for lvm new-db/new-wal/migrate commands

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
@@ -28,7 +28,7 @@ def deactivate_osd(osd_id=None, osd_uuid=None):
 
     for lv in lvs:
         if lv.tags.get('ceph.encrypted', '0') == '1':
-            encryption.dmcrypt_close(lv.lv_uuid)
+            encryption.dmcrypt_close(mapping=lv.lv_uuid, skip_path_check=True)
 
 
 class Deactivate(object):

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -23,19 +23,7 @@ def prepare_dmcrypt(key, device, device_type, tags):
         return ''
     tag_name = 'ceph.%s_uuid' % device_type
     uuid = tags[tag_name]
-    # format data device
-    encryption_utils.luks_format(
-        key,
-        device
-    )
-    encryption_utils.luks_open(
-        key,
-        device,
-        uuid
-    )
-
-    return '/dev/mapper/%s' % uuid
-
+    return encryption_utils.prepare_dmcrypt(key, device, uuid)
 
 def prepare_bluestore(block, wal, db, secrets, tags, osd_id, fsid):
     """

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -302,9 +302,8 @@ class Zap(object):
         self.zap(devices)
 
     def dmcrypt_close(self, dmcrypt_uuid):
-        dmcrypt_path = "/dev/mapper/{}".format(dmcrypt_uuid)
-        mlogger.info("Closing encrypted path %s", dmcrypt_path)
-        encryption.dmcrypt_close(dmcrypt_path)
+        mlogger.info("Closing encrypted volume %s", dmcrypt_uuid)
+        encryption.dmcrypt_close(mapping=dmcrypt_uuid, skip_path_check=True)
 
     def main(self):
         sub_command_help = dedent("""

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -22,18 +22,7 @@ def prepare_dmcrypt(key, device, device_type, fsid):
         return ''
     kname = disk.lsblk(device)['KNAME']
     mapping = 'ceph-{}-{}-{}-dmcrypt'.format(fsid, kname, device_type)
-    # format data device
-    encryption_utils.luks_format(
-        key,
-        device
-    )
-    encryption_utils.luks_open(
-        key,
-        device,
-        mapping
-    )
-
-    return '/dev/mapper/{}'.format(mapping)
+    return encryption_utils.prepare_dmcrypt(key, device, mapping)
 
 def prepare_bluestore(block, wal, db, secrets, osd_id, fsid, tmpfs):
     """

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_deactivate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_deactivate.py
@@ -56,4 +56,4 @@ class TestDeactivate(object):
         p_get_lvs.return_value = [FooVolume]
 
         deactivate.deactivate_osd(0)
-        p_dm_close.assert_called_with('123')
+        p_dm_close.assert_called_with(mapping='123', skip_path_check=True)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -1086,6 +1086,15 @@ class TestMigrate(object):
     def mock_get_lvs(self, *args, **kwargs):
         return self.mock_volumes.pop(0)
 
+    mock_prepare_dmcrypt_uuid = ''
+    def mock_prepare_dmcrypt(self, *args, **kwargs):
+        self.mock_prepare_dmcrypt_uuid = kwargs['mapping']
+        return '/dev/mapper/' + kwargs['mapping']
+
+    mock_dmcrypt_close_uuid = []
+    def mock_dmcrypt_close(self, *args, **kwargs):
+        self.mock_dmcrypt_close_uuid.append(kwargs['mapping'])
+
     def test_get_source_devices(self, monkeypatch):
 
         source_tags = 'ceph.osd_id=2,ceph.type=data,ceph.osd_fsid=1234'
@@ -1313,6 +1322,120 @@ Example calls for supported scenarios:
             'ceph-bluestore-tool',
             '--path', '/var/lib/ceph/osd/ceph-2',
             '--dev-target', '/dev/VolGroup/lv2_new',
+            '--command', 'bluefs-bdev-migrate',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block.db']
+
+    @patch('os.getuid')
+    def test_migrate_data_db_to_new_db_encrypted(self, m_getuid, monkeypatch):
+        m_getuid.return_value = 0
+
+        source_tags = 'ceph.osd_id=2,ceph.type=data,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,'\
+        'ceph.encrypted=1'
+        source_db_tags = 'ceph.osd_id=2,ceph.type=db,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,'\
+        'ceph.encrypted=1'
+
+        data_vol = api.Volume(lv_name='volume1',
+                              lv_uuid='datauuid',
+                              vg_name='vg',
+                              lv_path='/dev/VolGroup/lv1',
+                              lv_tags=source_tags)
+        db_vol = api.Volume(lv_name='volume2',
+                            lv_uuid='dbuuid',
+                            vg_name='vg',
+                            lv_path='/dev/VolGroup/lv2',
+                            lv_tags=source_db_tags)
+
+        self.mock_single_volumes = {
+            '/dev/VolGroup/lv1': data_vol,
+            '/dev/VolGroup/lv2': db_vol,
+        }
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
+
+        self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
+                                      vg_name='vg',
+                                      lv_path='/dev/VolGroup/lv2_new',
+                                      lv_tags='')
+        monkeypatch.setattr(api, 'get_lv_by_fullname',
+            self.mock_get_lv_by_fullname)
+
+        self.mock_process_input = []
+        monkeypatch.setattr(process, 'call', self.mock_process)
+
+        devices = []
+        devices.append([Device('/dev/VolGroup/lv1'), 'block'])
+        devices.append([Device('/dev/VolGroup/lv2'), 'db'])
+
+        monkeypatch.setattr(migrate, 'find_associated_devices',
+            lambda osd_id, osd_fsid: devices)
+
+
+        monkeypatch.setattr("ceph_volume.systemd.systemctl.osd_is_active",
+            lambda id: False)
+
+        monkeypatch.setattr(migrate, 'get_cluster_name',
+            lambda osd_id, osd_fsid: 'ceph')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr(encryption_utils, 'prepare_dmcrypt', self.mock_prepare_dmcrypt)
+        monkeypatch.setattr(encryption_utils, 'dmcrypt_close', self.mock_dmcrypt_close)
+
+        m = migrate.Migrate(argv=[
+            '--osd-id', '2',
+            '--osd-fsid', '1234',
+            '--from', 'data', 'db', 'wal',
+            '--target', 'vgname/new_wal'])
+        m.main()
+
+        assert self.mock_prepare_dmcrypt_uuid == self.mock_volume.lv_uuid
+
+        n = len(self.mock_dmcrypt_close_uuid)
+        assert n >= 1
+        assert self.mock_dmcrypt_close_uuid[n-1] == db_vol.lv_uuid
+
+        n = len(self.mock_process_input)
+        assert n >= 5
+
+        assert self. mock_process_input[n-5] == [
+            'lvchange',
+            '--deltag', 'ceph.osd_id=2',
+            '--deltag', 'ceph.type=db',
+            '--deltag', 'ceph.osd_fsid=1234',
+            '--deltag', 'ceph.cluster_name=ceph',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '--deltag', 'ceph.encrypted=1',
+            '/dev/VolGroup/lv2']
+
+        assert self. mock_process_input[n-4] == [
+            'lvchange',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '/dev/VolGroup/lv1']
+
+        assert self. mock_process_input[n-3] == [
+            'lvchange',
+            '--addtag', 'ceph.db_uuid=new-db-uuid',
+            '--addtag', 'ceph.db_device=/dev/VolGroup/lv2_new',
+            '/dev/VolGroup/lv1']
+
+        assert self. mock_process_input[n-2] == [
+            'lvchange',
+            '--addtag', 'ceph.osd_id=2',
+            '--addtag', 'ceph.type=db',
+            '--addtag', 'ceph.osd_fsid=1234',
+            '--addtag', 'ceph.cluster_name=ceph',
+            '--addtag', 'ceph.encrypted=1',
+            '--addtag', 'ceph.db_uuid=new-db-uuid',
+            '--addtag', 'ceph.db_device=/dev/VolGroup/lv2_new',
+            '/dev/VolGroup/lv2_new']
+
+        assert self. mock_process_input[n-1] == [
+            'ceph-bluestore-tool',
+            '--path', '/var/lib/ceph/osd/ceph-2',
+            '--dev-target', '/dev/mapper/new-db-uuid',
             '--command', 'bluefs-bdev-migrate',
             '--devs-source', '/var/lib/ceph/osd/ceph-2/block',
             '--devs-source', '/var/lib/ceph/osd/ceph-2/block.db']
@@ -1720,6 +1843,147 @@ Example calls for supported scenarios:
             'ceph-bluestore-tool',
             '--path', '/var/lib/ceph/osd/ceph-2',
             '--dev-target', '/dev/VolGroup/lv2_new',
+            '--command', 'bluefs-bdev-migrate',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block.db',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block.wal']
+
+    @patch('os.getuid')
+    def test_migrate_data_db_wal_to_new_db_encrypted(self, m_getuid, monkeypatch):
+        m_getuid.return_value = 0
+
+        source_tags = 'ceph.osd_id=2,ceph.type=data,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.wal_uuid=waluuid,ceph.wal_device=wal_dev,ceph.encrypted=1'
+        source_db_tags = 'ceph.osd_id=2,ceph.type=db,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.encrypted=1'
+        source_wal_tags = 'ceph.osd_id=0,ceph.type=wal,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.wal_uuid=waluuid,ceph.wal_device=wal_dev,ceph.encrypted=1'
+
+        data_vol = api.Volume(lv_name='volume1',
+                              lv_uuid='datauuid',
+                              vg_name='vg',
+                              lv_path='/dev/VolGroup/lv1',
+                              lv_tags=source_tags)
+        db_vol = api.Volume(lv_name='volume2',
+                            lv_uuid='dbuuid',
+                            vg_name='vg',
+                            lv_path='/dev/VolGroup/lv2',
+                            lv_tags=source_db_tags)
+
+        wal_vol = api.Volume(lv_name='volume3',
+                             lv_uuid='waluuid',
+                             vg_name='vg',
+                             lv_path='/dev/VolGroup/lv3',
+                             lv_tags=source_wal_tags)
+
+        self.mock_single_volumes = {
+            '/dev/VolGroup/lv1': data_vol,
+            '/dev/VolGroup/lv2': db_vol,
+            '/dev/VolGroup/lv3': wal_vol,
+        }
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
+
+        self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
+                                      vg_name='vg',
+                                      lv_path='/dev/VolGroup/lv2_new',
+                                      lv_tags='')
+        monkeypatch.setattr(api, 'get_lv_by_fullname',
+            self.mock_get_lv_by_fullname)
+
+        self.mock_process_input = []
+        monkeypatch.setattr(process, 'call', self.mock_process)
+
+        devices = []
+        devices.append([Device('/dev/VolGroup/lv1'), 'block'])
+        devices.append([Device('/dev/VolGroup/lv2'), 'db'])
+        devices.append([Device('/dev/VolGroup/lv3'), 'wal'])
+
+        monkeypatch.setattr(migrate, 'find_associated_devices',
+            lambda osd_id, osd_fsid: devices)
+
+        monkeypatch.setattr("ceph_volume.systemd.systemctl.osd_is_active",
+            lambda id: False)
+
+        monkeypatch.setattr(migrate, 'get_cluster_name',
+            lambda osd_id, osd_fsid: 'ceph')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr(encryption_utils, 'prepare_dmcrypt', self.mock_prepare_dmcrypt)
+        monkeypatch.setattr(encryption_utils, 'dmcrypt_close', self.mock_dmcrypt_close)
+
+        m = migrate.Migrate(argv=[
+            '--osd-id', '2',
+            '--osd-fsid', '1234',
+            '--from', 'data', 'db', 'wal',
+            '--target', 'vgname/new_wal'])
+        m.main()
+
+        assert self.mock_prepare_dmcrypt_uuid == self.mock_volume.lv_uuid
+
+        n = len(self.mock_dmcrypt_close_uuid)
+        assert n >= 2
+        assert self.mock_dmcrypt_close_uuid[n-2] == db_vol.lv_uuid
+        assert self.mock_dmcrypt_close_uuid[n-1] == wal_vol.lv_uuid
+
+        n = len(self.mock_process_input)
+        assert n >= 6
+
+        assert self. mock_process_input[n-6] == [
+            'lvchange',
+            '--deltag', 'ceph.osd_id=2',
+            '--deltag', 'ceph.type=db',
+            '--deltag', 'ceph.osd_fsid=1234',
+            '--deltag', 'ceph.cluster_name=ceph',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '--deltag', 'ceph.encrypted=1',
+            '/dev/VolGroup/lv2']
+
+        assert self. mock_process_input[n-5] == [
+            'lvchange',
+            '--deltag', 'ceph.osd_id=0',
+            '--deltag', 'ceph.type=wal',
+            '--deltag', 'ceph.osd_fsid=1234',
+            '--deltag', 'ceph.cluster_name=ceph',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '--deltag', 'ceph.wal_uuid=waluuid',
+            '--deltag', 'ceph.wal_device=wal_dev',
+            '--deltag', 'ceph.encrypted=1',
+            '/dev/VolGroup/lv3']
+
+        assert self. mock_process_input[n-4] == [
+            'lvchange',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '--deltag', 'ceph.wal_uuid=waluuid',
+            '--deltag', 'ceph.wal_device=wal_dev',
+            '/dev/VolGroup/lv1']
+
+        assert self. mock_process_input[n-3] == [
+            'lvchange',
+            '--addtag', 'ceph.db_uuid=new-db-uuid',
+            '--addtag', 'ceph.db_device=/dev/VolGroup/lv2_new',
+            '/dev/VolGroup/lv1']
+
+        assert self. mock_process_input[n-2] == [
+            'lvchange',
+            '--addtag', 'ceph.osd_id=2',
+            '--addtag', 'ceph.type=db',
+            '--addtag', 'ceph.osd_fsid=1234',
+            '--addtag', 'ceph.cluster_name=ceph',
+            '--addtag', 'ceph.encrypted=1',
+            '--addtag', 'ceph.db_uuid=new-db-uuid',
+            '--addtag', 'ceph.db_device=/dev/VolGroup/lv2_new',
+            '/dev/VolGroup/lv2_new']
+
+        assert self. mock_process_input[n-1] == [
+            'ceph-bluestore-tool',
+            '--path', '/var/lib/ceph/osd/ceph-2',
+            '--dev-target', '/dev/mapper/new-db-uuid',
             '--command', 'bluefs-bdev-migrate',
             '--devs-source', '/var/lib/ceph/osd/ceph-2/block',
             '--devs-source', '/var/lib/ceph/osd/ceph-2/block.db',
@@ -2182,6 +2446,120 @@ Example calls for supported scenarios:
             '--deltag', 'ceph.db_device=db_dev',
             '--deltag', 'ceph.wal_uuid=waluuid',
             '--deltag', 'ceph.wal_device=wal_dev',
+            '/dev/VolGroup/lv3']
+        assert self. mock_process_input[n-3] == [
+            'lvchange',
+            '--deltag', 'ceph.wal_uuid=waluuid',
+            '--deltag', 'ceph.wal_device=wal_dev',
+            '/dev/VolGroup/lv1']
+        assert self. mock_process_input[n-2] == [
+            'lvchange',
+            '--deltag', 'ceph.wal_uuid=waluuid',
+            '--deltag', 'ceph.wal_device=wal_dev',
+            '/dev/VolGroup/lv2']
+        assert self. mock_process_input[n-1] == [
+            'ceph-bluestore-tool',
+            '--path', '/var/lib/ceph/osd/ceph-2',
+            '--dev-target', '/var/lib/ceph/osd/ceph-2/block.db',
+            '--command', 'bluefs-bdev-migrate',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block',
+            '--devs-source', '/var/lib/ceph/osd/ceph-2/block.wal']
+
+    @patch('os.getuid')
+    def test_migrate_data_wal_to_db_encrypted(self,
+                                              m_getuid,
+                                              monkeypatch,
+                                              capsys):
+        m_getuid.return_value = 0
+
+        source_tags = 'ceph.osd_id=2,ceph.type=data,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.wal_uuid=waluuid,ceph.wal_device=wal_dev,ceph.encrypted=1'
+        source_db_tags = 'ceph.osd_id=2,ceph.type=db,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.wal_uuid=waluuid,ceph.wal_device=wal_dev,ceph.encrypted=1'
+        source_wal_tags = 'ceph.osd_id=2,ceph.type=wal,ceph.osd_fsid=1234,' \
+        'ceph.cluster_name=ceph,ceph.db_uuid=dbuuid,ceph.db_device=db_dev,' \
+        'ceph.wal_uuid=waluuid,ceph.wal_device=wal_dev,ceph.encrypted=1'
+
+        data_vol = api.Volume(lv_name='volume1',
+                              lv_uuid='datauuid',
+                              vg_name='vg',
+                              lv_path='/dev/VolGroup/lv1',
+                              lv_tags=source_tags)
+        db_vol = api.Volume(lv_name='volume2',
+                            lv_uuid='dbuuid',
+                            vg_name='vg',
+                            lv_path='/dev/VolGroup/lv2',
+                            lv_tags=source_db_tags)
+
+        wal_vol = api.Volume(lv_name='volume3',
+                             lv_uuid='waluuid',
+                             vg_name='vg',
+                             lv_path='/dev/VolGroup/lv3',
+                             lv_tags=source_wal_tags)
+
+        self.mock_single_volumes = {
+            '/dev/VolGroup/lv1': data_vol,
+            '/dev/VolGroup/lv2': db_vol,
+            '/dev/VolGroup/lv3': wal_vol,
+        }
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
+
+        self.mock_volume = db_vol
+        monkeypatch.setattr(api, 'get_lv_by_fullname',
+            self.mock_get_lv_by_fullname)
+
+        self.mock_process_input = []
+        monkeypatch.setattr(process, 'call', self.mock_process)
+
+        devices = []
+        devices.append([Device('/dev/VolGroup/lv1'), 'block'])
+        devices.append([Device('/dev/VolGroup/lv2'), 'db'])
+        devices.append([Device('/dev/VolGroup/lv3'), 'wal'])
+
+        monkeypatch.setattr(migrate, 'find_associated_devices',
+            lambda osd_id, osd_fsid: devices)
+
+        monkeypatch.setattr("ceph_volume.systemd.systemctl.osd_is_active",
+            lambda id: False)
+
+        monkeypatch.setattr(migrate, 'get_cluster_name',
+            lambda osd_id, osd_fsid: 'ceph')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr(encryption_utils, 'prepare_dmcrypt', self.mock_prepare_dmcrypt)
+        monkeypatch.setattr(encryption_utils, 'dmcrypt_close', self.mock_dmcrypt_close)
+        m = migrate.Migrate(argv=[
+            '--osd-id', '2',
+            '--osd-fsid', '1234',
+            '--from', 'db', 'data', 'wal',
+            '--target', 'vgname/db'])
+
+        m.main()
+
+        assert self.mock_prepare_dmcrypt_uuid == ''
+
+        n = len(self.mock_dmcrypt_close_uuid)
+        assert n >= 1
+        assert self.mock_dmcrypt_close_uuid[n-1] == wal_vol.lv_uuid
+
+        n = len(self.mock_process_input)
+        assert n >= 1
+        for s in self.mock_process_input:
+            print(s)
+
+        assert self. mock_process_input[n-4] == [
+            'lvchange',
+            '--deltag', 'ceph.osd_id=2',
+            '--deltag', 'ceph.type=wal',
+            '--deltag', 'ceph.osd_fsid=1234',
+            '--deltag', 'ceph.cluster_name=ceph',
+            '--deltag', 'ceph.db_uuid=dbuuid',
+            '--deltag', 'ceph.db_device=db_dev',
+            '--deltag', 'ceph.wal_uuid=waluuid',
+            '--deltag', 'ceph.wal_device=wal_dev',
+            '--deltag', 'ceph.encrypted=1',
             '/dev/VolGroup/lv3']
         assert self. mock_process_input[n-3] == [
             'lvchange',

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -106,19 +106,19 @@ def luks_open(key, device, mapping):
     process.call(command, stdin=key, terminal_verbose=True, show_command=True)
 
 
-def dmcrypt_close(mapping):
+def dmcrypt_close(mapping, skip_path_check=False):
     """
     Encrypt (close) a device, previously decrypted with cryptsetup
 
-    :param mapping:
+    :param mapping: mapping name or path used to correlate device.
+    :param skip_path_check: whether we need path presence validation.
     """
-    if not os.path.exists(mapping):
+    if not skip_path_check and not os.path.exists(mapping):
         logger.debug('device mapper path does not exist %s' % mapping)
         logger.debug('will skip cryptsetup removal')
         return
     # don't be strict about the remove call, but still warn on the terminal if it fails
     process.run(['cryptsetup', 'remove', mapping], stop_on_error=False)
-
 
 def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
     """
@@ -273,3 +273,22 @@ def legacy_encrypted(device):
             metadata['lockbox'] = d.path
             break
     return metadata
+
+def prepare_dmcrypt(key, device, mapping):
+    """
+    Helper for devices that are encrypted. The operations needed for
+    block, db, wal, or data/journal devices are all the same
+    """
+    if not device:
+        return ''
+    # format data device
+    luks_format(
+        key,
+        device
+    )
+    luks_open(
+        key,
+        device,
+        mapping
+    )
+    return '/dev/mapper/%s' % mapping


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/50427

backport tracker: https://tracker.ceph.com/issues/62358
parent tracker: https://tracker.ceph.com/issues/55167

Signed-off-by: Igor Fedotov [igor.fedotov@croit.io](mailto:igor.fedotov@croit.io)
