### PR TITLE
doc: Update mClock QOS documentation to discard osd_mclock_cost_per_*

### DIFF
--- a/doc/dev/osd_internals/mclock_wpq_cmp_study.rst
+++ b/doc/dev/osd_internals/mclock_wpq_cmp_study.rst
@@ -114,29 +114,6 @@ baseline throughput for each device type was determined:
           256 KiB. For HDDs, it was 40MiB. The above throughput was obtained
           by running 4 KiB random writes at a queue depth of 64 for 300 secs.
 
-Factoring I/O Cost in mClock
-============================
-
-The services using mClock have a cost associated with them. The cost can be
-different for each service type. The mClock scheduler factors in the cost
-during calculations for parameters like *reservation*, *weight* and *limit*.
-The calculations determine when the next op for the service type can be
-dequeued from the operation queue. In general, the higher the cost, the longer
-an op remains in the operation queue.
-
-A cost modeling study was performed to determine the cost per I/O and the cost
-per byte for SSD and HDD device types. The following cost specific options are
-used under the hood by mClock,
-
-- :confval:`osd_mclock_cost_per_io_usec`
-- :confval:`osd_mclock_cost_per_io_usec_hdd`
-- :confval:`osd_mclock_cost_per_io_usec_ssd`
-- :confval:`osd_mclock_cost_per_byte_usec`
-- :confval:`osd_mclock_cost_per_byte_usec_hdd`
-- :confval:`osd_mclock_cost_per_byte_usec_ssd`
-
-See :doc:`/rados/configuration/mclock-config-ref` for more details.
-
 MClock Profile Allocations
 ==========================
 


### PR DESCRIPTION
The cost parameters (osd_mclock_cost_per_*) have been removed.
The cost of an operation is now determined using the random IOPS
and maximum sequential bandwidth capability of the OSD's underlying device.

Fixes: https://tracker.ceph.com/issues/58529





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
