### PR TITLE
mgr/volumes: handle bad arguments during subvolume create

### DIFF
--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -83,7 +83,7 @@ class CmdParam(object):
 
     def __init__(self, type, name,
                  who=None, n=None, req=True, range=None, strings=None,
-                 goodchars=None, positional=True):
+                 goodchars=None, positional=True, **kwargs):
         self.type = type
         self.name = name
         self.who = who
@@ -93,6 +93,7 @@ class CmdParam(object):
         self.strings = strings.split('|') if strings else []
         self.goodchars = goodchars
         self.positional = positional != 'false'
+        self.allowempty = kwargs.pop('allowempty', True) in (True, 'True', 'true')
 
         assert who is None
 
@@ -108,6 +109,8 @@ class CmdParam(object):
             advanced.append('goodchars= ``{}`` '.format(self.goodchars))
         if self.n:
             advanced.append('(can be repeated)')
+        if self.allowempty:
+            advanced.append('(can be empty string)')
 
         advanced = advanced or ["(string)"]
         return ' '.join(advanced)

--- a/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/basic.yaml
@@ -6,4 +6,5 @@ tasks:
         - tasks.cephfs.test_volumes.TestVolumeCreate
         - tasks.cephfs.test_volumes.TestSubvolumeGroups
         - tasks.cephfs.test_volumes.TestSubvolumes
+        - tasks.cephfs.test_volumes.TestEmptyStringForCreates
         - tasks.cephfs.test_subvolume

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -834,7 +834,7 @@ class FilesystemBase(MDSClusterBase):
                 assert(subvols['create'] > 0)
 
                 self.run_ceph_cmd('fs', 'subvolumegroup', 'create', self.name, 'qa')
-                subvol_options = self.fs_config.get('subvol_options', '')
+                subvol_options = self.fs_config.get('subvol_options', None)
 
                 for sv in range(0, subvols['create']):
                     sv_name = f'sv_{sv}'

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -9778,3 +9778,48 @@ class TestPerModuleFinsherThread(TestVolumesHelper):
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
+
+class TestEmptyStringForCreates(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 1
+
+    def setUp(self):
+        super().setUp()
+        result = json.loads(self.get_ceph_cmd_stdout("fs", "volume", "ls"))
+        self.assertTrue(len(result) > 0)
+        self.volname = result[0]['name']
+
+    def tearDown(self):
+        # clean up
+        super().tearDown()
+
+    def test_empty_name_string_for_subvolumegroup_name(self):
+        """
+        To test that an empty string is unacceptable for a subvolumegroup name
+        """
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolumegroup", "create", self.volname, "")
+
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolumegroup", "create", self.volname, "''")
+
+    def test_empty_name_string_for_subvolume_name(self):
+        """
+        To test that an empty string is unacceptable for a subvolume name
+        """
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolume", "create", "")
+
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolume", "create", "''")
+
+    def test_empty_name_string_for_subvolumegroup_name_argument(self):
+        """
+        To test that an empty string is unacceptable for a subvolumegroup name
+        argument when creating a subvolume
+        """
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "sv1", "--group_name")
+
+        with self.assertRaises(CommandFailedError):
+            self.run_ceph_cmd("fs", "subvolume", "create", self.volname, "sv1", "--group_name", "''")

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -355,7 +355,7 @@ class CephString(CephArgtype):
     """
     String; pretty generic.  goodchars is a RE char class of valid chars
     """
-    def __init__(self, goodchars=''):
+    def __init__(self, goodchars='', allowempty=True):
         from string import printable
         try:
             re.compile(goodchars)
@@ -366,8 +366,12 @@ class CephString(CephArgtype):
         self.goodset = frozenset(
             [c for c in printable if re.match(goodchars, c)]
         )
+        self.allowempty = allowempty in (True, 'True', 'true')
 
     def valid(self, s: str, partial: bool = False) -> None:
+        if not self.allowempty and s == "":
+            raise ArgumentFormat("argument can't be an empty string")
+
         sset = set(s)
         if self.goodset and not sset <= self.goodset:
             raise ArgumentFormat("invalid chars {0} in {1}".
@@ -378,6 +382,7 @@ class CephString(CephArgtype):
         b = ''
         if self.goodchars:
             b += '(goodchars {0})'.format(self.goodchars)
+        b += f'(allowempty {self.allowempty})'
         return '<string{0}>'.format(b)
 
     def complete(self, s) -> List[str]:
@@ -389,6 +394,7 @@ class CephString(CephArgtype):
     def argdesc(self, attrs):
         if self.goodchars:
             attrs['goodchars'] = self.goodchars
+        attrs['allowempty'] = repr(self.allowempty)
         return super().argdesc(attrs)
 
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -86,7 +86,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'fs subvolumegroup create '
                    'name=vol_name,type=CephString '
-                   f'name=group_name,type=CephString,goodchars={goodchars} '
+                   f'name=group_name,type=CephString,goodchars={goodchars},allowempty=false '
                    'name=size,type=CephInt,req=false '
                    'name=pool_layout,type=CephString,req=false '
                    'name=uid,type=CephInt,req=false '
@@ -136,9 +136,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'fs subvolume create '
                    'name=vol_name,type=CephString '
-                   f'name=sub_name,type=CephString,goodchars={goodchars} '
+                   f'name=sub_name,type=CephString,goodchars={goodchars},allowempty=false '
                    'name=size,type=CephInt,req=false '
-                   'name=group_name,type=CephString,req=false '
+                   f'name=group_name,type=CephString,req=false,goodchars={goodchars},allowempty=false '
                    'name=pool_layout,type=CephString,req=false '
                    'name=uid,type=CephInt,req=false '
                    'name=gid,type=CephInt,req=false '


### PR DESCRIPTION
test subvolgroup and subvol names and declare empty/whitespace strings as bad names

Fixes: https://tracker.ceph.com/issues/58645
Signed-off-by: Milind Changire mchangir@redhat.com



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
