### PR TITLE
reef: RGW: bucket notification - hide auto generated topics when listing topics

### DIFF
--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -359,7 +359,10 @@ void rgw_pubsub_topics::dump(Formatter *f) const
 {
   Formatter::ArraySection s(*f, "topics");
   for (auto& t : topics) {
-    encode_json(t.first.c_str(), t.second, f);
+    auto& topic = t.second;
+    if (topic.name == topic.dest.arn_topic) {
+      encode_json(t.first.c_str(), topic, f);
+    }
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61484

---

backport of https://github.com/ceph/ceph/pull/51138
parent tracker: https://tracker.ceph.com/issues/50412

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh