### PR TITLE
debian: add missing bcrypt to ceph-mgr .requires to fix resulting package dependencies

### DIFF
--- a/debian/ceph-mgr.requires
+++ b/debian/ceph-mgr.requires
@@ -1,3 +1,4 @@
+bcrypt
 pyOpenSSL
 cephfs
 ceph-argparse


### PR DESCRIPTION
The `ceph-mgr` package lost its dependency on `python3-bcrypt` when the dependencies got moved from d/control to a dh_python3 compatible requires file. Add it again as the bcrypt module is still used there.

Otherwise, one gets errors when, e.g., calling `ceph -s` after a fresh installation:

> 13 mgr modules have failed dependencies
> Module 'balancer' has failed dependency: No module named 'bcrypt'
> Module 'crash' has failed dependency: No module named 'bcrypt'
> Module 'devicehealth' has failed dependency: No module named 'bcrypt'
> Module 'iostat' has failed dependency: No module named 'bcrypt'
> Module 'nfs' has failed dependency: No module named 'bcrypt'
> Module 'orchestrator' has failed dependency: No module named 'bcrypt'
> Module 'pg_autoscaler' has failed dependency: No module named 'bcrypt'
> Module 'progress' has failed dependency: No module named 'bcrypt'
> Module 'rbd_support' has failed dependency: No module named 'bcrypt'
> Module 'restful' has failed dependency: No module named 'bcrypt'
> Module 'status' has failed dependency: No module named 'bcrypt'
> Module 'telemetry' has failed dependency: No module named 'bcrypt'
> Module 'volumes' has failed dependency: No module named 'bcrypt'

Fixes: ef19547e83e ("debian: add .requires for specifying python3 deps")

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [X] ~Very~ recent bug (only present in latest stable release: Ceph Reef); introduced by ef19547e83e ("debian: add .requires for specifying python3 deps")
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests; simply compared builds with diffoscope showing that the `python3-bcrypt` is present again
