### PR TITLE
reef: crimson/mgr: Fix config show command

### DIFF
--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -96,6 +96,15 @@ public:
     return values.get();
   }
 
+  void get_config_bl(uint64_t have_version,
+		     ceph::buffer::list *bl,
+		     uint64_t *got_version) {
+    get_config().get_config_bl(get_config_values(), have_version,
+                               bl, got_version);
+  }
+  void get_defaults_bl(ceph::buffer::list *bl) {
+    get_config().get_defaults_bl(get_config_values(), bl);
+  }
   // required by sharded<>
   seastar::future<> start();
   seastar::future<> stop() {

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -72,6 +72,8 @@ void Client::ms_handle_connect(crimson::net::ConnectionRef c)
       // ask for the mgrconfigure message
       auto m = crimson::make_message<MMgrOpen>();
       m->daemon_name = local_conf()->name.get_id();
+      local_conf().get_config_bl(0, &m->config_bl, &last_config_bl_version);
+      local_conf().get_defaults_bl(&m->config_defaults_bl);
       return conn->send(std::move(m));
     } else {
       return seastar::now();

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -56,6 +56,7 @@ private:
   crimson::net::ConnectionRef conn;
   seastar::timer<seastar::lowres_clock> report_timer;
   crimson::common::Gated gate;
+  uint64_t last_config_bl_version = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const Client& client) {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52266

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

