### PR TITLE
reef: crimson/os/seastore/backref_manager: scan backref entries by journal seq

### DIFF
--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -397,34 +397,37 @@ BtreeBackrefManager::scan_mapped_space(
       );
     }).si_then([this, &scan_visitor, c, FNAME, block_size] {
       // traverse alloc-deltas in order
-      auto &backref_entry_mset = cache.get_backref_entry_mset();
-      DEBUGT("scan {} backref entries", c.trans, backref_entry_mset.size());
-      for (auto &backref_entry : backref_entry_mset) {
-	if (backref_entry.laddr == L_ADDR_NULL) {
-	  TRACET("backref entry {}~{} {} free",
-		 c.trans,
-		 backref_entry.paddr,
-		 backref_entry.len,
-		 backref_entry.type);
-	} else {
-	  TRACET("backref entry {}~{} {}~{} {} used",
-		 c.trans,
-		 backref_entry.paddr,
-		 backref_entry.len,
-		 backref_entry.laddr,
-		 backref_entry.len,
-		 backref_entry.type);
-	}
-	ceph_assert(backref_entry.paddr.is_absolute());
-	ceph_assert(backref_entry.len > 0 &&
-		    backref_entry.len % block_size == 0);
-	ceph_assert(!is_backref_node(backref_entry.type));
-	scan_visitor(
-	    backref_entry.paddr,
+      auto &backref_entryrefs = cache.get_backref_entryrefs_by_seq();
+      for (auto &[seq, refs] : backref_entryrefs) {
+	boost::ignore_unused(seq);
+	DEBUGT("scan {} backref entries", c.trans, refs.size());
+	for (auto &backref_entry : refs) {
+	  if (backref_entry->laddr == L_ADDR_NULL) {
+	    TRACET("backref entry {}~{} {} free",
+		   c.trans,
+		   backref_entry->paddr,
+		   backref_entry->len,
+		   backref_entry->type);
+	  } else {
+	    TRACET("backref entry {}~{} {}~{} {} used",
+		   c.trans,
+		   backref_entry->paddr,
+		   backref_entry->len,
+		   backref_entry->laddr,
+		   backref_entry->len,
+		   backref_entry->type);
+	  }
+	  ceph_assert(backref_entry->paddr.is_absolute());
+	  ceph_assert(backref_entry->len > 0 &&
+		      backref_entry->len % block_size == 0);
+	  ceph_assert(!is_backref_node(backref_entry->type));
+	  scan_visitor(
+	    backref_entry->paddr,
 	    P_ADDR_NULL,
-	    backref_entry.len,
-	    backref_entry.type,
-	    backref_entry.laddr);
+	    backref_entry->len,
+	    backref_entry->type,
+	    backref_entry->laddr);
+	}
       }
     }).si_then([this, &scan_visitor, block_size, c, FNAME] {
       BackrefBtree::mapped_space_visitor_t f =


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/51750
See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh