### PR TITLE
reef: mgr/dashboard: remove unnecessary failing hosts e2e

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/01-hosts.e2e-spec.ts
@@ -57,29 +57,5 @@ describe('Hosts page', () => {
       hosts.editLabels(hostname, labels, true);
       hosts.editLabels(hostname, labels, false);
     });
-
-    it('should enter host into maintenance', function () {
-      const hostname = Cypress._.sample(this.hosts).name;
-      const serviceList = new Array();
-      this.services.forEach((service: any) => {
-        if (hostname === service.hostname) {
-          serviceList.push(service.daemon_type);
-        }
-      });
-      let enterMaintenance = true;
-      serviceList.forEach((service: string) => {
-        if (service === 'mgr' || service === 'alertmanager') {
-          enterMaintenance = false;
-        }
-      });
-      if (enterMaintenance) {
-        hosts.maintenance(hostname);
-      }
-    });
-
-    it('should exit host from maintenance', function () {
-      const hostname = Cypress._.sample(this.hosts).name;
-      hosts.maintenance(hostname, true);
-    });
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62602

---

backport of https://github.com/ceph/ceph/pull/53141
parent tracker: https://tracker.ceph.com/issues/62491

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh