### PR TITLE
reef: osd: fix: slow scheduling when item_cost is large

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -340,8 +340,7 @@ uint32_t mClockScheduler::calc_scaled_cost(int item_cost)
       item_cost));
   auto cost_per_io = static_cast<uint32_t>(osd_bandwidth_cost_per_io);
 
-  // Calculate total scaled cost in bytes
-  return cost_per_io + cost;
+  return std::max<uint32_t>(cost, cost_per_io);
 }
 
 void mClockScheduler::update_configuration()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63125

---

backport of https://github.com/ceph/ceph/pull/53417
parent tracker: https://tracker.ceph.com/issues/62812

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh