### PR TITLE
pacific: rgw: s3website doesn't prefetch for web_dir() check

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4942,7 +4942,6 @@ bool RGWHandler_REST_S3Website::web_dir() const {
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
   obj_ctx.set_atomic(obj);
-  obj_ctx.set_prefetch_data(obj);
 
   RGWObjState* state = nullptr;
   if (store->getRados()->get_obj_state(s, &obj_ctx, s->bucket->get_info(), obj, &state, false, s->yield) < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63049

---

backport of https://github.com/ceph/ceph/pull/53602
parent tracker: https://tracker.ceph.com/issues/62938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh