### PR TITLE
reef: ceph-volume: fix mpath device support

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -1,7 +1,37 @@
 import os
 import pytest
 from ceph_volume.util import disk
-from mock.mock import patch
+from mock.mock import patch, MagicMock
+
+
+class TestFunctions:
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=False))
+    def test_is_device_path_does_not_exist(self):
+        assert not disk.is_device('/dev/foo')
+
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    def test_is_device_dev_doesnt_startswith_dev(self):
+        assert not disk.is_device('/foo')
+
+    @patch('ceph_volume.util.disk.allow_loop_devices', MagicMock(return_value=False))
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    def test_is_device_loop_not_allowed(self):
+        assert not disk.is_device('/dev/loop123')
+
+    @patch('ceph_volume.util.disk.lsblk', MagicMock(return_value={'NAME': 'foo', 'TYPE': 'disk'}))
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    def test_is_device_type_disk(self):
+        assert disk.is_device('/dev/foo')
+
+    @patch('ceph_volume.util.disk.lsblk', MagicMock(return_value={'NAME': 'foo', 'TYPE': 'mpath'}))
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    def test_is_device_type_mpath(self):
+        assert disk.is_device('/dev/foo')
+
+    @patch('ceph_volume.util.disk.lsblk', MagicMock(return_value={'NAME': 'foo1', 'TYPE': 'part'}))
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    def test_is_device_type_part(self):
+        assert not disk.is_device('/dev/foo1')
 
 
 class TestLsblkParser(object):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -359,6 +359,10 @@ def is_device(dev):
         if not allow_loop_devices():
             return False
 
+    TYPE = lsblk(dev).get('TYPE')
+    if TYPE:
+        return TYPE in ['disk', 'mpath']
+
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62893

---

backport of https://github.com/ceph/ceph/pull/53309
parent tracker: https://tracker.ceph.com/issues/62722

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh