### PR TITLE
quincy: mgr/dashboard: rbd image hide usage bar when disk usage is not provided

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -27,31 +27,6 @@
   </cd-rbd-details>
 </cd-table>
 
-<ng-template #scheduleStatus>
-  <div i18n
-       [innerHtml]="'Only available for RBD images with <strong>fast-diff</strong> enabled'"></div>
-</ng-template>
-
-<ng-template #provisionedNotAvailableTooltipTpl
-             let-row="row">
-  <span *ngIf="row.disk_usage === null && !row.features_name.includes('fast-diff'); else provisioned"
-        [ngbTooltip]="usageNotAvailableTooltipTpl"
-        placement="top"
-        i18n>N/A</span>
-  <ng-template #provisioned
-               i18n>{{row.disk_usage | dimlessBinary}}</ng-template>
-</ng-template>
-
-<ng-template #totalProvisionedNotAvailableTooltipTpl
-             let-row="row">
-  <span *ngIf="row.total_disk_usage === null && !row.features_name.includes('fast-diff'); else totalProvisioned"
-        [ngbTooltip]="usageNotAvailableTooltipTpl"
-        placement="top"
-        i18n>N/A</span>
-  <ng-template #totalProvisioned
-               i18n>{{row.total_disk_usage | dimlessBinary}}</ng-template>
-</ng-template>
-
 <ng-template #parentTpl
              let-value="value">
   <span *ngIf="value">{{ value.pool_name }}<span
@@ -145,10 +120,22 @@
 
 <ng-template #imageUsageTpl
              let-row="row">
-  <cd-usage-bar *ngIf="row"
-                [total]="row.size"
-                [used]="row.disk_usage"
-                [title]="row.name"
-                decimals="2">
+  <span *ngIf="row.features_name && (!row.features_name.includes('fast-diff') || row.mirror_mode === 'snapshot') ; else usageBar"
+        [ngbTooltip]="usageTooltip">
+    <span>-</span>
+  </span>
+  <ng-template #usageBar>
+    <cd-usage-bar *ngIf="row"
+                  [total]="row.size"
+                  [used]="row.disk_usage"
+                  [title]="row.name"
+                  decimals="2">
   </cd-usage-bar>
+  </ng-template>
+
+</ng-template>
+
+<ng-template #usageTooltip>
+  <div i18n
+       [innerHtml]="'Only available for RBD images with <strong>fast-diff</strong> enabled and without snapshot mirroring'"></div>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -63,10 +63,6 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   deleteTpl: TemplateRef<any>;
   @ViewChild('removingStatTpl', { static: true })
   removingStatTpl: TemplateRef<any>;
-  @ViewChild('provisionedNotAvailableTooltipTpl', { static: true })
-  provisionedNotAvailableTooltipTpl: TemplateRef<any>;
-  @ViewChild('totalProvisionedNotAvailableTooltipTpl', { static: true })
-  totalProvisionedNotAvailableTooltipTpl: TemplateRef<any>;
   @ViewChild('forcePromoteConfirmation', { static: true })
   forcePromoteConfirmation: TemplateRef<any>;
   @ViewChild('usedTmpl', { static: true })


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63090

---

backport of https://github.com/ceph/ceph/pull/53746
parent tracker: https://tracker.ceph.com/issues/63037

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh