### PR TITLE
reef: crimson/os/seastore/transaction_manager: data loss issues

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -475,7 +475,7 @@ public:
     extent_len_t length,
     Func &&extent_init_func) {
     CachedExtentRef ret;
-    LOG_PREFIX(Cache::get_extent);
+    LOG_PREFIX(Cache::get_absent_extent);
 
 #ifndef NDEBUG
     auto r = t.get_extent(offset, &ret);

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -19,10 +19,12 @@ namespace crimson::os::seastore {
 struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
   using Ref = TCachedExtentRef<ObjectDataBlock>;
 
-  ObjectDataBlock(ceph::bufferptr &&ptr)
+  explicit ObjectDataBlock(ceph::bufferptr &&ptr)
     : LogicalCachedExtent(std::move(ptr)) {}
-  ObjectDataBlock(const ObjectDataBlock &other)
+  explicit ObjectDataBlock(const ObjectDataBlock &other)
     : LogicalCachedExtent(other) {}
+  explicit ObjectDataBlock(extent_len_t length)
+    : LogicalCachedExtent(length) {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new ObjectDataBlock(*this));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52446

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

