### PR TITLE
qa: decrease pgbench scale factor to 32 for postgresql database test

### DIFF
--- a/qa/suites/fs/workload/tasks/5-workunit/postgres.yaml
+++ b/qa/suites/fs/workload/tasks/5-workunit/postgres.yaml
@@ -30,7 +30,7 @@ tasks:
       - sudo -u postgres -- postgresql-setup --initdb
       - sudo ls -lZaR /tmp/cephfs/postgres/
       - sudo systemctl start postgresql
-      - sudo -u postgres -- pgbench -s 500 -i
+      - sudo -u postgres -- pgbench -s 32 -i
       - sudo -u postgres -- pgbench -c 100 -j 4 --progress=5 --time=900
       - sudo systemctl stop postgresql
       - sudo ls -lZaR /tmp/cephfs/postgres/


### PR DESCRIPTION
The scale factor will depend on the node's performance and disk sizes being used to run the test, and 500 seems too large here as a common test case without knowing the nodes' configuration.

We should just follow the white-book:
https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/blob/distributed/doc/polardb/benchmark.md

Fixes: https://tracker.ceph.com/issues/62700





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
