### PR TITLE
quincy: qa/workunits: fix test_dashboard_e2e.sh: no spec files found

### DIFF
--- a/qa/workunits/cephadm/test_dashboard_e2e.sh
+++ b/qa/workunits/cephadm/test_dashboard_e2e.sh
@@ -96,12 +96,12 @@ ceph dashboard ac-user-set-password admin -i "${DASHBOARD_ADMIN_SECRET_FILE}" --
 # See /ceph/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/ folder.
 find cypress # List all specs
 
-cypress_run "orchestrator/01-hosts.e2e-spec.ts"
+cypress_run "cypress/e2e/orchestrator/01-hosts.e2e-spec.ts"
 
 # Hosts are removed and added in the previous step. Do a refresh again.
 ceph orch device ls --refresh
 sleep 10
 ceph orch device ls --format=json | tee cypress/fixtures/orchestrator/inventory.json
 
-cypress_run "orchestrator/03-inventory.e2e-spec.ts"
-cypress_run "orchestrator/04-osds.e2e-spec.ts" 300000
+cypress_run "cypress/e2e/orchestrator/03-inventory.e2e-spec.ts"
+cypress_run "cypress/e2e/orchestrator/04-osds.e2e-spec.ts" 300000


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63119

---

backport of https://github.com/ceph/ceph/pull/51955
parent tracker: https://tracker.ceph.com/issues/61578

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh