### PR TITLE
quincy: qa/rgw: add new POOL_APP_NOT_ENABLED failures to log-ignorelist

### DIFF
--- a/qa/rgw/ignore-pg-availability.yaml
+++ b/qa/rgw/ignore-pg-availability.yaml
@@ -1,9 +1,11 @@
 # https://tracker.ceph.com/issues/45802
 # https://tracker.ceph.com/issues/51282
 # https://tracker.ceph.com/issues/61168
+# https://tracker.ceph.com/issues/62504
 overrides:
   ceph:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
     - \(POOL_APP_NOT_ENABLED\)
+    - not have an application enabled

--- a/qa/rgw/ignore-pg-availability.yaml
+++ b/qa/rgw/ignore-pg-availability.yaml
@@ -1,7 +1,9 @@
 # https://tracker.ceph.com/issues/45802
 # https://tracker.ceph.com/issues/51282
+# https://tracker.ceph.com/issues/61168
 overrides:
   ceph:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
+    - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rgw/cloud-transition/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/cloud-transition/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/hadoop-s3a/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/hadoop-s3a/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/lifecycle/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/lifecycle/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/notifications/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/notifications/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/tempest/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/tempest/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/thrash/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/thrash/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/tools/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/tools/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml

--- a/qa/suites/rgw/website/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/website/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62743

---

backport of https://github.com/ceph/ceph/pull/53074
parent tracker: https://tracker.ceph.com/issues/62504

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh