### PR TITLE
reef: build: opentelemetry-cpp

### DIFF
--- a/cmake/modules/BuildOpentelemetry.cmake
+++ b/cmake/modules/BuildOpentelemetry.cmake
@@ -13,7 +13,12 @@ function(build_opentelemetry)
                                -DWITH_JAEGER=ON
                                -DBUILD_TESTING=OFF
                                -DCMAKE_BUILD_TYPE=Release
-                               -DWITH_EXAMPLES=OFF)
+                               -DWITH_EXAMPLES=OFF
+                               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                               -DCMAKE_AR=${CMAKE_AR})
 
   set(opentelemetry_libs
       ${opentelemetry_BINARY_DIR}/sdk/src/trace/libopentelemetry_trace.a


### PR DESCRIPTION
Building debian packages (make-debs.sh) in a host with several gcc versions triggers an LTO error:

lto1: fatal error: bytecode stream in file
'opentelemetry-cpp/sdk/src/trace/libopentelemetry_trace.a' generated with LTO version 12.0 instead of the expected 11.3.

Fixed by passing the CMake parameter set.

Fixes: https://tracker.ceph.com/issues/62488





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
