### PR TITLE
pacific: mgr/snap-schedule: use the right way to check the result returned by…

### DIFF
--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -282,7 +282,7 @@ class Schedule(object):
                              (path,))
             row = cur.fetchone()
 
-            if len(row) == 0:
+            if row is None:
                 log.info(f'no schedule for {path} found')
                 raise ValueError('SnapSchedule for {} not found'.format(path))
 

--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -327,7 +327,7 @@ class Schedule(object):
     def add_retention(cls, db, path, retention_spec):
         with db:
             row = db.execute(cls.GET_RETENTION, (path,)).fetchone()
-            if not row:
+            if row is None:
                 raise ValueError(f'No schedule found for {path}')
             retention = parse_retention(retention_spec)
             if not retention:
@@ -346,7 +346,7 @@ class Schedule(object):
     def rm_retention(cls, db, path, retention_spec):
         with db:
             row = db.execute(cls.GET_RETENTION, (path,)).fetchone()
-            if not row:
+            if row is None:
                 raise ValueError(f'No schedule found for {path}')
             retention = parse_retention(retention_spec)
             current = row['retention']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57260

---

backport of https://github.com/ceph/ceph/pull/47624
parent tracker: https://tracker.ceph.com/issues/57138

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh