### PR TITLE
reef: mgr/cephadm: don't use image tag in orch upgrade ls

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -267,6 +267,9 @@ class CephadmUpgrade:
         if not image:
             image = self.mgr.container_image_base
         reg_name, bare_image = image.split('/', 1)
+        if ':' in bare_image:
+            # for our purposes, we don't want to use the tag here
+            bare_image = bare_image.split(':')[0]
         reg = Registry(reg_name)
         (current_major, current_minor, _) = self._get_current_version()
         versions = []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62795

---

backport of https://github.com/ceph/ceph/pull/53252
parent tracker: https://tracker.ceph.com/issues/62679

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh