### PR TITLE
reef: client: readdir_r_cb: get rstat for dir only if using rbytes for size

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9269,7 +9269,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
     }
 
     int idx = pd - dir->readdir_cache.begin();
-    if (dn->inode->is_dir()) {
+    if (dn->inode->is_dir() && cct->_conf->client_dirsize_rbytes) {
       mask |= CEPH_STAT_RSTAT;
     }
     int r = _getattr(dn->inode, mask, dirp->perms);
@@ -9377,6 +9377,7 @@ int Client::_readdir_r_cb(int op,
   bool bypass_cache)
 {
   int caps = statx_to_mask(flags, want);
+  int rstat_on_dir = cct->_conf->client_dirsize_rbytes ? CEPH_STAT_RSTAT : 0;
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
@@ -9406,7 +9407,7 @@ int Client::_readdir_r_cb(int op,
     uint64_t next_off = 1;
 
     int r;
-    r = _getattr(diri, caps | CEPH_STAT_RSTAT, dirp->perms);
+    r = _getattr(diri, caps | rstat_on_dir, dirp->perms);
     if (r < 0)
       return r;
 
@@ -9439,7 +9440,7 @@ int Client::_readdir_r_cb(int op,
       in = diri->get_first_parent()->dir->parent_inode;
 
     int r;
-    r = _getattr(in, caps | CEPH_STAT_RSTAT, dirp->perms);
+    r = _getattr(in, caps | rstat_on_dir, dirp->perms);
     if (r < 0)
       return r;
 
@@ -9510,7 +9511,7 @@ int Client::_readdir_r_cb(int op,
       if (check_caps) {
 	int mask = caps;
 	if(entry.inode->is_dir()){
-          mask |= CEPH_STAT_RSTAT;
+          mask |= rstat_on_dir;
 	}
 	r = _getattr(entry.inode, mask, dirp->perms);
 	if (r < 0)

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -315,6 +315,8 @@ options:
   default: true
   services:
   - mds_client
+  flags:
+  - startup
   with_legacy: true
 - name: client_force_lazyio
   type: bool


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62004

---

backport of https://github.com/ceph/ceph/pull/46960
parent tracker: https://tracker.ceph.com/issues/61999

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh