### PR TITLE
pacific: libcephsqlite: fill 0s in unread portion of buffer

### DIFF
--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -295,7 +295,7 @@ static int Read(sqlite3_file *file, void *buf, int len, sqlite_int64 off)
     auto end = ceph::coarse_mono_clock::now();
     getdata(f->vfs).logger->tinc(P_OPF_READ, end-start);
     if (rc < len) {
-      memset(buf, 0, len-rc);
+      memset((unsigned char*)buf+rc, 0, len-rc);
       return SQLITE_IOERR_SHORT_READ;
     } else {
       return SQLITE_OK;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62555

---

backport of https://github.com/ceph/ceph/pull/53053
parent tracker: https://tracker.ceph.com/issues/62492

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh