### PR TITLE
osd/scrub: fixing the length of a day

### DIFF
--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -6,6 +6,8 @@
 
 #include "pg_scrubber.h"
 
+using namespace ::std::chrono;
+using namespace ::std::chrono_literals;
 using namespace ::std::literals;
 
 // ////////////////////////////////////////////////////////////////////////// //
@@ -97,7 +99,7 @@ ScrubQueue::ScrubQueue(CephContext* cct, Scrub::ScrubSchedListener& osds)
 std::optional<double> ScrubQueue::update_load_average()
 {
   int hb_interval = conf()->osd_heartbeat_interval;
-  int n_samples = 60 * 24 * 24;
+  int n_samples = std::chrono::duration_cast<seconds>(24h).count();
   if (hb_interval > 1) {
     n_samples /= hb_interval;
     if (n_samples < 1)


### PR DESCRIPTION
Turns out I was wrong in assuming 24-minute hours.
