### PR TITLE
crimson/admin/admin_socket: remove path file if it exists

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -237,6 +237,14 @@ seastar::future<> AdminSocket::start(const std::string& path)
   try {
     server_sock = seastar::engine().listen(sock_path);
   } catch (const std::system_error& e) {
+    if (e.code() == std::errc::address_in_use) {
+      logger().debug("{}: Admin Socket socket path={} already exists, retrying",
+                     __func__, path);
+      return seastar::remove_file(path).then([this, path] {
+        server_sock.reset();
+        return start(path);
+      });
+    }
     logger().error("{}: unable to listen({}): {}", __func__, path, e.what());
     server_sock.reset();
     return seastar::make_ready_future<>();


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62525

https://pulpito.ceph.com/matan-2023-08-22_16:08:32-crimson-rados-wip-matanb-crimson-asock-cleanup-distro-crimson-smithi/

Before this patch:
```
DEBUG 2023-08-21 10:37:04,849 [shard 0] osd - start: asok socket path=/var/run/ceph/ceph-osd.1.asok
ERROR 2023-08-21 10:37:04,849 [shard 0] osd - start: unable to listen(/var/run/ceph/ceph-osd.1.asok): posix_listen failed for address /var/run/ceph/ceph-osd.1.asok: Address already in use
```

After:
```
DEBUG 2023-08-22 17:03:45,213 [shard 0] osd - operator(): Admin Socket socket path=/var/run/ceph/ceph-osd.1.asok already exists, removing
DEBUG 2023-08-22 17:03:45,213 [shard 0] osd - operator(): asok socket path=/var/run/ceph/ceph-osd.1.asok
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
