### PR TITLE
pacific: log: fix the formatting when dumping thread IDs.

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -486,7 +486,9 @@ void Log::dump_recent()
   {
     char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
     ceph_pthread_getname(pthread_id, pthread_name, sizeof(pthread_name));
-    _log_message(fmt::format("  {} / {}",
+    // we want the ID to be printed in the same format as we use for a log entry.
+    // The reason is easier grepping.
+    _log_message(fmt::format("  {:x} / {}",
 			     tid_to_int(pthread_id), pthread_name), true);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50697

---

backport of https://github.com/ceph/ceph/pull/41155
parent tracker: https://tracker.ceph.com/issues/50653

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh