### PR TITLE
osd: Remove leaked clone objects (SnapMapper malformed key)

### DIFF
--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -236,7 +236,9 @@ public:
     ObjectStore *store,
     ObjectStore::CollectionHandle& ch,
     ghobject_t hoid,
-    unsigned max_txn_size);
+    unsigned max_txn_size,
+    bool& stop,
+    std::string& last_key);
 
   static bool _convert_malformed(
     CephContext *cct,

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -157,6 +157,7 @@ public:
   static const std::string LEGACY_MAPPING_PREFIX;
   static const std::string MAPPING_PREFIX;
   static const std::string OBJECT_PREFIX;
+  static const std::string MAPPING_CLEANUP_KEY;
   static const char *PURGED_SNAP_EPOCH_PREFIX;
   static const char *PURGED_SNAP_PREFIX;
 
@@ -236,6 +237,20 @@ public:
     ObjectStore::CollectionHandle& ch,
     ghobject_t hoid,
     unsigned max_txn_size);
+
+/**
+  * remove_possible_keys
+  *
+  * SnapMapper::convert_malformed() inserts all the possible keys.
+  * Remove the extra keys inserted once `force_reremove_snap` was used.
+  *
+  * TODO: bound to transaction size
+  */
+  static int remove_possible_keys(
+    CephContext *cct,
+    ObjectStore *store,
+    ObjectStore::CollectionHandle& ch,
+    ghobject_t hoid);
 #endif
 
   static void record_purged_snaps(

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -238,6 +238,15 @@ public:
     ghobject_t hoid,
     unsigned max_txn_size);
 
+  static bool _convert_malformed(
+    CephContext *cct,
+    ObjectStore *store,
+    ObjectStore::CollectionHandle& ch,
+    ghobject_t hoid,
+    ObjectMap::ObjectMapIterator& iter,
+    std::set<std::string>& old_keys,
+    std::map<std::string, ceph::buffer::list>& to_set);
+
 /**
   * remove_possible_keys
   *

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -207,6 +207,35 @@ public:
     ObjectStore::CollectionHandle& ch,
     ghobject_t hoid,
     unsigned max);
+
+/**
+  * convert_malformed_key
+  *
+  * Gets a malformed key kv entry and returns all possible fixed entries.
+  *
+  * TODO: use the OSD to get information to map the hobject_t to a PG
+  *       instead of adding all possible EC shard prefixes.
+  */
+  static std::set<std::string> convert_malformed_key(
+    const std::string& old_key,
+    const bufferlist& value);
+
+/**
+  * convert_malformed
+  *
+  * Scans the SnapMapper for malformed keys created by a bug
+  * during upgrade from N (and earlier) to O (up to 16.2.11).
+  * Each detected key is replaced with a valid key instead.
+  * See: https://tracker.ceph.com/issues/62596
+  *
+  * TODO: avoid overwriting the fixed key if it already exists
+  */
+  static int convert_malformed(
+    CephContext *cct,
+    ObjectStore *store,
+    ObjectStore::CollectionHandle& ch,
+    ghobject_t hoid,
+    unsigned max_txn_size);
 #endif
 
   static void record_purged_snaps(
@@ -234,10 +263,14 @@ private:
   std::string to_legacy_raw_key(
     const std::pair<snapid_t, hobject_t> &to_map);
   static bool is_legacy_mapping(const std::string &to_test);
+  static bool is_malformed_mapping(const std::string &to_test);
 
   static std::string get_prefix(int64_t pool, snapid_t snap);
   std::string to_raw_key(
     const std::pair<snapid_t, hobject_t> &to_map) const;
+
+  static std::set<std::string> to_raw_key_no_shard_prefix(
+    const std::pair<snapid_t, hobject_t> &to_map);
 
   std::string to_raw_key(snapid_t snap, const hobject_t& clone) const;
 


### PR DESCRIPTION
This PR aims to to solve a clone objects leak to clusters affected by: https://tracker.ceph.com/issues/56147

* Step 1: (for each affected osd)
Using a new asock command (`fix_malformed_snapmapper_keys`) that converts the malformed SnapMapper keys to the correct structure. 
To cover clone objects that belong to an EC pool, all possible shard prefixes are inserted. (Total of 128 keys).

* Step 2: (mon command) 
**Separated into #53235**
Since the correct key exists, `ceph osd pool force_reremove_snap <pool> <lower bound> <upper bound>` mon command can be used to remove any non-existing (already removed) snapshots. 

* Step 3: (for each affected osd)
Clean up the extra inserted keys in step 1 after re-deleting the snapshots by using (`cleanup_snapmapper_possible_keys`)

---

The leaked clone objects associated to the re-deleted snapshot will be removed once the key is fixed.

```
2023-08-08T17:43:24.928+0000 7fcb7e0f4700 10 snap_mapper.convert_malformed
2023-08-08T17:43:24.928+0000 7fcb7e0f4700 20 snap_mapper.convert_malformed old key: SNA_2_0000000000000001_
2023-08-08T17:43:24.928+0000 7fcb7e0f4700 20 snap_mapper.convert_malformed converted key: SNA_2_0000000000000001_0000000000000002.ECF34CE6.1.objectone..                                                                           
2023-08-08T17:43:24.929+0000 7fcb7e0f4700 10 snap_mapper.convert_malformed converted 1 keys
2023-08-08T17:43:24.929+0000 7fcb7e0f4700  1 snap_mapper.convert_malformed converted 1 keys in 0.000145347s
```

TO DO:
- [x] self-managed snaps
- [x] EC pool support
- [x] Remove additional keys inserted after snapshot is removed
- [x] Release osd_lock on SnapMapper traverse
- [ ] tests


Fixes: https://tracker.ceph.com/issues/62596

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
