### PR TITLE
cephadm: enhance logging behavior

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -173,6 +173,75 @@ files.  You can configure the logging retention schedule by modifying
 ``/etc/logrotate.d/ceph.<cluster-fsid>``.
 
 
+Per-node cephadm logs
+=====================
+
+The cephadm executable, either run directly by a user or by the cephadm
+orchestration module, may also generate logs. It does so independently of
+the other Ceph components running in containers. By default, this executable
+logs to the file ``/var/log/ceph/cephadm.log``.
+
+This logging destination is configurable and you may choose to log to the
+file, to the syslog/journal, or to both.
+
+Setting a cephadm log destination during bootstrap
+--------------------------------------------------
+
+The ``cephadm`` command may be executed with the option ``--log-dest=file``
+or with ``--log-dest=syslog`` or both. These options control where cephadm
+will store persistent logs for each invocation. When these options are
+specified for the ``cephadm bootstrap`` command the system will automatically
+record these settings for future invocations of ``cephadm`` by the cephadm
+orchestration module.
+
+For example:
+
+.. prompt:: bash #
+
+  cephadm --log-dest=syslog bootstrap # ... other bootstrap arguments ...
+
+If you want to manually specify exactly what log destination to use
+during bootstrap, independent from the ``--log-dest`` options, you may add
+a configuration key ``mgr/cephadm/cephadm_log_destination`` to the
+initial configuration file, under the ``[mgr]`` section. Valid values for
+the key are: ``file``, ``syslog``, and ``file,syslog``.
+
+For example:
+
+.. prompt:: bash #
+
+  cat >/tmp/bootstrap.conf <<EOF
+  [mgr]
+  mgr/cephadm/cephadm_log_destination = syslog
+  EOF
+  cephadm bootstrap --config /tmp/bootstrap.conf # ... other bootstrap arguments ...
+
+Setting a cephadm log destination on an existing cluster
+--------------------------------------------------------
+
+An existing Ceph cluster can be configured to use a specific cephadm log
+destination by setting the ``mgr/cephadm/cephadm_log_destination``
+configuration value to one of ``file``, ``syslog``, or ``file,syslog``. This
+will cause the cephadm orchestration module to run ``cephadm`` so that logs go
+to ``/var/log/ceph/cephadm.log``, the syslog/journal, or both, respectively.
+
+For example:
+
+.. prompt:: bash #
+
+  # set the cephadm executable to log to syslog
+  ceph config set mgr mgr/cephadm/cephadm_log_destination syslog
+  # set the cephadm executable to log to both the log file and syslog
+  ceph config set mgr mgr/cephadm/cephadm_log_destination file,syslog
+  # set the cephadm executable to log to the log file
+  ceph config set mgr mgr/cephadm/cephadm_log_destination file
+
+.. note:: If you execute cephadm commands directly, such as cephadm shell,
+   this option will not apply. To have cephadm log to locations other than
+   the default log file When running cephadm commands directly use the
+   ``--log-dest`` options described in the bootstrap section above.
+
+
 Data location
 =============
 

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -7,9 +7,9 @@ Cephadm Operations
 Watching cephadm log messages
 =============================
 
-Cephadm writes logs to the ``cephadm`` cluster log channel. You can
-monitor Ceph's activity in real time by reading the logs as they fill
-up. Run the following command to see the logs in real time:
+The cephadm orchestrator module writes logs to the ``cephadm`` cluster log
+channel. You can monitor Ceph's activity in real time by reading the logs as
+they fill up. Run the following command to see the logs in real time:
 
 .. prompt:: bash #
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -137,7 +137,7 @@ from cephadmlib.net_utils import (
 from cephadmlib.locking import FileLock
 from cephadmlib.daemon_identity import DaemonIdentity, DaemonSubIdentity
 from cephadmlib.packagers import create_packager, Packager
-from cephadmlib.logging import cephadm_init_logging
+from cephadmlib.logging import cephadm_init_logging, Highlight
 
 FuncT = TypeVar('FuncT', bound=Callable)
 
@@ -201,12 +201,6 @@ class DeploymentType(Enum):
     # Reconfiguring a daemon. Rewrites config
     # files and potentially restarts daemon.
     RECONFIG = 'Reconfig'
-
-
-class termcolor:
-    yellow = '\033[93m'
-    red = '\033[31m'
-    end = '\033[0m'
 
 ##################################
 
@@ -1615,7 +1609,7 @@ For information regarding the latest stable release:
     https://docs.ceph.com/docs/{}/cephadm/install
 """.format(LATEST_STABLE_RELEASE)
         for line in warn.splitlines():
-            logger.warning('{}{}{}'.format(termcolor.yellow, line, termcolor.end))
+            logger.warning(line, extra=Highlight.WARNING.extra())
     return DEFAULT_IMAGE
 
 
@@ -2519,9 +2513,9 @@ def _get_container_mounts_for_type(
                 mounts[ceph_folder + '/monitoring/ceph-mixin/dashboards_out'] = '/etc/grafana/dashboards/ceph-dashboard'
                 mounts[ceph_folder + '/monitoring/ceph-mixin/prometheus_alerts.yml'] = '/etc/prometheus/ceph/ceph_default_alerts.yml'
             else:
-                logger.error('{}{}{}'.format(termcolor.red,
-                                             'Ceph shared source folder does not exist.',
-                                             termcolor.end))
+                logger.error(
+                    'Ceph shared source folder does not exist.',
+                    extra=Highlight.FAILURE.extra())
     except AttributeError:
         pass
     return mounts

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -137,7 +137,7 @@ from cephadmlib.net_utils import (
 from cephadmlib.locking import FileLock
 from cephadmlib.daemon_identity import DaemonIdentity, DaemonSubIdentity
 from cephadmlib.packagers import create_packager, Packager
-from cephadmlib.logging import cephadm_init_logging, Highlight
+from cephadmlib.logging import cephadm_init_logging, Highlight, LogDestination
 
 FuncT = TypeVar('FuncT', bound=Callable)
 
@@ -8813,6 +8813,11 @@ def _get_parser():
         '--verbose', '-v',
         action='store_true',
         help='Show debug-level log messages')
+    parser.add_argument(
+        '--log-dest',
+        action='append',
+        choices=[v.name for v in LogDestination],
+        help='select one or more destination for persistent logging')
     parser.add_argument(
         '--timeout',
         type=int,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5664,6 +5664,16 @@ def command_bootstrap(ctx):
                  '-i', '/var/lib/ceph/user.conf'],
                 {tmp.name: '/var/lib/ceph/user.conf:z'})
 
+    if getattr(ctx, 'log_dest', None):
+        ldkey = 'mgr/cephadm/cephadm_log_destination'
+        cp = read_config(ctx.config)
+        if cp.has_option('mgr', ldkey):
+            logger.info('The cephadm log destination is set by the config file, ignoring cli option')
+        else:
+            value = ','.join(sorted(getattr(ctx, 'log_dest')))
+            logger.info('Setting cephadm log destination to match logging for cephadm boostrap: %s', value)
+            cli(['config', 'set', 'mgr', ldkey, value, '--force'])
+
     # wait for mgr to restart (after enabling a module)
     def wait_for_mgr_restart() -> None:
         # first get latest mgrmap epoch from the mon.  try newer 'mgr

--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -3,10 +3,11 @@
 import enum
 import logging
 import logging.config
+import logging.handlers
 import os
 import sys
 
-from typing import List, Any, Dict, cast
+from typing import List, Any, Dict, Optional, cast
 
 from .context import CephadmContext
 from .constants import QUIET_LOG_LEVEL, LOG_DIR
@@ -42,6 +43,11 @@ class Highlight(enum.Enum):
         return f'{color}{s}{_termcolors.end.value}'
 
 
+class LogDestination(str, enum.Enum):
+    file = 'log_file'
+    syslog = 'syslog'
+
+
 class _Colorizer(logging.Formatter):
     def format(self, record: Any) -> str:
         res = super().format(record)
@@ -70,6 +76,13 @@ _log_file_handler = {
     'filename': '%s/cephadm.log' % LOG_DIR,
 }
 
+_syslog_handler = {
+    'level': 'DEBUG',
+    'class': 'logging.handlers.SysLogHandler',
+    'formatter': 'cephadm',
+    'address': '/dev/log',
+}
+
 
 # During normal cephadm operations (cephadm ls, gather-facts, etc ) we use:
 # stdout: for JSON output only
@@ -84,11 +97,12 @@ _logging_config = {
             'class': 'logging.StreamHandler',
         },
         'log_file': _log_file_handler,
+        'syslog': _syslog_handler,
     },
     'loggers': {
         '': {
             'level': 'DEBUG',
-            'handlers': ['console', 'log_file'],
+            'handlers': ['console'],
         }
     },
 }
@@ -102,7 +116,7 @@ _interactive_logging_config = {
     'filters': {
         'exclude_errors': {
             '()': _ExcludeErrorsFilter,
-        },
+        }
     },
     'disable_existing_loggers': True,
     'formatters': _common_formatters,
@@ -120,11 +134,12 @@ _interactive_logging_config = {
             'formatter': 'colorized',
         },
         'log_file': _log_file_handler,
+        'syslog': _syslog_handler,
     },
     'loggers': {
         '': {
             'level': 'DEBUG',
-            'handlers': ['console_stdout', 'console_stderr', 'log_file'],
+            'handlers': ['console_stdout', 'console_stderr'],
         }
     },
 }
@@ -142,20 +157,68 @@ _logrotate_data = """# created by cephadm
 """
 
 
+_VERBOSE_HANDLERS = [
+    'console',
+    'console_stdout',
+    LogDestination.file.value,
+    LogDestination.syslog.value,
+]
+
+
+_INTERACTIVE_CMDS = ['bootstrap', 'rm-cluster']
+
+
+def _copy(obj: Any) -> Any:
+    """Recursively copy mutable items in the logging config dictionaries."""
+    # copy.deepcopy fails to pickle the config dicts (sys.stderr, etc)
+    # so it's either implement our own basic recursive copy or allow
+    # the global objects to be mutated by _complete_logging_config
+    if isinstance(obj, dict):
+        return {k: _copy(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_copy(v) for v in obj]
+    return obj
+
+
+def _complete_logging_config(
+    interactive: bool, destinations: Optional[List[str]]
+) -> Dict[str, Any]:
+    """Return a logging configuration dict, based on the runtime parameters
+    cephadm was invoked with.
+    """
+    # Use _copy to avoid mutating the global dicts
+    lc = _copy(_logging_config)
+    if interactive:
+        lc = _copy(_interactive_logging_config)
+
+    handlers = lc['loggers']['']['handlers']
+    if not destinations:
+        handlers.append(LogDestination.file.value)
+    for dest in destinations or []:
+        handlers.append(LogDestination[dest])
+
+    return lc
+
+
 def cephadm_init_logging(
     ctx: CephadmContext, logger: logging.Logger, args: List[str]
 ) -> None:
     """Configure the logging for cephadm as well as updating the system
     to have the expected log dir and logrotate configuration.
+
+    The context's log_dest attribute, if not None, determines what
+    persistent logging destination to use. The LogDestination
+    enum provides valid destination values.
     """
     logging.addLevelName(QUIET_LOG_LEVEL, 'QUIET')
     if not os.path.exists(LOG_DIR):
         os.makedirs(LOG_DIR)
-    operations = ['bootstrap', 'rm-cluster']
-    if any(op in args for op in operations):
-        logging.config.dictConfig(_interactive_logging_config)
-    else:
-        logging.config.dictConfig(_logging_config)
+
+    lc = _complete_logging_config(
+        any(op in args for op in _INTERACTIVE_CMDS),
+        getattr(ctx, 'log_dest', None),
+    )
+    logging.config.dictConfig(lc)
 
     logger.setLevel(QUIET_LOG_LEVEL)
 
@@ -163,8 +226,16 @@ def cephadm_init_logging(
         with open(ctx.logrotate_dir + '/cephadm', 'w') as f:
             f.write(_logrotate_data)
 
-    if ctx.verbose:
-        for handler in logger.handlers:
-            if handler.name in ['console', 'log_file', 'console_stdout']:
-                handler.setLevel(QUIET_LOG_LEVEL)
+    for handler in logger.handlers:
+        # the following little hack ensures that no matter how cephadm is named
+        # (eg. suffixed by a hash when copied by the mgr) we set a consistent
+        # syslog identifier. This way one can do things like run
+        # `journalctl -t cephadm`.
+        if handler.name == LogDestination.syslog:
+            # the space after the colon in the ident is significant!
+            cast(logging.handlers.SysLogHandler, handler).ident = 'cephadm: '
+        # set specific handlers to log extra level of detail when the verbose
+        # option is set
+        if ctx.verbose and handler.name in _VERBOSE_HANDLERS:
+            handler.setLevel(QUIET_LOG_LEVEL)
     logger.debug('%s\ncephadm %s' % ('-' * 80, args))

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -472,6 +472,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Default timeout applied to cephadm commands run directly on '
             'the host (in seconds)'
         ),
+        Option(
+            'cephadm_log_destination',
+            type='str',
+            default='',
+            desc="Destination for cephadm command's persistent logging",
+            enum_allowed=['file', 'syslog', 'file,syslog'],
+        ),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -554,6 +561,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.cgroups_split = True
             self.log_refresh_metadata = False
             self.default_cephadm_command_timeout = 0
+            self.cephadm_log_destination = ''
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1577,6 +1577,11 @@ class CephadmServe:
             timeout -= 5
         final_args += ['--timeout', str(timeout)]
 
+        if self.mgr.cephadm_log_destination:
+            values = self.mgr.cephadm_log_destination.split(',')
+            for value in values:
+                final_args.append(f'--log-dest={value}')
+
         # subcommand
         if isinstance(command, list):
             final_args.extend([str(v) for v in command])


### PR DESCRIPTION
Depends on #53297

Clean up the behavior of the colorized output cephadm sometimes produces. Avoid logging control chars to files & non-tty stderr.

Add support to cephadm for logging to syslog/journal. Example:

```
cephadm boostrap

cephadm --log-dest=syslog bootstrap

cephadm --log-dest=file bootstrap

cephadm --log-dest=syslog --log-dest=file bootstrap
```


The log destination used by cephadm commands emitted by the mgr module can set using `ceph config set mgr mgr/cephadm/cephadm_log_destination $VAL` where VAL can be one of 'file', 'syslog', or 'file,syslog'.

Update the `cephadm bootstrap` command to "remember" what --log-dest options it was called with and store them into the config option described above.

Documented it too.

Fixes: https://tracker.ceph.com/issues/62233


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests  --manually tested only--

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
