### PR TITLE
reef: crimson/osd/object_context: consider clones found as long as they're in SnapSet::clones

### DIFF
--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -82,11 +82,11 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_head_and_clone_obc(
+  ObjectContextLoader::with_clone_obc_direct(
     hobject_t oid,
     with_both_obc_func_t&& func)
   {
-    LOG_PREFIX(ObjectContextLoader::with_head_and_clone_obc);
+    LOG_PREFIX(ObjectContextLoader::with_clone_obc_direct);
     assert(!oid.is_head());
     return with_obc<RWState::RWREAD>(
       oid.get_head(),
@@ -227,7 +227,7 @@ using crimson::common::local_conf;
                                                  with_obc_func_t&&);
 
   template ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_head_and_clone_obc<RWState::RWWRITE>(
+  ObjectContextLoader::with_clone_obc_direct<RWState::RWWRITE>(
     hobject_t,
     with_both_obc_func_t&&);
 }

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -98,14 +98,13 @@ using crimson::common::local_conf;
           crimson::ct_error::enoent::make()
         };
       }
-      auto coid = resolve_oid(head->get_head_ss(), oid);
-      if (!coid) {
-        ERRORDPP("clone {} not found", dpp, oid);
-        return load_obc_iertr::future<>{
-          crimson::ct_error::enoent::make()
-        };
-      }
-      auto [clone, existed] = obc_registry.get_cached_obc(*coid);
+#ifndef NDEBUG
+      auto &ss = head->get_head_ss();
+      auto cit = std::find(
+	std::begin(ss.clones), std::end(ss.clones), oid.snap);
+      assert(cit != std::end(ss.clones));
+#endif
+      auto [clone, existed] = obc_registry.get_cached_obc(oid);
       return clone->template with_lock<State, IOInterruptCondition>(
         [existed=existed, clone=std::move(clone),
          func=std::move(func), head=std::move(head), this]()

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -53,7 +53,7 @@ public:
   // object *and* the matching clone object are being used
   // in func.
   template<RWState::State State>
-  load_obc_iertr::future<> with_head_and_clone_obc(
+  load_obc_iertr::future<> with_clone_obc_direct(
     hobject_t oid,
     with_both_obc_func_t&& func);
 

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -499,8 +499,8 @@ SnapTrimObjSubEvent::with_pg(
   }).then_interruptible([this] {
     logger().debug("{}: getting obc for {}", *this, coid);
     // end of commonality
-    // with_head_and_clone_obc lock both clone's and head's obcs
-    return pg->obc_loader.with_head_and_clone_obc<RWState::RWWRITE>(
+    // with_clone_obc_direct lock both clone's and head's obcs
+    return pg->obc_loader.with_clone_obc_direct<RWState::RWWRITE>(
       coid,
       [this](auto head_obc, auto clone_obc) {
       logger().debug("{}: got clone_obc={}", *this, clone_obc->get_oid());

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -30,6 +30,15 @@ namespace crimson {
 
 namespace crimson::osd {
 
+PG::interruptible_future<>
+PG::SnapTrimMutex::lock(SnapTrimEvent &st_event) noexcept
+{
+  return st_event.enter_stage<interruptor>(wait_pg
+  ).then_interruptible([this] {
+    return mutex.lock();
+  });
+}
+
 void SnapTrimEvent::SubOpBlocker::dump_detail(Formatter *f) const
 {
   f->open_array_section("dependent_operations");
@@ -110,6 +119,8 @@ SnapTrimEvent::with_pg(
       return enter_stage<interruptor>(
         pp().get_obc);
     }).then_interruptible([this] {
+      return pg->snaptrim_mutex.lock(*this);
+    }).then_interruptible([this] {
       return enter_stage<interruptor>(
         pp().process);
     }).then_interruptible([&shard_services, this] {
@@ -140,27 +151,32 @@ SnapTrimEvent::with_pg(
         if (to_trim.empty()) {
           // the legit ENOENT -> done
           logger().debug("{}: to_trim is empty! Stopping iteration", *this);
+	  pg->snaptrim_mutex.unlock();
           return snap_trim_iertr::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         }
-        for (const auto& object : to_trim) {
-          logger().debug("{}: trimming {}", *this, object);
-          auto [op, fut] = shard_services.start_operation_may_interrupt<
-	    interruptor, SnapTrimObjSubEvent>(
-            pg,
-            object,
-            snapid);
-          subop_blocker.emplace_back(
-            op->get_id(),
-            std::move(fut)
-          );
-        }
-        return enter_stage<interruptor>(
-          wait_subop
-        ).then_interruptible([this] {
+        return [&shard_services, this](const auto &to_trim) {
+	  for (const auto& object : to_trim) {
+	    logger().debug("{}: trimming {}", *this, object);
+	    auto [op, fut] = shard_services.start_operation_may_interrupt<
+	      interruptor, SnapTrimObjSubEvent>(
+	      pg,
+	      object,
+	      snapid);
+	    subop_blocker.emplace_back(
+	      op->get_id(),
+	      std::move(fut)
+	    );
+	  }
+	  return interruptor::now();
+	}(to_trim).then_interruptible([this] {
+	  return enter_stage<interruptor>(wait_subop);
+	}).then_interruptible([this] {
           logger().debug("{}: awaiting completion", *this);
           return subop_blocker.wait_completion();
-        }).safe_then_interruptible([this] {
+        }).finally([this] {
+	  pg->snaptrim_mutex.unlock();
+	}).safe_then_interruptible([this] {
           if (!needs_pause) {
             return interruptor::now();
           }

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -25,7 +25,6 @@ namespace crimson::osd {
 
 class OSD;
 class ShardServices;
-class PG;
 
 // trim up to `max` objects for snapshot `snapid
 class SnapTrimEvent final : public PhasedOperationT<SnapTrimEvent> {
@@ -107,9 +106,12 @@ public:
     CommonPGPipeline::GetOBC::BlockingEvent,
     CommonPGPipeline::Process::BlockingEvent,
     WaitSubop::BlockingEvent,
+    PG::SnapTrimMutex::WaitPG::BlockingEvent,
     WaitTrimTimer::BlockingEvent,
     CompletionEvent
   > tracking_events;
+
+  friend class PG::SnapTrimMutex;
 };
 
 // remove single object. a SnapTrimEvent can create multiple subrequests.


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52204

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

