### PR TITLE
qa/smoke,rados,perf-basic: add POOL_APP_NOT_ENABLED to ignorelist

### DIFF
--- a/qa/suites/orch/cephadm/orchestrator_cli/orchestrator_cli.yaml
+++ b/qa/suites/orch/cephadm/orchestrator_cli/orchestrator_cli.yaml
@@ -13,6 +13,7 @@ tasks:
         - \(PG_
         - replacing it with standby
         - No standby daemons available
+        - \(POOL_APP_NOT_ENABLED\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_orchestrator_cli

--- a/qa/suites/perf-basic/objectstore/bluestore.yaml
+++ b/qa/suites/perf-basic/objectstore/bluestore.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       osd:
         osd objectstore: bluestore

--- a/qa/suites/rados/objectstore/backends/alloc-hint.yaml
+++ b/qa/suites/rados/objectstore/backends/alloc-hint.yaml
@@ -17,6 +17,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/objectstore/backends/filejournal.yaml
+++ b/qa/suites/rados/objectstore/backends/filejournal.yaml
@@ -8,6 +8,8 @@ tasks:
 - install:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - exec:
     client.0:
       - ceph_test_filejournal

--- a/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_blogbench.yaml
+++ b/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_blogbench.yaml
@@ -1,6 +1,8 @@
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_fsstress.yaml
+++ b/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_fsstress.yaml
@@ -1,5 +1,7 @@
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_iozone.yaml
+++ b/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_iozone.yaml
@@ -1,5 +1,7 @@
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse: [client.0]
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/smoke/basic/tasks/test/cfuse_workunit_suites_pjd.yaml
@@ -1,6 +1,8 @@
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
     conf:
       mds:
         debug mds: 20

--- a/qa/suites/smoke/basic/tasks/test/kclient_workunit_direct_io.yaml
+++ b/qa/suites/smoke/basic/tasks/test/kclient_workunit_direct_io.yaml
@@ -5,6 +5,8 @@ overrides:
         ms die on skipped message: false
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - kclient:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_dbench.yaml
+++ b/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_dbench.yaml
@@ -6,6 +6,8 @@ overrides:
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - kclient:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_fsstress.yaml
+++ b/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_fsstress.yaml
@@ -6,6 +6,8 @@ overrides:
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - kclient:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_pjd.yaml
+++ b/qa/suites/smoke/basic/tasks/test/kclient_workunit_suites_pjd.yaml
@@ -6,6 +6,8 @@ overrides:
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - kclient:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/libcephfs_interface_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/libcephfs_interface_tests.yaml
@@ -9,6 +9,8 @@ overrides:
         debug mds: 20
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/rados_cls_all.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_cls_all.yaml
@@ -7,6 +7,8 @@ overrides:
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       client.0:

--- a/qa/suites/smoke/basic/tasks/test/rbd_cli_import_export.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rbd_cli_import_export.yaml
@@ -1,6 +1,8 @@
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/rbd_python_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rbd_python_api_tests.yaml
@@ -1,5 +1,7 @@
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/test/rbd_workunit_suites_iozone.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rbd_workunit_suites_iozone.yaml
@@ -7,6 +7,8 @@ overrides:
         rbd default features: 5
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - rbd:
     all:
       image_size: 20480

--- a/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
@@ -4,6 +4,8 @@ overrides:
     cache-pools: true
 tasks:
 - ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - rgw: [client.0]
 - s3tests:
     client.0:

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -1,6 +1,8 @@
 tasks:
 - ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
 - rgw: [client.0]
 - s3tests:
     client.0:

--- a/qa/suites/upgrade-clients/client-upgrade-quincy-reef/quincy-client-x/rbd/0-cluster/start.yaml
+++ b/qa/suites/upgrade-clients/client-upgrade-quincy-reef/quincy-client-x/rbd/0-cluster/start.yaml
@@ -17,3 +17,5 @@ roles:
 overrides:
   ceph:
     fs: xfs
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)


### PR DESCRIPTION
Some of the smoke, rados, perf-basic and upgrade-clients tests were failing
due to POOL_APP_NOT_ENABLED health check failure. Add 
POOL_APP_NOT_ENABLED to ignorelist for these tests.

Signed-off-by: Prashant D <pdhange@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
