### PR TITLE
reef: crimson/osd/heartbeat: Improve maybe_share_osdmap behavior

### DIFF
--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -311,25 +311,25 @@ seastar::future<> Heartbeat::maybe_share_osdmap(
   auto& peer = found->second;
 
   if (m->map_epoch > peer.get_projected_epoch()) {
-    logger().debug("{} updating session's projected_epoch"
-                   "from {} to peer's (id: {}) map epoch of {}",
-                   __func__, peer.get_projected_epoch(),
-                   from, m->map_epoch);
+    logger().debug("{} updating peer {} session's projected_epoch"
+                   "from {} to ping map epoch of {}",
+                   __func__, from, peer.get_projected_epoch(),
+                   m->map_epoch);
     peer.set_projected_epoch(m->map_epoch);
   }
 
   if (current_osdmap_epoch <= peer.get_projected_epoch()) {
-    logger().info("{} projected_epoch {} is already later "
-                  "than osdmap epoch of {}",
-                  __func__ , peer.get_projected_epoch(),
-                  current_osdmap_epoch);
+    logger().debug("{} peer {} projected_epoch {} is already later "
+		   "than our osdmap epoch of {}",
+		   __func__ , from, peer.get_projected_epoch(),
+		   current_osdmap_epoch);
     return seastar::now();
   }
 
-  logger().info("{} peer id: {} epoch is {} while osdmap is {}",
-                __func__ , from, m->map_epoch, current_osdmap_epoch);
+  logger().debug("{} peer {} projected_epoch is {} while osdmap is {}",
+		 __func__ , from, m->map_epoch, current_osdmap_epoch);
   if (current_osdmap_epoch > m->map_epoch) {
-    logger().debug("{} sharing osdmap epoch of {} with peer id {}",
+    logger().debug("{} sharing osdmap epoch of {} with peer {}",
                    __func__, current_osdmap_epoch, from);
     // Peer's newest map is m->map_epoch. Therfore it misses
     // the osdmaps in the range of `m->map_epoch` to `current_osdmap_epoch`.

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -311,18 +311,18 @@ seastar::future<> Heartbeat::maybe_share_osdmap(
   }
   auto& peer = found->second;
 
-  if (peer_epoch > peer.get_last_epoch_sent()) {
-    logger().debug("{} updating session's last epoch sent "
+  if (peer_epoch > peer.get_projected_epoch()) {
+    logger().debug("{} updating session's projected_epoch"
                    "from {} to peer's (id: {}) map epoch of {}",
-                   __func__, peer.get_last_epoch_sent(),
+                   __func__, peer.get_projected_epoch(),
                    from, peer_epoch);
-    peer.set_last_epoch_sent(peer_epoch);
+    peer.set_projected_epoch(peer_epoch);
   }
 
-  if (osdmap_epoch <= peer.get_last_epoch_sent()) {
-    logger().info("{} latest epoch sent {} is already later "
+  if (osdmap_epoch <= peer.get_projected_epoch()) {
+    logger().info("{} projected_epoch {} is already later "
                   "than osdmap epoch of {}",
-                  __func__ , peer.get_last_epoch_sent(),
+                  __func__ , peer.get_projected_epoch(),
                   osdmap_epoch);
     return seastar::now();
   }

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -277,8 +277,8 @@ class Heartbeat::Session {
   void set_epoch_added(epoch_t epoch_) { epoch = epoch_; }
   epoch_t get_epoch_added() const { return epoch; }
 
-  void set_last_epoch_sent(epoch_t epoch_) { last_sent_epoch = epoch_; }
-  epoch_t get_last_epoch_sent() const { return last_sent_epoch; }
+  void set_projected_epoch(epoch_t epoch_) { projected_epoch = epoch_; }
+  epoch_t get_projected_epoch() const { return projected_epoch; }
 
   bool is_started() const { return connected; }
   bool pinged() const {
@@ -389,8 +389,8 @@ class Heartbeat::Session {
   clock::time_point last_rx_back;
   // most recent epoch we wanted this peer
   epoch_t epoch; // rename me to epoch_added
-  // last epoch sent
-  epoch_t last_sent_epoch = 0;
+  // epoch we expect peer to be at once our sent incrementals are processed
+  epoch_t projected_epoch = 0;
 
   struct reply_t {
     clock::time_point deadline;
@@ -414,8 +414,8 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   void set_epoch_added(epoch_t epoch) { session.set_epoch_added(epoch); }
   epoch_t get_epoch_added() const { return session.get_epoch_added(); }
 
-  void set_last_epoch_sent(epoch_t epoch) { session.set_last_epoch_sent(epoch); }
-  epoch_t get_last_epoch_sent() const { return session.get_last_epoch_sent(); }
+  void set_projected_epoch(epoch_t epoch) { session.set_projected_epoch(epoch); }
+  epoch_t get_projected_epoch() const { return session.get_projected_epoch(); }
 
   // if failure, return time_point since last active
   // else, return clock::zero()


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51380

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

