### PR TITLE
RGW/STS: honor configured limits when updating max session duration

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3295,8 +3295,11 @@ options:
   type: uint
   level: advanced
   desc: Session token max duration
-  long_desc: Max duration in seconds for which the session token is valid.
+  long_desc: This option can be used to configure the upper limit of the
+    durationSeconds of temporary credentials returned by 'GetSessionToken'.
   default: 43200
+  see_also:
+  - rgw_sts_min_session_duration
   services:
   - rgw
   with_legacy: true
@@ -3304,10 +3307,14 @@ options:
   type: uint
   level: advanced
   desc: Minimum allowed duration of a session
+  long_desc: This option can be used to configure the lower limit of
+    durationSeconds of temporary credentials returned by 'AssumeRole*' calls.
   default: 900
   services:
   - rgw
   with_legacy: true
+  see_also:
+  - rgw_sts_max_session_duration
 - name: rgw_max_listing_results
   type: uint
   level: advanced

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6922,11 +6922,11 @@ int main(int argc, const char **argv)
       if (ret < 0) {
         return -ret;
       }
+      role->update_max_session_duration(max_session_duration);
       if (!role->validate_max_session_duration(dpp())) {
         ret = -EINVAL;
         return ret;
       }
-      role->update_max_session_duration(max_session_duration);
       ret = role->update(dpp(), null_yield);
       if (ret < 0) {
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6712,7 +6712,8 @@ int main(int argc, const char **argv)
         cerr << "failed to parse policy: " << e.what() << std::endl;
         return -EINVAL;
       }
-      std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(role_name, tenant, path, assume_role_doc);
+      std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(role_name, tenant, path,
+                                                                 assume_role_doc, max_session_duration);
       ret = role->create(dpp(), true, "", null_yield);
       if (ret < 0) {
         return -ret;

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -1005,12 +1005,12 @@ void RGWUpdateRole::execute(optional_yield y)
     }
   }
 
+  _role->update_max_session_duration(max_session_duration);
   if (!_role->validate_max_session_duration(this)) {
     op_ret = -EINVAL;
     return;
   }
 
-  _role->update_max_session_duration(max_session_duration);
   op_ret = _role->update(this, y);
 
   s->formatter->open_object_section("UpdateRoleResponse");


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/63109

### BEFORE

Creating a role uses the default 3600 sec as the session duration.

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role create --role-name=myrole --assume-role-policy-doc="{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
{
    "RoleId": "454b3f8d-3230-457f-9cc2-bb8811382a9c",
    "RoleName": "myrole",
    "Path": "/",
    "Arn": "arn:aws:iam:::role/myrole",
    "CreateDate": "2023-10-04T02:23:57.110Z",
    "MaxSessionDuration": 3600,
    "AssumeRolePolicyDocument": "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
}
</pre>

#### User can set a higher than allowed limit

Although hard-coded (and configured) limit is set to 43200, a user can set the limit higher than that:

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role update  --role-name=myrole  --max_session_duration=100000
Max session duration updated successfully for role: myrole
</pre>

Subsequent updates over that limit fails, though but user already breached the limit. The problem is role-creation and role-update uses the same validation codepath and role-update wrongly uses current session duration value (3600 in this case) rather than the new value (100K) for validation.

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role update  --role-name=myrole  --max_session_duration=99000
2023-10-03T22:27:23.462-0400 7fb27678c780  0 ERROR: Invalid session duration, should be between 900 and 43200 seconds
</pre>

#### Role creation doesn't honor --max_session_duration option

"role creation" doesn't honor the option --max_session_duration when it's valid:

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role create  --role-name=myrole --max-session-duration=43200 --path=/ --assume-role-policy-doc="{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser1\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
{
    "RoleId": "015ef813-5c6b-47c4-98c7-5926bef7e356",
    "RoleName": "myrole",
    "Path": "/",
    "Arn": "arn:aws:iam:::role/myrole",
    "CreateDate": "2023-10-07T01:39:41.379Z",
    "MaxSessionDuration": 3600,
    "AssumeRolePolicyDocument": "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser1\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
}
</pre>

Although "43200" is given, role still uses the default "3600".

### AFTER

With the fix:

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role create --role-name=myrole --assume-role-policy-doc="{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
{
    "RoleId": "bc660f5b-1d39-4c90-ace2-e576536f1a3d",
    "RoleName": "myrole",
    "Path": "/",
    "Arn": "arn:aws:iam:::role/myrole",
    "CreateDate": "2023-10-04T03:25:31.797Z",
    "MaxSessionDuration": 3600,
    "AssumeRolePolicyDocument": "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
}
</pre>

We now don't allow going over the limit.

<pre>
$ ./bin/radosgw-admin -c ./ceph.conf role update  --role-name=myrole  --max_session_duration=100000
2023-10-03T23:25:47.425-0400 7faa6e886780  0 ERROR: Invalid session duration 100000, should be between 900 and 43200 seconds
</pre>

Moreover, we can also now honor the max_session_duration option when creating the role:

<pre>
]$ ./bin/radosgw-admin -c ./ceph.conf role create  --role-name=myrole --max-session-duration=100000 --path=/ --assume-role-policy-doc="{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser1\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
2023-10-06T21:38:44.012-0400 7f1a77cb7780  0 ERROR: Invalid session duration, should be between 3600 and 43200 seconds

$ ./bin/radosgw-admin -c ./ceph.conf role create  --role-name=myrole --max-session-duration=43200 --path=/ --assume-role-policy-doc="{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser1\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
{
    "RoleId": "015ef813-5c6b-47c4-98c7-5926bef7e356",
    "RoleName": "myrole",
    "Path": "/",
    "Arn": "arn:aws:iam:::role/myrole",
    "CreateDate": "2023-10-07T01:39:41.379Z",
    "MaxSessionDuration": 43200,
    "AssumeRolePolicyDocument": "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/myuser1\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
</pre>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
