### PR TITLE
pacific: vstart_runner: use FileNotFoundError when os.stat() fails

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1332,13 +1332,9 @@ def teardown_cluster():
 
 
 def clear_old_log():
-    from os import stat
-
     try:
-        stat(logpath)
-    # would need an update when making this py3 compatible. Use FileNotFound
-    # instead.
-    except OSError:
+        os.stat(logpath)
+    except FileNotFoundError:
         return
     else:
         os.remove(logpath)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51653

---

backport of https://github.com/ceph/ceph/pull/42029
parent tracker: https://tracker.ceph.com/issues/51369

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh