### PR TITLE
mgr/dashboard: fix rgw buckets e2e 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.po.ts
@@ -10,6 +10,11 @@ export class BucketsPageHelper extends PageHelper {
 
   pages = pages;
 
+  columnIndex = {
+    name: 3,
+    owner: 4
+  };
+
   versioningStateEnabled = 'Enabled';
   versioningStateSuspended = 'Suspended';
 
@@ -73,18 +78,22 @@ export class BucketsPageHelper extends PageHelper {
       cy.get('input[id=versioning]').should('be.disabled');
       cy.contains('button', 'Edit Bucket').click();
 
+      this.getTableCell(this.columnIndex.name, name)
+        .parent()
+        .find(`datatable-body-cell:nth-child(${this.columnIndex.owner})`)
+        .should(($elements) => {
+          const bucketName = $elements.text();
+          expect(bucketName).to.eq(new_owner);
+        });
+
       // wait to be back on buckets page with table visible and click
       this.getExpandCollapseElement(name).click();
 
       // check its details table for edited owner field
-      cy.get('.table.table-striped.table-bordered')
-        .first()
-        .should('contains.text', new_owner)
-        .as('bucketDataTable');
+      cy.get('.table.table-striped.table-bordered').first().as('bucketDataTable');
 
       // Check versioning enabled:
-      cy.get('@bucketDataTable').find('tr').its(2).find('td').last().should('have.text', new_owner);
-      cy.get('@bucketDataTable').find('tr').its(11).find('td').last().as('versioningValueCell');
+      cy.get('@bucketDataTable').find('tr').its(0).find('td').last().as('versioningValueCell');
 
       return cy.get('@versioningValueCell').should('have.text', this.versioningStateEnabled);
     }
@@ -92,21 +101,23 @@ export class BucketsPageHelper extends PageHelper {
     cy.get('input[id=versioning]').should('not.be.checked');
     cy.get('label[for=versioning]').click();
     cy.get('input[id=versioning]').should('be.checked');
-
     cy.contains('button', 'Edit Bucket').click();
+
+    // Check if the owner is updated
+    this.getTableCell(this.columnIndex.name, name)
+      .parent()
+      .find(`datatable-body-cell:nth-child(${this.columnIndex.owner})`)
+      .should(($elements) => {
+        const bucketName = $elements.text();
+        expect(bucketName).to.eq(new_owner);
+      });
 
     // wait to be back on buckets page with table visible and click
     this.getExpandCollapseElement(name).click();
 
-    // check its details table for edited owner field
-    cy.get('.table.table-striped.table-bordered')
-      .first()
-      .should('contains.text', new_owner)
-      .as('bucketDataTable');
-
     // Check versioning enabled:
-    cy.get('@bucketDataTable').find('tr').its(2).find('td').last().should('have.text', new_owner);
-    cy.get('@bucketDataTable').find('tr').its(11).find('td').last().as('versioningValueCell');
+    cy.get('.table.table-striped.table-bordered').first().as('bucketDataTable');
+    cy.get('@bucketDataTable').find('tr').its(0).find('td').last().as('versioningValueCell');
 
     cy.get('@versioningValueCell').should('have.text', this.versioningStateEnabled);
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62458

Fixes [these failures](https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/13415/consoleFull#-4597494873a8703b-5adb-41c5-84a0-8cf4e065ba3d)
```
 1) RGW buckets page
       create, edit & delete bucket tests
         should edit bucket:
     AssertionError: Timed out retrying after 120000ms: expected '<input#versioning.custom-control-input.ng-untouched.ng-pristine.ng-valid>' not to be 'checked'
      at BucketsPageHelper.edit (cypress/e2e/rgw/buckets.po.ts:92:35)
      at descriptor.value [as edit] (cypress/e2e/page-helper.po.ts:25:11)
      at Context.eval (cypress/e2e/rgw/buckets.e2e-spec.ts:26:14)

  2) RGW buckets page
       create, edit & delete bucket tests
         should not allow to edit versioning if object locking is enabled:

      Timed out retrying after 120000ms
      + expected - actual

      -'VersioningEnabledEncryptionDisabledMFA DeleteDisabledIndex typeNormalPlacement ruledefault-placementLast modification time8/15/23 10:10:59 AM'
      +'testid'
      
      at BucketsPageHelper.edit (cypress/e2e/rgw/buckets.po.ts:82:9)
      at descriptor.value [as edit] (cypress/e2e/page-helper.po.ts:25:11)
      at Context.eval (cypress/e2e/rgw/buckets.e2e-spec.ts:46:14)

  3) RGW buckets page
       Invalid Input in Create and Edit tests
         should test invalid input in edit owner field:
     AssertionError: Timed out retrying after 120000ms: Expected to find element: `cd-table`, but never found it.
      at PageHelper.waitDataTableToLoad (cypress/e2e/page-helper.po.ts:135:23)
      at PageHelper.getFirstTableCell (cypress/e2e/page-helper.po.ts:189:9)
      at BucketsPageHelper.create (cypress/e2e/rgw/buckets.po.ts:52:9)
      at descriptor.value [as create] (cypress/e2e/page-helper.po.ts:25:11)
      at Context.eval (cypress/e2e/rgw/buckets.e2e-spec.ts:60:14)
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
