### PR TITLE
qa/tasks/thrashosds-health: fix log-ignorelist of thrashosds-health.yaml

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -17,5 +17,5 @@ overrides:
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
       - slow request
-      - timeout on replica
+      - timeout on reserving replicas
       - late reservation from


### PR DESCRIPTION
When any of secondary cannot respond from scrub reservation within a timeout period due to various reasons (e.g., peering), it can be caused by PgScrubber timeout on primary while reserving replicas.

There was a previous issues [1] that has been fixed already by pr [2]. However, it seems same problems occur in recent tests. [4-8]

In the previous commit [3], an log-ignorelist was updated for timeout logs. After that, as the log message was changed from "timeout on replica" to "timeout on reserving replicas" [4], the this message cannot filter out timeout warnings [5-9]. Because the log-ignorelist has’t been updated yet.

So to catch the "timeout on reserving replica" warning message, the log-ignorelist needs to be fixed from "timeout on replica" to “timeout on reserving replicas”.

1. https://tracker.ceph.com/issues/59333
2. https://github.com/ceph/ceph/pull/52590/commits/ebccd68b97239d9923f08745ca6112bd2c2bfbee
3. https://github.com/ceph/ceph/pull/48545/commits/7730baa6c5b7c6ee579a1fb22c6336e6340614c7
4. https://github.com/ceph/ceph/commit/525478da3698cfe8a154c642dedd0570f1d52b37
5. https://pulpito.ceph.com/yuriw-2023-10-13_14:50:14-rados-wip-neorados-learning-from-experience-distro-default-smithi/7424512/
6. https://pulpito.ceph.com/ksirivad-2023-10-13_01:58:36-rados-wip-ksirivad-fix-63183-distro-default-smithi/7423913/
7. https://pulpito.ceph.com/yuriw-2023-10-05_14:23:09-rados-wip-yuri6-testing-2023-10-04-0901-distro-default-smithi/7411594
8. https://pulpito.ceph.com/myoungwon-2023-10-11_15:51:58-rados-wip-ceph-dedup-tool-snap-add-distro-default-smithi/7421887
9. https://pulpito.ceph.com/myoungwon-2023-10-11_15:51:58-rados-wip-ceph-dedup-tool-snap-add-distro-default-smithi/7421930/
* The tests [8, 9] are not including the previous bug fix commit [2], but it looks the same problem would have occurred even if the previous commits were included.

It appears that “timeout on replica” logs are not generated because the log message has been changed.
Is there any reason to leave “timeout on replica” in thrashosds-health.yaml?
If so, new ignore message can be added leaving previous one.
Otherwise, it seems like it could be replaced with the new message like in this commit.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
