### PR TITLE
reef: rgw/crypt: don't deref null manifest_bl

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -615,7 +615,7 @@ int RGWGetObj_ObjStore_S3::get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter> 
       ldpp_dout(this, 1) << "failed to decode RGW_ATTR_CRYPT_PARTS" << dendl;
       return -EIO;
     }
-  } else {
+  } else if (manifest_bl) {
     // otherwise, we read the part lengths from the manifest
     res = RGWGetObj_BlockDecrypt::read_manifest_parts(this, *manifest_bl,
                                                       parts_len);
@@ -2788,7 +2788,7 @@ int RGWPutObj_ObjStore_S3::get_decrypt_filter(
       ldpp_dout(this, 1) << "failed to decode RGW_ATTR_CRYPT_PARTS" << dendl;
       return -EIO;
     }
-  } else {
+  } else if (manifest_bl) {
     // otherwise, we read the part lengths from the manifest
     res = RGWGetObj_BlockDecrypt::read_manifest_parts(this, *manifest_bl,
                                                       parts_len);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62935

---

backport of https://github.com/ceph/ceph/pull/53448
parent tracker: https://tracker.ceph.com/issues/62378

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh