### PR TITLE
pacific: mgr/nfs: clarify in the output message

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -76,6 +76,17 @@ service.
 For more details, refer :ref:`orchestrator-cli-placement-spec` but keep
 in mind that specifying the placement via a YAML file is not supported.
 
+Deployment of NFS daemons and the ingress service is asynchronous: the
+command may return before the services have completely started. You may
+wish to check that these services do successfully start and stay running.
+When using cephadm orchestration, these commands check service status:
+
+.. code:: bash
+
+    $ ceph orch ls --service_name=nfs.<cluster_id>
+    $ ceph orch ls --service_name=ingress.nfs.<cluster_id>
+
+
 Ingress
 -------
 
@@ -127,6 +138,18 @@ Delete NFS Ganesha Cluster
     $ ceph nfs cluster rm <cluster_id>
 
 This deletes the deployed cluster.
+
+
+Removal of NFS daemons and the ingress service is asynchronous: the
+command may return before the services have been completely deleted. You may
+wish to check that these services are no longer reported. When using cephadm
+orchestration, these commands check service status:
+
+.. code:: bash
+
+    $ ceph orch ls --service_name=nfs.<cluster_id>
+    $ ceph orch ls --service_name=ingress.nfs.<cluster_id>
+
 
 Updating an NFS Cluster
 -----------------------

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -119,7 +119,7 @@ class NFSCluster:
 
             if cluster_id not in available_clusters(self.mgr):
                 self._call_orch_apply_nfs(cluster_id, placement, virtual_ip, port)
-                return 0, "NFS Cluster Created Successfully", ""
+                return 0, "", ""
             return 0, "", f"{cluster_id} cluster already exists"
         except Exception as e:
             return exception_handler(e, f"NFS Cluster {cluster_id} could not be created")
@@ -134,7 +134,7 @@ class NFSCluster:
                 completion = self.mgr.remove_service('nfs.' + cluster_id)
                 orchestrator.raise_if_exception(completion)
                 self.delete_config_obj(cluster_id)
-                return 0, "NFS Cluster Deleted Successfully", ""
+                return 0, "", ""
             return 0, "", "Cluster does not exist"
         except Exception as e:
             return exception_handler(e, f"Failed to delete NFS Cluster {cluster_id}")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57476

---

backport of https://github.com/ceph/ceph/pull/45843
parent tracker: https://tracker.ceph.com/issues/55299

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh