### PR TITLE
reef: crimson/osd: add embedded suppression ruleset for LSan

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(crimson-osd
   backfill_state.cc
   ec_backend.cc
   heartbeat.cc
+  lsan_suppressions.cc
   main.cc
   main_config_bootstrap_helpers.cc
   osd.cc

--- a/src/crimson/osd/lsan_suppressions.cc
+++ b/src/crimson/osd/lsan_suppressions.cc
@@ -1,0 +1,18 @@
+#ifndef _NDEBUG
+// The callbacks we define here will be called from the sanitizer runtime, but
+// aren't referenced from the Chrome executable. We must ensure that those
+// callbacks are not sanitizer-instrumented, and that they aren't stripped by
+// the linker.
+#define SANITIZER_HOOK_ATTRIBUTE                                           \
+  extern "C"                                                               \
+  __attribute__((no_sanitize("address", "thread", "undefined")))           \
+  __attribute__((visibility("default")))                                   \
+  __attribute__((used))
+
+static char kLSanDefaultSuppressions[] =
+  "leak:InitModule\n";
+
+SANITIZER_HOOK_ATTRIBUTE const char *__lsan_default_suppressions() {
+  return kLSanDefaultSuppressions;
+}
+#endif // ! _NDEBUG


### PR DESCRIPTION
Backport of: #50598
See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh