### PR TITLE
tools, rgw/test: add std:: qualifiers to 'move'

### DIFF
--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -1906,7 +1906,7 @@ TEST_F(D4NFilterFixture, DataCheck) {
 
   ASSERT_EQ(testWriter->prepare(null_yield), 0);
   
-  ASSERT_EQ(testWriter->process(move(data), 0), 0);
+  ASSERT_EQ(testWriter->process(std::move(data), 0), 0);
 
   ASSERT_EQ(testWriter->complete(accounted_size, etag,
 		 &mtime, set_mtime,
@@ -1931,7 +1931,7 @@ TEST_F(D4NFilterFixture, DataCheck) {
 
   ASSERT_EQ(testWriter->prepare(null_yield), 0);
   
-  ASSERT_EQ(testWriter->process(move(dataNew), 0), 0);
+  ASSERT_EQ(testWriter->process(std::move(dataNew), 0), 0);
 
   ASSERT_EQ(testWriter->complete(accounted_size, etag,
 		 &mtime, set_mtime,

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -1101,7 +1101,7 @@ int estimate_dedup_ratio(const po::variables_map &opts)
 			     max_seconds));
     ptr->create("estimate_thread");
     ptr->set_debug(debug);
-    estimate_threads.push_back(move(ptr));
+    estimate_threads.push_back(std::move(ptr));
   }
   glock.unlock();
 
@@ -1319,7 +1319,7 @@ int chunk_scrub_common(const po::variables_map &opts)
       new ChunkScrub(io_ctx, i, max_thread, begin, end, chunk_io_ctx,
 		     report_period, s.num_objects));
     ptr->create("estimate_thread");
-    estimate_threads.push_back(move(ptr));
+    estimate_threads.push_back(std::move(ptr));
   }
   glock.unlock();
 


### PR DESCRIPTION
to silence compiler warnings.

as Clang now requires fully specifying std::move.
See https://reviews.llvm.org/D119670?id=408276
