### PR TITLE
pacific: cephfs_mirror: correctly set top level dir permissions

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1261,3 +1261,38 @@ class TestMirroring(CephFSTestCase):
         self.verify_snapshot('d2', 'snap0')
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_local_and_remote_dir_root_mode(self):
+        log.debug('reconfigure client auth caps')
+        cid = self.mount_b.client_id
+        data_pool = self.backup_fs.get_data_pool_name()
+        self.mds_cluster.mon_manager.raw_cluster_cmd_result(
+            'auth', 'caps', f"client.{cid}",
+            'mds', 'allow rw',
+            'mon', 'allow r',
+            'osd', f"allow rw pool={data_pool}, allow rw pool={data_pool}")
+
+        log.debug(f'mounting filesystem {self.secondary_fs_name}')
+        self.mount_b.umount_wait()
+        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+
+        self.mount_a.run_shell(["mkdir", "l1"])
+        self.mount_a.run_shell(["mkdir", "l1/.snap/snap0"])
+        self.mount_a.run_shell(["chmod", "go-rwx", "l1"])
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, '/l1')
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        time.sleep(60)
+        self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
+                               "client.mirror_remote@ceph", '/l1', 'snap0', 1)
+
+        mode_local = self.mount_a.run_shell(["stat", "--format=%A", "l1"]).stdout.getvalue().strip()
+        mode_remote = self.mount_b.run_shell(["stat", "--format=%A", "l1"]).stdout.getvalue().strip()
+
+        self.assertTrue(mode_local == mode_remote, f"mode mismatch, local mode: {mode_local}, remote mode: {mode_remote}")
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.mount_a.run_shell(["rmdir", "l1/.snap/snap0"])
+        self.mount_a.run_shell(["rmdir", "l1"])

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1125,6 +1125,27 @@ int PeerReplayer::pre_sync_check_and_open_handles(
   return 0;
 }
 
+// sync the mode of the remote dir_root with that of the local dir_root
+int PeerReplayer::sync_perms(const std::string& path) {
+  int r = 0;
+  struct ceph_statx tstx;
+
+  r = ceph_statx(m_local_mount, path.c_str(), &tstx, CEPH_STATX_MODE,
+		 AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  if (r < 0) {
+    derr << ": failed to fetch stat for local path: "
+	 << cpp_strerror(r) << dendl;
+    return r;
+  }
+  r = ceph_chmod(m_remote_mount, path.c_str(), tstx.stx_mode);
+  if (r < 0) {
+    derr << ": failed to set mode for remote path: "
+	 << cpp_strerror(r) << dendl;
+    return r;
+  }
+  return 0;
+}
+
 void PeerReplayer::post_sync_close_handles(const FHandles &fh) {
   dout(20) << dendl;
 
@@ -1496,8 +1517,13 @@ void PeerReplayer::run(SnapshotReplayerThread *replayer) {
         dout(5) << ": picked dir_root=" << *dir_root << dendl;
         int r = register_directory(*dir_root, replayer);
         if (r == 0) {
-          sync_snaps(*dir_root, locker);
-          unregister_directory(*dir_root);
+	  r = sync_perms(*dir_root);
+	  if (r < 0) {
+	    _inc_failed_count(*dir_root);
+	  } else {
+	    sync_snaps(*dir_root, locker);
+	  }
+	  unregister_directory(*dir_root);
         }
       }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -311,6 +311,7 @@ private:
                      const FHandles &fh, bool need_data_sync, bool need_attr_sync);
   int copy_to_remote(const std::string &dir_root, const std::string &epath, const struct ceph_statx &stx,
                      const FHandles &fh);
+  int sync_perms(const std::string& path);
 };
 
 } // namespace mirror


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59001

---

backport of https://github.com/ceph/ceph/pull/50049
parent tracker: https://tracker.ceph.com/issues/58678

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh