### PR TITLE
reef: crimson/os/seastore/btree: should add left's size when merging levels…

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -2039,7 +2039,7 @@ private:
 
         pos.node = replacement;
         if (donor_is_left) {
-          pos.pos += r->get_size();
+          pos.pos += l->get_size();
           parent_pos.pos--;
         }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52090

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

