### PR TITLE
mds: delay handing over preallocated inode range to client till session info is persisted

### DIFF
--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -186,7 +186,8 @@ public:
   CInode* prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino, unsigned mode,
 			    const file_layout_t *layout=nullptr);
   void journal_allocated_inos(MDRequestRef& mdr, EMetaBlob *blob);
-  void apply_allocated_inos(MDRequestRef& mdr, Session *session);
+  void try_delegate_inos(MDRequestRef& mdr, bool saving);
+  void apply_allocated_inos_and_delegate_inos(MDRequestRef& mdr);
 
   void _try_open_ino(MDRequestRef& mdr, int r, inodeno_t ino);
   CInode* rdlock_path_pin_ref(MDRequestRef& mdr, bool want_auth,

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -413,6 +413,19 @@ public:
     last_cap_renew = clock::zero();
   }
 
+  void inc_prealloc_dirty() {
+    ++prealloc_dirty;
+  }
+
+  void dec_prealloc_dirty() {
+    ceph_assert(prealloc_dirty > 0);
+    --prealloc_dirty;
+  }
+
+  bool is_prealloc_dirty() const {
+    return prealloc_dirty > 0;
+  }
+
   Session *reclaiming_from = nullptr;
   session_info_t info;                         ///< durable bits
   MDSAuthCaps auth_caps;
@@ -457,6 +470,8 @@ private:
   // Versions in this session was projected: used to verify
   // that appropriate mark_dirty calls follow.
   std::deque<version_t> projected;
+
+  uint64_t prealloc_dirty = 0;
 
   // request load average for this session
   DecayCounter load_avg;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1601,6 +1601,11 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
     }
   }
   if (sessionmapv) {
+    // NB: this value reflects the lag between the sessionmap version and
+    // the version recored in the blob, since, sessionmap.mark_projected()
+    // is called either once when (A): a new preallocated inode list is
+    // started or twice when (B): an inode is chosen from the preallocated
+    // list + (A) - therfore the diffrence being either 1 or 2.
     unsigned diff = (used_preallocated_ino && !preallocated_inos.empty()) ? 2 : 1;
     if (mds->sessionmap.get_version() >= sessionmapv ||
 	unlikely(type == EVENT_UPDATE && skip_replaying_inotable)) {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1590,27 +1590,27 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
       if (preallocated_inos.size())
 	mds->inotable->replay_alloc_ids(preallocated_inos);
 
-      // repair inotable updates in case inotable wasn't persist in time
+      // [repair bad inotable updates]
       if (inotablev > mds->inotable->get_version()) {
-        mds->clog->error() << "journal replay inotablev mismatch "
-            << mds->inotable->get_version() << " -> " << inotablev
-            << ", will force replay it.";
-        mds->inotable->force_replay_version(inotablev);
+	mds->clog->error() << "journal replay inotablev mismatch "
+	    << mds->inotable->get_version() << " -> " << inotablev;
+	mds->inotable->force_replay_version(inotablev);
       }
 
       ceph_assert(inotablev == mds->inotable->get_version());
     }
   }
   if (sessionmapv) {
+    unsigned diff = (used_preallocated_ino && !preallocated_inos.empty()) ? 2 : 1;
     if (mds->sessionmap.get_version() >= sessionmapv ||
 	unlikely(type == EVENT_UPDATE && skip_replaying_inotable)) {
       dout(10) << "EMetaBlob.replay sessionmap v " << sessionmapv
 	       << " <= table " << mds->sessionmap.get_version() << dendl;
       if (used_preallocated_ino)
         mds->mdcache->insert_taken_inos(used_preallocated_ino);
-    } else {
+    } else if (mds->sessionmap.get_version() + diff == sessionmapv) {
       dout(10) << "EMetaBlob.replay sessionmap v " << sessionmapv
-	       << ", table " << mds->sessionmap.get_version()
+	       << " - " << diff << " == table " << mds->sessionmap.get_version()
 	       << " prealloc " << preallocated_inos
 	       << " used " << used_preallocated_ino
 	       << dendl;
@@ -1630,6 +1630,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
 	  session->info.prealloc_inos.insert(preallocated_inos);
           mds->sessionmap.replay_dirty_session(session);
 	}
+
       } else {
 	dout(10) << "EMetaBlob.replay no session for " << client_name << dendl;
 	if (used_preallocated_ino)
@@ -1638,19 +1639,13 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
 	if (!preallocated_inos.empty())
 	  mds->sessionmap.replay_advance_version();
       }
-
-      // repair sessionmap updates in case sessionmap wasn't persist in time
-      if (sessionmapv > mds->sessionmap.get_version()) {
-        mds->clog->error() << "EMetaBlob.replay sessionmapv mismatch "
-            << sessionmapv << " -> " << mds->sessionmap.get_version()
-            << ", will force replay it.";
-        if (g_conf()->mds_wipe_sessions) {
-          mds->sessionmap.wipe();
-        }
-        // force replay sessionmap version
-        mds->sessionmap.set_version(sessionmapv);
-      }
       ceph_assert(sessionmapv == mds->sessionmap.get_version());
+    } else {
+      mds->clog->error() << "EMetaBlob.replay sessionmap v " << sessionmapv
+			 << " - " << diff << " > table " << mds->sessionmap.get_version();
+      ceph_assert(g_conf()->mds_wipe_sessions);
+      mds->sessionmap.wipe();
+      mds->sessionmap.set_version(sessionmapv);
     }
   }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/61009


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
