### PR TITLE
tasks: Add crimson collection mark for later use in the database

### DIFF
--- a/qa/tasks/cbt_performance.py
+++ b/qa/tasks/cbt_performance.py
@@ -36,8 +36,12 @@ class CBTperformance:
         for cbt_results in cbt_results_arry:
             cbt_results = json.loads(json.dumps(cbt_results))
             if cbt_results:
+                crimson_run = False
+                if ctx.config.get('flavor', 'default') == 'crimson':
+                    crimson_run = True
                 data = {
                     "job_id" : ctx.config.get('job_id', None),
+                    "crimson_run" : crimson_run,
                     "started_at" : ctx.config.get('timestamp', None),
                     "benchmark_mode" : cbt_results.get("Benchmark_mode", None),
                     "seq" : cbt_results.get("seq", None),
@@ -149,4 +153,4 @@ class CBTperformance:
         job_id = ctx.config.get('job_id', None)
         branch = ctx.config.get('branch', None)
 
-        return f'{server}:{grafana_port}/d/{Dash_id}?orgId=1&var-branch_name={branch}&var-job_id_selected={job_id}'
+        return f'{server}:{grafana_port}/d/{Dash_id}?orgId=1&var-branch_name={branch}&var-job_id_selected1={job_id}'


### PR DESCRIPTION
To identify crimson run, I added new boolean field in the database to let the Grafana views to filter crimson performance runs


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
