### PR TITLE
crimson/common/interruptible_future: deal with exceptions thrown from seastar::future::get() and seastar::thread::yield()

### DIFF
--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -83,6 +83,7 @@ SUBSYS(prioritycache, 1, 5)
 SUBSYS(test, 0, 5)
 SUBSYS(cephfs_mirror, 0, 5)
 SUBSYS(cephsqlite, 0, 5)
+SUBSYS(crimson_interrupt, 0, 5)
 SUBSYS(seastore, 0, 5)       // logs above seastore tm
 SUBSYS(seastore_onode, 0, 5)
 SUBSYS(seastore_odata, 0, 5)

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -114,6 +114,7 @@ struct interrupt_cond_t {
       ref_count);
   }
   void reset() {
+    assert(ref_count >= 1);
     if (--ref_count == 0) {
       INTR_FUT_DEBUG(
 	"{}: clearing interrupt_cond: {},{}",

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -11,7 +11,8 @@
 #include "crimson/common/log.h"
 #include "crimson/common/errorator.h"
 #ifndef NDEBUG
-#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_).trace(FMT_MSG, ##__VA_ARGS__)
+#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(\
+  ceph_subsys_crimson_interrupt).trace(FMT_MSG, ##__VA_ARGS__)
 #else
 #define INTR_FUT_DEBUG(FMT_MSG, ...)
 #endif

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1060,6 +1060,10 @@ struct interruptor
 public:
   using condition = InterruptCond;
 
+  static const void *get_interrupt_cond() {
+    return (const void*)interrupt_cond<InterruptCond>.interrupt_cond.get();
+  }
+
   template <typename FutureType>
   [[gnu::always_inline]]
   static interruptible_future_detail<InterruptCond, FutureType>

--- a/src/crimson/common/log.h
+++ b/src/crimson/common/log.h
@@ -52,37 +52,69 @@ static inline seastar::log_level to_log_level(int level) {
   LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOG(subname_, level_, MSG, ...) \
   LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
+#define LOGI(level_, MSG, ...) \
+  LOCAL_LOGGER.log(level_, "{} {}: " MSG, \
+    interruptor::get_interrupt_cond(), FNAME , ##__VA_ARGS__)
+#define SUBLOGI(subname_, level_, MSG, ...) \
+  LOGGER(subname_).log(level_, "{} {}: " MSG, \
+    interruptor::get_interrupt_cond(), FNAME , ##__VA_ARGS__)
 
 #define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
+#define TRACEI(...) LOGI(seastar::log_level::trace, __VA_ARGS__)
 #define SUBTRACE(subname_, ...) SUBLOG(subname_, seastar::log_level::trace, __VA_ARGS__)
+#define SUBTRACEI(subname_, ...) SUBLOGI(subname_, seastar::log_level::trace, __VA_ARGS__)
 
 #define DEBUG(...) LOG(seastar::log_level::debug, __VA_ARGS__)
+#define DEBUGI(...) LOGI(seastar::log_level::debug, __VA_ARGS__)
 #define SUBDEBUG(subname_, ...) SUBLOG(subname_, seastar::log_level::debug, __VA_ARGS__)
+#define SUBDEBUGI(subname_, ...) SUBLOGI(subname_, seastar::log_level::debug, __VA_ARGS__)
 
 #define INFO(...) LOG(seastar::log_level::info, __VA_ARGS__)
+#define INFOI(...) LOGI(seastar::log_level::info, __VA_ARGS__)
 #define SUBINFO(subname_, ...) SUBLOG(subname_, seastar::log_level::info, __VA_ARGS__)
+#define SUBINFOI(subname_, ...) SUBLOGI(subname_, seastar::log_level::info, __VA_ARGS__)
 
 #define WARN(...) LOG(seastar::log_level::warn, __VA_ARGS__)
+#define WARNI(...) LOGI(seastar::log_level::warn, __VA_ARGS__)
 #define SUBWARN(subname_, ...) SUBLOG(subname_, seastar::log_level::warn, __VA_ARGS__)
+#define SUBWARNI(subname_, ...) SUBLOGI(subname_, seastar::log_level::warn, __VA_ARGS__)
 
 #define ERROR(...) LOG(seastar::log_level::error, __VA_ARGS__)
+#define ERRORI(...) LOGI(seastar::log_level::error, __VA_ARGS__)
 #define SUBERROR(subname_, ...) SUBLOG(subname_, seastar::log_level::error, __VA_ARGS__)
+#define SUBERRORI(subname_, ...) SUBLOGI(subname_, seastar::log_level::error, __VA_ARGS__)
 
 // *DPP macros are intended to take DoutPrefixProvider implementations, but anything with
 // an operator<< will work as a prefix
 
 #define SUBLOGDPP(subname_, level_, MSG, dpp, ...) \
   LOGGER(subname_).log(level_, "{} {}: " MSG, dpp, FNAME , ##__VA_ARGS__)
+#define SUBLOGDPPI(subname_, level_, MSG, dpp, ...) \
+  LOGGER(subname_).log(level_, "{} {}: " MSG, \
+  interruptor::get_interrupt_cond(), dpp, FNAME , ##__VA_ARGS__)
 #define SUBTRACEDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::trace, __VA_ARGS__)
+#define SUBTRACEDPPI(subname_, ...) SUBLOGDPPI(subname_, seastar::log_level::trace, __VA_ARGS__)
 #define SUBDEBUGDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::debug, __VA_ARGS__)
+#define SUBDEBUGDPPI(subname_, ...) SUBLOGDPPI(subname_, seastar::log_level::debug, __VA_ARGS__)
 #define SUBINFODPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::info, __VA_ARGS__)
+#define SUBINFODPPI(subname_, ...) SUBLOGDPPI(subname_, seastar::log_level::info, __VA_ARGS__)
 #define SUBWARNDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::warn, __VA_ARGS__)
+#define SUBWARNDPPI(subname_, ...) SUBLOGDPPI(subname_, seastar::log_level::warn, __VA_ARGS__)
 #define SUBERRORDPP(subname_, ...) SUBLOGDPP(subname_, seastar::log_level::error, __VA_ARGS__)
+#define SUBERRORDPPI(subname_, ...) SUBLOGDPPI(subname_, seastar::log_level::error, __VA_ARGS__)
 
 #define LOGDPP(level_, MSG, dpp, ...) \
   LOCAL_LOGGER.log(level_, "{} {}: " MSG, dpp, FNAME , ##__VA_ARGS__)
+#define LOGDPPI(level_, MSG, dpp, ...) \
+  LOCAL_LOGGER.log(level_, "{} {}: " MSG, \
+  interruptor::get_interrupt_cond(), dpp, FNAME , ##__VA_ARGS__)
 #define TRACEDPP(...) LOGDPP(seastar::log_level::trace, __VA_ARGS__)
+#define TRACEDPPI(...) LOGDPPI(seastar::log_level::trace, __VA_ARGS__)
 #define DEBUGDPP(...) LOGDPP(seastar::log_level::debug, __VA_ARGS__)
+#define DEBUGDPPI(...) LOGDPPI(seastar::log_level::debug, __VA_ARGS__)
 #define INFODPP(...) LOGDPP(seastar::log_level::info, __VA_ARGS__)
+#define INFODPPI(...) LOGDPPI(seastar::log_level::info, __VA_ARGS__)
 #define WARNDPP(...) LOGDPP(seastar::log_level::warn, __VA_ARGS__)
+#define WARNDPPI(...) LOGDPPI(seastar::log_level::warn, __VA_ARGS__)
 #define ERRORDPP(...) LOGDPP(seastar::log_level::error, __VA_ARGS__)
+#define ERRORDPPI(...) LOGDPPI(seastar::log_level::error, __VA_ARGS__)

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -34,6 +34,8 @@ namespace crimson {
   };
 }
 
+SET_SUBSYS(osd);
+
 namespace crimson::osd {
 
 template <class T>
@@ -70,9 +72,11 @@ void BackgroundRecoveryT<T>::dump_detail(Formatter *f) const
 template <class T>
 seastar::future<> BackgroundRecoveryT<T>::start()
 {
-  logger().debug("{}: start", *this);
-
   typename T::IRef ref = static_cast<T*>(this);
+  using interruptor = typename T::interruptor;
+
+  LOG_PREFIX(BackgroundRecoveryT<T>::start);
+  DEBUGDPPI("{}: start", *pg, *this);
   auto maybe_delay = seastar::now();
   if (delay) {
     maybe_delay = seastar::sleep(
@@ -84,14 +88,15 @@ seastar::future<> BackgroundRecoveryT<T>::start()
       return ss.with_throttle_while(
         std::move(trigger),
         this, get_scheduler_params(), [this] {
-          return T::interruptor::with_interruption([this] {
+          return interruptor::with_interruption([this] {
             return do_recovery();
           }, [](std::exception_ptr) {
             return seastar::make_ready_future<bool>(false);
           }, pg);
         }).handle_exception_type([ref, this](const std::system_error& err) {
+	  LOG_PREFIX(BackgroundRecoveryT<T>::start);
           if (err.code() == std::make_error_code(std::errc::interrupted)) {
-            logger().debug("{} recovery interruped: {}", *pg, err.what());
+            DEBUGDPPI("recovery interruped: {}", *pg, err.what());
             return seastar::now();
           }
           return seastar::make_exception_future<>(err);
@@ -115,7 +120,8 @@ UrgentRecovery::UrgentRecovery(
 UrgentRecovery::interruptible_future<bool>
 UrgentRecovery::do_recovery()
 {
-  logger().debug("{}: {}", __func__, *this);
+  LOG_PREFIX(UrgentRecovery::do_recovery);
+  DEBUGDPPI("{}: {}", *pg, __func__, *this);
   if (!pg->has_reset_since(epoch_started)) {
     return with_blocking_event<RecoveryBackend::RecoveryBlockingEvent,
 			       interruptor>([this] (auto&& trigger) {
@@ -180,11 +186,12 @@ PGPeeringPipeline &BackfillRecovery::peering_pp(PG &pg)
 BackfillRecovery::interruptible_future<bool>
 BackfillRecovery::do_recovery()
 {
-  logger().debug("{}", __func__);
+  LOG_PREFIX(BackfillRecovery::do_recovery);
+  DEBUGDPPI("{}", *pg, __func__);
 
   if (pg->has_reset_since(epoch_started)) {
-    logger().debug("{}: pg got reset since epoch_started={}",
-                   __func__, epoch_started);
+    DEBUGDPPI("{}: pg got reset since epoch_started={}",
+		*pg, __func__, epoch_started);
     return seastar::make_ready_future<bool>(false);
   }
   // TODO: limits

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -20,6 +20,7 @@ namespace crimson {
   };
 }
 
+SET_SUBSYS(osd);
 
 namespace crimson::osd {
 
@@ -32,7 +33,8 @@ InternalClientRequest::InternalClientRequest(Ref<PG> pg)
 
 InternalClientRequest::~InternalClientRequest()
 {
-  logger().debug("{}: destroying", *this);
+  LOG_PREFIX(InternalClientRequest::~InternalClientRequest);
+  DEBUGI("{}: destroying", *this);
 }
 
 void InternalClientRequest::print(std::ostream &) const
@@ -53,7 +55,8 @@ seastar::future<> InternalClientRequest::start()
   track_event<StartEvent>();
   return crimson::common::handle_system_shutdown([this] {
     return seastar::repeat([this] {
-      logger().debug("{}: in repeat", *this);
+      LOG_PREFIX(InternalClientRequest::start);
+      DEBUGI("{}: in repeat", *this);
       return interruptor::with_interruption([this]() mutable {
         return enter_stage<interruptor>(
 	  client_pp().wait_for_active
@@ -71,10 +74,12 @@ seastar::future<> InternalClientRequest::start()
           return enter_stage<interruptor>(
             client_pp().get_obc);
         }).then_interruptible([this] () -> PG::load_obc_iertr::future<> {
-          logger().debug("{}: getting obc lock", *this);
+          LOG_PREFIX(InternalClientRequest::start);
+          DEBUGI("{}: getting obc lock", *this);
           return seastar::do_with(create_osd_ops(),
             [this](auto& osd_ops) mutable {
-            logger().debug("InternalClientRequest: got {} OSDOps to execute",
+            LOG_PREFIX(InternalClientRequest::start);
+            DEBUGI("InternalClientRequest: got {} OSDOps to execute",
                            std::size(osd_ops));
             [[maybe_unused]] const int ret = op_info.set_from_op(
               std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -16,6 +16,8 @@ namespace {
   }
 }
 
+SET_SUBSYS(osd);
+
 namespace crimson::osd {
 
 LogMissingRequest::LogMissingRequest(crimson::net::ConnectionRef&& conn,
@@ -63,11 +65,13 @@ ClientRequest::PGPipeline &LogMissingRequest::client_pp(PG &pg)
 seastar::future<> LogMissingRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
-  logger().debug("{}: LogMissingRequest::with_pg", *this);
+  LOG_PREFIX(LogMissingRequest::with_pg);
+  DEBUGI("{}: LogMissingRequest::with_pg", *this);
 
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
-    logger().debug("{}: pg present", *this);
+    LOG_PREFIX(LogMissingRequest::with_pg);
+    DEBUGI("{}: pg present", *this);
     return this->template enter_stage<interruptor>(client_pp(*pg).await_map
     ).then_interruptible([this, pg] {
       return this->template with_blocking_event<

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -20,19 +23,22 @@ namespace crimson {
   };
 }
 
+SET_SUBSYS(osd);
+
 namespace crimson::osd {
 
 seastar::future<> RecoverySubRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pgref)
 {
-  logger().debug("{}: {}", "RecoverySubRequest::with_pg", *this);
-
   track_event<StartEvent>();
   IRef opref = this;
   return interruptor::with_interruption([this, pgref] {
+    LOG_PREFIX(RecoverySubRequest::with_pg);
+    DEBUGI("{}: {}", "RecoverySubRequest::with_pg", *this);
     return pgref->get_recovery_backend()->handle_recovery_op(m, conn
     ).then_interruptible([this] {
-      logger().debug("{}: complete", *this);
+      LOG_PREFIX(RecoverySubRequest::with_pg);
+      DEBUGI("{}: complete", *this);
       return handle.complete();
     });
   }, [](std::exception_ptr) {

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -16,6 +16,8 @@ namespace {
   }
 }
 
+SET_SUBSYS(osd);
+
 namespace crimson::osd {
 
 RepRequest::RepRequest(crimson::net::ConnectionRef&& conn,
@@ -63,10 +65,12 @@ ClientRequest::PGPipeline &RepRequest::client_pp(PG &pg)
 seastar::future<> RepRequest::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {
-  logger().debug("{}: RepRequest::with_pg", *this);
+  LOG_PREFIX(RepRequest::with_pg);
+  DEBUGI("{}: RepRequest::with_pg", *this);
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
-    logger().debug("{}: pg present", *this);
+    LOG_PREFIX(RepRequest::with_pg);
+    DEBUGI("{}: pg present", *this);
     return this->template enter_stage<interruptor>(client_pp(*pg).await_map
     ).then_interruptible([this, pg] {
       return this->template with_blocking_event<


### PR DESCRIPTION
We must catch exceptions thrown by `seastar::future::get()` and `seastar::thread::yield()`, and set interrupt_conditions; otherwise, the global interrupt_cond may be inconsistent.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
