### PR TITLE
quincy: rgw/notification: remove non x-amz-meta-* attributes from bucket notifications

### DIFF
--- a/src/rgw/rgw_notify.cc
+++ b/src/rgw/rgw_notify.cc
@@ -634,6 +634,15 @@ rgw::sal::Object* get_object_with_atttributes(
   return src_obj;
 }
 
+static inline void filter_amz_meta(meta_map_t& dest, const meta_map_t& src) {
+  std::copy_if(src.cbegin(), src.cend(),
+               std::inserter(dest, dest.end()),
+               [](const auto& m) {
+                 return (boost::algorithm::starts_with(m.first, RGW_AMZ_META_PREFIX));
+               });
+}
+
+
 static inline void metadata_from_attributes(
   reservation_t& res, rgw::sal::Object* obj) {
   auto& metadata = res.x_meta_map;
@@ -736,7 +745,7 @@ static inline bool notification_match(reservation_t& res,
   if (!filter.s3_filter.metadata_filter.kv.empty()) {
     // metadata filter exists
     if (res.s) {
-      res.x_meta_map = res.s->info.x_meta_map;
+      filter_amz_meta(res.x_meta_map, res.s->info.x_meta_map);
     }
     metadata_from_attributes(res, obj);
     if (!match(filter.s3_filter.metadata_filter, res.x_meta_map)) {
@@ -973,13 +982,14 @@ reservation_t::reservation_t(const DoutPrefixProvider* _dpp,
   object(_object), src_object(_src_object), bucket(_s->bucket.get()),
   object_name(_object_name),
   tagset(_s->tagset),
-  x_meta_map(_s->info.x_meta_map),
   metadata_fetched_from_attributes(false),
   user_id(_s->user->get_id().id),
   user_tenant(_s->user->get_id().tenant),
   req_id(_s->req_id),
   yield(y)
-{}
+{
+  filter_amz_meta(x_meta_map, _s->info.x_meta_map);
+}
 
 reservation_t::reservation_t(const DoutPrefixProvider* _dpp,
 			     rgw::sal::RadosStore* _store,

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -342,6 +342,8 @@ def verify_events_by_elements(events, keys, exact_match=False, deletions=False):
             log.error(events)
             assert False, err
 
+META_PREFIX = 'x-amz-meta-'
+
 def verify_s3_records_by_elements(records, keys, exact_match=False, deletions=False, expected_sizes={}, etags=[]):
     """ verify there is at least one record per element """
     err = ''
@@ -360,6 +362,9 @@ def verify_s3_records_by_elements(records, keys, exact_match=False, deletions=Fa
                         #assert_equal(key.etag[1:-1], record['s3']['object']['eTag'])
                         if etags:
                             assert_in(key.etag[1:-1], etags)
+                        if len(record['s3']['object']['metadata']) > 0:
+                            for meta in record['s3']['object']['metadata']:
+                                assert(meta['key'].startswith(META_PREFIX))
                         if deletions and record['eventName'].startswith('ObjectRemoved'):
                             key_found = True
                             object_size = record['s3']['object']['size']
@@ -376,6 +381,9 @@ def verify_s3_records_by_elements(records, keys, exact_match=False, deletions=Fa
                     assert_equal(key.etag, record['s3']['object']['eTag'])
                     if etags:
                         assert_in(key.etag[1:-1], etags)
+                    if len(record['s3']['object']['metadata']) > 0:
+                        for meta in record['s3']['object']['metadata']:
+                            assert(meta['key'].startswith(META_PREFIX))
                     if deletions and record['eventName'].startswith('ObjectRemoved'):
                         key_found = True
                         object_size = record['s3']['object']['size']
@@ -2154,8 +2162,6 @@ def test_ps_s3_multipart_on_master():
     # delete the bucket
     conn.delete_bucket(bucket_name)
 
-META_PREFIX = 'x-amz-meta-'
-
 @attr('amqp_test')
 def test_ps_s3_metadata_filter_on_master():
     """ test s3 notification of metadata on master """
@@ -2287,7 +2293,7 @@ def test_ps_s3_metadata_on_master():
     notification_name = bucket_name + NOTIFICATION_SUFFIX
     meta_key = 'meta1'
     meta_value = 'This is my metadata value'
-    meta_prefix = 'x-amz-meta-'
+    meta_prefix = META_PREFIX
     topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
         'Events': ['s3:ObjectCreated:*', 's3:ObjectRemoved:*'],
     }]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59694

---

backport of https://github.com/ceph/ceph/pull/51308
parent tracker: https://tracker.ceph.com/issues/59592

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh