### PR TITLE
reef: crimson/osd: fix Notify life-time mismanagement in Watch::notify_ack

### DIFF
--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -125,7 +125,12 @@ seastar::future<> Watch::notify_ack(
   logger().debug("{} gid={} cookie={} notify_id={}",
                  __func__,  get_watcher_gid(), get_cookie(), notify_id);
   const auto it = in_progress_notifies.find(notify_id);
-  assert(it != std::end(in_progress_notifies));
+  if (it == std::end(in_progress_notifies)) {
+    logger().error("{} notify_id={} not found on the in-progess list."
+                   " Supressing but this should not happen.",
+                   __func__, notify_id);
+    return seastar::now();
+  }
   auto notify = *it;
   logger().debug("Watch::notify_ack gid={} cookie={} found notify(id={})",
     get_watcher_gid(),


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51945

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

