### PR TITLE
pacific: mgr/cephadm: ceph orch add fails when ipv6 address is surrounded by square brackets.

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -12,6 +12,7 @@ from ceph.deployment.inventory import Device  # noqa: F401; pylint: disable=unus
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, OSDMethod
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, service_spec_allow_invalid_from_json
 from ceph.deployment.hostspec import SpecValidationError
+from ceph.deployment.utils import unwrap_ipv6
 from ceph.utils import datetime_now
 
 from mgr_util import to_pretty_timedelta, format_bytes
@@ -348,6 +349,9 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         # split multiple labels passed in with --labels=label1,label2
         if labels and len(labels) == 1:
             labels = labels[0].split(',')
+
+        if addr is not None:
+            addr = unwrap_ipv6(addr)
 
         s = HostSpec(hostname=hostname, addr=addr, labels=labels, status=_status)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63115

---

backport of https://github.com/ceph/ceph/pull/52296
parent tracker: https://tracker.ceph.com/issues/61885

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh