### PR TITLE
reef: mgr/dashboard: remove empty popover when there are no health warns

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
@@ -55,6 +55,7 @@
             </li>
           </ul>
         </ng-template>
+        <ng-template #healthWarningAndError>
         <div class="info-card-content-clickable mt-1"
              [ngStyle]="healthData.health.status | healthColor"
              [ngbPopover]="healthChecks"
@@ -62,7 +63,13 @@
             {{ healthData.health.status | healthLabel | uppercase }}
           <i *ngIf="healthData.health?.status !== 'HEALTH_OK'"
              class="fa fa-exclamation-triangle"></i>
+        </div></ng-template>
+
+      <ng-container *ngIf="!healthData.health?.checks?.length; else healthWarningAndError">
+        <div [ngStyle]="healthData.health.status | healthColor">
+          {{ healthData.health.status | healthLabel | uppercase }}
         </div>
+      </ng-container>
       </div>
     </cd-card>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.spec.ts
@@ -179,4 +179,52 @@ describe('UpgradeComponent', () => {
     const loading = fixture.debugElement.nativeElement.querySelector('#upgrade-status-error');
     expect(loading.textContent).toContain('Failed to retrieve');
   });
+
+  it('should show popover when health warning is present', () => {
+    const healthPayload: Record<string, any> = {
+      health: {
+        status: 'HEALTH_WARN',
+        checks: [
+          {
+            severity: 'HEALTH_WARN',
+            summary: { message: '1 pool(s) do not have an application enabled', count: 1 },
+            detail: [
+              { message: "application not enabled on pool 'scbench'" },
+              {
+                message:
+                  "use 'ceph osd pool application enable <pool-name> <app-name>', where <app-name> is 'cephfs', 'rbd', 'rgw', or freeform for custom applications."
+              }
+            ],
+            muted: false,
+            type: 'POOL_APP_NOT_ENABLED'
+          }
+        ],
+        mutes: []
+      }
+    };
+
+    getHealthSpy.and.returnValue(of(healthPayload));
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    const popover = fixture.debugElement.nativeElement.querySelector(
+      '.info-card-content-clickable'
+    );
+    expect(popover).not.toBeNull();
+  });
+
+  it('should not show popover when health warning is not present', () => {
+    const healthPayload: Record<string, any> = {
+      health: {
+        status: 'HEALTH_OK'
+      }
+    };
+    getHealthSpy.and.returnValue(of(healthPayload));
+    component.ngOnInit();
+    fixture.detectChanges();
+    const popover = fixture.debugElement.nativeElement.querySelector(
+      '.info-card-content-clickable'
+    );
+    expect(popover).toBeNull();
+  });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62967

---

backport of https://github.com/ceph/ceph/pull/53479
parent tracker: https://tracker.ceph.com/issues/62846

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh