### PR TITLE
reef: cmake: ensure fmtlib is at least 8.1.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,7 +321,7 @@ if(NOT TARGET RapidJSON::RapidJSON)
 endif()
 
 option(WITH_FMT_HEADER_ONLY "use header-only version of fmt library" OFF)
-set(WITH_FMT_VERSION "7.0.0" CACHE
+set(WITH_FMT_VERSION "8.1.1" CACHE
   STRING "build with fmt version")
 find_package(fmt ${WITH_FMT_VERSION} QUIET)
 if(fmt_FOUND)


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/48705 to reef.