### PR TITLE
DNM: osd/scheduler: Factor in num of op threads to determine OSD shards' bandwidth capacity

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10714,8 +10714,8 @@ OSDShard::OSDShard(
     shard_lock_name(shard_name + "::shard_lock"),
     shard_lock{make_mutex(shard_lock_name)},
     scheduler(ceph::osd::scheduler::make_scheduler(
-      cct, osd->whoami, osd->num_shards, id, osd->store->is_rotational(),
-      osd->store->get_type(), osd->monc)),
+      cct, osd->whoami, osd->get_num_op_threads(), id,
+      osd->store->is_rotational(), osd->store->get_type(), osd->monc)),
     context_queue(sdata_wait_lock, sdata_cond)
 {
   dout(0) << "using op scheduler " << *scheduler << dendl;

--- a/src/osd/scheduler/OpScheduler.cc
+++ b/src/osd/scheduler/OpScheduler.cc
@@ -22,7 +22,7 @@
 namespace ceph::osd::scheduler {
 
 OpSchedulerRef make_scheduler(
-  CephContext *cct, int whoami, uint32_t num_shards, int shard_id,
+  CephContext *cct, int whoami, uint32_t num_op_shard_threads, int shard_id,
   bool is_rotational, std::string_view osd_objectstore, MonClient *monc)
 {
   const std::string *type = &cct->_conf->osd_op_queue;
@@ -46,7 +46,8 @@ OpSchedulerRef make_scheduler(
   } else if (*type == "mclock_scheduler") {
     // default is 'mclock_scheduler'
     return std::make_unique<
-      mClockScheduler>(cct, whoami, num_shards, shard_id, is_rotational, monc);
+      mClockScheduler>(cct, whoami, num_op_shard_threads, shard_id,
+        is_rotational, monc);
   } else {
     ceph_assert("Invalid choice of wq" == 0);
   }

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -62,7 +62,7 @@ std::ostream &operator<<(std::ostream &lhs, const OpScheduler &);
 using OpSchedulerRef = std::unique_ptr<OpScheduler>;
 
 OpSchedulerRef make_scheduler(
-  CephContext *cct, int whoami, uint32_t num_shards, int shard_id,
+  CephContext *cct, int whoami, uint32_t num_op_shard_threads, int shard_id,
   bool is_rotational, std::string_view osd_objectstore, MonClient *monc);
 
 /**


### PR DESCRIPTION
This change impacts OSDs configured with SSD as the backing device.

The number of threads per OSD shard must be factored in for calculating the per shard bandwidth capacity of an OSD. This is because there could be more than one worker thread configured per OSD shard and the OSD's bandwidth capacity must be shared on a per shard thread basis.

For instance, currently, if the underlying OSD device is of SSD type, each OSD shard is configured with two worker threads. Therefore, the per shard thread bandwidth capacity must actually be calculated as:

`  bandwidth_per_shard = OSD Bandwidth / (num_shards * threads_per_shard)`

This results in the correct allocation of QoS reservation and limits to the respective classes of service on the OSD. This has implications to client QoS where reservation and limits could be something other than MIN or MAX.

Without this change, and with SSD backing devices, each OSD shard thread is incorrectly assigned double (2 worker threads) the intended reservation and limit resulting in oversubscription of the OSD's bandwidth.

**Changes:**

- Pass osd->get_num_op_threads() instead of num_shards to OpScheduler::make_scheduler()
- This is now passed as 'num_op_shard_threads' instead of 'num_shards' to the mClockScheduler constructor.
- In the mClockScheduler, osd_bandwidth_capacity_per_shard is renamed to osd_bandwidth_capacity_per_shard_thread and is calculated using the passed in num_op_shard_threads.
- osd_bandwidth_capacity_per_shard_thread is then used in update_from_config() to calculate the reservation and limit quantities.

Currently, for HDD based OSDs this change has no impact because the number of threads per OSD shard is set to 1.

Fixes: https://tracker.ceph.com/issues/63197
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
