### PR TITLE
quincy: mgr/dashboard: set CORS header for unauthorized access

### DIFF
--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -183,6 +183,16 @@ class AuthManagerTool(cherrypy.Tool):
             if user:
                 self._check_authorization(user.username)
                 return
+
+        resp_head = cherrypy.response.headers
+        req_head = cherrypy.request.headers
+        req_header_cross_origin_url = req_head.get('Access-Control-Allow-Origin')
+        cross_origin_urls = mgr.get_module_option('cross_origin_url', '')
+        cross_origin_url_list = [url.strip() for url in cross_origin_urls.split(',')]
+
+        if req_header_cross_origin_url in cross_origin_url_list:
+            resp_head['Access-Control-Allow-Origin'] = req_header_cross_origin_url
+
         self.logger.debug('Unauthorized access to %s',
                           cherrypy.url(relative='server'))
         raise cherrypy.HTTPError(401, 'You are not authorized to access '


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62619

---

backport of https://github.com/ceph/ceph/pull/53171
parent tracker: https://tracker.ceph.com/issues/62612

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh