### PR TITLE
quincy: qa/suites/upgrade/quincy-p2p: skip TestClsRbd.mirror_snapshot test

### DIFF
--- a/qa/suites/upgrade/quincy-p2p/quincy-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/quincy-p2p/quincy-p2p-parallel/point-to-point-upgrade.yaml
@@ -124,7 +124,7 @@ workload_quincy:
          - rados/test.sh
          - cls
        env:
-         CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.snapshots_namespaces'
+         CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
    - print: "**** done rados/test.sh &  cls workload_quincy"
    - sequential:
      - rgw: [client.0]

--- a/qa/suites/upgrade/quincy-p2p/quincy-p2p-stress-split/4-workload/rbd-cls.yaml
+++ b/qa/suites/upgrade/quincy-p2p/quincy-p2p-stress-split/4-workload/rbd-cls.yaml
@@ -7,4 +7,6 @@ stress-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_snapshot'
 - print: "**** done cls/test_cls_rbd.sh 4-workload"


### PR DESCRIPTION
The behavior of the class method changed in reef; the change was backported to pacific and quincy.  An older quincy binary used against newer quincy OSDs produces an expected failure:

    [ RUN      ] TestClsRbd.mirror_snapshot
    .../ceph-17.2.0/src/test/cls_rbd/test_cls_rbd.cc:2278: Failure
    Expected equality of these values:
      -85
      mirror_image_snapshot_unlink_peer(&ioctx, oid, 1, "peer2")
        Which is: 0
    [  FAILED  ] TestClsRbd.mirror_snapshot (49 ms)

TestClsRbd.snapshots_namespaces test was removed in commit 4ad9d565a15c ("librbd: simplified retrieving snapshots from image header") many years ago.

Fixes: https://tracker.ceph.com/issues/62773





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
