### PR TITLE
reef: crimson/osd/osd_operations: consistent naming to pipeline users

### DIFF
--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -172,7 +172,7 @@ PglogBasedRecovery::do_recovery()
   });
 }
 
-PGPeeringPipeline &BackfillRecovery::bp(PG &pg)
+PGPeeringPipeline &BackfillRecovery::peering_pp(PG &pg)
 {
   return pg.peering_request_pg_pipeline;
 }
@@ -193,7 +193,7 @@ BackfillRecovery::do_recovery()
     // with the backfill_pipeline we protect it from a second entry from
     // the implementation of BackfillListener.
     // additionally, this stage serves to synchronize with PeeringEvent.
-    bp(*pg).process
+    peering_pp(*pg).process
   ).then_interruptible([this] {
     pg->get_recovery_handler()->dispatch_backfill_event(std::move(evt));
     return seastar::make_ready_future<bool>(false);

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -116,7 +116,7 @@ private:
   boost::intrusive_ptr<const boost::statechart::event_base> evt;
   PipelineHandle handle;
 
-  static PGPeeringPipeline &bp(PG &pg);
+  static PGPeeringPipeline &peering_pp(PG &pg);
   interruptible_future<bool> do_recovery() override;
 };
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -244,7 +244,7 @@ private:
       Ref<PG> &pg);
   bool is_pg_op() const;
 
-  PGPipeline &pp(PG &pg);
+  PGPipeline &client_pp(PG &pg);
 
   template <typename Errorator>
   using interruptible_errorator =

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -39,7 +39,7 @@ private:
   void print(std::ostream &) const final;
   void dump_detail(Formatter *f) const final;
 
-  CommonPGPipeline& pp();
+  CommonPGPipeline& client_pp();
 
   seastar::future<> do_process();
 

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -49,7 +49,7 @@ ConnectionPipeline &LogMissingRequest::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-ClientRequest::PGPipeline &LogMissingRequest::pp(PG &pg)
+ClientRequest::PGPipeline &LogMissingRequest::client_pp(PG &pg)
 {
   return pg.request_pg_pipeline;
 }

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -64,7 +64,7 @@ public:
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &client_pp(PG &pg);
 
   crimson::net::ConnectionRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.cc
@@ -49,7 +49,7 @@ ConnectionPipeline &LogMissingRequestReply::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-ClientRequest::PGPipeline &LogMissingRequestReply::pp(PG &pg)
+ClientRequest::PGPipeline &LogMissingRequestReply::client_pp(PG &pg)
 {
   return pg.request_pg_pipeline;
 }

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.h
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.h
@@ -64,7 +64,7 @@ public:
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &client_pp(PG &pg);
 
   crimson::net::ConnectionRef conn;
   // must be after `conn` to ensure the ConnectionPipeline's is alive

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -51,7 +51,7 @@ public:
   static constexpr OperationTypeCode type = OperationTypeCode::peering_event;
 
 protected:
-  PGPeeringPipeline &pp(PG &pg);
+  PGPeeringPipeline &peering_pp(PG &pg);
 
   PeeringCtx ctx;
   pg_shard_t from;

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -55,6 +55,11 @@ void PGAdvanceMap::dump_detail(Formatter *f) const
   f->close_section();
 }
 
+PGPeeringPipeline &PGAdvanceMap::peering_pp(PG &pg)
+{
+  return pg.peering_request_pg_pipeline;
+}
+
 seastar::future<> PGAdvanceMap::start()
 {
   using cached_map_t = OSDMapService::cached_map_t;
@@ -63,7 +68,7 @@ seastar::future<> PGAdvanceMap::start()
 
   IRef ref = this;
   return enter_stage<>(
-    pg->peering_request_pg_pipeline.process
+    peering_pp(*pg).process
   ).then([this] {
     /*
      * PGAdvanceMap is scheduled at pg creation and when

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -49,6 +49,9 @@ public:
   std::tuple<
     PGPeeringPipeline::Process::BlockingEvent
   > tracking_events;
+
+private:
+  PGPeeringPipeline &peering_pp(PG &pg);
 };
 
 }

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -49,7 +49,7 @@ ConnectionPipeline &RepRequest::get_connection_pipeline()
   return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
 }
 
-ClientRequest::PGPipeline &RepRequest::pp(PG &pg)
+ClientRequest::PGPipeline &RepRequest::client_pp(PG &pg)
 {
   return pg.request_pg_pipeline;
 }
@@ -61,7 +61,7 @@ seastar::future<> RepRequest::with_pg(
   IRef ref = this;
   return interruptor::with_interruption([this, pg] {
     logger().debug("{}: pg present", *this);
-    return this->template enter_stage<interruptor>(pp(*pg).await_map
+    return this->template enter_stage<interruptor>(client_pp(*pg).await_map
     ).then_interruptible([this, pg] {
       return this->template with_blocking_event<
         PG_OSDMapGate::OSDMapBlocker::BlockingEvent

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -66,7 +66,7 @@ public:
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &pp(PG &pg);
+  ClientRequest::PGPipeline &client_pp(PG &pg);
 
   crimson::net::ConnectionRef conn;
   PipelineHandle handle;

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -92,7 +92,7 @@ SnapTrimEvent::start()
   });
 }
 
-CommonPGPipeline& SnapTrimEvent::pp()
+CommonPGPipeline& SnapTrimEvent::client_pp()
 {
   return pg->request_pg_pipeline;
 }
@@ -103,7 +103,7 @@ SnapTrimEvent::with_pg(
 {
   return interruptor::with_interruption([&shard_services, this] {
     return enter_stage<interruptor>(
-      pp().wait_for_active
+      client_pp().wait_for_active
     ).then_interruptible([this] {
       return with_blocking_event<PGActivationBlocker::BlockingEvent,
                                  interruptor>([this] (auto&& trigger) {
@@ -111,18 +111,18 @@ SnapTrimEvent::with_pg(
       });
     }).then_interruptible([this] {
       return enter_stage<interruptor>(
-        pp().recover_missing);
+        client_pp().recover_missing);
     }).then_interruptible([] {
       //return do_recover_missing(pg, get_target_oid());
       return seastar::now();
     }).then_interruptible([this] {
       return enter_stage<interruptor>(
-        pp().get_obc);
+        client_pp().get_obc);
     }).then_interruptible([this] {
       return pg->snaptrim_mutex.lock(*this);
     }).then_interruptible([this] {
       return enter_stage<interruptor>(
-        pp().process);
+        client_pp().process);
     }).then_interruptible([&shard_services, this] {
       return interruptor::async([this] {
         std::vector<hobject_t> to_trim;
@@ -207,7 +207,7 @@ SnapTrimEvent::with_pg(
 }
 
 
-CommonPGPipeline& SnapTrimObjSubEvent::pp()
+CommonPGPipeline& SnapTrimObjSubEvent::client_pp()
 {
   return pg->request_pg_pipeline;
 }
@@ -497,7 +497,7 @@ SnapTrimObjSubEvent::with_pg(
   ShardServices &shard_services, Ref<PG> _pg)
 {
   return enter_stage<interruptor>(
-    pp().wait_for_active
+    client_pp().wait_for_active
   ).then_interruptible([this] {
     return with_blocking_event<PGActivationBlocker::BlockingEvent,
                                interruptor>([this] (auto&& trigger) {
@@ -505,13 +505,13 @@ SnapTrimObjSubEvent::with_pg(
     });
   }).then_interruptible([this] {
     return enter_stage<interruptor>(
-      pp().recover_missing);
+      client_pp().recover_missing);
   }).then_interruptible([] {
     //return do_recover_missing(pg, get_target_oid());
     return seastar::now();
   }).then_interruptible([this] {
     return enter_stage<interruptor>(
-      pp().get_obc);
+      client_pp().get_obc);
   }).then_interruptible([this] {
     logger().debug("{}: getting obc for {}", *this, coid);
     // end of commonality
@@ -521,7 +521,7 @@ SnapTrimObjSubEvent::with_pg(
       [this](auto head_obc, auto clone_obc) {
       logger().debug("{}: got clone_obc={}", *this, clone_obc->get_oid());
       return enter_stage<interruptor>(
-        pp().process
+        client_pp().process
       ).then_interruptible(
         [this,clone_obc=std::move(clone_obc), head_obc=std::move(head_obc)]() mutable {
         logger().debug("{}: processing clone_obc={}", *this, clone_obc->get_oid());

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -57,7 +57,7 @@ public:
     ShardServices &shard_services, Ref<PG> pg);
 
 private:
-  CommonPGPipeline& pp();
+  CommonPGPipeline& client_pp();
 
   // bases on 998cb8c141bb89aafae298a9d5e130fbd78fe5f2
   struct SubOpBlocker : crimson::BlockerT<SubOpBlocker> {
@@ -143,7 +143,7 @@ public:
   remove_or_update_iertr::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
 
-  CommonPGPipeline& pp();
+  CommonPGPipeline& client_pp();
 
 private:
   object_stat_sum_t delta_stats;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52223

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

