### PR TITLE
reef: qa: increase the http postBuffer size and disable sslVerify

### DIFF
--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# increase the cache size
+sudo git config --global http.sslVerify false
+sudo git config --global http.postBuffer 1048576000
+
 # try it again if the clone is slow and the second time
 retried=false
 trap -- 'retry' EXIT


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62866

---

backport of https://github.com/ceph/ceph/pull/53175
parent tracker: https://tracker.ceph.com/issues/59413


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
