### PR TITLE
rgw/lc: remove_bucket_config() doesn't update xattrs on bucket delete

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -451,9 +451,11 @@ int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp,
   }
 
   // remove lifecycle config, if any (XXX note could be made generic)
-  constexpr bool merge_attrs = false; // don't update xattrs, we're deleting
-  (void) store->getRados()->get_lc()->remove_bucket_config(
-    this, get_attrs(), merge_attrs);
+  if (get_attrs().count(RGW_ATTR_LC)) {
+    constexpr bool merge_attrs = false; // don't update xattrs, we're deleting
+    (void) store->getRados()->get_lc()->remove_bucket_config(
+      this, get_attrs(), merge_attrs);
+  }
 
   ret = store->ctl()->bucket->sync_user_stats(dpp, info.owner, info, y, nullptr);
   if (ret < 0) {

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -451,8 +451,9 @@ int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp,
   }
 
   // remove lifecycle config, if any (XXX note could be made generic)
+  constexpr bool merge_attrs = false; // don't update xattrs, we're deleting
   (void) store->getRados()->get_lc()->remove_bucket_config(
-    this, get_attrs());
+    this, get_attrs(), merge_attrs);
 
   ret = store->ctl()->bucket->sync_user_stats(dpp, info.owner, info, y, nullptr);
   if (ret < 0) {


### PR DESCRIPTION
on bucket deletion, we're going to delete the bucket instance metadata anyway so there's no reason for `RGWLC::remove_bucket_config()` to write an update that removes `RGW_ATTR_LC` first

and if the bucket doesn't have an `RGW_ATTR_LC`, we shouldn't need to remove it from the lc list either

this relates to https://tracker.ceph.com/issues/62411, but i don't think it really addresses the underlying issue

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
