### PR TITLE
common: fix compilation errors when -DWITH_JAEGER=OFF

### DIFF
--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -98,7 +98,7 @@ struct Tracer {
   jspan start_trace(std::string_view, bool enabled = true) { return {}; }
   jspan add_span(std::string_view, const jspan&) { return {}; }
   jspan add_span(std::string_view span_name, const jspan_context& parent_ctx) { return {}; }
-  void init(std::string_view service_name) {}
+  void init(CephContext* _cct, std::string_view service_name) {}
 };
   inline void encode(const jspan_context& span, bufferlist& bl, uint64_t f=0) {}
   inline void decode(jspan_context& span_ctx, ceph::buffer::list::const_iterator& bl) {}


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62782

fixes the following compilation errors:
```
[202/238] Building CXX object src/rgw/CMakeFiles/rgw_a.dir/rgw_appmain.cc.o                                                                                                      [3245/45492]
FAILED: src/rgw/CMakeFiles/rgw_a.dir/rgw_appmain.cc.o                                                                                                                                        
/usr/bin/ccache /usr/bin/clang++ -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT -DBOOST_USE_VALGRIND -DCLS_CLIENT_HIDE_IOCTX -DHAVE_CONFIG_H -D_FILE_O
FFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -Isrc/include -I../src -I../src/dmclock/support/src -I../src/rgw -I../src/rgw/driver/ra
dos -I../src/libkmip -I../src/rgw/services -I../src/spawn/include -isystem boost/include -isystem include -isystem ../src/xxHash -isystem ../src/fmt/include -isystem ../src/cpp_redis/includ
es -isystem ../src/cpp_redis/tacopie/includes -isystem ../src/s3select/rapidjson/include -std=gnu++20 -DNDEBUG -Wp,-D_GLIBCXX_ASSERTIONS -Wall -pipe  -fdiagnostics-color=always -fcolor-diag
nostics -mcmodel=large -frecord-gcc-switches -grecord-gcc-switches -fno-omit-frame-pointer -fstack-protector-strong -ggnu-pubnames -fasynchronous-unwind-tables -ggdb3 -gdwarf-4 -fcf-protect
ion=none -fstack-check -ftree-vectorize -ftree-slp-vectorize -feliminate-unused-debug-types -fno-signed-zeros -fno-trapping-math -fassociative-math -funsafe-math-optimizations -falign-loops
=16 -Wp,-D_FORTIFY_SOURCE=3 -march=native -mtune=native -mavx2 -mfma -ffp-contract=fast -ffast-math -mfpmath=sse -Ofast -Warray-bounds -fstrict-vtable-pointers --param=ssp-buffer-size=32 -f
use-ld=/usr/local/bin/ld.gold -Wl,--threads -Wl,--thread-count=8 -Wl,--gdb-index  -ffunction-sections -fdata-sections -Wno-unused-command-line-argument -fsized-deallocation -falign-function
s=64 -gz=zlib -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -DBOOST_PHOENIX_STL_TUPLE_H_ -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wigno
red-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move 
-Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designat
or -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -fdiagnostics-color=always -std=c++20 -MD -MT src/rgw/CMakeFiles/rgw_a.dir/rgw_appmain.cc.o -MF src/rgw/CMakeFiles/rgw_a.dir
/rgw_appmain.cc.o.d -o src/rgw/CMakeFiles/rgw_a.dir/rgw_appmain.cc.o -c ../src/rgw/rgw_appmain.cc                                                                                            
../src/rgw/rgw_appmain.cc:532:45: error: too many arguments to function call, expected single argument 'service_name', have 2 arguments                                                      
  tracing::rgw::tracer.init(dpp->get_cct(), "rgw");                                                                                                                                          
  ~~~~~~~~~~~~~~~~~~~~~~~~~                 ^~~~~   

[697/947] Building CXX object src/osd/CMakeFiles/osd.dir/OSD.cc.o                                                                                                                           
FAILED: src/osd/CMakeFiles/osd.dir/OSD.cc.o                                                                                                                                                  
/usr/bin/ccache /usr/bin/clang++ -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS -DBOOST_MPL_LIMIT_LIST_SIZE=30
 -DHAVE_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -Isrc/include -I../src -I../src/dmclock/src -I../src/dmclock/
support/src -isystem boost/include -isystem include -isystem ../src/xxHash -isystem ../src/fmt/include -isystem ../src/rocksdb/include -std=gnu++20 -DNDEBUG -Wp,-D_GLIBCXX_ASSERTIONS -Wall 
-pipe  -fdiagnostics-color=always -fcolor-diagnostics -mcmodel=large -frecord-gcc-switches -grecord-gcc-switches -fno-omit-frame-pointer -fstack-protector-strong -ggnu-pubnames -fasynchrono
us-unwind-tables -ggdb3 -gdwarf-4 -fcf-protection=none -fstack-check -ftree-vectorize -ftree-slp-vectorize -feliminate-unused-debug-types -fno-signed-zeros -fno-trapping-math -fassociative-
math -funsafe-math-optimizations -falign-loops=16 -Wp,-D_FORTIFY_SOURCE=3 -march=native -mtune=native -mavx2 -mfma -ffp-contract=fast -ffast-math -mfpmath=sse -Ofast -Warray-bounds -fstrict
-vtable-pointers --param=ssp-buffer-size=32 -fuse-ld=/usr/local/bin/ld.gold -Wl,--threads -Wl,--thread-count=8 -Wl,--gdb-index  -ffunction-sections -fdata-sections -Wno-unused-command-line-
argument -fsized-deallocation -falign-functions=64 -gz=zlib -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -DBOOST_PHOENIX_STL_TUPLE_H_ -Wall -fno-stri
ct-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-d
epth-1024 -Wpessimizing-move -Wredundant-move -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unused-function -Wno-unuse
d-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -fdiagnostics-color=always -std=c++20 -MD -MT src/osd/CMakeFiles/osd.dir/OSD.c
c.o -MF src/osd/CMakeFiles/osd.dir/OSD.cc.o.d -o src/osd/CMakeFiles/osd.dir/OSD.cc.o -c ../src/osd/OSD.cc                                                                                   
../src/osd/OSD.cc:3598:34: error: too many arguments to function call, expected single argument 'service_name', have 2 arguments                                                            
  tracing::osd::tracer.init(cct, "osd");                                                                                                                                                    
  ~~~~~~~~~~~~~~~~~~~~~~~~~      ^~~~~                                                                                                                                                      
../src/common/tracer.h:101:8: note: 'init' declared here                                                                                                                                    
  void init(std::string_view service_name) {}                                                                                                                                               
       ^                                                                                                                                                                                    
../src/osd/OSD.cc:11257:9: warning: variable 'work_count' set but not used [-Wunused-but-set-variable]                                                                                      
    int work_count = 0;                                                                                                                                                                     
        ^                                                                                                                                                                                   
1 warning and 1 error generated.                                  
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
