### PR TITLE
pacific: rados: increase osd_max_write_op_reply_len default to 64 bytes

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4084,7 +4084,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_max_write_op_reply_len", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
-    .set_default(32)
+    .set_default(64)
     .set_description("Max size of the per-op payload for requests with the RETURNVEC flag set")
     .set_long_description("This value caps the amount of data (per op; a request may have many ops) that will be sent back to the client and recorded in the PG log."),
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51195

---

backport of https://github.com/ceph/ceph/pull/41809
parent tracker: https://tracker.ceph.com/issues/51166

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh