### PR TITLE
reef: crimson/os/seastore/collection_manager: fill CollectionNode::decoded on clean reads

### DIFF
--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
@@ -46,7 +46,6 @@ std::ostream &CollectionNode::print_detail_l(std::ostream &out) const
 CollectionNode::list_ret
 CollectionNode::list()
 {
-  read_to_local();
   logger().debug("CollectionNode:{}, {}", __func__, *this);
   CollectionManager::list_ret_bare list_result;
   for (auto &[coll, bits] : decoded) {
@@ -60,7 +59,6 @@ CollectionNode::list()
 CollectionNode::create_ret
 CollectionNode::create(coll_context_t cc, coll_t coll, unsigned bits)
 {
-  read_to_local();
   logger().debug("CollectionNode:{}", __func__);
   if (!is_mutable()) {
     auto mut = cc.tm.get_mutable_extent(cc.t, this)->cast<CollectionNode>();
@@ -88,8 +86,8 @@ CollectionNode::create(coll_context_t cc, coll_t coll, unsigned bits)
 CollectionNode::update_ret
 CollectionNode::update(coll_context_t cc, coll_t coll, unsigned bits)
 {
-  read_to_local();
-  logger().debug("CollectionNode:{}", __func__);
+  logger().debug("trans.{} CollectionNode:{} {} {}",
+    cc.t.get_trans_id(), __func__, coll, bits);
   if (!is_mutable()) {
     auto mut = cc.tm.get_mutable_extent(cc.t, this)->cast<CollectionNode>();
     return mut->update(cc, coll, bits);
@@ -105,8 +103,8 @@ CollectionNode::update(coll_context_t cc, coll_t coll, unsigned bits)
 CollectionNode::remove_ret
 CollectionNode::remove(coll_context_t cc, coll_t coll)
 {
-  read_to_local();
-  logger().debug("CollectionNode:{}", __func__);
+  logger().debug("trans.{} CollectionNode:{} {}",
+    cc.t.get_trans_id(),__func__, coll);
   if (!is_mutable()) {
     auto mut = cc.tm.get_mutable_extent(cc.t, this)->cast<CollectionNode>();
     return mut->remove(cc, coll);

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -94,11 +94,11 @@ struct CollectionNode
   : LogicalCachedExtent {
   using CollectionNodeRef = TCachedExtentRef<CollectionNode>;
 
-  bool loaded = false;
-
-  template <typename... T>
-  CollectionNode(T&&... t)
-    : LogicalCachedExtent(std::forward<T>(t)...) {}
+  explicit CollectionNode(ceph::bufferptr &&ptr)
+    : LogicalCachedExtent(std::move(ptr)) {}
+  explicit CollectionNode(const CollectionNode &other)
+    : LogicalCachedExtent(other),
+      decoded(other.decoded) {}
 
   static constexpr extent_types_t type = extent_types_t::COLL_BLOCK;
 
@@ -134,13 +134,11 @@ struct CollectionNode
   using update_ret = CollectionManager::update_ret;
   update_ret update(coll_context_t cc, coll_t coll, unsigned bits);
 
-  void read_to_local() {
-    if (loaded) return;
+  void on_clean_read() final {
     bufferlist bl;
     bl.append(get_bptr());
     auto iter = bl.cbegin();
     decode((base_coll_map_t&)decoded, iter);
-    loaded = true;
   }
 
   void copy_to_node() {

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -80,7 +80,6 @@ FlatCollectionManager::create(coll_root_t &coll_root, Transaction &t,
           coll_root.update(root_extent->get_laddr(), root_extent->get_length());
 
 	  root_extent->decoded = extent->decoded;
-	  root_extent->loaded = true;
 	  return root_extent->create(
 	    get_coll_context(t), cid, info.split_bits
 	  ).si_then([=, this, &t](auto result) {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52221

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

