### PR TITLE
reef: crimson/os/seastore/onode_manager: populate value recorders of onodes to be erased

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -120,6 +120,10 @@ FLTreeOnodeManager::erase_onode_ret FLTreeOnodeManager::erase_onode(
   OnodeRef &onode)
 {
   auto &flonode = static_cast<FLTreeOnode&>(*onode);
+  assert(flonode.is_alive());
+  if (flonode.status == FLTreeOnode::status_t::MUTATED) {
+    flonode.populate_recorder(trans);
+  }
   flonode.mark_delete();
   return tree.erase(trans, flonode);
 }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53305

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

