### PR TITLE
quincy: install-deps: remove the legacy resolver flags

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -462,10 +462,7 @@ function populate_wheelhouse() {
     pip $PIP_OPTS $install \
       'setuptools >= 0.8' 'pip >= 21.0' 'wheel >= 0.24' 'tox >= 2.9.1' || return 1
     if test $# != 0 ; then
-        # '--use-feature=fast-deps --use-deprecated=legacy-resolver' added per
-        # https://github.com/pypa/pip/issues/9818 These should be able to be
-        # removed at some point in the future.
-        pip --use-feature=fast-deps --use-deprecated=legacy-resolver $PIP_OPTS $install $@ || return 1
+        pip $PIP_OPTS $install $@ || return 1
     fi
 }
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/52544

This was a workaround that was introduced long time ago. This will be something that could be deprectaed at some point [1]. And its preventing some of the dependencies to be downloaded or stored into the wheelhouse. Deps like jsonschema, parse, mypy, cryptography etc.

[1] https://pip.pypa.io/en/latest/user_guide/#deprecation-timeline

Fixes: https://tracker.ceph.com/issues/62082
Signed-off-by: Nizamudeen A <nia@redhat.com>
(cherry picked from commit d179b95ddf57f8ca48633aed9f6229e39ad83fef)