### PR TITLE
mon/OSDMonitor: remove unused crush rules after erasure code pools deleted

### DIFF
--- a/qa/standalone/mon/osd-crush.sh
+++ b/qa/standalone/mon/osd-crush.sh
@@ -26,7 +26,7 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
 
-    local funcs=${@:-$(set | ${SED} -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    local funcs=${@:-$(set | ${SED} -n -e 's/^\(TEST_erasure_pool_crush_rule_rm[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
         setup $dir || return 1
         $func $dir || return 1
@@ -118,6 +118,51 @@ function TEST_crush_rule_create_erasure() {
     ceph osd erasure-code-profile ls | grep default || return 1
     ceph osd crush rule rm $rule || return 1
     ! ceph osd crush rule ls | grep $rule || return 1
+}
+
+function TEST_erasure_pool_crush_rule_rm() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    # should have at least one OSD
+    run_osd $dir 0 || return 1
+
+    # create a new rule with pool name as rule name
+    # delete the rule when the pool is deleted
+    local pool_name=cpool
+    ceph osd erasure-code-profile set profile_name plugin=jerasure technique=reed_sol_van k=2 m=2 crush-failure-domain=osd || return 1
+    ceph osd pool create $pool_name 12 12 erasure profile_name || return 1
+    ceph osd crush rule ls | grep $pool_name || return 1
+    ceph osd pool delete $pool_name $pool_name --yes-i-really-really-mean-it || return 1
+    ! ceph osd crush rule ls | grep $pool_name || return 1
+
+    # create few pools that using the same rule
+    # make sure the rule is not deleted when the pool is deleted
+    # unlease it was the last pool using the rule
+    local pool_name1=pool_name1
+    local pool_name2=pool_name2
+
+    ceph osd pool create $pool_name1 12 12 erasure profile_name || return 1
+    ceph osd crush rule ls | grep $pool_name1 || return 1
+    ceph osd pool create $pool_name2 12 12 erasure profile_name || return 1
+    ceph osd crush rule ls | grep $pool_name2 || return 1
+    ceph osd pool delete $pool_name1 $pool_name1 --yes-i-really-really-mean-it || return 1
+    ! ceph osd crush rule ls | grep $pool_name || return 1
+    ceph osd pool delete $pool_name2 $pool_name2 --yes-i-really-really-mean-it || return 1
+    ! ceph osd crush rule ls | grep $pool_name2 || return 1
+
+    # crush rule should be deleted when the last pool using it is deleted
+    local default_rule_name=erasure-code
+    ceph osd pool create $pool_name-1 12 12 erasure || return 1
+    ceph osd pool create $pool_name-2 12 12 erasure || return 1
+    ceph osd pool create $pool_name-3 12 12 erasure || return 1
+    ceph osd crush rule ls | grep $default_rule_name || return 1
+    ceph osd pool delete $pool_name-1 $pool_name-1 --yes-i-really-really-mean-it || return 1
+    ceph osd crush rule ls | grep $default_rule_name || return 1
+    ceph osd pool delete $pool_name-2 $pool_name-2 --yes-i-really-really-mean-it || return 1
+    ceph osd crush rule ls | grep $default_rule_name || return 1
+    ceph osd pool delete $pool_name-3 $pool_name-3 --yes-i-really-really-mean-it || return 1
+    ! ceph osd crush rule ls | grep $default_rule_name || return 1
 }
 
 function TEST_add_rule_failed() {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14638,6 +14638,27 @@ int OSDMonitor::_prepare_remove_pool(
     pending_inc.crush.clear();
     newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
   }
+
+  // remove any crush rules for this pool
+  const pg_pool_t *pi = osdmap.get_pg_pool(pool);
+  if (pi->is_erasure() && newcrush.rule_exists(pi->get_crush_rule())) {
+    int ruleno = pi->get_crush_rule();
+    ceph_assert(ruleno >= 0);
+
+    auto rule_in_use = false;
+    auto rule_id = pi->get_crush_rule();
+    for (const auto &_pool : osdmap.pools) {
+      if (_pool.second.get_crush_rule() == rule_id && pool != _pool.first)
+        rule_in_use = true;
+    }
+    if (!rule_in_use) {
+      dout(10) << __func__ << " removing crush rule for pool " << pool << dendl;
+      newcrush.remove_rule(rule_id);
+      pending_inc.crush.clear();
+      newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
+    }
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
When erasure code pools are created, a corresponding Crush rule is concurrently added to the Crush map. However, when these pools are subsequently deleted, the associated rule persists within the Crush map. In the event that a pool is re-created with the same name, the rule already exists. However, if any modifications were made to the rule prior to the pool's deletion, the new pool will inherit these modifications.

The proposed solution involves the automatic deletion of the Crush rule when a pool is deleted, but only if no other pools are utilizing that particular rule.

Fixes: https://tracker.ceph.com/issues/62826
Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
