### PR TITLE
reef: crimson/ertr: assert on invocability of func provided to safe_then()

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -599,7 +599,9 @@ private:
       static_assert((... && std::is_invocable_v<ErrorVisitorT,
                                                 AllowedErrors>),
                     "provided Error Visitor is not exhaustive");
-
+      static_assert(std::is_void_v<ValueT> ? std::is_invocable_v<ValueFuncT>
+		                           : std::is_invocable_v<ValueFuncT, ValueT>,
+                    "Value Func is not invocable with future's value");
       using value_func_result_t =
         typename std::conditional_t<std::is_void_v<ValueT>,
 				    std::invoke_result<ValueFuncT>,


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52655

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

