### PR TITLE
crimson/osd/backfill_state: fixes two corner cases in backfilling

### DIFF
--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -73,6 +73,8 @@ BackfillState::Initial::Initial(my_context ctx)
   }
   ceph_assert(peering_state().get_backfill_targets().size());
   ceph_assert(!backfill_state().last_backfill_started.is_max());
+  backfill_state().replicas_in_backfill =
+    peering_state().get_backfill_targets().size();
 }
 
 boost::statechart::result
@@ -470,8 +472,6 @@ BackfillState::Waiting::react(ObjectPushed evt)
                                backfill_state().backfill_info,
                                backfill_state().peer_backfill_info)) {
     return transit<Enqueuing>();
-  } else if (backfill_state().progress_tracker->tracked_objects_completed()) {
-    return transit<Done>();
   } else {
     // we still have something to wait on
     logger().debug("Waiting::react() on ObjectPushed; still waiting");

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -36,6 +36,9 @@ public:
   void on_backfill_reserved();
   void dispatch_backfill_event(
     boost::intrusive_ptr<const boost::statechart::event_base> evt);
+  void backfill_target_finished() {
+    backfill_state->backfill_target_done();
+  }
 
   seastar::future<> stop() { return seastar::now(); }
 private:

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -217,8 +217,9 @@ RecoveryBackend::scan_for_backfill(
       bi.end = std::move(next);
       bi.version = pg.get_info().last_update;
       bi.objects = std::move(*version_map);
-      logger().debug("{} BackfillInterval filled, leaving",
-                     "scan_for_backfill");
+      logger().debug("{} BackfillInterval filled, leaving, {}",
+                     "scan_for_backfill",
+		     bi);
       return seastar::make_ready_future<BackfillInterval>(std::move(bi));
     });
   });

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -117,8 +117,8 @@ RecoveryBackend::handle_backfill_finish_ack(
   logger().debug("{}", __func__);
   ceph_assert(pg.is_primary());
   ceph_assert(crimson::common::local_conf()->osd_kill_backfill_at != 3);
-  // TODO:
-  // finish_recovery_op(hobject_t::get_max());
+  auto recovery_handler = pg.get_recovery_handler();
+  recovery_handler->backfill_target_finished();
   return seastar::now();
 }
 

--- a/src/test/crimson/test_backfill.cc
+++ b/src/test/crimson/test_backfill.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <algorithm>
 #include <cstdlib>
 #include <deque>
@@ -308,6 +311,9 @@ void BackfillFixture::maybe_flush()
 void BackfillFixture::update_peers_last_backfill(
   const hobject_t& new_last_backfill)
 {
+  if (new_last_backfill.is_max()) {
+    schedule_event(crimson::osd::BackfillState::RequestDone{});
+  }
 }
 
 bool BackfillFixture::budget_available() const
@@ -356,6 +362,7 @@ TEST(backfill, same_primary_same_replica)
   ).get_result();
 
   cluster_fixture.next_round();
+  cluster_fixture.next_round();
   EXPECT_CALL(cluster_fixture, backfilled);
   cluster_fixture.next_round();
   EXPECT_TRUE(cluster_fixture.all_stores_look_like(reference_store));
@@ -377,6 +384,7 @@ TEST(backfill, one_empty_replica)
   cluster_fixture.next_round();
   cluster_fixture.next_round();
   cluster_fixture.next_round(2);
+  cluster_fixture.next_round();
   EXPECT_CALL(cluster_fixture, backfilled);
   cluster_fixture.next_round();
   EXPECT_TRUE(cluster_fixture.all_stores_look_like(reference_store));


### PR DESCRIPTION
1. BACKFILL_FINISH messages may be dropped by replicas, if osdmap updates get processed by replicas before BACKFILL_FINISH messages; in this case, the peering for the osdmap updates will find replicas' backfills not finished, and try to do another round of backfilling, but, since there's nothing to be backfilled, there's no way to update peer backfill infos, which means the pg may never go clean.
2. The last round of scan may produce no objects that need to be backfilled; in this case, the current implementation doesn't set backfill infos for the primary and replicas and leaves the pg as unclean forever.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
