### PR TITLE
pacific: vstart_runner: maintain log level when --debug is passed

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -63,7 +63,7 @@ try:
 except:
     pass
 
-def init_log():
+def init_log(log_level=logging.INFO):
     global log
     if log is not None:
         del log
@@ -78,7 +78,7 @@ def init_log():
         datefmt='%Y-%m-%dT%H:%M:%S')
     handler.setFormatter(formatter)
     log.addHandler(handler)
-    log.setLevel(logging.INFO)
+    log.setLevel(log_level)
 
 log = None
 init_log()
@@ -1344,7 +1344,7 @@ def clear_old_log():
         os.remove(logpath)
         with open(logpath, 'w') as logfile:
             logfile.write('')
-        init_log()
+        init_log(log.level)
         log.debug('logging in a fresh file now...')
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51654

---

backport of https://github.com/ceph/ceph/pull/42030
parent tracker: https://tracker.ceph.com/issues/51344

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh