### PR TITLE
reef: cephadm: fix haproxy version with certain containers

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -7193,7 +7193,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                                            'haproxy', '-v'],
                                                           verbosity=CallVerbosity.QUIET)
                                     if not code and \
-                                       out.startswith('HA-Proxy version '):
+                                       out.startswith('HA-Proxy version ') or \
+                                       out.startswith('HAProxy version '):
                                         version = out.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'keepalived':


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/53715

---

Some builds of haproxy containers' output
from "haproxy -v" start with

HAProxy version

rather than

HA-Proxy version

no reason on our end not to accept both

Signed-off-by: Adam King <adking@redhat.com>
(cherry picked from commit 5540cd1882faaf67013771bf18291053dcf2164d)
