### PR TITLE
reef: qa: lengthen shutdown timeout for thrashed MDS

### DIFF
--- a/qa/suites/fs/thrash/multifs/overrides/client-shutdown.yaml
+++ b/qa/suites/fs/thrash/multifs/overrides/client-shutdown.yaml
@@ -1,0 +1,6 @@
+# Lengthen the timeout for thrashed MDS
+overrides:
+  ceph:
+    conf:
+      client:
+        client_shutdown_timeout: 120

--- a/qa/suites/fs/thrash/workloads/overrides/client-shutdown.yaml
+++ b/qa/suites/fs/thrash/workloads/overrides/client-shutdown.yaml
@@ -1,0 +1,6 @@
+# Lengthen the timeout for thrashed MDS
+overrides:
+  ceph:
+    conf:
+      client:
+        client_shutdown_timeout: 120


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62899

---

backport of https://github.com/ceph/ceph/pull/53149
parent tracker: https://tracker.ceph.com/issues/62579

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh