### PR TITLE
reef: rgw: fix 2 null versionID after convert_plain_entry_to_versioned

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1898,6 +1898,9 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
       return ret;
     }
     olh.set_tag(op.olh_tag);
+    if (op.key.instance.empty()){
+      obj.set_epoch(1);
+    }
   }
 
   /* update the olh log */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62752

---

backport of https://github.com/ceph/ceph/pull/52684
parent tracker: https://tracker.ceph.com/issues/62013

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh