### PR TITLE
reef: crimson/osd: fix ENOENT on accessing RadosGW user's index of buckets

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -11,6 +11,7 @@
 #include "crimson/osd/osd_operation_external_tracking.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_connection_priv.h"
+#include "osd/object_state_fmt.h"
 
 namespace {
   seastar::logger& logger() {
@@ -226,7 +227,7 @@ ClientRequest::process_op(instance_handle_t &ihref, Ref<PG> &pg)
           return pg->with_locked_obc(
             m->get_hobj(), op_info,
             [this, pg, &ihref](auto obc) mutable {
-              logger().debug("{}: got obc {}", *this, obc->obs.exists);
+              logger().debug("{}: got obc {}", *this, obc->obs);
               return ihref.enter_stage<interruptor>(
                 pp(*pg).process, *this
               ).then_interruptible([this, pg, obc, &ihref]() mutable {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -226,6 +226,7 @@ ClientRequest::process_op(instance_handle_t &ihref, Ref<PG> &pg)
           return pg->with_locked_obc(
             m->get_hobj(), op_info,
             [this, pg, &ihref](auto obc) mutable {
+              logger().debug("{}: got obc {}", *this, obc->obs.exists);
               return ihref.enter_stage<interruptor>(
                 pp(*pg).process, *this
               ).then_interruptible([this, pg, obc, &ihref]() mutable {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -226,11 +226,12 @@ ClientRequest::process_op(instance_handle_t &ihref, Ref<PG> &pg)
           return pg->with_locked_obc(
             m->get_hobj(), op_info,
             [this, pg, &ihref](auto obc) mutable {
-              return ihref.enter_stage<interruptor>(pp(*pg).process, *this
-            ).then_interruptible([this, pg, obc, &ihref]() mutable {
-              return do_process(ihref, pg, obc);
+              return ihref.enter_stage<interruptor>(
+                pp(*pg).process, *this
+              ).then_interruptible([this, pg, obc, &ihref]() mutable {
+                return do_process(ihref, pg, obc);
+              });
             });
-          });
         });
       }
     });

--- a/src/osd/object_state_fmt.h
+++ b/src/osd/object_state_fmt.h
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatters for some types.h classes
+ */
+
+#include "osd/object_state.h"
+#include "osd/osd_types_fmt.h"
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
+template <>
+struct fmt::formatter<ObjectState> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const ObjectState& os, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "exists {} oi {}", os.exists, os.oi);
+  }
+};


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51034

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

