### PR TITLE
quincy: rgw: Drain async_processor request queue during shutdown

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1032,6 +1032,12 @@ bool RGWIndexCompletionManager::handle_completion(completion_t cb, complete_op_d
 
 void RGWRados::finalize()
 {
+  /* Before joining any sync threads, drain outstanding requests &
+   * mark the async_processor as going_down() */
+  if (svc.rados) {
+    svc.rados->stop_processor();
+  }
+
   if (run_sync_thread) {
     std::lock_guard l{meta_sync_thread_lock};
     meta_sync_processor_thread->stop();

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -47,6 +47,13 @@ void RGWSI_RADOS::shutdown()
   }
 }
 
+void RGWSI_RADOS::stop_processor()
+{
+  if (async_processor) {
+    async_processor->stop();
+  }
+}
+
 librados::Rados* RGWSI_RADOS::get_rados_handle()
 {
   return &rados;

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -66,6 +66,7 @@ public:
 
   void init() {}
   void shutdown() override;
+  void stop_processor();
 
   std::string cluster_fsid();
   uint64_t instance_id();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57636

---

backport of https://github.com/ceph/ceph/pull/48021
parent tracker: https://tracker.ceph.com/issues/49666

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh