### PR TITLE
pacific: rgw: 'bucket check' deletes index of multipart meta when its pending_map is nonempty

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9159,6 +9159,11 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   std::string loc;
 
   rgw_obj obj(bucket, list_state.key);
+  MultipartMetaFilter multipart_meta_filter;
+  string temp_key;
+  if (multipart_meta_filter.filter(list_state.key.name, temp_key)) {
+    obj.set_in_extra_data(true);
+  }
 
   string oid;
   get_obj_bucket_and_oid_loc(obj, oid, loc);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57199

---

backport of https://github.com/ceph/ceph/pull/47228
parent tracker: https://tracker.ceph.com/issues/56673

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh