### PR TITLE
mgr/cephadm: fix upgrades with nvmeof

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -9,7 +9,7 @@ from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.utils import ceph_release_to_major, name_to_config_section, CEPH_UPGRADE_ORDER, \
-    MONITORING_STACK_TYPES, CEPH_TYPES, GATEWAY_TYPES
+    CEPH_TYPES, NON_CEPH_IMAGE_TYPES, GATEWAY_TYPES
 from cephadm.ssh import HostConnectionError
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 
@@ -398,7 +398,7 @@ class CephadmUpgrade:
         # in order for the user's selection of daemons to upgrade to be valid. for example,
         # if they say --daemon-types 'osd,mds' but mons have not been upgraded, we block.
         daemons = [d for d in self.mgr.cache.get_daemons(
-        ) if d.daemon_type not in MONITORING_STACK_TYPES]
+        ) if d.daemon_type not in NON_CEPH_IMAGE_TYPES]
         err_msg_base = 'Cannot start upgrade. '
         # "dtypes" will later be filled in with the types of daemons that will be upgraded with the given parameters
         dtypes = []
@@ -767,7 +767,7 @@ class CephadmUpgrade:
             if (
                 (self.mgr.use_repo_digest and d.matches_digests(target_digests))
                 or (not self.mgr.use_repo_digest and d.matches_image_name(target_name))
-                or (d.daemon_type in MONITORING_STACK_TYPES)
+                or (d.daemon_type in NON_CEPH_IMAGE_TYPES)
             ):
                 logger.debug('daemon %s.%s on correct image' % (
                     d.daemon_type, d.daemon_id))
@@ -1162,7 +1162,7 @@ class CephadmUpgrade:
                 # and monitoring stack daemons. Additionally, this case is only valid if
                 # the active mgr is already upgraded.
                 if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
-                    if daemon_type not in MONITORING_STACK_TYPES and daemon_type != 'mgr':
+                    if daemon_type not in NON_CEPH_IMAGE_TYPES and daemon_type != 'mgr':
                         continue
                 else:
                     self._mark_upgrade_complete()
@@ -1175,8 +1175,8 @@ class CephadmUpgrade:
             upgraded_daemon_count += done
             self._update_upgrade_progress(upgraded_daemon_count / len(daemons))
 
-            # make sure mgr and monitoring stack daemons are properly redeployed in staggered upgrade scenarios
-            if daemon_type == 'mgr' or daemon_type in MONITORING_STACK_TYPES:
+            # make sure mgr and non-ceph-image daemons are properly redeployed in staggered upgrade scenarios
+            if daemon_type == 'mgr' or daemon_type in NON_CEPH_IMAGE_TYPES:
                 if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
                     need_upgrade_names = [d[0].name() for d in need_upgrade] + \
                         [d[0].name() for d in need_upgrade_deployer]

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -33,6 +33,11 @@ CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
 # these daemon types use the ceph container image
 CEPH_IMAGE_TYPES = CEPH_TYPES + ['iscsi', 'nfs']
 
+# these daemons do not use the ceph image. There are other daemons
+# that also don't use the ceph image, but we only care about those
+# that are part of the upgrade order here
+NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof']
+
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter
 cephadmNoImage = CephadmNoImage.token
 


### PR DESCRIPTION
Currently, nvmeof was being treated as if it used
a ceph image during upgrades. This would cause logging of messages like (I've removed the nvmeof daemon id)
```
log [WRN] :     Upgrade daemon: nvmeof.<id>: Cannot redeploy
nvmeof.<id> with a new image: Supported types are: mgr, mon,
crash, osd, mds, rgw, rbd-mirror, cephfs-mirror, ceph-exporter,
iscsi, nfs
```
and if you had set a custom image for the
mgr/cephadm/container_image_nvmeof setting, this would be undone as part of the upgrade process.

Fixes: https://tracker.ceph.com/issues/63127





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
