### PR TITLE
mgr/dashboard: Fixed bug for block image list/get

### DIFF
--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -370,6 +370,8 @@ class RbdService(object):
 
                 snap['is_protected'] = None
                 if mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
+                    if not img.snap_exists(snap['name']):
+                        continue
                     snap['is_protected'] = img.is_protected_snap(snap['name'])
                 snap['used_bytes'] = None
                 snap['children'] = []


### PR DESCRIPTION
    mgr/dashboard: Fixed bug for block image list/get

    If the image has a snapshot, and this snapshot has delete into trash, this image will couldn't locate in dashboard.
    Because `img.is_protected_snap(snap['name'])` in `RbdService::_rbd_image` raise `ImageNotFound` exception but no catch it.

    Signed-off-by: 吴创豪 <wuch@yealink.com>