### PR TITLE
cephadm: introduce Daemon Forms

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -164,10 +164,12 @@ from cephadmlib.host_facts import HostFacts, list_networks
 from cephadmlib.ssh import authorize_ssh_key, check_ssh_connectivity
 from cephadmlib.daemon_form import (
     DaemonForm,
+    UnexpectedDaemonTypeError,
     create as daemon_form_create,
     register as register_daemon_form,
 )
 from cephadmlib.deploy import DeploymentType
+from cephadmlib.container_daemon_form import ContainerDaemonForm
 from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
 from cephadmlib.firewalld import Firewalld, update_firewalld
 
@@ -5257,10 +5259,42 @@ def _dispatch_deploy(
             deployment_type=deployment_type,
             endpoints=daemon_endpoints,
         )
-
     else:
-        raise Error('daemon type {} not implemented in command_deploy function'
-                    .format(daemon_type))
+        try:
+            _deploy_daemon_container(
+                ctx, ident, daemon_endpoints, deployment_type
+            )
+        except UnexpectedDaemonTypeError:
+            raise Error('daemon type {} not implemented in command_deploy function'
+                        .format(daemon_type))
+
+
+def _deploy_daemon_container(
+    ctx: CephadmContext,
+    ident: 'DaemonIdentity',
+    daemon_endpoints: List[EndPoint],
+    deployment_type: DeploymentType,
+) -> None:
+    daemon = daemon_form_create(ctx, ident)
+    assert isinstance(daemon, ContainerDaemonForm)
+    daemon.customize_container_endpoints(daemon_endpoints, deployment_type)
+    ctr = daemon.container(ctx)
+    ics = daemon.init_containers(ctx)
+    config, keyring = daemon.config_and_keyring(ctx)
+    uid, gid = daemon.uid_gid(ctx)
+    deploy_daemon(
+        ctx,
+        ident,
+        ctr,
+        uid,
+        gid,
+        config=config,
+        keyring=keyring,
+        deployment_type=deployment_type,
+        endpoints=daemon_endpoints,
+        osd_fsid=daemon.osd_fsid,
+        init_containers=ics,
+    )
 
 ##################################
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -551,7 +551,7 @@ class Monitoring(DaemonForm):
 
 
 @register_daemon_form
-class NFSGanesha(DaemonForm):
+class NFSGanesha(ContainerDaemonForm):
     """Defines a NFS-Ganesha container"""
 
     daemon_type = 'nfs'
@@ -699,6 +699,25 @@ class NFSGanesha(DaemonForm):
 
     def firewall_service_name(self) -> str:
         return 'nfs'
+
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        return get_deployment_container(ctx, self.identity)
+
+    def customize_container_endpoints(
+        self, endpoints: List[EndPoint], deployment_type: DeploymentType
+    ) -> None:
+        if deployment_type == DeploymentType.DEFAULT and not endpoints:
+            nfs_ports = list(NFSGanesha.port_map.values())
+            endpoints.extend([EndPoint('0.0.0.0', p) for p in nfs_ports])
+
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        # TODO: extract ganesha uid/gid (997, 994) ?
+        return extract_uid_gid(ctx)
+
+    def config_and_keyring(
+        self, ctx: CephadmContext
+    ) -> Tuple[Optional[str], Optional[str]]:
+        return get_config_and_keyring(ctx)
 
 ##################################
 
@@ -5112,28 +5131,6 @@ def _dispatch_deploy(
             c,
             uid,
             gid,
-            deployment_type=deployment_type,
-            endpoints=daemon_endpoints
-        )
-
-    elif daemon_type == NFSGanesha.daemon_type:
-        # only check ports if this is a fresh deployment
-        if deployment_type == DeploymentType.DEFAULT and not daemon_endpoints:
-            nfs_ports = list(NFSGanesha.port_map.values())
-            daemon_endpoints = [EndPoint('0.0.0.0', p) for p in nfs_ports]
-
-        config, keyring = get_config_and_keyring(ctx)
-        # TODO: extract ganesha uid/gid (997, 994) ?
-        uid, gid = extract_uid_gid(ctx)
-        c = get_deployment_container(ctx, ident)
-        deploy_daemon(
-            ctx,
-            ident,
-            c,
-            uid,
-            gid,
-            config=config,
-            keyring=keyring,
             deployment_type=deployment_type,
             endpoints=daemon_endpoints
         )

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -165,10 +165,11 @@ from cephadmlib.host_facts import HostFacts, list_networks
 from cephadmlib.ssh import authorize_ssh_key, check_ssh_connectivity
 from cephadmlib.daemon_form import (
     DaemonForm,
-    SysctlDaemonForm,
     create as daemon_form_create,
     register as register_daemon_form,
 )
+from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
+
 
 FuncT = TypeVar('FuncT', bound=Callable)
 
@@ -3211,106 +3212,6 @@ def update_firewalld(ctx, daemon_type):
         firewall = Firewalld(ctx)
         firewall.enable_service_for(daemon_type)
         firewall.apply_rules()
-
-
-def install_sysctl(ctx: CephadmContext, fsid: str, daemon: DaemonForm) -> None:
-    """
-    Set up sysctl settings
-    """
-    def _write(conf: Path, lines: List[str]) -> None:
-        lines = [
-            '# created by cephadm',
-            '',
-            *lines,
-            '',
-        ]
-        with write_new(conf, owner=None, perms=None) as f:
-            f.write('\n'.join(lines))
-
-    if not isinstance(daemon, SysctlDaemonForm):
-        return
-
-    daemon_type = daemon.identity.daemon_type
-    conf = Path(ctx.sysctl_dir).joinpath(f'90-ceph-{fsid}-{daemon_type}.conf')
-
-    lines = daemon.get_sysctl_settings()
-    lines = filter_sysctl_settings(ctx, lines)
-
-    # apply the sysctl settings
-    if lines:
-        Path(ctx.sysctl_dir).mkdir(mode=0o755, exist_ok=True)
-        _write(conf, lines)
-        call_throws(ctx, ['sysctl', '--system'])
-
-
-def sysctl_get(ctx: CephadmContext, variable: str) -> Union[str, None]:
-    """
-    Read a sysctl setting by executing 'sysctl -b {variable}'
-    """
-    out, err, code = call(ctx, ['sysctl', '-b', variable])
-    return out or None
-
-
-def filter_sysctl_settings(ctx: CephadmContext, lines: List[str]) -> List[str]:
-    """
-    Given a list of sysctl settings, examine the system's current configuration
-    and return those which are not currently set as described.
-    """
-    def test_setting(desired_line: str) -> bool:
-        # Remove any comments
-        comment_start = desired_line.find('#')
-        if comment_start != -1:
-            desired_line = desired_line[:comment_start]
-        desired_line = desired_line.strip()
-        if not desired_line or desired_line.isspace():
-            return False
-        setting, desired_value = map(lambda s: s.strip(), desired_line.split('='))
-        if not setting or not desired_value:
-            return False
-        actual_value = sysctl_get(ctx, setting)
-        return desired_value != actual_value
-    return list(filter(test_setting, lines))
-
-
-def migrate_sysctl_dir(ctx: CephadmContext, fsid: str) -> None:
-    """
-    Cephadm once used '/usr/lib/sysctl.d' for storing sysctl configuration.
-    This moves it to '/etc/sysctl.d'.
-    """
-    deprecated_location: str = '/usr/lib/sysctl.d'
-    deprecated_confs: List[str] = glob(f'{deprecated_location}/90-ceph-{fsid}-*.conf')
-    if not deprecated_confs:
-        return
-
-    file_count: int = len(deprecated_confs)
-    logger.info(f'Found sysctl {file_count} files in deprecated location {deprecated_location}. Starting Migration.')
-    for conf in deprecated_confs:
-        try:
-            shutil.move(conf, ctx.sysctl_dir)
-            file_count -= 1
-        except shutil.Error as err:
-            if str(err).endswith('already exists'):
-                logger.warning(f'Destination file already exists. Deleting {conf}.')
-                try:
-                    os.unlink(conf)
-                    file_count -= 1
-                except OSError as del_err:
-                    logger.warning(f'Could not remove {conf}: {del_err}.')
-            else:
-                logger.warning(f'Could not move {conf} from {deprecated_location} to {ctx.sysctl_dir}: {err}')
-
-    # Log successful migration
-    if file_count == 0:
-        logger.info(f'Successfully migrated sysctl config to {ctx.sysctl_dir}.')
-        return
-
-    # Log partially successful / unsuccessful migration
-    files_processed: int = len(deprecated_confs)
-    if file_count < files_processed:
-        status: str = f'partially successful (failed {file_count}/{files_processed})'
-    elif file_count == files_processed:
-        status = 'unsuccessful'
-    logger.warning(f'Migration of sysctl configuration {status}. You may want to perform a migration manually.')
 
 
 def install_base_units(ctx, fsid):

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -163,6 +163,10 @@ from cephadmlib.decorators import (
 )
 from cephadmlib.host_facts import HostFacts, list_networks
 from cephadmlib.ssh import authorize_ssh_key, check_ssh_connectivity
+from cephadmlib.daemon_form import (
+    DaemonForm,
+    register as register_daemon_form,
+)
 
 FuncT = TypeVar('FuncT', bound=Callable)
 
@@ -208,15 +212,38 @@ class DeploymentType(Enum):
 ##################################
 
 
-class Ceph(object):
+@register_daemon_form
+class Ceph(DaemonForm):
     daemons = ('mon', 'mgr', 'osd', 'mds', 'rgw', 'rbd-mirror',
                'crash', 'cephfs-mirror', 'ceph-exporter')
     gateways = ('iscsi', 'nfs', 'nvmeof')
 
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        # TODO: figure out a way to un-special-case osd
+        return daemon_type in cls.daemons and daemon_type != 'osd'
+
+    def __init__(self, ident: DaemonIdentity) -> None:
+        self._identity = ident
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'Ceph':
+        return cls(ident)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return self._identity
+
 ##################################
 
 
-class OSD(object):
+@register_daemon_form
+class OSD(Ceph):
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        # TODO: figure out a way to un-special-case osd
+        return daemon_type == 'osd'
+
     @staticmethod
     def get_sysctl_settings() -> List[str]:
         return [
@@ -229,13 +256,18 @@ class OSD(object):
 ##################################
 
 
-class SNMPGateway:
+@register_daemon_form
+class SNMPGateway(DaemonForm):
     """Defines an SNMP gateway between Prometheus and SNMP monitoring Frameworks"""
     daemon_type = 'snmp-gateway'
     SUPPORTED_VERSIONS = ['V2c', 'V3']
     default_image = DEFAULT_SNMP_GATEWAY_IMAGE
     DEFAULT_PORT = 9464
     env_filename = 'snmp-gateway.conf'
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx: CephadmContext,
@@ -270,6 +302,14 @@ class SNMPGateway:
         cfgs = fetch_configs(ctx)
         assert cfgs  # assert some config data was found
         return cls(ctx, fsid, daemon_id, cfgs, ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'SNMPGateway':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     @staticmethod
     def get_version(ctx: CephadmContext, fsid: str, daemon_id: str) -> Optional[str]:
@@ -371,7 +411,8 @@ class SNMPGateway:
 
 
 ##################################
-class Monitoring(object):
+@register_daemon_form
+class Monitoring(DaemonForm):
     """Define the configs for the monitoring containers"""
 
     port_map = {
@@ -454,6 +495,10 @@ class Monitoring(object):
         },
     }  # type: ignore
 
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return daemon_type in cls.components
+
     @staticmethod
     def get_version(ctx, container_id, daemon_type):
         # type: (CephadmContext, str, str) -> str
@@ -486,10 +531,22 @@ class Monitoring(object):
                 version = out.split(' ')[2]
         return version
 
+    def __init__(self, ident: DaemonIdentity) -> None:
+        self._identity = ident
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'Monitoring':
+        return cls(ident)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return self._identity
+
 ##################################
 
 
-class NFSGanesha(object):
+@register_daemon_form
+class NFSGanesha(DaemonForm):
     """Defines a NFS-Ganesha container"""
 
     daemon_type = 'nfs'
@@ -501,6 +558,10 @@ class NFSGanesha(object):
     port_map = {
         'nfs': 2049,
     }
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx,
@@ -529,6 +590,14 @@ class NFSGanesha(object):
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> NFSGanesha
         return cls(ctx, fsid, daemon_id, fetch_configs(ctx), ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'NFSGanesha':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
@@ -626,13 +695,18 @@ class NFSGanesha(object):
 ##################################
 
 
-class CephIscsi(object):
+@register_daemon_form
+class CephIscsi(DaemonForm):
     """Defines a Ceph-Iscsi container"""
 
     daemon_type = 'iscsi'
     entrypoint = '/usr/bin/rbd-target-api'
 
     required_files = ['iscsi-gateway.cfg']
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx,
@@ -657,6 +731,14 @@ class CephIscsi(object):
         # type: (CephadmContext, str, Union[int, str]) -> CephIscsi
         return cls(ctx, fsid, daemon_id,
                    fetch_configs(ctx), ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'CephIscsi':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     @staticmethod
     def get_container_mounts(data_dir, log_dir):
@@ -813,12 +895,17 @@ done
 ##################################
 
 
-class CephNvmeof(object):
+@register_daemon_form
+class CephNvmeof(DaemonForm):
     """Defines a Ceph-Nvmeof container"""
 
     daemon_type = 'nvmeof'
     required_files = ['ceph-nvmeof.conf']
     default_image = DEFAULT_NVMEOF_IMAGE
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx,
@@ -843,6 +930,14 @@ class CephNvmeof(object):
         # type: (CephadmContext, str, Union[int, str]) -> CephNvmeof
         return cls(ctx, fsid, daemon_id,
                    fetch_configs(ctx), ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'CephNvmeof':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     @staticmethod
     def get_container_mounts(data_dir: str) -> Dict[str, str]:
@@ -938,7 +1033,8 @@ class CephNvmeof(object):
 ##################################
 
 
-class CephExporter(object):
+@register_daemon_form
+class CephExporter(DaemonForm):
     """Defines a Ceph exporter container"""
 
     daemon_type = 'ceph-exporter'
@@ -947,6 +1043,10 @@ class CephExporter(object):
     port_map = {
         'ceph-exporter': DEFAULT_PORT,
     }
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx: CephadmContext,
@@ -974,6 +1074,14 @@ class CephExporter(object):
         return cls(ctx, fsid, daemon_id,
                    fetch_configs(ctx), ctx.image)
 
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'CephExporter':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
+
     @staticmethod
     def get_container_mounts() -> Dict[str, str]:
         mounts = dict()
@@ -998,11 +1106,16 @@ class CephExporter(object):
 ##################################
 
 
-class HAproxy(object):
+@register_daemon_form
+class HAproxy(DaemonForm):
     """Defines an HAproxy container"""
     daemon_type = 'haproxy'
     required_files = ['haproxy.cfg']
     default_image = DEFAULT_HAPROXY_IMAGE
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx: CephadmContext,
@@ -1023,6 +1136,14 @@ class HAproxy(object):
              fsid: str, daemon_id: Union[int, str]) -> 'HAproxy':
         return cls(ctx, fsid, daemon_id, fetch_configs(ctx),
                    ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'HAproxy':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -1086,11 +1207,16 @@ class HAproxy(object):
 ##################################
 
 
-class Keepalived(object):
+@register_daemon_form
+class Keepalived(DaemonForm):
     """Defines an Keepalived container"""
     daemon_type = 'keepalived'
     required_files = ['keepalived.conf']
     default_image = DEFAULT_KEEPALIVED_IMAGE
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  ctx: CephadmContext,
@@ -1111,6 +1237,14 @@ class Keepalived(object):
              daemon_id: Union[int, str]) -> 'Keepalived':
         return cls(ctx, fsid, daemon_id,
                    fetch_configs(ctx), ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'Keepalived':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -1182,7 +1316,8 @@ class Keepalived(object):
 ##################################
 
 
-class Tracing(object):
+@register_daemon_form
+class Tracing(DaemonForm):
     """Define the configs for the jaeger tracing containers"""
 
     components: Dict[str, Dict[str, Any]] = {
@@ -1201,6 +1336,10 @@ class Tracing(object):
         },
     }  # type: ignore
 
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return daemon_type in cls.components
+
     @staticmethod
     def set_configuration(config: Dict[str, str], daemon_type: str) -> None:
         if daemon_type in ['jaeger-collector', 'jaeger-query']:
@@ -1215,12 +1354,28 @@ class Tracing(object):
                 '--processor.jaeger-compact.server-host-port=6799'
             ]
 
+    def __init__(self, ident: DaemonIdentity) -> None:
+        self._identity = ident
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'Tracing':
+        return cls(ident)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return self._identity
+
 ##################################
 
 
-class CustomContainer(object):
+@register_daemon_form
+class CustomContainer(DaemonForm):
     """Defines a custom container"""
     daemon_type = 'container'
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
 
     def __init__(self,
                  fsid: str, daemon_id: Union[int, str],
@@ -1247,6 +1402,14 @@ class CustomContainer(object):
              fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
         return cls(fsid, daemon_id,
                    fetch_configs(ctx), ctx.image)
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'CustomContainer':
+        return cls.init(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -262,7 +262,7 @@ class OSD(Ceph):
 
 
 @register_daemon_form
-class SNMPGateway(DaemonForm):
+class SNMPGateway(ContainerDaemonForm):
     """Defines an SNMP gateway between Prometheus and SNMP monitoring Frameworks"""
     daemon_type = 'snmp-gateway'
     SUPPORTED_VERSIONS = ['V2c', 'V3']
@@ -413,6 +413,12 @@ class SNMPGateway(DaemonForm):
 
         if not self.destination:
             raise Error('config is missing destination attribute(<ip>:<port>) of the target SNMP listener')
+
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        return get_deployment_container(ctx, self.identity)
+
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        return self.uid, self.gid
 
 
 ##################################
@@ -5241,18 +5247,6 @@ def _dispatch_deploy(
             endpoints=daemon_endpoints,
         )
 
-    elif daemon_type == SNMPGateway.daemon_type:
-        sc = SNMPGateway.init(ctx, ident.fsid, ident.daemon_id)
-        c = get_deployment_container(ctx, ident)
-        deploy_daemon(
-            ctx,
-            ident,
-            c,
-            sc.uid,
-            sc.gid,
-            deployment_type=deployment_type,
-            endpoints=daemon_endpoints,
-        )
     else:
         try:
             _deploy_daemon_container(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -165,11 +165,11 @@ from cephadmlib.host_facts import HostFacts, list_networks
 from cephadmlib.ssh import authorize_ssh_key, check_ssh_connectivity
 from cephadmlib.daemon_form import (
     DaemonForm,
-    FirewalledServiceDaemonForm,
     create as daemon_form_create,
     register as register_daemon_form,
 )
 from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
+from cephadmlib.firewalld import Firewalld, update_firewalld
 
 
 FuncT = TypeVar('FuncT', bound=Callable)
@@ -3100,127 +3100,6 @@ def _write_iscsi_unit_poststop_commands(
     f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-pid' % (ident.fsid, ident.daemon_type, ident.daemon_id + '.tcmu') + '\n')
     f.write('! ' + 'rm ' + runtime_dir + '/ceph-%s@%s.%s.service-cid' % (ident.fsid, ident.daemon_type, ident.daemon_id + '.tcmu') + '\n')
     f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=False)) + '\n')
-
-
-class Firewalld(object):
-
-    # for specifying ports we should always open when opening
-    # ports for a daemon of that type. Main use case is for ports
-    # that we should open when deploying the daemon type but that
-    # the daemon itself may not necessarily need to bind to the port.
-    # This needs to be handed differently as we don't want to fail
-    # deployment if the port cannot be bound to but we still want to
-    # open the port in the firewall.
-    external_ports: Dict[str, List[int]] = {
-        'iscsi': [3260]  # 3260 is the well known iSCSI port
-    }
-
-    def __init__(self, ctx):
-        # type: (CephadmContext) -> None
-        self.ctx = ctx
-        self.available = self.check()
-
-    def check(self):
-        # type: () -> bool
-        self.cmd = find_executable('firewall-cmd')
-        if not self.cmd:
-            logger.debug('firewalld does not appear to be present')
-            return False
-        (enabled, state, _) = check_unit(self.ctx, 'firewalld.service')
-        if not enabled:
-            logger.debug('firewalld.service is not enabled')
-            return False
-        if state != 'running':
-            logger.debug('firewalld.service is not running')
-            return False
-
-        logger.info('firewalld ready')
-        return True
-
-    def enable_service_for(self, svc: str) -> None:
-        assert svc, 'service name not provided'
-        if not self.available:
-            logger.debug('Not possible to enable service <%s>. firewalld.service is not available' % svc)
-            return
-
-        if not self.cmd:
-            raise RuntimeError('command not defined')
-
-        out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-service', svc], verbosity=CallVerbosity.DEBUG)
-        if ret:
-            logger.info('Enabling firewalld service %s in current zone...' % svc)
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-service', svc])
-            if ret:
-                raise RuntimeError(
-                    'unable to add service %s to current zone: %s' % (svc, err))
-        else:
-            logger.debug('firewalld service %s is enabled in current zone' % svc)
-
-    def open_ports(self, fw_ports):
-        # type: (List[int]) -> None
-        if not self.available:
-            logger.debug('Not possible to open ports <%s>. firewalld.service is not available' % fw_ports)
-            return
-
-        if not self.cmd:
-            raise RuntimeError('command not defined')
-
-        for port in fw_ports:
-            tcp_port = str(port) + '/tcp'
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
-            if ret:
-                logger.info('Enabling firewalld port %s in current zone...' % tcp_port)
-                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-port', tcp_port])
-                if ret:
-                    raise RuntimeError('unable to add port %s to current zone: %s' %
-                                       (tcp_port, err))
-            else:
-                logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
-
-    def close_ports(self, fw_ports):
-        # type: (List[int]) -> None
-        if not self.available:
-            logger.debug('Not possible to close ports <%s>. firewalld.service is not available' % fw_ports)
-            return
-
-        if not self.cmd:
-            raise RuntimeError('command not defined')
-
-        for port in fw_ports:
-            tcp_port = str(port) + '/tcp'
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
-            if not ret:
-                logger.info('Disabling port %s in current zone...' % tcp_port)
-                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--remove-port', tcp_port])
-                if ret:
-                    raise RuntimeError('unable to remove port %s from current zone: %s' %
-                                       (tcp_port, err))
-                else:
-                    logger.info(f'Port {tcp_port} disabled')
-            else:
-                logger.info(f'firewalld port {tcp_port} already closed')
-
-    def apply_rules(self):
-        # type: () -> None
-        if not self.available:
-            return
-
-        if not self.cmd:
-            raise RuntimeError('command not defined')
-
-        call_throws(self.ctx, [self.cmd, '--reload'])
-
-
-def update_firewalld(ctx: CephadmContext, daemon: DaemonForm) -> None:
-    if not ('skip_firewalld' in ctx and ctx.skip_firewalld) and isinstance(
-        daemon, FirewalledServiceDaemonForm
-    ):
-        svc = daemon.firewall_service_name()
-        if not svc:
-            return
-        firewall = Firewalld(ctx)
-        firewall.enable_service_for(svc)
-        firewall.apply_rules()
 
 
 def install_base_units(ctx, fsid):

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -18,7 +18,6 @@ import tempfile
 import time
 import errno
 import ssl
-from enum import Enum
 from typing import Dict, List, Tuple, Optional, Union, Any, Callable, IO, Sequence, TypeVar, cast, Iterable, TextIO
 
 import re
@@ -168,6 +167,7 @@ from cephadmlib.daemon_form import (
     create as daemon_form_create,
     register as register_daemon_form,
 )
+from cephadmlib.deploy import DeploymentType
 from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
 from cephadmlib.firewalld import Firewalld, update_firewalld
 
@@ -201,17 +201,6 @@ class ContainerInfo:
                 and self.image_id == other.image_id
                 and self.start == other.start
                 and self.version == other.version)
-
-
-class DeploymentType(Enum):
-    # Fresh deployment of a daemon.
-    DEFAULT = 'Deploy'
-    # Redeploying a daemon. Works the same as fresh
-    # deployment minus port checking.
-    REDEPLOY = 'Redeploy'
-    # Reconfiguring a daemon. Rewrites config
-    # files and potentially restarts daemon.
-    RECONFIG = 'Reconfig'
 
 ##################################
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3356,7 +3356,8 @@ class MgrListener(Thread):
             self.agent.wakeup()
 
 
-class CephadmAgent():
+@register_daemon_form
+class CephadmAgent(DaemonForm):
 
     daemon_type = 'agent'
     default_port = 8498
@@ -3370,6 +3371,18 @@ class CephadmAgent():
         'listener.crt',
         'listener.key',
     ]
+
+    @classmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        return cls.daemon_type == daemon_type
+
+    @classmethod
+    def create(cls, ctx: CephadmContext, ident: DaemonIdentity) -> 'CephadmAgent':
+        return cls(ctx, ident.fsid, ident.daemon_id)
+
+    @property
+    def identity(self) -> DaemonIdentity:
+        return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     def __init__(self, ctx: CephadmContext, fsid: str, daemon_id: Union[int, str] = ''):
         self.ctx = ctx

--- a/src/cephadm/cephadmlib/container_daemon_form.py
+++ b/src/cephadm/cephadmlib/container_daemon_form.py
@@ -1,0 +1,82 @@
+# container_deamon_form.py - base class for container based daemon forms
+
+import abc
+
+from typing import List, Tuple, Optional
+
+from .container_types import CephContainer, InitContainer
+from .context import CephadmContext
+from .daemon_form import DaemonForm
+from .deploy import DeploymentType
+from .net_utils import EndPoint
+
+
+class ContainerDaemonForm(DaemonForm):
+    """A ContainerDaemonForm is a variety of DaemonForm that runs a
+    single primary daemon process under as a container.
+    It requires that the `container` method be implemented by subclasses.
+    A number of other optional methods may also be overridden.
+    """
+
+    @abc.abstractmethod
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        """Return the CephContainer instance that will be used to build and run
+        the daemon.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    @abc.abstractmethod
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        """Return a (uid, gid) tuple indicating what UID and GID the daemon is
+        expected to run as. This function is permitted to take complex actions
+        such as running a container to get the needed information.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    def init_containers(self, ctx: CephadmContext) -> List[InitContainer]:
+        """Returns a list of init containers to execute prior to the primary
+        container running. By default, returns an empty list.
+        """
+        return []
+
+    def customize_container_binds(self, binds: List[List[str]]) -> None:
+        """Given a list of container binds this function can update, delete,
+        or otherwise mutate the binds that the container will use.
+        """
+        pass
+
+    def customize_container_mounts(self, mounts: List[str]) -> None:
+        """Given a list of container mounts this function can update, delete,
+        or otherwise mutate the mounts that the container will use.
+        """
+        pass
+
+    def customize_container_args(self, args: List[str]) -> None:
+        """Given a list of container arguments this function can update,
+        delete, or otherwise mutate the arguments that the container engine
+        will use.
+        """
+        pass
+
+    def customize_container_endpoints(
+        self, endpoints: List[EndPoint], deployment_type: DeploymentType
+    ) -> None:
+        """Given a list of entrypoints this function can update, delete,
+        or otherwise mutate the entrypoints that the container will use.
+        """
+        pass
+
+    def config_and_keyring(
+        self, ctx: CephadmContext
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Return a tuple of strings containing the ceph confguration
+        and keyring for the daemon. Returns (None, None) by default.
+        """
+        return None, None
+
+    @property
+    def osd_fsid(self) -> Optional[str]:
+        """Return the OSD FSID or None. Pretty specific to OSDs. You are not
+        expected to understand this.
+        """
+        return None

--- a/src/cephadm/cephadmlib/daemon_form.py
+++ b/src/cephadm/cephadmlib/daemon_form.py
@@ -1,0 +1,125 @@
+# deamon_form.py - base class for creating and managing daemons
+
+import abc
+
+from typing import Type, TypeVar, List
+
+from .context import CephadmContext
+from .daemon_identity import DaemonIdentity
+
+
+class DaemonForm(abc.ABC):
+    """Base class for all types used to build, customize, or otherwise give
+    form to a deaemon managed by cephadm.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def for_daemon_type(cls, daemon_type: str) -> bool:
+        """The for_daemon_type class method accepts a string identifying a
+        daemon type and should return true if the class can form a daemon of
+        the named type. Using a method allows supporting arbitrary daemon names
+        and multiple names for a single class.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    @abc.abstractmethod
+    def create(
+        cls, ctx: CephadmContext, ident: DaemonIdentity
+    ) -> 'DaemonForm':
+        """The create class method acts as a common interface for creating
+        any DaemonForm instance. This means that each class implementing a
+        DaemonForm can have an __init__ tuned to it's specific needs but
+        this common interface can be used to intantiate any DaemonForm.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    @property
+    @abc.abstractmethod
+    def identity(self) -> DaemonIdentity:
+        """All DaemonForm instances must be able to identify themselves.
+        The identity property returns a DaemonIdentity tied to the form
+        being created or manged.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+
+DF = TypeVar('DF', bound=DaemonForm)
+
+
+# Optional daemon form subtypes follow:
+# These optional subtypes use the abc modules __subclasshook__ feature.
+# Classes that implement these "interfaces" do not need to inherit
+# directly from these classes, but can simply implment the optional
+# methods. If these methods are avilable then `isinstance` and
+# `issubclass` will return true for that class and you can
+# safely use the desired method(s).
+# Example:
+# >>> # daemon1 implements get_sysctl_settings
+# >>> assert isinstance(daemon1, SysctlDaemonForm)
+# >>> daemon1.get_sysctl_settings()
+# >>> # daemon2 doesn't implement get_sysctl_settings
+# >>> assert not isinstance(daemon2, SysctlDaemonForm)
+
+
+class SysctlDaemonForm(DaemonForm, metaclass=abc.ABCMeta):
+    """The SysctlDaemonForm is an optional subclass that some DaemonForm
+    types may choose to implement. A SysctlDaemonForm must implement
+    get_sysctl_settings.
+    """
+
+    @abc.abstractmethod
+    def get_sysctl_settings(self) -> List[str]:
+        """Return a list of sysctl settings for the deamon."""
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    def __subclasshook__(cls, other: Type[DF]) -> bool:
+        return callable(getattr(other, 'get_sysctl_settings', None))
+
+
+class FirewalledServiceDaemonForm(DaemonForm, metaclass=abc.ABCMeta):
+    """The FirewalledServiceDaemonForm is an optional subclass that some
+    DaemonForm types may choose to implement. A FirewalledServiceDaemonForm
+    must implement firewall_service_name.
+    """
+
+    @abc.abstractmethod
+    def firewall_service_name(self) -> str:
+        """Return the name of the service known to the firewalld system."""
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    def __subclasshook__(cls, other: Type[DF]) -> bool:
+        return callable(getattr(other, 'firewall_service_name', None))
+
+
+_DAEMON_FORMERS = []
+
+
+class UnexpectedDaemonTypeError(KeyError):
+    pass
+
+
+def register(cls: Type[DF]) -> Type[DF]:
+    """Decorator to be placed on DaemonForm types if the type is to be added to
+    the daemon form registry.
+    """
+    _DAEMON_FORMERS.append(cls)
+    return cls
+
+
+def choose(daemon_type: str) -> Type[DF]:
+    """Return a daemon form *class* that is compatible with the given daemon
+    type name.
+    """
+    for dftype in _DAEMON_FORMERS:
+        if dftype.for_daemon_type(daemon_type):
+            return dftype
+    raise UnexpectedDaemonTypeError(daemon_type)
+
+
+def create(ctx: CephadmContext, ident: DaemonIdentity) -> DaemonForm:
+    cls: Type[DaemonForm] = choose(ident.daemon_type)
+    return cls.create(ctx, ident)

--- a/src/cephadm/cephadmlib/deploy.py
+++ b/src/cephadm/cephadmlib/deploy.py
@@ -1,0 +1,14 @@
+# deploy.py - fundamental deployment types
+
+from enum import Enum
+
+
+class DeploymentType(Enum):
+    # Fresh deployment of a daemon.
+    DEFAULT = 'Deploy'
+    # Redeploying a daemon. Works the same as fresh
+    # deployment minus port checking.
+    REDEPLOY = 'Redeploy'
+    # Reconfiguring a daemon. Rewrites config
+    # files and potentially restarts daemon.
+    RECONFIG = 'Reconfig'

--- a/src/cephadm/cephadmlib/firewalld.py
+++ b/src/cephadm/cephadmlib/firewalld.py
@@ -1,0 +1,134 @@
+# firewalld.py - functions and types for working with firewalld
+
+import logging
+
+from typing import List, Dict
+
+from .call_wrappers import call, call_throws, CallVerbosity
+from .context import CephadmContext
+from .daemon_form import DaemonForm, FirewalledServiceDaemonForm
+from .exe_utils import find_executable
+from .systemd import check_unit
+
+logger = logging.getLogger()
+
+
+class Firewalld(object):
+
+    # for specifying ports we should always open when opening
+    # ports for a daemon of that type. Main use case is for ports
+    # that we should open when deploying the daemon type but that
+    # the daemon itself may not necessarily need to bind to the port.
+    # This needs to be handed differently as we don't want to fail
+    # deployment if the port cannot be bound to but we still want to
+    # open the port in the firewall.
+    external_ports: Dict[str, List[int]] = {
+        'iscsi': [3260]  # 3260 is the well known iSCSI port
+    }
+
+    def __init__(self, ctx):
+        # type: (CephadmContext) -> None
+        self.ctx = ctx
+        self.available = self.check()
+
+    def check(self):
+        # type: () -> bool
+        self.cmd = find_executable('firewall-cmd')
+        if not self.cmd:
+            logger.debug('firewalld does not appear to be present')
+            return False
+        (enabled, state, _) = check_unit(self.ctx, 'firewalld.service')
+        if not enabled:
+            logger.debug('firewalld.service is not enabled')
+            return False
+        if state != 'running':
+            logger.debug('firewalld.service is not running')
+            return False
+
+        logger.info('firewalld ready')
+        return True
+
+    def enable_service_for(self, svc: str) -> None:
+        assert svc, 'service name not provided'
+        if not self.available:
+            logger.debug('Not possible to enable service <%s>. firewalld.service is not available' % svc)
+            return
+
+        if not self.cmd:
+            raise RuntimeError('command not defined')
+
+        out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-service', svc], verbosity=CallVerbosity.DEBUG)
+        if ret:
+            logger.info('Enabling firewalld service %s in current zone...' % svc)
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-service', svc])
+            if ret:
+                raise RuntimeError(
+                    'unable to add service %s to current zone: %s' % (svc, err))
+        else:
+            logger.debug('firewalld service %s is enabled in current zone' % svc)
+
+    def open_ports(self, fw_ports):
+        # type: (List[int]) -> None
+        if not self.available:
+            logger.debug('Not possible to open ports <%s>. firewalld.service is not available' % fw_ports)
+            return
+
+        if not self.cmd:
+            raise RuntimeError('command not defined')
+
+        for port in fw_ports:
+            tcp_port = str(port) + '/tcp'
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            if ret:
+                logger.info('Enabling firewalld port %s in current zone...' % tcp_port)
+                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-port', tcp_port])
+                if ret:
+                    raise RuntimeError('unable to add port %s to current zone: %s' %
+                                       (tcp_port, err))
+            else:
+                logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
+
+    def close_ports(self, fw_ports):
+        # type: (List[int]) -> None
+        if not self.available:
+            logger.debug('Not possible to close ports <%s>. firewalld.service is not available' % fw_ports)
+            return
+
+        if not self.cmd:
+            raise RuntimeError('command not defined')
+
+        for port in fw_ports:
+            tcp_port = str(port) + '/tcp'
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            if not ret:
+                logger.info('Disabling port %s in current zone...' % tcp_port)
+                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--remove-port', tcp_port])
+                if ret:
+                    raise RuntimeError('unable to remove port %s from current zone: %s' %
+                                       (tcp_port, err))
+                else:
+                    logger.info(f'Port {tcp_port} disabled')
+            else:
+                logger.info(f'firewalld port {tcp_port} already closed')
+
+    def apply_rules(self):
+        # type: () -> None
+        if not self.available:
+            return
+
+        if not self.cmd:
+            raise RuntimeError('command not defined')
+
+        call_throws(self.ctx, [self.cmd, '--reload'])
+
+
+def update_firewalld(ctx: CephadmContext, daemon: DaemonForm) -> None:
+    if not ('skip_firewalld' in ctx and ctx.skip_firewalld) and isinstance(
+        daemon, FirewalledServiceDaemonForm
+    ):
+        svc = daemon.firewall_service_name()
+        if not svc:
+            return
+        firewall = Firewalld(ctx)
+        firewall.enable_service_for(svc)
+        firewall.apply_rules()

--- a/src/cephadm/cephadmlib/sysctl.py
+++ b/src/cephadm/cephadmlib/sysctl.py
@@ -1,0 +1,116 @@
+# sysctl.py - functions for working with linux sysctl properties
+
+import logging
+import os
+import shutil
+
+from glob import glob
+from pathlib import Path
+from typing import List, Union
+
+from .call_wrappers import call, call_throws
+from .context import CephadmContext
+from .daemon_form import DaemonForm, SysctlDaemonForm
+from .file_utils import write_new
+
+logger = logging.getLogger()
+
+
+def install_sysctl(ctx: CephadmContext, fsid: str, daemon: DaemonForm) -> None:
+    """
+    Set up sysctl settings
+    """
+    def _write(conf: Path, lines: List[str]) -> None:
+        lines = [
+            '# created by cephadm',
+            '',
+            *lines,
+            '',
+        ]
+        with write_new(conf, owner=None, perms=None) as f:
+            f.write('\n'.join(lines))
+
+    if not isinstance(daemon, SysctlDaemonForm):
+        return
+
+    daemon_type = daemon.identity.daemon_type
+    conf = Path(ctx.sysctl_dir).joinpath(f'90-ceph-{fsid}-{daemon_type}.conf')
+
+    lines = daemon.get_sysctl_settings()
+    lines = filter_sysctl_settings(ctx, lines)
+
+    # apply the sysctl settings
+    if lines:
+        Path(ctx.sysctl_dir).mkdir(mode=0o755, exist_ok=True)
+        _write(conf, lines)
+        call_throws(ctx, ['sysctl', '--system'])
+
+
+def sysctl_get(ctx: CephadmContext, variable: str) -> Union[str, None]:
+    """
+    Read a sysctl setting by executing 'sysctl -b {variable}'
+    """
+    out, err, code = call(ctx, ['sysctl', '-b', variable])
+    return out or None
+
+
+def filter_sysctl_settings(ctx: CephadmContext, lines: List[str]) -> List[str]:
+    """
+    Given a list of sysctl settings, examine the system's current configuration
+    and return those which are not currently set as described.
+    """
+    def test_setting(desired_line: str) -> bool:
+        # Remove any comments
+        comment_start = desired_line.find('#')
+        if comment_start != -1:
+            desired_line = desired_line[:comment_start]
+        desired_line = desired_line.strip()
+        if not desired_line or desired_line.isspace():
+            return False
+        setting, desired_value = map(lambda s: s.strip(), desired_line.split('='))
+        if not setting or not desired_value:
+            return False
+        actual_value = sysctl_get(ctx, setting)
+        return desired_value != actual_value
+    return list(filter(test_setting, lines))
+
+
+def migrate_sysctl_dir(ctx: CephadmContext, fsid: str) -> None:
+    """
+    Cephadm once used '/usr/lib/sysctl.d' for storing sysctl configuration.
+    This moves it to '/etc/sysctl.d'.
+    """
+    deprecated_location: str = '/usr/lib/sysctl.d'
+    deprecated_confs: List[str] = glob(f'{deprecated_location}/90-ceph-{fsid}-*.conf')
+    if not deprecated_confs:
+        return
+
+    file_count: int = len(deprecated_confs)
+    logger.info(f'Found sysctl {file_count} files in deprecated location {deprecated_location}. Starting Migration.')
+    for conf in deprecated_confs:
+        try:
+            shutil.move(conf, ctx.sysctl_dir)
+            file_count -= 1
+        except shutil.Error as err:
+            if str(err).endswith('already exists'):
+                logger.warning(f'Destination file already exists. Deleting {conf}.')
+                try:
+                    os.unlink(conf)
+                    file_count -= 1
+                except OSError as del_err:
+                    logger.warning(f'Could not remove {conf}: {del_err}.')
+            else:
+                logger.warning(f'Could not move {conf} from {deprecated_location} to {ctx.sysctl_dir}: {err}')
+
+    # Log successful migration
+    if file_count == 0:
+        logger.info(f'Successfully migrated sysctl config to {ctx.sysctl_dir}.')
+        return
+
+    # Log partially successful / unsuccessful migration
+    files_processed: int = len(deprecated_confs)
+    if file_count < files_processed:
+        status: str = f'partially successful (failed {file_count}/{files_processed})'
+    elif file_count == files_processed:
+        status = 'unsuccessful'
+    logger.warning(f'Migration of sysctl configuration {status}. You may want to perform a migration manually.')

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -2506,8 +2506,10 @@ cluster_network=3.3.3.0/24, 4.4.4.0/24
         assert _str_to_networks(cluster_network) == ['3.3.3.0/24', '4.4.4.0/24']
 
 class TestSysctl:
-    @mock.patch('cephadm.sysctl_get')
+    @mock.patch('cephadmlib.sysctl.sysctl_get')
     def test_filter_sysctl_settings(self, _sysctl_get):
+        from cephadmlib.sysctl import filter_sysctl_settings
+
         ctx = _cephadm.CephadmContext()
         input = [
             # comment-only lines should be ignored
@@ -2531,7 +2533,7 @@ class TestSysctl:
             "65530",
             "something else",
         ]
-        result = _cephadm.filter_sysctl_settings(ctx, input)
+        result = filter_sysctl_settings(ctx, input)
         assert len(_sysctl_get.call_args_list) == 6
         assert _sysctl_get.call_args_list[0].args[1] == "something"
         assert _sysctl_get.call_args_list[1].args[1] == "fs.aio-max-nr"

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -294,15 +294,20 @@ class TestCephAdm(object):
         """
 
         ctx = _cephadm.CephadmContext()
+        mon = _cephadm.Ceph.create(ctx, _cephadm.DaemonIdentity(
+            fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',
+            daemon_type='mon',
+            daemon_id='a',
+        ))
         with pytest.raises(Exception):
-            _cephadm.update_firewalld(ctx, 'mon')
+            _cephadm.update_firewalld(ctx, mon)
 
         ctx.skip_firewalld = True
-        _cephadm.update_firewalld(ctx, 'mon')
+        _cephadm.update_firewalld(ctx, mon)
 
         ctx.skip_firewalld = False
         with pytest.raises(Exception):
-            _cephadm.update_firewalld(ctx, 'mon')
+            _cephadm.update_firewalld(ctx, mon)
 
         ctx = _cephadm.CephadmContext()
         ctx.ssl_dashboard_port = 8888

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -286,6 +286,7 @@ class TestCephAdm(object):
         for address, expected in tests:
             wrap_test(address, expected)
 
+    @mock.patch('cephadmlib.firewalld.Firewalld', mock_bad_firewalld)
     @mock.patch('cephadm.Firewalld', mock_bad_firewalld)
     @mock.patch('cephadm.logger')
     def test_skip_firewalld(self, _logger, cephadm_fs):

--- a/src/cephadm/tests/test_daemon_form.py
+++ b/src/cephadm/tests/test_daemon_form.py
@@ -1,0 +1,86 @@
+from unittest import mock
+
+import pytest
+
+from .fixtures import import_cephadm
+
+from cephadmlib import daemon_form
+from cephadmlib import daemon_identity
+
+_cephadm = import_cephadm()
+
+
+@pytest.mark.parametrize(
+    'daemon_type,cls',
+    [
+        ('container', _cephadm.CustomContainer),
+        ('grafana', _cephadm.Monitoring),
+        ('iscsi', _cephadm.CephIscsi),
+        ('jaeger-agent', _cephadm.Tracing),
+        ('jaeger-query', _cephadm.Tracing),
+        ('mds', _cephadm.Ceph),
+        ('mon', _cephadm.Ceph),
+        ('nfs', _cephadm.NFSGanesha),
+        ('nvmeof', _cephadm.CephNvmeof),
+        ('osd', _cephadm.OSD),
+        ('prometheus', _cephadm.Monitoring),
+        ('snmp-gateway', _cephadm.SNMPGateway),
+    ],
+)
+def test_choose_daemon_form(daemon_type, cls):
+    daemon_form.choose(daemon_type) == cls
+
+
+def test_choose_daemon_form_error():
+    with pytest.raises(daemon_form.UnexpectedDaemonTypeError):
+        daemon_form.choose('__nope__nope__')
+
+
+@pytest.mark.parametrize(
+    'dt,is_sdf',
+    [
+        ('haproxy', True),
+        ('iscsi', False),
+        ('keepalived', True),
+        ('mon', False),
+        ('nfs', False),
+        ('nvmeof', True),
+        ('osd', True),
+    ],
+)
+def test_is_sysctl_daemon_form(dt, is_sdf):
+    uuid = 'daeb985e-58c7-11ee-a536-201e8814f771'
+    ctx = mock.MagicMock()
+    ctx.config_blobs = {
+        'files': _dmock(),
+        'pool': 'swimming',
+        'destination': 'earth',
+    }
+    ident = daemon_identity.DaemonIdentity(uuid, dt, 'abc')
+    inst = daemon_form.create(ctx, ident)
+    assert isinstance(inst, daemon_form.SysctlDaemonForm) == is_sdf
+
+
+def test_can_create_all_daemon_forms():
+    uuid = 'daeb985e-58c7-11ee-a536-201e8814f771'
+    ctx = mock.MagicMock()
+    ctx.config_blobs = {
+        'files': _dmock(),
+        'pool': 'swimming',
+        'destination': 'earth',
+    }
+    dtypes = _cephadm.get_supported_daemons()
+    for daemon_type in dtypes:
+        if daemon_type == 'agent':
+            # skip agent because it is special & not currently a daemonform
+            continue
+        ident = daemon_identity.DaemonIdentity(uuid, daemon_type, 'xyz')
+        inst = daemon_form.create(ctx, ident)
+        assert inst.identity.daemon_type == daemon_type
+
+
+def _dmock():
+    dmock = mock.MagicMock()
+    dmock.__contains__.return_value = True
+    dmock.__getitem__.return_value = ''
+    return dmock

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -1,0 +1,86 @@
+import pathlib
+import unittest
+from unittest import mock
+
+from .fixtures import (
+    cephadm_fs,
+    import_cephadm,
+    mock_podman,
+    with_cephadm_ctx,
+)
+
+
+_cephadm = import_cephadm()
+
+
+def test_deploy_nfs_container(cephadm_fs, monkeypatch):
+    _call = mock.MagicMock(return_value=('', '', 0))
+    monkeypatch.setattr('cephadmlib.container_types.call', _call)
+    _firewalld = mock.MagicMock()
+    _firewalld().external_ports.get.return_value = []
+    monkeypatch.setattr('cephadm.Firewalld', _firewalld)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'nfs.fun'
+        ctx.image = 'quay.io/ceph/ceph:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'pool': 'foo',
+            'files': {
+                'ganesha.conf': 'FAKE',
+            },
+            'config': 'BALONEY',
+            'keyring': 'BUNKUS',
+        }
+        _cephadm._common_deploy(ctx)
+
+    with open(f'/var/lib/ceph/{fsid}/nfs.fun/unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith('quay.io/ceph/ceph:latest -F -L STDERR')
+    _firewalld().open_ports.assert_called_with([2049])
+    with open(f'/var/lib/ceph/{fsid}/nfs.fun/config') as f:
+        assert f.read() == 'BALONEY'
+    with open(f'/var/lib/ceph/{fsid}/nfs.fun/keyring') as f:
+        assert f.read() == 'BUNKUS'
+    with open(f'/var/lib/ceph/{fsid}/nfs.fun/etc/ganesha/ganesha.conf') as f:
+        assert f.read() == 'FAKE'
+
+
+def test_deploy_snmp_container(cephadm_fs, monkeypatch):
+    _call = mock.MagicMock(return_value=('', '', 0))
+    monkeypatch.setattr('cephadmlib.container_types.call', _call)
+    _call_throws = mock.MagicMock(return_value=0)
+    monkeypatch.setattr(
+        'cephadmlib.container_types.call_throws', _call_throws
+    )
+    _firewalld = mock.MagicMock()
+    _firewalld().external_ports.get.return_value = []
+    monkeypatch.setattr('cephadm.Firewalld', _firewalld)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'snmp-gateway.sunmop'
+        ctx.image = 'quay.io/aaabbb/snmp:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'destination': '192.168.100.10:8899',
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+        }
+        _cephadm._common_deploy(ctx)
+
+    with open(f'/var/lib/ceph/{fsid}/snmp-gateway.sunmop/unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith(
+        'quay.io/aaabbb/snmp:latest --web.listen-address=:9464 --snmp.destination=192.168.100.10:8899 --snmp.version=V2c --log.level=info --snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl'
+    )
+    _firewalld().open_ports.assert_not_called()
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/snmp-gateway.sunmop')
+    assert basedir.is_dir()
+    assert not (basedir / 'config').exists()
+    assert not (basedir / 'keyring').exists()


### PR DESCRIPTION
Introduce the DaemonForm, an ABC and some helpers that creates a standard way of putting together the various "daemon type" classes and instances that cephadm currently instantiates (or not) to do  daemon specific setup steps and get daemon specific customization.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactoring
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
