### PR TITLE
quincy: qa: Wait for purge to complete

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -668,14 +668,16 @@ class TestVolumes(TestVolumesHelper):
         subvolname = self._generate_random_subvolume_name()
         # create subvolume
         self._fs_cmd("subvolume", "create", self.volname, subvolname, "--mode=777")
-        # create 3K files of 0.1MB
-        self._do_subvolume_io(subvolname, number_of_files=3000, file_size=0.1)
+        # create 3K zero byte files
+        self._do_subvolume_io(subvolname, number_of_files=3000, file_size=0)
         # Delete the subvolume
         self._fs_cmd("subvolume", "rm", self.volname, subvolname)
         # get volume metadata
         vol_info = json.loads(self._get_volume_info(self.volname))
         self.assertNotEqual(vol_info['pending_subvolume_deletions'], 0,
                             "pending_subvolume_deletions should be 1")
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
 
     def test_volume_info_without_subvolumegroup(self):
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62404

backport of https://github.com/ceph/ceph/pull/52940
parent tracker: https://tracker.ceph.com/issues/62278

