### PR TITLE
reef: crimson/vstart: default seastore_device_size will be out of space f…

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -986,7 +986,7 @@ segment_id_t SegmentCleaner::allocate_segment(
   ERROR("out of space with {} {} {} {}",
         type, segment_seq_printer_t{seq}, category,
         rewrite_gen_printer_t{generation});
-  ceph_abort();
+  ceph_abort("seastore device size setting is too small");
   return NULL_SEG_ID;
 }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53432

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

