### PR TITLE
quincy: mds: acquire inode snaplock in open

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4377,6 +4377,7 @@ void Server::handle_client_open(MDRequestRef& mdr)
   }
 
   MutationImpl::LockOpVec lov;
+  lov.add_rdlock(&cur->snaplock);
 
   unsigned mask = req->head.args.open.mask;
   if (mask) {
@@ -4548,11 +4549,6 @@ void Server::handle_client_openc(MDRequestRef& mdr)
   if (!excl && !dnl->is_null()) {
     // it existed.
     ceph_assert(mdr.get()->is_rdlocked(&dn->lock));
-
-    MutationImpl::LockOpVec lov;
-    lov.add_rdlock(&dnl->get_inode()->snaplock);
-    if (!mds->locker->acquire_locks(mdr, lov))
-      return;
 
     handle_client_open(mdr);
     return;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62516

---

backport of https://github.com/ceph/ceph/pull/52520
parent tracker: https://tracker.ceph.com/issues/62058

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh