### PR TITLE
reef: crimson/os/seastore: enable SMR HDD

### DIFF
--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -61,7 +61,7 @@ CMAKE_DEPENDENT_OPTION(WITH_ZNS "enable Linux ZNS support" OFF
 if(WITH_ZNS)
   find_package(LinuxZNS REQUIRED)
   list(APPEND crimson_seastore_srcs
-    segment_manager/zns.cc)
+    segment_manager/zbd.cc)
 endif()
 
 add_library(crimson-seastore STATIC

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -779,8 +779,8 @@ device_type_t string_to_device_type(std::string type) {
   if (type == "SSD") {
     return device_type_t::SSD;
   }
-  if (type == "ZNS") {
-    return device_type_t::ZNS;
+  if (type == "ZBD") {
+    return device_type_t::ZBD;
   }
   if (type == "RANDOM_BLOCK_SSD") {
     return device_type_t::RANDOM_BLOCK_SSD;
@@ -797,8 +797,8 @@ std::ostream& operator<<(std::ostream& out, device_type_t t)
     return out << "HDD";
   case device_type_t::SSD:
     return out << "SSD";
-  case device_type_t::ZNS:
-    return out << "ZNS";
+  case device_type_t::ZBD:
+    return out << "ZBD";
   case device_type_t::EPHEMERAL_COLD:
     return out << "EPHEMERAL_COLD";
   case device_type_t::EPHEMERAL_MAIN:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -882,7 +882,7 @@ enum class device_type_t : uint8_t {
   NONE = 0,
   HDD,
   SSD,
-  ZBD,
+  ZBD,            // ZNS SSD or SMR HDD
   EPHEMERAL_COLD,
   EPHEMERAL_MAIN,
   RANDOM_BLOCK_SSD,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -882,7 +882,7 @@ enum class device_type_t : uint8_t {
   NONE = 0,
   HDD,
   SSD,
-  ZNS,
+  ZBD,
   EPHEMERAL_COLD,
   EPHEMERAL_MAIN,
   RANDOM_BLOCK_SSD,
@@ -896,7 +896,7 @@ bool can_delay_allocation(device_type_t type);
 device_type_t string_to_device_type(std::string type);
 
 enum class backend_type_t {
-  SEGMENTED,    // SegmentManager: SSD, ZNS, HDD
+  SEGMENTED,    // SegmentManager: SSD, ZBD, HDD
   RANDOM_BLOCK  // RBMDevice:      RANDOM_BLOCK_SSD
 };
 

--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -6,7 +6,7 @@
 #include "crimson/os/seastore/logging.h"
 
 #ifdef HAVE_ZNS
-#include "crimson/os/seastore/segment_manager/zns.h"
+#include "crimson/os/seastore/segment_manager/zbd.h"
 SET_SUBSYS(seastore_device);
 #endif
 
@@ -79,7 +79,7 @@ LOG_PREFIX(SegmentManager::get_segment_manager);
 	INFO("Found {} zones.", nr_zones);
 	if (nr_zones != 0) {
 	  return std::make_unique<
-	    segment_manager::zns::ZNSSegmentManager
+	    segment_manager::zbd::ZBDSegmentManager
 	    >(device + "/block");
 	} else {
 	  return std::make_unique<

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -153,7 +153,7 @@ public:
    * advance_wp
    *
    * advance the segment write pointer,
-   * needed when writing at wp is strictly implemented. ex: ZNS backed segments
+   * needed when writing at wp is strictly implemented. ex: ZBD backed segments
    * @param offset: advance write pointer till the given offset
    */
   virtual write_ertr::future<> advance_wp(


### PR DESCRIPTION
backport of: #51355
See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh