### PR TITLE
quincy: cephfs-journal-tool: disambiguate usage of all keyword (in tool help).

### DIFF
--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -62,7 +62,7 @@ void JournalTool::usage()
     << "    <output>: [summary|list|binary|json] [--path <path>]\n"
     << "\n"
     << "General options:\n"
-    << "  --rank=filesystem:mds-rank|all Journal rank (mandatory)\n"
+    << "  --rank=filesystem:{mds-rank|all} journal rank or \"all\" ranks (mandatory)\n"
     << "  --journal=<mdlog|purge_queue>  Journal type (purge_queue means\n"
     << "                                 this journal is used to queue for purge operation,\n"
     << "                                 default is mdlog, and only mdlog support event mode)\n"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61804

---

backport of https://github.com/ceph/ceph/pull/52149
parent tracker: https://tracker.ceph.com/issues/61753

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh