### PR TITLE
quincy: mon, qa: issue pool application warning even if pool is empty

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1226,8 +1226,8 @@ The health check will be silenced for a specific pool only if
 POOL_APP_NOT_ENABLED
 ____________________
 
-A pool exists that contains one or more objects, but the pool has not been
-tagged for use by a particular application.
+A pool exists but the pool has not been tagged for use by a particular
+application.
 
 To resolve this issue, tag the pool for use by an application. For
 example, if the pool is used by RBD, run the following command:

--- a/qa/standalone/mon/mon-last-epoch-clean.sh
+++ b/qa/standalone/mon/mon-last-epoch-clean.sh
@@ -173,7 +173,7 @@ function TEST_mon_last_clean_epoch() {
   local dir=$1
 
   run_mon $dir a || return 1
-  run_mgr $dir x || return 1
+  run_mgr $dir x --mon-warn-on-pool-no-app=false || return 1
   run_osd $dir 0 || return 1
   run_osd $dir 1 || return 1
   run_osd $dir 2 || return 1

--- a/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
+++ b/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
@@ -4,6 +4,7 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(TOO_FEW_PGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/rados_striper.yaml
+++ b/qa/suites/rados/basic/tasks/rados_striper.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
    client.0:

--- a/qa/suites/rados/basic/tasks/readwrite.yaml
+++ b/qa/suites/rados/basic/tasks/readwrite.yaml
@@ -6,6 +6,8 @@ overrides:
         mon osd initial require min compat client: luminous
       osd:
         osd_discard_disconnected_ops: false
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/basic/tasks/repair_test.yaml
+++ b/qa/suites/rados/basic/tasks/repair_test.yaml
@@ -22,6 +22,7 @@ overrides:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         filestore debug inject read err: true

--- a/qa/suites/rados/basic/tasks/scrub_test.yaml
+++ b/qa/suites/rados/basic/tasks/scrub_test.yaml
@@ -22,6 +22,7 @@ overrides:
     - \(PG_
     - \(OSD_SCRUB_ERRORS\)
     - \(TOO_FEW_PGS\)
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd deep scrub update digest min age: 0

--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -7,6 +7,8 @@ overrides:
     conf:
       osd:
         osd mclock override recovery settings: true
+      mgr:
+        mon warn on pool no app: false
 
 tasks:
   - install:

--- a/qa/suites/rados/mgr/tasks/crash.yaml
+++ b/qa/suites/rados/mgr/tasks/crash.yaml
@@ -12,6 +12,7 @@ tasks:
         - \(RECENT_CRASH\)
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_crash

--- a/qa/suites/rados/mgr/tasks/failover.yaml
+++ b/qa/suites/rados/mgr/tasks/failover.yaml
@@ -11,6 +11,7 @@ tasks:
         - \(PG_
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_failover

--- a/qa/suites/rados/mgr/tasks/insights.yaml
+++ b/qa/suites/rados/mgr/tasks/insights.yaml
@@ -14,6 +14,7 @@ tasks:
         - \(RECENT_CRASH\)
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_insights

--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -21,6 +21,7 @@ tasks:
         - Failed to open Telegraf
         - evicting unresponsive client
         - 1 mgr modules have recently crashed \(RECENT_MGR_MODULE_CRASH\)
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest

--- a/qa/suites/rados/mgr/tasks/per_module_finisher_stats.yaml
+++ b/qa/suites/rados/mgr/tasks/per_module_finisher_stats.yaml
@@ -2,6 +2,8 @@ tasks:
   - install:
   - ceph:
       wait-for-scrub: false
+      log-ignorelist:
+        - \(POOL_APP_NOT_ENABLED\)
   - check-counter:
       counters:
         mgr:

--- a/qa/suites/rados/mgr/tasks/progress.yaml
+++ b/qa/suites/rados/mgr/tasks/progress.yaml
@@ -24,6 +24,7 @@ tasks:
         - \(OSDMAP_FLAGS\)
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_progress

--- a/qa/suites/rados/mgr/tasks/prometheus.yaml
+++ b/qa/suites/rados/mgr/tasks/prometheus.yaml
@@ -11,6 +11,7 @@ tasks:
         - \(PG_
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_prometheus

--- a/qa/suites/rados/mgr/tasks/workunits.yaml
+++ b/qa/suites/rados/mgr/tasks/workunits.yaml
@@ -10,6 +10,7 @@ tasks:
         - \(PG_
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - workunit:
       clients:
         client.0:

--- a/qa/suites/rados/monthrash/thrashers/force-sync-many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/force-sync-many.yaml
@@ -4,6 +4,7 @@ overrides:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(TOO_FEW_PGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - mon_thrash:
     revive_delay: 90

--- a/qa/suites/rados/monthrash/thrashers/many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/many.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         mon client ping interval: 4

--- a/qa/suites/rados/monthrash/thrashers/one.yaml
+++ b/qa/suites/rados/monthrash/thrashers/one.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - mon_thrash:
     revive_delay: 20

--- a/qa/suites/rados/monthrash/thrashers/sync-many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/sync-many.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         paxos min: 10

--- a/qa/suites/rados/monthrash/thrashers/sync.yaml
+++ b/qa/suites/rados/monthrash/thrashers/sync.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         paxos min: 10

--- a/qa/suites/rados/monthrash/workloads/pool-create-delete.yaml
+++ b/qa/suites/rados/monthrash/workloads/pool-create-delete.yaml
@@ -3,7 +3,6 @@ overrides:
     log-ignorelist:
       - slow request
       - overall HEALTH_
-      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/monthrash/workloads/rados_5925.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_5925.yaml
@@ -2,7 +2,6 @@ overrides:
   ceph:
      log-ignorelist:
        - overall HEALTH_
-       - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -9,7 +9,6 @@ overrides:
       - \(SLOW_OPS\)
       - \(MON_DOWN\)
       - \(PG_
-      - \(POOL_APP_NOT_ENABLED\)
       - \(SMALLER_PGP_NUM\)
       - slow request
     conf:

--- a/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
@@ -7,5 +7,6 @@ tasks:
     - clocks not synchronized
     - overall HEALTH_
     - \(MON_CLOCK_SKEW\)
+    - \(POOL_APP_NOT_ENABLED\)
 - mon_clock_skew_check:
     expect-skew: false

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -20,5 +20,6 @@ tasks:
     - \(SLOW_OPS\)
     - No standby daemons available
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
 - mon_clock_skew_check:
     expect-skew: true

--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -7,4 +7,5 @@ tasks:
       - \(PG_AVAILABILITY\)
       - \(SLOW_OPS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - mon_recovery:

--- a/qa/suites/rados/objectstore/backends/objectcacher-stress.yaml
+++ b/qa/suites/rados/objectstore/backends/objectcacher-stress.yaml
@@ -8,6 +8,8 @@ tasks:
 - install:
 - ceph:
     fs: xfs
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/perf/ceph.yaml
+++ b/qa/suites/rados/perf/ceph.yaml
@@ -15,4 +15,5 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - overall HEALTH
+      - \(POOL_APP_NOT_ENABLED\)
 - ssh_keys:

--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -14,6 +14,7 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - \(OSDMAP_FLAGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 - exec:
     mon.a:
       - ceph restful create-key admin

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -15,6 +15,7 @@ overrides:
       - \(OSD_FULL\)
       - \(MDS_READ_ONLY\)
       - \(POOL_FULL\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -8,6 +8,7 @@ tasks:
     fs: xfs
     log-ignorelist:
       - \(PG_AVAILABILITY\)
+      - \(POOL_APP_NOT_ENABLED\)
 - cram:
     clients:
       client.0:

--- a/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -12,6 +12,7 @@ tasks:
     log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       global:
         osd max object name len: 460

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -17,6 +17,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
@@ -17,6 +17,7 @@ tasks:
     log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       global:
         osd max object name len: 460

--- a/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -14,6 +14,7 @@ overrides:
       - \(POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(CACHE_POOL_NEAR_FULL\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -16,6 +16,7 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -22,6 +22,7 @@ tasks:
       - \(PG_
       - \(OSD_
       - \(OBJECT_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
@@ -9,6 +9,8 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/admin-socket.yaml
+++ b/qa/suites/rados/singleton/all/admin-socket.yaml
@@ -11,6 +11,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 - admin_socket:
     osd.0:
       version:

--- a/qa/suites/rados/singleton/all/backfill-toofull.yaml
+++ b/qa/suites/rados/singleton/all/backfill-toofull.yaml
@@ -30,6 +30,7 @@ tasks:
       - \(TOO_FEW_PGS\)
       - Monitor daemon marked osd\.[[:digit:]]+ down, but it is still running
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/dump-stuck.yaml
+++ b/qa/suites/rados/singleton/all/dump-stuck.yaml
@@ -18,4 +18,5 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
 - dump_stuck:

--- a/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
+++ b/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
@@ -29,6 +29,7 @@ tasks:
       - repair
       - slow request
       - unfound
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -26,4 +26,5 @@ tasks:
       - \(OBJECT_
       - \(SLOW_OPS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - ec_lost_unfound:

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -24,4 +24,5 @@ tasks:
       - \(OBJECT_
       - \(SLOW_OPS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - rep_lost_unfound_delete:

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -24,4 +24,5 @@ tasks:
       - \(OBJECT_
       - \(SLOW_OPS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - lost_unfound:

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
@@ -21,6 +21,7 @@ overrides:
     log-ignorelist:
       - \(TOO_FEW_PGS\)
       - \(PENDING_CREATING_PGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
@@ -24,6 +24,7 @@ overrides:
       - \(TOO_FEW_PGS\)
       - \(PG_
       - \(PENDING_CREATING_PGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
@@ -24,6 +24,7 @@ overrides:
       - \(TOO_FEW_PGS\)
       - \(PG_
       - \(PENDING_CREATING_PGS\)
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/mon-auth-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-auth-caps.yaml
@@ -13,6 +13,7 @@ tasks:
     log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
@@ -13,6 +13,7 @@ tasks:
     log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-config.yaml
+++ b/qa/suites/rados/singleton/all/mon-config.yaml
@@ -16,6 +16,8 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/rados/singleton/all/osd-backfill.yaml
@@ -22,6 +22,7 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
@@ -23,6 +23,7 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -24,6 +24,7 @@ tasks:
       - \(OBJECT_DEGRADED\)
       - \(SLOW_OPS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/peer.yaml
+++ b/qa/suites/rados/singleton/all/peer.yaml
@@ -24,4 +24,5 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
 - peer:

--- a/qa/suites/rados/singleton/all/pg-autoscaler-progress-off.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler-progress-off.yaml
@@ -34,6 +34,7 @@ tasks:
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - exec:
     client.0:
     - ceph progress off

--- a/qa/suites/rados/singleton/all/pg-autoscaler.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler.yaml
@@ -30,6 +30,7 @@ tasks:
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -21,6 +21,7 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
 - exec:
     client.0:
       - sudo ceph osd pool create foo 128 128

--- a/qa/suites/rados/singleton/all/rebuild-mondb.yaml
+++ b/qa/suites/rados/singleton/all/rebuild-mondb.yaml
@@ -24,6 +24,7 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         debug auth: 30

--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -10,6 +10,7 @@ tasks:
         - Reduced data availability
         - OSD_.*DOWN
         - \(RECENT_CRASH\)
+        - \(POOL_APP_NOT_ENABLED\)
   - workunit:
       clients:
          client.0:

--- a/qa/suites/rados/singleton/all/test-noautoscale-flag.yaml
+++ b/qa/suites/rados/singleton/all/test-noautoscale-flag.yaml
@@ -30,6 +30,7 @@ overrides:
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
       - slow request
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -38,6 +38,7 @@ tasks:
     - \(TOO_FEW_PGS\)
     - \(POOL_BACKFILLFULL\)
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -35,6 +35,7 @@ tasks:
     - \(OBJECT_
     - \(TOO_FEW_PGS\)
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/singleton/all/thrash-rados/thrash-rados.yaml
+++ b/qa/suites/rados/singleton/all/thrash-rados/thrash-rados.yaml
@@ -17,6 +17,7 @@ tasks:
 - ceph:
     log-ignorelist:
       - but it is still running
+      - \(POOL_APP_NOT_ENABLED\)
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -22,6 +22,7 @@ tasks:
       - slow request
       - overall HEALTH_
       - \(CACHE_POOL_
+      - \(POOL_APP_NOT_ENABLED\)
 - exec:
     client.0:
       - sudo ceph osd pool create base 4

--- a/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
+++ b/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
@@ -30,5 +30,6 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_DEGRADED\)
+      - \(POOL_APP_NOT_ENABLED\)
 - watch_notify_same_primary:
     clients: [client.0]

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         osd pool default ec fast read: true

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - osd_map_cache_size
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         mon min osdmap epochs: 2

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
@@ -8,6 +8,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - slow request
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         osd pool default ec fast read: true

--- a/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     create_rbd_pool: False
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force

--- a/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
@@ -8,6 +8,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-old-clients/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/default.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/thrash-old-clients/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/mapgap.yaml
@@ -4,6 +4,7 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     - osd_map_cache_size
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       mon:
         mon min osdmap epochs: 50

--- a/qa/suites/rados/thrash-old-clients/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/morepggrow.yaml
@@ -12,6 +12,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rados/thrash-old-clients/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/pggrow.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
+    - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
+++ b/qa/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
@@ -3,6 +3,8 @@ overrides:
     conf:
       client.0:
         admin socket: /var/run/ceph/ceph-$name.asok
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - radosbench:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache-snaps-balanced.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-snaps-balanced.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-snaps.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/cache.yaml
+++ b/qa/suites/rados/thrash/workloads/cache.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - must scrub before tier agent can activate
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         # override short_pg_log_entries.yaml (which sets these under [global])

--- a/qa/suites/rados/thrash/workloads/dedup-io-mixed.yaml
+++ b/qa/suites/rados/thrash/workloads/dedup-io-mixed.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
+++ b/qa/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
@@ -2,6 +2,9 @@ override:
   conf:
     osd:
       osd deep scrub update digest min age: 0
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
+++ b/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
@@ -5,6 +5,8 @@ overrides:
         debug ms: 1
         debug objecter: 20
         debug rados: 20
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - full_sequential:
   - radosbench:

--- a/qa/suites/rados/thrash/workloads/radosbench.yaml
+++ b/qa/suites/rados/thrash/workloads/radosbench.yaml
@@ -5,6 +5,8 @@ overrides:
         debug ms: 1
         debug objecter: 20
         debug rados: 20
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - full_sequential:
   - radosbench:

--- a/qa/suites/rados/thrash/workloads/redirect.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/redirect_promote_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect_promote_tests.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/redirect_set_object.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect_set_object.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/set-chunks-read.yaml
+++ b/qa/suites/rados/thrash/workloads/set-chunks-read.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rados/thrash/workloads/small-objects-balanced.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects-balanced.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     crush_tunables: jewel
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/small-objects-localized.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects-localized.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     crush_tunables: jewel
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/small-objects.yaml
+++ b/qa/suites/rados/thrash/workloads/small-objects.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     crush_tunables: jewel
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/snaps-few-objects-balanced.yaml
+++ b/qa/suites/rados/thrash/workloads/snaps-few-objects-balanced.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/snaps-few-objects-localized.yaml
+++ b/qa/suites/rados/thrash/workloads/snaps-few-objects-localized.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/snaps-few-objects.yaml
+++ b/qa/suites/rados/thrash/workloads/snaps-few-objects.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/thrash/workloads/write_fadvise_dontneed.yaml
+++ b/qa/suites/rados/thrash/workloads/write_fadvise_dontneed.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/valgrind-leaks/1-start.yaml
+++ b/qa/suites/rados/valgrind-leaks/1-start.yaml
@@ -11,6 +11,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(PG_
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       global:
         osd heartbeat grace: 40

--- a/qa/suites/rados/verify/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/verify/tasks/rados_cls_all.yaml
@@ -4,6 +4,8 @@ overrides:
       osd:
         osd_class_load_list: "*"
         osd_class_default_list: "*"
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - workunit:
     clients:

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -285,6 +285,7 @@ class PoolTest(DashboardTestCase):
                     'pool': 'dashboard_pool_quota1',
                     'pg_num': '32',
                     'pool_type': 'replicated',
+                    'application_metadata': ['rbd'],
                 },
                 'pool_quotas_to_check': {
                     'quota_max_objects': 0,
@@ -296,6 +297,7 @@ class PoolTest(DashboardTestCase):
                     'pool': 'dashboard_pool_quota2',
                     'pg_num': '32',
                     'pool_type': 'replicated',
+                    'application_metadata': ['rbd'],
                     'quota_max_objects': 1024,
                     'quota_max_bytes': 1000,
                 },

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3333,19 +3333,9 @@ void PGMap::get_health_checks(
     for (auto &it : pools) {
       const pg_pool_t &pool = it.second;
       const string& pool_name = osdmap.get_pool_name(it.first);
-      auto it2 = pg_pool_sum.find(it.first);
-      if (it2 == pg_pool_sum.end()) {
-        continue;
-      }
-      const pool_stat_t *pstat = &it2->second;
-      if (pstat == nullptr) {
-        continue;
-      }
-      const object_stat_sum_t& sum = pstat->stats.sum;
       // application metadata is not encoded until luminous is minimum
       // required release
-      if (sum.num_objects > 0 && pool.application_metadata.empty() &&
-          !pool.is_tier()) {
+      if (pool.application_metadata.empty() && !pool.is_tier()) {
         stringstream ss;
         ss << "application not enabled on pool '" << pool_name << "'";
         detail.push_back(ss.str());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62479

---

backport of https://github.com/ceph/ceph/pull/47560
parent tracker: https://tracker.ceph.com/issues/57097

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh