### PR TITLE
script/ceph-backport: perform cherry-pick in single command

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -95,6 +95,11 @@ declare -A comp_hash=(
 
 declare -A flagged_pr_hash=()
 
+function run {
+    printf '%s\n' "$*" >&2
+    "$@"
+}
+
 function abort_due_to_setup_problem {
     error "problem detected in your setup"
     info "Run \"${this_script} --setup\" to fix"
@@ -228,32 +233,29 @@ function cherry_pick_phase {
             false
         fi
     fi
+    base_sha="$(printf '%s' "${remote_api_output}" | jq -r .base.sha)"
+    head_sha="$(printf '%s' "${remote_api_output}" | jq -r .head.sha)"
     merged=$(echo "${remote_api_output}" | jq -r '.merged')
     if [ "$merged" = "true" ] ; then
-        true
+        # Use the merge commit in case the branch HEAD changes after merge.
+        merge_commit_sha=$(printf '%s' "$remote_api_output" | jq -r '.merge_commit_sha')
+        if [ -z "$merge_commit_sha" ]; then
+            error "Could not determine the merge commit of ${original_pr_url}"
+            bail_out_github_api "$remote_api_output"
+            false
+        fi
+        cherry_pick_sha="${merge_commit_sha}^..${merge_commit_sha}^2"
     else
         if [ "$FORCE" ] ; then
             warning "${original_pr_url} is not merged yet"
             info "--force was given, so continuing anyway"
+            cherry_pick_sha="${base_sha}..${head_sha}"
         else
             error "${original_pr_url} is not merged yet"
             info "Cowardly refusing to perform automated cherry-pick"
             false
         fi
     fi
-    number_of_commits=$(echo "${remote_api_output}" | jq '.commits')
-    if [ "$number_of_commits" -eq "$number_of_commits" ] 2>/dev/null ; then
-        # \$number_of_commits is set, and is an integer
-        if [ "$number_of_commits" -eq "1" ] ; then
-            singular_or_plural_commit="commit"
-        else
-            singular_or_plural_commit="commits"
-        fi
-    else
-        error "Could not determine the number of commits in ${original_pr_url}"
-        bail_out_github_api "$remote_api_output"
-    fi
-    info "Found $number_of_commits $singular_or_plural_commit in $original_pr_url"
 
     set -x
     git fetch "$upstream_remote"
@@ -294,33 +296,16 @@ function cherry_pick_phase {
 
     set +x
     maybe_restore_set_x
-    info "Attempting to cherry pick $number_of_commits commits from ${original_pr_url} into local branch $local_branch"
-    offset="$((number_of_commits - 1))" || true
-    for ((i=offset; i>=0; i--)) ; do
-        info "Running \"git cherry-pick -x\" on $(git log --oneline --max-count=1 --no-decorate "pr-${original_pr}~${i}")"
-        sha1_to_cherry_pick=$(git rev-parse --verify "pr-${original_pr}~${i}")
-        set -x
-        if git cherry-pick -x "$sha1_to_cherry_pick" ; then
-            set +x
-            maybe_restore_set_x
-        else
-            set +x
-            maybe_restore_set_x
-            [ "$VERBOSE" ] && git status
-            error "Cherry pick failed"
-            info "Next, manually fix conflicts and complete the current cherry-pick"
-            if [ "$i" -gt "0" ] >/dev/null 2>&1 ; then
-                info "Then, cherry-pick the remaining commits from ${original_pr_url}, i.e.:"
-                for ((j=i-1; j>=0; j--)) ; do
-                    info "-> missing commit: $(git log --oneline --max-count=1 --no-decorate "pr-${original_pr}~${j}")"
-                done
-                info "Finally, re-run the script"
-            else
-                info "Then re-run the script"
-            fi
-            false
-        fi
-    done
+    info "Attempting to cherry pick ${original_pr_url} into local branch $local_branch"
+    if ! run git cherry-pick -x "$cherry_pick_sha"; then
+        [ "$VERBOSE" ] && git status
+        error "Cherry pick failed due to conflicts?"
+        info "Manually fix conflicts and complete the current cherry-pick:"
+        info "    git cherry-pick --continue"
+        info "Finally, re-run this script"
+        false
+    fi
+
     info "Cherry picking completed without conflicts"
 }
 


### PR DESCRIPTION
This simplifies conflict resolution as running:

    git cherry-pick --resume

will continue cherry-picking all the required commits in series without copy-pasting the commits from the script's output.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
