### PR TITLE
reef: crimson/os/seastore/cached_extent: add prepare_commit interface

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -564,7 +564,7 @@ struct FixedKVInternalNode
     return this->get_split_pivot().get_offset();
   }
 
-  void prepare_write() final {
+  void prepare_commit() final {
     if (this->is_initial_pending()) {
       if (this->is_rewrite()) {
 	this->set_children_from_prior_instance();
@@ -1004,7 +1004,7 @@ struct FixedKVLeafNode
     }
   }
 
-  void prepare_write() final {
+  void prepare_commit() final {
     if constexpr (has_children) {
       if (this->is_initial_pending()) {
 	if (this->is_rewrite()) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1098,6 +1098,7 @@ record_t Cache::prepare_record(
 
     i->prepare_write();
     i->set_io_wait();
+    i->prepare_commit();
 
     assert(i->get_version() > 0);
     auto final_crc = i->get_crc32c();
@@ -1200,6 +1201,7 @@ record_t Cache::prepare_record(
 
     bufferlist bl;
     i->prepare_write();
+    i->prepare_commit();
     bl.append(i->get_bptr());
     if (i->get_type() == extent_types_t::ROOT) {
       ceph_assert(0 == "ROOT never gets written as a fresh block");
@@ -1240,6 +1242,7 @@ record_t Cache::prepare_record(
     assert(!i->is_inline());
     get_by_ext(efforts.fresh_ool_by_ext,
                i->get_type()).increment(i->get_length());
+    i->prepare_commit();
     if (is_backref_mapped_extent_node(i)) {
       alloc_delta.alloc_blk_ranges.emplace_back(
 	i->get_paddr(),

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -251,6 +251,14 @@ public:
   virtual void prepare_write() {}
 
   /**
+   * prepare_commit
+   *
+   * Called prior to committing the transaction in which this extent
+   * is living.
+   */
+  virtual void prepare_commit() {}
+
+  /**
    * on_initial_write
    *
    * Called after commit of extent.  State will be CLEAN.


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51948

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

