### PR TITLE
reef: mgr/dashboard: Fix user/bucket count in rgw overview dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -450,11 +450,22 @@ class RgwBucketUi(RgwBucket):
         users_count = 0
         daemon_object = RgwDaemon()
         daemons = json.loads(daemon_object.list())
+        unique_realms = set()
         for daemon in daemons:
-            buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
-            users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
-            users_count += len(users)
-            buckets_count += len(buckets)
+            realm_name = daemon.get('realm_name', None)
+            if realm_name:
+                if realm_name not in unique_realms:
+                    unique_realms.add(realm_name)
+                    buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
+                    users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
+                    users_count += len(users)
+                    buckets_count += len(buckets)
+            else:
+                buckets = json.loads(RgwBucket.list(self, daemon_name=daemon['id']))
+                users = json.loads(RgwUser.list(self, daemon_name=daemon['id']))
+                users_count = len(users)
+                buckets_count = len(buckets)
+
         return {
             'buckets_count': buckets_count,
             'users_count': users_count


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63098

---

backport of https://github.com/ceph/ceph/pull/53642
parent tracker: https://tracker.ceph.com/issues/62964

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh