### PR TITLE
reef: mgr/cephadm: fix upgrades with nvmeof

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -9,7 +9,7 @@ from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.utils import ceph_release_to_major, name_to_config_section, CEPH_UPGRADE_ORDER, \
-    MONITORING_STACK_TYPES, CEPH_TYPES, GATEWAY_TYPES
+    CEPH_TYPES, NON_CEPH_IMAGE_TYPES, GATEWAY_TYPES
 from cephadm.ssh import HostConnectionError
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 
@@ -395,7 +395,7 @@ class CephadmUpgrade:
         # in order for the user's selection of daemons to upgrade to be valid. for example,
         # if they say --daemon-types 'osd,mds' but mons have not been upgraded, we block.
         daemons = [d for d in self.mgr.cache.get_daemons(
-        ) if d.daemon_type not in MONITORING_STACK_TYPES]
+        ) if d.daemon_type not in NON_CEPH_IMAGE_TYPES]
         err_msg_base = 'Cannot start upgrade. '
         # "dtypes" will later be filled in with the types of daemons that will be upgraded with the given parameters
         dtypes = []
@@ -764,7 +764,7 @@ class CephadmUpgrade:
             if (
                 (self.mgr.use_repo_digest and d.matches_digests(target_digests))
                 or (not self.mgr.use_repo_digest and d.matches_image_name(target_name))
-                or (d.daemon_type in MONITORING_STACK_TYPES)
+                or (d.daemon_type in NON_CEPH_IMAGE_TYPES)
             ):
                 logger.debug('daemon %s.%s on correct image' % (
                     d.daemon_type, d.daemon_id))
@@ -1171,7 +1171,7 @@ class CephadmUpgrade:
                 # and monitoring stack daemons. Additionally, this case is only valid if
                 # the active mgr is already upgraded.
                 if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
-                    if daemon_type not in MONITORING_STACK_TYPES and daemon_type != 'mgr':
+                    if daemon_type not in NON_CEPH_IMAGE_TYPES and daemon_type != 'mgr':
                         continue
                 else:
                     self._mark_upgrade_complete()
@@ -1184,8 +1184,8 @@ class CephadmUpgrade:
             upgraded_daemon_count += done
             self._update_upgrade_progress(upgraded_daemon_count / len(daemons))
 
-            # make sure mgr and monitoring stack daemons are properly redeployed in staggered upgrade scenarios
-            if daemon_type == 'mgr' or daemon_type in MONITORING_STACK_TYPES:
+            # make sure mgr and non-ceph-image daemons are properly redeployed in staggered upgrade scenarios
+            if daemon_type == 'mgr' or daemon_type in NON_CEPH_IMAGE_TYPES:
                 if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
                     need_upgrade_names = [d[0].name() for d in need_upgrade] + \
                         [d[0].name() for d in need_upgrade_deployer]

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -33,6 +33,11 @@ CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
 # these daemon types use the ceph container image
 CEPH_IMAGE_TYPES = CEPH_TYPES + ['iscsi', 'nfs']
 
+# these daemons do not use the ceph image. There are other daemons
+# that also don't use the ceph image, but we only care about those
+# that are part of the upgrade order here
+NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof']
+
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter
 cephadmNoImage = CephadmNoImage.token
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63169

---

backport of https://github.com/ceph/ceph/pull/53862
parent tracker: https://tracker.ceph.com/issues/63127

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh