### PR TITLE
reef: crimson/os/seastore/cbj: fix a potential overflow bug on segment_seq

### DIFF
--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -41,8 +41,10 @@ CircularJournalSpace::roll_ertr::future<> CircularJournalSpace::roll() {
     get_records_start(),
     get_device_id());
   auto seq = get_written_to();
+  seq.segment_seq++;
+  assert(seq.segment_seq < MAX_SEG_SEQ);
   set_written_to(
-    journal_seq_t{++seq.segment_seq, paddr});
+    journal_seq_t{seq.segment_seq, paddr});
   return roll_ertr::now();
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -210,7 +210,7 @@ constexpr segment_id_t NULL_SEG_ID = MAX_SEG_ID;
 
 /* Monotonically increasing segment seq, uniquely identifies
  * the incarnation of a segment */
-using segment_seq_t = uint32_t;
+using segment_seq_t = uint64_t;
 static constexpr segment_seq_t MAX_SEG_SEQ =
   std::numeric_limits<segment_seq_t>::max();
 static constexpr segment_seq_t NULL_SEG_SEQ = MAX_SEG_SEQ;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53230

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

