### PR TITLE
mds: use LogSegment dump for debugging

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -679,17 +679,15 @@ void MDLog::trim(int m)
     
     if (pending_events.count(ls->seq) ||
 	ls->end > safe_pos) {
-      dout(5) << "trim segment " << ls->seq << "/" << ls->offset << ", not fully flushed yet, safe "
+      dout(5) << "trim " << *ls << " is not fully flushed yet: safe "
 	      << journaler->get_write_safe_pos() << " < end " << ls->end << dendl;
       break;
     }
 
     if (expiring_segments.count(ls)) {
-      dout(5) << "trim already expiring segment " << ls->seq << "/" << ls->offset
-	      << ", " << ls->num_events << " events" << dendl;
+      dout(5) << "trim already expiring " << *ls << dendl;
     } else if (expired_segments.count(ls)) {
-      dout(5) << "trim already expired segment " << ls->seq << "/" << ls->offset
-	      << ", " << ls->num_events << " events" << dendl;
+      dout(5) << "trim already expired " << *ls << dendl;
     } else {
       ceph_assert(expiring_segments.count(ls) == 0);
       new_expiring_segments++;
@@ -753,17 +751,15 @@ int MDLog::trim_all()
 
     // Caller should have flushed journaler before calling this
     if (pending_events.count(ls->seq)) {
-      dout(5) << __func__ << ": segment " << ls->seq << " has pending events" << dendl;
+      dout(5) << __func__ << ": " << *ls << " has pending events" << dendl;
       submit_mutex.unlock();
       return -CEPHFS_EAGAIN;
     }
 
     if (expiring_segments.count(ls)) {
-      dout(5) << "trim already expiring segment " << ls->seq << "/" << ls->offset
-	      << ", " << ls->num_events << " events" << dendl;
+      dout(5) << "trim already expiring " << *ls << dendl;
     } else if (expired_segments.count(ls)) {
-      dout(5) << "trim already expired segment " << ls->seq << "/" << ls->offset
-	      << ", " << ls->num_events << " events" << dendl;
+      dout(5) << "trim already expired " << *ls << dendl;
     } else {
       ceph_assert(expiring_segments.count(ls) == 0);
       expiring_segments.insert(ls);
@@ -790,11 +786,11 @@ void MDLog::try_expire(LogSegment *ls, int op_prio)
   ls->try_to_expire(mds, gather_bld, op_prio);
 
   if (gather_bld.has_subs()) {
-    dout(5) << "try_expire expiring segment " << ls->seq << "/" << ls->offset << dendl;
+    dout(5) << "try_expire expiring " << *ls << dendl;
     gather_bld.set_finisher(new C_MaybeExpiredSegment(this, ls, op_prio));
     gather_bld.activate();
   } else {
-    dout(10) << "try_expire expired segment " << ls->seq << "/" << ls->offset << dendl;
+    dout(10) << "try_expire expired " << *ls << dendl;
     submit_mutex.lock();
     ceph_assert(expiring_segments.count(ls));
     expiring_segments.erase(ls);
@@ -814,8 +810,7 @@ void MDLog::_maybe_expired(LogSegment *ls, int op_prio)
     return;
   }
 
-  dout(10) << "_maybe_expired segment " << ls->seq << "/" << ls->offset
-	   << ", " << ls->num_events << " events" << dendl;
+  dout(10) << "_maybe_expired " << *ls << dendl;
   try_expire(ls, op_prio);
 }
 
@@ -830,10 +825,10 @@ void MDLog::_trim_expired_segments()
   uint64_t end = 0;
   for (auto it = segments.begin(); it != segments.end(); ++it) {
     auto& [seq, ls] = *it;
-    dout(20) << __func__ << ": examining seq=" << seq << " ls=" << *ls << dendl;
+    dout(20) << __func__ << ": examining " << *ls << dendl;
 
     if (auto msit = major_segments.find(seq); msit != major_segments.end() && end > 0) {
-      dout(10) << __func__ << ": expiring up to this major segment " << seq << dendl;
+      dout(10) << __func__ << ": expiring up to this major segment seq=" << seq << dendl;
       uint64_t expire_pos = 0;
       for (auto& [seq2, ls2] : segments) {
         if (seq <= seq2) {
@@ -896,12 +891,10 @@ void MDLog::_expired(LogSegment *ls)
 {
   ceph_assert(ceph_mutex_is_locked_by_me(submit_mutex));
 
-  dout(5) << "_expired segment " << ls->seq << "/" << ls->offset
-	  << ", " << ls->num_events << " events" << dendl;
+  dout(5) << "_expired " << *ls << dendl;
 
   if (!mds_is_shutting_down && ls == peek_current_segment()) {
-    dout(5) << "_expired not expiring " << ls->seq << "/" << ls->offset
-	    << ", last one and !mds_is_shutting_down" << dendl;
+    dout(5) << "_expired not expiring current segment, and !mds_is_shutting_down" << dendl;
   } else {
     // expired.
     expired_segments.insert(ls);
@@ -1512,11 +1505,10 @@ void MDLog::standby_trim_segments()
 
   bool removed_segment = false;
   while (have_any_segments()) {
-    LogSegment *seg = get_oldest_segment();
-    dout(10) << " segment seq=" << seg->seq << " " << seg->offset <<
-      "~" << seg->end - seg->offset << dendl;
+    LogSegment *ls = get_oldest_segment();
+    dout(10) << " maybe trim " << *ls << dendl;
 
-    if (seg->end > expire_pos) {
+    if (ls->end > expire_pos) {
       dout(10) << " won't remove, not expired!" << dendl;
       break;
     }
@@ -1527,7 +1519,7 @@ void MDLog::standby_trim_segments()
     }
 
     dout(10) << " removing segment" << dendl;
-    mds->mdcache->standby_trim_segment(seg);
+    mds->mdcache->standby_trim_segment(ls);
     remove_oldest_segment();
     removed_segment = true;
   }


### PR DESCRIPTION
Looks like:

```
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700  5 mds.0.log try_expire expiring LogSegment(2/0x400030 events=34)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 20 mds.0.log _trim_expired_segments: examining LogSegment(1/0x400000 events=1)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 10 mds.0.log _trim_expired_segments: maybe expiring LogSegment(1/0x400000 events=1)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 20 mds.0.log _trim_expired_segments: examining LogSegment(2/0x400030 events=34)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 10 mds.0.log _trim_expired_segments: expiring up to this major segment seq=2
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 20 mds.0.log _trim_expired_segments: expiring LogSegment(1/0x400000 events=1)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.937+0000 7fddc11e9700 10 mds.0.log _trim_expired_segments waiting for expiry LogSegment(2/0x400030 events=34)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.938+0000 7fddc11e9700 20 mds.0.log _trim_expired_segments: examining LogSegment(2/0x400030 events=34)
./remote/smithi159/log/dc13d9da-5179-11ee-9ab7-7b867c8bd7da/ceph-mds.b.log.gz:2023-09-12T14:47:52.938+0000 7fddc11e9700 10 mds.0.log _trim_expired_segments waiting for expiry LogSegment(2/0x400030 events=34)
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
