### PR TITLE
cephadm: convert more types to be based on ContainerDaemonForm

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -928,7 +928,7 @@ done
 
 
 @register_daemon_form
-class CephNvmeof(DaemonForm):
+class CephNvmeof(ContainerDaemonForm):
     """Defines a Ceph-Nvmeof container"""
 
     daemon_type = 'nvmeof'
@@ -1060,6 +1060,17 @@ class CephNvmeof(DaemonForm):
         return [
             'vm.nr_hugepages = 4096',
         ]
+
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        return get_deployment_container(ctx, self.identity)
+
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        return 167, 167  # TODO: need to get properly the uid/gid
+
+    def config_and_keyring(
+        self, ctx: CephadmContext
+    ) -> Tuple[Optional[str], Optional[str]]:
+        return get_config_and_keyring(ctx)
 
 
 ##################################
@@ -5208,21 +5219,6 @@ def _dispatch_deploy(
             keyring=keyring,
             deployment_type=deployment_type,
             endpoints=daemon_endpoints
-        )
-    elif daemon_type == CephNvmeof.daemon_type:
-        config, keyring = get_config_and_keyring(ctx)
-        uid, gid = 167, 167  # TODO: need to get properly the uid/gid
-        c = get_deployment_container(ctx, ident)
-        deploy_daemon(
-            ctx,
-            ident,
-            c,
-            uid,
-            gid,
-            config=config,
-            keyring=keyring,
-            deployment_type=deployment_type,
-            endpoints=daemon_endpoints,
         )
 
     elif daemon_type == CephadmAgent.daemon_type:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -211,7 +211,6 @@ class ContainerInfo:
 class Ceph(DaemonForm):
     daemons = ('mon', 'mgr', 'osd', 'mds', 'rgw', 'rbd-mirror',
                'crash', 'cephfs-mirror', 'ceph-exporter')
-    gateways = ('iscsi', 'nfs', 'nvmeof')
 
     @classmethod
     def for_daemon_type(cls, daemon_type: str) -> bool:
@@ -2553,7 +2552,11 @@ def get_container(
         envs.append('TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728')
     if container_args is None:
         container_args = []
-    if daemon_type in Ceph.daemons or daemon_type in Ceph.gateways:
+    unlimited_daemons = set(Ceph.daemons)
+    unlimited_daemons.add(CephIscsi.daemon_type)
+    unlimited_daemons.add(CephNvmeof.daemon_type)
+    unlimited_daemons.add(NFSGanesha.daemon_type)
+    if daemon_type in unlimited_daemons:
         set_pids_limit_unlimited(ctx, container_args)
     if daemon_type in ['mon', 'osd']:
         # mon and osd need privileged in order for libudev to query devices

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -728,7 +728,7 @@ class NFSGanesha(ContainerDaemonForm):
 
 
 @register_daemon_form
-class CephIscsi(DaemonForm):
+class CephIscsi(ContainerDaemonForm):
     """Defines a Ceph-Iscsi container"""
 
     daemon_type = 'iscsi'
@@ -922,6 +922,17 @@ done
         tcmu_container.entrypoint = '/usr/local/scripts/tcmu-runner-entrypoint.sh'
         tcmu_container.cname = self.get_container_name(desc='tcmu')
         return tcmu_container
+
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        return get_deployment_container(ctx, self.identity)
+
+    def config_and_keyring(
+        self, ctx: CephadmContext
+    ) -> Tuple[Optional[str], Optional[str]]:
+        return get_config_and_keyring(ctx)
+
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        return extract_uid_gid(ctx)
 
 
 ##################################
@@ -5201,22 +5212,6 @@ def _dispatch_deploy(
             c,
             uid,
             gid,
-            deployment_type=deployment_type,
-            endpoints=daemon_endpoints
-        )
-
-    elif daemon_type == CephIscsi.daemon_type:
-        config, keyring = get_config_and_keyring(ctx)
-        uid, gid = extract_uid_gid(ctx)
-        c = get_deployment_container(ctx, ident)
-        deploy_daemon(
-            ctx,
-            ident,
-            c,
-            uid,
-            gid,
-            config=config,
-            keyring=keyring,
             deployment_type=deployment_type,
             endpoints=daemon_endpoints
         )

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1356,7 +1356,7 @@ class Keepalived(ContainerDaemonForm):
 
 
 @register_daemon_form
-class Tracing(DaemonForm):
+class Tracing(ContainerDaemonForm):
     """Define the configs for the jaeger tracing containers"""
 
     components: Dict[str, Dict[str, Any]] = {
@@ -1403,6 +1403,14 @@ class Tracing(DaemonForm):
     @property
     def identity(self) -> DaemonIdentity:
         return self._identity
+
+    def container(self, ctx: CephadmContext) -> CephContainer:
+        # TODO(jjm) this looks to be the only container for deployment
+        # not using get_deployment_container. Previous oversight?
+        return get_container(ctx, self.identity)
+
+    def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
+        return 65534, 65534
 
 ##################################
 
@@ -5213,18 +5221,6 @@ def _dispatch_deploy(
             gid,
             config=config,
             keyring=keyring,
-            deployment_type=deployment_type,
-            endpoints=daemon_endpoints,
-        )
-    elif daemon_type in Tracing.components:
-        uid, gid = 65534, 65534
-        c = get_container(ctx, ident)
-        deploy_daemon(
-            ctx,
-            ident,
-            c,
-            uid,
-            gid,
             deployment_type=deployment_type,
             endpoints=daemon_endpoints,
         )

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5236,18 +5236,8 @@ def _common_deploy(ctx: CephadmContext) -> None:
 
     # Get and check ports explicitly required to be opened
     endpoints = fetch_endpoints(ctx)
-    _dispatch_deploy(ctx, ident, endpoints, deployment_type)
 
-
-def _dispatch_deploy(
-    ctx: CephadmContext,
-    ident: 'DaemonIdentity',
-    daemon_endpoints: List[EndPoint],
-    deployment_type: DeploymentType,
-) -> None:
-    daemon_type = ident.daemon_type
-
-    if daemon_type == CephadmAgent.daemon_type:
+    if ident.daemon_type == CephadmAgent.daemon_type:
         # get current user gid and uid
         uid = os.getuid()
         gid = os.getgid()
@@ -5258,17 +5248,15 @@ def _dispatch_deploy(
             uid,
             gid,
             deployment_type=deployment_type,
-            endpoints=daemon_endpoints,
+            endpoints=endpoints,
         )
 
     else:
         try:
-            _deploy_daemon_container(
-                ctx, ident, daemon_endpoints, deployment_type
-            )
+            _deploy_daemon_container(ctx, ident, endpoints, deployment_type)
         except UnexpectedDaemonTypeError:
             raise Error('daemon type {} not implemented in command_deploy function'
-                        .format(daemon_type))
+                        .format(ident.daemon_type))
 
 
 def _deploy_daemon_container(

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -423,13 +423,12 @@ class TestCephAdm(object):
         )
 
         def _crush_location_checker(ctx, ident, container, uid, gid, **kwargs):
-            print(container.args)
-            raise Exception(' '.join(container.args))
+            argval = ' '.join(container.args)
+            assert '--set-crush-location database=a' in argval
 
         _deploy_daemon.side_effect = _crush_location_checker
-
-        with pytest.raises(Exception, match='--set-crush-location database=a'):
-            _cephadm.command_deploy_from(ctx)
+        _cephadm.command_deploy_from(ctx)
+        _deploy_daemon.assert_called()
 
     @mock.patch('cephadm.logger')
     @mock.patch('cephadm.fetch_custom_config_files')

--- a/src/cephadm/tests/test_daemon_form.py
+++ b/src/cephadm/tests/test_daemon_form.py
@@ -61,7 +61,7 @@ def test_is_sysctl_daemon_form(dt, is_sdf):
     assert isinstance(inst, daemon_form.SysctlDaemonForm) == is_sdf
 
 
-def test_can_create_all_daemon_forms():
+def test_can_create_all_daemon_forms(monkeypatch):
     uuid = 'daeb985e-58c7-11ee-a536-201e8814f771'
     ctx = mock.MagicMock()
     ctx.config_blobs = {
@@ -69,6 +69,8 @@ def test_can_create_all_daemon_forms():
         'pool': 'swimming',
         'destination': 'earth',
     }
+    _os_path_isdir = mock.MagicMock(return_value=True)
+    monkeypatch.setattr('os.path.isdir', _os_path_isdir)
     dtypes = _cephadm.get_supported_daemons()
     for daemon_type in dtypes:
         if daemon_type == 'agent':

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import unittest
 from unittest import mock
@@ -84,3 +85,57 @@ def test_deploy_snmp_container(cephadm_fs, monkeypatch):
     assert basedir.is_dir()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()
+
+
+def test_deploy_keepalived_container(cephadm_fs, monkeypatch):
+    _call = mock.MagicMock(return_value=('', '', 0))
+    monkeypatch.setattr('cephadmlib.container_types.call', _call)
+    _call_throws = mock.MagicMock(return_value=0)
+    monkeypatch.setattr(
+        'cephadmlib.container_types.call_throws', _call_throws
+    )
+    _firewalld = mock.MagicMock()
+    _firewalld().external_ports.get.return_value = []
+    monkeypatch.setattr('cephadm.Firewalld', _firewalld)
+    _extract_uid_gid = mock.MagicMock()
+    _extract_uid_gid.return_value = (8765, 8765)
+    monkeypatch.setattr('cephadm.extract_uid_gid', _extract_uid_gid)
+    _install_sysctl = mock.MagicMock()
+    monkeypatch.setattr('cephadm.install_sysctl', _install_sysctl)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'keepalived.uiop'
+        ctx.image = 'quay.io/eeranimated/keepalived:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'destination': '192.168.100.10:8899',
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+            'files': {
+                'keepalived.conf': 'neversayneveragain',
+            },
+        }
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/keepalived.uiop')
+    assert basedir.is_dir()
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith('quay.io/eeranimated/keepalived:latest')
+    _firewalld().open_ports.assert_not_called()
+    assert not (basedir / 'config').exists()
+    assert not (basedir / 'keyring').exists()
+    with open(basedir / 'keepalived.conf') as f:
+        assert f.read() == 'neversayneveragain'
+    with open(basedir / 'keepalived.conf') as f:
+        assert f.read() == 'neversayneveragain'
+        si = os.fstat(f.fileno())
+        assert (si.st_uid, si.st_gid) == (8765, 8765)
+    assert (basedir / 'keepalived').is_dir()
+    si = (basedir / 'keepalived').stat()
+    assert (si.st_uid, si.st_gid) == (8765, 8765)
+    assert _install_sysctl.call_count == 1
+    assert len(_install_sysctl.call_args[0][-1].get_sysctl_settings()) > 1

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -223,3 +223,42 @@ def test_deploy_iscsi_container(cephadm_fs, monkeypatch):
         assert f.read() == 'portal'
         si = os.fstat(f.fileno())
         assert (si.st_uid, si.st_gid) == (8765, 8765)
+
+
+def test_deploy_nvmeof_container(cephadm_fs, monkeypatch):
+    mocks = _common_mp(monkeypatch)
+    _firewalld = mocks['Firewalld']
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'nvmeof.andu'
+        ctx.image = 'quay.io/ownf/nmve:latest'
+        ctx.reconfig = False
+        ctx.config_blobs = {
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+            'files': {
+                'ceph-nvmeof.conf': 'icantbeliveitsnotiscsi',
+            },
+        }
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/nvmeof.andu')
+    assert basedir.is_dir()
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith('quay.io/ownf/nmve:latest')
+    _firewalld().open_ports.assert_not_called()
+    with open(basedir / 'config') as f:
+        assert f.read() == 'XXXXXXX'
+    with open(basedir / 'keyring') as f:
+        assert f.read() == 'YYYYYY'
+    assert (basedir / 'configfs').is_dir()
+    si = (basedir / 'configfs').stat()
+    assert (si.st_uid, si.st_gid) == (167, 167)
+    with open(basedir / 'ceph-nvmeof.conf') as f:
+        assert f.read() == 'icantbeliveitsnotiscsi'
+        si = os.fstat(f.fileno())
+        assert (si.st_uid, si.st_gid) == (167, 167)

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -330,3 +330,41 @@ def test_deploy_a_tracing_container(cephadm_fs, monkeypatch):
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()
+
+
+def test_deploy_ceph_mgr_container(cephadm_fs, monkeypatch):
+    mocks = _common_mp(monkeypatch)
+    _firewalld = mocks['Firewalld']
+    _make_var_run = mock.MagicMock()
+    monkeypatch.setattr('cephadm.make_var_run', _make_var_run)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'mgr.foo'
+        ctx.image = 'quay.io/ceph/ceph:latest'
+        ctx.reconfig = False
+        ctx.allow_ptrace = False
+        ctx.osd_fsid = '00000000-0000-0000-0000-000000000000'
+        ctx.config_blobs = {
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+        }
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/mgr.foo')
+    assert basedir.is_dir()
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith(
+        'quay.io/ceph/ceph:latest -n mgr.foo -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false'
+    )
+    _firewalld().open_ports.assert_not_called()
+    with open(basedir / 'config') as f:
+        assert f.read() == 'XXXXXXX'
+    with open(basedir / 'keyring') as f:
+        assert f.read() == 'YYYYYY'
+    assert _make_var_run.call_count == 1
+    assert _make_var_run.call_args[0][2] == 8765
+    assert _make_var_run.call_args[0][3] == 8765

--- a/src/cephadm/tests/test_ingress.py
+++ b/src/cephadm/tests/test_ingress.py
@@ -331,7 +331,7 @@ def test_keepalived_extract_uid_gid_keepalived():
         )
         with mock.patch("cephadm.CephContainer") as cc:
             cc.return_value.run.return_value = "500 500"
-            uid, gid = kad.extract_uid_gid_keepalived()
+            uid, gid = kad.uid_gid(ctx)
             cc.return_value.run.assert_called()
         assert uid == 500
         assert gid == 500

--- a/src/cephadm/tests/test_ingress.py
+++ b/src/cephadm/tests/test_ingress.py
@@ -168,7 +168,7 @@ def test_haproxy_extract_uid_gid_haproxy():
         )
         with mock.patch("cephadm.CephContainer") as cc:
             cc.return_value.run.return_value = "500 500"
-            uid, gid = hap.extract_uid_gid_haproxy()
+            uid, gid = hap.uid_gid(ctx)
             cc.return_value.run.assert_called()
         assert uid == 500
         assert gid == 500


### PR DESCRIPTION
Depends on #53621

Add more test coverage so that the codepath that is being updated gets exercised by the unit test framework. Convert the remaining types that are container based and get deployed by cephadm to be based on ContainerDaemonForm class. Fix issues with the CephExporter class.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactoring
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
