### PR TITLE
reef: crimson/os/seastore: fix ceph_assert in segment_manager.h

### DIFF
--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -63,18 +63,26 @@ SegmentManager::get_segment_manager(
 LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::do_with(
     static_cast<size_t>(0),
-    [&](auto &nr_zones) {
+    [FNAME,
+     dtype,
+     device](auto &nr_zones) {
       return seastar::open_file_dma(
 	device + "/block",
 	seastar::open_flags::rw
-      ).then([&](auto file) {
+      ).then([FNAME,
+	      dtype,
+	      device,
+	      &nr_zones](auto file) {
 	return seastar::do_with(
 	  file,
-	  [=, &nr_zones](auto &f) -> seastar::future<int> {
+	  [&nr_zones](auto &f) -> seastar::future<int> {
 	    ceph_assert(f);
 	    return f.ioctl(BLKGETNRZONES, (void *)&nr_zones);
 	  });
-      }).then([&](auto ret) -> crimson::os::seastore::SegmentManagerRef {
+      }).then([FNAME,
+	       dtype,
+	       device,
+	       &nr_zones](auto ret) -> crimson::os::seastore::SegmentManagerRef {
 	crimson::os::seastore::SegmentManagerRef sm;
 	INFO("Found {} zones.", nr_zones);
 	if (nr_zones != 0) {


### PR DESCRIPTION
Backport of: #51475
See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1


this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh