### PR TITLE
reef: mgr/dashboard: fix rgw page issues when hostname not resolvable 

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -19,7 +19,9 @@ class RgwControllerTestCase(ControllerTestCase):
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(return_value=True))
     @patch.object(RgwClient, '_is_system_user', Mock(return_value=True))
-    def test_status_available(self):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_status_available(self, send_command):
+        send_command.return_value = ''
         self._get('/test/ui-api/rgw/status')
         self.assertStatus(200)
         self.assertJsonBody({'available': True, 'message': None})
@@ -27,7 +29,9 @@ class RgwControllerTestCase(ControllerTestCase):
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(
         side_effect=RequestException('My test error')))
-    def test_status_online_check_error(self):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_status_online_check_error(self, send_command):
+        send_command.return_value = ''
         self._get('/test/ui-api/rgw/status')
         self.assertStatus(200)
         self.assertJsonBody({'available': False,
@@ -35,7 +39,9 @@ class RgwControllerTestCase(ControllerTestCase):
 
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(return_value=False))
-    def test_status_not_online(self):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_status_not_online(self, send_command):
+        send_command.return_value = ''
         self._get('/test/ui-api/rgw/status')
         self.assertStatus(200)
         self.assertJsonBody({'available': False,
@@ -44,7 +50,9 @@ class RgwControllerTestCase(ControllerTestCase):
     @patch.object(RgwClient, '_get_user_id', Mock(return_value='fake-user'))
     @patch.object(RgwClient, 'is_service_online', Mock(return_value=True))
     @patch.object(RgwClient, '_is_system_user', Mock(return_value=False))
-    def test_status_not_system_user(self):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_status_not_system_user(self, send_command):
+        send_command.return_value = ''
         self._get('/test/ui-api/rgw/status')
         self.assertStatus(200)
         self.assertJsonBody({'available': False,
@@ -64,7 +72,9 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
 
     @patch('dashboard.services.rgw_client.RgwClient._get_user_id', Mock(
         return_value='dummy_admin'))
-    def test_list(self):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_list(self, send_command):
+        send_command.return_value = ''
         RgwStub.get_daemons()
         RgwStub.get_settings()
         mgr.list_servers.return_value = [{
@@ -159,7 +169,9 @@ class RgwUserControllerTestCase(ControllerTestCase):
         self.assertJsonBody(['test1', 'test2', 'test3', 'admin'])
 
     @patch('dashboard.controllers.rgw.RgwRESTController.proxy')
-    def test_user_list_duplicate_marker(self, mock_proxy):
+    @patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_user_list_duplicate_marker(self, mock_proxy, send_command):
+        send_command.return_value = ''
         mock_proxy.side_effect = [{
             'count': 3,
             'keys': ['test1', 'test2', 'test3'],

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -14,6 +14,8 @@ from ..tests import CLICommandTestMixin, RgwStub
 
 @patch('dashboard.services.rgw_client.RgwClient._get_user_id', Mock(
     return_value='dummy_admin'))
+@patch('dashboard.services.ceph_service.CephService.send_command', Mock(
+    return_value=''))
 class RgwClientTest(TestCase, CLICommandTestMixin):
     _dashboard_user_realm1_access_key = 'VUOFXZFK24H81ISTVBTR'
     _dashboard_user_realm1_secret_key = '0PGsCvXPGWS3AGgibUZEcd9efLrbbshlUkY3jruR'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62631

---

backport of https://github.com/ceph/ceph/pull/53133
parent tracker: https://tracker.ceph.com/issues/62396

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh