### PR TITLE
reef: qa: fix keystone in rgw/crypt/barbican.yaml

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,7 +27,11 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/xena
+      force-branch: stable/2023.1
+      services:
+        - name: swift
+          type: object-store
+          description: Swift Service
       projects:
         - name: rgwcrypt
           description: Encryption Tenant
@@ -62,10 +66,6 @@ tasks:
         - name: creator
           user: s3-user
           project: s3
-      services:
-        - name: swift
-          type: object-store
-          description: Swift Service
 - barbican:
     client.0:
       force-branch: stable/xena

--- a/qa/suites/rgw/crypt/supported-random-distro$
+++ b/qa/suites/rgw/crypt/supported-random-distro$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/rgw/crypt/ubuntu_latest.yaml
+++ b/qa/suites/rgw/crypt/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_latest.yaml

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -136,9 +136,8 @@ def set_authtoken_params(ctx, cclient, cconfig):
                         ['sed', '-i',
                          '/[[]filter:authtoken]/{p;s##'+'auth_uri = {}'.format(url)+'#;}',
                          'etc/barbican/barbican-api-paste.ini'])
-    admin_host, admin_port = ctx.keystone.admin_endpoints[keystone_role]
-    admin_url = 'http://{host}:{port}/v3'.format(host=admin_host,
-                                                 port=admin_port)
+    admin_url = 'http://{host}:{port}/v3'.format(host=public_host,
+                                                 port=public_port)
     run_in_barbican_dir(ctx, cclient,
                         ['sed', '-i',
                          '/[[]filter:authtoken]/{p;s##'+'auth_url = {}'.format(admin_url)+'#;}',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62352

---

backport of https://github.com/ceph/ceph/pull/52494
parent tracker: https://tracker.ceph.com/issues/61772

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh