### PR TITLE
cephadm: move logging configuration into cephadmlib

### DIFF
--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -1,0 +1,133 @@
+# logging.py - cephadm specific logging behavior
+
+import logging
+import logging.config
+import os
+import sys
+
+from typing import List
+
+from .context import CephadmContext
+from .constants import QUIET_LOG_LEVEL, LOG_DIR
+
+
+# During normal cephadm operations (cephadm ls, gather-facts, etc ) we use:
+# stdout: for JSON output only
+# stderr: for error, debug, info, etc
+logging_config = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'cephadm': {
+            'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+        'log_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'cephadm',
+            'filename': '%s/cephadm.log' % LOG_DIR,
+        }
+    },
+    'loggers': {
+        '': {
+            'level': 'DEBUG',
+            'handlers': ['console', 'log_file'],
+        }
+    }
+}
+
+
+class ExcludeErrorsFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Only lets through log messages with log level below WARNING ."""
+        return record.levelno < logging.WARNING
+
+
+# When cephadm is used as standard binary (bootstrap, rm-cluster, etc) we use:
+# stdout: for debug and info
+# stderr: for errors and warnings
+interactive_logging_config = {
+    'version': 1,
+    'filters': {
+        'exclude_errors': {
+            '()': ExcludeErrorsFilter
+        }
+    },
+    'disable_existing_loggers': True,
+    'formatters': {
+        'cephadm': {
+            'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
+        },
+    },
+    'handlers': {
+        'console_stdout': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'filters': ['exclude_errors'],
+            'stream': sys.stdout
+        },
+        'console_stderr': {
+            'level': 'WARNING',
+            'class': 'logging.StreamHandler',
+            'stream': sys.stderr
+        },
+        'log_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'cephadm',
+            'filename': '%s/cephadm.log' % LOG_DIR,
+        }
+    },
+    'loggers': {
+        '': {
+            'level': 'DEBUG',
+            'handlers': ['console_stdout', 'console_stderr', 'log_file'],
+        }
+    }
+}
+
+
+_logrotate_data = """# created by cephadm
+/var/log/ceph/cephadm.log {
+    rotate 7
+    daily
+    compress
+    missingok
+    notifempty
+    su root root
+}
+"""
+
+
+def cephadm_init_logging(
+    ctx: CephadmContext, logger: logging.Logger, args: List[str]
+) -> None:
+    """Configure the logging for cephadm as well as updating the system
+    to have the expected log dir and logrotate configuration.
+    """
+    logging.addLevelName(QUIET_LOG_LEVEL, 'QUIET')
+    if not os.path.exists(LOG_DIR):
+        os.makedirs(LOG_DIR)
+    operations = ['bootstrap', 'rm-cluster']
+    if any(op in args for op in operations):
+        logging.config.dictConfig(interactive_logging_config)
+    else:
+        logging.config.dictConfig(logging_config)
+
+    logger.setLevel(QUIET_LOG_LEVEL)
+
+    if not os.path.exists(ctx.logrotate_dir + '/cephadm'):
+        with open(ctx.logrotate_dir + '/cephadm', 'w') as f:
+            f.write(_logrotate_data)
+
+    if ctx.verbose:
+        for handler in logger.handlers:
+            if handler.name in ['console', 'log_file', 'console_stdout']:
+                handler.setLevel(QUIET_LOG_LEVEL)
+    logger.debug('%s\ncephadm %s' % ('-' * 80, args))

--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -19,7 +19,7 @@ class _ExcludeErrorsFilter(logging.Filter):
 
 _common_formatters = {
     'cephadm': {
-        'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
+        'format': '%(asctime)s %(thread)x %(levelname)s %(message)s',
     },
 }
 
@@ -51,7 +51,7 @@ _logging_config = {
             'level': 'DEBUG',
             'handlers': ['console', 'log_file'],
         }
-    }
+    },
 }
 
 
@@ -62,8 +62,8 @@ _interactive_logging_config = {
     'version': 1,
     'filters': {
         'exclude_errors': {
-            '()': _ExcludeErrorsFilter
-        }
+            '()': _ExcludeErrorsFilter,
+        },
     },
     'disable_existing_loggers': True,
     'formatters': _common_formatters,
@@ -72,12 +72,12 @@ _interactive_logging_config = {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
             'filters': ['exclude_errors'],
-            'stream': sys.stdout
+            'stream': sys.stdout,
         },
         'console_stderr': {
             'level': 'WARNING',
             'class': 'logging.StreamHandler',
-            'stream': sys.stderr
+            'stream': sys.stderr,
         },
         'log_file': _log_file_handler,
     },
@@ -86,7 +86,7 @@ _interactive_logging_config = {
             'level': 'DEBUG',
             'handlers': ['console_stdout', 'console_stderr', 'log_file'],
         }
-    }
+    },
 }
 
 

--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -11,28 +11,40 @@ from .context import CephadmContext
 from .constants import QUIET_LOG_LEVEL, LOG_DIR
 
 
+class _ExcludeErrorsFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Only lets through log messages with log level below WARNING ."""
+        return record.levelno < logging.WARNING
+
+
+_common_formatters = {
+    'cephadm': {
+        'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
+    },
+}
+
+
+_log_file_handler = {
+    'level': 'DEBUG',
+    'class': 'logging.handlers.WatchedFileHandler',
+    'formatter': 'cephadm',
+    'filename': '%s/cephadm.log' % LOG_DIR,
+}
+
+
 # During normal cephadm operations (cephadm ls, gather-facts, etc ) we use:
 # stdout: for JSON output only
 # stderr: for error, debug, info, etc
 _logging_config = {
     'version': 1,
     'disable_existing_loggers': True,
-    'formatters': {
-        'cephadm': {
-            'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
-        },
-    },
+    'formatters': _common_formatters,
     'handlers': {
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
         },
-        'log_file': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.WatchedFileHandler',
-            'formatter': 'cephadm',
-            'filename': '%s/cephadm.log' % LOG_DIR,
-        }
+        'log_file': _log_file_handler,
     },
     'loggers': {
         '': {
@@ -41,12 +53,6 @@ _logging_config = {
         }
     }
 }
-
-
-class _ExcludeErrorsFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Only lets through log messages with log level below WARNING ."""
-        return record.levelno < logging.WARNING
 
 
 # When cephadm is used as standard binary (bootstrap, rm-cluster, etc) we use:
@@ -60,11 +66,7 @@ _interactive_logging_config = {
         }
     },
     'disable_existing_loggers': True,
-    'formatters': {
-        'cephadm': {
-            'format': '%(asctime)s %(thread)x %(levelname)s %(message)s'
-        },
-    },
+    'formatters': _common_formatters,
     'handlers': {
         'console_stdout': {
             'level': 'INFO',
@@ -77,12 +79,7 @@ _interactive_logging_config = {
             'class': 'logging.StreamHandler',
             'stream': sys.stderr
         },
-        'log_file': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.WatchedFileHandler',
-            'formatter': 'cephadm',
-            'filename': '%s/cephadm.log' % LOG_DIR,
-        }
+        'log_file': _log_file_handler,
     },
     'loggers': {
         '': {

--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -14,7 +14,7 @@ from .constants import QUIET_LOG_LEVEL, LOG_DIR
 # During normal cephadm operations (cephadm ls, gather-facts, etc ) we use:
 # stdout: for JSON output only
 # stderr: for error, debug, info, etc
-logging_config = {
+_logging_config = {
     'version': 1,
     'disable_existing_loggers': True,
     'formatters': {
@@ -43,7 +43,7 @@ logging_config = {
 }
 
 
-class ExcludeErrorsFilter(logging.Filter):
+class _ExcludeErrorsFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Only lets through log messages with log level below WARNING ."""
         return record.levelno < logging.WARNING
@@ -52,11 +52,11 @@ class ExcludeErrorsFilter(logging.Filter):
 # When cephadm is used as standard binary (bootstrap, rm-cluster, etc) we use:
 # stdout: for debug and info
 # stderr: for errors and warnings
-interactive_logging_config = {
+_interactive_logging_config = {
     'version': 1,
     'filters': {
         'exclude_errors': {
-            '()': ExcludeErrorsFilter
+            '()': _ExcludeErrorsFilter
         }
     },
     'disable_existing_loggers': True,
@@ -116,9 +116,9 @@ def cephadm_init_logging(
         os.makedirs(LOG_DIR)
     operations = ['bootstrap', 'rm-cluster']
     if any(op in args for op in operations):
-        logging.config.dictConfig(interactive_logging_config)
+        logging.config.dictConfig(_interactive_logging_config)
     else:
-        logging.config.dictConfig(logging_config)
+        logging.config.dictConfig(_logging_config)
 
     logger.setLevel(QUIET_LOG_LEVEL)
 


### PR DESCRIPTION

Move the logging configuration, the config-dicts and the function(s), into a new logging.py in cephadmlib. This is the first move to cephadmlib that requires a change to the code to work due to namespacing. However the change should be relatively simple to see - the function no longer uses a global logger - the logger is now passed as an argument.
A few small followup patches clean up the new module to try and aid the reader and organize things a little bit better.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Uses existing tests, indirectly

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
