### PR TITLE
os/bluestore: replicate bdev label 

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -442,7 +442,7 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
       break;
     case BDEV_DB:
     case BDEV_NEWDB:
-      reserved = DB_SUPER_RESERVED;
+      reserved = SUPER_RESERVED;
       break;
     case BDEV_SLOW:
       reserved = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -144,7 +144,7 @@ const string BLUESTORE_GLOBAL_STATFS_KEY = "bluestore_statfs";
 
 // Label offsets where they might be replicated. It is possible on previous versions where these offsets
 // were already used so labels won't exist there.
-const vector<uint64_t> BDEV_LABEL_OFFSETS = {0, 1073741824, 107374182400, 1099511627776};
+const vector<uint64_t> bdev_label_offsets = {0, 1073741824, 107374182400, 1099511627776};
 
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
@@ -5481,7 +5481,7 @@ int BlueStore::_replicate_bdev_label(const string &path, bluestore_bdev_label_t 
   }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
   int r = 0;
-  for (uint64_t offset : BDEV_LABEL_OFFSETS) {
+  for (uint64_t offset : bdev_label_offsets) {
     if (alloc_available) {
       if (offset >= bdev->get_size()) {
         break;
@@ -5529,7 +5529,7 @@ int BlueStore::_write_bdev_label(CephContext *cct,
   }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
   int r = 0;
-  for (uint64_t offset : BDEV_LABEL_OFFSETS) {
+  for (uint64_t offset : bdev_label_offsets) {
     r = bl.write_fd(fd, offset);
     if (r < 0) {
       derr << __func__ << " failed to write to " << path
@@ -5555,7 +5555,7 @@ int BlueStore::_read_bdev_label(CephContext* cct, const string &path,
   string error;
   bluestore_bdev_label_t tmp_label;
   size_t crcs_failed = 0;
-  for (uint64_t offset : BDEV_LABEL_OFFSETS) {
+  for (uint64_t offset : bdev_label_offsets) {
     bl.clear();
     int r = bl.pread_file(path.c_str(), offset, BDEV_LABEL_BLOCK_SIZE, &error);
     if (r < 0) {
@@ -5592,7 +5592,7 @@ int BlueStore::_read_bdev_label(CephContext* cct, const string &path,
     *label = tmp_label;
     break;
   }
-  if ((replicated && crcs_failed == 1) || crcs_failed == BDEV_LABEL_OFFSETS.size()) {
+  if ((replicated && crcs_failed == 1) || crcs_failed == bdev_label_offsets.size()) {
     return -EIO;
   }
 
@@ -7864,7 +7864,7 @@ int BlueStore::_mount()
   }
 
   // Allocate bdev replicated label offsets
-  for (uint64_t offset : BDEV_LABEL_OFFSETS) {
+  for (uint64_t offset : bdev_label_offsets) {
     _unalloc_bdev_label_offset(offset);
   }
 
@@ -9306,7 +9306,7 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
     return r;
   }
 
-  for (uint64_t offset : BDEV_LABEL_OFFSETS) {
+  for (uint64_t offset : bdev_label_offsets) {
     if (offset >= bdev->get_size()) {
       break;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9286,6 +9286,15 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
   if (r < 0) {
     return r;
   }
+
+  if (repair) {
+    string p = path + "/block";
+    bluestore_bdev_label_t label;
+    _read_bdev_label(cct, p, &label);
+    _replicate_bdev_label(p, label);
+  }
+
+
   auto close_db = make_scope_guard([&] {
     _close_db_and_around();
   });

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7851,10 +7851,12 @@ int BlueStore::_mount()
     return r;
   }
 
-  string p = path + "/block";
-  bluestore_bdev_label_t label;
-  _read_bdev_label(cct, p, &label);
-  _replicate_bdev_label(path + "/block", label);
+  if (cct->_conf->bluestore_label_replicate_on_mount) {
+    string p = path + "/block";
+    bluestore_bdev_label_t label;
+    _read_bdev_label(cct, p, &label);
+    _replicate_bdev_label(path + "/block", label);
+  }
 
   auto close_db = make_scope_guard([&] {
     if (!mounted) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2683,7 +2683,7 @@ public:
   static int _write_bdev_label(CephContext* cct,
 			       const std::string &path, bluestore_bdev_label_t label);
   static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label, bool replicated=false);
+			      bluestore_bdev_label_t *label, bool recovery_mode=false);
   void _unalloc_bdev_label_offset(uint64_t offset);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2679,15 +2679,15 @@ public:
     return deferred_last_submitted;
   }
 
+  int _replicate_bdev_label(const std::string &path, bluestore_bdev_label_t label);
   static int _write_bdev_label(CephContext* cct,
-			       const std::string &path, bluestore_bdev_label_t label, 
-                               bool replicated=false);
+			       const std::string &path, bluestore_bdev_label_t label);
   static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label, bool replicated=false);
+			      bluestore_bdev_label_t *label);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
-			       bool create, bool replicated=false);
-  int _set_bdev_label_size(const std::string& path, uint64_t size, bool replicated=false);
+			       bool create);
+  int _set_bdev_label_size(const std::string& path, uint64_t size);
 
   int _open_super_meta();
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2679,11 +2679,12 @@ public:
     return deferred_last_submitted;
   }
 
-  int _replicate_bdev_label(const std::string &path, bluestore_bdev_label_t label);
+  int _replicate_bdev_label(const std::string &path, bluestore_bdev_label_t label, bool alloc_available=true);
   static int _write_bdev_label(CephContext* cct,
 			       const std::string &path, bluestore_bdev_label_t label);
   static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label);
+			      bluestore_bdev_label_t *label, bool replicated=false);
+  void _unalloc_bdev_label_offset(uint64_t offset);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2680,13 +2680,14 @@ public:
   }
 
   static int _write_bdev_label(CephContext* cct,
-			       const std::string &path, bluestore_bdev_label_t label);
+			       const std::string &path, bluestore_bdev_label_t label, 
+                               bool replicated=false);
   static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label);
+			      bluestore_bdev_label_t *label, bool replicated=false);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
-			       bool create);
-  int _set_bdev_label_size(const std::string& path, uint64_t size);
+			       bool create, bool replicated=false);
+  int _set_bdev_label_size(const std::string& path, uint64_t size, bool replicated=false);
 
   int _open_super_meta();
 

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -69,7 +69,7 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
 
 // reserved for standalone DB volume:
 // label (4k) + bluefs super (4k), which means we start at 8k.
-#define DB_SUPER_RESERVED  (BDEV_LABEL_BLOCK_SIZE + 4096)
+#define SUPER_RESERVED  (BDEV_LABEL_BLOCK_SIZE + 4096)
 
 
 #endif

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10224,6 +10224,37 @@ TEST_P(StoreTest, CorruptedLabelRecovery) {
   store->mount();
 }
 
+TEST_P(StoreTest, CorruptedLabelFsck) {
+  bufferlist bl;
+  bl.append_zero(16);
+  store->umount();
+  string block_file = data_dir + "/block";
+  int fd = ::open(block_file.c_str(), O_WRONLY|O_CLOEXEC|O_DIRECT);
+  if (fd == -1) {
+    cout << "error opening block file\n";
+    cout << errno;
+    abort();
+  }
+  // let's corrupt first label offset
+  int r = bl.write_fd(fd, 64);
+  if (r < 0) {
+    cout << "error writing block file\n";
+    cout << r << std::endl;
+    cout << errno << std::endl;
+    abort();
+  }
+  r = ::fsync(fd);
+  if (r == -1) {
+    cout << "error fsync block file\n";
+    cout << errno;
+    abort();
+  }
+  ::close(fd);
+  // now it should still go all ok
+  ASSERT_EQ(store->fsck(false), 0);
+  ASSERT_EQ(store->fsck(true), 0);
+  store->mount();
+}
 
 
 TEST_P(StoreTestSpecificAUSize, BluestoreEnforceHWSettingsHdd) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10194,6 +10194,37 @@ TEST_P(StoreTest, FixSMRWritePointer) {
   ASSERT_EQ(0, r);
 }
 
+TEST_P(StoreTest, CorruptedLabelRecovery) {
+  bufferlist bl;
+  bl.append_zero(16);
+  store->umount();
+  string block_file = data_dir + "/block";
+  int fd = ::open(block_file.c_str(), O_WRONLY|O_CLOEXEC|O_DIRECT);
+  if (fd == -1) {
+    cout << "error opening block file\n";
+    cout << errno;
+    abort();
+  }
+  // let's corrupt first label offset
+  int r = bl.write_fd(fd, 64);
+  if (r < 0) {
+    cout << "error writing block file\n";
+    cout << r << std::endl;
+    cout << errno << std::endl;
+    abort();
+  }
+  r = ::fsync(fd);
+  if (r == -1) {
+    cout << "error fsync block file\n";
+    cout << errno;
+    abort();
+  }
+  ::close(fd);
+  // now it should still go all ok
+  store->mount();
+}
+
+
 
 TEST_P(StoreTestSpecificAUSize, BluestoreEnforceHWSettingsHdd) {
   if (string(GetParam()) != "bluestore")

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -8,7 +8,6 @@ class ObjectStore;
 
 class StoreTestFixture : virtual public ::testing::Test {
   const std::string type;
-  const std::string data_dir;
 
   std::stack<std::pair<std::string, std::string>> saved_settings;
   ConfigProxy* conf = nullptr;
@@ -16,6 +15,7 @@ class StoreTestFixture : virtual public ::testing::Test {
   std::string orig_death_test_style;
 
 public:
+  const std::string data_dir;
   std::unique_ptr<ObjectStore> store;
   ObjectStore::CollectionHandle ch;
 

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -107,8 +107,8 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
-  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
+  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - SUPER_RESERVED);
+  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - SUPER_RESERVED);
   fs.umount();
 }
 


### PR DESCRIPTION
Currently this is wip as I'm working on trying to replicate bluestore's label while not messing existing allocations on where replicated label will be placed in case of backports.

The idea is to replicate bluestore's label on different offsets like: 0, 1GiB 10GiB and 1TiB. Currently, only /block is being replicated but it is expected to expand this onto bluefs if possible.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
