### PR TITLE
reef: test/crimson/seastore/rbm: add sub-tests regarding RBM to the existing tests

### DIFF
--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -352,7 +352,8 @@ public:
   overwrite_plan_t(laddr_t offset,
 		   extent_len_t len,
 		   const lba_pin_list_t& pins,
-		   extent_len_t block_size) :
+		   extent_len_t block_size,
+		   Transaction& t) :
       pin_begin(pins.front()->get_key()),
       pin_end(pins.back()->get_key() + pins.back()->get_length()),
       left_paddr(pins.front()->get_val()),
@@ -365,7 +366,7 @@ public:
       right_operation(overwrite_operation_t::UNKNOWN),
       block_size(block_size) {
     validate();
-    evaluate_operations();
+    evaluate_operations(t);
     assert(left_operation != overwrite_operation_t::UNKNOWN);
     assert(right_operation != overwrite_operation_t::UNKNOWN);
   }
@@ -393,19 +394,31 @@ private:
    * original extent into at most three parts: origin-left, part-to-be-modified
    * and origin-right.
    */
-  void evaluate_operations() {
+  void evaluate_operations(Transaction& t) {
     auto actual_write_size = get_pins_size();
     auto aligned_data_size = get_aligned_data_size();
     auto left_ext_size = get_left_extent_size();
     auto right_ext_size = get_right_extent_size();
 
+    auto can_merge = [](Transaction& t, paddr_t paddr) {
+      CachedExtentRef ext;
+      if (paddr.is_relative() || paddr.is_delayed()) {
+	  return true;
+      } else if (t.get_extent(paddr, &ext) ==
+	Transaction::get_extent_ret::PRESENT) {
+	// FIXME: there is no need to lookup the cache if the pin can 
+	// be associated with the extent state
+	if (ext->is_mutable()) {
+	  return true;
+	}
+      }
+      return false;
+    };
     if (left_paddr.is_zero()) {
       actual_write_size -= left_ext_size;
       left_ext_size = 0;
       left_operation = overwrite_operation_t::OVERWRITE_ZERO;
-    // FIXME: left_paddr can be absolute and pending
-    } else if (left_paddr.is_relative() ||
-	       left_paddr.is_delayed()) {
+    } else if (can_merge(t, left_paddr)) {
       aligned_data_size += left_ext_size;
       left_ext_size = 0;
       left_operation = overwrite_operation_t::MERGE_EXISTING;
@@ -415,9 +428,7 @@ private:
       actual_write_size -= right_ext_size;
       right_ext_size = 0;
       right_operation = overwrite_operation_t::OVERWRITE_ZERO;
-    // FIXME: right_paddr can be absolute and pending
-    } else if (right_paddr.is_relative() ||
-	       right_paddr.is_delayed()) {
+    } else if (can_merge(t, right_paddr)) {
       aligned_data_size += right_ext_size;
       right_ext_size = 0;
       right_operation = overwrite_operation_t::MERGE_EXISTING;
@@ -858,7 +869,7 @@ ObjectDataHandler::write_ret ObjectDataHandler::overwrite(
   if (bl.has_value()) {
     assert(bl->length() == len);
   }
-  overwrite_plan_t overwrite_plan(offset, len, _pins, ctx.tm.get_block_size());
+  overwrite_plan_t overwrite_plan(offset, len, _pins, ctx.tm.get_block_size(), ctx.t);
   return seastar::do_with(
     std::move(_pins),
     extent_to_write_list_t(),

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -235,7 +235,7 @@ struct fltree_onode_manager_test_t
   fltree_onode_manager_test_t() {}
 };
 
-TEST_F(fltree_onode_manager_test_t, 1_single)
+TEST_P(fltree_onode_manager_test_t, 1_single)
 {
   run_async([this] {
     uint64_t block_size = tm->get_block_size();
@@ -263,7 +263,7 @@ TEST_F(fltree_onode_manager_test_t, 1_single)
   });
 }
 
-TEST_F(fltree_onode_manager_test_t, 2_synthetic)
+TEST_P(fltree_onode_manager_test_t, 2_synthetic)
 {
   run_async([this] {
     uint64_t block_size = tm->get_block_size();
@@ -315,3 +315,12 @@ TEST_F(fltree_onode_manager_test_t, 2_synthetic)
     validate_list_onodes(pool);
   });
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  fltree_onode__manager_test,
+  fltree_onode_manager_test_t,
+  ::testing::Values (
+    "segmented",
+    "circularbounded"
+  )
+);

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1572,7 +1572,7 @@ struct d_seastore_tm_test_t :
   }
 };
 
-TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
+TEST_P(d_seastore_tm_test_t, 6_random_tree_insert_erase)
 {
   run_async([this] {
     constexpr bool TEST_SEASTORE = true;
@@ -1662,7 +1662,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
   });
 }
 
-TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
+TEST_P(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 {
   run_async([this] {
     constexpr double EAGAIN_PROBABILITY = 0.1;
@@ -1781,3 +1781,12 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
     tree.reset();
   });
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  d_seastore_tm_test,
+  d_seastore_tm_test_t,
+  ::testing::Values (
+    "segmented",
+    "circularbounded"
+  )
+);

--- a/src/test/crimson/seastore/test_collection_manager.cc
+++ b/src/test/crimson/seastore/test_collection_manager.cc
@@ -100,7 +100,7 @@ struct collection_manager_test_t :
   }
 };
 
-TEST_F(collection_manager_test_t, basic)
+TEST_P(collection_manager_test_t, basic)
 {
   run_async([this] {
     coll_root_t coll_root = get_root();
@@ -137,7 +137,7 @@ TEST_F(collection_manager_test_t, basic)
   });
 }
 
-TEST_F(collection_manager_test_t, overflow)
+TEST_P(collection_manager_test_t, overflow)
 {
   run_async([this] {
     coll_root_t coll_root = get_root();
@@ -158,7 +158,7 @@ TEST_F(collection_manager_test_t, overflow)
   });
 }
 
-TEST_F(collection_manager_test_t, update)
+TEST_P(collection_manager_test_t, update)
 {
   run_async([this] {
     coll_root_t coll_root = get_root();
@@ -184,3 +184,12 @@ TEST_F(collection_manager_test_t, update)
     checking_mappings(coll_root);
   });
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  collection_manager_test,
+  collection_manager_test_t,
+  ::testing::Values (
+    "segmented",
+    "circularbounded"
+  )
+);

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -160,7 +160,7 @@ struct object_data_handler_test_t:
   }
 };
 
-TEST_F(object_data_handler_test_t, single_write)
+TEST_P(object_data_handler_test_t, single_write)
 {
   run_async([this] {
     write(1<<20, 8<<10, 'c');
@@ -170,7 +170,7 @@ TEST_F(object_data_handler_test_t, single_write)
   });
 }
 
-TEST_F(object_data_handler_test_t, multi_write)
+TEST_P(object_data_handler_test_t, multi_write)
 {
   run_async([this] {
     write((1<<20) - (4<<10), 4<<10, 'a');
@@ -185,7 +185,7 @@ TEST_F(object_data_handler_test_t, multi_write)
   });
 }
 
-TEST_F(object_data_handler_test_t, write_hole)
+TEST_P(object_data_handler_test_t, write_hole)
 {
   run_async([this] {
     write((1<<20) - (4<<10), 4<<10, 'a');
@@ -200,7 +200,7 @@ TEST_F(object_data_handler_test_t, write_hole)
   });
 }
 
-TEST_F(object_data_handler_test_t, overwrite_single)
+TEST_P(object_data_handler_test_t, overwrite_single)
 {
   run_async([this] {
     write((1<<20), 4<<10, 'a');
@@ -211,7 +211,7 @@ TEST_F(object_data_handler_test_t, overwrite_single)
   });
 }
 
-TEST_F(object_data_handler_test_t, overwrite_double)
+TEST_P(object_data_handler_test_t, overwrite_double)
 {
   run_async([this] {
     write((1<<20), 4<<10, 'a');
@@ -229,7 +229,7 @@ TEST_F(object_data_handler_test_t, overwrite_double)
   });
 }
 
-TEST_F(object_data_handler_test_t, overwrite_partial)
+TEST_P(object_data_handler_test_t, overwrite_partial)
 {
   run_async([this] {
     write((1<<20), 12<<10, 'a');
@@ -254,7 +254,7 @@ TEST_F(object_data_handler_test_t, overwrite_partial)
   });
 }
 
-TEST_F(object_data_handler_test_t, unaligned_write)
+TEST_P(object_data_handler_test_t, unaligned_write)
 {
   run_async([this] {
     objaddr_t base = 1<<20;
@@ -271,7 +271,7 @@ TEST_F(object_data_handler_test_t, unaligned_write)
   });
 }
 
-TEST_F(object_data_handler_test_t, unaligned_overwrite)
+TEST_P(object_data_handler_test_t, unaligned_overwrite)
 {
   run_async([this] {
     objaddr_t base = 1<<20;
@@ -292,7 +292,7 @@ TEST_F(object_data_handler_test_t, unaligned_overwrite)
   });
 }
 
-TEST_F(object_data_handler_test_t, truncate)
+TEST_P(object_data_handler_test_t, truncate)
 {
   run_async([this] {
     objaddr_t base = 1<<20;
@@ -314,7 +314,7 @@ TEST_F(object_data_handler_test_t, truncate)
   });
 }
 
-TEST_F(object_data_handler_test_t, no_split) {
+TEST_P(object_data_handler_test_t, no_split) {
   run_async([this] {
     write(0, 8<<10, 'x');
     write(0, 8<<10, 'a');
@@ -326,7 +326,7 @@ TEST_F(object_data_handler_test_t, no_split) {
   });
 }
 
-TEST_F(object_data_handler_test_t, split_left) {
+TEST_P(object_data_handler_test_t, split_left) {
   run_async([this] {
     write(0, 128<<10, 'x');
 
@@ -346,7 +346,7 @@ TEST_F(object_data_handler_test_t, split_left) {
   });
 }
 
-TEST_F(object_data_handler_test_t, split_right) {
+TEST_P(object_data_handler_test_t, split_right) {
   run_async([this] {
     write(0, 128<<10, 'x');
     write(4<<10, 60<<10, 'a');
@@ -364,7 +364,7 @@ TEST_F(object_data_handler_test_t, split_right) {
     read(0, 128<<10);
   });
 }
-TEST_F(object_data_handler_test_t, split_left_right) {
+TEST_P(object_data_handler_test_t, split_left_right) {
   run_async([this] {
     write(0, 128<<10, 'x');
     write(48<<10, 32<<10, 'a');
@@ -381,7 +381,7 @@ TEST_F(object_data_handler_test_t, split_left_right) {
     }
   });
 }
-TEST_F(object_data_handler_test_t, multiple_split) {
+TEST_P(object_data_handler_test_t, multiple_split) {
   run_async([this] {
     write(0, 128<<10, 'x');
 
@@ -415,3 +415,14 @@ TEST_F(object_data_handler_test_t, multiple_split) {
     read(0, 128<<10);
   });
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  object_data_handler_test,
+  object_data_handler_test_t,
+  ::testing::Values (
+    "segmented",
+    "circularbounded"
+  )
+);
+
+

--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -280,7 +280,7 @@ struct omap_manager_test_t :
   }
 };
 
-TEST_F(omap_manager_test_t, basic)
+TEST_P(omap_manager_test_t, basic)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -312,7 +312,7 @@ TEST_F(omap_manager_test_t, basic)
   });
 }
 
-TEST_F(omap_manager_test_t, force_leafnode_split)
+TEST_P(omap_manager_test_t, force_leafnode_split)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -333,7 +333,7 @@ TEST_F(omap_manager_test_t, force_leafnode_split)
   });
 }
 
-TEST_F(omap_manager_test_t, force_leafnode_split_merge)
+TEST_P(omap_manager_test_t, force_leafnode_split_merge)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -376,7 +376,7 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge)
   });
 }
 
-TEST_F(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
+TEST_P(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -423,7 +423,7 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
   });
 }
 
-TEST_F(omap_manager_test_t, force_split_listkeys_list_rmkey_range_clear)
+TEST_P(omap_manager_test_t, force_split_listkeys_list_rmkey_range_clear)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -511,7 +511,7 @@ TEST_F(omap_manager_test_t, force_split_listkeys_list_rmkey_range_clear)
   });
 }
 
-TEST_F(omap_manager_test_t, force_inner_node_split_list_rmkey_range)
+TEST_P(omap_manager_test_t, force_inner_node_split_list_rmkey_range)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -584,7 +584,7 @@ TEST_F(omap_manager_test_t, force_inner_node_split_list_rmkey_range)
 }
 
 
-TEST_F(omap_manager_test_t, internal_force_split)
+TEST_P(omap_manager_test_t, internal_force_split)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -606,7 +606,7 @@ TEST_F(omap_manager_test_t, internal_force_split)
   });
 }
 
-TEST_F(omap_manager_test_t, internal_force_merge_fullandbalanced)
+TEST_P(omap_manager_test_t, internal_force_merge_fullandbalanced)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -646,7 +646,7 @@ TEST_F(omap_manager_test_t, internal_force_merge_fullandbalanced)
   });
 }
 
-TEST_F(omap_manager_test_t, replay)
+TEST_P(omap_manager_test_t, replay)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -692,7 +692,7 @@ TEST_F(omap_manager_test_t, replay)
 }
 
 
-TEST_F(omap_manager_test_t, internal_force_split_to_root)
+TEST_P(omap_manager_test_t, internal_force_split_to_root)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -719,3 +719,12 @@ TEST_F(omap_manager_test_t, internal_force_split_to_root)
     check_mappings(omap_root);
   });
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  omap_manager_test,
+  omap_manager_test_t,
+  ::testing::Values (
+    "segmented",
+    "circularbounded"
+  )
+);

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -56,8 +56,7 @@ ghobject_t make_temp_oid(int i) {
 
 struct seastore_test_t :
   public seastar_test_suite_t,
-  SeaStoreTestState,
-  ::testing::WithParamInterface<const char*> {
+  SeaStoreTestState {
 
   coll_t coll_name{spg_t{pg_t{0, 0}}};
   CollectionRef coll;
@@ -65,16 +64,7 @@ struct seastore_test_t :
   seastore_test_t() {}
 
   seastar::future<> set_up_fut() final {
-    std::string j_type = GetParam();
-    journal_type_t journal;
-    if (j_type == "segmented") {
-      journal = journal_type_t::SEGMENTED;
-    } else if (j_type == "circularbounded") {
-      journal = journal_type_t::RANDOM_BLOCK;
-    } else {
-      ceph_assert(0 == "no support");
-    }
-    return tm_setup(journal
+    return tm_setup(
     ).then([this] {
       return sharded_seastore->create_new_collection(coll_name);
     }).then([this](auto coll_ref) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -56,8 +56,7 @@ struct fmt::formatter<test_extent_record_t> : fmt::formatter<std::string_view> {
 
 struct transaction_manager_test_t :
   public seastar_test_suite_t,
-  TMTestState,
-  ::testing::WithParamInterface<const char*> {
+  TMTestState {
 
   std::random_device rd;
   std::mt19937 gen;
@@ -76,14 +75,7 @@ struct transaction_manager_test_t :
   }
 
   seastar::future<> set_up_fut() final {
-    std::string j_type = GetParam();
-    if (j_type == "segmented") {
-      return tm_setup(journal_type_t::SEGMENTED);
-    } else if (j_type == "circularbounded") {
-      return tm_setup(journal_type_t::RANDOM_BLOCK);
-    } else {
-      ceph_assert(0 == "no support");
-    }
+    return tm_setup();
   }
 
   seastar::future<> tear_down_fut() final {

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -167,7 +167,7 @@ public:
   void set_primary_device_ref(DeviceRef) final;
 };
 
-class EphemeralTestState {
+class EphemeralTestState : public ::testing::WithParamInterface<const char*> {
 protected:
   journal_type_t journal_type;
   size_t num_main_device_managers = 0;
@@ -209,16 +209,15 @@ protected:
     restart_fut().get0();
   }
 
-  seastar::future<> tm_setup(
-    journal_type_t type = journal_type_t::SEGMENTED) {
+  seastar::future<> tm_setup() {
     LOG_PREFIX(EphemeralTestState::tm_setup);
-    journal_type = type;
-    if (journal_type == journal_type_t::SEGMENTED) {
+    std::string j_type = GetParam();
+    if (j_type == "segmented") {
       devices.reset(new
         EphemeralSegmentedDevices(
           num_main_device_managers, num_cold_device_managers));
     } else {
-      assert(journal_type == journal_type_t::RANDOM_BLOCK);
+      assert(j_type == "circularbounded");
       //TODO: multiple devices
       ceph_assert(num_main_device_managers == 1);
       ceph_assert(num_cold_device_managers == 0);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53232

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

