### PR TITLE
quincy: rgw: fix unwatch crash at radosgw startup

### DIFF
--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -247,7 +247,8 @@ void RGWSI_Notify::finalize_watch()
 {
   for (int i = 0; i < num_watchers; i++) {
     RGWWatcher *watcher = watchers[i];
-    watcher->unregister_watch();
+    if (watchers_set.find(i) != watchers_set.end())
+      watcher->unregister_watch();
     delete watcher;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63059

---

backport of https://github.com/ceph/ceph/pull/53691
parent tracker: https://tracker.ceph.com/issues/60094

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh