### PR TITLE
reef: qa/suites/crimson-rados: Use centos8 for testing

### DIFF
--- a/qa/suites/crimson-rados/basic/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/basic/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/basic/centos_latest.yaml
+++ b/qa/suites/crimson-rados/basic/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/crimson-rados/rbd/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/rbd/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/rbd/centos_latest.yaml
+++ b/qa/suites/crimson-rados/rbd/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/crimson-rados/thrash/centos_8.stream.yaml
+++ b/qa/suites/crimson-rados/thrash/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_8.stream.yaml

--- a/qa/suites/crimson-rados/thrash/centos_latest.yaml
+++ b/qa/suites/crimson-rados/thrash/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52598

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

