### PR TITLE
pacific: radosgw-admin: don't crash on --placement-id without --storage-class

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5564,11 +5564,10 @@ int main(int argc, const char **argv)
   else if (opt_cmd == OPT::USER_SUSPEND)
     user_op.set_suspension(true);
 
-  if (!placement_id.empty() ||
-      (opt_storage_class && !opt_storage_class->empty())) {
+  if (!placement_id.empty()) {
     rgw_placement_rule target_rule;
     target_rule.name = placement_id;
-    target_rule.storage_class = *opt_storage_class;
+    target_rule.storage_class = opt_storage_class.value_or("");
     if (!store->svc()->zone->get_zone_params().valid_placement(target_rule)) {
       cerr << "NOTICE: invalid dest placement: " << target_rule.to_str() << std::endl;
       return EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55701

---

backport of https://github.com/ceph/ceph/pull/46152
parent tracker: https://tracker.ceph.com/issues/55548

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh