### PR TITLE
mgr/rgw: Add usage trim support on interval

### DIFF
--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -149,8 +149,8 @@ list of realms.
 
 Set the ``usage_trim_older_than_days`` config option to the amount of
 days usage logs older than this should be trimmed. Optionally you can
-set the interval that trim will be performed with ``usage_trim_interval``,
-it defaults to every twelve hours.
+set the interval in seconds that trim will be performed with
+``usage_trim_interval``, it defaults to every twelve hours.
 
 The below example will trim logs from start date 1970-01-01 to the current
 date minus 30 days.

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -143,21 +143,22 @@ RGW admin command
 Automatic usage log trimming
 ----------------------------
 
-Enable automatic usage log trimming for one or more RGW realms by
-setting the config option ``usage_trim_realms`` to a comma separated
-list of realms or to an asterisk (``*``) for all realms.
+Enable automatic usage log trimming for one or more RGW realms by setting the
+``usage_trim_older_than_days`` config option to the amount of days usage logs
+older than this should be trimmed.
 
-Set the ``usage_trim_older_than_days`` config option to the amount of
-days usage logs older than this should be trimmed. Optionally you can
-set the interval in minutes that trim will be performed with
-``usage_trim_interval``, it defaults to every twelve hours (720 minutes).
+Optionally you can set the interval in minutes that trim will be performed
+with ``usage_trim_interval``, it defaults to every twelve hours (720 minutes).
+
+You can set the config option ``usage_realms_to_trim`` to a comma separated
+list of realms or to an asterisk (``*``) (the default) for all realms.
 
 The below example will trim logs from start date 1970-01-01 to the current
 date minus 30 days.
 
 ::
 
-    ceph config set mgr mgr/rgw/usage_trim_realms default
+    ceph config set mgr mgr/rgw/usage_realms_to_trim default
     ceph config set mgr mgr/rgw/usage_trim_older_than_days 30
 
 The above is equivalent to running the following command assuming that todays

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -139,3 +139,32 @@ Join an existing realm by creating a new secondary zone (using the realm token)
   ceph rgw admin [*]
 
 RGW admin command
+
+Automatic usage log trimming
+----------------------------
+
+Enable automatic usage log trimming for one or more RGW realms by
+setting the config option ``usage_trim_realms`` to a comma separated
+list of realms.
+
+Set the ``usage_trim_older_than_days`` config option to the amount of
+days usage logs older than this should be trimmed. Optionally you can
+set the interval that trim will be performed with ``usage_trim_interval``,
+it defaults to every twelve hours.
+
+The below example will trim logs from start date 1970-01-01 to the current
+date minus 30 days.
+
+::
+
+    ceph config set mgr mgr/rgw/usage_trim_realms default
+    ceph config set mgr mgr/rgw/usage_trim_older_than_days 30
+
+The above is equivalent to running the following command assuming that todays
+date is 2022-11-13.
+::
+
+    radosgw-admin --rgw-realm=default usage trim --start-date=1970-01-01 --end-date=2022-10-14
+
+End date is thus calculated as (today - usage_trim_older_than_days) which is
+equal to (2022-11-13 - 30 days) = 2022-10-14.

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -145,7 +145,7 @@ Automatic usage log trimming
 
 Enable automatic usage log trimming for one or more RGW realms by
 setting the config option ``usage_trim_realms`` to a comma separated
-list of realms.
+list of realms or to an asterisk (``*``) for all realms.
 
 Set the ``usage_trim_older_than_days`` config option to the amount of
 days usage logs older than this should be trimmed. Optionally you can

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -150,22 +150,31 @@ older than this should be trimmed.
 Optionally you can set the interval in minutes that trim will be performed
 with ``usage_trim_interval``, it defaults to every twelve hours (720 minutes).
 
-You can set the config option ``usage_realms_to_trim`` to a comma separated
-list of realms or to an asterisk (``*``) (the default) for all realms.
+Optionally you can set the config option ``usage_realms_to_trim`` to a comma
+separated list of realms or to an asterisk (``*``, the default for this config
+option) for all realms.
 
 The below example will trim logs from start date 1970-01-01 to the current
-date minus 30 days.
+date minus 30 days for all realms.
 
 ::
 
-    ceph config set mgr mgr/rgw/usage_realms_to_trim default
     ceph config set mgr mgr/rgw/usage_trim_older_than_days 30
 
-The above is equivalent to running the following command assuming that todays
-date is 2022-11-13.
+The above is equivalent to running the following commands assuming that todays
+date is 2022-11-13 and that there are two realms.
+
 ::
 
-    radosgw-admin --rgw-realm=default usage trim --start-date=1970-01-01 --end-date=2022-10-14
+    radosgw-admin --rgw-realm=realm1 usage trim --start-date=1970-01-01 --end-date=2022-10-14
+    radosgw-admin --rgw-realm=realm2 usage trim --start-date=1970-01-01 --end-date=2022-10-14
 
 End date is thus calculated as (today - usage_trim_older_than_days) which is
 equal to (2022-11-13 - 30 days) = 2022-10-14.
+
+If you want to only trim the usage log for a realm named ``realm1`` you can
+set ``usage_realms_to_trim`` like below.
+
+::
+
+    ceph config set mgr mgr/rgw/usage_realms_to_trim realm1

--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -149,8 +149,8 @@ list of realms or to an asterisk (``*``) for all realms.
 
 Set the ``usage_trim_older_than_days`` config option to the amount of
 days usage logs older than this should be trimmed. Optionally you can
-set the interval in seconds that trim will be performed with
-``usage_trim_interval``, it defaults to every twelve hours.
+set the interval in minutes that trim will be performed with
+``usage_trim_interval``, it defaults to every twelve hours (720 minutes).
 
 The below example will trim logs from start date 1970-01-01 to the current
 date minus 30 days.

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -154,6 +154,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                     self.get_ceph_option(opt))
             self.log.debug(' native option %s = %s', opt, getattr(self, opt))  # type: ignore
 
+        self.event.set()
+
     @CLICommand('rgw admin', perm='rw')
     def _cmd_rgw_admin(self, params: Sequence[str]) -> HandleCommandResult:
         """rgw admin"""

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -382,8 +382,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')
             realms = cast(str, self.usage_trim_realms, default='').split(',')
             for realm in realms:
-                self.log.info('Running usage trim for realm {} with startDate={} and endDate={}'.format(
-                              realm, startDate, endDate))
+                self.log.info(f'Running usage trim for realm {realm} with startDate={startDate} and endDate={endDate}')
                 try:
                     RGWAM(self.env).usage_op().trim(realm=realm, startDate=startDate, endDate=endDate)
                 except Exception:

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -110,8 +110,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                default=0,
                desc='Trim usage log entries older than this amount of days, must be set to a positive value'),
         Option(name='usage_trim_interval',
-               default=43200,
-               desc='Interval in seconds between trimming usage log entries, defaults to 12 hours'),
+               default=720,
+               desc='Interval in minutes between trimming usage log entries, defaults to 12 hours'),
     ]
 
     # These are "native" Ceph options that this module cares about.
@@ -399,7 +399,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                     self.log.exception("Failed to trim usage log:")
 
             usage_trim_interval = cast(int, self.get_module_option('usage_trim_interval'))
-            self.event.wait(usage_trim_interval)
+            usage_trim_interval_secs = (usage_trim_interval * 60)
+            self.event.wait(usage_trim_interval_secs)
 
     def shutdown(self) -> None:
         """

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -103,8 +103,8 @@ def check_orchestrator(func: FuncT) -> FuncT:
 
 class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     MODULE_OPTIONS: List[Option] = [
-        Option(name='usage_trim_realms',
-               default='',
+        Option(name='usage_realms_to_trim',
+               default='*',
                desc='Comma separated list of realms or asterisk for all realms'),
         Option(name='usage_trim_older_than_days',
                default=0,
@@ -387,11 +387,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             startDate = '1970-01-01'
             endDate = (datetime.today() - timedelta(days=usage_trim_older_than_days)).strftime('%Y-%m-%d')
 
-            usage_trim_realms = cast(str, self.get_module_option('usage_trim_realms'))
-            if usage_trim_realms == '*':
+            usage_realms_to_trim = cast(str, self.get_module_option('usage_realms_to_trim'))
+            if usage_realms_to_trim == '*':
                 realms = am.realm_op().list()
             else:
-                realms = usage_trim_realms.split(',')
+                realms = usage_realms_to_trim.split(',')
 
             for realm in realms:
                 self.log.info(f'Running usage trim for realm {realm} with startDate={startDate} and endDate={endDate}')

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -111,7 +111,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                desc='Trim usage log entries older than this amount of days, must be set to a positive value'),
         Option(name='usage_trim_interval',
                default=43200,
-               desc='Interval between trimming usage log entries, defaults to 12 hours'),
+               desc='Interval in seconds between trimming usage log entries, defaults to 12 hours'),
     ]
 
     # These are "native" Ceph options that this module cares about.

--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -375,8 +375,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self.log.info('Starting usage trim loop')
         while self.run:
             if self.usage_trim_older_than_days <= 0:
-                self.log.info('Skipping usage trim because usage_trim_older_than_days is not > 0')
-                self.event.sleep(self.usage_trim_interval)
+                self.log.debug('Skipping usage trim because usage_trim_older_than_days is not > 0')
+                self.event.sleep(60)
                 continue
             startDate = '1970-01-01'
             endDate = (datetime.today() - timedelta(days=self.usage_trim_older_than_days)).strftime('%Y-%m-%d')

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -424,15 +424,16 @@ class UsageOp:
     def __init__(self, env):
         self.env = env
 
-    def trim(self, realm: EntityKey = None, startDate: str = '', endDate: str = ''):
+    def trim(self, realm: EntityKey = None, startDate: Optional[str] = None,
+             endDate: Optional[str] = None):
         ze = ZoneEnv(self.env, realm=realm)
 
         params = ['trim']
 
-        if startDate != '':
+        if startDate is not None:
             params += ['--start-date=%s' % startDate]
 
-        if endDate != '':
+        if endDate is not None:
             params += ['--end-date=%s' % endDate]
 
         return RGWAdminCmd(ze).run(params)

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -420,6 +420,24 @@ class UserOp:
         return RGWAdminCmd(ze).run(params)
 
 
+class UsageOp:
+    def __init__(self, env):
+        self.env = env
+
+    def trim(self, realm: EntityKey = None, startDate: str = '', endDate: str = ''):
+        ze = ZoneEnv(self.env, realm=realm)
+
+        params = ['trim']
+
+        if startDate != '':
+            params += ['--start-date=%s' % startDate]
+
+        if endDate != '':
+            params += ['--end-date=%s' % endDate]
+
+        return RGWAdminCmd(ze).run(params)
+
+
 class RGWAM:
     def __init__(self, env):
         self.env = env
@@ -438,6 +456,9 @@ class RGWAM:
 
     def user_op(self):
         return UserOp(self.env)
+
+    def usage_op(self):
+        return UsageOp(self.env)
 
     def get_realm(self, realm_name):
         try:

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -429,7 +429,7 @@ class UsageOp:
              endDate: Optional[str] = None):
         ze = ZoneEnv(self.env, realm=realm)
 
-        params = ['trim']
+        params = ['usage', 'trim']
 
         if startDate is not None:
             params += ['--start-date=%s' % startDate]

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -12,6 +12,7 @@ import socket
 import base64
 import logging
 import errno
+from typing import Optional
 
 from .types import RGWAMException, RGWAMCmdRunException, RGWPeriod, RGWUser, RealmToken
 from .diff import RealmsEPs


### PR DESCRIPTION
This adds support in the rgw ceph-mgr module to trim the usage log on a regular interval so that one does not need to run radosgw-admin inside a cronjob or manually.

This is a continuation from the previous stale PR https://github.com/ceph/ceph/pull/48815 that got closed