### PR TITLE
osd: fix: slow scheduling when item_cost is large

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -340,8 +340,7 @@ uint32_t mClockScheduler::calc_scaled_cost(int item_cost)
       item_cost));
   auto cost_per_io = static_cast<uint32_t>(osd_bandwidth_cost_per_io);
 
-  // Calculate total scaled cost in bytes
-  return cost_per_io + cost;
+  return std::max<uint32_t>(cost, cost_per_io);
 }
 
 void mClockScheduler::update_configuration()


### PR DESCRIPTION
osd/scheduler/mClockScheduler: Take the maximum value of item_cost and osd_bandwidth_cost_per_io to solve the problem of slow scheduling when item_cost is large

We use the iops and bandwidth tested by
`ceph tell osd.0 bench 10737418240 204800 204800 100`
to verify the QoS function. iops was 400 and bandwidth was 80MiB/s.
When osd_mclock_scheduler_client_lim is set to 1,
the sequential write bandwidth is only half of the capacity.
Therefore, we believe that it should not unconditionally increase
osd_bandwidth_cost_per_io for each IO, but take the maximum of the two.

Fixes: https://tracker.ceph.com/issues/62812
Signed-off-by: Jrchyang Yu <yuzhiqiang_yewu@cmss.chinamobile.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
