### PR TITLE
rgw: pool creation error message improvement. 

### DIFF
--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -30,7 +30,7 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
     if (r == -ERANGE) {
       ldpp_dout(dpp, 0)
         << __func__
-        << " ERROR: librados::Rados::pool_create returned " << cpp_strerror(-r)
+        << " ERROR: librados::Rados::pool_create " << pool.name << " returned " << cpp_strerror(-r)
         << " (this can be due to a pool or placement group misconfiguration, e.g."
         << " pg_num < pgp_num or mon_max_pg_per_osd exceeded)"
         << dendl;


### PR DESCRIPTION
Show pool.name when failing to create pool from rgw

Even though the error is elsewhere, the rgw will automatically try to create pools and if it fails, it might be nice to see which pool it tried to create from the error message.

In a recent issue* my workaround was to create them manually, but until that issue is fixed, or if someone gets a similar issue, you need to see what pools the rgw failed to create.

*) https://tracker.ceph.com/issues/62770



Signed-off-by: Janne Johansson <icepic.dz@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
