### PR TITLE
mgr/nfs: enable reporting err status in Responder decorator, enhance err reporting in nfs export apply

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -404,6 +404,13 @@ class TestNFS(MgrTestCase):
         self._cmd('fs', 'volume', 'rm', fs_name, '--yes-i-really-mean-it')
         self._test_delete_cluster()
 
+    def _nfs_export_apply(self, cluster, exports, raise_on_error=False):
+        return self.ctx.cluster.run(args=['ceph', 'nfs', 'export', 'apply',
+                                          cluster, '-i', '-'],
+                                    check_status=raise_on_error,
+                                    stdin=json.dumps(exports),
+                                    stdout=StringIO(), stderr=StringIO())
+
     def test_create_and_delete_cluster(self):
         '''
         Test successful creation and deletion of the nfs cluster.
@@ -876,3 +883,194 @@ class TestNFS(MgrTestCase):
                 raise
         self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}/*'])
         self._delete_cluster_with_fs(self.fs_name, mnt_pt, preserve_mode)
+
+    def test_nfs_export_apply_multiple_exports(self):
+        """
+        Test multiple export creation/update with multiple
+        export blocks provided in the json/conf file using:
+        ceph nfs export apply <nfs_cluster> -i <{conf/json}_file>, and check
+        1) if there are multiple failure:
+        -> Return the EIO and error status to CLI (along with JSON output
+           containing status of every export).
+        2) if there is single failure:
+        -> Return the respective errno and error status to CLI (along with
+           JSON output containing status of every export).
+        """
+
+        mnt_pt = self._sys_cmd(['mktemp', '-d']).decode().strip()
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
+        try:
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir1'])
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir2'])
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir3'])
+            self._create_export(export_id='1',
+                                extra_cmd=['--pseudo-path', self.pseudo_path,
+                                           '--path', '/testdir1'])
+            self._create_export(export_id='2',
+                                extra_cmd=['--pseudo-path',
+                                           self.pseudo_path+'2',
+                                           '--path', '/testdir2'])
+            exports = [
+                {
+                    "export_id": 11,  # export_id change not allowed
+                    "path": "/testdir1",
+                    "pseudo": self.pseudo_path,
+                    "squash": "none",
+                    "access_type": "rw",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.1",
+                        "fs_name": self.fs_name
+                    }
+                },
+                {
+                    "export_id": 2,
+                    "path": "/testdir2",
+                    "pseudo": self.pseudo_path+'2',
+                    "squash": "none",
+                    "access_type": "rw",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.2",
+                        "fs_name": "invalid_fs_name"  # invalid fs
+                    }
+                },
+                {   # no error, export creation should succeed
+                    "export_id": 3,
+                    "path": "/testdir3",
+                    "pseudo": self.pseudo_path+'3',
+                    "squash": "none",
+                    "access_type": "rw",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.3",
+                        "fs_name": self.fs_name
+                    }
+                }
+            ]
+
+            # multiple failures
+            ret = self._nfs_export_apply(self.cluster_id, exports)
+            self.assertEqual(ret[0].returncode, errno.EIO)
+            self.assertIn("2 export blocks (at index 1, 2) failed to be "
+                          "created/updated", ret[0].stderr.getvalue())
+
+            # single failure
+            exports[1]["fsal"]["fs_name"] = self.fs_name  # correct the fs
+            ret = self._nfs_export_apply(self.cluster_id, exports)
+            self.assertEqual(ret[0].returncode, errno.EINVAL)
+            self.assertIn("Export ID changed, Cannot update export for "
+                          "export block at index 1", ret[0].stderr.getvalue())
+        finally:
+            self._delete_cluster_with_fs(self.fs_name, mnt_pt)
+            self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}'])
+
+    def test_nfs_export_apply_single_export(self):
+        """
+        Test that when single export creation/update fails with multiple
+        export blocks provided in the json/conf file using:
+        ceph nfs export apply <nfs_cluster> -i <{conf/json}_file>, it
+        returns the respective errno and error status to CLI (along with
+        JSON output containing status of every export).
+        """
+
+        mnt_pt = self._sys_cmd(['mktemp', '-d']).decode().strip()
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
+        try:
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir1'])
+            self._create_export(export_id='1',
+                                extra_cmd=['--pseudo-path', self.pseudo_path,
+                                           '--path', '/testdir1'])
+            export = {
+                "export_id": 1,
+                "path": "/testdir1",
+                "pseudo": self.pseudo_path,
+                "squash": "none",
+                "access_type": "rw",
+                "protocols": [4],
+                "fsal": {
+                    "name": "CEPH",
+                    "user_id": "nfs.test.1",
+                    "fs_name": "invalid_fs_name"  # invalid fs
+                }
+            }
+            ret = self._nfs_export_apply(self.cluster_id, export)
+            self.assertEqual(ret[0].returncode, errno.ENOENT)
+            self.assertIn("filesystem invalid_fs_name not found for "
+                          "export block at index 1", ret[0].stderr.getvalue())
+        finally:
+            self._delete_cluster_with_fs(self.fs_name, mnt_pt)
+            self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}'])
+
+    def test_nfs_export_apply_json_output_states(self):
+        """
+        If export creation/update is done using:
+        ceph nfs export apply <nfs_cluster> -i <{conf/json}_file> then the
+        "status" field in the json output maybe added, updated, error or
+        warning. Test different scenarios to make sure these states are
+        in the json output as expected.
+        """
+
+        mnt_pt = self._sys_cmd(['mktemp', '-d']).decode().strip()
+        self._create_cluster_with_fs(self.fs_name, mnt_pt)
+        try:
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir1'])
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir2'])
+            self.ctx.cluster.run(args=['mkdir', f'{mnt_pt}/testdir3'])
+            self._create_export(export_id='1',
+                                extra_cmd=['--pseudo-path', self.pseudo_path,
+                                           '--path', '/testdir1'])
+            exports = [
+                {   # change pseudo, state should be "updated"
+                    "export_id": 1,
+                    "path": "/testdir1",
+                    "pseudo": self.pseudo_path+'1',
+                    "squash": "none",
+                    "access_type": "rw",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.1",
+                        "fs_name": self.fs_name
+                    }
+                },
+                {   # a new export, state should be "added"
+                    "export_id": 2,
+                    "path": "/testdir2",
+                    "pseudo": self.pseudo_path+'2',
+                    "squash": "none",
+                    "access_type": "rw",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.2",
+                        "fs_name": self.fs_name
+                    }
+                },
+                {   # error in export block, state should be "error" since the
+                    # fs_name is invalid
+                    "export_id": 3,
+                    "path": "/testdir3",
+                    "pseudo": self.pseudo_path+'3',
+                    "squash": "none",
+                    "access_type": "RW",
+                    "protocols": [4],
+                    "fsal": {
+                        "name": "CEPH",
+                        "user_id": "nfs.test.3",
+                        "fs_name": "invalid_fs_name"
+                    }
+                }
+            ]
+            ret = self._nfs_export_apply(self.cluster_id, exports)
+            json_output = json.loads(ret[0].stdout.getvalue().strip())
+            self.assertEqual(len(json_output), 3)
+            self.assertEqual(json_output[0]["state"], "updated")
+            self.assertEqual(json_output[1]["state"], "added")
+            self.assertEqual(json_output[2]["state"], "error")
+        finally:
+            self._delete_cluster_with_fs(self.fs_name, mnt_pt)
+            self.ctx.cluster.run(args=['rm', '-rf', f'{mnt_pt}'])

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -167,9 +167,22 @@ class AppliedExportResults:
     def __init__(self) -> None:
         self.changes: List[Dict[str, str]] = []
         self.has_error = False
+        self.exceptions: List[Exception] = []
+        self.faulty_export_block_indices = ""
+        self.num_errors = 0
+        self.status = ""
 
-    def append(self, value: Dict[str, str]) -> None:
+    def append(self, value: Dict[str, Any]) -> None:
         if value.get("state", "") == "error":
+            self.num_errors += 1
+            # If there is an error then there must be an exception in the dict.
+            self.exceptions.append(value.pop("exception"))
+            # Index is for indicating at which export block in the conf/json
+            # file did the export creation/update failed.
+            if len(self.faulty_export_block_indices) == 0:
+                self.faulty_export_block_indices = str(value.pop("index"))
+            else:
+                self.faulty_export_block_indices += f", {value.pop('index')}"
             self.has_error = True
         self.changes.append(value)
 
@@ -177,7 +190,29 @@ class AppliedExportResults:
         return self.changes
 
     def mgr_return_value(self) -> int:
-        return -errno.EIO if self.has_error else 0
+        if self.has_error:
+            if len(self.exceptions) == 1:
+                ex = self.exceptions[0]
+                if isinstance(ex, NFSException):
+                    return ex.errno
+                # Some non-nfs exception occurred, this can be anything
+                # therefore return EAGAIN as a generalised errno.
+                return -errno.EAGAIN
+            # There are multiple failures so returning EIO as a generalised
+            # errno.
+            return -errno.EIO
+        return 0
+
+    def mgr_status_value(self) -> str:
+        if self.has_error:
+            if len(self.faulty_export_block_indices) == 1:
+                self.status = f"{str(self.exceptions[0])} for export block" \
+                              f" at index {self.faulty_export_block_indices}"
+            elif len(self.faulty_export_block_indices) > 1:
+                self.status = f"{self.num_errors} export blocks (at index" \
+                              f" {self.faulty_export_block_indices}) failed" \
+                              " to be created/updated"
+        return self.status
 
 
 class ExportMgr:
@@ -501,7 +536,12 @@ class ExportMgr:
 
         aeresults = AppliedExportResults()
         for export in exports:
-            aeresults.append(self._change_export(cluster_id, export))
+            changed_export = self._change_export(cluster_id, export)
+            # This will help figure out which export blocks in conf/json file
+            # are problematic.
+            if changed_export.get("state", "") == "error":
+                changed_export.update({"index": exports.index(export) + 1})
+            aeresults.append(changed_export)
         return aeresults
 
     def _read_export_config(self, cluster_id: str, export_config: str) -> List[Dict]:
@@ -525,7 +565,7 @@ class ExportMgr:
             return j  # j is already a list object
         return [j]  # return a single object list, with j as the only item
 
-    def _change_export(self, cluster_id: str, export: Dict) -> Dict[str, str]:
+    def _change_export(self, cluster_id: str, export: Dict) -> Dict[str, Any]:
         try:
             return self._apply_export(cluster_id, export)
         except NotImplementedError:
@@ -543,7 +583,7 @@ class ExportMgr:
         except Exception as ex:
             msg = f'Failed to apply export: {ex}'
             log.exception(msg)
-            return {"state": "error", "msg": msg}
+            return {"state": "error", "msg": msg, "exception": ex}
 
     def _update_user_id(
             self,

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -235,6 +235,15 @@ class ReturnValueProvider(Protocol):
         ...  # pragma: no cover
 
 
+class StatusValueProvider(Protocol):
+    def mgr_status_value(self) -> str:
+        """Return a string value to provide the Ceph MGR with an error status
+        for the MGR's response tuple. Empty string means success. Return a string
+        containing error info otherwise.
+        """
+        ...  # pragma: no cover
+
+
 class CommonFormatter(Protocol):
     """A protocol that indicates the type is a formatter for multiple
     possible formats.
@@ -274,6 +283,11 @@ def _is_yaml_data_provider(obj: YAMLDataProvider) -> bool:
 def _is_return_value_provider(obj: ReturnValueProvider) -> bool:
     """Return true if obj is usable as a YAMLDataProvider."""
     return callable(getattr(obj, 'mgr_return_value', None))
+
+
+def _is_status_value_provider(obj: StatusValueProvider) -> bool:
+    """Return true if obj is usable as a StatusValueProvider"""
+    return callable(getattr(obj, 'mgr_status_value', None))
 
 
 class ObjectFormatAdapter:
@@ -366,6 +380,27 @@ class ReturnValueAdapter:
         return self.default_return_value
 
 
+class StatusValueAdapter:
+    """A status-value adapter for an object.
+    Given an input object, this type will attempt to get a mgr status value
+    from the object if provides a `mgr_status_value` function.
+    If not it returns a default status value, typically an empty string.
+    """
+
+    def __init__(
+            self,
+            obj: Any,
+            default: str = "",
+    ) -> None:
+        self.obj = obj
+        self.default_status = default
+
+    def mgr_status_value(self) -> str:
+        if _is_status_value_provider(self.obj):
+            return str(self.obj.mgr_status_value())
+        return self.default_status
+
+
 class ErrorResponseBase(Exception):
     """An exception that can directly be converted to a mgr reponse."""
 
@@ -448,6 +483,7 @@ ObjectResponseFuncType = Union[
     Callable[..., JSONDataProvider],
     Callable[..., YAMLDataProvider],
     Callable[..., ReturnValueProvider],
+    Callable[..., StatusValueProvider],
 ]
 
 
@@ -487,6 +523,10 @@ class Responder:
         """Return a ReturnValueProvider for the given object."""
         return ReturnValueAdapter(obj)
 
+    def _statusval_provider(self, obj: Any) -> StatusValueProvider:
+        """Return a StatusValueProvider for the given object."""
+        return StatusValueAdapter(obj)
+
     def _get_format_func(
         self, obj: Any, format_req: Optional[str] = None
     ) -> Callable:
@@ -515,6 +555,12 @@ class Responder:
         """Return a mgr return-value for the given object (usually zero)."""
         return self._retval_provider(obj).mgr_return_value()
 
+    def _return_status(self, obj: Any) -> str:
+        """Return a mgr status-value for the given object (usually empty
+        string).
+        """
+        return self._statusval_provider(obj).mgr_status_value()
+
     def __call__(self, f: ObjectResponseFuncType) -> HandlerFuncType:
         """Wrap a python function so that the original function's return value
         becomes the source for an automatically formatted mgr response.
@@ -528,9 +574,10 @@ class Responder:
                 robj = f(*args, **kwargs)
                 body = self._formatted(robj, format_req)
                 retval = self._return_value(robj)
+                statusval = self._return_status(robj)
             except ErrorResponseBase as e:
                 return e.format_response()
-            return retval, body, ""
+            return retval, body, statusval
 
         # set the extra args on our wrapper function. this will be consumed by
         # the CLICommand decorator and added to the set of optional arguments

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -228,8 +228,8 @@ class YAMLFormatter(Protocol):
 
 class ReturnValueProvider(Protocol):
     def mgr_return_value(self) -> int:
-        """Return an integer value to provide the Ceph MGR with a error code
-        for the MGR's response tuple. Zero means success. Return an negative
+        """Return an integer value to provide the Ceph MGR with an error code
+        for the MGR's response tuple. Zero means success. Return a negative
         errno otherwise.
         """
         ...  # pragma: no cover
@@ -281,7 +281,7 @@ def _is_yaml_data_provider(obj: YAMLDataProvider) -> bool:
 
 
 def _is_return_value_provider(obj: ReturnValueProvider) -> bool:
-    """Return true if obj is usable as a YAMLDataProvider."""
+    """Return true if obj is usable as a ReturnValueProvider."""
     return callable(getattr(obj, 'mgr_return_value', None))
 
 

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -115,11 +115,17 @@ def test_format_yaml(obj: Any, compatible: bool, yaml_val: str):
 
 
 class Retty:
-    def __init__(self, v) -> None:
+    def __init__(self, v, status="") -> None:
         self.value = v
+        self.status = status
 
     def mgr_return_value(self) -> int:
         return self.value
+
+    def mgr_status_value(self) -> str:
+        if self.status:
+            return self.status
+        return "NOPE"
 
 
 @pytest.mark.parametrize(
@@ -137,6 +143,24 @@ def test_return_value(obj: Any, ret: int):
     # a ReturnValueAdapter instance meets the ReturnValueProvider protocol.
     assert object_format._is_return_value_provider(rva)
     assert rva.mgr_return_value() == ret
+
+
+@pytest.mark.parametrize(
+    "obj, ret",
+    [
+        ({}, ""),
+        ({"fish": "sticks"}, ""),
+        (-55, ""),
+        (Retty(0), "NOPE"),
+        (Retty(-55, "cake"), "cake"),
+        (Retty(-50, "pie"), "pie"),
+    ],
+)
+def test_return_status(obj: Any, ret: str):
+    rva = object_format.StatusValueAdapter(obj)
+    # a StatusValueAdapter instance meets the StatusValueProvider protocol.
+    assert object_format._is_status_value_provider(rva)
+    assert rva.mgr_status_value() == ret
 
 
 def test_valid_formats():


### PR DESCRIPTION
Prior to this patch, using `ceph nfs export apply -i <nfs_cluster> -i <{json/conf}_file>` would report something like this when the export update/creation failed:

```
$ ceph nfs export apply my-nfs -i exports.json 
[
  {
    "msg": "Failed to apply export: export FSAL user_id must be 'nfs.my-nfs.1'",
    "state": "error"
  }
]
Error EIO:
```

The last line is incomplete and on top of that `EIO` would be thrown as errno, it makes sense to have a generalised errno since the json/conf file can have multiple export blocks and there can be multiple failures while updating/creating exports but this doesn't make sense when there is a single export block or there is a single export update/creation failure. From my conversation with @adk3798 and @phlogistonjohn in the orch weekly meeting about two weeks back, we decided to:

a) if multiple export blocks?
- in case of multiple failure: report EIO with the err status string
- in case of single failure: report the respective errno with the err status string

b) if single export block?
- report the respective errno with the err status string

This PR makes the changes that were required to be done in the `Responder` class in `pybind/mgr/object_format.py` to make it capable of returning an err status and changes in the `AppliedExportResults` class to adjust the errno and err status string as per the number of failures.

Fixes: https://tracker.ceph.com/issues/62641
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
