### PR TITLE
reef: mds/FSMap: allow upgrades if no up mds

### DIFF
--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -205,8 +205,16 @@ public:
   void print(std::ostream& out) const;
 
   bool is_upgradeable() const {
-    return (mds_map.allows_standby_replay() && mds_map.get_num_in_mds() == 0)
-       || (!mds_map.allows_standby_replay() && mds_map.get_num_in_mds() <= 1);
+    bool asr = mds_map.allows_standby_replay();
+    auto in_mds = mds_map.get_num_in_mds();
+    auto up_mds = mds_map.get_num_up_mds();
+    return
+              /* fs was "down" */
+              (in_mds == 0)
+              /* max_mds was set to 1; asr must be disabled */
+           || (!asr && in_mds == 1)
+              /* max_mds any value and all MDS were failed; asr must be disabled */
+           || (!asr && up_mds == 0);
   }
 
   /**


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63082

---

backport of https://github.com/ceph/ceph/pull/53600
parent tracker: https://tracker.ceph.com/issues/62682

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh