### PR TITLE
quincy: mds: disable delegating inode ranges to clients

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -51,6 +51,9 @@
   For multi-site deployments that make any use of Server-Side Encryption, we
   recommended running this command against every bucket in every zone after all
   zones have upgraded.
+CephFS: Disallow delegating preallocated inode ranges to clients. Config
+  `mds_client_delegate_inos_pct` defaults to 0 which disables async dirops
+  in the kclient.
 
 >=18.0.0
 

--- a/qa/suites/fs/workload/delegate_inos/default.yaml
+++ b/qa/suites/fs/workload/delegate_inos/default.yaml
@@ -1,0 +1,1 @@
+# Use default (0)

--- a/qa/suites/fs/workload/delegate_inos/enabled.yaml
+++ b/qa/suites/fs/workload/delegate_inos/enabled.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      mds:
+        mds_client_delegate_inos_pct: 50

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -445,7 +445,7 @@ options:
   type: uint
   level: advanced
   desc: percentage of preallocated inos to delegate to client
-  default: 50
+  default: 0
   services:
   - mds
   flags:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63111

---

backport of https://github.com/ceph/ceph/pull/53836
parent tracker: https://tracker.ceph.com/issues/63103

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh