### PR TITLE
mgr/dashboard: fix image columns naming

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -142,3 +142,15 @@
     </strong>
   </div>
 </ng-template>
+
+<ng-template #usedTmpl>
+  <span i18n
+        i18n-ngbTooltip
+        ngbTooltip="Stored data">Used</span>
+</ng-template>
+
+<ng-template #totalUsedTmpl>
+  <span i18n
+        i18n-ngbTooltip
+        ngbTooltip="Total space used by the image">Total Used</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -127,7 +127,7 @@ describe('RbdListComponent', () => {
         '.datatable-body-cell-label span'
       );
       // check image with disk usage = null & fast-diff disabled
-      expect(spanWithoutFastDiff[6].textContent).toBe('N/A');
+      expect(spanWithoutFastDiff[4].textContent).toBe('N/A');
 
       images[0]['features_name'] = ['layering', 'exclusive-lock', 'object-map', 'fast-diff'];
       component.images = images;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -69,6 +69,10 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   totalProvisionedNotAvailableTooltipTpl: TemplateRef<any>;
   @ViewChild('forcePromoteConfirmation', { static: true })
   forcePromoteConfirmation: TemplateRef<any>;
+  @ViewChild('usedTmpl', { static: true })
+  usedTmpl: TemplateRef<any>;
+  @ViewChild('totalUsedTmpl', { static: true })
+  totalUsedTmpl: TemplateRef<any>;
 
   permission: Permission;
   tableActions: CdTableAction[];
@@ -272,6 +276,26 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         pipe: this.dimlessBinaryPipe
       },
       {
+        name: $localize`Used`,
+        prop: 'disk_usage',
+        cellClass: 'text-right',
+        flexGrow: 1,
+        pipe: this.dimlessBinaryPipe,
+        sortable: false,
+        headerTemplate: this.usedTmpl,
+        cellTemplate: this.provisionedNotAvailableTooltipTpl
+      },
+      {
+        name: $localize`Total used`,
+        prop: 'total_disk_usage',
+        cellClass: 'text-right',
+        flexGrow: 1,
+        pipe: this.dimlessBinaryPipe,
+        sortable: false,
+        headerTemplate: this.totalUsedTmpl,
+        cellTemplate: this.totalProvisionedNotAvailableTooltipTpl
+      },
+      {
         name: $localize`Objects`,
         prop: 'num_objs',
         flexGrow: 1,
@@ -286,24 +310,6 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         cellClass: 'text-right',
         sortable: false,
         pipe: this.dimlessBinaryPipe
-      },
-      {
-        name: $localize`Provisioned`,
-        prop: 'disk_usage',
-        cellClass: 'text-center',
-        flexGrow: 1,
-        pipe: this.dimlessBinaryPipe,
-        sortable: false,
-        cellTemplate: this.provisionedNotAvailableTooltipTpl
-      },
-      {
-        name: $localize`Total provisioned`,
-        prop: 'total_disk_usage',
-        cellClass: 'text-center',
-        flexGrow: 1,
-        pipe: this.dimlessBinaryPipe,
-        sortable: false,
-        cellTemplate: this.totalProvisionedNotAvailableTooltipTpl
       },
       {
         name: $localize`Parent`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -118,7 +118,7 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
         pipe: this.dimlessBinaryPipe
       },
       {
-        name: $localize`Provisioned`,
+        name: $localize`Used`,
         prop: 'disk_usage',
         flexGrow: 1,
         cellClass: 'text-right',


### PR DESCRIPTION
Before:
![image](https://github.com/ceph/ceph/assets/106810838/9155e506-10fd-488e-8a41-aa67d56e2986)

Now:
![image](https://github.com/ceph/ceph/assets/106810838/c4f41512-9ceb-44e6-b134-2189255790ee)

Changed `Provisioned` and `Total provisioned` columns naming to `Used` and `Total used` since those refer to the disk usage. 


Fixes: https://tracker.ceph.com/issues/62551
Signed-off-by: Pedro Gonzalez Gomez <pegonzal@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
