### PR TITLE
reef: mds: dump locks when printing mutation ops

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -13,6 +13,12 @@ from teuthology.exceptions import CommandFailedError
 
 log = logging.getLogger(__name__)
 
+def classhook(m):
+    def dec(cls):
+        getattr(cls, m)()
+        return cls
+    return dec
+
 def for_teuthology(f):
     """
     Decorator that adds an "is_for_teuthology" attribute to the wrapped function

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -8,7 +8,7 @@ from os.path import join as os_path_join
 
 from teuthology.exceptions import CommandFailedError
 
-from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from tasks.cephfs.cephfs_test_case import CephFSTestCase, classhook
 from tasks.cephfs.filesystem import FileLayout, FSMissing
 from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.caps_helper import CapTester
@@ -37,6 +37,34 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
+@classhook('_add_valid_tell')
+class TestValidTell(TestAdminCommands):
+    @classmethod
+    def _add_valid_tell(cls):
+        tells = [
+          ['cache', 'status'],
+          ['damage', 'ls'],
+          ['dump_blocked_ops'],
+          ['dump_blocked_ops_count'],
+          ['dump_historic_ops'],
+          ['dump_historic_ops_by_duration'],
+          ['dump_mempools'],
+          ['dump_ops_in_flight'],
+          ['flush', 'journal'],
+          ['get', 'subtrees'],
+          ['ops', 'locks'],
+          ['ops'],
+          ['status'],
+          ['version'],
+        ]
+        def test(c):
+            def f(self):
+                J = self.fs.rank_tell(c)
+                json.dumps(J)
+                log.debug("dumped:\n%s", str(J))
+            return f
+        for c in tells:
+            setattr(cls, 'test_valid_' + '_'.join(c), test(c))
 
 class TestFsStatus(TestAdminCommands):
     """

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -311,6 +311,11 @@ void JSONFormatter::add_value(std::string_view name, std::string_view val, bool 
   }
 }
 
+void JSONFormatter::dump_null(std::string_view name)
+{
+  add_value(name, "null");
+}
+
 void JSONFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   add_value(name, u);
@@ -469,6 +474,14 @@ void XMLFormatter::add_value(std::string_view name, T val)
   print_spaces();
   m_ss.precision(std::numeric_limits<T>::max_digits10);
   m_ss << "<" << e << ">" << val << "</" << e << ">";
+  if (m_pretty)
+    m_ss << "\n";
+}
+
+void XMLFormatter::dump_null(std::string_view name)
+{
+  print_spaces();
+  m_ss << "<" << get_xml_name(name) << " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\" />";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -843,6 +856,11 @@ void TableFormatter::add_value(std::string_view name, T val) {
   m_vec[i].push_back(std::make_pair(get_section_name(name), m_ss.str()));
   m_ss.clear();
   m_ss.str("");
+}
+
+void TableFormatter::dump_null(std::string_view name)
+{
+  add_value(name, "null");
 }
 
 void TableFormatter::dump_unsigned(std::string_view name, uint64_t u)

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -441,14 +441,20 @@ void XMLFormatter::open_array_section_in_ns(std::string_view name, const char *n
   open_section_in_ns(name, ns, NULL);
 }
 
+std::string XMLFormatter::get_xml_name(std::string_view name) const
+{
+  std::string e(name);
+  std::transform(e.begin(), e.end(), e.begin(),
+      [this](char c) { return this->to_lower_underscore(c); });
+  return e;
+}
+
 void XMLFormatter::close_section()
 {
   ceph_assert(!m_sections.empty());
   finish_pending_string();
 
-  std::string section = m_sections.back();
-  std::transform(section.begin(), section.end(), section.begin(),
-	 [this](char c) { return this->to_lower_underscore(c); });
+  auto section = get_xml_name(m_sections.back());
   m_sections.pop_back();
   print_spaces();
   m_ss << "</" << section << ">";
@@ -459,10 +465,7 @@ void XMLFormatter::close_section()
 template <class T>
 void XMLFormatter::add_value(std::string_view name, T val)
 {
-  std::string e(name);
-  std::transform(e.begin(), e.end(), e.begin(),
-      [this](char c) { return this->to_lower_underscore(c); });
-
+  auto e = get_xml_name(name);
   print_spaces();
   m_ss.precision(std::numeric_limits<T>::max_digits10);
   m_ss << "<" << e << ">" << val << "</" << e << ">";
@@ -487,10 +490,7 @@ void XMLFormatter::dump_float(std::string_view name, double d)
 
 void XMLFormatter::dump_string(std::string_view name, std::string_view s)
 {
-  std::string e(name);
-  std::transform(e.begin(), e.end(), e.begin(),
-      [this](char c) { return this->to_lower_underscore(c); });
-
+  auto e = get_xml_name(name);
   print_spaces();
   m_ss << "<" << e << ">" << xml_stream_escaper(s) << "</" << e << ">";
   if (m_pretty)
@@ -499,10 +499,7 @@ void XMLFormatter::dump_string(std::string_view name, std::string_view s)
 
 void XMLFormatter::dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs)
 {
-  std::string e(name);
-  std::transform(e.begin(), e.end(), e.begin(),
-      [this](char c) { return this->to_lower_underscore(c); });
-
+  auto e = get_xml_name(name);
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
@@ -523,9 +520,7 @@ void XMLFormatter::dump_format_va(std::string_view name, const char *ns, bool qu
 {
   char buf[LARGE_SIZE];
   size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
-  std::string e(name);
-  std::transform(e.begin(), e.end(), e.begin(),
-      [this](char c) { return this->to_lower_underscore(c); });
+  auto e = get_xml_name(name);
 
   print_spaces();
   if (ns) {
@@ -577,9 +572,7 @@ void XMLFormatter::open_section_in_ns(std::string_view name, const char *ns, con
     get_attrs_str(attrs, attrs_str);
   }
 
-  std::string e(name);
-  std::transform(e.begin(), e.end(), e.begin(),
-      [this](char c) { return this->to_lower_underscore(c); });
+  auto e = get_xml_name(name);
 
   if (ns) {
     m_ss << "<" << e << attrs_str << " xmlns=\"" << ns << "\">";

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -249,6 +249,7 @@ namespace ceph {
     void print_spaces();
     void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
     char to_lower_underscore(char c) const;
+    std::string get_xml_name(std::string_view name) const;
 
     std::stringstream m_ss, m_pending_string;
     std::deque<std::string> m_sections;

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -87,6 +87,7 @@ namespace ceph {
     virtual void open_object_section(std::string_view name) = 0;
     virtual void open_object_section_in_ns(std::string_view name, const char *ns) = 0;
     virtual void close_section() = 0;
+    virtual void dump_null(std::string_view name) = 0;
     virtual void dump_unsigned(std::string_view name, uint64_t u) = 0;
     virtual void dump_int(std::string_view name, int64_t s) = 0;
     virtual void dump_float(std::string_view name, double d) = 0;
@@ -156,6 +157,7 @@ namespace ceph {
     void open_object_section(std::string_view name) override;
     void open_object_section_in_ns(std::string_view name, const char *ns) override;
     void close_section() override;
+    void dump_null(std::string_view name) override;
     void dump_unsigned(std::string_view name, uint64_t u) override;
     void dump_int(std::string_view name, int64_t s) override;
     void dump_float(std::string_view name, double d) override;
@@ -228,6 +230,7 @@ namespace ceph {
     void open_object_section(std::string_view name) override;
     void open_object_section_in_ns(std::string_view name, const char *ns) override;
     void close_section() override;
+    void dump_null(std::string_view name) override;
     void dump_unsigned(std::string_view name, uint64_t u) override;
     void dump_int(std::string_view name, int64_t s) override;
     void dump_float(std::string_view name, double d) override;
@@ -284,6 +287,7 @@ namespace ceph {
     void open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs) override;
 
     void close_section() override;
+    void dump_null(std::string_view name) override;
     void dump_unsigned(std::string_view name, uint64_t u) override;
     void dump_int(std::string_view name, int64_t s) override;
     void dump_float(std::string_view name, double d) override;

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -134,7 +134,7 @@ void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters, bool by
 	if (!i->second->filter_out(filters))
 	  continue;
 	f->open_object_section("op");
-	i->second->dump(now, f);
+	i->second->dump(now, f, OpTracker::default_dumper);
 	f->close_section();
       }
     };
@@ -214,7 +214,7 @@ void OpHistory::dump_slow_ops(utime_t now, Formatter *f, set<string> filters)
       if (!i->second->filter_out(filters))
         continue;
       f->open_object_section("Op");
-      i->second->dump(now, f);
+      i->second->dump(now, f, OpTracker::default_dumper);
       f->close_section();
     }
     f->close_section();
@@ -233,7 +233,7 @@ bool OpTracker::dump_historic_slow_ops(Formatter *f, set<string> filters)
   return true;
 }
 
-bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<string> filters, bool count_only)
+bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<string> filters, bool count_only, dumper lambda)
 {
   if (!tracking_enabled)
     return false;
@@ -259,7 +259,7 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<st
       
       if (!count_only) {
         f->open_object_section("op");
-        op.dump(now, f);
+        op.dump(now, f, lambda);
         f->close_section(); // this TrackedOp
       }
 
@@ -496,7 +496,7 @@ void TrackedOp::mark_event(std::string_view event, utime_t stamp)
   _event_marked();
 }
 
-void TrackedOp::dump(utime_t now, Formatter *f) const
+void TrackedOp::dump(utime_t now, Formatter *f, OpTracker::dumper lambda) const
 {
   // Ignore if still in the constructor
   if (!state)
@@ -507,7 +507,7 @@ void TrackedOp::dump(utime_t now, Formatter *f) const
   f->dump_float("duration", get_duration());
   {
     f->open_object_section("type_data");
-    _dump(f);
+    lambda(*this, f);
     f->close_section();
   }
 }

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -392,9 +392,9 @@ public:
     warn_interval_multiplier = 0;
   }
 
-  virtual std::string_view state_string() const {
+  std::string state_string() const {
     std::lock_guard l(lock);
-    return events.empty() ? std::string_view() : std::string_view(events.rbegin()->str);
+    return _get_state_string();
   }
 
   void dump(utime_t now, ceph::Formatter *f) const;
@@ -413,6 +413,11 @@ public:
   }
   friend void intrusive_ptr_release(TrackedOp *o) {
     o->put();
+  }
+
+protected:
+  virtual std::string _get_state_string() const {
+    return events.empty() ? std::string() : std::string(events.rbegin()->str);
   }
 };
 

--- a/src/mds/BatchOp.h
+++ b/src/mds/BatchOp.h
@@ -27,7 +27,7 @@ public:
   virtual void add_request(const ceph::ref_t<class MDRequestImpl>& mdr) = 0;
   virtual ceph::ref_t<class MDRequestImpl> find_new_head() = 0;
 
-  virtual void print(std::ostream&) = 0;
+  virtual void print(std::ostream&) const = 0;
 
   void forward(mds_rank_t target);
   void respond(int r);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-ostream& CDentry::print_db_line_prefix(ostream& out)
+ostream& CDentry::print_db_line_prefix(ostream& out) const
 {
   return out << ceph_clock_now() << " mds." << dir->mdcache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
 }
@@ -137,7 +137,7 @@ bool operator<(const CDentry& l, const CDentry& r)
 }
 
 
-void CDentry::print(ostream& out)
+void CDentry::print(ostream& out) const
 {
   out << *this;
 }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -358,8 +358,8 @@ public:
   void remove_client_lease(ClientLease *r, Locker *locker);  // returns remaining mask (if any), and kicks locker eval_gathers
   void remove_client_leases(Locker *locker);
 
-  std::ostream& print_db_line_prefix(std::ostream& out) override;
-  void print(std::ostream& out) override;
+  std::ostream& print_db_line_prefix(std::ostream& out) const override;
+  void print(std::ostream& out) const override;
   void dump(ceph::Formatter *f) const;
 
   static void encode_remote(inodeno_t& ino, unsigned char d_type,

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -180,7 +180,7 @@ ostream& operator<<(ostream& out, const CDir& dir)
 }
 
 
-void CDir::print(ostream& out) 
+void CDir::print(ostream& out) const
 {
   out << *this;
 }
@@ -188,7 +188,7 @@ void CDir::print(ostream& out)
 
 
 
-ostream& CDir::print_db_line_prefix(ostream& out) 
+ostream& CDir::print_db_line_prefix(ostream& out) const
 {
   return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") ";
 }

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -611,8 +611,8 @@ public:
   }
   void enable_frozen_inode();
 
-  std::ostream& print_db_line_prefix(std::ostream& out) override;
-  void print(std::ostream& out) override;
+  std::ostream& print_db_line_prefix(std::ostream& out) const override;
+  void print(std::ostream& out) const override;
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;
   void dump_load(ceph::Formatter *f);
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -131,7 +131,7 @@ std::string_view CInode::pin_name(int p) const
 }
 
 //int cinode_pins[CINODE_NUM_PINS];  // counts
-ostream& CInode::print_db_line_prefix(ostream& out)
+ostream& CInode::print_db_line_prefix(ostream& out) const
 {
   return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << ino() << ") ";
 }
@@ -338,7 +338,7 @@ CInode::CInode(MDCache *c, bool auth, snapid_t f, snapid_t l) :
     state_set(STATE_AUTH);
 }
 
-void CInode::print(ostream& out)
+void CInode::print(ostream& out) const
 {
   out << *this;
 }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -423,7 +423,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   std::string_view pin_name(int p) const override;
 
-  std::ostream& print_db_line_prefix(std::ostream& out) override;
+  std::ostream& print_db_line_prefix(std::ostream& out) const override;
 
   const scrub_info_t *scrub_info() const {
     if (!scrub_infop)
@@ -1032,7 +1032,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
            state_test(STATE_RANDEPHEMERALPIN);
   }
 
-  void print(std::ostream& out) override;
+  void print(std::ostream& out) const override;
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;
 
   /**

--- a/src/mds/FSMapUser.cc
+++ b/src/mds/FSMapUser.cc
@@ -62,7 +62,7 @@ void FSMapUser::print(std::ostream& out) const
     out << " id " <<  p.second.cid << " name " << p.second.name << std::endl;
 }
 
-void FSMapUser::print_summary(ceph::Formatter *f, std::ostream *out)
+void FSMapUser::print_summary(ceph::Formatter *f, std::ostream *out) const
 {
   std::map<mds_role_t,std::string> by_rank;
   std::map<std::string,int> by_state;

--- a/src/mds/FSMapUser.h
+++ b/src/mds/FSMapUser.h
@@ -46,7 +46,7 @@ public:
   void decode(ceph::buffer::list::const_iterator& bl);
 
   void print(std::ostream& out) const;
-  void print_summary(ceph::Formatter *f, std::ostream *out);
+  void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
   static void generate_test_instances(std::list<FSMapUser*>& ls);
 
@@ -57,7 +57,7 @@ public:
 WRITE_CLASS_ENCODER_FEATURES(FSMapUser::fs_info_t)
 WRITE_CLASS_ENCODER_FEATURES(FSMapUser)
 
-inline std::ostream& operator<<(std::ostream& out, FSMapUser& m) {
+inline std::ostream& operator<<(std::ostream& out, const FSMapUser& m) {
   m.print_summary(NULL, &out);
   return out;
 }

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -98,8 +98,8 @@ class MDSCacheObject {
   std::string_view generic_pin_name(int p) const;
 
   // printing
-  virtual void print(std::ostream& out) = 0;
-  virtual std::ostream& print_db_line_prefix(std::ostream& out) { 
+  virtual void print(std::ostream& out) const = 0;
+  virtual std::ostream& print_db_line_prefix(std::ostream& out) const {
     return out << "mdscacheobject(" << this << ") "; 
   }
 
@@ -326,11 +326,7 @@ class MDSCacheObject {
   static uint64_t last_wait_seq;
 };
 
-std::ostream& operator<<(std::ostream& out, const mdsco_db_line_prefix& o);
-// printer
-std::ostream& operator<<(std::ostream& out, const MDSCacheObject &o);
-
-inline std::ostream& operator<<(std::ostream& out, MDSCacheObject &o) {
+inline std::ostream& operator<<(std::ostream& out, const MDSCacheObject& o) {
   o.print(out);
   return out;
 }

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -258,7 +258,9 @@ void MDSDaemon::set_up_admin_socket()
   r = admin_socket->register_command("dump_ops_in_flight", asok_hook,
 				     "show the ops currently in flight");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("ops", asok_hook,
+  r = admin_socket->register_command("ops "
+				     "name=flags,type=CephChoices,strings=locks,n=N,req=false ",
+                                     asok_hook,
 				     "show the ops currently in flight");
   ceph_assert(r == 0);
   r = admin_socket->register_command("dump_blocked_ops",

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -38,6 +38,7 @@
 #include "mon/MonClient.h"
 #include "common/HeartbeatMap.h"
 #include "ScrubStack.h"
+#include "Mutation.h"
 
 
 #include "MDSRank.h"
@@ -2604,9 +2605,29 @@ void MDSRankDispatcher::handle_asok_command(
   int r = 0;
   CachedStackStringStream css;
   bufferlist outbl;
-  if (command == "dump_ops_in_flight" ||
-      command == "ops") {
+  dout(10) << __func__ << ": " << command << dendl;
+  if (command == "dump_ops_in_flight") {
     if (!op_tracker.dump_ops_in_flight(f)) {
+      *css << "op_tracker disabled; set mds_enable_op_tracker=true to enable";
+    }
+  } else if (command == "ops") {
+    vector<string> flags;
+    cmd_getval(cmdmap, "flags", flags);
+    std::unique_lock l(mds_lock, std::defer_lock);
+    auto lambda = OpTracker::default_dumper;
+    if (flags.size()) {
+      /* use std::function if we actually want to capture flags someday */
+      lambda = [](const TrackedOp& op, Formatter* f) {
+        auto* req = dynamic_cast<const MDRequestImpl*>(&op);
+        if (req) {
+          req->dump_with_mds_lock(f);
+        } else {
+          op.dump_type(f);
+        }
+      };
+      l.lock();
+    }
+    if (!op_tracker.dump_ops_in_flight(f, false, {""}, false, lambda)) {
       *css << "op_tracker disabled; set mds_enable_op_tracker=true to enable";
     }
   } else if (command == "dump_blocked_ops") {

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -481,10 +481,6 @@ void MDRequestImpl::_dump(Formatter *f) const
   f->dump_object("reqid", reqid);
   if (client_request) {
     f->dump_string("op_type", "client_request");
-    f->open_object_section("client_info");
-    f->dump_stream("client") << client_request->get_orig_source();
-    f->dump_int("tid", client_request->get_tid());
-    f->close_section(); // client_info
   } else if (is_peer()) { // replies go to an existing mdr
     f->dump_string("op_type", "peer_request");
     f->open_object_section("leader_info");

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -481,7 +481,7 @@ void MDRequestImpl::dump(Formatter *f) const
 
 void MDRequestImpl::_dump(Formatter *f) const
 {
-  f->dump_string("flag_point", state_string());
+  f->dump_string("flag_point", _get_state_string());
   f->dump_stream("reqid") << reqid;
   {
     msg_lock.lock();

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -446,22 +446,17 @@ int MDRequestImpl::compare_paths()
 
 cref_t<MClientRequest> MDRequestImpl::release_client_request()
 {
-  msg_lock.lock();
+  std::lock_guard l(lock);
   cref_t<MClientRequest> req;
   req.swap(client_request);
   client_request = req;
-  msg_lock.unlock();
   return req;
 }
 
 void MDRequestImpl::reset_peer_request(const cref_t<MMDSPeerRequest>& req)
 {
-  msg_lock.lock();
-  cref_t<MMDSPeerRequest> old;
-  old.swap(peer_request);
+  std::lock_guard l(lock);
   peer_request = req;
-  msg_lock.unlock();
-  old.reset();
 }
 
 void MDRequestImpl::print(ostream &out) const
@@ -484,49 +479,42 @@ void MDRequestImpl::_dump(Formatter *f) const
   std::lock_guard l(lock);
   f->dump_string("flag_point", _get_state_string());
   f->dump_stream("reqid") << reqid;
-  {
-    msg_lock.lock();
-    auto _client_request = client_request;
-    auto _peer_request =peer_request;
-    msg_lock.unlock();
+  if (client_request) {
+    f->dump_string("op_type", "client_request");
+    f->open_object_section("client_info");
+    f->dump_stream("client") << client_request->get_orig_source();
+    f->dump_int("tid", client_request->get_tid());
+    f->close_section(); // client_info
+  } else if (is_peer()) { // replies go to an existing mdr
+    f->dump_string("op_type", "peer_request");
+    f->open_object_section("leader_info");
+    f->dump_stream("leader") << peer_to_mds;
+    f->close_section(); // leader_info
 
-    if (_client_request) {
-      f->dump_string("op_type", "client_request");
-      f->open_object_section("client_info");
-      f->dump_stream("client") << _client_request->get_orig_source();
-      f->dump_int("tid", _client_request->get_tid());
-      f->close_section(); // client_info
-    } else if (is_peer()) { // replies go to an existing mdr
-      f->dump_string("op_type", "peer_request");
-      f->open_object_section("leader_info");
-      f->dump_stream("leader") << peer_to_mds;
-      f->close_section(); // leader_info
-
-      if (_peer_request) {
-        f->open_object_section("request_info");
-        f->dump_int("attempt", _peer_request->get_attempt());
-        f->dump_string("op_type",
-           MMDSPeerRequest::get_opname(_peer_request->get_op()));
-        f->dump_int("lock_type", _peer_request->get_lock_type());
-        f->dump_stream("object_info") << _peer_request->get_object_info();
-        f->dump_stream("srcdnpath") << _peer_request->srcdnpath;
-        f->dump_stream("destdnpath") << _peer_request->destdnpath;
-        f->dump_stream("witnesses") << _peer_request->witnesses;
-        f->dump_bool("has_inode_export",
-           _peer_request->inode_export_v != 0);
-        f->dump_int("inode_export_v", _peer_request->inode_export_v);
-        f->dump_stream("op_stamp") << _peer_request->op_stamp;
-        f->close_section(); // request_info
-      }
+    if (peer_request) {
+      f->open_object_section("request_info");
+      f->dump_int("attempt", peer_request->get_attempt());
+      f->dump_string("op_type",
+         MMDSPeerRequest::get_opname(peer_request->get_op()));
+      f->dump_int("lock_type", peer_request->get_lock_type());
+      f->dump_stream("object_info") << peer_request->get_object_info();
+      f->dump_stream("srcdnpath") << peer_request->srcdnpath;
+      f->dump_stream("destdnpath") << peer_request->destdnpath;
+      f->dump_stream("witnesses") << peer_request->witnesses;
+      f->dump_bool("has_inode_export",
+         peer_request->inode_export_v != 0);
+      f->dump_int("inode_export_v", peer_request->inode_export_v);
+      f->dump_stream("op_stamp") << peer_request->op_stamp;
+      f->close_section(); // request_info
     }
-    else if (internal_op != -1) { // internal request
-      f->dump_string("op_type", "internal_op");
-      f->dump_int("internal_op", internal_op);
-      f->dump_string("op_name", ceph_mds_op_name(internal_op));
-    }
-    else {
-      f->dump_string("op_type", "no_available_op_found");
-    }
+  }
+  else if (internal_op != -1) { // internal request
+    f->dump_string("op_type", "internal_op");
+    f->dump_int("internal_op", internal_op);
+    f->dump_string("op_name", ceph_mds_op_name(internal_op));
+  }
+  else {
+    f->dump_string("op_type", "no_available_op_found");
   }
 
   {
@@ -538,25 +526,20 @@ void MDRequestImpl::_dump(Formatter *f) const
   }
 }
 
-void MDRequestImpl::_dump_op_descriptor(ostream& stream) const
+void MDRequestImpl::_dump_op_descriptor(ostream& os) const
 {
-  msg_lock.lock();
-  auto _client_request = client_request;
-  auto _peer_request = peer_request;
-  msg_lock.unlock();
-
-  if (_client_request) {
-    _client_request->print(stream);
-  } else if (_peer_request) {
-    _peer_request->print(stream);
+  if (client_request) {
+    client_request->print(os);
+  } else if (peer_request) {
+    peer_request->print(os);
   } else if (is_peer()) {
-    stream << "peer_request:" << reqid;
+    os << "peer_request:" << reqid;
   } else if (internal_op >= 0) {
-    stream << "internal op " << ceph_mds_op_name(internal_op) << ":" << reqid;
+    os << "internal op " << ceph_mds_op_name(internal_op) << ":" << reqid;
   } else {
     // drat, it's triggered by a peer request, but we don't have a message
     // FIXME
-    stream << "rejoin:" << reqid;
+    os << "rejoin:" << reqid;
   }
 }
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -481,6 +481,7 @@ void MDRequestImpl::dump(Formatter *f) const
 
 void MDRequestImpl::_dump(Formatter *f) const
 {
+  std::lock_guard l(lock);
   f->dump_string("flag_point", _get_state_string());
   f->dump_stream("reqid") << reqid;
   {
@@ -527,9 +528,9 @@ void MDRequestImpl::_dump(Formatter *f) const
       f->dump_string("op_type", "no_available_op_found");
     }
   }
+
   {
     f->open_array_section("events");
-    std::lock_guard l(lock);
     for (auto& i : events) {
       f->dump_object("event", i);
     }

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -268,7 +268,7 @@ void MutationImpl::cleanup()
   drop_pins();
 }
 
-void MutationImpl::_dump_op_descriptor_unlocked(ostream& stream) const
+void MutationImpl::_dump_op_descriptor(ostream& stream) const
 {
   stream << "Mutation";
 }
@@ -537,7 +537,7 @@ void MDRequestImpl::_dump(Formatter *f) const
   }
 }
 
-void MDRequestImpl::_dump_op_descriptor_unlocked(ostream& stream) const
+void MDRequestImpl::_dump_op_descriptor(ostream& stream) const
 {
   msg_lock.lock();
   auto _client_request = client_request;

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -478,7 +478,7 @@ void MDRequestImpl::_dump(Formatter *f) const
 {
   std::lock_guard l(lock);
   f->dump_string("flag_point", _get_state_string());
-  f->dump_stream("reqid") << reqid;
+  f->dump_object("reqid", reqid);
   if (client_request) {
     f->dump_string("op_type", "client_request");
     f->open_object_section("client_info");

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -221,7 +221,7 @@ public:
   }
 
   virtual void dump(ceph::Formatter *f) const {}
-  void _dump_op_descriptor_unlocked(std::ostream& stream) const override;
+  void _dump_op_descriptor(std::ostream& stream) const override;
 
   metareqid_t reqid;
   __u32 attempt = 0;      // which attempt for this request
@@ -453,7 +453,7 @@ struct MDRequestImpl : public MutationImpl {
 
 protected:
   void _dump(ceph::Formatter *f) const override;
-  void _dump_op_descriptor_unlocked(std::ostream& stream) const override;
+  void _dump_op_descriptor(std::ostream& stream) const override;
 private:
   mutable ceph::spinlock msg_lock;
 };

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -454,8 +454,6 @@ struct MDRequestImpl : public MutationImpl {
 protected:
   void _dump(ceph::Formatter *f) const override;
   void _dump_op_descriptor(std::ostream& stream) const override;
-private:
-  mutable ceph::spinlock msg_lock;
 };
 
 struct MDPeerUpdate {

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -396,7 +396,9 @@ struct MDRequestImpl : public MutationImpl {
   std::unique_ptr<BatchOp> release_batch_op();
 
   void print(std::ostream &out) const override;
-  void dump(ceph::Formatter *f) const override;
+  void dump_with_mds_lock(ceph::Formatter* f) const {
+    return _dump(f, true);
+  }
 
   ceph::cref_t<MClientRequest> release_client_request();
   void reset_peer_request(const ceph::cref_t<MMDSPeerRequest>& req=nullptr);
@@ -452,7 +454,10 @@ struct MDRequestImpl : public MutationImpl {
   bool waited_for_osdmap = false;
 
 protected:
-  void _dump(ceph::Formatter *f) const override;
+  void _dump(ceph::Formatter *f) const override {
+    _dump(f, false);
+  }
+  void _dump(ceph::Formatter *f, bool has_mds_lock) const;
   void _dump_op_descriptor(std::ostream& stream) const override;
 };
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -138,7 +138,7 @@ public:
     batch_reqs.clear();
     server->reply_client_request(mdr, make_message<MClientReply>(*mdr->client_request, r));
   }
-  void print(std::ostream& o) {
+  void print(std::ostream& o) const override {
     o << "[batch front=" << *mdr << "]";
   }
 };

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -37,8 +37,8 @@ void SimpleLock::dump(ceph::Formatter *f) const {
   f->dump_int("num_wrlocks", get_num_wrlocks());
   f->dump_int("num_xlocks", get_num_xlocks());
   f->open_object_section("xlock_by");
-  if (get_xlock_by()) {
-    get_xlock_by()->dump(f);
+  if (auto mut = get_xlock_by(); mut) {
+    f->dump_object("reqid", mut->reqid);
   }
   f->close_section();
 }

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -31,6 +31,7 @@ void SimpleLock::dump(ceph::Formatter *f) const {
   f->close_section();
 
   f->dump_string("state", get_state_name(get_state()));
+  f->dump_string("type", get_lock_type_name(get_type()));
   f->dump_bool("is_leased", is_leased());
   f->dump_int("num_rdlocks", get_num_rdlocks());
   f->dump_int("num_wrlocks", get_num_wrlocks());

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -771,6 +771,10 @@ void mds_table_pending_t::generate_test_instances(std::list<mds_table_pending_t*
   ls.back()->tid = 35434;
 }
 
+void metareqid_t::dump(ceph::Formatter* f) const {
+  f->dump_object("entity", name);
+  f->dump_unsigned("tid", tid);
+}
 
 /*
  * inode_load_vec_t

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -621,6 +621,7 @@ struct metareqid_t {
     decode(name, p);
     decode(tid, p);
   }
+  void dump(ceph::Formatter *f) const;
 
   entity_name_t name;
   uint64_t tid = 0;

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -37,6 +37,11 @@ void PyFormatter::open_object_section(std::string_view name)
   cursor = dict;
 }
 
+void PyFormatter::dump_null(std::string_view name)
+{
+  dump_pyobject(name, Py_None);
+}
+
 void PyFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   PyObject *p = PyLong_FromUnsignedLong(u);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -87,6 +87,7 @@ public:
     stack.pop();
   }
   void dump_bool(std::string_view name, bool b) override;
+  void dump_null(std::string_view name) override;
   void dump_unsigned(std::string_view name, uint64_t u) override;
   void dump_int(std::string_view name, int64_t u) override;
   void dump_float(std::string_view name, double d) override;

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -131,7 +131,7 @@ private:
   }
 
 protected:
-  void _dump_op_descriptor_unlocked(std::ostream& stream) const override {
+  void _dump_op_descriptor(std::ostream& stream) const override {
     get_req()->print(stream);
   }
 

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -88,7 +88,7 @@ void OpRequest::_dump(Formatter *f) const
   }
 }
 
-void OpRequest::_dump_op_descriptor_unlocked(ostream& stream) const
+void OpRequest::_dump_op_descriptor(ostream& stream) const
 {
   get_req()->print(stream);
 }

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -107,7 +107,7 @@ public:
     return latest_flag_point;
   }
 
-  std::string_view state_string() const override {
+  std::string _get_state_string() const override {
     switch(latest_flag_point) {
     case flag_queued_for_pg: return "queued for pg";
     case flag_reached_pg: return "reached pg";

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -74,7 +74,7 @@ private:
   OpRequest(Message *req, OpTracker *tracker);
 
 protected:
-  void _dump_op_descriptor_unlocked(std::ostream& stream) const override;
+  void _dump_op_descriptor(std::ostream& stream) const override;
   void _unregistered() override;
   bool filter_out(const std::set<std::string>& filters) override;
 

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -113,6 +113,11 @@ void RGWFormatter_Plain::close_section()
   stack.pop_back();
 }
 
+void RGWFormatter_Plain::dump_null(std::string_view name)
+{
+  dump_value_int(name, "null"); /* I feel a little bad about this. */
+}
+
 void RGWFormatter_Plain::dump_unsigned(std::string_view name, uint64_t u)
 {
   dump_value_int(name, "%" PRIu64, u);

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -37,6 +37,7 @@ public:
   void open_object_section(std::string_view name) override;
   void open_object_section_in_ns(std::string_view name, const char *ns) override;
   void close_section() override;
+  void dump_null(std::string_view name) override;
   void dump_unsigned(std::string_view name, uint64_t u) override;
   void dump_int(std::string_view name, int64_t u) override;
   void dump_float(std::string_view name, double d) override;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62422

---

backport of https://github.com/ceph/ceph/pull/52547
parent tracker: https://tracker.ceph.com/issues/62086

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh