### PR TITLE
reef: rgw: s3website doesn't prefetch for web_dir() check

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5279,7 +5279,6 @@ bool RGWHandler_REST_S3Website::web_dir() const {
   std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(subdir_name));
 
   obj->set_atomic();
-  obj->set_prefetch_data();
 
   RGWObjState* state = nullptr;
   if (obj->get_obj_state(s, &state, s->yield) < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63051

---

backport of https://github.com/ceph/ceph/pull/53602
parent tracker: https://tracker.ceph.com/issues/62938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh