### PR TITLE
pacific: mds,qa: some balancer debug messages (<=5) not printed when debug_mds is >=5

### DIFF
--- a/qa/cephfs/conf/mds.yaml
+++ b/qa/cephfs/conf/mds.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       mds:
         debug mds: 20
+        debug mds balancer: 20
         debug ms: 1
         mds debug frag: true
         mds debug scatterstat: true

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -38,6 +38,11 @@ using std::chrono::duration_cast;
 #include "common/config.h"
 #include "common/errno.h"
 
+/* Note, by default debug_mds_balancer is 1/5. For debug messages 1<lvl<=5,
+ * should_gather (below) will be true; so, debug_mds will be ignored even if
+ * set to 20/20. For this reason, some messages may not appear in the log.
+ * Increase both debug levels to get expected output!
+ */
 #define dout_context g_ceph_context
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".bal " << __func__ << " "

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -19,6 +19,11 @@
 #include "common/Clock.h"
 #include "CInode.h"
 
+/* Note, by default debug_mds_balancer is 1/5. For debug messages 1<lvl<=5,
+ * should_gather (below) will be true; so, debug_mds will be ignored even if
+ * set to 20/20. For this reason, some messages may not appear in the log.
+ * Increase both debug levels to get expected output!
+ */
 #define dout_context g_ceph_context
 #undef dout_prefix
 #define dout_prefix *_dout << "mds.mantle "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62906

---

backport of https://github.com/ceph/ceph/pull/46602
parent tracker: https://tracker.ceph.com/issues/55980

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh