### PR TITLE
rgw: s3website doesn't prefetch for web_dir() check

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5282,7 +5282,6 @@ bool RGWHandler_REST_S3Website::web_dir() const {
   std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(subdir_name));
 
   obj->set_atomic();
-  obj->set_prefetch_data();
 
   RGWObjState* state = nullptr;
   if (obj->get_obj_state(s, &state, s->yield) < 0) {


### PR DESCRIPTION
this function only needs to check for existence of the given path. the `sal::Object` is destroyed before the function returns, so it's wasteful to prefetch its data

Fixes: https://tracker.ceph.com/issues/62938

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
