### PR TITLE
quincy: librbd: kick ExclusiveLock state machine on client being blocklisted when waiting for lock

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -578,8 +578,7 @@ void ImageWatcher<I>::schedule_request_lock(bool use_timer, int timer_delay) {
     return;
   }
 
-  std::shared_lock watch_locker{this->m_watch_lock};
-  if (this->is_registered(this->m_watch_lock)) {
+  if (is_registered()) {
     ldout(m_image_ctx.cct, 15) << this << " requesting exclusive lock" << dendl;
 
     auto ctx = new LambdaContext([this](int r) {
@@ -597,6 +596,10 @@ void ImageWatcher<I>::schedule_request_lock(bool use_timer, int timer_delay) {
     } else {
       m_task_finisher->queue(TASK_CODE_REQUEST_LOCK, ctx);
     }
+  } else if (is_blocklisted()) {
+    lderr(m_image_ctx.cct) << this << " blocklisted waiting for exclusive lock"
+                           << dendl;
+    m_image_ctx.exclusive_lock->handle_peer_notification(0);
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62685

---

backport of https://github.com/ceph/ceph/pull/52990
parent tracker: https://tracker.ceph.com/issues/61607

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh