### PR TITLE
rgw: fix http error checks in keystone/barbican/vault clients

### DIFF
--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -307,15 +307,16 @@ protected:
     }
 
     res = secret_req.process(y);
-    if (res < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: Request to Vault failed with error " << res << dendl;
-      return res;
-    }
 
+    // map 401 to EACCES instead of EPERM
     if (secret_req.get_http_status() ==
         RGWHTTPTransceiver::HTTP_STATUS_UNAUTHORIZED) {
       ldpp_dout(dpp, 0) << "ERROR: Vault request failed authorization" << dendl;
       return -EACCES;
+    }
+    if (res < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: Request to Vault failed with error " << res << dendl;
+      return res;
     }
 
     ldpp_dout(dpp, 20) << "Request to Vault returned " << res << " and HTTP status "
@@ -937,12 +938,13 @@ static int request_key_from_barbican(const DoutPrefixProvider *dpp,
   secret_req.append_header("X-Auth-Token", barbican_token);
 
   res = secret_req.process(y);
-  if (res < 0) {
-    return res;
-  }
+  // map 401 to EACCES instead of EPERM
   if (secret_req.get_http_status() ==
       RGWHTTPTransceiver::HTTP_STATUS_UNAUTHORIZED) {
     return -EACCES;
+  }
+  if (res < 0) {
+    return res;
   }
 
   if (secret_req.get_http_status() >=200 &&


### PR DESCRIPTION
when `RGWHTTPManager` encounters an http error, it uses `rgw_http_error_to_errno()` to map that to a negative posix error code. `RGWHTTPClient::process()` returns that mapped error code, and exposes the original http error via `get_http_status()`

the http client code for keystone, barbican, and vault were returning early on the errors from `process()`, so weren't getting to the http error checks

these clients now check for specific http errors before testing the result of `process()`

Fixes: https://tracker.ceph.com/issues/62989

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
