### PR TITLE
reef: crimson/os/seastore: add metrics about total invalidated transactions

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -225,9 +225,9 @@ void Cache::register_metrics()
           "cache",
           {
             sm::make_counter(
-              "trans_invalidated",
+              "trans_invalidated_by_extent",
               counter,
-              sm::description("total number of transaction invalidated"),
+              sm::description("total number of transactions invalidated by extents"),
               {src_label, ext_label}
             ),
           }
@@ -295,6 +295,12 @@ void Cache::register_metrics()
       metrics.add_group(
         "cache",
         {
+          sm::make_counter(
+            "trans_invalidated",
+            efforts.total_trans_invalidated,
+            sm::description("total number of transactions invalidated"),
+            {src_label}
+          ),
           sm::make_counter(
             "invalidated_delta_bytes",
             efforts.mutate_delta_bytes,
@@ -843,6 +849,7 @@ void Cache::mark_transaction_conflicted(
 
   auto& efforts = get_by_src(stats.invalidated_efforts_by_src,
                              t.get_src());
+  ++efforts.total_trans_invalidated;
 
   auto& counter = get_by_ext(efforts.num_trans_invalidated,
                              conflicting_extent.get_type());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1342,6 +1342,7 @@ private:
     io_stat_t fresh;
     io_stat_t fresh_ool_written;
     counter_by_extent_t<uint64_t> num_trans_invalidated;
+    uint64_t total_trans_invalidated = 0;
     uint64_t num_ool_records = 0;
     uint64_t ool_record_bytes = 0;
   };


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52369

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

