### PR TITLE
examples: fixed errors with the if-match header in the examples of rgw-cache nginx configs

### DIFF
--- a/examples/rgw/rgw-cache/nginx-default.conf
+++ b/examples/rgw/rgw-cache/nginx-default.conf
@@ -122,7 +122,7 @@ server {
             set $do_not_cache "no";
             set $date $http_x_amz_date;
         }
-        proxy_set_header if_match $http_if_match;
+        proxy_set_header if-match $http_if_match;
         proxy_set_header Range $myrange;
         # Use the original x-amz-date if the aws auth module didn't create one 
         proxy_set_header x-amz-date $date;

--- a/examples/rgw/rgw-cache/nginx-noprefetch.conf
+++ b/examples/rgw/rgw-cache/nginx-noprefetch.conf
@@ -90,6 +90,7 @@ server {
         if ($request_uri ~* (\?)) {
             set $do_not_cache "no";
         }
+        proxy_set_header if-match $http_if_match;
         # Use the original x-amz-date if the aws auth module didn't create one 
         proxy_no_cache $do_not_cache;
         proxy_set_header Authorization $http_authorization;

--- a/examples/rgw/rgw-cache/nginx-slicing.conf
+++ b/examples/rgw/rgw-cache/nginx-slicing.conf
@@ -124,7 +124,7 @@ server {
             set $do_not_cache "no";
             set $date $http_x_amz_date;
         }
-        proxy_set_header if_match $http_if_match;
+        proxy_set_header if-match $http_if_match;
         # Use the original x-amz-date if the aws auth module didn't create one 
         proxy_set_header x-amz-date $date;
         proxy_set_header X-Amz-Cache $authvar;


### PR DESCRIPTION


The rgw-cache nginx examples contain incorrect header. All HTTP header names are written with a hyphen, not an underscore.
Like here https://http.dev/if-match

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
