### PR TITLE
reef: crimson/os/object_data_handler: splitting right side doesn't mean splitting only one extent

### DIFF
--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -259,7 +259,6 @@ overwrite_ops_t prepare_ops_list(
       assert(to_write.size() > 1);
       assert(back.addr + back.len ==
         back.pin->get_key() + back.pin->get_length());
-      assert((*(to_write.begin())).addr == back.pin->get_key());
       ops.to_remap.push_back(extent_to_remap_t::create_remap(
         std::move(back.pin),
         back.addr - back.pin->get_key(),


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52390

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

