### PR TITLE
cephadm: add option to install systemd unit only

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5493,6 +5493,24 @@ def command_ceph_volume(ctx):
 ##################################
 
 
+def command_unit_install(ctx):
+    # type: (CephadmContext) -> int
+    if not ctx.fsid:
+        raise Error('must pass --fsid to specify cluster')
+
+    fsid = ctx.fsid
+    install_base_units(ctx, fsid)
+    unit = get_unit_file(ctx, fsid)
+    unit_file = 'ceph-%s@.service' % (fsid)
+    with open(ctx.unit_dir + '/' + unit_file + '.new', 'w') as f:
+        f.write(unit)
+        os.rename(ctx.unit_dir + '/' + unit_file + '.new',
+                  ctx.unit_dir + '/' + unit_file)
+    call_throws(ctx, ['systemctl', 'daemon-reload'])
+
+    return 0
+
+
 @infer_fsid
 def command_unit(ctx):
     # type: (CephadmContext) -> int
@@ -7222,6 +7240,10 @@ def _get_parser():
         '--name', '-n',
         required=True,
         help='daemon name (type.id)')
+
+    parser_unit_install = subparsers.add_parser(
+        'unit-install', help="Install the daemon's systemd unit")
+    parser_unit_install.set_defaults(func=command_unit_install)
 
     parser_logs = subparsers.add_parser(
         'logs', help='print journald logs for a daemon container')


### PR DESCRIPTION
# Description

We have the need of having a way to re-create the systemd unit files that cephadm creates, for specific internal reasons. I have not found out a way to call cephadm to do this job (and only this) in a satisfactory manner.
I have then written this small patch that adds a new command, `cephadm unit-install` that will install the systemd units and do nothing else. We use it locally, it suits us well so I'd figure people might be interested in having this upstreamed.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation (I believe the --help is enough for this feature ?)
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests -- Tested locally and works as expected