### PR TITLE
mon/ConfigMonitor: --format=json does not work for config get or show

### DIFF
--- a/qa/suites/rados/basic/tasks/commands.yaml
+++ b/qa/suites/rados/basic/tasks/commands.yaml
@@ -1,0 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        debug ms: 1
+      mon:
+        mon warn on pool no app: false
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.tests.test_commands

--- a/qa/tasks/tests/test_commands.py
+++ b/qa/tasks/tests/test_commands.py
@@ -1,0 +1,27 @@
+import json
+from tasks.ceph_test_case import CephTestCase
+
+class TestCommands(CephTestCase):
+
+  def setUp(self):
+    super().setUp()
+    mon_stat = json.loads(self.cluster_cmd("mon stat --format=json"))
+    self.leader_mon_name = "mon.%s" % mon_stat['leader']
+
+  def validate_config_response(self, key, response):
+    # expecting {"<key>": "<value>"}
+    # yes, all values are stringified.
+    self.assertTrue(isinstance(response, dict))
+    self.assertEqual(1, len(response))
+    self.assertIn(key, response)
+    self.assertTrue(isinstance(response[key], str))
+
+  def test_config_show(self):
+    key = "mon_allow_pool_delete"
+    cmd = "config show %s %s --format=json" % (self.leader_mon_name, key)
+    self.validate_config_response(key, json.loads(self.cluster_cmd(cmd)))
+
+  def test_config_get(self):
+    key = "mon_allow_pool_delete"
+    cmd = "config get mon %s --format=json" % (key)
+    self.validate_config_response(key, json.loads(self.cluster_cmd(cmd)))

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -102,15 +102,16 @@ class VolumeClient(CephfsClient["Module"]):
                 "stored in the filesystem '{0}'. If you are *ABSOLUTELY CERTAIN* " \
                 "that is what you want, re-issue the command followed by " \
                 "--yes-i-really-mean-it.".format(volname)
-
+        key = 'mon_allow_pool_delete'
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config get',
-            'key': 'mon_allow_pool_delete',
+            'key': key,
             'who': 'mon',
             'format': 'json',
         })
-        mon_allow_pool_delete = json.loads(out)
-        if not mon_allow_pool_delete:
+        config = json.loads(out)
+        # config values are returned as strings
+        if not json.loads(config[key]):
             return -errno.EPERM, "", "pool deletion is disabled; you must first " \
                 "set the mon_allow_pool_delete config option to true before volumes " \
                 "can be deleted"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44089

The root cause of the unexpected newline for `--format=json*` is this legacy code which I didn't want to change in this PR:

`src/ceph.in:1275`
```
            # hack: old code printed status line before many json outputs
            # (osd dump, etc.) that consumers know to ignore.  Add blank line
            # to satisfy consumers that skip the first line, but not annoy
            # consumers that don't.
            if parsed_args.output_format and \
               parsed_args.output_format.startswith('json'):
                print()
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
