### PR TITLE
pacific: mds: log message when exiting due to asok command

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -152,6 +152,7 @@ void MDSDaemon::asok_command(
 		    // our response before seeing us disappear from mdsmap
 		    sleep(1);
 		    std::lock_guard l(mds_lock);
+                    derr << "Exiting due to admin socket command" << dendl;
 		    suicide();
 		  });
     t.detach();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62902

---

backport of https://github.com/ceph/ceph/pull/53145
parent tracker: https://tracker.ceph.com/issues/62577

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh