### PR TITLE
pacific: qa: ignore expected cluster warning from damage tests

### DIFF
--- a/qa/suites/fs/functional/tasks/damage.yaml
+++ b/qa/suites/fs/functional/tasks/damage.yaml
@@ -19,6 +19,7 @@ overrides:
       - MDS_READ_ONLY
       - force file system read-only
       - with standby daemon mds
+      - MDS abort because newly corrupt dentry
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -608,8 +608,9 @@ class TestDamage(CephFSTestCase):
         self.fs.flush()
         self.config_set("mds", "mds_inject_rename_corrupt_dentry_first", "1.0")
         time.sleep(5) # for conf to percolate
-        p = self.mount_a.run_shell_payload("timeout 60 mv a/b a/z", wait=False)
-        self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(), timeout=self.fs.beacon_timeout)
+        with self.assert_cluster_log("MDS abort because newly corrupt dentry"):
+            p = self.mount_a.run_shell_payload("timeout 60 mv a/b a/z", wait=False)
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(), timeout=self.fs.beacon_timeout)
         self.config_rm("mds", "mds_inject_rename_corrupt_dentry_first")
         self.fs.rank_freeze(False, rank=0)
         self.delete_mds_coredump(rank0['name'])
@@ -642,9 +643,10 @@ class TestDamage(CephFSTestCase):
         rank0 = self.fs.get_rank()
         self.fs.rank_freeze(True, rank=0)
         # so now we want to trigger commit but this will crash, so:
-        c = ['--connect-timeout=60', 'tell', f"mds.{fscid}:0", "flush", "journal"]
-        p = self.ceph_cluster.mon_manager.run_cluster_cmd(args=c, wait=False, timeoutcmd=30)
-        self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(), timeout=self.fs.beacon_timeout)
+        with self.assert_cluster_log("MDS abort because newly corrupt dentry"):
+            c = ['--connect-timeout=60', 'tell', f"mds.{fscid}:0", "flush", "journal"]
+            p = self.ceph_cluster.mon_manager.run_cluster_cmd(args=c, wait=False, timeoutcmd=30)
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(), timeout=self.fs.beacon_timeout)
         self.config_rm("mds", "mds_inject_journal_corrupt_dentry_first")
         self.fs.rank_freeze(False, rank=0)
         self.delete_mds_coredump(rank0['name'])

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -696,7 +696,7 @@ bool CDentry::check_corruption(bool load)
     }
     if (!load && g_conf().get_val<bool>("mds_abort_on_newly_corrupt_dentry")) {
       dir->mdcache->mds->clog->error() << "MDS abort because newly corrupt dentry to be committed: " << *this;
-      ceph_abort("detected newly corrupt dentry"); /* avoid writing out newly corrupted dn */
+      dir->mdcache->mds->abort("detected newly corrupt dentry"); /* avoid writing out newly corrupted dn */
     }
     return true;
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -926,6 +926,12 @@ void MDSRank::respawn()
   }
 }
 
+void MDSRank::abort(std::string_view msg)
+{
+  monc->flush_log();
+  ceph_abort(msg);
+}
+
 void MDSRank::damaged()
 {
   ceph_assert(whoami != MDS_RANK_NONE);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -297,6 +297,13 @@ class MDSRank {
     }
 
     /**
+     * Abort the MDS and flush any clog messages.
+     *
+     * Callers must already hold mds_lock.
+     */
+    void abort(std::string_view msg);
+
+    /**
      * Report state DAMAGED to the mon, and then pass on to respawn().  Call
      * this when an unrecoverable error is encountered while attempting
      * to load an MDS rank's data structures.  This is *not* for use with


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62854

---

backport of https://github.com/ceph/ceph/pull/52638
parent tracker: https://tracker.ceph.com/issues/62164

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh