### PR TITLE
Fragmentation Simulator Visualization

### DIFF
--- a/src/test/objectstore/Fragmentation_simulator.cc
+++ b/src/test/objectstore/Fragmentation_simulator.cc
@@ -87,7 +87,8 @@ public:
   using WorkloadGeneratorRef = std::shared_ptr<WorkloadGenerator>;
 
   void add_generator(WorkloadGeneratorRef gen);
-  int begin_simulation_with_generators(unsigned iterations);
+  int begin_simulation(unsigned iterations, const std::string &img_path,
+                       unsigned img_size);
   void init(const std::string &alloc_type, uint64_t size,
             uint64_t min_alloc_size = 4096);
 
@@ -122,8 +123,9 @@ void FragmentationSimulator::add_generator(WorkloadGeneratorRef gen) {
   generators.push_back(gen);
 }
 
-int FragmentationSimulator::begin_simulation_with_generators(
-    unsigned iterations) {
+int FragmentationSimulator::begin_simulation(unsigned iterations,
+                                             const std::string &img_path,
+                                             unsigned img_size) {
   ObjectStore::CollectionHandle ch = os->create_new_collection(coll_t::meta());
 
   ObjectStore::Transaction t;
@@ -144,6 +146,7 @@ int FragmentationSimulator::begin_simulation_with_generators(
   os->print_per_object_fragmentation();
   os->print_per_access_fragmentation();
   os->print_allocator_profile();
+  os->output_fragmentation_img(img_path, img_size);
 
   return 0;
 }
@@ -414,21 +417,24 @@ private:
 // ----------- Tests -----------
 
 TEST_P(FragmentationSimulator, SimpleCWGenerator) {
-  init(GetParam(), _1Gb);
+  std::string alloc = GetParam();
+  init(alloc, _1Gb);
   add_generator(std::make_shared<SimpleCWGenerator>());
-  begin_simulation_with_generators(1);
+  begin_simulation(1, fmt::format("{}_simple.ppm", alloc), 128);
 }
 
 TEST_P(FragmentationSimulator, RandomCWGenerator) {
-  init(GetParam(), _1Mb * 16);
+  std::string alloc = GetParam();
+  init(alloc, _1Mb * 16);
   add_generator(std::make_shared<RandomCWGenerator>());
-  begin_simulation_with_generators(1);
+  begin_simulation(1, fmt::format("{}_random.ppm", alloc), 16);
 }
 
 TEST_P(FragmentationSimulator, MultiThreadedCWGenerator) {
-  init(GetParam(), _1Mb * 4);
+  std::string alloc = GetParam();
+  init(alloc, _1Mb * 4);
   add_generator(std::make_shared<MultiThreadedCWGenerator>());
-  begin_simulation_with_generators(1);
+  begin_simulation(1, fmt::format("{}_multi.ppm", alloc), 4);
 }
 
 // ----------- main -----------

--- a/src/test/objectstore/Fragmentation_simulator.cc
+++ b/src/test/objectstore/Fragmentation_simulator.cc
@@ -84,7 +84,7 @@ public:
 
   void add_generator(WorkloadGeneratorRef gen);
   int begin_simulation(unsigned iterations, const std::string &img_path,
-                       unsigned img_size);
+                       unsigned img_dimension);
   void init(const std::string &alloc_type, uint64_t size,
             uint64_t min_alloc_size = 4096);
 
@@ -121,7 +121,7 @@ void FragmentationSimulator::add_generator(WorkloadGeneratorRef gen) {
 
 int FragmentationSimulator::begin_simulation(unsigned iterations,
                                              const std::string &img_path,
-                                             unsigned img_size) {
+                                             unsigned img_dimension) {
   ObjectStore::CollectionHandle ch = os->create_new_collection(coll_t::meta());
 
   ObjectStore::Transaction t;
@@ -142,7 +142,7 @@ int FragmentationSimulator::begin_simulation(unsigned iterations,
   os->print_per_object_fragmentation();
   os->print_per_access_fragmentation();
   os->print_allocator_profile();
-  os->output_fragmentation_img(img_path, img_size);
+  os->output_fragmentation_img(img_path, img_dimension);
 
   return 0;
 }

--- a/src/test/objectstore/Fragmentation_simulator.cc
+++ b/src/test/objectstore/Fragmentation_simulator.cc
@@ -239,8 +239,8 @@ struct RandomCWGenerator : public FragmentationSimulator::WorkloadGenerator {
     os->queue_transactions(ch, tls);
     wait_till_finish();
 
-    boost::uniform_int<> u_size(0, _1Mb * 4);
-    boost::uniform_int<> u_offset(0, _1Mb);
+    boost::uniform_int<> u_size(0, _1Mb * 16);
+    boost::uniform_int<> u_offset(0, _1Mb * 32);
 
     for (unsigned i{0}; i < 200; ++i) {
       tls.clear();
@@ -421,7 +421,7 @@ TEST_P(FragmentationSimulator, SimpleCWGenerator) {
 
 TEST_P(FragmentationSimulator, RandomCWGenerator) {
   std::string alloc = GetParam();
-  init(alloc, _1Mb * 256);
+  init(alloc, _1Gb);
   add_generator(std::make_shared<RandomCWGenerator>());
   begin_simulation(1, fmt::format("{}_random.ppm", alloc), 128);
 }

--- a/src/test/objectstore/Fragmentation_simulator.cc
+++ b/src/test/objectstore/Fragmentation_simulator.cc
@@ -25,10 +25,6 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_test
 
-constexpr uint64_t _1Kb = 1024;
-constexpr uint64_t _1Mb = 1024 * _1Kb;
-constexpr uint64_t _1Gb = 1024 * _1Mb;
-
 typedef boost::mt11213b gen_type;
 
 static bufferlist make_bl(size_t len, char c) {

--- a/src/test/objectstore/Fragmentation_simulator.cc
+++ b/src/test/objectstore/Fragmentation_simulator.cc
@@ -416,21 +416,21 @@ TEST_P(FragmentationSimulator, SimpleCWGenerator) {
   std::string alloc = GetParam();
   init(alloc, _1Gb);
   add_generator(std::make_shared<SimpleCWGenerator>());
-  begin_simulation(1, fmt::format("{}_simple.ppm", alloc), 128);
+  begin_simulation(1, fmt::format("{}_simple.ppm", alloc), 0);
 }
 
 TEST_P(FragmentationSimulator, RandomCWGenerator) {
   std::string alloc = GetParam();
-  init(alloc, _1Mb * 16);
+  init(alloc, _1Mb * 256);
   add_generator(std::make_shared<RandomCWGenerator>());
-  begin_simulation(1, fmt::format("{}_random.ppm", alloc), 16);
+  begin_simulation(1, fmt::format("{}_random.ppm", alloc), 128);
 }
 
 TEST_P(FragmentationSimulator, MultiThreadedCWGenerator) {
   std::string alloc = GetParam();
   init(alloc, _1Mb * 4);
   add_generator(std::make_shared<MultiThreadedCWGenerator>());
-  begin_simulation(1, fmt::format("{}_multi.ppm", alloc), 4);
+  begin_simulation(1, fmt::format("{}_multi.ppm", alloc), 0);
 }
 
 // ----------- main -----------

--- a/src/test/objectstore/ObjectStoreImitator.cc
+++ b/src/test/objectstore/ObjectStoreImitator.cc
@@ -275,6 +275,15 @@ void ObjectStoreImitator::output_fragmentation_img(const std::string &path,
   if (path.empty() || n == 0)
     return;
 
+  uint64_t cells = n * n;
+  uint64_t cell_size = alloc->get_capacity() / cells;
+  if (cell_size < alloc->get_block_size()) {
+    derr << "Image dimensions too small, use a different n that's at least the "
+            "allocator block size"
+         << dendl;
+    return;
+  }
+
   ImageGenerator img_gen;
   if (!img_gen.init_out(path)) {
     derr << "Error initializing output file" << dendl;
@@ -305,9 +314,6 @@ void ObjectStoreImitator::output_fragmentation_img(const std::string &path,
       length = 0;
     }
   });
-
-  uint64_t cells = n * n;
-  uint64_t cell_size = alloc->get_capacity() / cells;
 
   auto it = free_extents.rbegin();
   while (it != free_extents.rend()) {

--- a/src/test/objectstore/ObjectStoreImitator.cc
+++ b/src/test/objectstore/ObjectStoreImitator.cc
@@ -298,6 +298,9 @@ void ObjectStoreImitator::output_fragmentation_img(const std::string &path,
         continue;
       }
 
+      if (length < alloc->get_block_size())
+        break;
+
       free_extents.insert(length);
       length = 0;
     }

--- a/src/test/objectstore/ObjectStoreImitator.h
+++ b/src/test/objectstore/ObjectStoreImitator.h
@@ -14,7 +14,10 @@
 #include <algorithm>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
-#define META_POOL_ID ((uint64_t)-1ull)
+constexpr uint64_t META_POOL_ID = ((uint64_t)-1ull);
+constexpr uint64_t _1Kb = 1024;
+constexpr uint64_t _1Mb = 1024 * _1Kb;
+constexpr uint64_t _1Gb = 1024 * _1Mb;
 
 /**
  * ObjectStoreImitator will simulate how BlueStore does IO (as of the time
@@ -215,6 +218,22 @@ private:
     void write_pixel(uint8_t red, uint8_t green, uint8_t blue) {
       unsigned char buf[] = {red, green, blue};
       o.write((char *)buf, sizeof(buf));
+    }
+
+    // 1: blue, 0: red
+    void write_ratio_red_blue(double value) {
+      uint8_t red{}, green{}, blue{};
+      if (value <= 0.5) {
+        value *= 2.0;
+        red = (uint8_t)(255 * (1 - value) + 0.5);
+        green = (uint8_t)(255 * value + 0.5);
+      } else {
+        value = value * 2 - 1;
+        green = (uint8_t)(255 * (1 - value) + 0.5);
+        blue = (uint8_t)(255 * value + 0.5);
+      }
+
+      write_pixel(red, green, blue);
     }
     ~ImageGenerator() = default;
 

--- a/src/test/objectstore/ObjectStoreImitator.h
+++ b/src/test/objectstore/ObjectStoreImitator.h
@@ -210,10 +210,11 @@ private:
     }
     void write_header(int width_, int height_) {
       width = width_, height = height_;
-      o << "P3\n" << fmt::format("{} {}\n", width, height) << "255\n";
+      o << fmt::format("P6\n{} {}\n255\n", width, height);
     }
     void write_pixel(uint8_t red, uint8_t green, uint8_t blue) {
-      o << fmt::format("{} {} {}\n", red, green, blue);
+      unsigned char buf[] = {red, green, blue};
+      o.write((char *)buf, sizeof(buf));
     }
     ~ImageGenerator() = default;
 

--- a/src/test/objectstore/ObjectStoreImitator.h
+++ b/src/test/objectstore/ObjectStoreImitator.h
@@ -219,7 +219,7 @@ private:
       unsigned char buf[] = {red, green, blue};
       o.write((char *)buf, sizeof(buf));
     }
-
+    void write_white_pixel() { write_pixel(255, 255, 255); }
     // 1: blue, 0: red
     void write_ratio_red_blue(double value) {
       uint8_t red{}, green{}, blue{};


### PR DESCRIPTION
## Summary

Outputs an `.ppm` image with each pixel's color representing the size of the available free space extents. Blue is 16Mb, red is 4Kb.

Example:
![image](https://github.com/ceph/ceph/assets/87549865/a78c458d-b0da-459a-b165-eb817f8b4689)

*Note:* This is after converting to `.png` with `convert hybrid_random.ppm -scale 400% hybrid_random.png`

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
