### PR TITLE
pacific: test: explicitly link to ceph-common for some libcephfs tests

### DIFF
--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -54,6 +54,7 @@ if(${WITH_CEPHFS})
     reclaim.cc
   )
   target_link_libraries(ceph_test_libcephfs_reclaim
+    ceph-common
     cephfs
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
@@ -65,7 +66,8 @@ if(${WITH_CEPHFS})
   add_executable(ceph_test_libcephfs_lazyio
     lazyio.cc
   )
-  target_link_libraries(ceph_test_libcephfs_lazyio
+target_link_libraries(ceph_test_libcephfs_lazyio
+    ceph-common
     cephfs
     librados
     ${UNITTEST_LIBS}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62288

---

backport of https://github.com/ceph/ceph/pull/52754
parent tracker: https://tracker.ceph.com/issues/57206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh