### PR TITLE
reef: crimson/admin/admin_socket: remove path file if it exists

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -236,6 +236,14 @@ seastar::future<> AdminSocket::start(const std::string& path)
   try {
     server_sock = seastar::engine().listen(sock_path);
   } catch (const std::system_error& e) {
+    if (e.code() == std::errc::address_in_use) {
+      logger().debug("{}: Admin Socket socket path={} already exists, retrying",
+                     __func__, path);
+      return seastar::remove_file(path).then([this, path] {
+        server_sock.reset();
+        return start(path);
+      });
+    }
     logger().error("{}: unable to listen({}): {}", __func__, path, e.what());
     server_sock.reset();
     return seastar::make_ready_future<>();


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53082

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

