### PR TITLE
reef: rgw/notifications: allow cross tenant notification management

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -647,9 +647,11 @@ void RGWPSCreateNotifOp::execute(optional_yield y) {
 
   std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->get_bucket(this, user.get(), s->owner.get_id().tenant, s->bucket_name, &bucket, y);
+  op_ret = driver->get_bucket(this, user.get(), s->bucket_tenant, s->bucket_name, &bucket, y);
   if (op_ret < 0) {
-    ldpp_dout(this, 1) << "failed to get bucket '" << s->bucket_name << "' info, ret = " << op_ret << dendl;
+    ldpp_dout(this, 1) << "failed to get bucket '" << 
+      (s->bucket_tenant.empty() ? s->bucket_name : s->bucket_tenant + ":" + s->bucket_name) << 
+      "' info, ret = " << op_ret << dendl;
     return;
   }
 
@@ -782,9 +784,11 @@ void RGWPSDeleteNotifOp::execute(optional_yield y) {
 
   std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->get_bucket(this, user.get(), s->owner.get_id().tenant, s->bucket_name, &bucket, y);
+  op_ret = driver->get_bucket(this, user.get(), s->bucket_tenant, s->bucket_name, &bucket, y);
   if (op_ret < 0) {
-    ldpp_dout(this, 1) << "failed to get bucket '" << s->bucket_name << "' info, ret = " << op_ret << dendl;
+    ldpp_dout(this, 1) << "failed to get bucket '" << 
+      (s->bucket_tenant.empty() ? s->bucket_name : s->bucket_tenant + ":" + s->bucket_name) << 
+      "' info, ret = " << op_ret << dendl;
     return;
   }
 
@@ -877,9 +881,11 @@ void RGWPSListNotifsOp::execute(optional_yield y) {
 
   std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->get_bucket(this, user.get(), s->owner.get_id().tenant, s->bucket_name, &bucket, y);
+  op_ret = driver->get_bucket(this, user.get(), s->bucket_tenant, s->bucket_name, &bucket, y);
   if (op_ret < 0) {
-    ldpp_dout(this, 1) << "failed to get bucket '" << s->bucket_name << "' info, ret = " << op_ret << dendl;
+    ldpp_dout(this, 1) << "failed to get bucket '" << 
+      (s->bucket_tenant.empty() ? s->bucket_name : s->bucket_tenant + ":" + s->bucket_name) << 
+      "' info, ret = " << op_ret << dendl;
     return;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62803

---

backport of https://github.com/ceph/ceph/pull/53369
parent tracker: https://tracker.ceph.com/issues/62784

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh