### PR TITLE
rgw/notifications/test: fix rabbitmq and kafka issues in centos9

### DIFF
--- a/qa/suites/rgw/notifications/tasks/0-install.yaml
+++ b/qa/suites/rgw/notifications/tasks/0-install.yaml
@@ -6,6 +6,13 @@ tasks:
     client.0:
 
 overrides:
+  install:
+    ceph:
+      extra_system_packages:
+        rpm:
+        - java
+        deb:
+        - default-jre
   ceph:
     conf:
       global:

--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -17,9 +17,11 @@ def get_kafka_version(config):
             kafka_version = client_config.get('kafka_version')
     return kafka_version
 
+kafka_prefix = 'kafka_2.13-'
+
 def get_kafka_dir(ctx, config):
     kafka_version = get_kafka_version(config)
-    current_version = 'kafka-' + kafka_version + '-src'
+    current_version = kafka_prefix + kafka_version
     return '{tdir}/{ver}'.format(tdir=teuthology.get_testdir(ctx),ver=current_version)
 
 
@@ -36,14 +38,15 @@ def install_kafka(ctx, config):
         test_dir=teuthology.get_testdir(ctx)
         current_version = get_kafka_version(config)
 
-        link1 = 'https://archive.apache.org/dist/kafka/' + current_version + '/kafka-' + current_version + '-src.tgz'
+        kafka_file =  kafka_prefix + current_version + '.tgz'
+
+        link1 = 'https://archive.apache.org/dist/kafka/' + current_version + '/' + kafka_file
         ctx.cluster.only(client).run(
             args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'), 'wget', link1],
         )
 
-        file1 = 'kafka-' + current_version + '-src.tgz'
         ctx.cluster.only(client).run(
-            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'), 'tar', '-xvzf', file1],
+            args=['cd', '{tdir}'.format(tdir=test_dir), run.Raw('&&'), 'tar', '-xvzf', kafka_file],
         )
 
     try:
@@ -61,9 +64,8 @@ def install_kafka(ctx, config):
                 args=['rm', '-rf', test_dir],
             )
 
-            rmfile1 = 'kafka-' + current_version + '-src.tgz'
             ctx.cluster.only(client).run(
-                args=['rm', '-rf', '{tdir}/{doc}'.format(tdir=teuthology.get_testdir(ctx),doc=rmfile1)],
+                args=['rm', '-rf', '{tdir}/{doc}'.format(tdir=teuthology.get_testdir(ctx),doc=kafka_file)],
             )
 
 
@@ -78,13 +80,6 @@ def run_kafka(ctx,config):
     log.info('Bringing up Zookeeper and Kafka services...')
     for (client,_) in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
-
-        ctx.cluster.only(client).run(
-            args=['cd', '{tdir}'.format(tdir=get_kafka_dir(ctx, config)), run.Raw('&&'),
-             './gradlew', 'jar', 
-             '-PscalaVersion=2.13.2'
-            ],
-        )
 
         ctx.cluster.only(client).run(
             args=['cd', '{tdir}/bin'.format(tdir=get_kafka_dir(ctx, config)), run.Raw('&&'),

--- a/qa/tasks/rabbitmq.py
+++ b/qa/tasks/rabbitmq.py
@@ -23,7 +23,7 @@ def install_rabbitmq(ctx, config):
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'yum', '-y', 'install', 'epel-release'
+             'sudo', 'dnf', '-y', 'install', 'epel-release'
         ])
 
         link1 = 'https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh'
@@ -33,7 +33,7 @@ def install_rabbitmq(ctx, config):
         ])
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'yum', '-y', 'install', 'erlang'
+             'sudo', 'dnf', '-y', 'install', 'erlang'
         ])
 
         link2 = 'https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh'
@@ -43,7 +43,7 @@ def install_rabbitmq(ctx, config):
         ])
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'yum', '-y', 'install', 'rabbitmq-server'
+             'sudo', 'dnf', '-y', 'install', 'rabbitmq-server'
         ])
 
     try:
@@ -53,7 +53,7 @@ def install_rabbitmq(ctx, config):
 
         for (client, _) in config.items():
             ctx.cluster.only(client).run(args=[
-                 'sudo', 'yum', '-y', 'remove', 'rabbitmq-server.noarch'
+                 'sudo', 'dnf', '-y', 'remove', 'rabbitmq-server.noarch'
             ])
 
 
@@ -70,7 +70,7 @@ def run_rabbitmq(ctx, config):
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'chkconfig', 'rabbitmq-server', 'on'
+             'sudo', 'systemctl', 'enable', 'rabbitmq-server.service'
             ],
         )
 

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -1615,8 +1615,7 @@ def test_ps_s3_notification_push_kafka_on_master():
         time.sleep(5)
         receiver.verify_s3_events(keys, exact_match=True, deletions=True, etags=etags)
     except Exception as e:
-        print(e)
-        assert False
+        assert False, str(e)
     finally:
         # cleanup
         if s3_notification_conf is not None:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63205

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
