### PR TITLE
quincy: mgr/dashboard: fix image columns naming

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -142,3 +142,15 @@
     </strong>
   </div>
 </ng-template>
+
+<ng-template #usedTmpl>
+  <span i18n
+        i18n-ngbTooltip
+        ngbTooltip="Stored data">Used</span>
+</ng-template>
+
+<ng-template #totalUsedTmpl>
+  <span i18n
+        i18n-ngbTooltip
+        ngbTooltip="Total space used by the image">Total Used</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -127,7 +127,7 @@ describe('RbdListComponent', () => {
         '.datatable-body-cell-label span'
       );
       // check image with disk usage = null & fast-diff disabled
-      expect(spanWithoutFastDiff[6].textContent).toBe('N/A');
+      expect(spanWithoutFastDiff[4].textContent).toBe('N/A');
 
       images[0]['features_name'] = ['layering', 'exclusive-lock', 'object-map', 'fast-diff'];
       component.images = images;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -69,6 +69,10 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   totalProvisionedNotAvailableTooltipTpl: TemplateRef<any>;
   @ViewChild('forcePromoteConfirmation', { static: true })
   forcePromoteConfirmation: TemplateRef<any>;
+  @ViewChild('usedTmpl', { static: true })
+  usedTmpl: TemplateRef<any>;
+  @ViewChild('totalUsedTmpl', { static: true })
+  totalUsedTmpl: TemplateRef<any>;
 
   permission: Permission;
   tableActions: CdTableAction[];
@@ -272,6 +276,26 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         pipe: this.dimlessBinaryPipe
       },
       {
+        name: $localize`Used`,
+        prop: 'disk_usage',
+        cellClass: 'text-right',
+        flexGrow: 1,
+        pipe: this.dimlessBinaryPipe,
+        sortable: false,
+        headerTemplate: this.usedTmpl,
+        cellTemplate: this.provisionedNotAvailableTooltipTpl
+      },
+      {
+        name: $localize`Total used`,
+        prop: 'total_disk_usage',
+        cellClass: 'text-right',
+        flexGrow: 1,
+        pipe: this.dimlessBinaryPipe,
+        sortable: false,
+        headerTemplate: this.totalUsedTmpl,
+        cellTemplate: this.totalProvisionedNotAvailableTooltipTpl
+      },
+      {
         name: $localize`Objects`,
         prop: 'num_objs',
         flexGrow: 1,
@@ -286,24 +310,6 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         cellClass: 'text-right',
         sortable: false,
         pipe: this.dimlessBinaryPipe
-      },
-      {
-        name: $localize`Provisioned`,
-        prop: 'disk_usage',
-        cellClass: 'text-center',
-        flexGrow: 1,
-        pipe: this.dimlessBinaryPipe,
-        sortable: false,
-        cellTemplate: this.provisionedNotAvailableTooltipTpl
-      },
-      {
-        name: $localize`Total provisioned`,
-        prop: 'total_disk_usage',
-        cellClass: 'text-center',
-        flexGrow: 1,
-        pipe: this.dimlessBinaryPipe,
-        sortable: false,
-        cellTemplate: this.totalProvisionedNotAvailableTooltipTpl
       },
       {
         name: $localize`Parent`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -118,7 +118,7 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
         pipe: this.dimlessBinaryPipe
       },
       {
-        name: $localize`Provisioned`,
+        name: $localize`Used`,
         prop: 'disk_usage',
         flexGrow: 1,
         cellClass: 'text-right',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62656

---

backport of https://github.com/ceph/ceph/pull/53100
parent tracker: https://tracker.ceph.com/issues/62551

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh