### PR TITLE
pacific: cephfs-top: include the missing fields in --dump output

### DIFF
--- a/qa/tasks/cephfs/test_fstop.py
+++ b/qa/tasks/cephfs/test_fstop.py
@@ -66,7 +66,7 @@ class TestFSTop(CephFSTestCase):
         Tests 'cephfs-top --dump' output is valid
         """
         def verify_fstop_metrics(metrics):
-            clients = metrics.get(self.fs.name, {})
+            clients = metrics.get('filesystems').get(self.fs.name, {})
             if str(self.mount_a.get_global_id()) in clients and \
                str(self.mount_b.get_global_id()) in clients:
                 return True

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -168,8 +168,8 @@ class FSTopBase(object):
                 return False
         return True
 
-    def __build_clients(self, fs):
-        fs_meta = self.dump_json.setdefault(fs, {})
+    def __build_clients(self, fs, clients_json):
+        fs_meta = clients_json.setdefault(fs, {})
         fs_key = self.stats_json[GLOBAL_METRICS_KEY].get(fs, {})
         clients = fs_key.keys()
         for client_id in clients:
@@ -249,13 +249,32 @@ class FSTopBase(object):
             self.stats_json = self.perf_stats_query()
             if fs_name:  # --dumpfs
                 if fs_name in fs_list:
-                    self.__build_clients(fs_name)
+                    self.__build_clients(fs_name, clients_json=self.dump_json)
                 else:
                     sys.stdout.write(f"Filesystem {fs_name} not available\n")
                     return
             else:  # --dump
+                num_clients = num_mounts = num_kclients = num_libs = 0
+                for fs_name in fs_list:
+                    client_metadata = self.stats_json[CLIENT_METADATA_KEY].get(fs_name, {})
+                    client_cnt = len(client_metadata)
+                    if client_cnt:
+                        num_clients = num_clients + client_cnt
+                        num_mounts = num_mounts + len(
+                            [client for client, metadata in client_metadata.items() if
+                             CLIENT_METADATA_MOUNT_POINT_KEY in metadata
+                             and metadata[CLIENT_METADATA_MOUNT_POINT_KEY] != 'N/A'])
+                        num_kclients = num_kclients + len(
+                            [client for client, metadata in client_metadata.items() if
+                             "kernel_version" in metadata])
+                        num_libs = num_clients - (num_mounts + num_kclients)
+                self.dump_json.update({'date': datetime.now().ctime()})
+                client_count = self.dump_json.setdefault("client_count", {})
+                client_count.update({'total_clients': num_clients, 'fuse': num_mounts,
+                                     'kclient': num_kclients, 'libcephfs': num_libs})
+                clients_json = self.dump_json.setdefault("filesystems", {})
                 for fs in fs_list:
-                    self.__build_clients(fs)
+                    self.__build_clients(fs, clients_json)
             sys.stdout.write(json.dumps(self.dump_json))
             sys.stdout.write("\n")
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62834

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>