### PR TITLE
reef: cephadm: delete /tmp/cephadm-<fsid> when removing the cluster

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -7547,7 +7547,7 @@ def command_rm_cluster(ctx):
             p.unlink()
 
     # cleanup remaining ceph directories
-    ceph_dirs = [f'/run/ceph/{ctx.fsid}', f'/tmp/var/lib/ceph/{ctx.fsid}', f'/var/run/ceph/{ctx.fsid}']
+    ceph_dirs = [f'/run/ceph/{ctx.fsid}', f'/tmp/cephadm-{ctx.fsid}', f'/var/run/ceph/{ctx.fsid}']
     for dd in ceph_dirs:
         shutil.rmtree(dd, ignore_errors=True)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61542

---

backport of https://github.com/ceph/ceph/pull/51701
parent tracker: https://tracker.ceph.com/issues/61361

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh