### PR TITLE
quincy: mgr/dashboard: images -> edit -> disable checkboxes for layering and deef-flatten

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-feature.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-feature.interface.ts
@@ -6,4 +6,5 @@ export interface RbdImageFeature {
   interlockedWith?: string;
   key?: string;
   initDisabled?: boolean;
+  helperHtml?: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -142,7 +142,6 @@ describe('RbdFormComponent', () => {
       expect(component['rbdImage'].observers.length).toEqual(0);
       component.ngOnInit(); // Subscribes to image once during init
       component.submit();
-      expect(component['rbdImage'].observers.length).toEqual(1);
       expect(createAction).toHaveBeenCalledTimes(0);
       expect(editAction).toHaveBeenCalledTimes(1);
       expect(cloneAction).toHaveBeenCalledTimes(0);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -133,13 +133,15 @@ export class RbdFormComponent extends CdForm implements OnInit {
         desc: $localize`Deep flatten`,
         requires: null,
         allowEnable: false,
-        allowDisable: true
+        allowDisable: true,
+        helperHtml: $localize`Feature can be disabled but can't be re-enabled later`
       },
       layering: {
         desc: $localize`Layering`,
         requires: null,
         allowEnable: false,
-        allowDisable: false
+        allowDisable: false,
+        helperHtml: $localize`Feature can't be manipulated after the image is created`
       },
       'exclusive-lock': {
         desc: $localize`Exclusive lock`,
@@ -224,6 +226,11 @@ export class RbdFormComponent extends CdForm implements OnInit {
         this.rbdForm.get('deep-flatten').disable();
         this.rbdForm.get('layering').disable();
         this.rbdForm.get('exclusive-lock').disable();
+      } else {
+        if (!this.rbdForm.get('deep-flatten').value) {
+          this.rbdForm.get('deep-flatten').disable();
+        }
+        this.rbdForm.get('layering').disable();
       }
     });
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62789

---

backport of https://github.com/ceph/ceph/pull/53071
parent tracker: https://tracker.ceph.com/issues/62502

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh