### PR TITLE
RGW/STS: when generating keys, take the trailing null character into account

### DIFF
--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -54,7 +54,7 @@ int Credentials::generateCredentials(const DoutPrefixProvider *dpp,
                           rgw::auth::Identity* identity)
 {
   uuid_d accessKey, secretKey;
-  char accessKeyId_str[MAX_ACCESS_KEY_LEN], secretAccessKey_str[MAX_SECRET_KEY_LEN];
+  char accessKeyId_str[MAX_ACCESS_KEY_LEN + 1], secretAccessKey_str[MAX_SECRET_KEY_LEN + 1];
 
   //AccessKeyId
   gen_rand_alphanumeric_plain(cct, accessKeyId_str, sizeof(accessKeyId_str));


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63085

Otherwise, STS acckey has 19 and secret key has 39 alphanumeric chars.

BEFORE:
<pre>
$ aws --profile second_user --endpoint-url=http://localhost:8000 sts assume-role --role-arn "arn:aws:iam:::role/roleuser1role" --role-session-name test
{
    "Credentials": {
        "AccessKeyId": "8lmDlypSzQlZzw5VM9I",
        "SecretAccessKey": "DZT7MX23YUBX4MY57X4SJDU7BIFFUQ5HLDAAGRO",
        "SessionToken": "/cm3GkS+qVGTll63u+w6vNMkOp/ZFWCtLJrXya9wX8TGyjDH6IHq9ihRtSZT2g4Pzv77VwUT2q4sewtAI3CvO99bUDW4Affpj6FPjb6HXXkuUvftu7OOl0o7jzGsKVZ9Hf0VqZeUxlpkrjAGNv/oRC2zH7GRrwixoDd64tXtexhzBzEIxtjmIsS3Y2hePmf6Z57WP1NcxHBzM/M/Oo4uzd5k3QDc+9jG52wV4l7C0D5MyS3cSiBGJa8h9MtAa0yfu2/PYlxOef9eQ2cIWm6kBrFYhD12HizOgkzHPN3xmQpSeFsvJvv0e1iaodptu+C+",
        "Expiration": "2023-10-03T23:07:07.235836709Z"
    },
    "AssumedRoleUser": {
        "Arn": "arn:aws:sts:::assumed-role/roleuser1role/test"
    },
    "PackedPolicySize": 0
}

$ python3
Python 3.6.8 (default, May 31 2023, 10:28:59)
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> len("8lmDlypSzQlZzw5VM9I")
19
>>> len("DZT7MX23YUBX4MY57X4SJDU7BIFFUQ5HLDAAGRO")
39
>>>
</pre>

AFTER:
<pre>
$ aws --profile second_user --endpoint-url=http://localhost:8000 sts assume-role --role-arn "arn:aws:iam:::role/roleuser1role" --role-session-name test
{
    "Credentials": {
        "AccessKeyId": "fl2nKFzajVn7Nk40XmPc",
        "SecretAccessKey": "G3Z4LJ0M4H1G74KH7TXD9EG2S96TA3IIP5927998",
        "SessionToken": "gjbjaZPho3zV7U7MePc1ySQuTbYVJVSzxvPMSCowc/HhKcCBaLQkT1anZL5zpDgS1plwEw80VkgC6IgWhKi6L8oVLaTDlJXtdnU58j0BRr34F7wY30OMl36nqnbK4xnzOORTdJ5v0gz9nLKxaXPIyCDSFkYYB8sfvK1mZZTwdNg98sSWgdS0/nefvE3hMBSFf6G9ZT305j/VB0waiMnpHklLrBluxAJFR+qid9mXDMJPN2J/OP2WtbKAHOy+ytHkVwvsTEn7i2QBBa+GgM33CcnNEPVK8NjpAqzPRgmOlu/Cc+I+2WSO0uq0h5hVEYXnQJPcfvrojrueBqAzdw5+5w==",
        "Expiration": "2023-10-03T20:57:26.447779382Z"
    },
    "AssumedRoleUser": {
        "Arn": "arn:aws:sts:::assumed-role/roleuser1role/test"
    },
    "PackedPolicySize": 0
}

$ python3
Python 3.6.8 (default, May 31 2023, 10:28:59)
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> len("fl2nKFzajVn7Nk40XmPc")
20
>>> len("G3Z4LJ0M4H1G74KH7TXD9EG2S96TA3IIP5927998")
40
>>>
</pre>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
