### PR TITLE
pacific: python-common: drive_selection: fix KeyError when osdspec_affinity is not set

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -131,9 +131,10 @@ class DriveSelection(object):
             if not disk.available and disk.ceph_device and disk.lvs:
                 other_osdspec_affinity = ''
                 for lv in disk.lvs:
-                    if lv['osdspec_affinity'] != self.spec.service_id:
-                        other_osdspec_affinity = lv['osdspec_affinity']
-                        break
+                    if 'osdspec_affinity' in lv.keys():
+                        if lv['osdspec_affinity'] != self.spec.service_id:
+                            other_osdspec_affinity = lv['osdspec_affinity']
+                            break
                 if other_osdspec_affinity:
                     logger.debug("{} is already used in spec {}, "
                                  "skipping it.".format(disk.path, other_osdspec_affinity))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62591

---

backport of https://github.com/ceph/ceph/pull/52532
parent tracker: https://tracker.ceph.com/issues/58946

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh