### PR TITLE
mgr/cephadm: support for removing host entry from crush map during host removal

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -316,9 +316,32 @@ create a new CRUSH host located in the specified hierarchy.
 
   The ``location`` attribute will be only affect the initial CRUSH location. Subsequent
   changes of the ``location`` property will be ignored. Also, removing a host will not remove
-  any CRUSH buckets.
+  any CRUSH buckets unless the ``--rm-crush-entry`` flag is provided to the ``orch host rm`` command
 
 See also :ref:`crush_map_default_types`.
+
+Removing a host from the CRUSH map
+==================================
+
+The ``ceph orch host rm`` command has support for removing the bucket entry for the host
+in the CRUSH map. This is done by providing the ``--rm-crush-entry`` flag.
+
+.. prompt:: bash [ceph:root@host1/]#
+
+   ceph orch host rm host1 --rm-crush-entry
+
+When this flag is specified, cephadm will attempt to remove the bucket entry
+for the host from the CRUSH map as part of the host removal process. Note that if
+it fails to do so, cephadm will report the failure and the host will remain under
+cephadm control.
+
+.. note:: 
+
+  The removal from the CRUSH map will fail if there are OSDs deployed on the
+  host. If you would like to remove all the host's OSDs as well, please start
+  by using  the ``ceph orch host drain`` command to do so. Once the OSDs
+  are all gone, then you may have cephadm remove the CRUSH entry along with the
+  host using the ``--rm-crush-entry`` flag.
 
 OS Tuning Profiles
 ==================

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -36,11 +36,27 @@ tasks:
           sleep 15
           HOST_C_DAEMONS=$(ceph orch ps --hostname $HOST_C)
         done
+        # we want to check the ability to remove the host from
+        # the CRUSH map, so we should first verify the host is in
+        # the CRUSH map.
+        ceph osd getcrushmap -o compiled-crushmap
+        crushtool -d compiled-crushmap -o crushmap.txt
+        CRUSH_MAP=$(cat crushmap.txt)
+        if ! grep -q "$HOST_C" <<< "$CRUSH_MAP"; then
+          printf "Expected to see $HOST_C in CRUSH map. Saw:\n\n$CRUSH_MAP"
+          exit 1
+        fi
         # If the drain was successful, we should be able to remove the
         # host without force with no issues. If there are still daemons
         # we will get a response telling us to drain the host and a
         # non-zero return code
-        ceph orch host rm $HOST_C
-        
-        
-        
+        ceph orch host rm $HOST_C --rm-crush-entry
+        # verify we've successfully removed the host from the CRUSH map
+        sleep 30
+        ceph osd getcrushmap -o compiled-crushmap
+        crushtool -d compiled-crushmap -o crushmap.txt
+        CRUSH_MAP=$(cat crushmap.txt)
+        if grep -q "$HOST_C" <<< "$CRUSH_MAP"; then
+          printf "Saw $HOST_C in CRUSH map after it should have been removed.\n\n$CRUSH_MAP"
+          exit 1
+        fi

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -1,0 +1,46 @@
+roles:
+- - host.a
+  - mon.a
+  - mgr.a
+  - osd.0
+  - osd.1
+- - host.b
+  - mon.b
+  - mgr.b
+  - osd.2
+  - osd.3
+- - host.c
+  - mon.c
+  - osd.4
+  - osd.5
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - |
+        set -ex
+        HOSTNAMES=$(ceph orch host ls --format json | jq -r '.[] | .hostname')
+        for host in $HOSTNAMES; do
+          # find the hostname for "host.c" which will have no mgr
+          HAS_MGRS=$(ceph orch ps --hostname ${host} --format json | jq 'any(.daemon_type == "mgr")')
+          if [ "$HAS_MGRS" == "false" ]; then
+            HOST_C="${host}"
+          fi
+        done
+        # now drain that host
+        ceph orch host drain $HOST_C --zap-osd-devices
+        # wait for drain to complete
+        HOST_C_DAEMONS=$(ceph orch ps --hostname $HOST_C)
+        while [ "$HOST_C_DAEMONS" != "No daemons reported" ]; do
+          sleep 15
+          HOST_C_DAEMONS=$(ceph orch ps --hostname $HOST_C)
+        done
+        # If the drain was successful, we should be able to remove the
+        # host without force with no issues. If there are still daemons
+        # we will get a response telling us to drain the host and a
+        # non-zero return code
+        ceph orch host rm $HOST_C
+        
+        
+        

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -359,7 +359,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_host(self, host: str, force: bool, offline: bool) -> OrchResult[str]:
+    def remove_host(self, host: str, force: bool, offline: bool, rm_crush_entry: bool) -> OrchResult[str]:
         """
         Remove a host from the orchestrator inventory.
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -488,9 +488,9 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return self._apply_misc([s], False, Format.plain)
 
     @_cli_write_command('orch host rm')
-    def _remove_host(self, hostname: str, force: bool = False, offline: bool = False) -> HandleCommandResult:
+    def _remove_host(self, hostname: str, force: bool = False, offline: bool = False, rm_crush_entry: bool = False) -> HandleCommandResult:
         """Remove a host"""
-        completion = self.remove_host(hostname, force, offline)
+        completion = self.remove_host(hostname, force, offline, rm_crush_entry)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -284,7 +284,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return ''
 
     @handle_orch_error
-    def remove_host(self, host, force: bool, offline: bool):
+    def remove_host(self, host, force: bool, offline: bool, rm_crush_entry: bool):
         assert isinstance(host, str)
         return 'done'
 


### PR DESCRIPTION
This will tell cephadm to try and remove the
crush bucket for the host at the end of the host
removal process. If this fails, we still consider the
host as having been successfully remove from
cephadm's POV, but the user will get back an error
message telling them we failed to remove the
host from the crush map

Also to note, "ceph osd crush remove" command gives a 0 returncode if the entity provided to it is not present in the crush map, so cases where the host had no entry will complete normally.

This also includes a teuthology test for host draining, since that was the best mechanism I could come up with to test this feature properly.

Fixes: https://tracker.ceph.com/issues/63031

Signed-off-by: Adam King <adking@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
