### PR TITLE
commom,osd: support for default fmtlib formatters

### DIFF
--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file default fmtlib formatters for specifically-tagged types
+ */
+#include <fmt/format.h>
+
+/**
+ * an implementation note:
+ * not including fmt/ranges.h here because it grabs every structure that
+ * has a begin()/end() method pair. This is a problem because we have
+ * such classes in Crimson.
+ */
+/**
+ * Tagging classes that provide support for default fmtlib formatting,
+ * by having either
+ * std::string fmt_print() const
+ * *or*
+ * std::string alt_fmt_print(bool short_format) const
+ * as public member functions.
+ */
+template<class T>
+concept has_fmt_print = requires(T t) {
+  { t.fmt_print() } -> std::same_as<std::string>;
+};
+template<class T>
+concept has_alt_fmt_print = requires(T t) {
+  { t.alt_fmt_print(bool{}) } -> std::same_as<std::string>;
+};
+
+namespace fmt {
+
+template <has_fmt_print T>
+struct formatter<T> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const T& k, FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "{}", k.fmt_print());
+  }
+};
+
+template <has_alt_fmt_print T>
+struct formatter<T> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it == 's') {
+      verbose = false;
+      ++it;
+    }
+    return it;
+  }
+  template <typename FormatContext>
+  auto format(const T& k, FormatContext& ctx) const {
+    if (verbose) {
+      return fmt::format_to(ctx.out(), "{}", k.alt_fmt_print(true));
+    }
+    return fmt::format_to(ctx.out(), "{}", k.alt_fmt_print(false));
+  }
+  bool verbose{true};
+};
+}  // namespace fmt

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <ostream>
 
+#include "common/fmt_common.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/fwd.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/node_types.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/value.h"
@@ -207,19 +208,18 @@ struct staged_position_t {
 
   index_t index;
   nxt_t nxt;
-};
-template <match_stage_t STAGE>
-std::ostream& operator<<(std::ostream& os, const staged_position_t<STAGE>& pos) {
-  if (pos.index == INDEX_END) {
-    os << "END";
-  } else if (pos.index == INDEX_LAST) {
-    os << "LAST";
-  } else {
-    os << pos.index;
-    assert(is_valid_index(pos.index));
+
+  std::string fmt_print() const {
+    if (index == INDEX_END) {
+      return fmt::format("END, {}", nxt.fmt_print());
+    }
+    if (index == INDEX_LAST) {
+      return fmt::format("LAST, {}", nxt.fmt_print());
+    }
+    assert(is_valid_index(index));
+    return fmt::format("{}, {}", index, nxt.fmt_print());
   }
-  return os << ", " << pos.nxt;
-}
+};
 
 template <>
 struct staged_position_t<STAGE_BOTTOM> {
@@ -280,19 +280,17 @@ struct staged_position_t<STAGE_BOTTOM> {
   static me_t end() { return {INDEX_END}; }
 
   index_t index;
-};
-template <>
-inline std::ostream& operator<<(std::ostream& os, const staged_position_t<STAGE_BOTTOM>& pos) {
-  if (pos.index == INDEX_END) {
-    os << "END";
-  } else if (pos.index == INDEX_LAST) {
-    os << "LAST";
-  } else {
-    os << pos.index;
-    assert(is_valid_index(pos.index));
+  std::string fmt_print() const {
+    if (index == INDEX_END) {
+      return "END";
+    }
+    if (index == INDEX_LAST) {
+      return "LAST";
+    }
+    assert(is_valid_index(index));
+    return std::to_string(index);
   }
-  return os;
-}
+};
 
 using search_position_t = staged_position_t<STAGE_TOP>;
 
@@ -433,10 +431,30 @@ struct node_stats_t {
   unsigned num_kvs = 0;
 };
 
+} // namespace crimson::os::seastore::onode
+
+namespace std {
+template <crimson::os::seastore::onode::match_stage_t STAGE>
+std::ostream& operator<<(
+    std::ostream& os,
+    const crimson::os::seastore::onode::staged_position_t<STAGE>& pos) {
+  return os << pos.fmt_print();
 }
+} // namespace std
+
+
+namespace fmt {
+template <crimson::os::seastore::onode::match_stage_t S>
+struct formatter<crimson::os::seastore::onode::staged_position_t<S>> {
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const crimson::os::seastore::onode::staged_position_t<S>& k,
+              FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "{}", k.fmt_print());
+  }
+};
 
 #if FMT_VERSION >= 90000
-template <crimson::os::seastore::onode::match_stage_t S>
-struct fmt::formatter<crimson::os::seastore::onode::staged_position_t<S>> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::os::seastore::onode::MatchHistory> : fmt::ostream_formatter {};
+template <> struct formatter<crimson::os::seastore::onode::MatchHistory> : ostream_formatter {};
 #endif
+}  // namespace fmt

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -229,6 +229,21 @@ std::ostream& operator<<(std::ostream& out, const entity_addr_t &addr)
   return out;
 }
 
+std::string entity_addr_t::fmt_print() const
+{
+  if (type == entity_addr_t::TYPE_NONE) {
+    return "-";
+  }
+  std::ostringstream out;  //< \todo use fmt::format
+  out << get_sockaddr();
+
+  if (type == entity_addr_t::TYPE_ANY) {
+    return fmt::format("{}/{}", out.str(), nonce);
+  } else {
+    return fmt::format("{}:{}/{}", get_type_name(type), out.str(), nonce);
+  }
+}
+
 std::ostream& operator<<(std::ostream& out, const sockaddr *psa)
 {
   char buf[NI_MAXHOST] = { 0 };

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -18,7 +18,7 @@
 #include <sstream>
 
 #include <netinet/in.h>
-#include <fmt/format.h>
+#include "common/fmt_common.h"
 #if FMT_VERSION >= 90000
 #include <fmt/ostream.h>
 #endif
@@ -545,15 +545,13 @@ struct entity_addr_t {
   }
 
   void dump(ceph::Formatter *f) const;
+  std::string fmt_print() const; ///< used by the default fmt formatter
 
   static void generate_test_instances(std::list<entity_addr_t*>& o);
 };
 WRITE_CLASS_ENCODER_FEATURES(entity_addr_t)
 
 std::ostream& operator<<(std::ostream& out, const entity_addr_t &addr);
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<entity_addr_t> : fmt::ostream_formatter {};
-#endif
 
 inline bool operator==(const entity_addr_t& a, const entity_addr_t& b) { return memcmp(&a, &b, sizeof(a)) == 0; }
 inline bool operator!=(const entity_addr_t& a, const entity_addr_t& b) { return memcmp(&a, &b, sizeof(a)) != 0; }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6542,7 +6542,7 @@ void ObjectRecoveryProgress::decode(ceph::buffer::list::const_iterator &bl)
 
 ostream &operator<<(ostream &out, const ObjectRecoveryProgress &prog)
 {
-  return prog.print(out);
+  return out << prog.fmt_print();
 }
 
 void ObjectRecoveryProgress::generate_test_instances(
@@ -6563,14 +6563,16 @@ void ObjectRecoveryProgress::generate_test_instances(
 
 ostream &ObjectRecoveryProgress::print(ostream &out) const
 {
-  return out << "ObjectRecoveryProgress("
-	     << ( first ? "" : "!" ) << "first, "
-	     << "data_recovered_to:" << data_recovered_to
-	     << ", data_complete:" << ( data_complete ? "true" : "false" )
-	     << ", omap_recovered_to:" << omap_recovered_to
-	     << ", omap_complete:" << ( omap_complete ? "true" : "false" )
-	     << ", error:" << ( error ? "true" : "false" )
-	     << ")";
+  return out << fmt_print();
+}
+
+std::string ObjectRecoveryProgress::fmt_print() const {
+  return fmt::format(
+      "ObjectRecoveryProgress({}first, data_recovered_to: {}, "
+      "data_complete: {}, omap_recovered_to: {}, omap_complete: "
+      "{}, error: {})",
+      (first ? "" : "!"), data_recovered_to, data_complete, omap_recovered_to,
+      omap_complete, error);
 }
 
 void ObjectRecoveryProgress::dump(Formatter *f) const

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5995,6 +5995,13 @@ void watch_info_t::dump(Formatter *f) const
   f->close_section();
 }
 
+std::string watch_info_t::fmt_print() const
+{
+  return fmt::format(
+      "watch(cookie {} {}s {})", cookie, timeout_seconds, addr);
+}
+
+
 void watch_info_t::generate_test_instances(list<watch_info_t*>& o)
 {
   o.push_back(new watch_info_t);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6659,19 +6659,15 @@ void ObjectRecoveryInfo::dump(Formatter *f) const
 
 ostream& operator<<(ostream& out, const ObjectRecoveryInfo &inf)
 {
-  return inf.print(out);
+  return out << inf.fmt_print();
 }
 
-ostream &ObjectRecoveryInfo::print(ostream &out) const
+std::string ObjectRecoveryInfo::fmt_print() const
 {
-  return out << "ObjectRecoveryInfo("
-	     << soid << "@" << version
-	     << ", size: " << size
-	     << ", copy_subset: " << copy_subset
-	     << ", clone_subset: " << clone_subset
-	     << ", snapset: " << ss
-	     << ", object_exist: " << object_exist
-	     << ")";
+  return fmt::format(
+      "ObjectRecoveryInfo({}@{}, size: {}, copy_subset: {}, "
+      "clone_subset: {}, snapset: {}, object_exist: {})",
+      soid, version, size, copy_subset, clone_subset, ss, object_exist);
 }
 
 // -- PushReplyOp --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4075,6 +4075,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
+  std::string fmt_print() const;
   static void generate_test_instances(std::list<ObjectCleanRegions*>& o);
 };
 WRITE_CLASS_ENCODER(ObjectCleanRegions)
@@ -4298,7 +4299,7 @@ struct pg_log_entry_t {
      invalid_hash(false), invalid_pool(false) {
     snaps.reassign_to_mempool(mempool::mempool_osd_pglog);
   }
-      
+
   bool is_clone() const { return op == CLONE; }
   bool is_modify() const { return op == MODIFY; }
   bool is_promote() const { return op == PROMOTE; }
@@ -4357,6 +4358,7 @@ struct pg_log_entry_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
+  std::string fmt_print() const;
   static void generate_test_instances(std::list<pg_log_entry_t*>& o);
 
 };

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4223,6 +4223,16 @@ struct pg_log_op_return_item_t {
   }
 };
 WRITE_CLASS_ENCODER(pg_log_op_return_item_t)
+namespace fmt {
+template <>
+struct formatter<pg_log_op_return_item_t> {
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const pg_log_op_return_item_t& litm, FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "r={}+{}b", litm.rval, litm.bl.length());
+  }
+};
+} // namespace fmt
 
 /**
  * pg_log_entry_t - single entry/event in pg log

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -6005,7 +6005,7 @@ struct ObjectRecoveryInfo {
   static void generate_test_instances(std::list<ObjectRecoveryInfo*>& o);
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl, int64_t pool = -1);
-  std::ostream &print(std::ostream &out) const;
+  std::string fmt_print() const;
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER_FEATURES(ObjectRecoveryInfo)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -31,6 +31,7 @@
 
 #include "include/rados/rados_types.hpp"
 #include "include/mempool.h"
+#include "common/fmt_common.h"
 
 #include "msg/msg_types.h"
 #include "include/compat.h"

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3231,6 +3231,7 @@ public:
     void encode(ceph::buffer::list& bl) const;
     void decode(ceph::buffer::list::const_iterator& bl);
     void dump(ceph::Formatter *f) const;
+    std::string fmt_print() const;
     static void generate_test_instances(std::list<pg_interval_t*>& o);
   };
 
@@ -3255,6 +3256,7 @@ public:
     virtual void encode(ceph::buffer::list &bl) const = 0;
     virtual void decode(ceph::buffer::list::const_iterator &bl) = 0;
     virtual void dump(ceph::Formatter *f) const = 0;
+    virtual std::string print() const = 0;
     virtual void iterate_mayberw_back_to(
       epoch_t les,
       std::function<void(epoch_t, const std::set<pg_shard_t> &)> &&f) const = 0;
@@ -3300,6 +3302,9 @@ public:
     ceph_assert(past_intervals);
     past_intervals->dump(f);
   }
+
+  std::string fmt_print() const;
+
   static void generate_test_instances(std::list<PastIntervals *> & o);
 
   /**
@@ -3508,6 +3513,8 @@ public:
     bool affected_by_map(
       const OSDMap &osdmap,
       const DoutPrefixProvider *dpp) const;
+
+    std::string fmt_print() const;
 
     // For verifying tests
     PriorSet(

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5519,11 +5519,11 @@ struct SnapSet {
 
   /// get space accounted to clone
   uint64_t get_clone_bytes(snapid_t clone) const;
-    
+
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapSet*>& o);  
+  static void generate_test_instances(std::list<SnapSet*>& o);
 
   SnapContext get_ssc_as_of(snapid_t as_of) const {
     SnapContext out;
@@ -5564,6 +5564,7 @@ struct watch_info_t {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
+  std::string fmt_print() const;
   static void generate_test_instances(std::list<watch_info_t*>& o);
 };
 WRITE_CLASS_ENCODER_FEATURES(watch_info_t)
@@ -5574,8 +5575,7 @@ static inline bool operator==(const watch_info_t& l, const watch_info_t& r) {
 }
 
 static inline std::ostream& operator<<(std::ostream& out, const watch_info_t& w) {
-  return out << "watch(cookie " << w.cookie << " " << w.timeout_seconds << "s"
-    << " " << w.addr << ")";
+  return out << w.fmt_print();
 }
 
 struct notify_info_t {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -6012,17 +6012,14 @@ WRITE_CLASS_ENCODER_FEATURES(ObjectRecoveryInfo)
 std::ostream& operator<<(std::ostream& out, const ObjectRecoveryInfo &inf);
 
 struct ObjectRecoveryProgress {
-  uint64_t data_recovered_to;
+  uint64_t data_recovered_to{0};
   std::string omap_recovered_to;
-  bool first;
-  bool data_complete;
-  bool omap_complete;
-  bool error = false;
+  bool first{true};
+  bool data_complete{false};
+  bool omap_complete{false};
+  bool error{false};
 
-  ObjectRecoveryProgress()
-    : data_recovered_to(0),
-      first(true),
-      data_complete(false), omap_complete(false) { }
+  ObjectRecoveryProgress() {}
 
   bool is_complete(const ObjectRecoveryInfo& info) const {
     return (data_recovered_to >= (
@@ -6040,6 +6037,7 @@ struct ObjectRecoveryProgress {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   std::ostream &print(std::ostream &out) const;
+  std::string fmt_print() const;
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(ObjectRecoveryProgress)

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -329,7 +329,6 @@ struct fmt::formatter<ScrubMap> {
 };
 
 #if FMT_VERSION >= 90000
-template <> struct fmt::formatter<PastIntervals> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<pg_log_op_return_item_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<watch_info_t> : fmt::ostream_formatter {};
 template <bool TrackChanges> struct fmt::formatter<pg_missing_set<TrackChanges>> : fmt::ostream_formatter {};

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -329,7 +329,6 @@ struct fmt::formatter<ScrubMap> {
 };
 
 #if FMT_VERSION >= 90000
-template <> struct fmt::formatter<ObjectRecoveryInfo> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<ObjectRecoveryProgress> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<PastIntervals> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<pg_log_op_return_item_t> : fmt::ostream_formatter {};

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -329,6 +329,5 @@ struct fmt::formatter<ScrubMap> {
 };
 
 #if FMT_VERSION >= 90000
-template <> struct fmt::formatter<watch_info_t> : fmt::ostream_formatter {};
 template <bool TrackChanges> struct fmt::formatter<pg_missing_set<TrackChanges>> : fmt::ostream_formatter {};
 #endif

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -329,7 +329,6 @@ struct fmt::formatter<ScrubMap> {
 };
 
 #if FMT_VERSION >= 90000
-template <> struct fmt::formatter<pg_log_op_return_item_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<watch_info_t> : fmt::ostream_formatter {};
 template <bool TrackChanges> struct fmt::formatter<pg_missing_set<TrackChanges>> : fmt::ostream_formatter {};
 #endif

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -332,6 +332,5 @@ struct fmt::formatter<ScrubMap> {
 template <> struct fmt::formatter<PastIntervals> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<pg_log_op_return_item_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<watch_info_t> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<pg_log_entry_t> : fmt::ostream_formatter {};
 template <bool TrackChanges> struct fmt::formatter<pg_missing_set<TrackChanges>> : fmt::ostream_formatter {};
 #endif

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -329,7 +329,6 @@ struct fmt::formatter<ScrubMap> {
 };
 
 #if FMT_VERSION >= 90000
-template <> struct fmt::formatter<ObjectRecoveryProgress> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<PastIntervals> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<pg_log_op_return_item_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<watch_info_t> : fmt::ostream_formatter {};


### PR DESCRIPTION
Switching the "easy path" for providing a class with a fmt-based formatter, from the
current "use the ostream out operator" default to:
if the class matches one of two new concepts, by providing either
fmt_print() or alt_fmt_print(..) (with specific signatures),
an fmt-based formatter is auto-created.

The PR includes initial examples of using the new default to provide "native" (not the slower ostream based)
support for multiple OSD structures that currently uses ostream.