### PR TITLE
reef: qa/suites/crimson-rados: add centos9 to supported distros

### DIFF
--- a/qa/distros/crimson-supported-all-distro/centos_8.yaml
+++ b/qa/distros/crimson-supported-all-distro/centos_8.yaml
@@ -1,0 +1,1 @@
+../all/centos_8.yaml

--- a/qa/distros/crimson-supported-all-distro/centos_latest.yaml
+++ b/qa/distros/crimson-supported-all-distro/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/suites/crimson-rados/basic/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/basic/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/

--- a/qa/suites/crimson-rados/rbd/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/rbd/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/

--- a/qa/suites/crimson-rados/thrash/crimson-supported-all-distro
+++ b/qa/suites/crimson-rados/thrash/crimson-supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/crimson-supported-all-distro/


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52784

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

