### PR TITLE
rgw: ObjectCache::put() discards older object versions

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -132,6 +132,7 @@ void RGWObjVersionTracker::prepare_op_for_read(ObjectReadOperation* op)
   obj_version* check_objv = version_for_check();
 
   if (check_objv) {
+    dout(20) << "RGWObjVersionTracker::prepare_op_for_read check=" << *check_objv << dendl;
     cls_version_check(*op, *check_objv, VER_COND_EQ);
   }
 
@@ -144,6 +145,7 @@ void RGWObjVersionTracker::prepare_op_for_write(ObjectWriteOperation *op)
   obj_version* modify_version = version_for_write();
 
   if (check_objv) {
+    dout(20) << "RGWObjVersionTracker::prepare_op_for_write check=" << *check_objv << dendl;
     cls_version_check(*op, *check_objv, VER_COND_EQ);
   }
 
@@ -162,8 +164,10 @@ void RGWObjVersionTracker::apply_write()
   if (checked && incremented) {
     // apply cls_version_inc() so our next operation can recheck it
     ++read_version.ver;
+    dout(20) << "RGWObjVersionTracker::apply_write incremented " << read_version << dendl;
   } else {
     read_version = write_version;
+    dout(20) << "RGWObjVersionTracker::apply_write set " << read_version << dendl;
   }
   write_version = obj_version();
 }

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -179,6 +179,17 @@ void ObjectCache::put(const DoutPrefixProvider *dpp, const string& name, ObjectC
     cache_info->gen = entry.gen;
   }
 
+  // detect out-of-order notifications on the same cls_version tag
+  if (target.flags & CACHE_FLAG_OBJV &&
+      info.flags & CACHE_FLAG_OBJV &&
+      target.version.tag == info.version.tag &&
+      target.version.ver > info.version.ver) {
+    ldpp_dout(dpp, 10) << "cache put: discarding older version ("
+       << info.version.ver << " < " << target.version.ver
+       << ") of existing entry" << dendl;
+    return;
+  }
+
   // put() must include the latest version if we're going to keep caching it
   target.flags &= ~CACHE_FLAG_OBJV;
 


### PR DESCRIPTION
watch/notify may deliver cache notifications out of order. prevent these updates from overwriting an existing cache entry with a newer version

Fixes: https://tracker.ceph.com/issues/62411

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
