### PR TITLE
rgw/test: fix compiler warning

### DIFF
--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -93,11 +93,11 @@ namespace {
       } // page_ix
     }
 
-    int size() { return pages.size(); }
+    int size() const { return pages.size(); }
 
     struct iovec* get_iovs() { return iovs; }
 
-    bool operator==(const ZPageSet& rhs) {
+    bool operator==(const ZPageSet& rhs) const {
       int n = size();
       for (int page_ix = 0; page_ix < n; ++page_ix) {
 	ZPage* p1 = pages[page_ix];


### PR DESCRIPTION
Fixing a compiler warning regarding ambiguity of
the overloaded operator '==' (as it allows a one-sided const operand)
