### PR TITLE
reef: ceph-volume/cephadm: support lv devices in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -6,6 +6,7 @@ set of utilities for interacting with LVM.
 import logging
 import os
 import uuid
+import re
 from itertools import repeat
 from math import floor
 from ceph_volume import process, util, conf
@@ -1209,3 +1210,39 @@ def get_lv_by_fullname(full_name):
     except ValueError:
         res_lv = None
     return res_lv
+
+def get_lv_path_from_mapper(mapper):
+    """
+    This functions translates a given mapper device under the format:
+    /dev/mapper/LV to the format /dev/VG/LV.
+    eg:
+    from:
+    /dev/mapper/ceph--c1a97e46--234c--46aa--a549--3ca1d1f356a9-osd--block--32e8e896--172e--4a38--a06a--3702598510ec
+    to:
+    /dev/ceph-c1a97e46-234c-46aa-a549-3ca1d1f356a9/osd-block-32e8e896-172e-4a38-a06a-3702598510ec
+    """
+    results = re.split(r'^\/dev\/mapper\/(.+\w)-(\w.+)', mapper)
+    results = list(filter(None, results))
+
+    if len(results) != 2:
+        return None
+
+    return f"/dev/{results[0].replace('--', '-')}/{results[1].replace('--', '-')}"
+
+def get_mapper_from_lv_path(lv_path):
+    """
+    This functions translates a given lv path under the format:
+    /dev/VG/LV to the format /dev/mapper/LV.
+    eg:
+    from:
+    /dev/ceph-c1a97e46-234c-46aa-a549-3ca1d1f356a9/osd-block-32e8e896-172e-4a38-a06a-3702598510ec
+    to:
+    /dev/mapper/ceph--c1a97e46--234c--46aa--a549--3ca1d1f356a9-osd--block--32e8e896--172e--4a38--a06a--3702598510ec
+    """
+    results = re.split(r'^\/dev\/(.+\w)-(\w.+)', lv_path)
+    results = list(filter(None, results))
+
+    if len(results) != 2:
+        return None
+
+    return f"/dev/mapper/{results[0].replace('-', '--')}/{results[1].replace('-', '--')}"

--- a/src/ceph-volume/ceph_volume/inventory/main.py
+++ b/src/ceph-volume/ceph_volume/inventory/main.py
@@ -45,18 +45,27 @@ class Inventory(object):
                   'libstoragemgmt'),
             default=False,
         )
+        parser.add_argument(
+            '--list-all',
+            action='store_true',
+            help=('Whether ceph-volume should list lvm devices'),
+            default=False
+        )
         self.args = parser.parse_args(self.argv)
         if self.args.path:
             self.format_report(Device(self.args.path, with_lsm=self.args.with_lsm))
         else:
             self.format_report(Devices(filter_for_batch=self.args.filter_for_batch,
-                                       with_lsm=self.args.with_lsm))
+                                       with_lsm=self.args.with_lsm,
+                                       list_all=self.args.list_all))
 
     def get_report(self):
         if self.args.path:
             return Device(self.args.path, with_lsm=self.args.with_lsm).json_report()
         else:
-            return Devices(filter_for_batch=self.args.filter_for_batch, with_lsm=self.args.with_lsm).json_report()
+            return Devices(filter_for_batch=self.args.filter_for_batch,
+                           with_lsm=self.args.with_lsm,
+                           list_all=self.args.list_all).json_report()
 
     def format_report(self, inventory):
         if self.args.format == 'json':

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -883,3 +883,15 @@ class TestGetSingleLV(object):
 
         assert isinstance(lv_, api.Volume)
         assert lv_.name == 'lv1'
+
+
+class TestHelpers:
+    def test_get_lv_path_from_mapper(self):
+        mapper = '/dev/mapper/ceph--c1a97e46--234c--46aa--a549--3ca1d1f356a9-osd--block--32e8e896--172e--4a38--a06a--3702598510ec'
+        lv_path = api.get_lv_path_from_mapper(mapper)
+        assert lv_path == '/dev/ceph-c1a97e46-234c-46aa-a549-3ca1d1f356a9/osd-block-32e8e896-172e-4a38-a06a-3702598510ec'
+
+    def test_get_mapper_from_lv_path(self):
+        lv_path = '/dev/ceph-c1a97e46-234c-46aa-a549-3ca1d1f356a9/osd-block-32e8e896-172e-4a38-a06a-3702598510ec'
+        mapper = api.get_mapper_from_lv_path(lv_path)
+        assert mapper == '/dev/mapper/ceph--c1a97e46--234c--46aa--a549--3ca1d1f356a9/osd--block--32e8e896--172e--4a38--a06a/3702598510ec'

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -225,7 +225,6 @@ class TestGetDevices(object):
         result = disk.get_devices(_sys_block_path=str(tmpdir))
         assert result == {}
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_sda_block_is_found(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
@@ -235,7 +234,6 @@ class TestGetDevices(object):
         assert result[sda_path]['model'] == ''
         assert result[sda_path]['partitions'] == {}
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_sda_size(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
@@ -244,7 +242,6 @@ class TestGetDevices(object):
         assert list(result.keys()) == [sda_path]
         assert result[sda_path]['human_readable_size'] == '512.00 KB'
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_sda_sectorsize_fallsback(self, patched_get_block_devs_sysfs, fake_filesystem):
         # if no sectorsize, it will use queue/hw_sector_size
         sda_path = '/dev/sda'
@@ -254,7 +251,6 @@ class TestGetDevices(object):
         assert list(result.keys()) == [sda_path]
         assert result[sda_path]['sectorsize'] == '1024'
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_sda_sectorsize_from_logical_block(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
@@ -262,7 +258,6 @@ class TestGetDevices(object):
         result = disk.get_devices()
         assert result[sda_path]['sectorsize'] == '99'
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_sda_sectorsize_does_not_fallback(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
@@ -271,7 +266,6 @@ class TestGetDevices(object):
         result = disk.get_devices()
         assert result[sda_path]['sectorsize'] == '99'
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_is_rotational(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
@@ -279,14 +273,12 @@ class TestGetDevices(object):
         result = disk.get_devices()
         assert result[sda_path]['rotational'] == '1'
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_is_ceph_rbd(self, patched_get_block_devs_sysfs, fake_filesystem):
         rbd_path = '/dev/rbd0'
         patched_get_block_devs_sysfs.return_value = [[rbd_path, rbd_path, 'disk']]
         result = disk.get_devices()
         assert rbd_path not in result
 
-    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
     def test_actuator_device(self, patched_get_block_devs_sysfs, fake_filesystem):
         sda_path = '/dev/sda'
         fake_actuator_nb = 2

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -490,7 +490,7 @@ class Device(object):
 
     @property
     def is_acceptable_device(self):
-        return self.is_device or self.is_partition
+        return self.is_device or self.is_partition or self.is_lv
 
     @property
     def is_encrypted(self):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -33,20 +33,28 @@ class Devices(object):
     A container for Device instances with reporting
     """
 
-    def __init__(self, filter_for_batch=False, with_lsm=False):
+    def __init__(self,
+                 filter_for_batch=False,
+                 with_lsm=False,
+                 list_all=False):
         lvs = lvm.get_lvs()
         lsblk_all = disk.lsblk_all()
         all_devices_vgs = lvm.get_all_devices_vgs()
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
-        self.devices = [Device(k,
-                               with_lsm,
-                               lvs=lvs,
-                               lsblk_all=lsblk_all,
-                               all_devices_vgs=all_devices_vgs) for k in
-                        sys_info.devices.keys()]
-        if filter_for_batch:
-            self.devices = [d for d in self.devices if d.available_lvm_batch]
+        self._devices = [Device(k,
+                                with_lsm,
+                                lvs=lvs,
+                                lsblk_all=lsblk_all,
+                                all_devices_vgs=all_devices_vgs) for k in
+                         sys_info.devices.keys()]
+        self.devices = []
+        for device in self._devices:
+            if filter_for_batch and not device.available_lvm_batch:
+                continue
+            if device.is_lv and not list_all:
+                continue
+            self.devices.append(device)
 
     def pretty_report(self):
         output = [

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -54,6 +54,8 @@ class Devices(object):
                 continue
             if device.is_lv and not list_all:
                 continue
+            if device.is_partition and not list_all:
+                continue
             self.devices.append(device)
 
     def pretty_report(self):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -594,7 +594,6 @@ class Device(object):
         reasons = [
             ('removable', 1, 'removable'),
             ('ro', 1, 'read-only'),
-            ('locked', 1, 'locked'),
         ]
         rejected = [reason for (k, v, reason) in reasons if
                     self.sys_api.get(k, '') == v]
@@ -630,6 +629,8 @@ class Device(object):
             rejected.append('Has GPT headers')
         if self.has_partitions:
             rejected.append('Has partitions')
+        if self.has_fs:
+            rejected.append('Has a FileSystem')
         return rejected
 
     def _check_lvm_reject_reasons(self):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -845,11 +845,13 @@ def get_devices(_sys_block_path='/sys/block', device=''):
 
     block_devs = get_block_devs_sysfs(_sys_block_path)
 
-    block_types = ['disk', 'mpath']
+    block_types = ['disk', 'mpath', 'lvm']
     if allow_loop_devices():
         block_types.append('loop')
 
     for block in block_devs:
+        if block[2] == 'lvm':
+            block[1] = lvm.get_lv_path_from_mapper(block[1])
         devname = os.path.basename(block[0])
         diskname = block[1]
         if block[2] not in block_types:

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -807,6 +807,19 @@ def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys
         result.append([name, kname, "part"])
     return sorted(result, key=lambda x: x[0])
 
+def get_partitions(_sys_dev_block_path ='/sys/dev/block'):
+    devices = os.listdir(_sys_dev_block_path)
+    result = dict()
+    for device in devices:
+        device_path = os.path.join(_sys_dev_block_path, device)
+        is_partition = get_file_contents(os.path.join(device_path, 'partition')) == "1"
+        if not is_partition:
+            continue
+
+        partition_sys_name = os.path.basename(os.readlink(device_path))
+        parent_device_sys_name = os.readlink(device_path).split('/')[-2:-1][0]
+        result[partition_sys_name] = parent_device_sys_name
+    return result
 
 def get_devices(_sys_block_path='/sys/block', device=''):
     """
@@ -822,8 +835,9 @@ def get_devices(_sys_block_path='/sys/block', device=''):
     device_facts = {}
 
     block_devs = get_block_devs_sysfs(_sys_block_path)
+    partitions = get_partitions()
 
-    block_types = ['disk', 'mpath', 'lvm']
+    block_types = ['disk', 'mpath', 'lvm', 'part']
     if allow_loop_devices():
         block_types.append('loop')
 
@@ -835,6 +849,8 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         if block[2] not in block_types:
             continue
         sysdir = os.path.join(_sys_block_path, devname)
+        if block[2] == 'part':
+            sysdir = os.path.join(_sys_block_path, partitions[devname], devname)
         metadata = {}
 
         # If the device is ceph rbd it gets excluded
@@ -862,11 +878,17 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         for key, file_ in facts:
             metadata[key] = get_file_contents(os.path.join(sysdir, file_))
 
-        device_slaves = os.listdir(os.path.join(sysdir, 'slaves'))
+        if block[2] != 'part':
+            device_slaves = os.listdir(os.path.join(sysdir, 'slaves'))
+            metadata['partitions'] = get_partitions_facts(sysdir)
+
         if device_slaves:
             metadata['device_nodes'] = ','.join(device_slaves)
         else:
-            metadata['device_nodes'] = devname
+            if block[2] == 'part':
+                metadata['device_nodes'] = partitions[devname]
+            else:
+                metadata['device_nodes'] = devname
 
         metadata['actuators'] = None
         if os.path.isdir(sysdir + "/queue/independent_access_ranges/"):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -734,28 +734,6 @@ def is_mapper_device(device_name):
     return device_name.startswith(('/dev/mapper', '/dev/dm-'))
 
 
-def is_locked_raw_device(disk_path):
-    """
-    A device can be locked by a third party software like a database.
-    To detect that case, the device is opened in Read/Write and exclusive mode
-    """
-    open_flags = (os.O_RDWR | os.O_EXCL)
-    open_mode = 0
-    fd = None
-
-    try:
-        fd = os.open(disk_path, open_flags, open_mode)
-    except OSError:
-        return 1
-
-    try:
-        os.close(fd)
-    except OSError:
-        return 1
-
-    return 0
-
-
 class AllowLoopDevices(object):
     allow = False
     warned = False
@@ -916,7 +894,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         metadata['size'] = float(size) * 512
         metadata['human_readable_size'] = human_readable_size(metadata['size'])
         metadata['path'] = diskname
-        metadata['locked'] = is_locked_raw_device(metadata['path'])
         metadata['type'] = block[2]
 
         device_facts[diskname] = metadata

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -168,6 +168,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Use libstoragemgmt during device scans',
         ),
         Option(
+            'inventory_list_all',
+            type='bool',
+            default=False,
+            desc='Whether ceph-volume inventory should report '
+            'more devices (mostly mappers (LVs / mpaths), partitions...)',
+        ),
+        Option(
             'daemon_cache_timeout',
             type='secs',
             default=10 * 60,
@@ -543,6 +550,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
             self.device_enhanced_scan = False
+            self.inventory_list_all = False
             self.cgroups_split = True
             self.log_refresh_metadata = False
             self.default_cephadm_command_timeout = 0

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -379,11 +379,14 @@ class CephadmServe:
 
     def _refresh_host_devices(self, host: str) -> Optional[str]:
         with_lsm = self.mgr.device_enhanced_scan
+        list_all = self.mgr.inventory_list_all
         inventory_args = ['--', 'inventory',
                           '--format=json-pretty',
                           '--filter-for-batch']
         if with_lsm:
             inventory_args.insert(-1, "--with-lsm")
+        if list_all:
+            inventory_args.insert(-1, "--list-all")
 
         try:
             try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62708

---

backport of https://github.com/ceph/ceph/pull/52877
parent tracker: https://tracker.ceph.com/issues/62362

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh