### PR TITLE
reef: mgr/dashboard: disable protect if layering is not enabled on the image

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
@@ -44,7 +44,9 @@ export class RbdSnapshotActionsModel {
       visible: (selection: CdTableSelection) =>
         selection.hasSingleSelection && !selection.first().is_protected,
       name: actionLabels.PROTECT,
-      disable: (selection: CdTableSelection) => this.disableForMirrorSnapshot(selection)
+      disable: (selection: CdTableSelection) =>
+        this.disableForMirrorSnapshot(selection) ||
+        this.getDisableDesc(selection, this.featuresName)
     };
     this.unprotect = {
       permission: 'update',
@@ -58,7 +60,7 @@ export class RbdSnapshotActionsModel {
       permission: 'create',
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
-        this.getCloneDisableDesc(selection, this.featuresName) ||
+        this.getDisableDesc(selection, this.featuresName) ||
         this.disableForMirrorSnapshot(selection),
       icon: Icons.clone,
       name: actionLabels.CLONE
@@ -107,10 +109,10 @@ export class RbdSnapshotActionsModel {
     ];
   }
 
-  getCloneDisableDesc(selection: CdTableSelection, featuresName: string[]): boolean | string {
+  getDisableDesc(selection: CdTableSelection, featuresName: string[]): boolean | string {
     if (selection.hasSingleSelection && !selection.first().cdExecuting) {
       if (!featuresName?.includes('layering')) {
-        return $localize`Parent image must support Layering`;
+        return $localize`The layering feature needs to be enabled on parent image`;
       }
 
       if (this.cloneFormatVersion === 1 && !selection.first().is_protected) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -288,7 +288,7 @@ describe('RbdSnapshotListComponent', () => {
 
     it('should be disabled with version 1 and protected false', () => {
       const selection = new CdTableSelection([{ name: 'someName', is_protected: false }]);
-      const disableDesc = actions.getCloneDisableDesc(selection, ['layering']);
+      const disableDesc = actions.getDisableDesc(selection, ['layering']);
       expect(disableDesc).toBe('Snapshot must be protected in order to clone.');
     });
 
@@ -299,8 +299,25 @@ describe('RbdSnapshotListComponent', () => {
     ])('should be enabled with version %d and protected %s', (version, is_protected) => {
       actions.cloneFormatVersion = version;
       const selection = new CdTableSelection([{ name: 'someName', is_protected: is_protected }]);
-      const disableDesc = actions.getCloneDisableDesc(selection, ['layering']);
+      const disableDesc = actions.getDisableDesc(selection, ['layering']);
       expect(disableDesc).toBe(false);
+    });
+  });
+
+  describe('protect button disable state', () => {
+    let actions: RbdSnapshotActionsModel;
+
+    beforeEach(() => {
+      fixture.detectChanges();
+      const rbdService = TestBed.inject(RbdService);
+      const actionLabelsI18n = TestBed.inject(ActionLabelsI18n);
+      actions = new RbdSnapshotActionsModel(actionLabelsI18n, [], rbdService);
+    });
+
+    it('should be disabled if layering not supported', () => {
+      const selection = new CdTableSelection([{ name: 'someName', is_protected: false }]);
+      const disableDesc = actions.getDisableDesc(selection, ['deep-flatten', 'fast-diff']);
+      expect(disableDesc).toBe('The layering feature needs to be enabled on parent image');
     });
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62600

---

backport of https://github.com/ceph/ceph/pull/53066
parent tracker: https://tracker.ceph.com/issues/62498

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh