### PR TITLE
reef: crimson/os/seastore/zbd: zbdsegmentmanager write path fixes.

### DIFF
--- a/src/crimson/os/seastore/segment_manager/zbd.cc
+++ b/src/crimson/os/seastore/segment_manager/zbd.cc
@@ -16,7 +16,7 @@ SET_SUBSYS(seastore_device);
 #define SECT_SHIFT	9
 #define RESERVED_ZONES 	1
 // limit the max padding buf size to 1MB
-#define MAX_PADDING_SIZE 1048576
+#define MAX_PADDING_SIZE 4194304
 
 using z_op = crimson::os::seastore::segment_manager::zbd::zone_op;
 template <> struct fmt::formatter<z_op>: fmt::formatter<std::string_view> {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52420

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

