### PR TITLE
os/bluestore: Add data segmentation

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6325,6 +6325,15 @@ options:
   desc: How long cleaner should sleep before re-checking utilization
   default: 5
   with_legacy: true
+- name: bluestore_segment_data_size
+  type: uint
+  level: advanced
+  desc: When objects size grows too large BlueStore splits allocation metadata into
+    smaller RocksDB keys (shards). Sometimes when multiple blobs overlap each other
+    some of them must belongs to more then one shards. Its inefficient.
+    Segmentation of data causes blobs to never cross specific lines.
+  default: 0
+  with_legacy: true
 - name: jaeger_tracing_enable
   type: bool
   level: advanced

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3595,6 +3595,7 @@ void BlueStore::ExtentMap::reshard(
     dout(20) << __func__ << "   spanning blob " << p.first << " " << *p.second
 	     << dendl;
   }
+  uint64_t data_reshard_end;
   // determine shard index range
   unsigned si_begin = 0, si_end = 0;
   if (!shards.empty()) {
@@ -3624,7 +3625,11 @@ void BlueStore::ExtentMap::reshard(
   }
 
   fault_range(db, needs_reshard_begin, (needs_reshard_end - needs_reshard_begin));
-
+  if (needs_reshard_end == OBJECT_MAX_SIZE) {
+    data_reshard_end = extent_map.empty() ? needs_reshard_end : extent_map.rbegin()->blob_end();
+  } else {
+    data_reshard_end = needs_reshard_end;
+  }
   // we may need to fault in a larger interval later must have all
   // referring extents for spanning blobs loaded in order to have
   // accurate use_tracker values.
@@ -3661,6 +3666,12 @@ void BlueStore::ExtentMap::reshard(
   dout(20) << __func__ << "  extent_avg " << extent_avg << ", target " << target
 	   << ", slop " << slop << dendl;
 
+  uint32_t data_segment_size = cct->_conf->bluestore_segment_data_size;
+  uint32_t next_boundary = data_segment_size;
+  uint32_t encoded_segment_estimate = /* bytes / ((needs_reshard_end - needs_reshard_begin) / data_segment_size) */
+    bytes * data_segment_size / (data_reshard_end - needs_reshard_begin);
+
+  bool onode_data_has_boundaries = (data_segment_size != 0);
   // reshard
   unsigned estimate = 0;
   unsigned offset = needs_reshard_begin;
@@ -3675,10 +3686,25 @@ void BlueStore::ExtentMap::reshard(
     }
     dout(30) << " extent " << *e << dendl;
 
-    // disfavor shard boundaries that span a blob
-    bool would_span = (e->logical_offset < max_blob_end) || e->blob_offset;
-    if (estimate &&
-	estimate + extent_avg > target + (would_span ? slop : 0)) {
+    bool make_shard_here = false;
+    if (onode_data_has_boundaries) {
+      if (e->blob_start() >= next_boundary) {
+	// this it the place we want to have shard boundary
+	if ((estimate >= target /*we have enough already*/) ||
+	    (estimate + encoded_segment_estimate >= target * 3 / 2)
+	    /*we will be too large if we wait for next segment*/) {
+	  make_shard_here = true;
+	}
+	next_boundary = p2align(e->blob_end() + data_segment_size, data_segment_size);
+      }
+    } else {
+      // disfavor shard boundaries that span a blob
+      bool would_span = (e->logical_offset < max_blob_end) || (e->blob_offset != 0);
+      if (estimate && estimate + extent_avg > target + (would_span ? slop : 0)) {
+	make_shard_here = true;
+      }
+    }
+    if (make_shard_here) {
       // new shard
       if (offset == needs_reshard_begin) {
 	new_shard_info.emplace_back(bluestore_onode_t::shard_info());
@@ -17052,8 +17078,20 @@ void BlueStore::_do_write_data(
     if (head_length) {
       _do_write_small(txc, c, o, head_offset, head_length, p, wctx);
     }
-
-    _do_write_big(txc, c, o, middle_offset, middle_length, p, wctx);
+    uint32_t segment_size = cct->_conf->bluestore_segment_data_size;
+    if (segment_size) {
+      // split data to chunks
+      uint64_t write_offset = middle_offset;
+      while (write_offset < middle_offset + middle_length) {
+	uint64_t segment_end = std::min(
+	  p2roundup<uint64_t>(write_offset + segment_size, segment_size),
+	  middle_offset + middle_length);
+	_do_write_big(txc, c, o, write_offset, segment_end - write_offset, p, wctx);
+	write_offset = segment_end;
+      }
+    } else {
+      _do_write_big(txc, c, o, middle_offset, middle_length, p, wctx);
+    }
 
     if (tail_length) {
       _do_write_small(txc, c, o, tail_offset, tail_length, p, wctx);


### PR DESCRIPTION
Split object data into segments of `conf.bluestore_segment_data_size` bytes. 
This means that no blob will be in two segments at the same time. 
Modified reshard function to prefer segment separation lines. 
As a result no spanning blobs are created.

This was originally a part of improve recompression effort,
but it is enabling manipulation of `conf.bluestore_extent_map_shard_target_size` configurable
even in compressed random write environments without significant performance hit.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
