### PR TITLE
pacific: doc: discuss the standard multi-tenant CephFS security model

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -24,6 +24,16 @@ that directory.
 To restrict clients to only mount and work within a certain directory, use
 path-based MDS authentication capabilities.
 
+Note that this restriction *only* impacts the filesystem hierarchy -- the metadata
+tree managed by the MDS. Clients will still be able to access the underlying
+file data in RADOS directly. To segregate clients fully, you must also isolate
+untrusted clients in their own RADOS namespace. You can place a client's
+filesystem subtree in a particular namespace using `file layouts`_ and then
+restrict their RADOS access to that namespace using `OSD capabilities`_
+
+.. _file layouts: ./file-layouts
+.. _OSD capabilities: ../rados/operations/user-management/#authorization-capabilities
+
 Syntax
 ------
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57776

---

backport of https://github.com/ceph/ceph/pull/48319
parent tracker: https://tracker.ceph.com/issues/57737

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh