### PR TITLE
os/bluestore: optional SharedBlob on Blob structure

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16908,10 +16908,7 @@ int BlueStore::_do_remove(
 	// but now those 2 blobs share it.
 	// This is illegal, as empty shared blobs should be unique.
 	// Fixing by re-creation.
-
-	// Here we skip set_shared_blob() because e.blob is already in BufferCacheShard
-	// and cannot do add_blob() twice
-        e.blob->get_dirty_shared_blob() = new SharedBlob(c.get());
+        e.blob->get_dirty_shared_blob() = nullptr;
       }
       h->extent_map.dirty_range(e.logical_offset, 1);
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2071,7 +2071,7 @@ void BlueStore::OnodeSpace::dump(CephContext *cct)
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.sharedblob(" << this << ") "
 #undef dout_context
-#define dout_context coll->store->cct
+#define dout_context collection->store->cct
 
 void BlueStore::SharedBlob::dump(Formatter* f) const
 {
@@ -2096,7 +2096,7 @@ ostream& operator<<(ostream& out, const BlueStore::SharedBlob& sb)
 }
 
 BlueStore::SharedBlob::SharedBlob(uint64_t i, Collection *_coll)
-  : coll(_coll), sbid_unloaded(i)
+  : collection(_coll), sbid_unloaded(i)
 {
   ceph_assert(sbid_unloaded > 0);
 }
@@ -2115,10 +2115,10 @@ void BlueStore::SharedBlob::put()
 	     << " removing self from set " << get_parent()
 	     << dendl;
   again:
-    auto coll_snap = coll;
+    auto coll_snap = collection;
     if (coll_snap) {
       std::lock_guard l(coll_snap->cache->lock);
-      if (coll_snap != coll) {
+      if (coll_snap != collection) {
 	goto again;
       }
       if (!coll_snap->shared_blob_set.remove(this, true)) {
@@ -2886,7 +2886,7 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
 }
 
 #undef dout_context
-#define dout_context coll->store->cct
+#define dout_context collection->store->cct
 
 void BlueStore::Blob::finish_write(uint64_t seq)
 {
@@ -5174,7 +5174,7 @@ void BlueStore::Collection::split_cache(
 	cache->rm_blob();
 	dest->cache->add_blob();
 	SharedBlob* sb = b->shared_blob.get();
-	if (sb && sb->coll == dest && b->collection) {
+	if (sb && sb->collection == dest && b->collection) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
 				<< dendl;
 	  return;
@@ -5188,7 +5188,7 @@ void BlueStore::Collection::split_cache(
 	  dest->shared_blob_set.add(dest, sb);
 	}
         if (sb) {
-          sb->coll = dest;
+          sb->collection = dest;
         }
         b->collection = dest;
       };

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5175,19 +5175,23 @@ void BlueStore::Collection::split_cache(
 	cache->rm_blob();
 	dest->cache->add_blob();
 	SharedBlob* sb = b->shared_blob.get();
-	if (sb->coll == dest) {
+	if (sb && sb->coll == dest && b->collection) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
 				<< dendl;
 	  return;
 	}
-	ldout(store->cct, 20) << __func__ << "  moving " << *sb << dendl;
-	if (sb->get_sbid()) {
+	ldout(store->cct, 20) << __func__ << "  moving " << *b << dendl;
+	if (b->get_sbid()) {
+          ldout(store->cct, 20) << __func__ << "  moving " << *sb << dendl;
 	  ldout(store->cct, 20) << __func__
 				<< "   moving registration " << *sb << dendl;
 	  shared_blob_set.remove(sb);
 	  dest->shared_blob_set.add(dest, sb);
 	}
-	sb->coll = dest;
+        if (sb) {
+          sb->coll = dest;
+        }
+        b->collection = dest;
       };
 
       for (auto& e : o->extent_map.extent_map) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5174,7 +5174,8 @@ void BlueStore::Collection::split_cache(
 	cache->rm_blob();
 	dest->cache->add_blob();
 	SharedBlob* sb = b->shared_blob.get();
-	if (sb && sb->collection == dest && b->collection) {
+        b->collection = dest;
+	if (sb && sb->collection == dest) {
 	  ldout(store->cct, 20) << __func__ << "  already moved " << *sb
 				<< dendl;
 	  return;
@@ -5190,7 +5191,6 @@ void BlueStore::Collection::split_cache(
         if (sb) {
           sb->collection = dest;
         }
-        b->collection = dest;
       };
 
       for (auto& e : o->extent_map.extent_map) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2172,10 +2172,10 @@ BlueStore::Blob::~Blob()
     return;
   }
  again:
-  auto coll_cache = sb->get_cache();
+  auto coll_cache = get_cache();
   if (coll_cache) {
     std::lock_guard l(coll_cache->lock);
-    if (coll_cache != sb->get_cache()) {
+    if (coll_cache != get_cache()) {
       goto again;
     }
     bc._clear(coll_cache);
@@ -3920,7 +3920,6 @@ bool BlueStore::ExtentMap::encode_some(
       denc_varint(0, bound); // len
       denc_varint(0, bound); // blob_offset
 
-      dout(1) << "Pere blob " << p->blob << dendl;
       p->blob->bound_encode(
         bound,
         struct_v,
@@ -4986,6 +4985,7 @@ void BlueStore::Collection::open_shared_blob(uint64_t sbid, BlobRef b)
   const bluestore_blob_t& blob = b->get_blob();
   if (!blob.is_shared()) {
     b->collection = this;
+    b->get_cache()->add_blob();
     return;
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16899,17 +16899,7 @@ int BlueStore::_do_remove(
       dout(20) << __func__ << "  unsharing " << e << dendl;
       bluestore_blob_t& blob = e.blob->dirty_blob();
       blob.clear_flag(bluestore_blob_t::FLAG_SHARED);
-      if (e.blob->get_shared_blob()->nref > 1) {
-	// Each blob on creation gets its own unique (empty) shared_blob.
-	// In function ExtentMap::dup() we sometimes merge 2 blobs,
-	// so they share common shared_blob used for ref counting.
-	// Imagine 2 blobs having same shared_blob, and shared blob gets just unshared.
-	// We cleared shared_blob content so it is now logically empty,
-	// but now those 2 blobs share it.
-	// This is illegal, as empty shared blobs should be unique.
-	// Fixing by re-creation.
-        e.blob->get_dirty_shared_blob() = nullptr;
-      }
+      e.blob->get_dirty_shared_blob() = nullptr;
       h->extent_map.dirty_range(e.logical_offset, 1);
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4023,7 +4023,8 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_extent(
     if (blobid) {
       consume_blobid(le, false, blobid - 1);
     } else {
-      BlobRef b = c->new_blob();
+      // dummy onodes might not have collections, we need a check for it.
+      BlobRef b = c ? c->new_blob() : new Blob(nullptr);
       uint64_t sbid = 0;
       b->decode(p, struct_v, &sbid, false, c);
       consume_blob(le, extent_pos, sbid, b);
@@ -4071,7 +4072,7 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_spanning_blobs(
   unsigned n;
   denc_varint(n, p);
   while (n--) {
-    BlueStore::BlobRef b = c->new_blob();
+    BlobRef b = c ? c->new_blob() : new Blob(nullptr);
     denc_varint(b->id, p);
     uint64_t sbid = 0;
     b->decode(p, struct_v, &sbid, true, c);
@@ -11051,7 +11052,7 @@ void BlueStore::inject_zombie_spanning_blob(coll_t cid, ghobject_t oid,
     o->extent_map.fault_range(db, 0, OBJECT_MAX_SIZE);
   }
 
-  BlobRef b = c->new_blob();
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
   b->id = blob_id;
   o->extent_map.spanning_blob_map[blob_id] = b;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -611,8 +611,8 @@ public:
     void set_shared_blob(SharedBlobRef sb) {
       ceph_assert((bool)sb);
       ceph_assert(!shared_blob);
+      ceph_assert(sb->collection = collection);
       shared_blob = sb;
-      collection = sb->collection;
       ceph_assert(get_cache());
     }
     BufferSpace bc;
@@ -727,13 +727,13 @@ public:
       return shared_blob && shared_blob->is_loaded();
     }
     inline BufferCacheShard* get_cache() {
-      return shared_blob ? shared_blob->get_cache() : collection->cache;
+      return collection->cache;
     }
     uint64_t get_sbid() const {
       return shared_blob ? shared_blob->get_sbid() : 0;
     }
     CollectionRef get_collection() const {
-      return shared_blob ? shared_blob->collection : collection;
+      return collection;
     }
 
     ~Blob();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -615,6 +615,7 @@ public:
       ceph_assert(!shared_blob);
       sbid_unloaded = sb->get_sbid();
       shared_blob = sb;
+      collection = sb->coll;
       ceph_assert(get_cache());
       get_cache()->add_blob();
     }
@@ -1628,6 +1629,7 @@ private:
     BlobRef new_blob() {
       BlobRef b = new Blob();
       b->collection = this;
+      b->get_cache()->add_blob();
       return b;
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -617,7 +617,6 @@ public:
       shared_blob = sb;
       collection = sb->coll;
       ceph_assert(get_cache());
-      get_cache()->add_blob();
     }
     BufferSpace bc;
   private:

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -615,6 +615,7 @@ public:
       shared_blob = sb;
       ceph_assert(get_cache());
     }
+    Blob(CollectionRef collection) : collection(collection) {}
     BufferSpace bc;
   private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
@@ -723,7 +724,7 @@ public:
       if (--nref == 0)
 	delete this;
     }
-    bool is_loaded() const {
+    bool is_shared_loaded() const {
       return shared_blob && shared_blob->is_loaded();
     }
     inline BufferCacheShard* get_cache() {
@@ -1623,8 +1624,7 @@ private:
     uint64_t make_blob_unshared(SharedBlob *sb);
 
     BlobRef new_blob() {
-      BlobRef b = new Blob();
-      b->collection = this;
+      BlobRef b = new Blob(this);
       b->get_cache()->add_blob();
       return b;
     }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -605,7 +605,6 @@ public:
     std::atomic_int nref = {0};     ///< reference count
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
-    SharedBlobRef shared_blob;      ///< shared blob state (if any)
     CollectionRef collection;
 
     void set_shared_blob(SharedBlobRef sb) {
@@ -618,6 +617,7 @@ public:
     Blob(CollectionRef collection) : collection(collection) {}
     BufferSpace bc;
   private:
+    SharedBlobRef shared_blob;      ///< shared blob state (if any)
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
 #ifdef CACHE_BLOB_BL
     mutable ceph::buffer::list blob_bl;     ///< cached encoded blob, blob is dirty if empty
@@ -639,6 +639,15 @@ public:
     bluestore_blob_use_tracker_t& dirty_blob_use_tracker() {
       return used_in_blob;
     }
+
+    const SharedBlobRef& get_shared_blob() const {
+      return shared_blob;
+    }
+
+    SharedBlobRef& get_dirty_shared_blob() {
+      return shared_blob;
+    }
+
     bool is_referenced() const {
       return used_in_blob.is_not_empty();
     }
@@ -1906,7 +1915,7 @@ private:
     void write_onode(OnodeRef& o) {
       onodes.insert(o);
     }
-    void write_shared_blob(SharedBlobRef &sb) {
+    void write_shared_blob(const SharedBlobRef &sb) {
       shared_blobs.insert(sb);
     }
     void unshare_blob(SharedBlob *sb) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -606,13 +606,17 @@ public:
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
+    bool loaded = false;
+    CollectionRef collection;
+    uint64_t sbid_unloaded = 0;
 
     void set_shared_blob(SharedBlobRef sb) {
       ceph_assert((bool)sb);
       ceph_assert(!shared_blob);
+      sbid_unloaded = sb->get_sbid();
       shared_blob = sb;
-      ceph_assert(shared_blob->get_cache());
-      shared_blob->get_cache()->add_blob();
+      ceph_assert(get_cache());
+      get_cache()->add_blob();
     }
     BufferSpace bc;
   private:
@@ -648,8 +652,8 @@ public:
       return id >= 0;
     }
 
-    bool can_split() const {
-      std::lock_guard l(shared_blob->get_cache()->lock);
+    bool can_split() {
+      std::lock_guard l(get_cache()->lock);
       // splitting a BufferSpace writing list is too hard; don't try.
       return get_bc().writing.empty() &&
              used_in_blob.can_split() &&
@@ -722,6 +726,19 @@ public:
       if (--nref == 0)
 	delete this;
     }
+    bool is_loaded() const {
+      return shared_blob && shared_blob->is_loaded();
+    }
+    inline BufferCacheShard* get_cache() {
+      return shared_blob ? shared_blob->get_cache() : collection->cache;
+    }
+    uint64_t get_sbid() const {
+      return shared_blob ? shared_blob->get_sbid() : sbid_unloaded;
+    }
+    CollectionRef get_collection() const {
+      return shared_blob ? shared_blob->coll : collection;
+    }
+
     ~Blob();
 
 #ifdef CACHE_BLOB_BL
@@ -824,7 +841,7 @@ public:
     }
     ~Extent() {
       if (blob) {
-	blob->shared_blob->get_cache()->rm_extent();
+	blob->get_cache()->rm_extent();
       }
     }
 
@@ -833,7 +850,7 @@ public:
     void assign_blob(const BlobRef& b) {
       ceph_assert(!blob);
       blob = b;
-      blob->shared_blob->get_cache()->add_extent();
+      blob->get_cache()->add_extent();
     }
 
     // comparators for intrusive_set
@@ -1610,7 +1627,7 @@ private:
 
     BlobRef new_blob() {
       BlobRef b = new Blob();
-      b->set_shared_blob(new SharedBlob(this));
+      b->collection = this;
       return b;
     }
 
@@ -2832,7 +2849,7 @@ private:
     uint64_t offset,
     ceph::buffer::list& bl,
     unsigned flags) {
-    b->dirty_bc().write(b->shared_blob->get_cache(), txc->seq, offset, bl,
+    b->dirty_bc().write(b->get_cache(), txc->seq, offset, bl,
 			     flags);
     txc->blobs_written.insert(b);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -728,7 +728,7 @@ public:
       return shared_blob && shared_blob->is_loaded();
     }
     inline BufferCacheShard* get_cache() {
-      return collection->cache;
+      return collection ? collection->cache : nullptr;
     }
     uint64_t get_sbid() const {
       return shared_blob ? shared_blob->get_sbid() : 0;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -434,7 +434,6 @@ TEST(Blob, put_ref)
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob b(coll.get());
-    b.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x40715000, 0x2000));
     b.dirty_blob().allocated_test(
       bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
@@ -467,7 +466,6 @@ TEST(Blob, put_ref)
 
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(0, mas * 2));
@@ -488,7 +486,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(123, mas * 2));
@@ -512,7 +509,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
@@ -550,7 +546,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
@@ -591,7 +586,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 6));
@@ -623,7 +617,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -661,7 +654,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -716,7 +708,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -771,7 +762,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 8));
@@ -814,7 +804,6 @@ TEST(Blob, put_ref)
   // verify csum chunk size if factored in properly
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(0, mas*4));
@@ -832,7 +821,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(0x40101000, 0x4000));
     b.allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
@@ -854,7 +842,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x5000));
@@ -872,7 +859,6 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x7000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
@@ -901,7 +887,6 @@ TEST(Blob, put_ref)
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob B(coll.get());
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
@@ -991,8 +976,6 @@ TEST(Blob, split)
   {
     BlueStore::Blob L(coll.get());
     BlueStore::Blob R(coll.get());
-    L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x2000));
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     L.get_ref(coll.get(), 0, 0x2000);
@@ -1013,8 +996,6 @@ TEST(Blob, split)
   {
     BlueStore::Blob L(coll.get());
     BlueStore::Blob R(coll.get());
-    L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x1000));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x12000, 0x1000));
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
@@ -1048,7 +1029,6 @@ TEST(Blob, legacy_decode)
   {
     BlueStore::Blob B(coll.get());
 
-    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     B.dirty_blob().allocated_test(bluestore_pextent_t(0x1, 0x2000));
     B.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     B.get_ref(coll.get(), 0, 0xff0);
@@ -1094,8 +1074,6 @@ TEST(Blob, legacy_decode)
     auto p2 = bl2.front().begin_deep();
     BlueStore::Blob Bres(coll.get());
     BlueStore::Blob Bres2(coll.get());
-    Bres.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    Bres2.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
     uint64_t sbid, sbid2;
     Bres.decode(
@@ -1130,7 +1108,6 @@ TEST(ExtentMap, seek_lextent)
   BlueStore::ExtentMap em(&onode,
     g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
   BlueStore::BlobRef br(coll->new_blob());
-  br->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(100));
@@ -1183,7 +1160,6 @@ TEST(ExtentMap, has_any_lextents)
   BlueStore::ExtentMap em(&onode,
     g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
   BlueStore::BlobRef b(coll->new_blob());
-  b->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
   ASSERT_FALSE(em.has_any_lextents(0, 0));
   ASSERT_FALSE(em.has_any_lextents(0, 1000));
@@ -1880,10 +1856,6 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::BlobRef b2(coll->new_blob());
     BlueStore::BlobRef b3(coll->new_blob());
     BlueStore::BlobRef b4(coll->new_blob());
-    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x2000, 0x1000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x1000));
     b2->dirty_blob().allocated_test(bluestore_pextent_t(1, 0x1000));
@@ -1946,10 +1918,6 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::BlobRef b2(coll->new_blob());
     BlueStore::BlobRef b3(coll->new_blob());
     BlueStore::BlobRef b4(coll->new_blob());
-    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x40000, 0x20000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x20000));
     b2->dirty_blob().allocated_test(bluestore_pextent_t(1, 0x10000));
@@ -2017,8 +1985,6 @@ TEST(GarbageCollector, BasicTest)
     int64_t saving;
     BlueStore::BlobRef b1(coll->new_blob());
     BlueStore::BlobRef b2(coll->new_blob());
-    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x4000, 0x2000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x2000));
     b2->dirty_blob().set_compressed(0x4000, 0x2000);
@@ -2075,11 +2041,6 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::BlobRef b2(coll->new_blob());
     BlueStore::BlobRef b3(coll->new_blob());
     BlueStore::BlobRef b4(coll->new_blob());
-    b0->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
-    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b0->dirty_blob().set_compressed(0x2000, 0x1000);
     b0->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x10000));
     b1->dirty_blob().set_compressed(0x20000, 0x10000);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1701,7 +1701,7 @@ TEST(ExtentMap, dup_extent_map)
     BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
     ASSERT_TRUE(b2->get_blob().is_shared());
     ASSERT_EQ(b2->get_referenced_bytes(), ext1_len);
-    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
+    ASSERT_EQ(b1->get_shared_blob(), b2->get_shared_blob());
     auto &_b2 = b2->get_blob();
     ASSERT_EQ(_b1.get_csum_count(), _b2.get_csum_count());
     for(size_t i = 0; i < _b2.get_csum_count(); i++) {
@@ -1733,14 +1733,14 @@ TEST(ExtentMap, dup_extent_map)
     // make sure (basically) onode1&2 are unmodified
     BlueStore::BlobRef b1 = em1.seek_lextent(ext1_offs)->blob;
     BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
-    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
+    ASSERT_EQ(b1->get_shared_blob(), b2->get_shared_blob());
 
     BlueStore::Extent &ext3 = *em3.seek_lextent(clone_offs);
     ASSERT_EQ(ext3.blob_offset, clone_shift);
     ASSERT_EQ(ext3.length, clone_len);
     BlueStore::BlobRef b3 = ext3.blob;
     ASSERT_TRUE(b3->get_blob().is_shared());
-    ASSERT_EQ(b3->shared_blob, b1->shared_blob);
+    ASSERT_EQ(b3->get_shared_blob(), b1->get_shared_blob());
     ASSERT_EQ(b3->get_referenced_bytes(), clone_len);
     auto ll = b3->get_blob().get_logical_length();
     ASSERT_EQ(ll, ext1_len);
@@ -1777,8 +1777,8 @@ TEST(ExtentMap, dup_extent_map)
     BlueStore::BlobRef b1 = em1.seek_lextent(ext1_offs)->blob;
     BlueStore::BlobRef b2 = em2.seek_lextent(ext1_offs)->blob;
     BlueStore::BlobRef b3 = em3.seek_lextent(ext1_offs)->blob;
-    ASSERT_EQ(b1->shared_blob, b2->shared_blob);
-    ASSERT_EQ(b1->shared_blob, b3->shared_blob);
+    ASSERT_EQ(b1->get_shared_blob(), b2->get_shared_blob());
+    ASSERT_EQ(b1->get_shared_blob(), b3->get_shared_blob());
     auto &_b2 = b2->get_blob();
 
     BlueStore::Extent &ext4 = *em4.seek_lextent(clone_offs);
@@ -1786,7 +1786,7 @@ TEST(ExtentMap, dup_extent_map)
     ASSERT_EQ(ext4.length, clone_len);
     BlueStore::BlobRef b4 = ext4.blob;
     ASSERT_TRUE(b4->get_blob().is_shared());
-    ASSERT_EQ(b4->shared_blob, b2->shared_blob);
+    ASSERT_EQ(b4->get_shared_blob(), b2->get_shared_blob());
     ASSERT_EQ(b4->get_referenced_bytes(), clone_len);
     auto &_b4 = b4->get_blob();
     auto ll = _b4.get_logical_length();

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -434,7 +434,8 @@ TEST(Blob, put_ref)
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob b;
-    b.shared_blob = new BlueStore::SharedBlob(coll.get());
+    b.collection = coll;
+    b.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x40715000, 0x2000));
     b.dirty_blob().allocated_test(
       bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
@@ -467,7 +468,8 @@ TEST(Blob, put_ref)
 
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(0, mas * 2));
@@ -488,7 +490,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(123, mas * 2));
@@ -512,7 +515,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
@@ -550,7 +554,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
@@ -591,7 +596,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 6));
@@ -623,7 +629,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -661,7 +668,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -716,7 +724,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
@@ -771,7 +780,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 8));
@@ -814,7 +824,8 @@ TEST(Blob, put_ref)
   // verify csum chunk size if factored in properly
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(0, mas*4));
@@ -832,7 +843,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(0x40101000, 0x4000));
     b.allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
@@ -854,7 +866,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x5000));
@@ -872,7 +885,8 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x7000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
@@ -901,7 +915,8 @@ TEST(Blob, put_ref)
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob B;
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.collection = coll;
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
@@ -990,8 +1005,10 @@ TEST(Blob, split)
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   {
     BlueStore::Blob L, R;
-    L.shared_blob = new BlueStore::SharedBlob(coll.get());
-    R.shared_blob = new BlueStore::SharedBlob(coll.get());
+    L.collection = coll;
+    R.collection = coll;
+    L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x2000));
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     L.get_ref(coll.get(), 0, 0x2000);
@@ -1011,8 +1028,10 @@ TEST(Blob, split)
   }
   {
     BlueStore::Blob L, R;
-    L.shared_blob = new BlueStore::SharedBlob(coll.get());
-    R.shared_blob = new BlueStore::SharedBlob(coll.get());
+    L.collection = coll;
+    R.collection = coll;
+    L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x1000));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x12000, 0x1000));
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
@@ -1045,8 +1064,9 @@ TEST(Blob, legacy_decode)
   bufferlist bl, bl2;
   {
     BlueStore::Blob B;
+    B.collection = coll;
 
-    B.shared_blob = new BlueStore::SharedBlob(coll.get());
+    B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     B.dirty_blob().allocated_test(bluestore_pextent_t(0x1, 0x2000));
     B.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     B.get_ref(coll.get(), 0, 0xff0);
@@ -1091,8 +1111,10 @@ TEST(Blob, legacy_decode)
     auto p = bl.front().begin_deep();
     auto p2 = bl2.front().begin_deep();
     BlueStore::Blob Bres, Bres2;
-    Bres.shared_blob = new BlueStore::SharedBlob(coll.get());
-    Bres2.shared_blob = new BlueStore::SharedBlob(coll.get());
+    Bres.collection = coll;
+    Bres2.collection = coll;
+    Bres.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    Bres2.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
     uint64_t sbid, sbid2;
     Bres.decode(
@@ -1126,8 +1148,8 @@ TEST(ExtentMap, seek_lextent)
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode,
     g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::BlobRef br(new BlueStore::Blob);
-  br->shared_blob = new BlueStore::SharedBlob(coll.get());
+  BlueStore::BlobRef br(coll->new_blob());
+  br->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(100));
@@ -1179,8 +1201,8 @@ TEST(ExtentMap, has_any_lextents)
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode,
     g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::BlobRef b(new BlueStore::Blob);
-  b->shared_blob = new BlueStore::SharedBlob(coll.get());
+  BlueStore::BlobRef b(coll->new_blob());
+  b->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
   ASSERT_FALSE(em.has_any_lextents(0, 0));
   ASSERT_FALSE(em.has_any_lextents(0, 1000));
@@ -1239,12 +1261,12 @@ TEST(ExtentMap, compress_extent_map)
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode,
     g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::BlobRef b1(new BlueStore::Blob);
-  BlueStore::BlobRef b2(new BlueStore::Blob);
-  BlueStore::BlobRef b3(new BlueStore::Blob);
-  b1->shared_blob = new BlueStore::SharedBlob(coll.get());
-  b2->shared_blob = new BlueStore::SharedBlob(coll.get());
-  b3->shared_blob = new BlueStore::SharedBlob(coll.get());
+  BlueStore::BlobRef b1(coll->new_blob());
+  BlueStore::BlobRef b2(coll->new_blob());
+  BlueStore::BlobRef b3(coll->new_blob());
+  b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+  b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+  b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
   em.extent_map.insert(*new BlueStore::Extent(0, 0, 100, b1));
   em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, b2));
@@ -1417,8 +1439,8 @@ public:
       uint32_t num_aus     // number of aus, first, first+1.. first+num_au-1
     ) {
       uint32_t blob_length = (empty_aus + num_aus) * au_size;
-      BlueStore::BlobRef b(new BlueStore::Blob);
-      b->shared_blob = new BlueStore::SharedBlob(coll.get());
+      BlueStore::BlobRef b(coll->new_blob());
+      b->collection = coll;
       bluestore_blob_t& bb = b->dirty_blob();
       bb.init_csum(Checksummer::CSUM_CRC32C, csum_order, blob_length);
       for(size_t i = 0; i < num_aus; ++i) {
@@ -1683,8 +1705,8 @@ TEST(ExtentMap, dup_extent_map)
   size_t ext1_offs = 0x0;
   size_t ext1_len = 0x2000;
   size_t ext1_boffs = 0x0;
-  BlueStore::BlobRef b1(new BlueStore::Blob);
-  b1->shared_blob = new BlueStore::SharedBlob(coll.get());
+  BlueStore::BlobRef b1(coll->new_blob());
+  b1->collection = coll;
   auto &_b1 = b1->dirty_blob();
   _b1.init_csum(Checksummer::CSUM_CRC32C, csum_order, ext1_len);
   for(size_t i = 0; i < _b1.get_csum_count(); i++) {
@@ -1875,14 +1897,14 @@ TEST(GarbageCollector, BasicTest)
   {
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
-    BlueStore::BlobRef b1(new BlueStore::Blob);
-    BlueStore::BlobRef b2(new BlueStore::Blob);
-    BlueStore::BlobRef b3(new BlueStore::Blob);
-    BlueStore::BlobRef b4(new BlueStore::Blob);
-    b1->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b2->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b3->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b4->shared_blob = new BlueStore::SharedBlob(coll.get());
+    BlueStore::BlobRef b1(coll->new_blob());
+    BlueStore::BlobRef b2(coll->new_blob());
+    BlueStore::BlobRef b3(coll->new_blob());
+    BlueStore::BlobRef b4(coll->new_blob());
+    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x2000, 0x1000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x1000));
     b2->dirty_blob().allocated_test(bluestore_pextent_t(1, 0x1000));
@@ -1941,14 +1963,14 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
-    BlueStore::BlobRef b1(new BlueStore::Blob);
-    BlueStore::BlobRef b2(new BlueStore::Blob);
-    BlueStore::BlobRef b3(new BlueStore::Blob);
-    BlueStore::BlobRef b4(new BlueStore::Blob);
-    b1->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b2->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b3->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b4->shared_blob = new BlueStore::SharedBlob(coll.get());
+    BlueStore::BlobRef b1(coll->new_blob());
+    BlueStore::BlobRef b2(coll->new_blob());
+    BlueStore::BlobRef b3(coll->new_blob());
+    BlueStore::BlobRef b4(coll->new_blob());
+    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x40000, 0x20000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x20000));
     b2->dirty_blob().allocated_test(bluestore_pextent_t(1, 0x10000));
@@ -2014,10 +2036,10 @@ TEST(GarbageCollector, BasicTest)
   {
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
-    BlueStore::BlobRef b1(new BlueStore::Blob);
-    BlueStore::BlobRef b2(new BlueStore::Blob);
-    b1->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b2->shared_blob = new BlueStore::SharedBlob(coll.get());
+    BlueStore::BlobRef b1(coll->new_blob());
+    BlueStore::BlobRef b2(coll->new_blob());
+    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b1->dirty_blob().set_compressed(0x4000, 0x2000);
     b1->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x2000));
     b2->dirty_blob().set_compressed(0x4000, 0x2000);
@@ -2069,16 +2091,16 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
-    BlueStore::BlobRef b0(new BlueStore::Blob);
-    BlueStore::BlobRef b1(new BlueStore::Blob);
-    BlueStore::BlobRef b2(new BlueStore::Blob);
-    BlueStore::BlobRef b3(new BlueStore::Blob);
-    BlueStore::BlobRef b4(new BlueStore::Blob);
-    b0->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b1->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b2->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b3->shared_blob = new BlueStore::SharedBlob(coll.get());
-    b4->shared_blob = new BlueStore::SharedBlob(coll.get());
+    BlueStore::BlobRef b0(coll->new_blob());
+    BlueStore::BlobRef b1(coll->new_blob());
+    BlueStore::BlobRef b2(coll->new_blob());
+    BlueStore::BlobRef b3(coll->new_blob());
+    BlueStore::BlobRef b4(coll->new_blob());
+    b0->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b1->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b2->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b3->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
+    b4->set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b0->dirty_blob().set_compressed(0x2000, 0x1000);
     b0->dirty_blob().allocated_test(bluestore_pextent_t(0, 0x10000));
     b1->dirty_blob().set_compressed(0x20000, 0x10000);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -433,8 +433,7 @@ TEST(Blob, put_ref)
       g_ceph_context, "lru", NULL);
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
-    BlueStore::Blob b;
-    b.collection = coll;
+    BlueStore::Blob b(coll.get());
     b.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x40715000, 0x2000));
     b.dirty_blob().allocated_test(
@@ -467,8 +466,7 @@ TEST(Blob, put_ref)
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
 
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -489,8 +487,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*2, b.get_extents()[0].length);
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -514,8 +511,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*2, b.get_extents()[0].length);
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -553,8 +549,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(3u, b.get_extents().size());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -595,8 +590,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.get_extents()[4].is_valid());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll);
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -628,8 +622,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.get_extents()[2].is_valid());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll);
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -667,8 +660,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.get_extents()[2].is_valid());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll);
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -723,8 +715,7 @@ TEST(Blob, put_ref)
     ASSERT_FALSE(b.get_extents()[0].is_valid());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll);
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -779,8 +770,7 @@ TEST(Blob, put_ref)
     ASSERT_FALSE(b.get_extents()[0].is_valid());
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -823,8 +813,7 @@ TEST(Blob, put_ref)
   }
   // verify csum chunk size if factored in properly
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
@@ -842,8 +831,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*4, b.get_extents()[0].length);
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(0x40101000, 0x4000));
@@ -865,8 +853,7 @@ TEST(Blob, put_ref)
     cout << "r " << r << std::endl;
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
@@ -884,8 +871,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(0x2000u, r[0].length);
   }
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x7000));
@@ -914,8 +900,7 @@ TEST(Blob, put_ref)
       g_ceph_context, "lru", NULL);
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     bluestore_blob_t& b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
@@ -1004,9 +989,8 @@ TEST(Blob, split)
       g_ceph_context, "lru", NULL);
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   {
-    BlueStore::Blob L, R;
-    L.collection = coll;
-    R.collection = coll;
+    BlueStore::Blob L(coll.get());
+    BlueStore::Blob R(coll.get());
     L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x2000));
@@ -1027,9 +1011,8 @@ TEST(Blob, split)
     ASSERT_EQ(0x1000u, R.get_referenced_bytes());
   }
   {
-    BlueStore::Blob L, R;
-    L.collection = coll;
-    R.collection = coll;
+    BlueStore::Blob L(coll.get());
+    BlueStore::Blob R(coll.get());
     L.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     R.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     L.dirty_blob().allocated_test(bluestore_pextent_t(0x2000, 0x1000));
@@ -1063,8 +1046,7 @@ TEST(Blob, legacy_decode)
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   bufferlist bl, bl2;
   {
-    BlueStore::Blob B;
-    B.collection = coll;
+    BlueStore::Blob B(coll.get());
 
     B.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     B.dirty_blob().allocated_test(bluestore_pextent_t(0x1, 0x2000));
@@ -1110,9 +1092,8 @@ TEST(Blob, legacy_decode)
 
     auto p = bl.front().begin_deep();
     auto p2 = bl2.front().begin_deep();
-    BlueStore::Blob Bres, Bres2;
-    Bres.collection = coll;
-    Bres2.collection = coll;
+    BlueStore::Blob Bres(coll.get());
+    BlueStore::Blob Bres2(coll.get());
     Bres.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
     Bres2.set_shared_blob(new BlueStore::SharedBlob(coll.get()));
 
@@ -1440,7 +1421,6 @@ public:
     ) {
       uint32_t blob_length = (empty_aus + num_aus) * au_size;
       BlueStore::BlobRef b(coll->new_blob());
-      b->collection = coll;
       bluestore_blob_t& bb = b->dirty_blob();
       bb.init_csum(Checksummer::CSUM_CRC32C, csum_order, blob_length);
       for(size_t i = 0; i < num_aus; ++i) {
@@ -1705,8 +1685,7 @@ TEST(ExtentMap, dup_extent_map)
   size_t ext1_offs = 0x0;
   size_t ext1_len = 0x2000;
   size_t ext1_boffs = 0x0;
-  BlueStore::BlobRef b1(coll->new_blob());
-  b1->collection = coll;
+  BlueStore::BlobRef b1 = coll->new_blob();
   auto &_b1 = b1->dirty_blob();
   _b1.init_csum(Checksummer::CSUM_CRC32C, csum_order, ext1_len);
   for(size_t i = 0; i < _b1.get_csum_count(); i++) {


### PR DESCRIPTION
Blob::shared_blob was always set to something even though a SharedBlob wasn't really "created". In this PR we make shared_blob truly optional and only set it to a real instance if it's really necessary.

**Some results:**
```bash
bin/rados bench 10 write -p .mgr -t 4 --num-objects 20000 --no-cleanup
# with changes
"bluestore_blob_bytes": 4939272,
"bluestore_blob_items": 22867,
"bluestore_shared_blob_bytes": 0,
"bluestore_shared_blob_items": 0,

# without changes
"bluestore_blob_bytes": 4618200,
"bluestore_blob_items": 23091,
"bluestore_shared_blob_bytes": 554184,
"bluestore_shared_blob_items": 23091,
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
