### PR TITLE
pacific: ceph-volume: fix raw list for lvm devices

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -89,6 +89,9 @@ class List(object):
             # determine whether a parent is bluestore, we should err on the side of not reporting
             # the child so as not to give a false negative.
             info_device = [info for info in info_devices if info['NAME'] == dev][0]
+            if info_device['TYPE'] == 'lvm':
+                # lvm devices are not raw devices
+                continue
             if 'PKNAME' in info_device and info_device['PKNAME'] != "":
                 parent = info_device['PKNAME']
                 try:

--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -88,18 +88,18 @@ class List(object):
             # parent isn't bluestore, then the child could be a valid bluestore OSD. If we fail to
             # determine whether a parent is bluestore, we should err on the side of not reporting
             # the child so as not to give a false negative.
-            for info_device in info_devices:
-                if 'PKNAME' in info_device and info_device['PKNAME'] != "":
-                    parent = info_device['PKNAME']
-                    try:
-                        if disk.has_bluestore_label(parent):
-                            logger.warning(('ignoring child device {} whose parent {} is a BlueStore OSD.'.format(dev, parent),
-                                            'device is likely a phantom Atari partition. device info: {}'.format(info_device)))
-                            continue
-                    except OSError as e:
-                        logger.error(('ignoring child device {} to avoid reporting invalid BlueStore data from phantom Atari partitions.'.format(dev),
-                                    'failed to determine if parent device {} is BlueStore. err: {}'.format(parent, e)))
+            info_device = [info for info in info_devices if info['NAME'] == dev][0]
+            if 'PKNAME' in info_device and info_device['PKNAME'] != "":
+                parent = info_device['PKNAME']
+                try:
+                    if disk.has_bluestore_label(parent):
+                        logger.warning(('ignoring child device {} whose parent {} is a BlueStore OSD.'.format(dev, parent),
+                                        'device is likely a phantom Atari partition. device info: {}'.format(info_device)))
                         continue
+                except OSError as e:
+                    logger.error(('ignoring child device {} to avoid reporting invalid BlueStore data from phantom Atari partitions.'.format(dev),
+                                'failed to determine if parent device {} is BlueStore. err: {}'.format(parent, e)))
+                    continue
 
             bs_info = _get_bluestore_info(dev)
             if bs_info is None:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62154

---

backport of https://github.com/ceph/ceph/pull/52429
parent tracker: https://tracker.ceph.com/issues/62001

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh