### PR TITLE
reef: mds: adjust pre_segments_size for MDLog when trimming segments for st…

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1494,6 +1494,9 @@ void MDLog::standby_trim_segments()
     dout(10) << " removing segment" << dendl;
     mds->mdcache->standby_trim_segment(seg);
     remove_oldest_segment();
+    if (pre_segments_size > 0) {
+      --pre_segments_size;
+    }
     removed_segment = true;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63174

---

backport of https://github.com/ceph/ceph/pull/52755
parent tracker: https://tracker.ceph.com/issues/59833

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh