### PR TITLE
perf: optimize osd_op_num_shard and thread to reduce op latency

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -841,7 +841,7 @@ options:
 - name: osd_op_num_threads_per_shard_hdd
   type: int
   level: advanced
-  default: 1
+  default: 5
   see_also:
   - osd_op_num_threads_per_shard
   flags:
@@ -850,7 +850,7 @@ options:
 - name: osd_op_num_threads_per_shard_ssd
   type: int
   level: advanced
-  default: 2
+  default: 16
   see_also:
   - osd_op_num_threads_per_shard
   flags:
@@ -870,7 +870,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for rotational media).
-  default: 5
+  default: 1
   see_also:
   - osd_op_num_shards
   flags:
@@ -880,7 +880,7 @@ options:
   type: int
   level: advanced
   fmt_desc: the number of shards allocated for a given OSD (for solid state media).
-  default: 8
+  default: 1
   see_also:
   - osd_op_num_shards
   flags:


### PR DESCRIPTION
```
Author: zhangjianwei <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Thu Sep 28 13:54:23 2023 +0800

    perf: optimize osd_op_num_shard and thread to reduce op latency
    
    rados bench 60 write -t 5 -p test-pool -b 204800 --show-time
    
    case-1: res=1/lim=1/wgt=60/bw=240M/iops=240 ，num_shards=5, thread=1
      - res_bw = 48MBps / lim_bw = 48MBps
      - op delay latency = 1M / 48 MBps = 0.02083s = 20.83ms,
      - bw : 1000ms/20.83ms * 200K / 1024K * 5(shard) = 46.88MBps
      - avg_lat=0.0272721s = 27.27ms
        - it's op avg_lat higher than expected(6.44/20.83=0.3091) 30.91%
      - bw = 35.77 MBps
        - it's bw lower than expected (11.11/46.88=0.2369) 23.69%
    case-2: res=1/lim=1/wgt=60/bw=240M/iops=240 ，num_shards=1, thread=5
      - res_bw = 240 MBps / lim_bw = 240 MBps
      - op delay latency = 1M / 240 MBps = 0.0.00416s = 4.16 ms
        - concurrency=5, 5 * 4.166 = 20.83 ms
      - bw : 1000 / 4.16 * 200 / 1024 = 46.95 MBps
      - avg_lat = 0.0209406s = 20.94 ms
        - very close
      - bw = 46.61 MBps
        - very close
    reason:
    - since the shard queue the op enters is based on
      - the random hash of the pgid where op.oid is located,
      - absolute balance cannot be achieved.
    - On a macro scale, the number of ops processed by each shard queue
      - is basically balanced,
      - and there will be no order of magnitude difference.
    - But on a micro scale, at the same time,
      - some shard queues have a small number of ops accumulated,
      - some shard queues have a large number of ops accumulated,
      - which will directly cause op latency.
    
    issue: https://tracker.ceph.com/issues/63014
```