### PR TITLE
reef: nofail option in fstab not supported

### DIFF
--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -39,8 +39,11 @@ def ceph_options_compat(device):
     return [ 'ceph.' + opt for opt in device.split(',') ]
 
 def fs_options(opts, ceph_opts):
-    # strip out noauto and _netdev options; libfuse doesn't like it
-    strip_opts = ['defaults', 'noauto', '_netdev']
+    # - strip out noauto and _netdev options; libfuse doesn't like it
+    # - nofail option is also not recognized by libfuse.
+    #   Starting with fuse 3.2.2 the option is also ignored by mount.fuse, see
+    #   https://github.com/libfuse/libfuse/commit/a83cd72f641671b71b8268b1765e449cae071f3e
+    strip_opts = ['defaults', 'noauto', '_netdev', 'nofail']
     return ','.join(list(set(opts) - set(ceph_opts) - set(strip_opts)))
 
 def main(arguments):


### PR DESCRIPTION
Fixes-Backport: https://tracker.ceph.com/issues/62425
Fixes: https://tracker.ceph.com/issues/58394
Original-PR: https://github.com/ceph/ceph/pull/52834

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
