### PR TITLE
pacific: radosgw-admin: allow 'bi purge' to delete index if entrypoint doesn't exist

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6675,12 +6675,13 @@ next:
     RGWBucketInfo cur_bucket_info;
     rgw_bucket cur_bucket;
     ret = init_bucket(tenant, bucket_name, string(), cur_bucket_info, cur_bucket);
-    if (ret < 0) {
+    if (ret == -ENOENT) {
+      // no bucket entrypoint
+    } else if (ret < 0) {
       cerr << "ERROR: could not init current bucket info for bucket_name=" << bucket_name << ": " << cpp_strerror(-ret) << std::endl;
       return -ret;
-    }
-
-    if (cur_bucket_info.bucket.bucket_id == bucket_info.bucket.bucket_id && !yes_i_really_mean_it) {
+    } else if (cur_bucket_info.bucket.bucket_id == bucket_info.bucket.bucket_id &&
+               !yes_i_really_mean_it) {
       cerr << "specified bucket instance points to a current bucket instance" << std::endl;
       cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
       return EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53152

---

backport of https://github.com/ceph/ceph/pull/43591
parent tracker: https://tracker.ceph.com/issues/52976

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh