### PR TITLE
doc/dev: Fix typos in cephfs-mirroring.rst and  deduplication.rst

### DIFF
--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -377,7 +377,7 @@ information. To check which mirror daemon a directory has been mapped to use::
     "state": "mapped"
   }
 
-.. note:: `instance_id` is the RAODS instance-id associated with a mirror daemon.
+.. note:: `instance_id` is the RADOS instance-id associated with a mirror daemon.
 
 Other information such as `state` and `last_shuffled` are interesting when running
 multiple mirror daemons.

--- a/doc/dev/deduplication.rst
+++ b/doc/dev/deduplication.rst
@@ -314,7 +314,7 @@ object size in ``BASE_POOL`` is zero (evicted) and chunks objects are genereated
 ^^^^^^^^^^^^^^^^^^
 
 After step 3, the users don't need to consider anything about I/Os. Deduplicated objects are
-completely compatible with existing RAODS operations.
+completely compatible with existing RADOS operations.
 
 
 5. Run scrub to fix reference count 


### PR DESCRIPTION
CEPHFS: DOCS. Update Typo in Doc File cephfs-mirroring.rst
RADOS: DOCS. Update Typo in Doc File deduplication.rst

Typo Error in Doc, replace RAODS with RADOS
Signed-off-by: Daniel Parkes <dparkes@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests



