### PR TITLE
quincy: mgr/dashboard: n/a entries behind primary snapshot mode

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
@@ -64,3 +64,13 @@
                      [showValue]="true"></ngb-progressbar>
   </div>
 </ng-template>
+
+<ng-template #entriesBehindPrimaryTpl
+             let-row="row"
+             let-value="value">
+  <span *ngIf="row.mirror_mode === 'journal'">
+    {{ value }}
+  </span>
+  <span *ngIf="row.mirror_mode === 'snapshot'"
+        ngbTooltip="Not available with mirroring snapshot mode">-</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
@@ -17,6 +17,8 @@ export class ImageListComponent implements OnInit, OnDestroy {
   syncTmpl: TemplateRef<any>;
   @ViewChild('progressTmpl', { static: true })
   progressTmpl: TemplateRef<any>;
+  @ViewChild('entriesBehindPrimaryTpl', { static: true })
+  entriesBehindPrimaryTpl: TemplateRef<any>;
 
   subs: Subscription;
 
@@ -66,7 +68,12 @@ export class ImageListComponent implements OnInit, OnDestroy {
         flexGrow: 2
       },
       { prop: 'bytes_per_second', name: $localize`Bytes per second`, flexGrow: 2 },
-      { prop: 'entries_behind_primary', name: $localize`Entries behind primary`, flexGrow: 2 }
+      {
+        prop: 'entries_behind_primary',
+        name: $localize`Entries behind primary`,
+        cellTemplate: this.entriesBehindPrimaryTpl,
+        flexGrow: 2
+      }
     ];
 
     this.image_ready.columns = [


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62599

---

backport of https://github.com/ceph/ceph/pull/52005
parent tracker: https://tracker.ceph.com/issues/62576

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh