### PR TITLE
reef: mgr/cephadm: removing double quotes from the generated nvmeof config

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -30,5 +30,5 @@ transports = {{ spec.transports }}
 transport_tcp_options = {{ transport_tcp_options }}
 {% endif %}
 {% if spec.tgt_cmd_extra_args %}
-tgt_cmd_extra_args = {{ spec.tgt_cmd_extra_args | tojson }}
+tgt_cmd_extra_args = {{ spec.tgt_cmd_extra_args }}
 {% endif %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -361,6 +361,7 @@ class TestNVMEOFService:
 
         nvmeof_daemon_id = 'testpool.test.qwert'
         pool = 'testpool'
+        tgt_cmd_extra_args = '--cpumask=0xFF --msg-mempool-size=524288'
         default_port = 5500
         group = 'mygroup'
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
@@ -394,10 +395,12 @@ timeout = 60
 log_level = WARN
 conn_retries = 10
 transports = tcp
-transport_tcp_options = {{"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7}}\n"""
+transport_tcp_options = {{"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7}}
+tgt_cmd_extra_args = {tgt_cmd_extra_args}\n"""
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, NvmeofServiceSpec(service_id=pool,
+                                                                tgt_cmd_extra_args=tgt_cmd_extra_args,
                                                                 group=group,
                                                                 pool=pool)):
                 _run_cephadm.assert_called_with(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62960

---

backport of https://github.com/ceph/ceph/pull/53575
parent tracker: https://tracker.ceph.com/issues/62838

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh