### PR TITLE
reef: crimson/os/seastore/rbm: make rbm support multiple shards

### DIFF
--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -174,8 +174,8 @@ CircularJournalSpace::read_header()
   assert(device);
   auto bptr = bufferptr(ceph::buffer::create_page_aligned(
 			device->get_block_size()));
-  DEBUG("reading {}", device->get_journal_start());
-  return device->read(device->get_journal_start(), bptr
+  DEBUG("reading {}", device->get_shard_journal_start());
+  return device->read(device->get_shard_journal_start(), bptr
   ).safe_then([bptr, FNAME]() mutable
     -> read_header_ret {
     bufferlist bl;
@@ -222,7 +222,7 @@ CircularJournalSpace::write_header()
   assert(bl.length() < get_block_size());
   bufferptr bp = bufferptr(ceph::buffer::create_page_aligned(get_block_size()));
   iter.copy(bl.length(), bp.c_str());
-  return device->write(device->get_journal_start(), std::move(bp)
+  return device->write(device->get_shard_journal_start(), std::move(bp)
   ).handle_error(
     write_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error device->write" }

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -188,7 +188,7 @@ class CircularJournalSpace : public JournalAllocator {
   }
   rbm_abs_addr get_records_start() const {
     assert(device);
-    return device->get_journal_start() + get_block_size();
+    return device->get_shard_journal_start() + get_block_size();
   }
   size_t get_records_available_size() const {
     return get_records_total_size() - get_records_used_size();
@@ -206,7 +206,7 @@ class CircularJournalSpace : public JournalAllocator {
   }
   rbm_abs_addr get_journal_end() const {
     assert(device);
-    return device->get_journal_start() + device->get_journal_size();
+    return device->get_shard_journal_start() + device->get_journal_size();
   }
 
   read_ertr::future<> read(

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -78,7 +78,7 @@ BlockRBManager::open_ertr::future<> BlockRBManager::open()
   auto ool_start = get_start_rbm_addr();
   allocator->init(
     ool_start,
-    device->get_available_size() -
+    device->get_shard_end() -
     ool_start,
     device->get_block_size());
   return open_ertr::now();
@@ -91,8 +91,8 @@ BlockRBManager::write_ertr::future<> BlockRBManager::write(
   LOG_PREFIX(BlockRBManager::write);
   ceph_assert(device);
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-  rbm_abs_addr start = 0;
-  rbm_abs_addr end = device->get_available_size();
+  rbm_abs_addr start = device->get_shard_start();
+  rbm_abs_addr end = device->get_shard_end();
   if (addr < start || addr + bptr.length() > end) {
     ERROR("out of range: start {}, end {}, addr {}, length {}",
       start, end, addr, bptr.length());
@@ -112,8 +112,8 @@ BlockRBManager::read_ertr::future<> BlockRBManager::read(
   LOG_PREFIX(BlockRBManager::read);
   ceph_assert(device);
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-  rbm_abs_addr start = 0;
-  rbm_abs_addr end = device->get_available_size();
+  rbm_abs_addr start = device->get_shard_start();
+  rbm_abs_addr end = device->get_shard_end();
   if (addr < start || addr + bptr.length() > end) {
     ERROR("out of range: start {}, end {}, addr {}, length {}",
       start, end, addr, bptr.length());
@@ -158,7 +158,18 @@ std::ostream &operator<<(std::ostream &out, const rbm_metadata_header_t &header)
        << ", feature=" << header.feature
        << ", journal_size=" << header.journal_size
        << ", crc=" << header.crc
-       << ", config=" << header.config;
+       << ", config=" << header.config
+       << ", shard_num=" << header.shard_num;
+  for (auto p : header.shard_infos) {
+    out << p;
+  }
+  return out << ")";
+}
+
+std::ostream &operator<<(std::ostream &out, const rbm_shard_info_t &shard)
+{
+  out << " rbm_shard_info_t(size=" << shard.size
+      << ", start_offset=" << shard.start_offset;
   return out << ")";
 }
 

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -62,10 +62,10 @@ public:
   void complete_allocation(paddr_t addr, size_t size) final;
 
   size_t get_start_rbm_addr() const {
-    return device->get_journal_start() + device->get_journal_size();
+    return device->get_shard_journal_start() + device->get_journal_size();
   }
   size_t get_size() const final {
-    return device->get_available_size() - get_start_rbm_addr(); 
+    return device->get_shard_end() - get_start_rbm_addr();
   };
   extent_len_t get_block_size() const final { return device->get_block_size(); }
 
@@ -97,7 +97,7 @@ public:
     assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
-	   addr + len <= device->get_available_size());
+	   addr + len <= device->get_shard_end());
     allocator->mark_extent_used(addr, len);
   }
 
@@ -105,7 +105,7 @@ public:
     assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
-	   addr + len <= device->get_available_size());
+	   addr + len <= device->get_shard_end());
     allocator->free_extent(addr, len);
   }
 
@@ -119,7 +119,7 @@ public:
     assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
     assert(addr >= get_start_rbm_addr() &&
-	   addr + size <= device->get_available_size());
+	   addr + size <= device->get_shard_end());
     return allocator->get_extent_state(addr, size);
   }
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -666,7 +666,7 @@ TransactionManagerRef make_transaction_manager(
 		->get_journal_size() - primary_device->get_block_size();
     // see CircularBoundedJournal::get_records_start()
     roll_start = static_cast<random_block_device::RBMDevice*>(primary_device)
-		 ->get_journal_start() + primary_device->get_block_size();
+		 ->get_shard_journal_start() + primary_device->get_block_size();
     ceph_assert_always(roll_size <= DEVICE_OFF_MAX);
     ceph_assert_always((std::size_t)roll_size + roll_start <=
                        primary_device->get_available_size());


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51770

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

