### PR TITLE
common: add CephContext parameter to tracing::Tracer::init() in !HAVE_JAEGER branch

### DIFF
--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -94,14 +94,16 @@ class jspan {
 namespace tracing {
 
 struct Tracer {
+  void init(CephContext* _cct, std::string_view service_name) {}
   bool is_enabled() const { return false; }
   jspan start_trace(std::string_view, bool enabled = true) { return {}; }
   jspan add_span(std::string_view, const jspan&) { return {}; }
   jspan add_span(std::string_view span_name, const jspan_context& parent_ctx) { return {}; }
-  void init(std::string_view service_name) {}
 };
-  inline void encode(const jspan_context& span, bufferlist& bl, uint64_t f=0) {}
-  inline void decode(jspan_context& span_ctx, ceph::buffer::list::const_iterator& bl) {}
+
+inline void encode(const jspan_context& span, bufferlist& bl, uint64_t f=0) {}
+inline void decode(jspan_context& span_ctx, ceph::buffer::list::const_iterator& bl) {}
+
 }
 
 #endif // !HAVE_JAEGER


### PR DESCRIPTION
Followup to https://github.com/ceph/ceph/pull/50948. This wasn't originally caught since the centos 8 default build passed, but it did fail the crimson build: https://shaman.ceph.com/builds/ceph/wip-yuri3-testing-2023-08-15-0955/b5259484dbc61e8573f27e692560c6c107b9d4c1/

Fixes: https://tracker.ceph.com/issues/62761





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
