### PR TITLE
os/bluestore: cut down the bluefs compact frequency

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -16,6 +16,9 @@
 #define dout_subsys ceph_subsys_bluefs
 #undef dout_prefix
 #define dout_prefix *_dout << "bluefs "
+
+#define FLUSH_COMPACT_INTERVAL 86400
+
 using TOPNSPC::common::cmd_getval;
 
 using std::byte;
@@ -3697,7 +3700,10 @@ int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
   if (old_dirty_seq) {
     _flush_and_sync_log_LD(old_dirty_seq);
   }
-  _maybe_compact_log_LNF_NF_LD_D();
+  if (next_flush_compact <= ceph::coarse_real_clock::now()) {
+    _maybe_compact_log_LNF_NF_LD_D();
+    next_flush_compact = ceph::coarse_real_clock::now() + make_timespan(FLUSH_COMPACT_INTERVAL);
+  }
 
   return 0;
 }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -412,6 +412,8 @@ private:
   // used to trigger zeros into read (debug / verify)
   std::atomic<uint64_t> inject_read_zeros{0};
 
+  ceph::coarse_real_time next_flush_compact;
+
   void _init_logger();
   void _shutdown_logger();
   void _update_logger_stats();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -413,7 +413,6 @@ private:
   std::atomic<uint64_t> inject_read_zeros{0};
 
   ceph::coarse_real_time next_flush_compact;
-
   void _init_logger();
   void _shutdown_logger();
   void _update_logger_stats();
@@ -445,7 +444,7 @@ private:
   int _signal_dirty_to_log_D(FileWriter *h);
   int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_F(FileWriter *h, bool force);
   uint64_t _flush_special(FileWriter *h);
   int _fsync(FileWriter *h);
 


### PR DESCRIPTION
In https://github.com/ceph/ceph/pull/35473,  adding compact judgement in flush and fsync of bluefs, which leading to more bluefs log compact. In fact, besides sync_metadata, one log compact daily is enough in fsync. And there is no need to call compact function in flush as a result of compact in fsync daily.

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>