### PR TITLE
win32_build.sh: use ENABLE_SHARED=ON by default

### DIFF
--- a/README.windows.rst
+++ b/README.windows.rst
@@ -54,7 +54,7 @@ EMBEDDED_DBG_SYM   By default, the generated
                    symbols. If this flag is set,
                    the debug symbols will remain
                    embedded in the executables.
-ENABLE_SHARED      Dynamically link Ceph libs.      False
+ENABLE_SHARED      Dynamically link Ceph libs.      ON
 =================  ===============================  ===============================
 
 The following command will build the binaries and add them to a zip archive

--- a/mingw_conf.sh
+++ b/mingw_conf.sh
@@ -17,6 +17,9 @@
 SCRIPT_DIR="$(dirname "$BASH_SOURCE")"
 SCRIPT_DIR="$(realpath "$SCRIPT_DIR")"
 
+MINGW_CMAKE_FILE=${MINGW_CMAKE_FILE:-}
+MINGW_POSIX_FLAGS=${MINGW_POSIX_FLAGS:-}
+
 if [[ -n $USE_MINGW_LLVM ]]; then
     MINGW_LLVM_DIR=${MINGW_LLVM_DIR:-"$SCRIPT_DIR/build.deps/mingw-llvm"}
 fi

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -58,7 +58,6 @@ if [[ -z $OS ]]; then
         ;;
     esac
 fi
-export OS="$OS"
 
 # The main advantages of mingw-llvm:
 # * not affected by the libstdc++/winpthread rw lock bugs
@@ -68,7 +67,7 @@ TOOLCHAIN=${TOOLCHAIN:-"mingw-llvm"}
 case "$TOOLCHAIN" in
     mingw-llvm)
         echo "Using mingw-llvm."
-        export USE_MINGW_LLVM=1
+        USE_MINGW_LLVM=1
         ;;
     mingw-gcc)
         echo "Using mingw-gcc"
@@ -93,9 +92,7 @@ if [[ -z $CMAKE_BUILD_TYPE ]]; then
   CMAKE_BUILD_TYPE=Release
 fi
 
-# Some tests can't use shared libraries yet due to unspecified dependencies.
-# We'll do a static build by default for now.
-ENABLE_SHARED=${ENABLE_SHARED:-OFF}
+ENABLE_SHARED=${ENABLE_SHARED:-ON}
 
 binDir="$BUILD_DIR/bin"
 strippedBinDir="$BUILD_DIR/bin_stripped"
@@ -145,8 +142,12 @@ cd $BUILD_DIR
 
 if [[ ! -f ${depsToolsetDir}/completed ]]; then
     echo "Preparing dependencies: $DEPS_DIR. Log: ${BUILD_DIR}/build_deps.log"
-    NUM_WORKERS=$NUM_WORKERS DEPS_DIR=$DEPS_DIR OS="$OS"\
-        "$SCRIPT_DIR/win32_deps_build.sh" | tee "${BUILD_DIR}/build_deps.log"
+    NUM_WORKERS=$NUM_WORKERS \
+        DEPS_DIR=$DEPS_DIR \
+        OS="$OS" \
+        ENABLE_SHARED=$ENABLE_SHARED \
+        USE_MINGW_LLVM=$USE_MINGW_LLVM \
+            "$SCRIPT_DIR/win32_deps_build.sh" | tee "${BUILD_DIR}/build_deps.log"
 fi
 
 # Due to distribution specific mingw settings, the mingw.cmake file

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 SCRIPT_DIR="$(dirname "$BASH_SOURCE")"
 SCRIPT_DIR="$(realpath "$SCRIPT_DIR")"
 
-USE_MINGW_LLVM=${USE_MINGW_LLVM:-}
-ENABLE_SHARED=${ENABLE_SHARED:-OFF}
-
-num_vcpus=$(nproc)
-NUM_WORKERS=${NUM_WORKERS:-$num_vcpus}
-
-DEPS_DIR="${DEPS_DIR:-$SCRIPT_DIR/build.deps}"
 depsSrcDir="$DEPS_DIR/src"
 depsToolsetDir="$DEPS_DIR/mingw"
 
@@ -50,11 +43,6 @@ dokanLibDir="${depsToolsetDir}/dokany/lib"
 mingwLlvmUrl="https://github.com/mstorsjo/llvm-mingw/releases/download/20230320/llvm-mingw-20230320-msvcrt-ubuntu-18.04-x86_64.tar.xz"
 mingwLlvmSha256Sum="bc97745e702fb9e8f2a16f7d09dd5061ceeef16554dd12e542f619ce937e8d7a"
 mingwLlvmDir="${DEPS_DIR}/mingw-llvm"
-
-# Allow for OS specific customizations through the OS flag (normally
-# passed through from win32_build).
-# Valid options are currently "ubuntu", "rhel", and "suse".
-OS=${OS:-"ubuntu"}
 
 function _make() {
   make -j $NUM_WORKERS $@


### PR DESCRIPTION
The Windows build script uses static linking by default, the reason being that some tests were failing to build otherwise, mostly due to unspecified dependencies.

Now that the issue was addressed, we can enable dynamic linking by default.

Worth mentioning that the Ceph MSI build script already uses dynamic linking.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
