### PR TITLE
cephfs-shell: use pkg_resources rather than packaging module

### DIFF
--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -56,7 +56,7 @@ Options
 
 .. code:: bash
 
-    [build]$ python3 -m venv venv && source venv/bin/activate && pip3 install cmd2 colorama packaging
+    [build]$ python3 -m venv venv && source venv/bin/activate && pip3 install cmd2 colorama
     [build]$ source vstart_environment.sh && source venv/bin/activate && python3 ../src/tools/cephfs/shell/cephfs-shell
 
 Commands

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -1701,11 +1701,11 @@ def read_shell_conf(shell, shell_conf_file):
 
     sec = 'cephfs-shell'
     opts = []
-    if version.parse(cmd2_version) >= version.parse("0.10.0"):
+    if Version(cmd2_version) >= Version("0.10.0"):
         for attr in shell.settables.keys():
             opts.append(attr)
     else:
-        if version.parse(cmd2_version) <= version.parse("0.9.13"):
+        if Version(cmd2_version) <= Version("0.9.13"):
             # hardcoding options for 0.7.9 because -
             # 1. we use cmd2 v0.7.9 with teuthology and
             # 2. there's no way distinguish between a shell setting and shell
@@ -1714,7 +1714,7 @@ def read_shell_conf(shell, shell_conf_file):
                     'continuation_prompt', 'debug', 'echo', 'editor',
                     'feedback_to_output', 'locals_in_py', 'prompt', 'quiet',
                     'timing']
-        elif version.parse(cmd2_version) >= version.parse("0.9.23"):
+        elif Version(cmd2_version) >= Version("0.9.23"):
             opts.append('allow_style')
         # no equivalent option was defined by cmd2.
         else:
@@ -1769,7 +1769,7 @@ def manage_args():
     args.exe_and_quit = False    # Execute and quit, don't launch the shell.
 
     if args.batch:
-        if version.parse(cmd2_version) <= version.parse("0.9.13"):
+        if Version(cmd2_version) <= Version("0.9.13"):
             args.commands = ['load ' + args.batch, ',quit']
         else:
             args.commands = ['run_script ' + args.batch, ',quit']
@@ -1814,7 +1814,7 @@ def execute_cmds_and_quit(args):
     # value to indicate whether the execution of the commands should stop, but
     # since 0.9.7 it returns the return value of do_* methods only if it's
     # not None. When it is None it returns False instead of None.
-    if version.parse(cmd2_version) <= version.parse("0.9.6"):
+    if Version(cmd2_version) <= Version("0.9.6"):
         stop_exec_val = None
     else:
         stop_exec_val = False

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -16,13 +16,14 @@ import shlex
 import stat
 import errno
 
-from packaging import version
+from pkg_resources import packaging  # type: ignore
 
 from cmd2 import Cmd
 from cmd2 import __version__ as cmd2_version
 # XXX: In cmd2 versions < 1.0.1, we'll get SystemExit(2) instead of
 # Cmd2ArgparseError
-if version.parse(cmd2_version) >= version.parse("1.0.1"):
+Version = packaging.version.Version
+if Version(cmd2_version) >= Version("1.0.1"):
     from cmd2.exceptions import Cmd2ArgparseError
 else:
     # HACK: so that we don't have check for version everywhere


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62739

Follow up on #53529 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
