### PR TITLE
reef: python-common/drive_group: handle fields outside of 'spec' even when 'spec' is provided

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -288,8 +288,8 @@ class DriveGroupSpec(ServiceSpec):
         # spec: was not mandatory in octopus
         if 'spec' in args:
             args['spec'].update(cls._drive_group_spec_from_json(s_id, args['spec']))
-        else:
-            args.update(cls._drive_group_spec_from_json(s_id, args))
+        args.update(cls._drive_group_spec_from_json(
+                    s_id, {k: v for k, v in args.items() if k != 'spec'}))
 
         return super(DriveGroupSpec, cls)._from_json_impl(args)
 

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -35,6 +35,18 @@ data_devices:
   - path: /dev/sda
     crush_device_class: ssd"""
     ),
+    (
+        """service_type: osd
+service_id: testing_drivegroup
+placement:
+  host_pattern: hostname
+spec:
+  osds_per_device: 2
+data_devices:
+  paths:
+  - path: /dev/sda
+    crush_device_class: hdd"""
+    ),
 ])
 def test_DriveGroup(test_input):
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61684

---

backport of https://github.com/ceph/ceph/pull/51861
parent tracker: https://tracker.ceph.com/issues/61533

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh