### PR TITLE
pacific: [CVE-2023-43040] rgw: Fix bucket validation against POST policies

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2661,10 +2661,6 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
 
   map_qs_metadata(s);
 
-  ldpp_dout(this, 20) << "adding bucket to policy env: " << s->bucket->get_name()
-		    << dendl;
-  env.add_var("bucket", s->bucket->get_name());
-
   bool done;
   do {
     struct post_form_part part;
@@ -2714,6 +2710,10 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
     string part_str(part.data.c_str(), part.data.length());
     env.add_var(part.name, part_str);
   } while (!done);
+
+  ldpp_dout(this, 20) << "adding bucket to policy env: " << s->bucket->get_name()
+		    << dendl;
+  env.add_var("bucket", s->bucket->get_name());
 
   string object_str;
   if (!part_str(parts, "key", &object_str)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63040

---

backport of https://github.com/ceph/ceph/pull/53714
parent tracker: https://tracker.ceph.com/issues/63004

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh