### PR TITLE
quincy: Bluestore: fix bluestore collection_list latency perf counter

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11784,7 +11784,7 @@ int BlueStore::_collection_list(
     [&, start_time = mono_clock::now(), func_name = __func__] {
     log_latency_fn(
       func_name,
-      l_bluestore_remove_lat,
+      l_bluestore_clist_lat,
       mono_clock::now() - start_time,
       cct->_conf->bluestore_log_collection_list_age,
       [&](const ceph::timespan& lat) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61724

---

backport of https://github.com/ceph/ceph/pull/51706
parent tracker: https://tracker.ceph.com/issues/61460

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh