### PR TITLE
valgrind: UninitCondition under __run_exit_handlers suppression

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -674,3 +674,15 @@
   fun:EVP_DecryptFinal_ex
   ...
 }
+{
+   tracker #62141 : valgrind: UninitCondition under __run_exit_handlers
+   Memcheck:Cond
+   fun:free
+   fun:free_res
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+


### PR DESCRIPTION
required for CentOS / RHEL 9 & Ubuntu 22.04.1 LTS

Fixes: https://tracker.ceph.com/issues/62141


```
<error>
  <unique>0xe8b91</unique>
  <tid>1</tid>
  <kind>UninitCondition</kind>
  <what>Conditional jump or move depends on uninitialised value(s)</what>
  <stack>
    <frame>
      <ip>0x4847097</ip>
      <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
      <fn>free</fn>
      <dir>/builddir/build/BUILD/valgrind-3.19.0/coregrind/m_replacemalloc</dir>
      <file>vg_replace_malloc.c</file>
      <line>872</line>
    </frame>
    <frame>
      <ip>0x7A36B13</ip>
      <obj>/usr/lib64/libc.so.6</obj>
      <fn>free_res</fn>
    </frame>
    <frame>
      <ip>0x7A36B81</ip>
      <obj>/usr/lib64/libc.so.6</obj>
      <fn>__libc_freeres</fn>
    </frame>
    <frame>
      <ip>0x48391E7</ip>
      <obj>/usr/libexec/valgrind/vgpreload_core-amd64-linux.so</obj>
      <fn>_vgnU_freeres</fn>
      <dir>/builddir/build/BUILD/valgrind-3.19.0/coregrind</dir>
      <file>vg_preloaded.c</file>
      <line>74</line>
    </frame>
    <frame>
      <ip>0x78F2571</ip>
      <obj>/usr/lib64/libc.so.6</obj>
      <fn>__run_exit_handlers</fn>
    </frame>
    <frame>
      <ip>0x78F262F</ip>
      <obj>/usr/lib64/libc.so.6</obj>
      <fn>exit</fn>
    </frame>
    <frame>
      <ip>0x78DAEB6</ip>
      <obj>/usr/lib64/libc.so.6</obj>
      <fn>(below main)</fn>
    </frame>
  </stack>
</error>
```

suppression generated with `--gen-suppressions=all`
```
valgrind --soname-synonyms=somalloc="*tcmalloc*" --vgdb=no --trace-children=no --child-silent-after-fork=yes --num-callers=20 --track-origins=yes --time-stamp=yes  --suppressions=../qa/valgrind.supp --xml=yes --xml-file=./valgrind_log_8000.xml --tool=memcheck --max-threads=2048 --gen-suppressions=all -- ./bin/radosgw ...
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
