### PR TITLE
pacific: qa/suites/upgrade/pacific-p2p: skip TestClsRbd.mirror_snapshot test

### DIFF
--- a/qa/suites/upgrade/pacific-p2p/pacific-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/pacific-p2p/pacific-p2p-parallel/point-to-point-upgrade.yaml
@@ -123,7 +123,7 @@ workload_pacific:
          - rados/test.sh
          - cls
        env:
-         CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.snapshots_namespaces'
+         CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
    - print: "**** done rados/test.sh &  cls workload_pacific"
    - sequential:
      - rgw: [client.0]

--- a/qa/suites/upgrade/pacific-p2p/pacific-p2p-stress-split/4-workload/rbd-cls.yaml
+++ b/qa/suites/upgrade/pacific-p2p/pacific-p2p-stress-split/4-workload/rbd-cls.yaml
@@ -7,4 +7,6 @@ stress-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
 - print: "**** done cls/test_cls_rbd.sh 4-workload"


### PR DESCRIPTION
The behavior of the class method changed in reef; the change was backported to pacific and quincy.  An older pacific binary used against newer pacific OSDs produces an expected failure:

    [ RUN      ] TestClsRbd.mirror_snapshot
    .../ceph-16.2.7/src/test/cls_rbd/test_cls_rbd.cc:2278: Failure
    Expected equality of these values:
      -85
      mirror_image_snapshot_unlink_peer(&ioctx, oid, 1, "peer2")
        Which is: 0
    [  FAILED  ] TestClsRbd.mirror_snapshot (30 ms)

TestClsRbd.snapshots_namespaces test was removed in commit 4ad9d565a15c ("librbd: simplified retrieving snapshots from image header") many years ago.

Fixes: https://tracker.ceph.com/issues/62586