### PR TITLE
test/librbd/fsx: fix wnbd check

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -209,6 +209,8 @@ FILE *	fsxlogf = NULL;
 int badoff = -1;
 int closeopen = 0;
 
+bool wnbd_disk = false;
+
 void
 vwarnc(int code, const char *fmt, va_list ap) {
   fprintf(stderr, "fsx: ");
@@ -2269,7 +2271,7 @@ doread(unsigned offset, unsigned size)
 	int ret;
 
 	offset -= offset % readbdy;
-	if (o_direct || ops == &wnbd_operations)
+	if (o_direct || wnbd_disk)
 		size -= size % readbdy;
 	if (size == 0) {
 		if (!quiet && testcalls > simulatedopcount && !o_direct)
@@ -2359,7 +2361,7 @@ dowrite(unsigned offset, unsigned size)
 	off_t newsize;
 
 	offset -= offset % writebdy;
-	if (o_direct || ops == &wnbd_operations)
+	if (o_direct || wnbd_disk)
 		size -= size % writebdy;
 	if (size == 0) {
 		if (!quiet && testcalls > simulatedopcount && !o_direct)
@@ -3457,6 +3459,7 @@ main(int argc, char **argv)
 		case 'M':
 			prt("rbd-wnbd mode enabled\n");
 			ops = &wnbd_operations;
+			wnbd_disk = true;
 			break;
 #endif
 		case 'L':


### PR DESCRIPTION
When using WNBD, the IO size must be a multiple of the sector size (WNBD only supports 512 at the moment).

We're currently checking the "wnbd_operations" variable, however it's only defined on Windows, leading to a compilation failure on other platforms.

We'll switch back to a separate boolean variable called "wnbd_disk".

Fixes: https://tracker.ceph.com/issues/62475



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
