### PR TITLE
reef: qa/tasks: set defer_client_eviction_on_laggy_osds=false in api tests

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -104,7 +104,11 @@ class MgrTestCase(CephTestCase):
             raise SkipTest(
                 "Only have {0} manager daemons, {1} are required".format(
                     len(cls.mgr_cluster.mgr_ids), cls.MGRS_REQUIRED))
-
+        
+        # We expect laggy OSDs in this testing environment so turn off this warning.
+        # See https://tracker.ceph.com/issues/61907
+        cls.mgr_cluster.mon_manager.raw_cluster_cmd('config', 'set', 'mds',
+                                                    'defer_client_eviction_on_laggy_osds', 'false')
         cls.setup_mgrs()
 
     @classmethod


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62443

---

backport of https://github.com/ceph/ceph/pull/52342
parent tracker: https://tracker.ceph.com/issues/61907

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh