### PR TITLE
quincy: mgr/dashboard: enable protect option if layering enabled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -141,7 +141,7 @@ export class RbdFormComponent extends CdForm implements OnInit {
         requires: null,
         allowEnable: false,
         allowDisable: false,
-        helperHtml: $localize`Feature can't be manipulated after the image is created`
+        helperHtml: $localize`Feature flag can't be manipulated after the image is created. Disabling this option will also disable the Protect and Clone actions on Snapshot`
       },
       'exclusive-lock': {
         desc: $localize`Exclusive lock`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
@@ -46,7 +46,7 @@ export class RbdSnapshotActionsModel {
       name: actionLabels.PROTECT,
       disable: (selection: CdTableSelection) =>
         this.disableForMirrorSnapshot(selection) ||
-        this.getDisableDesc(selection, this.featuresName)
+        this.getProtectDisableDesc(selection, this.featuresName)
     };
     this.unprotect = {
       permission: 'update',
@@ -60,8 +60,7 @@ export class RbdSnapshotActionsModel {
       permission: 'create',
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
-        this.getDisableDesc(selection, this.featuresName) ||
-        this.disableForMirrorSnapshot(selection),
+        this.getCloneDisableDesc(selection) || this.disableForMirrorSnapshot(selection),
       icon: Icons.clone,
       name: actionLabels.CLONE
     };
@@ -109,19 +108,23 @@ export class RbdSnapshotActionsModel {
     ];
   }
 
-  getDisableDesc(selection: CdTableSelection, featuresName: string[]): boolean | string {
+  getProtectDisableDesc(selection: CdTableSelection, featuresName: string[]): boolean | string {
     if (selection.hasSingleSelection && !selection.first().cdExecuting) {
       if (!featuresName?.includes('layering')) {
         return $localize`The layering feature needs to be enabled on parent image`;
       }
+      return false;
+    }
+    return true;
+  }
 
+  getCloneDisableDesc(selection: CdTableSelection): boolean | string {
+    if (selection.hasSingleSelection && !selection.first().cdExecuting) {
       if (this.cloneFormatVersion === 1 && !selection.first().is_protected) {
         return $localize`Snapshot must be protected in order to clone.`;
       }
-
       return false;
     }
-
     return true;
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -288,7 +288,7 @@ describe('RbdSnapshotListComponent', () => {
 
     it('should be disabled with version 1 and protected false', () => {
       const selection = new CdTableSelection([{ name: 'someName', is_protected: false }]);
-      const disableDesc = actions.getDisableDesc(selection, ['layering']);
+      const disableDesc = actions.getCloneDisableDesc(selection);
       expect(disableDesc).toBe('Snapshot must be protected in order to clone.');
     });
 
@@ -299,7 +299,7 @@ describe('RbdSnapshotListComponent', () => {
     ])('should be enabled with version %d and protected %s', (version, is_protected) => {
       actions.cloneFormatVersion = version;
       const selection = new CdTableSelection([{ name: 'someName', is_protected: is_protected }]);
-      const disableDesc = actions.getDisableDesc(selection, ['layering']);
+      const disableDesc = actions.getCloneDisableDesc(selection);
       expect(disableDesc).toBe(false);
     });
   });
@@ -316,7 +316,7 @@ describe('RbdSnapshotListComponent', () => {
 
     it('should be disabled if layering not supported', () => {
       const selection = new CdTableSelection([{ name: 'someName', is_protected: false }]);
-      const disableDesc = actions.getDisableDesc(selection, ['deep-flatten', 'fast-diff']);
+      const disableDesc = actions.getProtectDisableDesc(selection, ['deep-flatten', 'fast-diff']);
       expect(disableDesc).toBe('The layering feature needs to be enabled on parent image');
     });
   });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63078

---

backport of https://github.com/ceph/ceph/pull/53671
parent tracker: https://tracker.ceph.com/issues/63076

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh