### PR TITLE
quincy: os/bluestore: don't require bluestore_db_block_size when attaching new

### DIFF
--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -878,17 +878,17 @@ int main(int argc, char **argv)
 	return {"", false};
       }
       std::error_code ec;
-      fs::path target_path = fs::weakly_canonical(fs::path{dev_target}, ec);
+      fs::path target = fs::weakly_canonical(fs::path{dev_target}, ec);
       if (ec) {
 	cerr << "failed to retrieve absolute path for " << dev_target
 	     << ": " << ec.message()
 	     << std::endl;
 	exit(EXIT_FAILURE);
       }
-      return {target_path.native(),
-              (fs::exists(target_path) &&
-	       fs::is_regular_file(target_path) &&
-	       fs::file_size(target_path) > 0)};
+      return {target.native(),
+              fs::exists(target) &&
+               (fs::is_block_file(target) ||
+	         (fs::is_regular_file(target) && fs::file_size(target) > 0))};
     }();
     // Attach either DB or WAL volume, create if needed
     // check if we need additional size specification


### PR DESCRIPTION
db/wal

backport of https://github.com/ceph/ceph/pull/52193

backport tracker: https://tracker.ceph.com/issues/62060
parent tracker: https://tracker.ceph.com/issues/55260

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>
(cherry picked from commit 9c3a8980bab0dd98185b0bb751c0dac09a9ab79e)
