### PR TITLE
pacific: rgw: use unique_ptr for flat_map emplace in BucketTrimWatche

### DIFF
--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -250,8 +250,10 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   BucketTrimWatcher(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
                     TrimCounters::Server *counters)
     : store(store), obj(obj) {
-    handlers.emplace(NotifyTrimCounters, new TrimCounters::Handler(counters));
-    handlers.emplace(NotifyTrimComplete, new TrimComplete::Handler(counters));
+    handlers.emplace(NotifyTrimCounters,
+        std::make_unique<TrimCounters::Handler>(counters));
+    handlers.emplace(NotifyTrimComplete,
+        std::make_unique<TrimComplete::Handler>(counters));
   }
 
   ~BucketTrimWatcher() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59026

---

backport of https://github.com/ceph/ceph/pull/50346
parent tracker: https://tracker.ceph.com/issues/57938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh