### PR TITLE
quincy: cephfs-mirror: do not run concurrent C_RestartMirroring context

### DIFF
--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -52,9 +52,33 @@ public:
            m_mirror_watcher->is_failed();
   }
 
+  utime_t get_failed_ts() {
+    std::scoped_lock locker(m_lock);
+    if (m_instance_watcher) {
+      return m_instance_watcher->get_failed_ts();
+    }
+    if (m_mirror_watcher) {
+      return m_mirror_watcher->get_failed_ts();
+    }
+
+    return utime_t();
+  }
+
   bool is_blocklisted() {
     std::scoped_lock locker(m_lock);
     return is_blocklisted(locker);
+  }
+
+  utime_t get_blocklisted_ts() {
+    std::scoped_lock locker(m_lock);
+    if (m_instance_watcher) {
+      return m_instance_watcher->get_blocklisted_ts();
+    }
+    if (m_mirror_watcher) {
+      return m_mirror_watcher->get_blocklisted_ts();
+    }
+
+    return utime_t();
   }
 
   Peers get_peers() {

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -116,12 +116,15 @@ void InstanceWatcher::handle_rewatch_complete(int r) {
     dout(0) << ": client blocklisted" <<dendl;
     std::scoped_lock locker(m_lock);
     m_blocklisted = true;
+    m_blocklisted_ts = ceph_clock_now();
   } else if (r == -ENOENT) {
     derr << ": mirroring object deleted" << dendl;
     m_failed = true;
+    m_failed_ts = ceph_clock_now();
   } else if (r < 0) {
     derr << ": rewatch error: " << cpp_strerror(r) << dendl;
     m_failed = true;
+    m_failed_ts = ceph_clock_now();
   }
 }
 

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -49,9 +49,19 @@ public:
     return m_blocklisted;
   }
 
+  utime_t get_blocklisted_ts() {
+    std::scoped_lock locker(m_lock);
+    return m_blocklisted_ts;
+  }
+
   bool is_failed() {
     std::scoped_lock locker(m_lock);
     return m_failed;
+  }
+
+  utime_t get_failed_ts() {
+    std::scoped_lock locker(m_lock);
+    return m_failed_ts;
   }
 
 private:
@@ -65,6 +75,9 @@ private:
 
   bool m_blocklisted = false;
   bool m_failed = false;
+
+  utime_t m_blocklisted_ts;
+  utime_t m_failed_ts;
 
   void create_instance();
   void handle_create_instance(int r);

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -196,8 +196,6 @@ Mirror::Mirror(CephContext *cct, const std::vector<const char*> &args,
     m_monc(monc),
     m_msgr(msgr),
     m_listener(this),
-    m_last_blocklist_check(ceph_clock_now()),
-    m_last_failure_check(ceph_clock_now()),
     m_local(new librados::Rados()) {
   auto thread_pool = &(cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
                          "cephfs::mirror::thread_pool", false, cct));
@@ -498,50 +496,34 @@ void Mirror::update_fs_mirrors() {
   auto now = ceph_clock_now();
   double blocklist_interval = g_ceph_context->_conf.get_val<std::chrono::seconds>
     ("cephfs_mirror_restart_mirror_on_blocklist_interval").count();
-  bool check_blocklist = blocklist_interval > 0 && ((now - m_last_blocklist_check) >= blocklist_interval);
-
   double failed_interval = g_ceph_context->_conf.get_val<std::chrono::seconds>
     ("cephfs_mirror_restart_mirror_on_failure_interval").count();
-  bool check_failure = failed_interval > 0 && ((now - m_last_failure_check) >= failed_interval);
 
   {
     std::scoped_lock locker(m_lock);
     for (auto &[filesystem, mirror_action] : m_mirror_actions) {
-      auto failed = mirror_action.fs_mirror && mirror_action.fs_mirror->is_failed();
-      auto blocklisted = mirror_action.fs_mirror && mirror_action.fs_mirror->is_blocklisted();
+      auto failed_restart = mirror_action.fs_mirror && mirror_action.fs_mirror->is_failed() &&
+	(failed_interval > 0 && (mirror_action.fs_mirror->get_failed_ts() - now) > failed_interval);
+      auto blocklisted_restart = mirror_action.fs_mirror && mirror_action.fs_mirror->is_blocklisted() &&
+	(blocklist_interval > 0 && (mirror_action.fs_mirror->get_blocklisted_ts() - now) > blocklist_interval);
 
-      if (check_failure && !mirror_action.action_in_progress &&
-	  !_is_restarting(filesystem) && failed) {
-        // about to restart failed mirror instance -- nothing
-        // should interfere
-        dout(5) << ": filesystem=" << filesystem << " failed mirroring -- restarting" << dendl;
-	_set_restarting(filesystem);
-        auto peers = mirror_action.fs_mirror->get_peers();
-        auto ctx =  new C_RestartMirroring(this, filesystem, mirror_action.pool_id, peers);
-        ctx->complete(0);
-      } else if (check_blocklist && !mirror_action.action_in_progress &&
-		 !_is_restarting(filesystem) && blocklisted) {
-        // about to restart blocklisted mirror instance -- nothing
-        // should interfere
-	_set_restarting(filesystem);
-        dout(5) << ": filesystem=" << filesystem << " is blocklisted -- restarting" << dendl;
-        auto peers = mirror_action.fs_mirror->get_peers();
-        auto ctx = new C_RestartMirroring(this, filesystem, mirror_action.pool_id, peers);
-        ctx->complete(0);
+      if (!mirror_action.action_in_progress && !_is_restarting(filesystem)) {
+	if (failed_restart || blocklisted_restart) {
+	  dout(5) << ": filesystem=" << filesystem << " failed mirroring (failed: "
+		  << failed_restart << ", blocklisted: " << blocklisted_restart << dendl;
+	  _set_restarting(filesystem);
+	  auto peers = mirror_action.fs_mirror->get_peers();
+	  auto ctx =  new C_RestartMirroring(this, filesystem, mirror_action.pool_id, peers);
+	  ctx->complete(0);
+	}
       }
-      if (!failed && !blocklisted && !mirror_action.action_ctxs.empty()
+
+      if (!failed_restart && !blocklisted_restart && !mirror_action.action_ctxs.empty()
           && !mirror_action.action_in_progress) {
         auto ctx = std::move(mirror_action.action_ctxs.front());
         mirror_action.action_ctxs.pop_front();
         ctx->complete(0);
       }
-    }
-
-    if (check_blocklist) {
-      m_last_blocklist_check = now;
-    }
-    if (check_failure) {
-      m_last_failure_check = now;
     }
   }
 

--- a/src/tools/cephfs_mirror/Mirror.h
+++ b/src/tools/cephfs_mirror/Mirror.h
@@ -101,9 +101,6 @@ private:
   std::unique_ptr<ClusterWatcher> m_cluster_watcher;
   std::map<Filesystem, MirrorAction> m_mirror_actions;
 
-  utime_t m_last_blocklist_check;
-  utime_t m_last_failure_check;
-
   RadosRef m_local;
   std::unique_ptr<ServiceDaemon> m_service_daemon;
 

--- a/src/tools/cephfs_mirror/Mirror.h
+++ b/src/tools/cephfs_mirror/Mirror.h
@@ -77,6 +77,7 @@ private:
 
     uint64_t pool_id; // for restarting blocklisted mirror instance
     bool action_in_progress = false;
+    bool restarting = false;
     std::list<Context *> action_ctxs;
     std::unique_ptr<FSMirror> fs_mirror;
   };
@@ -132,6 +133,21 @@ private:
   void update_fs_mirrors();
 
   void reopen_logs();
+
+  void _set_restarting(const Filesystem &filesystem) {
+    auto &mirror_action = m_mirror_actions.at(filesystem);
+    mirror_action.restarting = true;
+  }
+
+  void _unset_restarting(const Filesystem &filesystem) {
+    auto &mirror_action = m_mirror_actions.at(filesystem);
+    mirror_action.restarting = false;
+  }
+
+  bool _is_restarting(const Filesystem &filesystem) {
+    auto &mirror_action = m_mirror_actions.at(filesystem);
+    return mirror_action.restarting;
+  }
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/MirrorWatcher.cc
+++ b/src/tools/cephfs_mirror/MirrorWatcher.cc
@@ -93,12 +93,15 @@ void MirrorWatcher::handle_rewatch_complete(int r) {
     dout(0) << ": client blocklisted" <<dendl;
     std::scoped_lock locker(m_lock);
     m_blocklisted = true;
+    m_blocklisted_ts = ceph_clock_now();
   } else if (r == -ENOENT) {
     derr << ": mirroring object deleted" << dendl;
     m_failed = true;
+    m_failed_ts = ceph_clock_now();
   } else if (r < 0) {
     derr << ": rewatch error: " << cpp_strerror(r) << dendl;
     m_failed = true;
+    m_failed_ts = ceph_clock_now();
   }
 }
 

--- a/src/tools/cephfs_mirror/MirrorWatcher.h
+++ b/src/tools/cephfs_mirror/MirrorWatcher.h
@@ -47,9 +47,19 @@ public:
     return m_blocklisted;
   }
 
+  utime_t get_blocklisted_ts() {
+    std::scoped_lock locker(m_lock);
+    return m_blocklisted_ts;
+  }
+
   bool is_failed() {
     std::scoped_lock locker(m_lock);
     return m_failed;
+  }
+
+  utime_t get_failed_ts() {
+    std::scoped_lock locker(m_lock);
+    return m_failed_ts;
   }
 
 private:
@@ -65,6 +75,9 @@ private:
 
   bool m_blocklisted = false;
   bool m_failed = false;
+
+  utime_t m_blocklisted_ts;
+  utime_t m_failed_ts;
 
   void register_watcher();
   void handle_register_watcher(int r);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62948

---

backport of https://github.com/ceph/ceph/pull/52747
parent tracker: https://tracker.ceph.com/issues/62072

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh