### PR TITLE
qa/rgw/sts: keycloak task installs java manually

### DIFF
--- a/qa/suites/rgw/sts/tasks/1-keycloak.yaml
+++ b/qa/suites/rgw/sts/tasks/1-keycloak.yaml
@@ -3,3 +3,12 @@ tasks:
 - keycloak:
     client.0:
       keycloak_version: 11.0.0
+
+overrides:
+  install:
+    ceph:
+      extra_system_packages:
+        rpm:
+        - java-17-openjdk-headless
+        deb:
+        - openjdk-17-jdk-headless


### PR DESCRIPTION
java had already been installed automatically before centos 9. add an override to install the jdk-17 packages manually

Fixes: https://tracker.ceph.com/issues/62536

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
