### PR TITLE
quincy: mon/MDSMonitor: plug paxos when maybe manipulating osdmap

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -146,10 +146,6 @@ class FsNewHandler : public FileSystemCommandHandler
   {
   }
 
-  bool batched_propose() override {
-    return true;
-  }
-
   int handle(
       Monitor *mon,
       FSMap& fsmap,
@@ -871,10 +867,6 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     : FileSystemCommandHandler("fs add_data_pool"), m_paxos(paxos)
   {}
 
-  bool batched_propose() override {
-    return true;
-  }
-
   int handle(
       Monitor *mon,
       FSMap& fsmap,
@@ -1094,10 +1086,6 @@ class RenameFilesystemHandler : public FileSystemCommandHandler
   explicit RenameFilesystemHandler(Paxos *paxos)
     : FileSystemCommandHandler("fs rename"), m_paxos(paxos)
   {
-  }
-
-  bool batched_propose() override {
-    return true;
   }
 
   int handle(

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -78,10 +78,6 @@ public:
 
   static std::list<std::shared_ptr<FileSystemCommandHandler> > load(Paxos *paxos);
 
-  virtual bool batched_propose() {
-    return false;
-  }
-
   virtual int handle(
     Monitor *mon,
     FSMap &fsmap,

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -804,6 +804,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
         last_beacon.erase(followergid);
       }
       request_proposal(mon.osdmon());
+      force_immediate_propose();
       pending.damaged(rankgid, blocklist_epoch);
       last_beacon.erase(rankgid);
 
@@ -1277,6 +1278,8 @@ bool MDSMonitor::fail_mds_gid(FSMap &fsmap, mds_gid_t gid)
     utime_t until = ceph_clock_now();
     until += g_conf().get_val<double>("mon_mds_blocklist_interval");
     blocklist_epoch = mon.osdmon()->blocklist(info.addrs, until);
+    /* do not delay when we are evicting an MDS */
+    force_immediate_propose();
   }
 
   fsmap.erase(gid, blocklist_epoch);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -550,28 +550,35 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
   auto m = op->get_req<PaxosServiceMessage>();
   dout(7) << "prepare_update " << *m << dendl;
 
+  bool r = false;
+
+  /* batch any changes to pending with any changes to osdmap */
+  paxos.plug();
+
   switch (m->get_type()) {
-    
-  case MSG_MDS_BEACON:
-    return prepare_beacon(op);
-
-  case MSG_MON_COMMAND:
-    try {
-      return prepare_command(op);
-    } catch (const bad_cmd_get& e) {
-      bufferlist bl;
-      mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
-      return false; /* nothing to propose */
-    }
-
-  case MSG_MDS_OFFLOAD_TARGETS:
-    return prepare_offload_targets(op);
-  
-  default:
-    ceph_abort();
+    case MSG_MDS_BEACON:
+      r = prepare_beacon(op);
+      break;
+    case MSG_MON_COMMAND:
+      try {
+        r = prepare_command(op);
+      } catch (const bad_cmd_get& e) {
+        bufferlist bl;
+        mon.reply_command(op, -EINVAL, e.what(), bl, get_last_committed());
+        r = false;
+      }
+      break;
+    case MSG_MDS_OFFLOAD_TARGETS:
+      r = prepare_offload_targets(op);
+      break;
+    default:
+      ceph_abort();
+      break;
   }
 
-  return false; /* nothing to propose! */
+  paxos.unplug();
+
+  return r;
 }
 
 bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
@@ -1389,7 +1396,6 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
 
   auto &pending = get_pending_fsmap_writeable();
 
-  bool batched_propose = false;
   for (const auto &h : handlers) {
     r = h->can_handle(prefix, op, pending, cmdmap, ss);
     if (r == 1) {
@@ -1400,14 +1406,7 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
       goto out;
     }
 
-    batched_propose = h->batched_propose();
-    if (batched_propose) {
-      paxos.plug();
-    }
     r = h->handle(&mon, pending, op, cmdmap, ss);
-    if (batched_propose) {
-      paxos.unplug();
-    }
 
     if (r == -EAGAIN) {
       // message has been enqueued for retry; return.
@@ -1448,9 +1447,6 @@ out:
     // success.. delay reply
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, r, rs,
 					      get_last_committed() + 1));
-    if (batched_propose) {
-      force_immediate_propose();
-    }
     return true;
   } else {
     // reply immediately
@@ -2321,6 +2317,9 @@ void MDSMonitor::tick()
 
   auto &pending = get_pending_fsmap_writeable();
 
+  /* batch any changes to pending with any changes to osdmap */
+  paxos.plug();
+
   bool do_propose = false;
   bool propose_osdmap = false;
 
@@ -2375,6 +2374,9 @@ void MDSMonitor::tick()
   if (propose_osdmap) {
     request_proposal(mon.osdmon());
   }
+
+  /* allow MDSMonitor::propose_pending() to push the proposal through */
+  paxos.unplug();
 
   if (do_propose) {
     propose_pending();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61799

---

backport of https://github.com/ceph/ceph/pull/50908
parent tracker: https://tracker.ceph.com/issues/59314

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh