### PR TITLE
pacific: rgw/notification: remove non x-amz-meta-* attributes from bucket notifications

### DIFF
--- a/src/rgw/rgw_notify.h
+++ b/src/rgw/rgw_notify.h
@@ -62,8 +62,7 @@ struct reservation_t {
   KeyValueMap cached_metadata;
 
   reservation_t(const DoutPrefixProvider *_dpp, rgw::sal::RGWRadosStore* _store, const req_state* _s,
-                rgw::sal::RGWObject* _object, const std::string* _object_name=nullptr) :
-      dpp(_dpp), store(_store), s(_s), object(_object), object_name(_object_name) {}
+                rgw::sal::RGWObject* _object, const std::string* _object_name=nullptr);
 
   // dtor doing resource leak guarding
   // aborting the reservation if not already committed or aborted


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59692

---

backport of https://github.com/ceph/ceph/pull/51308
parent tracker: https://tracker.ceph.com/issues/59592

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh