### PR TITLE
pacific: ceph-volume: add --osd-id option to raw prepare

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -49,4 +49,10 @@ def create_parser(prog, description):
         action='store_true',
         help='Enable device encryption via dm-crypt',
     )
+    parser.add_argument(
+        '--osd-id',
+        help='Reuse an existing OSD id',
+        default=None,
+        type=arg_validators.valid_osd_id,
+    )
     return parser

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -122,7 +122,9 @@ class Prepare(object):
 
         # reuse a given ID if it exists, otherwise create a new ID
         self.osd_id = prepare_utils.create_id(
-            osd_fsid, json.dumps(secrets))
+            osd_fsid,
+            json.dumps(secrets),
+            osd_id=self.args.osd_id)
 
         prepare_bluestore(
             self.args.data,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62038

---

backport of https://github.com/ceph/ceph/pull/52422
parent tracker: https://tracker.ceph.com/issues/61995

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh