### PR TITLE
reef: mgr/dashboard: Object gateway sync status cards keeps loading when multisite is not configured

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
@@ -112,11 +112,13 @@
     <cd-card cardTitle="Multisite Sync Status"
              i18n-title>
       <ng-template #notConfigured>
-        <cd-alert-panel type="info"
-                        i18n>
-          Multisite needs to be configured in order to see the multisite sync status.
-          Please consult the <cd-doc section="multisite"></cd-doc> on how to configure and enable the multisite functionality.
-        </cd-alert-panel>
+        <span class="pe-5 ps-5">
+          <cd-alert-panel type="info"
+                          i18n>
+            Multisite needs to be configured in order to see the multisite sync status.
+            Please consult the <cd-doc section="multisite"></cd-doc> on how to configure and enable the multisite functionality.
+          </cd-alert-panel>
+        </span>
       </ng-template>
       <span *ngIf="loading"
             class="d-flex justify-content-center">

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1545,7 +1545,7 @@ class RgwMultisite:
         try:
             exit_code, out, _ = mgr.send_rgwadmin_command(rgw_multisite_sync_status_cmd, False)
             if exit_code > 0:
-                raise DashboardException('Unable to get multisite sync status',
+                raise DashboardException('Unable to get sync status',
                                          http_status_code=500, component='rgw')
             if out:
                 return self.process_data(out)
@@ -1555,8 +1555,10 @@ class RgwMultisite:
 
     def process_data(self, data):
         primary_zone_data, metadata_sync_data = self.extract_metadata_and_primary_zone_data(data)
-        datasync_info = self.extract_datasync_info(data)
-        replica_zones_info = [self.extract_replica_zone_data(item) for item in datasync_info]
+        replica_zones_info = []
+        if metadata_sync_data != {}:
+            datasync_info = self.extract_datasync_info(data)
+            replica_zones_info = [self.extract_replica_zone_data(item) for item in datasync_info]
 
         replica_zones_info_object = {
             'metadataSyncInfo': metadata_sync_data,
@@ -1575,7 +1577,10 @@ class RgwMultisite:
         zone = self.get_primary_zonedata(primary_zone_tree[2])
 
         primary_zone_data = [realm, zonegroup, zone]
-        metadata_sync_data = self.extract_metadata_sync_data(metadata_sync_infoormation)
+        zonegroup_info = self.get_zonegroup(zonegroup)
+        metadata_sync_data = {}
+        if len(zonegroup_info['zones']) > 1:
+            metadata_sync_data = self.extract_metadata_sync_data(metadata_sync_infoormation)
 
         return primary_zone_data, metadata_sync_data
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62768

---

backport of https://github.com/ceph/ceph/pull/53244
parent tracker: https://tracker.ceph.com/issues/62665

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh