### PR TITLE
mgr/dashboard: Fix user/bucket count in rgw overview dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -450,11 +450,22 @@ class RgwBucketUi(RgwBucket):
         users_count = 0
         daemon_object = RgwDaemon()
         daemons = json.loads(daemon_object.list())
+        unique_realms = set()
         for daemon in daemons:
-            buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
-            users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
-            users_count += len(users)
-            buckets_count += len(buckets)
+            realm_name = daemon.get('realm_name', None)
+            if realm_name:
+                if realm_name not in unique_realms:
+                    unique_realms.add(realm_name)
+                    buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
+                    users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
+                    users_count += len(users)
+                    buckets_count += len(buckets)
+            else:
+                buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
+                users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
+                users_count = len(users)
+                buckets_count = len(buckets)
+
         return {
             'buckets_count': buckets_count,
             'users_count': users_count


### PR DESCRIPTION
Do not consider buckets/users count from daemons that have similar realm name

Fixes: https://tracker.ceph.com/issues/62964





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
