### PR TITLE
quincy: rgw: remove potentially conficting definition of dout_subsys

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -467,6 +467,10 @@ int OpsLogFile::log_json(struct req_state* s, bufferlist& bl)
   return 0;
 }
 
+unsigned OpsLogFile::get_subsys() const {
+  return dout_subsys;
+}
+
 JsonOpsLogSink::JsonOpsLogSink() {
   formatter = new JSONFormatter;
 }
@@ -720,4 +724,3 @@ void rgw_log_entry::dump(Formatter *f) const
   f->dump_string("trans_id", trans_id);
   f->dump_unsigned("identity_type", identity_type);
 }
-

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -10,8 +10,6 @@
 #include <vector>
 #include <fstream>
 
-#define dout_subsys ceph_subsys_rgw
-
 namespace rgw { namespace sal {
   class Store;
 } }
@@ -260,7 +258,7 @@ public:
   OpsLogFile(CephContext* cct, std::string& path, uint64_t max_data_size);
   ~OpsLogFile() override;
   CephContext *get_cct() const override { return cct; }
-  unsigned get_subsys() const override { return dout_subsys; }
+  unsigned get_subsys() const override;
   std::ostream& gen_prefix(std::ostream& out) const override { return out << "rgw OpsLogFile: "; }
   void reopen();
   void start();

--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -3,6 +3,8 @@
 
 #include "rgw_s3select_private.h"
 
+#define dout_subsys ceph_subsys_rgw
+
 namespace rgw::s3select {
 RGWOp* create_s3select_op()
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55678

---

backport of https://github.com/ceph/ceph/pull/46265
parent tracker: https://tracker.ceph.com/issues/55657

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh