### PR TITLE
rgw: add support key rotation for sse-s3 vault integration

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -270,6 +270,7 @@ SSE-S3 Settings
 .. confval:: rgw_crypt_sse_s3_vault_ssl_cacert
 .. confval:: rgw_crypt_sse_s3_vault_ssl_clientcert
 .. confval:: rgw_crypt_sse_s3_vault_ssl_clientkey
+.. confval:: rgw_crypt_sse_s3_vault_key_rotation_period
 
 
 QoS Settings

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3320,6 +3320,15 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_sse_s3_vault_key_rotation_period
+  type: secs
+  level: advanced
+  desc: The period at which this key should be rotated automatically
+  long_desc: Setting this to "0" (the default) will disable automatic key rotation.
+    This value cannot be shorter than one hour.
+  default: 0
+  services:
+  - rgw
 - name: rgw_list_bucket_min_readahead
   type: int
   level: advanced

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -149,7 +149,7 @@ static bool string_ends_maybe_slash(std::string_view hay,
 
 template<typename E, typename A = ZeroPoolAllocator>
 static inline void
-add_name_val_to_obj(std::string &n, std::string &v, rapidjson::GenericValue<E,A> &d,
+add_name_val_to_obj(const std::string &n, const std::string &v, rapidjson::GenericValue<E,A> &d,
   A &allocator)
 {
   rapidjson::GenericValue<E,A> name, val;
@@ -160,7 +160,7 @@ add_name_val_to_obj(std::string &n, std::string &v, rapidjson::GenericValue<E,A>
 
 template<typename E, typename A = ZeroPoolAllocator>
 static inline void
-add_name_val_to_obj(std::string &n, bool v, rapidjson::GenericValue<E,A> &d,
+add_name_val_to_obj(const std::string &n, const bool v, rapidjson::GenericValue<E,A> &d,
   A &allocator)
 {
   rapidjson::GenericValue<E,A> name, val;
@@ -171,7 +171,7 @@ add_name_val_to_obj(std::string &n, bool v, rapidjson::GenericValue<E,A> &d,
 
 template<typename E, typename A = ZeroPoolAllocator>
 static inline void
-add_name_val_to_obj(const char *n, std::string &v, rapidjson::GenericValue<E,A> &d,
+add_name_val_to_obj(const char *n, const std::string &v, rapidjson::GenericValue<E,A> &d,
   A &allocator)
 {
   std::string ns{n, strlen(n) };
@@ -180,7 +180,7 @@ add_name_val_to_obj(const char *n, std::string &v, rapidjson::GenericValue<E,A> 
 
 template<typename E, typename A = ZeroPoolAllocator>
 static inline void
-add_name_val_to_obj(const char *n, bool v, rapidjson::GenericValue<E,A> &d,
+add_name_val_to_obj(const char *n, const bool v, rapidjson::GenericValue<E,A> &d,
   A &allocator)
 {
   std::string ns{n, strlen(n) };
@@ -644,9 +644,11 @@ public:
     auto &allocator { d.GetAllocator() };
     bufferlist dummy_bl;
     std::string chacha20_poly1305 { "chacha20-poly1305" };
+    auto auto_rotate_period = cct->_conf.get_val<std::chrono::seconds>("rgw_crypt_sse_s3_vault_key_rotation_period");
 
     add_name_val_to_obj("type", chacha20_poly1305, d, allocator);
     add_name_val_to_obj("derived", true, d, allocator);
+    add_name_val_to_obj("auto_rotate_period", std::to_string(auto_rotate_period.count()), d, allocator);
     rapidjson::StringBuffer buf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
     if (!d.Accept(writer)) {

--- a/src/test/rgw/test_rgw_kms.cc
+++ b/src/test/rgw/test_rgw_kms.cc
@@ -176,6 +176,23 @@ TEST_F(TestSSEKMS, test_transit_backend){
 }
 
 
+TEST_F(TestSSEKMS, test_transit_create_bucket_key){
+  cct->_conf.set_val("rgw_crypt_sse_s3_vault_key_rotation_period", "1 day");
+
+  const std::string my_key("my_key");
+  const NoDoutPrefix no_dpp(cct, 1);
+
+  // Mocks the expected return Value from Vault Server using custom Argument Action
+  string post_data = R"({"type":"chacha20-poly1305","derived":true,"auto_rotate_period":"86400"})";
+  EXPECT_CALL(*transit_engine, send_request(&no_dpp, StrEq("POST"), StrEq("/keys/"), StrEq("my_key"), StrEq(post_data), _, _))
+		.WillOnce(SetPointedValue(""));
+
+  int res = transit_engine->create_bucket_key(&no_dpp, my_key, null_yield);
+
+  ASSERT_EQ(res, 0);
+}
+
+
 TEST_F(TestSSEKMS, test_transit_makekey){
 
   std::string_view my_key("my_key");


### PR DESCRIPTION
Add support key rotation (https://developer.hashicorp.com/vault/api-docs/secret/transit#auto_rotate_period) config for the bucket keys.

Fixes: https://tracker.ceph.com/issues/62699