### PR TITLE
reef: mgr/dashboard: cleanup rbd-mirror process in dashboard e2e  

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -39,7 +39,7 @@ start_ceph() {
     # start rbd-mirror daemon in the cluster
     KEY=$(ceph auth get client.admin --format=json | jq -r .[0].key)
     MON_CLUSTER_1=$(grep "mon host" ${FULL_PATH_BUILD_DIR}/run/1/ceph.conf | awk '{print $4}')
-    ${FULL_PATH_BUILD_DIR}/bin/rbd-mirror --mon_host $MON_CLUSTER_1 --key $KEY -c ${FULL_PATH_BUILD_DIR}/run/1/ceph.conf &
+    ${FULL_PATH_BUILD_DIR}/bin/rbd-mirror --mon_host $MON_CLUSTER_1 --key $KEY -c ${FULL_PATH_BUILD_DIR}/run/1/ceph.conf
 
     set +x
 }
@@ -50,6 +50,11 @@ stop() {
         for cluster in ${CLUSTERS[@]}; do
             ../src/mstop.sh $cluster
         done
+        pids=$(pgrep rbd-mirror)
+        if [ -n "$pids" ]; then
+            echo Killing rbd-mirror processes: $pids
+            kill -9 $pids
+        fi
     fi
     exit $1
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62642

---

backport of https://github.com/ceph/ceph/pull/53211
parent tracker: https://tracker.ceph.com/issues/61703

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh