### PR TITLE
pacific: pybind/mgr/autoscaler: Donot show NEW PG_NUM value if autoscaler is not on

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -585,7 +585,8 @@ class PgAutoscaler(MgrModule):
             if (final_pg_target > p['pg_num_target'] * threshold or
                     final_pg_target < p['pg_num_target'] / threshold) and \
                     final_ratio >= 0.0 and \
-                    final_ratio <= 1.0:
+                    final_ratio <= 1.0 and \
+                    p['pg_autoscale_mode'] == 'on':
                 adjust = True
 
             assert pool_pg_target is not None


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56649

---

backport of https://github.com/ceph/ceph/pull/46761
parent tracker: https://tracker.ceph.com/issues/56136

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh