### PR TITLE
reef: test: explicitly link to ceph-common for some libcephfs tests

### DIFF
--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -55,7 +55,8 @@ if(WITH_LIBCEPHFS)
     add_executable(ceph_test_libcephfs_reclaim
       reclaim.cc
     )
-    target_link_libraries(ceph_test_libcephfs_reclaim
+  target_link_libraries(ceph_test_libcephfs_reclaim
+      ceph-common
       cephfs
       ${UNITTEST_LIBS}
       ${EXTRALIBS}
@@ -68,7 +69,8 @@ if(WITH_LIBCEPHFS)
   add_executable(ceph_test_libcephfs_lazyio
     lazyio.cc
   )
-  target_link_libraries(ceph_test_libcephfs_lazyio
+target_link_libraries(ceph_test_libcephfs_lazyio
+    ceph-common
     cephfs
     librados
     ${UNITTEST_LIBS}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62287

---

backport of https://github.com/ceph/ceph/pull/52754
parent tracker: https://tracker.ceph.com/issues/57206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh