### PR TITLE
qa/suites/upgrade: fix env indentation in stress-split upgrade tests

### DIFF
--- a/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"


### PR DESCRIPTION
This is an issue with the stress-split yaml files, as introduced in https://github.com/ceph/ceph/pull/51889.

The stress-split tests have an incorrectly-intented "env" section, which teuthology detects as an entry for "clients".

Fixes: https://tracker.ceph.com/issues/63158





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
