### PR TITLE
qa: use unique name for the CephFS created during testing

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -23,7 +23,7 @@ import yaml
 from paramiko import SSHException
 from tasks.ceph_manager import CephManager, write_conf, get_valgrind_args
 from tarfile import ReadError
-from tasks.cephfs.filesystem import MDSCluster, Filesystem
+from tasks.cephfs.filesystem import MDSCluster, Filesystem, gen_fsname
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology import exceptions
@@ -496,7 +496,7 @@ def cephfs_setup(ctx, config):
     if mdss.remotes:
         log.info('Setting up CephFS filesystem(s)...')
         cephfs_config = config.get('cephfs', {})
-        fs_configs =  cephfs_config.pop('fs', [{'name': 'cephfs'}])
+        fs_configs = cephfs_config.get('fs', [{'name': gen_fsname()}])
 
         # wait for standbys to become available (slow due to valgrind, perhaps)
         mdsc = MDSCluster(ctx)

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -495,8 +495,17 @@ def cephfs_setup(ctx, config):
     # Do this last because requires mon cluster to be up and running
     if mdss.remotes:
         log.info('Setting up CephFS filesystem(s)...')
+
         cephfs_config = config.get('cephfs', {})
-        fs_configs = cephfs_config.get('fs', [{'name': gen_fsname()}])
+        if not cephfs_config:
+            log.info('msg123 1 setting name for default fs...')
+            cephfs_config.update({'cephfs': {'fs': [{'name': gen_fsname()}]}})
+
+        fs_configs = cephfs_config.get('fs', None)
+        if fs_configs is None:
+            log.info('msg123 2 setting name for default fs...')
+            fs_configs = [{'name': gen_fsname()}]
+            config.update({'cephfs': {'fs': fs_configs}})
 
         # wait for standbys to become available (slow due to valgrind, perhaps)
         mdsc = MDSCluster(ctx)

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -120,6 +120,8 @@ class CephFSTestCase(CephTestCase):
 
     def setUp(self):
         super(CephFSTestCase, self).setUp()
+        log.info('Running CephFSTestCase.setUp() now.')
+        self._log_monmap_and_fsmap()
 
         self.config_set('mon', 'mon_allow_pool_delete', True)
 
@@ -206,7 +208,13 @@ class CephFSTestCase(CephTestCase):
 
         self.configs_set = set()
 
+        log.info('Finished running CephFSTestCase.setUp().')
+        self._log_monmap_and_fsmap()
+
     def tearDown(self):
+        log.info('Running CephFSTestCase.tearDown() now.')
+        self._log_monmap_and_fsmap()
+
         self.mds_cluster.clear_firewall()
         for m in self.mounts:
             m.teardown()
@@ -220,7 +228,13 @@ class CephFSTestCase(CephTestCase):
         for subsys, key in self.configs_set:
             self.mds_cluster.clear_ceph_conf(subsys, key)
 
+        log.info('Finished running CephFSTestCase.tearDown().')
+        self._log_monmap_and_fsmap()
         return super(CephFSTestCase, self).tearDown()
+
+    def _log_monmap_and_fsmap(self):
+        self.run_ceph_cmd('mon dump --format json-pretty')
+        self.run_ceph_cmd('fs dump --format json-pretty')
 
     def set_conf(self, subsys, key, value):
         self.configs_set.add((subsys, key))

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -190,7 +190,7 @@ class CephFSTestCase(CephTestCase):
 
             # Mount the requested number of clients
             for i in range(0, self.CLIENTS_REQUIRED):
-                self.mounts[i].mount_wait()
+                self.mounts[i].mount_wait(cephfs_name=self.fs.name)
 
         if self.REQUIRE_BACKUP_FILESYSTEM:
             if not self.REQUIRE_FILESYSTEM:

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -51,8 +51,6 @@ class KernelMountBase(CephFSMount):
 
         if not self.cephfs_mntpt:
             self.cephfs_mntpt = '/'
-        if not self.cephfs_name:
-            self.cephfs_name = 'cephfs'
 
         self._create_mntpt()
 
@@ -109,6 +107,11 @@ class KernelMountBase(CephFSMount):
             if self.cephfs_name:
                 optd['mds_namespace'] = self.cephfs_name
         elif self.syntax_style == 'v2':
+            if not self.cephfs_name:
+                raise RuntimeError('self.cephfs_name is not set. It is '
+                                   'mandatory to provide it when using '
+                                   'v2 style kernel mount command.')
+
             mnt_stx = f'{self.client_id}@.{self.cephfs_name}={self.cephfs_mntpt}'
         else:
             assert 0, f'invalid syntax style: {self.syntax_style}'

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1651,8 +1651,6 @@ class CephFSMountBase(object):
 
         if mount_subvol_num is not None:
             # mount_subvol must be an index into the subvol path array for the fs
-            if not self.cephfs_name:
-                self.cephfs_name = 'cephfs'
             assert(hasattr(self.ctx, "created_subvols"))
             # mount_subvol must be specified under client.[0-9] yaml section
             subvol_paths = self.ctx.created_subvols[self.cephfs_name]

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1040,7 +1040,7 @@ class TestRenameCommand(TestAdminCommands):
         """
         That renaming a file system fails if the new name refers to an existing file system.
         """
-        self.fs2 = self.mds_cluster.newfs(name='cephfs2', create=True)
+        self.fs2 = self.mds_cluster.newfs()
 
         # let's unmount the client before failing the FS
         self.mount_a.umount_wait(require_clean=True)
@@ -1401,7 +1401,7 @@ class TestCompatCommands(CephFSTestCase):
         Like test_standby_incompat_reject but with a second fs.
         """
 
-        fs2 = self.mds_cluster.newfs(name="cephfs2", create=True)
+        fs2 = self.mds_cluster.newfs()
         fs2.fail()
         fs2.add_incompat(63, 'placeholder')
         fs2.set_joinable()
@@ -1814,8 +1814,8 @@ class TestFsAuthorize(CephFSTestCase):
         # let's unmount both client before deleting the FS
         self.mount_b.umount_wait(require_clean=True)
         self.mds_cluster.delete_all_filesystems()
-        fs_name = "cephfs-_."
-        self.fs = self.mds_cluster.newfs(name=fs_name)
+        fsname = "testcephfs-_."
+        self.fs = self.mds_cluster.newfs(name=fsname)
         self.fs.wait_for_daemons()
         self.run_ceph_cmd(f'auth caps client.{self.mount_a.client_id} '
                           f'mon "allow r" '
@@ -2016,7 +2016,7 @@ class TestFsAuthorizeUpdate(CephFSTestCase):
         that already had caps for first FS.
         """
         self.fs1 = self.fs
-        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.fs2 = self.mds_cluster.newfs()
         self.mount_b.remount(cephfs_name=self.fs2.name)
         self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
         self.fs1.authorize(self.client_id, ('/', 'rw'))

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -112,7 +112,7 @@ class TestClusterAffinity(CephFSTestCase):
         """
         That a vanilla standby is preferred over others with mds_join_fs set to another fs.
         """
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         status, target = self._verify_init()
         active = self.fs.get_active_names(status=status)[0]
         status2, _ = self._verify_init(fs=fs2)
@@ -145,7 +145,7 @@ class TestClusterAffinity(CephFSTestCase):
         standbys = [info['name'] for info in status.get_standbys()]
         for mds in standbys:
             self.config_set('mds.'+mds, 'mds_join_fs', 'cephfs2')
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         for mds in standbys:
             self._change_target_state(target, mds, {'join_fscid': fs2.id})
         self.fs.rank_fail()
@@ -170,7 +170,7 @@ class TestClusterAffinity(CephFSTestCase):
         standbys = [info['name'] for info in status.get_standbys()]
         for mds in standbys:
             self.config_set('mds.'+mds, 'mds_join_fs', 'cephfs2')
-        fs2 = self.mds_cluster.newfs(name="cephfs2")
+        fs2 = self.mds_cluster.newfs()
         for mds in standbys:
             self._change_target_state(target, mds, {'join_fscid': fs2.id})
         self.fs.set_refuse_standby_for_another_fs(True)
@@ -792,8 +792,8 @@ class TestMultiFilesystems(CephFSTestCase):
                           "true", "--yes-i-really-mean-it")
 
     def _setup_two(self):
-        fs_a = self.mds_cluster.newfs(name="alpha")
-        fs_b = self.mds_cluster.newfs(name="bravo")
+        fs_a = self.mds_cluster.newfs()
+        fs_b = self.mds_cluster.newfs()
 
         self.mds_cluster.mds_restart()
 

--- a/qa/tasks/cephfs/test_mds_metrics.py
+++ b/qa/tasks/cephfs/test_mds_metrics.py
@@ -105,8 +105,8 @@ class TestMDSMetrics(CephFSTestCase):
                     break
         return done, metrics
 
-    def _setup_fs(self, fs_name):
-        fs_a = self.mds_cluster.newfs(name=fs_name)
+    def _setup_fs(self):
+        fs_a = self.mds_cluster.newfs()
 
         self.mds_cluster.mds_restart()
 
@@ -505,7 +505,7 @@ class TestMDSMetrics(CephFSTestCase):
             "true", "--yes-i-really-mean-it")
 
         # creating filesystem
-        fs_a = self._setup_fs(fs_name="fs1")
+        fs_a = self._setup_fs()
 
         # Mount a client on fs_a
         self.mount_a.mount_wait(cephfs_name=fs_a.name)
@@ -515,7 +515,7 @@ class TestMDSMetrics(CephFSTestCase):
         self.mount_a.create_files()
 
         # creating another filesystem
-        fs_b = self._setup_fs(fs_name="fs2")
+        fs_b = self._setup_fs()
 
         # Mount a client on fs_b
         self.mount_b.mount_wait(cephfs_name=fs_b.name)
@@ -573,7 +573,7 @@ class TestMDSMetrics(CephFSTestCase):
             "true", "--yes-i-really-mean-it")
 
         # creating filesystem
-        fs_b = self._setup_fs(fs_name="fs2")
+        fs_b = self._setup_fs()
 
         # Mount a client on fs_b
         self.mount_b.mount_wait(cephfs_name=fs_b.name)
@@ -582,7 +582,7 @@ class TestMDSMetrics(CephFSTestCase):
         self.mount_b.create_files()
 
         # creating another filesystem
-        fs_a = self._setup_fs(fs_name="fs1")
+        fs_a = self._setup_fs()
 
         # Mount a client on fs_a
         self.mount_a.mount_wait(cephfs_name=fs_a.name)

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -29,7 +29,7 @@ class TestMultiFS(CephFSTestCase):
         self.run_ceph_cmd(f'auth rm {self.client_name}')
 
         self.fs1 = self.fs
-        self.fs2 = self.mds_cluster.newfs(name='cephfs2', create=True)
+        self.fs2 = self.mds_cluster.newfs()
 
         # we'll reassign caps to client.1 so that it can operate with cephfs2
         self.run_ceph_cmd(f'auth caps client.{self.mount_b.client_id} mon '

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -90,7 +90,12 @@ def task(ctx, config):
         deep_merge(client_config, client_config_overrides)
         log.info(f"{entity} config is {client_config}")
 
-        cephfs_name = client_config.get("cephfs_name")
+        cephfs_name = client_config.get("cephfs_name", None)
+        if cephfs_name is None:
+            if (config.get('cephfs', None) is not None and
+                len(config.get('cephfs').get('fs')) == 1):
+                cephfs_name = config.get('cephfs').get('fs')[0]['name']
+
         if config.get("disabled", False) or not client_config.get('mounted', True):
             continue
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -913,6 +913,7 @@ class LocalCephCluster(tasks.cephfs.filesystem.CephClusterBase):
         self._write_conf()
 
 tasks.cephfs.filesystem.CephCluster = LocalCephCluster
+gen_fsname = tasks.cephfs.filesystem.gen_fsname
 
 class LocalMDSCluster(LocalCephCluster, tasks.cephfs.filesystem.MDSClusterBase):
     def __init__(self, ctx, cluster_name='ceph'):
@@ -934,7 +935,8 @@ class LocalMDSCluster(LocalCephCluster, tasks.cephfs.filesystem.MDSClusterBase):
         # FIXME: unimplemented
         pass
 
-    def newfs(self, name='cephfs', create=True, **kwargs):
+    def newfs(self, name=None, create=True, **kwargs):
+        name = gen_fsname() if name is None else name
         return LocalFilesystem(self._ctx, name=name, create=create, **kwargs)
 
     def delete_all_filesystems(self):

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -918,7 +918,7 @@ function test_tell_output_file()
 
 function test_mds_tell()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   if ! mds_exists ; then
       echo "Skipping test, no MDS found"
       return
@@ -966,7 +966,7 @@ function test_mds_tell()
 
 function test_mon_mds()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   remove_all_fs
 
   ceph osd pool create fs_data 16
@@ -1008,48 +1008,48 @@ function test_mon_mds()
   ceph osd pool create data3 16
   data2_pool=$(ceph osd dump | grep "pool.*'data2'" | awk '{print $2;}')
   data3_pool=$(ceph osd dump | grep "pool.*'data3'" | awk '{print $2;}')
-  ceph fs add_data_pool cephfs $data2_pool
-  ceph fs add_data_pool cephfs $data3_pool
-  ceph fs add_data_pool cephfs 100 >& $TMPFILE || true
+  ceph fs add_data_pool testcephfs1 $data2_pool
+  ceph fs add_data_pool testcephfs1 $data3_pool
+  ceph fs add_data_pool testcephfs1 100 >& $TMPFILE || true
   check_response "Error ENOENT"
-  ceph fs add_data_pool cephfs foobarbaz >& $TMPFILE || true
+  ceph fs add_data_pool testcephfs1 foobarbaz >& $TMPFILE || true
   check_response "Error ENOENT"
-  ceph fs rm_data_pool cephfs $data2_pool
-  ceph fs rm_data_pool cephfs $data3_pool
+  ceph fs rm_data_pool testcephfs1 $data2_pool
+  ceph fs rm_data_pool testcephfs1 $data3_pool
   ceph osd pool delete data2 data2 --yes-i-really-really-mean-it
   ceph osd pool delete data3 data3 --yes-i-really-really-mean-it
-  ceph fs set cephfs max_mds 4
-  ceph fs set cephfs max_mds 3
-  ceph fs set cephfs max_mds 256
-  expect_false ceph fs set cephfs max_mds 257
-  ceph fs set cephfs max_mds 4
-  ceph fs set cephfs max_mds 256
-  expect_false ceph fs set cephfs max_mds 257
-  expect_false ceph fs set cephfs max_mds asdf
-  expect_false ceph fs set cephfs inline_data true
-  ceph fs set cephfs inline_data true --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data yes --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data 1 --yes-i-really-really-mean-it
-  expect_false ceph fs set cephfs inline_data --yes-i-really-really-mean-it
-  ceph fs set cephfs inline_data false
-  ceph fs set cephfs inline_data no
-  ceph fs set cephfs inline_data 0
-  expect_false ceph fs set cephfs inline_data asdf
-  ceph fs set cephfs max_file_size 1048576
-  expect_false ceph fs set cephfs max_file_size 123asdf
+  ceph fs set testcephfs1 max_mds 4
+  ceph fs set testcephfs1 max_mds 3
+  ceph fs set testcephfs1 max_mds 256
+  expect_false ceph fs set testcephfs1 max_mds 257
+  ceph fs set testcephfs1 max_mds 4
+  ceph fs set testcephfs1 max_mds 256
+  expect_false ceph fs set testcephfs1 max_mds 257
+  expect_false ceph fs set testcephfs1 max_mds asdf
+  expect_false ceph fs set testcephfs1 inline_data true
+  ceph fs set testcephfs1 inline_data true --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data yes --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data 1 --yes-i-really-really-mean-it
+  expect_false ceph fs set testcephfs1 inline_data --yes-i-really-really-mean-it
+  ceph fs set testcephfs1 inline_data false
+  ceph fs set testcephfs1 inline_data no
+  ceph fs set testcephfs1 inline_data 0
+  expect_false ceph fs set testcephfs1 inline_data asdf
+  ceph fs set testcephfs1 max_file_size 1048576
+  expect_false ceph fs set testcephfs1 max_file_size 123asdf
 
-  expect_false ceph fs set cephfs allow_new_snaps
-  ceph fs set cephfs allow_new_snaps true
-  ceph fs set cephfs allow_new_snaps 0
-  ceph fs set cephfs allow_new_snaps false
-  ceph fs set cephfs allow_new_snaps no
-  expect_false ceph fs set cephfs allow_new_snaps taco
+  expect_false ceph fs set testcephfs1 allow_new_snaps
+  ceph fs set testcephfs1 allow_new_snaps true
+  ceph fs set testcephfs1 allow_new_snaps 0
+  ceph fs set testcephfs1 allow_new_snaps false
+  ceph fs set testcephfs1 allow_new_snaps no
+  expect_false ceph fs set testcephfs1 allow_new_snaps taco
 
   # we should never be able to add EC pools as data or metadata pools
   # create an ec-pool...
   ceph osd pool create mds-ec-pool 16 16 erasure
   set +e
-  ceph fs add_data_pool cephfs mds-ec-pool 2>$TMPFILE
+  ceph fs add_data_pool testcephfs1 mds-ec-pool 2>$TMPFILE
   check_response 'erasure-code' $? 22
   set -e
   ec_poolnum=$(ceph osd dump | grep "pool.* 'mds-ec-pool" | awk '{print $2;}')
@@ -1065,7 +1065,7 @@ function test_mon_mds()
   set -e
 
   # Check that `fs new` is no longer permitted
-  expect_false ceph fs new cephfs $metadata_poolnum $data_poolnum --yes-i-really-mean-it 2>$TMPFILE
+  expect_false ceph fs new testcephfs1 $metadata_poolnum $data_poolnum --yes-i-really-mean-it 2>$TMPFILE
 
   # Check that 'fs reset' runs
   ceph fs reset $FS_NAME --yes-i-really-mean-it
@@ -1074,16 +1074,16 @@ function test_mon_mds()
   ceph osd pool create fs_metadata2 16
   ceph osd pool create fs_data2 16
   set +e
-  expect_false ceph fs new cephfs2 fs_metadata2 fs_data2
+  expect_false ceph fs new testcephfs2 fs_metadata2 fs_data2
   set -e
 
   # Check that setting enable_multiple enables creation of second fs
   ceph fs flag set enable_multiple true --yes-i-really-mean-it
-  ceph fs new cephfs2 fs_metadata2 fs_data2
+  ceph fs new testcephfs2 fs_metadata2 fs_data2
 
   # Clean up multi-fs stuff
-  fail_all_mds cephfs2
-  ceph fs rm cephfs2 --yes-i-really-mean-it
+  fail_all_mds testcephfs2
+  ceph fs rm testcephfs2 --yes-i-really-mean-it
   ceph osd pool delete fs_metadata2 fs_metadata2 --yes-i-really-really-mean-it
   ceph osd pool delete fs_data2 fs_data2 --yes-i-really-really-mean-it
 
@@ -2826,7 +2826,7 @@ function test_osd_compact()
 
 function test_mds_tell_help_command()
 {
-  local FS_NAME=cephfs
+  local FS_NAME=testcephfs1
   if ! mds_exists ; then
       echo "Skipping test, no MDS found"
       return


### PR DESCRIPTION
Just 'cephfs' is not easy to track through logs because we have -

* a CephFS named "cephfs"
* a python module named "cephfs" (that contains functional tests for CephFS),
* a config file section named "cephfs"
* package names starting with or ending with "cephfs"
* CephFS related tools start with string "cephfs" (example: cepfs-shell, ceph-top, cephfs-data-scan, etc.)
* daemon names start with "cephfs" (example: cephfs-mirror)
* OSD pool application tag named "cephfs"

So a unique/distinct name for CephFS make it easy to go through logs.

Fixes: https://tracker.ceph.com/issues/62876






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>