### PR TITLE
pacific: mgr/dashboard: allow tls 1.2 with a config option

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -35,7 +35,7 @@ from .services.auth import AuthManager, AuthManagerTool, JwtManager
 from .services.exception import dashboard_exception_handler
 from .services.rgw_client import configure_rgw_credentials
 from .services.sso import SSO_COMMANDS, handle_sso_command
-from .settings import handle_option_command, options_command_list, options_schema_list
+from .settings import Settings, handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
     prepare_url_prefix, str_to_bool
 
@@ -180,9 +180,15 @@ class CherryPyConfig(object):
             context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             context.load_cert_chain(cert_fname, pkey_fname)
             if sys.version_info >= (3, 7):
-                context.minimum_version = ssl.TLSVersion.TLSv1_3
+                if Settings.UNSAFE_TLS_v1_2:
+                    context.minimum_version = ssl.TLSVersion.TLSv1_2
+                else:
+                    context.minimum_version = ssl.TLSVersion.TLSv1_3
             else:
-                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
+                if Settings.UNSAFE_TLS_v1_2:
+                    context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                else:
+                    context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
 
             config['server.ssl_module'] = 'builtin'
             config['server.ssl_certificate'] = cert_fname

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -118,6 +118,8 @@ class Options(object):
                                                   'gateway', 'logs', 'crush', 'maps']),
                                         [str])
 
+    UNSAFE_TLS_v1_2 = Setting(False, [bool])
+
     @staticmethod
     def has_default_value(name):
         return getattr(Settings, name, None) is None or \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63070

---

backport of https://github.com/ceph/ceph/pull/53699
parent tracker: https://tracker.ceph.com/issues/62940

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh