### PR TITLE
rgw: add subuser to user policy condition check

### DIFF
--- a/src/rgw/rgw_iam_policy_keywords.gperf
+++ b/src/rgw/rgw_iam_policy_keywords.gperf
@@ -115,6 +115,8 @@ Null, TokenKind::cond_op, TokenID::Null, (uint64_t) Type::null, true, true
 #s3:authType, TokenKind::cond_key, TokenID::s3authType, (uint64_t) Type::string, true, false
 #s3:signatureAge, TokenKind::cond_key, TokenID::s3signatureAge, (uint64_t) Type::number, true, false
 #s3:x-amz-content-sha256, TokenKind::cond_key, TokenID::s3x_amz_content_sha256, (uint64_t) Type::string, true, false
+# RGW
+#rgw:subuser, TokenKind::cond_key, TokenID::rgwsubuser, (uint64_t) Type::string, true, false
 # STS
 #sts:authentication, TokenKind::cond_key, TokenID::stsauthentication, (uint64_t) Type::boolean, true, false
 #

--- a/src/rgw/rgw_iam_policy_keywords.h
+++ b/src/rgw/rgw_iam_policy_keywords.h
@@ -89,6 +89,7 @@ enum class TokenID {
   s3authType,
   s3signatureAge,
   s3x_amz_content_sha256,
+  rgwsubuser,
 #else
   CondKey,
 #endif

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -922,6 +922,10 @@ void rgw_build_iam_environment(rgw::sal::Driver* driver,
     s->env.emplace("aws:username", s->user->get_id().id);
   }
 
+  if (s->auth.identity) {
+    s->env.emplace("rgw:subuser", s->auth.identity->get_subuser().c_str());
+  }
+
   i = m.find("HTTP_X_AMZ_SECURITY_TOKEN");
   if (i != m.end()) {
     s->env.emplace("sts:authentication", "true");


### PR DESCRIPTION
Add rgw:subuser field (with subuser name) to user policy condition for managing multi keys in user policy engine. So that if user has multiple keys, user policy by condition can defined which key from user is requesting.

Signed-off-by: ivan [i.makarychev@tinkoff.ru](mailto:i.makarychev@tinkoff.ru)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
