### PR TITLE
mgr/dashboard: replace sync progress bar with last synced timestamp in rgw multisite sync status card

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-sync-data-info/rgw-sync-data-info.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-sync-data-info/rgw-sync-data-info.component.html
@@ -17,6 +17,9 @@
   </ul>
 </ng-template>
 <ul class="me-2">
+  <ng-template #upToDateTpl>
+    <li class="badge badge-success">Up to Date</li>
+  </ng-template>
   <ng-template #showStatus>
     <a *ngIf="zone.syncstatus !== 'Not Syncing From Zone'"
        class="lead text-primary"
@@ -40,24 +43,9 @@
        placement="top"
        popoverClass="rgw-overview-card-popover"
        i18n>Error</a></li>
-  <li class="mt-4 w-100 text-center"
-      *ngIf="zone.syncstatus === 'preparing for full sync'">
-    <b>Full sync progress:</b>
-    <cd-usage-bar *ngIf="zone.fullSync"
-                  [total]="zone.fullSync[1]"
-                  [showMultisiteTooltip]="true"
-                  [used]="zone.fullSync[0]"
-                  [title]="shards"
-                  decimals="2">
-    </cd-usage-bar></li>
-  <li class="mt-4 w-100 text-center"
-      *ngIf="zone.incrementalSync">
-  <b>Sync Progress:</b>
-  <cd-usage-bar *ngIf="zone.incrementalSync"
-                [total]="zone.totalShards"
-                [showMultisiteTooltip]="true"
-                [used]="zone.usedShards"
-                [title]="shards"
-                decimals="2">
-  </cd-usage-bar></li>
+  <li class="mt-4 fw-bold">
+    Last Synced:
+  </li>
+  <li class="badge badge-info"
+      *ngIf="zone.timestamp; else upToDateTpl">{{ zone.timestamp | relativeDate }}</li>
 </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-sync-metadata-info/rgw-sync-metadata-info.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-sync-metadata-info/rgw-sync-metadata-info.component.html
@@ -7,6 +7,7 @@
 <span *ngIf="metadataSyncInfo !== 'no sync (zone is master)'">
   <ng-template #metadataSyncPopover>
     <ul class="text-center">
+      <li><h5><b>Metadata Sync Status:</b></h5></li>
       <li *ngFor="let status of metadataSyncInfo.fullSyncStatus">
         <span *ngIf="!status?.includes(metadataSyncInfo.syncstatus) && !status?.includes('failed') && !status?.includes('error')">
           <span *ngIf="status?.includes(':')">
@@ -23,6 +24,9 @@
     </ul>
   </ng-template>
   <ul class="me-2">
+    <ng-template #upToDateTpl>
+      <li class="badge badge-success">Up to Date</li>
+    </ng-template>
     <ng-template #showMetadataStatus>
       <a *ngIf="metadataSyncInfo.syncstatus !== 'Not Syncing From Zone'"
          class="lead text-primary"
@@ -46,25 +50,10 @@
          placement="top"
          popoverClass="rgw-overview-card-popover"
          i18n>Error</a></li>
-    <li class="mt-4 setwidth text-center"
-        *ngIf="metadataSyncInfo.syncstatus === 'preparing for full sync'">
-      <b>Full sync progress:</b>
-    <cd-usage-bar *ngIf="metadataSyncInfo.fullSync"
-                  [total]="metadataSyncInfo.fullSync[1]"
-                  [showMultisiteTooltip]="true"
-                  [used]="metadataSyncInfo.fullSync[0]"
-                  [title]="shards"
-                  decimals="2">
-    </cd-usage-bar></li>
-    <li class="mt-4 setwidth text-center"
-        *ngIf="metadataSyncInfo.incrementalSync">
-    <b>Sync Progress:</b>
-    <cd-usage-bar *ngIf="metadataSyncInfo.incrementalSync"
-                  [total]="metadataSyncInfo.totalShards"
-                  [showMultisiteTooltip]="true"
-                  [used]="metadataSyncInfo.usedShards"
-                  [title]="shards"
-                  decimals="2">
-    </cd-usage-bar></li>
+    <li class="mt-4 fw-bold">
+      Last Synced:
+    </li>
+    <li class="badge badge-info"
+        *ngIf="metadataSyncInfo.timestamp; else upToDateTpl">{{ metadataSyncInfo.timestamp | relativeDate }}</li>
   </ul>
 </span>

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1593,25 +1593,17 @@ class RgwMultisite:
 
         metadata_sync_data = {}
         metadata_sync_info_array = metadata_sync_info.split('\n') if metadata_sync_info else []
-        metadata_sync_data['syncstatus'] = metadata_sync_info_array[1].strip() if len(metadata_sync_info_array) > 1 else None  # noqa E501  #pylint: disable=line-too-long
+        metadata_sync_data['syncstatus'] = metadata_sync_info_array[0].strip() if len(metadata_sync_info_array) > 0 else None  # noqa E501  #pylint: disable=line-too-long
 
         for item in metadata_sync_info_array:
             self.extract_metadata_sync_info(metadata_sync_data, item)
 
-        metadata_sync_data['totalShards'] = metadata_sync_data['incrementalSync'][1] if len(metadata_sync_data['incrementalSync']) > 1 else 0  # noqa E501  #pylint: disable=line-too-long
-        metadata_sync_data['usedShards'] = int(metadata_sync_data['incrementalSync'][1]) - int(metadata_sync_data['behindShards'])  # noqa E501  #pylint: disable=line-too-long
+        metadata_sync_data['fullSyncStatus'] = metadata_sync_info_array
         return metadata_sync_data
 
     def extract_metadata_sync_info(self, metadata_sync_data, item):
-        if 'full sync' in item and item.endswith('shards'):
-            metadata_sync_data['fullSync'] = self.get_shards_info(item.strip()).split('/')
-        elif 'incremental sync' in item:
-            metadata_sync_data['incrementalSync'] = self.get_shards_info(item.strip()).split('/')
-        elif 'data is behind' in item or 'data is caught up' in item:
-            metadata_sync_data['dataSyncStatus'] = item.strip()
-
-            if 'data is behind' in item:
-                metadata_sync_data['behindShards'] = self.get_behind_shards(item)
+        if 'oldest incremental change not applied:' in item:
+            metadata_sync_data['timestamp'] = item.split('applied:')[1].split()[0].strip()
 
     def extract_datasync_info(self, data):
         metadata_sync_infoormation = data.split('metadata sync')[1] if 'metadata sync' in data else None  # noqa E501  #pylint: disable=line-too-long
@@ -1629,15 +1621,6 @@ class RgwMultisite:
         replica_zone_data['fullSyncStatus'] = datasync_info_array
         for item in datasync_info_array:
             self.extract_metadata_sync_info(replica_zone_data, item)
-
-        if 'incrementalSync' in replica_zone_data:
-            replica_zone_data['totalShards'] = int(replica_zone_data['incrementalSync'][1]) if len(replica_zone_data['incrementalSync']) > 1 else 0  # noqa E501  #pylint: disable=line-too-long
-
-            if 'behindShards' in replica_zone_data:
-                replica_zone_data['usedShards'] = (int(replica_zone_data['incrementalSync'][1]) - int(replica_zone_data['behindShards'])) if len(replica_zone_data['incrementalSync']) > 1 else 0  # noqa E501  #pylint: disable=line-too-long
-            else:
-                replica_zone_data['usedShards'] = replica_zone_data['totalShards']
-
         return replica_zone_data
 
     def get_primary_zonedata(self, data):
@@ -1648,21 +1631,3 @@ class RgwMultisite:
             return match.group(1)
 
         return ''
-
-    def get_shards_info(self, data):
-        regex = r'\d+/\d+'
-        match = re.search(regex, data)
-
-        if match:
-            return match.group(0)
-
-        return None
-
-    def get_behind_shards(self, data):
-        regex = r'on\s+(\d+)\s+shards'
-        match = re.search(regex, data, re.IGNORECASE)
-
-        if match:
-            return match.group(1)
-
-        return None


### PR DESCRIPTION
The current implementation of the multisite sync status card in rgw overview dashboard includes a sync progress bar which is being calculated by the difference of total incremental shards and the behind shards..On discussion with the RGW team it was suggested that this info can be misleading to the user as its not the best way to calculate the sync progress. One other suggestion was to replace this sync progress bar with a timestamp that is the relative time difference between the current time and the `oldest incremental change not applied`. This PR intends to replace the sync progress bar with Last Synced timestamp

[Screencast from 2023-09-04 14-36-31.webm](https://github.com/ceph/ceph/assets/66050535/fc6ff02d-d07f-462e-b82f-97fd5981b952)


Fixes: https://tracker.ceph.com/issues/62684





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
