### PR TITLE
crimson/os/seastore/onode_manager: populate value recorders of onodes to be erased

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -120,6 +120,10 @@ FLTreeOnodeManager::erase_onode_ret FLTreeOnodeManager::erase_onode(
   OnodeRef &onode)
 {
   auto &flonode = static_cast<FLTreeOnode&>(*onode);
+  assert(flonode.is_alive());
+  if (flonode.status == FLTreeOnode::status_t::MUTATED) {
+    flonode.populate_recorder(trans);
+  }
   flonode.mark_delete();
   return tree.erase(trans, flonode);
 }


### PR DESCRIPTION
Otherwise, the following modification sequence with the same transaction might lead to onode extents' crc inconsistency during journal replay:

1. modify the last mapping in an onode extent;
2. erase the last mapping in that onode extent.

During journal replay, if the first modification is not recorded in the delta, the onode extent's content would be inconsistent with that before the system reboot

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
