### PR TITLE
librbd: data corruption on mirroring cloned images

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -71,6 +71,10 @@ private:
    *    v          |
    * READ ---------/
    *    |
+   *    |
+   *    v
+   * COPY_UP (for cloned image)
+   *    |
    *    |     /-----------\
    *    |     |           | (repeat for each snapshot)
    *    v     v           |
@@ -134,6 +138,9 @@ private:
 
   void send_update_object_map();
   void handle_update_object_map(int r);
+
+  void trigger_copyup();
+  void handle_trigger_copyup(int r);
 
   void process_copyup();
   void send_write_object();

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -902,6 +902,11 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
     if (end_snap_id <= first_snap_id) {
       // don't include deltas from the starting snapshots, but we iterate over
       // it to track its existence and size
+      // Note: if the image is a clone and a copyup was performed on the
+      // object, the older snaps will be updated with the parent data.
+      // When called by snapshot based rbd-mirror, the diff in the older snap is ignored
+      // as it was processed earlier, causing the snapshot_delta to not include
+      // the parent data.
       ldout(cct, 20) << "skipping prior snapshot " << dendl;
       continue;
     }

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -76,7 +76,13 @@ private:
    *                    OPEN_REMOTE_PARENT  * * * * * * * | * * *   *
    *                        |                             |       * *
    *                        v                             |         *
+   *                    OPEN_LOCAL_PARENT   * * * * * * * | * * *   *
+   *                        |                             |       * *
+   *                        v                             |         *
    *                    CLONE_IMAGE                       |         *
+   *                        |                             |         *
+   *                        v                             |         *
+   *                    CLOSE_LOCAL_PARENT                |         *
    *                        |                             |         *
    *                        v                             |         *
    *                    CLOSE_REMOTE_PARENT               |         *
@@ -101,11 +107,14 @@ private:
   cls::rbd::ParentImageSpec m_remote_parent_spec;
 
   librados::IoCtx m_local_parent_io_ctx;
+  ImageCtxT *m_local_parent_image_ctx = nullptr;
   cls::rbd::ParentImageSpec m_local_parent_spec;
 
   bufferlist m_out_bl;
   std::string m_parent_global_image_id;
   std::string m_parent_pool_name;
+  std::string m_snap_name;
+  cls::rbd::SnapshotNamespace m_snap_namespace;
   int m_ret_val = 0;
 
   void create_image();
@@ -120,11 +129,17 @@ private:
   void open_remote_parent_image();
   void handle_open_remote_parent_image(int r);
 
+  void open_local_parent_image();
+  void handle_open_local_parent_image(int r);
+
   void clone_image();
   void handle_clone_image(int r);
 
   void close_remote_parent_image();
   void handle_close_remote_parent_image(int r);
+
+  void close_local_parent_image();
+  void handle_close_local_parent_image(int r);
 
   void error(int r);
   void finish(int r);


### PR DESCRIPTION
Parent data is not synced to the non-primary after a copyup operation on the primary image with snapshot based rbd-mirroring. Writing to a non-existent object in an rbd clone image triggers a copyup operation.The new  write data and the data from the parent are combined and written to the new clone object and any existing snapshots on the clone are updated with the parent data.
The rbd-mirror daemon uses deep_copy with subsets of snapshots. If a copyup has modified the already synced older snapshot with the parent data, a snapshot diff will only return the new data that was written to the clone. As the deep_copy writes data to the dst object using rados calls instead of rbd apis, a copyup is not performed and the parent data is lost. The fix involves triggering a copyup on the object if the image is a clone. This does not affect other deep_copy users as they copy the image and all the existing snapshots as a whole.

Fixes: https://tracker.ceph.com/issues/61891



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
