### PR TITLE
pacific: ceph-volume,python-common: Data allocate fraction

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -1,6 +1,7 @@
 import argparse
 from collections import namedtuple
 import json
+import math
 import logging
 from textwrap import dedent
 from ceph_volume import terminal, decorators
@@ -53,7 +54,7 @@ def get_physical_osds(devices, args):
     data_slots = args.osds_per_device
     if args.data_slots:
         data_slots = max(args.data_slots, args.osds_per_device)
-    rel_data_size = 1.0 / data_slots
+    rel_data_size = args.data_allocate_fraction / data_slots
     mlogger.debug('relative data size: {}'.format(rel_data_size))
     ret = []
     for dev in devices:
@@ -296,6 +297,17 @@ class Batch(object):
             help=('Provision more than 1 (the default) OSD slot per device'
                   ' if more slots then osds-per-device are specified, slots'
                   'will stay unoccupied'),
+        )
+        def data_allocate_fraction(pct):
+            pct_float = float(pct)
+            if math.isnan(pct_float) or pct_float == 0.0  or pct_float < 0.0 or pct_float > 1.0:
+                raise argparse.ArgumentTypeError('Percentage not in (0,1.0]')
+            return pct_float
+        parser.add_argument(
+            '--data-allocate-fraction',
+            type=data_allocate_fraction,
+            help='Fraction to allocate from data device (0,1.0]',
+            default=1.0
         )
         parser.add_argument(
             '--block-db-size',

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -1,7 +1,6 @@
 import argparse
 from collections import namedtuple
 import json
-import math
 import logging
 from textwrap import dedent
 from ceph_volume import terminal, decorators
@@ -298,14 +297,9 @@ class Batch(object):
                   ' if more slots then osds-per-device are specified, slots'
                   'will stay unoccupied'),
         )
-        def data_allocate_fraction(pct):
-            pct_float = float(pct)
-            if math.isnan(pct_float) or pct_float == 0.0  or pct_float < 0.0 or pct_float > 1.0:
-                raise argparse.ArgumentTypeError('Percentage not in (0,1.0]')
-            return pct_float
         parser.add_argument(
             '--data-allocate-fraction',
-            type=data_allocate_fraction,
+            type=arg_validators.ValidFraction(),
             help='Fraction to allocate from data device (0,1.0]',
             default=1.0
         )

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -319,3 +319,7 @@ def fake_filesystem(fs):
     fs.create_dir('/sys/block/sda/queue')
     fs.create_dir('/sys/block/rbd0')
     yield fs
+
+@pytest.fixture(params=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.999, 1.0])
+def data_allocate_fraction(request):
+    return request.param

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -57,6 +57,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -79,6 +80,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -104,6 +106,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -131,6 +134,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -178,30 +182,35 @@ class TestBatch(object):
                                           osds_per_device):
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=1.0)
         osds = batch.get_physical_osds(mock_devices_available, args)
         assert len(osds) == len(mock_devices_available) * osds_per_device
 
     def test_get_physical_osds_rel_size(self, factory,
                                           mock_devices_available,
                                           conf_ceph_stub,
-                                          osds_per_device):
+                                          osds_per_device,
+                                          data_allocate_fraction):
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=data_allocate_fraction)
         osds = batch.get_physical_osds(mock_devices_available, args)
         for osd in osds:
-            assert osd.data[1] == 1.0 / osds_per_device
+            assert osd.data[1] == data_allocate_fraction / osds_per_device
 
     def test_get_physical_osds_abs_size(self, factory,
                                           mock_devices_available,
                                           conf_ceph_stub,
-                                          osds_per_device):
+                                          osds_per_device,
+                                          data_allocate_fraction):
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=data_allocate_fraction)
         osds = batch.get_physical_osds(mock_devices_available, args)
         for osd, dev in zip(osds, mock_devices_available):
-            assert osd.data[2] == int(dev.vg_size[0] / osds_per_device)
+            assert osd.data[2] == int(dev.vg_size[0] * (data_allocate_fraction / osds_per_device))
 
     def test_get_physical_osds_osd_ids(self, factory,
                                           mock_devices_available,

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -336,3 +336,28 @@ class TestValidBatchDataDevice(object):
         )
         self.validator.zap = False
         assert self.validator('/dev/foo')
+
+class TestValidFraction(object):
+
+    def setup(self):
+        self.validator = arg_validators.ValidFraction()
+
+    def test_fraction_is_valid(self, fake_call):
+        result = self.validator('0.8')
+        assert result == 0.8
+
+    def test_fraction_is_nan(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('NaN')
+
+    def test_fraction_is_negative(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('-1.0')
+
+    def test_fraction_is_zero(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('0.0')
+
+    def test_fraction_is_greater_one(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('1.1')

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -346,6 +346,10 @@ class TestValidFraction(object):
         result = self.validator('0.8')
         assert result == 0.8
 
+    def test_fraction_not_float(self, fake_call):
+        with pytest.raises(ValueError):
+            self.validator('xyz')
+
     def test_fraction_is_nan(self, fake_call):
         with pytest.raises(argparse.ArgumentError):
             self.validator('NaN')

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import math
 from ceph_volume import terminal, decorators, process
 from ceph_volume.util.device import Device
 from ceph_volume.util import disk
@@ -220,3 +221,14 @@ def exclude_group_options(parser, groups, argv=None):
                     terminal.warning(msg)
             last_group = group_name
         last_flag = flag
+
+class ValidFraction(object):
+    """
+    Validate fraction is in (0, 1.0]
+    """
+
+    def __call__(self, fraction):
+        fraction_float = float(fraction)
+        if math.isnan(fraction_float) or fraction_float <= 0.0 or fraction_float > 1.0:
+            raise argparse.ArgumentTypeError('Fraction not in (0,1.0]')
+        return fraction_float

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -230,5 +230,5 @@ class ValidFraction(object):
     def __call__(self, fraction):
         fraction_float = float(fraction)
         if math.isnan(fraction_float) or fraction_float <= 0.0 or fraction_float > 1.0:
-            raise argparse.ArgumentTypeError('Fraction not in (0,1.0]')
+            raise argparse.ArgumentError(None, 'Fraction %f not in (0,1.0]' % fraction_float)
         return fraction_float


### PR DESCRIPTION
Backport of #40659

We ended up with the python-common bits of this backported (hence why those commits are absent in this backport), which allows users to add the data_allocate_fraction to drive group specs, but the actual ceph-volume feature underneath never made it to pacific.
