### PR TITLE
pacific: mgr: fix a race condition in DaemonServer::handle_report()

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -641,9 +641,8 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
 
     DaemonStatePtr daemon;
     // Look up the DaemonState
-    if (daemon_state.exists(key)) {
+    if (daemon = daemon_state.get(key); daemon != nullptr) {
       dout(20) << "updating existing DaemonState for " << key << dendl;
-      daemon = daemon_state.get(key);
     } else {
       locker.unlock();
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57474

---

backport of https://github.com/ceph/ceph/pull/47002
parent tracker: https://tracker.ceph.com/issues/45591

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh