### PR TITLE
mgr/dashboard: start using alertmanager v2

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -46,9 +46,9 @@ class PrometheusRESTController(RESTController):
         # type (str, str, dict, dict)
         user, password, cert_file = self.get_access_info('alertmanager')
         verify = cert_file.name if cert_file else Settings.ALERTMANAGER_API_SSL_VERIFY
-        response = self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST),
+        response = self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST, version='v2'),
                                method, path, 'Alertmanager', params, payload,
-                               user=user, password=password, verify=verify)
+                               user=user, password=password, verify=verify, is_alertmanager=True)
         if cert_file:
             cert_file.close()
             os.unlink(cert_file.name)
@@ -81,15 +81,16 @@ class PrometheusRESTController(RESTController):
 
         return user, password, cert_file
 
-    def _get_api_url(self, host):
-        return host.rstrip('/') + '/api/v1'
+    def _get_api_url(self, host, version='v1'):
+        return f'{host.rstrip("/")}/api/{version}'
 
     def balancer_status(self):
         return ceph_service.CephService.send_command('mon', 'balancer status')
 
     def _proxy(self, base_url, method, path, api_name, params=None, payload=None, verify=True,
-               user=None, password=None):
+               user=None, password=None, is_alertmanager=False):
         # type (str, str, str, str, dict, dict, bool)
+        content = None
         try:
             from requests.auth import HTTPBasicAuth
             auth = HTTPBasicAuth(user, password) if user and password else None
@@ -102,11 +103,14 @@ class PrometheusRESTController(RESTController):
                 http_status_code=404,
                 component='prometheus')
         try:
-            content = json.loads(response.content, strict=False)
+            if response.content:
+                content = json.loads(response.content, strict=False)
         except json.JSONDecodeError as e:
             raise DashboardException(
                 "Error parsing Prometheus Alertmanager response: {}".format(e.msg),
                 component='prometheus')
+        if is_alertmanager:
+            return content
         balancer_status = self.balancer_status()
         if content['status'] == 'success':  # pylint: disable=R1702
             alerts_info = []
@@ -145,6 +149,10 @@ class Prometheus(PrometheusRESTController):
     @RESTController.Collection(method='DELETE', path='/silence/{s_id}', status=204)
     def delete_silence(self, s_id):
         return self.alert_proxy('DELETE', '/silence/' + s_id) if s_id else None
+
+    @RESTController.Collection(method='GET', path='/alertgroup')
+    def get_alertgroup(self, **params):
+        return self.alert_proxy('GET', '/alerts/groups', params)
 
     @RESTController.Collection(method='GET', path='/prometheus_query_data')
     def get_prometeus_query_data(self, **params):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10295,6 +10295,28 @@ paths:
       - jwt: []
       tags:
       - Prometheus
+  /api/prometheus/alertgroup:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Prometheus
   /api/prometheus/data:
     get:
       parameters: []

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -12,7 +12,7 @@ from ..tests import ControllerTestCase
 
 class PrometheusControllerTest(ControllerTestCase):
     alert_host = 'http://alertmanager:9093/mock'
-    alert_host_api = alert_host + '/api/v1'
+    alert_host_api = alert_host + '/api/v2'
 
     prometheus_host = 'http://prometheus:9090/mock'
     prometheus_host_api = prometheus_host + '/api/v1'


### PR DESCRIPTION
I was looking into sorting the alerts and saw there is an api v2 for alertmanager which also has an endpoint like `alerts/groups` which might be something that is useful for us.

Fixes: https://tracker.ceph.com/issues/65070

Refer: https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
