### PR TITLE
osd: OSDMap: provide cleaner interfaces for map_to_pg(), object_locator_to_pg()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6494,14 +6494,10 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       command == "injectecwriteerr" || command == "injectecclearwriteerr" ||
       command == "injectparityread" || command == "injectclearparityread"
     ) {
-    pg_t rawpg;
     int64_t pool;
     OSDMapRef curmap = service->get_osdmap();
-    int r = -1;
 
-    string poolstr;
-
-    cmd_getval(cmdmap, "pool", poolstr);
+    string poolstr = cmd_getval_or<string>(cmdmap, "pool", string{"xxx"});
     pool = curmap->lookup_pg_pool_name(poolstr);
     //If we can't find it by name then maybe id specified
     if (pool < 0 && isdigit(poolstr[0]))
@@ -6511,20 +6507,20 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       return;
     }
 
-    string objname, nspace;
-    cmd_getval(cmdmap, "objname", objname);
+    string objname = cmd_getval_or<string>(cmdmap, "objname", string{"xxx"});
+    string nspace;
     std::size_t found = objname.find_first_of('/');
     if (found != string::npos) {
       nspace = objname.substr(0, found);
       objname = objname.substr(found+1);
     }
     object_locator_t oloc(pool, nspace);
-    r = curmap->object_locator_to_pg(object_t(objname), oloc,  rawpg);
-
-    if (r < 0) {
+    auto maybe_pg = curmap->object_locator_to_expected_pg(object_t(objname), oloc);
+    if (!maybe_pg.has_value()) {
       ss << "Invalid namespace/objname";
       return;
     }
+    pg_t rawpg = maybe_pg.value();
 
     shard_id_t shardid =
 	cmd_getval_cast_or<int64_t>(cmdmap, "shardid", shard_id_t::NO_SHARD);
@@ -6556,6 +6552,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
         }
     }
 
+    int r = -1;
     ObjectStore::Transaction t;
 
     if (command == "setomapval") {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -23,6 +23,8 @@
 #include <iomanip>
 #include <optional>
 #include <random>
+#include <string>
+#include <string_view>
 #include <sstream>
 #include <fmt/format.h>
 
@@ -2727,6 +2729,24 @@ int OSDMap::map_to_pg(
   return 0;
 }
 
+tl::expected<pg_t, int> OSDMap::map_to_pg(
+  int64_t poolid,
+  std::string_view name,
+  std::string_view key,
+  std::string_view nspace) const
+{
+  // calculate ps (placement seed)
+  const pg_pool_t *pool = get_pg_pool(poolid);
+  if (!pool)
+    return tl::unexpected(-ENOENT);
+  ps_t ps;
+  if (key.empty())
+    ps = pool->hash_key(name, nspace);
+  else
+    ps = pool->hash_key(key, nspace);
+  return pg_t(ps, poolid);
+}
+
 int OSDMap::object_locator_to_pg(
   const object_t& oid, const object_locator_t& loc, pg_t &pg) const
 {
@@ -2738,6 +2758,19 @@ int OSDMap::object_locator_to_pg(
     return 0;
   }
   return map_to_pg(loc.get_pool(), oid.name, loc.key, loc.nspace, &pg);
+}
+
+tl::expected<pg_t, int> OSDMap::object_locator_to_expected_pg(
+  const object_t& oid,
+  const object_locator_t& loc) const
+{
+  if (loc.hash >= 0) {
+    if (!get_pg_pool(loc.get_pool())) {
+      return tl::unexpected(-ENOENT);
+    }
+    return pg_t(loc.hash, loc.get_pool());
+  }
+  return map_to_pg(loc.get_pool(), oid.name, loc.key, loc.nspace);
 }
 
 ceph_object_layout OSDMap::make_object_layout(

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -35,6 +35,7 @@
 #include "include/btree_map.h"
 #include "include/common_fwd.h"
 #include "include/fs_types.h" // for struct file_layout_t
+#include "include/expected.hpp"
 #include "include/types.h"
 #include "common/ceph_releases.h"
 #include "osd_types.h"
@@ -1184,14 +1185,25 @@ public:
     const std::string& key,
     const std::string& nspace,
     pg_t *pg) const;
+
+  tl::expected<pg_t, int> map_to_pg(
+    int64_t pool,
+    std::string_view name,
+    std::string_view key,
+    std::string_view nspace) const;
+
   int object_locator_to_pg(const object_t& oid, const object_locator_t& loc,
 			   pg_t &pg) const;
+
+  tl::expected<pg_t, int> object_locator_to_expected_pg(
+    const object_t& oid,
+    const object_locator_t& loc) const;
+
   pg_t object_locator_to_pg(const object_t& oid,
 			    const object_locator_t& loc) const {
-    pg_t pg;
-    int ret = object_locator_to_pg(oid, loc, pg);
-    ceph_assert(ret == 0);
-    return pg;
+    auto expected_pg = object_locator_to_expected_pg(oid, loc);
+    ceph_assert(expected_pg.has_value());
+    return expected_pg.value();
   }
 
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7208,12 +7208,12 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  result = -EINVAL;
 	  goto fail;
 	}
-	pg_t raw_pg;
-	result = get_osdmap()->object_locator_to_pg(target_name, target_oloc, raw_pg);
-	if (result < 0) {
-	  dout(5) << " pool information is invalid: " << result << dendl;
+        auto maybe_pg = get_osdmap()->object_locator_to_expected_pg(target_name, target_oloc);
+	if (!maybe_pg) {
+	  dout(5) << " pool information is invalid: " << maybe_pg.error() << dendl;
 	  break;
 	}
+	pg_t raw_pg = *maybe_pg;
 	hobject_t target(target_name, target_oloc.key, target_snapid,
 		raw_pg.ps(), raw_pg.pool(),
 		target_oloc.nspace);
@@ -7360,13 +7360,12 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  }
 	}
 
-	pg_t raw_pg;
-	chunk_info_t chunk_info;
-	result = get_osdmap()->object_locator_to_pg(tgt_name, tgt_oloc, raw_pg);
-	if (result < 0) {
-	  dout(5) << " pool information is invalid: " << result << dendl;
+	auto maybe_pg = get_osdmap()->object_locator_to_expected_pg(tgt_name, tgt_oloc);
+	if (!maybe_pg) {
+	  dout(5) << " pool information is invalid: " << maybe_pg.error() << dendl;
 	  break;
 	}
+	pg_t raw_pg = *maybe_pg;
 	hobject_t target(tgt_name, tgt_oloc.key, snapid_t(),
 			 raw_pg.ps(), raw_pg.pool(),
 			 tgt_oloc.nspace);
@@ -7377,6 +7376,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  dout(5) << " the object is already a manifest " << dendl;
 	  break;
 	}
+	chunk_info_t chunk_info;
 	chunk_info.oid = target;
 	chunk_info.offset = tgt_offset;
 	chunk_info.length = src_length;
@@ -8181,10 +8181,14 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 		   src_version);
 	if (op_finisher == nullptr) {
 	  // start
-	  pg_t raw_pg;
-	  get_osdmap()->object_locator_to_pg(src_name, src_oloc, raw_pg);
+          auto raw_pg =
+	    get_osdmap()->object_locator_to_expected_pg(src_name, src_oloc);
+	  if (!raw_pg) {
+	    result = -EINVAL;
+	    break;
+	  }
 	  hobject_t src(src_name, src_oloc.key, src_snapid,
-			raw_pg.ps(), raw_pg.pool(),
+			raw_pg.value().ps(), raw_pg.value().pool(),
 			src_oloc.nspace);
 	  if (src == soid) {
 	    dout(20) << " copy from self is invalid" << dendl;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1816,7 +1816,7 @@ SnapContext pg_pool_t::get_snap_context() const
   return SnapContext(get_snap_seq(), s);
 }
 
-uint32_t pg_pool_t::hash_key(const string& key, const string& ns) const
+uint32_t pg_pool_t::hash_key(std::string_view key, std::string_view ns) const
 {
  if (ns.empty()) 
     return ceph_str_hash(object_hash, key.data(), key.length());

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1936,7 +1936,7 @@ public:
   SnapContext get_snap_context() const;
 
   /// hash a object name+namespace key to a hash position
-  uint32_t hash_key(const std::string& key, const std::string& ns) const;
+  uint32_t hash_key(std::string_view key, std::string_view ns) const;
 
   /// round a hash position down to a pg num
   uint32_t raw_hash_to_pg(uint32_t v) const;


### PR DESCRIPTION
Returning an "expected" PG, instead of using an in/out parameter.
Replacing const strings with string_views.

Some clients modified to use the new interface.


