### PR TITLE
quincy: make-dist: download liburing from kernel.io instead of github

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -196,8 +196,7 @@ download_boost $boost_version 953db31e016db7bb207f11432bef7df100516eeb746843fa04
                https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa
-download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \
-                  https://github.com/axboe/liburing/archive \
+download_liburing 0.7 05d0cf8493d573c76b11abfcf34aabc7153affebe17ff95f9ae88b0de062a59d \
                   https://git.kernel.dk/cgit/liburing/snapshot
 pmdk_version=1.10
 download_pmdk $pmdk_version 08dafcf94db5ac13fac9139c92225d9aa5f3724ea74beee4e6ca19a01a2eb20c \


### PR DESCRIPTION
Backport of #53194