### PR TITLE
rgw: fix radosgw-admin bucket check stat calculation bug

### DIFF
--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -53,7 +53,15 @@ def main():
     ok_keys = ['a', 'b', 'c', 'd']
     unlinked_keys = ['c', 'd', 'e', 'f']
     ok_objs = put_objects(bucket, ok_keys)
-
+    
+    # TESTCASE 'recalculated bucket check stats are correct'
+    log.debug('TEST: recalculated bucket check stats are correct\n')
+    exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
+    out = exec_cmd(f'radosgw-admin bucket stats --bucket {BUCKET_NAME}')
+    json_out = json.loads(out)
+    log.debug(json_out['usage'])
+    assert json_out['usage']['rgw.main']['num_objects'] == 6
+    
     # TESTCASE 'bucket check unlinked does not report normal entries'
     log.debug('TEST: bucket check unlinked does not report normal entries\n')
     out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --min-age-hours 0 --dump-keys')

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3090,7 +3090,7 @@ static int check_index(cls_method_context_t hctx,
         return -EIO;
       }
 
-      if (entry.exists && entry.key.instance.empty()) {
+      if (entry.exists && entry.flags == 0) {
         rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
         stats.num_entries++;
         stats.total_size += entry.meta.accounted_size;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -403,7 +403,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
   accounted_stats->total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
   accounted_stats->actual_size += entry.meta.size;
   if (type == BIIndexType::Plain) {
-    return entry.exists && entry.key.instance.empty();
+    return entry.exists && entry.flags == 0;
   } else if (type == BIIndexType::Instance) {
     return entry.exists;
   }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1223,6 +1223,8 @@ int RGWBucketAdminOp::check_index(rgw::sal::Driver* driver, RGWBucketAdminOpStat
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
 
+  formatter->open_object_section("bucket_check");
+
   ret = bucket.check_bad_index_multipart(op_state, flusher, dpp, y);
   if (ret < 0)
     return ret;
@@ -1238,6 +1240,8 @@ int RGWBucketAdminOp::check_index(rgw::sal::Driver* driver, RGWBucketAdminOpStat
     return ret;
 
   dump_index_check(existing_stats, calculated_stats, formatter);
+  
+  formatter->close_section();
   flusher.flush();
 
   return 0;


### PR DESCRIPTION
Fixes a regression with radosgw-admin bucket check stat
calculation and bucket reshard stat calculation when
there are objects that have transitioned from unversioned
to versioned. The bug was introduced in 152aadb71b61c53a4832a1c8cf82fce3d64b68d1.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
