### PR TITLE
crimson/osd/pg: disable concurrent error_log submissions

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -994,6 +994,7 @@ PG::do_osd_ops(
     seastar::make_lw_shared<OpsExecuter>(
       Ref<PG>{this}, obc, op_info, *m, conn, snapc),
     m->ops,
+    // success_func
     [this, m, obc, may_write = op_info.may_write(),
      may_read = op_info.may_read(), rvec = op_info.allows_returnvec()] {
       // TODO: should stop at the first op which returns a negative retval,
@@ -1032,6 +1033,7 @@ PG::do_osd_ops(
       return do_osd_ops_iertr::make_ready_future<MURef<MOSDOpReply>>(
         std::move(reply));
     },
+    // failure_func
     [m, &op_info, obc, this] (const std::error_code& e) {
     return seastar::do_with(eversion_t(), [m, &op_info, obc, e, this](auto &version) {
       auto fut = seastar::now();

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -555,6 +555,8 @@ private:
     }
   } snaptrim_mutex;
 
+  seastar::shared_mutex error_log_lock;
+
   using do_osd_ops_ertr = crimson::errorator<
    crimson::ct_error::eagain>;
   using do_osd_ops_iertr =


### PR DESCRIPTION
Changeset:
* Readability refactor to `do_osd_ops_execute()`
* Added comments in `do_osd_ops_execute()`
* disabling concurrent error_log submissions:

Introduced in https://github.com/ceph/ceph/commit/a48a8fb81fd7d8d2524fe4702c428bb0ec72d8d2
```
submit_error_log contains the logic where we send the
LogMissingRequest messages to the replicas.
failure_func is part of a concurrent (non-exclusive)
pipeline stage (WaitRepop) so successive ops can reorder.
Disable concurrent error log submissions so
as to maintain correct message order.
```

Fixes: https://tracker.ceph.com/issues/61651

Tests look ok (mostly perf suite infra failures, other failures aren't related):
https://pulpito.ceph.com/matan-2023-09-07_10:45:43-crimson-rados-wip-matanb-crimson-do_osd_ops_execute-ref-crimson-only-distro-crimson-smithi/

Drafted:
Using a lock inside a `OrderedConcurrentPhaseT` breaks the pipeline design in a way. However, the locking is part of the error-handling case which isn't in the hot path and it's relevantly a simple fix.
Other alternatives:
* Restructuring `do_osd_ops_execute` to properly distinguish the phases (Concurrent/Exclusive) of sending LogMissingRequest messages to the awaiting of their responses. Same as in processing MOSDop and awaiting MOSDRepop.
* (WIP) Can we handle `submit_error_log()` outside of WaitRepop logic?

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
