### PR TITLE
test/rgw: don't compile POSIX test unless enabled

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -316,13 +316,15 @@ target_link_libraries(radosgw-cr-test ${rgw_libs} librados
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   GTest::GTest)
 
-# unittest_posix_bucket_cache
-add_executable(unittest_posix_bucket_cache
-	test_posix_bucket_cache.cc)
-add_ceph_unittest(unittest_posix_bucket_cache)
-target_compile_definitions(unittest_posix_bucket_cache PUBLIC LMDB_SAFE_NO_CPP_UTILITIES)
-target_include_directories(unittest_posix_bucket_cache
-  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
-  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/driver/posix")
-target_link_libraries(unittest_posix_bucket_cache  ${UNITTEST_LIBS}
-  ${rgw_libs} ${LMDB_LIBRARIES})
+if(WITH_RADOSGW_POSIX)
+  # unittest_posix_bucket_cache
+  add_executable(unittest_posix_bucket_cache
+          test_posix_bucket_cache.cc)
+  add_ceph_unittest(unittest_posix_bucket_cache)
+  target_compile_definitions(unittest_posix_bucket_cache PUBLIC LMDB_SAFE_NO_CPP_UTILITIES)
+  target_include_directories(unittest_posix_bucket_cache
+    SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+    SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/driver/posix")
+  target_link_libraries(unittest_posix_bucket_cache  ${UNITTEST_LIBS}
+    ${rgw_libs} ${LMDB_LIBRARIES})
+endif(WITH_RADOSGW_POSIX)


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
