### PR TITLE
rgw/sal: get_placement_target_names() returns void

### DIFF
--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -826,13 +826,11 @@ bool DaosZoneGroup::placement_target_exists(std::string& target) const {
   return !!group.placement_targets.count(target);
 }
 
-int DaosZoneGroup::get_placement_target_names(
+void DaosZoneGroup::get_placement_target_names(
     std::set<std::string>& names) const {
   for (const auto& target : group.placement_targets) {
     names.emplace(target.second.name);
   }
-
-  return 0;
 }
 
 int DaosZoneGroup::get_placement_tier(const rgw_placement_rule& rule,

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -414,7 +414,7 @@ class DaosZoneGroup : public StoreZoneGroup {
   virtual const std::string& get_api_name() const override {
     return group.api_name;
   };
-  virtual int get_placement_target_names(
+  virtual void get_placement_target_names(
       std::set<std::string>& names) const override;
   virtual const std::string& get_default_placement_name() const override {
     return group.default_placement.name;

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -1086,13 +1086,11 @@ bool MotrZoneGroup::placement_target_exists(std::string& target) const
   return !!group.placement_targets.count(target);
 }
 
-int MotrZoneGroup::get_placement_target_names(std::set<std::string>& names) const
+void MotrZoneGroup::get_placement_target_names(std::set<std::string>& names) const
 {
   for (const auto& target : group.placement_targets) {
     names.emplace(target.second.name);
   }
-
-  return 0;
 }
 
 int MotrZoneGroup::get_placement_tier(const rgw_placement_rule& rule,

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -446,7 +446,7 @@ public:
     return group.is_master_zonegroup();
   };
   virtual const std::string& get_api_name() const override { return group.api_name; };
-  virtual int get_placement_target_names(std::set<std::string>& names) const override;
+  virtual void get_placement_target_names(std::set<std::string>& names) const override;
   virtual const std::string& get_default_placement_name() const override {
     return group.default_placement.name; };
   virtual int get_hostnames(std::list<std::string>& names) const override {

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3192,13 +3192,11 @@ bool RadosZoneGroup::placement_target_exists(std::string& target) const
   return !!group.placement_targets.count(target);
 }
 
-int RadosZoneGroup::get_placement_target_names(std::set<std::string>& names) const
+void RadosZoneGroup::get_placement_target_names(std::set<std::string>& names) const
 {
   for (const auto& target : group.placement_targets) {
     names.emplace(target.second.name);
   }
-
-  return 0;
 }
 
 int RadosZoneGroup::get_placement_tier(const rgw_placement_rule& rule,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -62,7 +62,7 @@ public:
     return group.is_master_zonegroup();
   };
   virtual const std::string& get_api_name() const override { return group.api_name; };
-  virtual int get_placement_target_names(std::set<std::string>& names) const override;
+  virtual void get_placement_target_names(std::set<std::string>& names) const override;
   virtual const std::string& get_default_placement_name() const override {
     return group.default_placement.name; };
   virtual int get_hostnames(std::list<std::string>& names) const override {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2527,10 +2527,9 @@ void RGWListBuckets::execute(optional_yield y)
      * isn't actually used in a given account. In such situation its usage
      * stats would be simply full of zeros. */
     std::set<std::string> targets;
-    if (driver->get_zone()->get_zonegroup().get_placement_target_names(targets)) {
-      for (const auto& policy : targets) {
-	policies_stats.emplace(policy, decltype(policies_stats)::mapped_type());
-      }
+    driver->get_zone()->get_zonegroup().get_placement_target_names(targets);
+    for (const auto& policy : targets) {
+      policies_stats.emplace(policy, decltype(policies_stats)::mapped_type());
     }
 
     std::map<std::string, std::unique_ptr<rgw::sal::Bucket>>& m = buckets.get_buckets();

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1908,14 +1908,13 @@ void RGWInfo_ObjStore_SWIFT::list_swift_data(Formatter& formatter,
   const rgw::sal::ZoneGroup& zonegroup = driver->get_zone()->get_zonegroup();
 
   std::set<std::string> targets;
-  if (zonegroup.get_placement_target_names(targets)) {
-    for (const auto& placement_targets : targets) {
-      formatter.open_object_section("policy");
-      if (placement_targets.compare(zonegroup.get_default_placement_name()) == 0)
-	formatter.dump_bool("default", true);
-      formatter.dump_string("name", placement_targets.c_str());
-      formatter.close_section();
-    }
+  zonegroup.get_placement_target_names(targets);
+  for (const auto& placement_targets : targets) {
+    formatter.open_object_section("policy");
+    if (placement_targets.compare(zonegroup.get_default_placement_name()) == 0)
+      formatter.dump_bool("default", true);
+    formatter.dump_string("name", placement_targets.c_str());
+    formatter.close_section();
   }
   formatter.close_section();
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1477,7 +1477,7 @@ public:
   /** Get the API name of this zonegroup */
   virtual const std::string& get_api_name() const = 0;
   /** Get the list of placement target names for this zone */
-  virtual int get_placement_target_names(std::set<std::string>& names) const = 0;
+  virtual void get_placement_target_names(std::set<std::string>& names) const = 0;
   /** Get the name of the default placement target for this zone */
   virtual const std::string& get_default_placement_name() const = 0;
   /** Get the list of hostnames from this zone */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -525,12 +525,10 @@ namespace rgw::sal {
     return !!group->placement_targets.count(target);
   }
 
-  int DBZoneGroup::get_placement_target_names(std::set<std::string>& names) const {
+  void DBZoneGroup::get_placement_target_names(std::set<std::string>& names) const {
     for (const auto& target : group->placement_targets) {
       names.emplace(target.second.name);
     }
-
-    return 0;
   }
 
   ZoneGroup& DBZone::get_zonegroup()

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -270,7 +270,7 @@ protected:
       return group->is_master_zonegroup();
     };
     virtual const std::string& get_api_name() const override { return group->api_name; };
-    virtual int get_placement_target_names(std::set<std::string>& names) const override;
+    virtual void get_placement_target_names(std::set<std::string>& names) const override;
     virtual const std::string& get_default_placement_name() const override {
       return group->default_placement.name; };
     virtual int get_hostnames(std::list<std::string>& names) const override {

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -58,8 +58,8 @@ public:
     { return next->is_master_zonegroup(); }
   virtual const std::string& get_api_name() const override
     { return next->get_api_name(); }
-  virtual int get_placement_target_names(std::set<std::string>& names) const override
-    { return next->get_placement_target_names(names); }
+  virtual void get_placement_target_names(std::set<std::string>& names) const override
+    { next->get_placement_target_names(names); }
   virtual const std::string& get_default_placement_name() const override
     { return next->get_default_placement_name(); }
   virtual int get_hostnames(std::list<std::string>& names) const override


### PR DESCRIPTION
the function returned an integer error code, but two callers were incorrectly testing the return value as a boolean

the function just returns placement ids that are in-memory, so none of the drivers have a failure case; change the return value to void

Fixes: https://tracker.ceph.com/issues/62771

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
