### PR TITLE
pacific: mon/ConfigMonitor: Show localized name in "config dump --format json" output

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -32,6 +32,14 @@
   in certain recovery scenarios, e.g., monitor database lost and rebuilt, and
   the restored file system is expected to have the same ID as before.
 
+>=16.2.15
+----------
+* `ceph config dump --format <json|xml>` output will display the localized
+  option names instead of its normalized version. For e.g.,
+  "mgr/prometheus/x/server_port" will be displayed instead of
+  "mgr/prometheus/server_port". This matches the output of the non pretty-print
+  formatted version of the command.
+
 >= 16.2.14
 ----------
 

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -66,7 +66,7 @@ void OptionMask::dump(Formatter *f) const
 
 void MaskedOption::dump(Formatter *f) const
 {
-  f->dump_string("name", opt->name);
+  f->dump_string("name", localized_name);
   f->dump_string("value", raw_value);
   f->dump_string("level", Option::level_to_str(opt->level));
   f->dump_bool("can_update_at_runtime", opt->can_update_at_runtime());
@@ -76,7 +76,7 @@ void MaskedOption::dump(Formatter *f) const
 
 ostream& operator<<(ostream& out, const MaskedOption& o)
 {
-  out << o.opt->name;
+  out << o.localized_name;
   if (o.mask.location_type.size()) {
     out << "@" << o.mask.location_type << '=' << o.mask.location_value;
   }

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -62,6 +62,7 @@ struct MaskedOption {
   const Option *opt;              ///< the option
   OptionMask mask;
   std::unique_ptr<const Option> unknown_opt; ///< if fabricated for an unknown option
+  std::string localized_name;     ///< localized name for the option
 
   MaskedOption(const Option *o, bool fab=false) : opt(o) {
     if (fab) {
@@ -73,6 +74,7 @@ struct MaskedOption {
     opt = o.opt;
     mask = std::move(o.mask);
     unknown_opt = std::move(o.unknown_opt);
+    localized_name = std::move(o.localized_name);
   }
   const MaskedOption& operator=(const MaskedOption& o) = delete;
   const MaskedOption& operator=(MaskedOption&& o) = delete;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -843,6 +843,7 @@ void ConfigMonitor::load_config()
     
     MaskedOption mopt(opt);
     mopt.raw_value = value;
+    mopt.localized_name = name;
     string section_name;
     if (who.size() &&
 	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63185

---

backport of https://github.com/ceph/ceph/pull/52906
parent tracker: https://tracker.ceph.com/issues/62379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh