### PR TITLE
quincy: rgw: fix rgw cache invalidation after unregister_watch() error

### DIFF
--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -32,6 +32,7 @@ class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
   RGWSI_RADOS::Obj obj;
   uint64_t watch_handle;
   int register_ret{0};
+  bool unregister_done{false};
   librados::AioCompletion *register_completion{nullptr};
 
   class C_ReinitWatch : public Context {
@@ -85,20 +86,23 @@ public:
   }
 
   void reinit() {
-    int ret = unregister_watch();
-    if (ret < 0) {
-      ldout(cct, 0) << "ERROR: unregister_watch() returned ret=" << ret << dendl;
-      return;
+    if(!unregister_done) {
+      int ret = unregister_watch();
+      if (ret < 0) {
+        ldout(cct, 0) << "ERROR: unregister_watch() returned ret=" << ret << dendl;
+      }
     }
-    ret = register_watch();
+    int ret = register_watch();
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: register_watch() returned ret=" << ret << dendl;
+      svc->schedule_context(new C_ReinitWatch(this));
       return;
     }
   }
 
   int unregister_watch() {
     int r = svc->unwatch(obj, watch_handle);
+    unregister_done = true;
     if (r < 0) {
       return r;
     }
@@ -135,6 +139,7 @@ public:
       return r;
     }
     svc->add_watcher(index);
+    unregister_done = false;
     return 0;
   }
 
@@ -144,6 +149,7 @@ public:
       return r;
     }
     svc->add_watcher(index);
+    unregister_done = false;
     return 0;
   }
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59362

---

backport of https://github.com/ceph/ceph/pull/50707
parent tracker: https://tracker.ceph.com/issues/59217

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh