### PR TITLE
cephfs.py error 500 on dashboard 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -376,7 +376,10 @@ class CephFS(RESTController):
                 client['type'] = "kernel"
                 client['version'] = client['client_metadata']['kernel_version']
                 client['hostname'] = client['client_metadata']['hostname']
-                client['root'] = client['client_metadata']['root']
+                if "root" in client['client_metadata']: #for very old clients, root does not seem to be available
+                    client['root'] = client['client_metadata']['root']
+                else:
+                    client['root'] = "unknown" 
             else:  # pragma: no cover - no complexity there
                 client['type'] = "unknown"
                 client['version'] = ""


### PR DESCRIPTION
the dashboard was throwing an error on our installation:

Internal Server Error
Traceback (most recent call last):
  File "/usr/share/ceph/mgr/dashboard/services/exception.py", line 47, in dashboard_exception_handler
    return handler(*args, **kwargs)
  File "/lib/python3.6/site-packages/cherrypy/_cpdispatch.py", line 54, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/share/ceph/mgr/dashboard/controllers/_base_controller.py", line 258, in inner
    ret = func(*args, **kwargs)
  File "/usr/share/ceph/mgr/dashboard/controllers/_rest_controller.py", line 191, in wrapper
    return func(*vpath, **params)
  File "/usr/share/ceph/mgr/dashboard/controllers/cephfs.py", line 529, in tabs
  File "/usr/share/ceph/mgr/dashboard/controllers/cephfs.py", line 314, in _clients
    else:  # pragma: no cover - no complexity there
KeyError: 'root'

We have old kernel 4.1.12 clients and mds session ls does not return "root" inside "client_metadata" for those specific clients. 