### PR TITLE
osd: Add force-reremove-snap mon command

### DIFF
--- a/qa/suites/rados/thrash/workloads/pool-snaps-few-objects-redelete.yaml
+++ b/qa/suites/rados/thrash/workloads/pool-snaps-few-objects-redelete.yaml
@@ -1,0 +1,23 @@
+overrides:
+  conf:
+    osd:
+      osd deep scrub update digest min age: 0
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+tasks:
+- thrashosds:
+    chance_force_reremove_snap: 0.5
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 50
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50
+      copy_from: 50

--- a/qa/suites/rados/thrash/workloads/snaps-few-objects-redelete.yaml
+++ b/qa/suites/rados/thrash/workloads/snaps-few-objects-redelete.yaml
@@ -1,0 +1,19 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
+tasks:
+- thrashosds:
+    chance_force_reremove_snap: 0.5
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 50
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50
+      copy_from: 50

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -234,6 +234,7 @@ class OSDThrasher(Thrasher):
         self.chance_thrash_pg_upmap_items = self.config.get('chance_thrash_pg_upmap', 1.0)
         self.random_eio = self.config.get('random_eio')
         self.chance_force_recovery = self.config.get('chance_force_recovery', 0.3)
+        self.chance_force_reremove_snap = self.config.get('chance_force_reremove_snap', 0)
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * len(num_osds)
@@ -779,6 +780,25 @@ class OSDThrasher(Thrasher):
         else:
            self.cancel_force_recovery()
 
+    def force_reremove_snap(self):
+        """
+        Force reremove already removed snapshots.
+        Please note that internal snap ids are the ones being
+        used to detect purges snaps. The internal snap ids are
+        *not* the same snap ids used by thrasher.
+        """
+        self.log('force_reremove_snap')
+        pool = self.ceph_manager.get_pool()
+        if pool is None:
+            self.log('Failed to get pool')
+            return
+        try:
+            self.ceph_manager.raw_cluster_cmd('osd', 'pool',
+                                              'force-reremove-snap',
+                                              pool)
+        except CommandFailedError:
+            self.log('Failed to force reremove snap, ignoring')
+
     def all_up(self):
         """
         Make sure all osds are up and not out.
@@ -1229,6 +1249,8 @@ class OSDThrasher(Thrasher):
             actions.append((self.thrash_pg_upmap_items, self.chance_thrash_pg_upmap_items,))
         if self.chance_force_recovery > 0:
             actions.append((self.force_cancel_recovery, self.chance_force_recovery))
+        if self.chance_force_reremove_snap > 0:
+            actions.append((self.force_reremove_snap, self.chance_force_reremove_snap))
 
         for key in ['heartbeat_inject_failure', 'filestore_inject_stall']:
             for scenario in [

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1071,6 +1071,17 @@ COMMAND("osd pool rmsnap "
 	"name=pool,type=CephPoolname "
 	"name=snap,type=CephString",
 	"remove snapshot <snap> from <pool>", "osd", "rw")
+COMMAND("osd pool force-reremove-snap "
+	"name=pool,type=CephPoolname "
+	"name=lower_snapid_bound,type=CephInt,range=0,req=false "
+	"name=upper_snapid_bound,type=CephInt,range=0,req=false "
+	"name=dry_run,type=CephBool,req=false",
+	"Forces re-removal of already removed snapshots in the range "
+	"[lower_snapid_bound, upper_snapid_bound) on pool <pool> in "
+	"order to cause OSDs to re-trim them after fixing malformed "
+	"snap_mapper entries. See bug #62596 for details."
+	"See also OSD admin socket command fix_malformed_snapmapper_keys.",
+	"osd", "rw")
 COMMAND("osd pool ls "
 	"name=detail,type=CephChoices,strings=detail,req=false",
 	"list pools", "osd", "r")


### PR DESCRIPTION
This PR is taken out of #52971 since this is an independent change that may be useful in various possible repair cases.
Splitting this change will also allow better testing coverage for each part of the original fix before merging.

---

```
Forces re-removal of already removed snapshots in the range
[lower_snapid_bound, upper_snapid_bound) on pool <pool>
in order to cause OSDs to re-trim them after fixing malformed
snap_mapper entries.
See bug #62596 for details.
See also OSD admin socket command fix_malformed_snapmapper_keys.
```

Fixes: Part 2/3 - https://tracker.ceph.com/issues/62596


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
