### PR TITLE
quincy: mds: adjust cap acquisition throttles

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -338,7 +338,7 @@ options:
   long_desc: The half-life for the session cap acquisition counter of caps acquired
     by readdir. This is used for throttling readdir requests from clients slow to
     release caps.
-  default: 10
+  default: 30
   services:
   - mds
   flags:
@@ -347,7 +347,7 @@ options:
   type: uint
   level: advanced
   desc: throttle point for cap acquisition decay counter
-  default: 500000
+  default: 100000
   services:
   - mds
 - name: mds_session_max_caps_throttle_ratio


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62420

---

backport of https://github.com/ceph/ceph/pull/52577
parent tracker: https://tracker.ceph.com/issues/62114

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh