### PR TITLE
quincy: qa/suites/upgrade/octopus-x: skip TestClsRbd.mirror_snapshot test

### DIFF
--- a/qa/suites/upgrade/octopus-x/parallel/workload/rados_api.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/workload/rados_api.yaml
@@ -9,4 +9,6 @@ workload:
         clients:
           client.0:
             - cls
+        env:
+          CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
     - print: "**** done end rados_api.yaml"

--- a/qa/suites/upgrade/octopus-x/stress-split-no-cephadm/4-workload/rbd-cls.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split-no-cephadm/4-workload/rbd-cls.yaml
@@ -7,4 +7,6 @@ stress-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
 - print: "**** done cls/test_cls_rbd.sh 5-workload"

--- a/qa/suites/upgrade/octopus-x/stress-split/2-first-half-tasks/rbd-cls.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split/2-first-half-tasks/rbd-cls.yaml
@@ -7,4 +7,6 @@ first-half-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
 - print: "**** done cls/test_cls_rbd.sh 5-workload"

--- a/qa/suites/upgrade/octopus-x/stress-split/3-stress-tasks/rbd-cls.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split/3-stress-tasks/rbd-cls.yaml
@@ -7,4 +7,6 @@ stress-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
 - print: "**** done cls/test_cls_rbd.sh 5-workload"


### PR DESCRIPTION
The behavior of the class method changed in reef; the change was backported to pacific and quincy.  An octopus test binary used against quincy OSDs produces an expected failure:

    [ RUN      ] TestClsRbd.mirror_snapshot
    .../15.2.17/rpm/el8/BUILD/ceph-15.2.17/src/test/cls_rbd/test_cls_rbd.cc:2279: Failure
    Expected equality of these values:
      -85
      mirror_image_snapshot_unlink_peer(&ioctx, oid, 1, "peer2")
        Which is: 0
    [  FAILED  ] TestClsRbd.mirror_snapshot (6 ms)

Fixes: https://tracker.ceph.com/issues/62402