### PR TITLE
pacific: mds/Server: mark a cap acquisition throttle event in the request

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4749,6 +4749,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
       if (logger)
           logger->inc(l_mdss_cap_acquisition_throttle);
 
+      mdr->mark_event("cap_acquisition_throttle");
       mds->timer.add_event_after(caps_throttle_retry_request_timeout, new C_MDS_RetryRequest(mdcache, mdr));
       return;
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62572
Signed-off-by: Leonid Usov <leonid.usov@ibm.com>
(cherry picked from commit 749c7706762025163d37481eb7316e2a79035344)

Parent ticket: https://tracker.ceph.com/issues/59067
Parent PR: https://github.com/ceph/ceph/pull/52676

---

This PR doesn't include the `snapdiff` modification and the corresponding tests, since this functionality isn't available in pacific

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
