### PR TITLE
src/ceph-volume/ceph_volume/devices/lvm/listing.py : lvm list filters with vg name

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -153,7 +153,9 @@ class List(object):
         elif arg[0] == '/':
             lv = api.get_lvs_from_path(arg)
         else:
-            lv = [api.get_single_lv(filters={'lv_name': arg.split('/')[1]})]
+            vg_name, lv_name = arg.split('/')
+            lv = [api.get_single_lv(filters={'lv_name': lv_name,
+                                             'vg_name': vg_name})]
 
         report = self.create_report(lv)
 


### PR DESCRIPTION
This PR fix the listing of LVs that have the same name on multiple VG

Setup and prepare are already done properly, only listing was faulty.

Fixes: https://tracker.ceph.com/issues/62320
Signed-off-by: Pierre Lemay <pierre.lemay@gmail.com>