### PR TITLE
reef: qa/suites/upgrade: fix env indentation in stress-split upgrade tests

### DIFF
--- a/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/2-first-half-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ first-half-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"

--- a/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/3-stress-tasks/rbd_api.yaml
@@ -7,6 +7,6 @@ stress-tasks:
      clients:
         client.0:
            - rbd/test_librbd.sh
-        env:
-          RBD_FEATURES: "61"
+     env:
+       RBD_FEATURES: "61"
 - print: "**** done rbd/test_librbd.sh 7-workload"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63168

---

backport of https://github.com/ceph/ceph/pull/53900
parent tracker: https://tracker.ceph.com/issues/63158

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh