### PR TITLE
quincy: RGW - Get quota on OPs with a bucket

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1350,9 +1350,8 @@ int RGWOp::init_quota()
     return 0;
   }
 
-  /* only interested in object related ops */
-  if (rgw::sal::Bucket::empty(s->bucket.get())
-      || rgw::sal::Object::empty(s->object.get())) {
+  /* Need a bucket to get quota */
+  if (rgw::sal::Bucket::empty(s->bucket.get())) {
     return 0;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54610

---

backport of https://github.com/ceph/ceph/pull/45343
parent tracker: https://tracker.ceph.com/issues/54488

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh