### PR TITLE
os/bluestore: Recompression, part 1. Nice debugs.

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -15,6 +15,7 @@ if(WITH_BLUESTORE)
     bluestore/bluefs_types.cc
     bluestore/BlueRocksEnv.cc
     bluestore/BlueStore.cc
+    bluestore/BlueStore_debug.cc
     bluestore/simple_bitmap.cc
     bluestore/bluestore_types.cc
     bluestore/fastbmap_allocator_impl.cc

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -143,9 +143,6 @@ const vector<uint64_t> bdev_label_positions = {
   100*_1G,
   1000*_1G};
 
-#define OBJECT_MAX_SIZE 0xffffffff // 32 bits
-
-
 /*
  * extent map blob encoding
  *

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -631,43 +631,6 @@ void _dump_onode(CephContext *cct, const BlueStore::Onode& o)
   }
 }
 
-std::ostream& operator<<(std::ostream& out, const BlueStore::Onode::printer &p)
-{
-  using P = BlueStore::printer;
-  const BlueStore::Onode& o = p.onode;
-  uint16_t mode = p.mode;
-  out << &o << " " << o.oid
-      << " nid " << o.onode.nid
-      << " size 0x" << std::hex << o.onode.size
-      << " (" << std::dec << o.onode.size << ")"
-      << " expected_object_size " << o.onode.expected_object_size
-      << " expected_write_size " << o.onode.expected_write_size
-      << " in " << o.onode.extent_map_shards.size() << " shards"
-      << ", " << o.extent_map.spanning_blob_map.size()
-      << " spanning blobs" << std::endl;
-  const BlueStore::ExtentMap& map = o.extent_map;
-  std::set<BlueStore::Blob*> visited;
-  for (const auto& e : map.extent_map) {
-    BlueStore::Blob* b = e.blob.get();
-    if (!visited.contains(b)) {
-      out << b->print(mode) << std::endl;
-      visited.insert(b);
-    }
-  }
-  // to make printing extents in-sync with blobs
-  bool mode_extent = mode & (P::ptr | P::nick);
-  for (const auto& e : map.extent_map) {
-    out << e.print(mode_extent) << std::endl;
-  }
-  if (mode & P::attrs) {
-    for (const auto& p : o.onode.attrs) {
-      out << "  attr " << p.first
-        << " len " << p.second.length() << std::endl;
-    }
-  }
-  return out;
-}
-
 template <int LogLevelV>
 void _dump_transaction(CephContext *cct, ObjectStore::Transaction *t)
 {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -637,7 +637,24 @@ public:
 
     void dump(ceph::Formatter* f) const;
     friend std::ostream& operator<<(std::ostream& out, const Blob &b);
-
+    struct printer {
+      const Blob& blob;
+      uint8_t mode;
+      printer(const Blob& blob, uint8_t mode)
+      :blob(blob), mode(mode) {}
+      static constexpr uint8_t ptr = 1;    //pointer to Blob
+      static constexpr uint8_t nick = 2;   //a nickname of this Blob
+      static constexpr uint8_t disk = 4;   //disk allocations of Blob
+      static constexpr uint8_t sdisk = 8;  //shortened version of disk allocaitons
+      static constexpr uint8_t use = 16;   //use tracker
+      static constexpr uint8_t suse = 32;  //shortened use tracker
+      static constexpr uint8_t chk = 64;   //checksum, full dump
+      static constexpr uint8_t schk = 128; //only base checksum info
+    };
+    friend std::ostream& operator<<(std::ostream& out, const printer &p);
+    printer print(uint8_t mode) const {
+      return printer(*this, mode);
+    }
     const bluestore_blob_use_tracker_t& get_blob_use_tracker() const {
       return used_in_blob;
     }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -285,6 +285,7 @@ public:
     static constexpr uint16_t schk = 128; // only base checksum info
     static constexpr uint16_t buf = 256;  // print Blob's buffers (takes cache lock)
     static constexpr uint16_t sbuf = 512; // short print Blob's buffers (takes cache lock)
+    static constexpr uint16_t attrs = 1024; // print attrs in onode
   };
 
   /// cached buffer
@@ -1446,6 +1447,17 @@ public:
     void decode_omap_key(const std::string& key, std::string *user_key);
 
     void finish_write(TransContext* txc, uint32_t offset, uint32_t length);
+
+    struct printer : public BlueStore::printer {
+      const Onode& onode;
+      uint16_t mode;
+      printer(const Onode& onode, uint16_t mode)
+      :onode(onode), mode(mode) {}
+    };
+    friend std::ostream& operator<<(std::ostream& out, const printer &p);
+    printer print(uint16_t mode) const {
+      return printer(*this, mode);
+    }
   };
 
   /// A generic Cache Shard

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -275,14 +275,16 @@ public:
   };
 
   struct printer {
-    static constexpr uint8_t ptr = 1;   // pointer to Blob
-    static constexpr uint8_t nick = 2;  // a nickname of this Blob
-    static constexpr uint8_t disk = 4;  // disk allocations of Blob
-    static constexpr uint8_t sdisk = 8; // shortened version of disk allocaitons
-    static constexpr uint8_t use = 16;  // use tracker
-    static constexpr uint8_t suse = 32; // shortened use tracker
-    static constexpr uint8_t chk = 64;  // checksum, full dump
-    static constexpr uint8_t schk = 128; // only base checksum info
+    static constexpr uint16_t ptr = 1;   // pointer to Blob
+    static constexpr uint16_t nick = 2;  // a nickname of this Blob
+    static constexpr uint16_t disk = 4;  // disk allocations of Blob
+    static constexpr uint16_t sdisk = 8; // shortened version of disk allocaitons
+    static constexpr uint16_t use = 16;  // use tracker
+    static constexpr uint16_t suse = 32; // shortened use tracker
+    static constexpr uint16_t chk = 64;  // checksum, full dump
+    static constexpr uint16_t schk = 128; // only base checksum info
+    static constexpr uint16_t buf = 256;  // print Blob's buffers (takes cache lock)
+    static constexpr uint16_t sbuf = 512; // short print Blob's buffers (takes cache lock)
   };
 
   /// cached buffer
@@ -298,6 +300,16 @@ public:
       switch (s) {
       case STATE_EMPTY: return "empty";
       case STATE_CLEAN: return "clean";
+      case STATE_WRITING: return "writing";
+      default: return "???";
+      }
+    }
+    // Short version of state name.
+    // Not print "clean", as it is most frequent.
+    static const char *get_state_name_short(int s) {
+      switch (s) {
+      case STATE_EMPTY: return "empty";
+      case STATE_CLEAN: return "";
       case STATE_WRITING: return "writing";
       default: return "???";
       }
@@ -650,12 +662,12 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const Blob &b);
     struct printer : public BlueStore::printer {
       const Blob& blob;
-      uint8_t mode;
-      printer(const Blob& blob, uint8_t mode)
+      uint16_t mode;
+      printer(const Blob& blob, uint16_t mode)
       :blob(blob), mode(mode) {}
     };
     friend std::ostream& operator<<(std::ostream& out, const printer &p);
-    printer print(uint8_t mode) const {
+    printer print(uint16_t mode) const {
       return printer(*this, mode);
     }
     const bluestore_blob_use_tracker_t& get_blob_use_tracker() const {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -274,6 +274,7 @@ public:
     virtual ~AioContext() {}
   };
 
+  static constexpr uint32_t OBJECT_MAX_SIZE = 0xffffffff; // 32 bits
   struct printer {
     static constexpr uint16_t PTR = 1;   // pointer to Blob
     static constexpr uint16_t NICK = 2;  // a nickname of this Blob

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -274,6 +274,17 @@ public:
     virtual ~AioContext() {}
   };
 
+  struct printer {
+    static constexpr uint8_t ptr = 1;   // pointer to Blob
+    static constexpr uint8_t nick = 2;  // a nickname of this Blob
+    static constexpr uint8_t disk = 4;  // disk allocations of Blob
+    static constexpr uint8_t sdisk = 8; // shortened version of disk allocaitons
+    static constexpr uint8_t use = 16;  // use tracker
+    static constexpr uint8_t suse = 32; // shortened use tracker
+    static constexpr uint8_t chk = 64;  // checksum, full dump
+    static constexpr uint8_t schk = 128; // only base checksum info
+  };
+
   /// cached buffer
   struct Buffer {
     MEMPOOL_CLASS_HELPERS();
@@ -637,19 +648,11 @@ public:
 
     void dump(ceph::Formatter* f) const;
     friend std::ostream& operator<<(std::ostream& out, const Blob &b);
-    struct printer {
+    struct printer : public BlueStore::printer {
       const Blob& blob;
       uint8_t mode;
       printer(const Blob& blob, uint8_t mode)
       :blob(blob), mode(mode) {}
-      static constexpr uint8_t ptr = 1;    //pointer to Blob
-      static constexpr uint8_t nick = 2;   //a nickname of this Blob
-      static constexpr uint8_t disk = 4;   //disk allocations of Blob
-      static constexpr uint8_t sdisk = 8;  //shortened version of disk allocaitons
-      static constexpr uint8_t use = 16;   //use tracker
-      static constexpr uint8_t suse = 32;  //shortened use tracker
-      static constexpr uint8_t chk = 64;   //checksum, full dump
-      static constexpr uint8_t schk = 128; //only base checksum info
     };
     friend std::ostream& operator<<(std::ostream& out, const printer &p);
     printer print(uint8_t mode) const {
@@ -858,6 +861,16 @@ public:
       if (blob) {
 	blob->get_cache()->rm_extent();
       }
+    }
+    struct printer : public BlueStore::printer {
+      const Extent& ext;
+      uint8_t mode;
+      printer(const Extent& ext, uint8_t mode)
+      :ext(ext), mode(mode) {}
+    };
+    friend std::ostream& operator<<(std::ostream& out, const printer &p);
+    printer print(uint8_t mode) const {
+      return printer(*this, mode);
     }
 
     void dump(ceph::Formatter* f) const;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1451,14 +1451,18 @@ public:
     void finish_write(TransContext* txc, uint32_t offset, uint32_t length);
 
     struct printer : public BlueStore::printer {
-      const Onode& onode;
+      const Onode &onode;
       uint16_t mode;
-      printer(const Onode& onode, uint16_t mode)
-      :onode(onode), mode(mode) {}
+      uint32_t from = 0;
+      uint32_t end = OBJECT_MAX_SIZE;
+      printer(const Onode &onode, uint16_t mode) : onode(onode), mode(mode) {}
+      printer(const Onode &onode, uint16_t mode, uint32_t from, uint32_t end)
+          : onode(onode), mode(mode), from(from), end(end) {}
     };
-    friend std::ostream& operator<<(std::ostream& out, const printer &p);
-    printer print(uint16_t mode) const {
-      return printer(*this, mode);
+    friend std::ostream &operator<<(std::ostream &out, const printer &p);
+    printer print(uint16_t mode) const { return printer(*this, mode); }
+    printer print(uint16_t mode, uint32_t from, uint32_t end) const {
+      return printer(*this, mode, from, end);
     }
   };
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -275,17 +275,17 @@ public:
   };
 
   struct printer {
-    static constexpr uint16_t ptr = 1;   // pointer to Blob
-    static constexpr uint16_t nick = 2;  // a nickname of this Blob
-    static constexpr uint16_t disk = 4;  // disk allocations of Blob
-    static constexpr uint16_t sdisk = 8; // shortened version of disk allocaitons
-    static constexpr uint16_t use = 16;  // use tracker
-    static constexpr uint16_t suse = 32; // shortened use tracker
-    static constexpr uint16_t chk = 64;  // checksum, full dump
-    static constexpr uint16_t schk = 128; // only base checksum info
-    static constexpr uint16_t buf = 256;  // print Blob's buffers (takes cache lock)
-    static constexpr uint16_t sbuf = 512; // short print Blob's buffers (takes cache lock)
-    static constexpr uint16_t attrs = 1024; // print attrs in onode
+    static constexpr uint16_t PTR = 1;   // pointer to Blob
+    static constexpr uint16_t NICK = 2;  // a nickname of this Blob
+    static constexpr uint16_t DISK = 4;  // disk allocations of Blob
+    static constexpr uint16_t SDISK = 8; // shortened version of disk allocaitons
+    static constexpr uint16_t USE = 16;  // use tracker
+    static constexpr uint16_t SUSE = 32; // shortened use tracker
+    static constexpr uint16_t CHK = 64;  // checksum, full dump
+    static constexpr uint16_t SCHK = 128; // only base checksum info
+    static constexpr uint16_t BUF = 256;  // print Blob's buffers (takes cache lock)
+    static constexpr uint16_t SBUF = 512; // short print Blob's buffers (takes cache lock)
+    static constexpr uint16_t ATTRS = 1024; // print attrs in onode
   };
 
   /// cached buffer
@@ -877,12 +877,12 @@ public:
     }
     struct printer : public BlueStore::printer {
       const Extent& ext;
-      uint8_t mode;
-      printer(const Extent& ext, uint8_t mode)
+      uint16_t mode;
+      printer(const Extent& ext, uint16_t mode)
       :ext(ext), mode(mode) {}
     };
     friend std::ostream& operator<<(std::ostream& out, const printer &p);
-    printer print(uint8_t mode) const {
+    printer print(uint16_t mode) const {
       return printer(*this, mode);
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -286,6 +286,7 @@ public:
     static constexpr uint16_t BUF = 256;  // print Blob's buffers (takes cache lock)
     static constexpr uint16_t SBUF = 512; // short print Blob's buffers (takes cache lock)
     static constexpr uint16_t ATTRS = 1024; // print attrs in onode
+    static constexpr uint16_t JUSTID = 2048; // used to suppress printing length, spanning and shared blob
   };
 
   /// cached buffer
@@ -309,9 +310,9 @@ public:
     // Not print "clean", as it is most frequent.
     static const char *get_state_name_short(int s) {
       switch (s) {
-      case STATE_EMPTY: return "empty";
+      case STATE_EMPTY: return ",empty";
       case STATE_CLEAN: return "";
-      case STATE_WRITING: return "writing";
+      case STATE_WRITING: return ",writing";
       default: return "???";
       }
     }

--- a/src/os/bluestore/BlueStore_debug.cc
+++ b/src/os/bluestore/BlueStore_debug.cc
@@ -209,31 +209,6 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::Blob::printer &p)
     out << " " << *p.blob.shared_blob;
   }
   out << ")";
-  // here printing Buffers
-  if (p.mode & (P::BUF | P::SBUF)) {
-    std::lock_guard l(p.blob.collection->cache->lock);
-    if (p.mode & P::SBUF) {
-      // summary buf mode, only print what is mapped what options are, one liner
-      out << " bufs(";
-      bool space = false;
-      for (auto& i : p.blob.get_bc().buffer_map) {
-        if (space) out << " ";
-        out << "0x" << std::hex << i.first << "~" << i.second.length << std::dec
-          << BlueStore::Buffer::get_state_name_short(i.second.state);
-        if (i.second.flags) {
-          out << "," << BlueStore::Buffer::get_flag_name(i.second.flags);
-        }
-        space = true;
-      }
-      out << ")";
-    } else {
-      for (auto& i : p.blob.get_bc().buffer_map) {
-        out << std::endl << "  0x" << std::hex << i.first
-          << "~" << i.second.length << std::dec
-          << " " << i.second;
-      }
-    }
-  }
   return out;
 }
 
@@ -274,6 +249,31 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::Onode::printer &p)
   }
   for (const auto& i : visited) {
     out << std::endl << i->print(mode);
+  }
+  // here printing Buffers
+  if (p.mode & (P::BUF | P::SBUF)) {
+    std::lock_guard l(o.c->cache->lock);
+    if (p.mode & P::SBUF) {
+      // summary buf mode, only print what is mapped what options are, one liner
+      out << " bufs(";
+      bool space = false;
+      for (auto& i : o.bc.buffer_map) {
+        if (space) out << " ";
+        out << "0x" << std::hex << i.offset << "~" << i.length << std::dec
+          << BlueStore::Buffer::get_state_name_short(i.state);
+        if (i.flags) {
+          out << "," << BlueStore::Buffer::get_flag_name(i.flags);
+        }
+        space = true;
+      }
+      out << ")";
+    } else {
+      for (auto& i : o.bc.buffer_map) {
+        out << std::endl << "  0x" << std::hex << i.offset
+          << "~" << i.length << std::dec
+          << " " << i;
+      }
+    }
   }
   if (mode & P::ATTRS) {
     for (const auto& p : o.onode.attrs) {

--- a/src/os/bluestore/BlueStore_debug.cc
+++ b/src/os/bluestore/BlueStore_debug.cc
@@ -82,7 +82,7 @@ std::ostream &operator<<(std::ostream &out, const maybe_K &k) {
 
 std::ostream& operator<<(std::ostream& out, const BlueStore::Blob::printer &p)
 {
-  using P = BlueStore::Blob::printer;
+  using P = BlueStore::printer;
   out << "Blob(";
   if (p.mode & P::ptr) {
     out << &p.blob << " ";
@@ -214,3 +214,10 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::Blob::printer &p)
   return out;
 }
 
+std::ostream& operator<<(std::ostream& out, const BlueStore::Extent::printer &p)
+{
+  out << std::hex << "0x" << p.ext.logical_offset << "~" << p.ext.length
+    << ": 0x" << p.ext.blob_offset << "~" << p.ext.length << std::dec
+	<< " " << p.ext.blob->print(p.mode);
+  return out;
+}

--- a/src/os/bluestore/BlueStore_debug.cc
+++ b/src/os/bluestore/BlueStore_debug.cc
@@ -1,0 +1,216 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include <cstdint>
+#include <ostream>
+#include "BlueStore.h"
+
+static const std::string transition_table[26] = {
+"bcdfghjklmnprstuvxyz", //a
+"aeiloruy",//b
+"aeiloruvy",//c
+"aeilmnoruvy",//d
+"bcdfghjklmnprstvxz",//e
+
+"ailou",//f
+"aeilnoru",//g
+"aeiloru",//h
+"dfghklmnpqrstvwx",//i
+"aeiou",//j
+
+"aeiloru",//k
+"aeimnou",//l
+"aeinotuy",//m
+"aeiou",//n
+"bcdfghjklmnpqrstvwxz",//o
+"aehiloruy",//p
+
+"aeiloru",//q
+"adefiklmnotuvy",//r
+"aehiklmnopqrtuvwy",//s
+"acefhiklmnorsuvwy",//t
+"bcdfghklmnpqrsvwxyz",//u
+
+"acdeiklmorsu",//v
+"aehilnorstu",//w
+"aeilnorstuy",//x
+"aehinorsuxz",//y
+"aeiouy" //z
+};
+
+std::string int_to_fancy_name(uint64_t x)
+{
+  std::string result;
+  uint8_t c = x % 26;
+  x = x / 26;
+  result.push_back(c+'a');
+  while (x > 0) {
+    uint8_t range = transition_table[c].length();
+    uint8_t p = x % range;
+    c = transition_table[c][p] - 'a';
+    x = x / range;
+    result.push_back(c+'a');
+  }
+  return result;
+}
+
+// Use special printing for multiplies of 1024; print K suffix
+struct maybe_K {
+  uint32_t x;
+  maybe_K(uint32_t x) : x(x) {}
+};
+std::ostream &operator<<(std::ostream &out, const maybe_K &k) {
+  if (((k.x & 0x3ff) == 0) && (k.x != 0)) {
+    if (k.x != 0x400)
+      out << (k.x / 0x400);
+    out << "K";
+  } else {
+    out << std::hex << k.x << std::dec;
+  }
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const BlueStore::Blob::printer &p)
+{
+  using P = BlueStore::Blob::printer;
+  out << "Blob(";
+  if (p.mode & P::ptr) {
+    out << &p.blob << " ";
+  }
+  if (p.mode & P::nick) {
+    uint64_t v = uint64_t(&p.blob);
+    v = (v - 0x555550000000) / 16;
+    out << int_to_fancy_name(v) << " ";
+  }
+  const bluestore_blob_t& bblob = p.blob.get_blob();
+  if (p.mode & P::disk) {
+    //use default printer for std::vector * bluestore_pextent_t
+    out << "disk=" << bblob.get_extents() << " ";
+  }
+  if (p.mode & P::sdisk) {
+    const PExtentVector& ev = bblob.get_extents();
+    uint64_t bits = 0;
+    for (auto i : ev) {
+      if (i.is_valid()) bits |= i.offset;
+      bits |= i.length;
+    }
+    uint32_t zeros = 0; //zeros to apply to all values
+    while ((bits & 0xf) == 0) {
+      bits = bits >> 4;
+      ++zeros;
+    }
+    out << "disk=0x[" << std::hex;
+    for (size_t i = 0; i < ev.size(); ++i) {
+      if (i != 0) {
+        out << ",";
+      }
+      if (ev[i].is_valid()) {
+        out << (ev[i].offset >> zeros * 4) << "~";
+      } else {
+        out << "!";
+      }
+      out << (ev[i].length >> zeros * 4);
+    }
+    out << "]" << std::dec;
+    while (zeros > 0) {
+      out << "0";
+      --zeros;
+    }
+    out << " ";
+  }
+  //always print lengths, if not printing use tracker
+  if (!(p.mode & (P::use | P::suse)) || bblob.is_compressed()) {
+    // Need to print blob logical length, no tracker printing
+    // + there is no real tracker for compressed blobs
+    if (bblob.is_compressed()) {
+      out << "len=" << std::hex << bblob.get_logical_length() << "->"
+          << bblob.get_compressed_payload_length() << " " << std::dec;
+    } else {
+      out << "len=" << std::hex << bblob.get_logical_length() << std::dec << " ";
+    }
+  }
+  if ((p.mode & P::use) && !bblob.is_compressed()) {
+    out << p.blob.get_blob_use_tracker() << " ";
+  }
+  if (p.mode & P::suse) {
+    auto& tracker = p.blob.get_blob_use_tracker();
+    if (bblob.is_compressed()) {
+      out << "[" << std::hex << tracker.get_referenced_bytes() << std::dec << "] ";
+    } else {
+      const uint32_t* au_array = tracker.get_au_array();
+      uint16_t zeros = 0;
+      uint16_t full = 0;
+      uint16_t num_au = tracker.get_num_au();
+      uint32_t au_size = tracker.au_size;
+      uint32_t def = std::numeric_limits<uint32_t>::max();
+      out << "track=" << tracker.get_num_au() << "*" << maybe_K(tracker.au_size);
+      for (size_t i = 0; i < num_au; i++) {
+        if (au_array[i] == 0) ++zeros;
+        if (au_array[i] == au_size) ++full;
+      }
+      if (zeros >= num_au - 3 && num_au > 6) def = 0;
+      if (full >= num_au - 3 && num_au > 6) def = au_size;
+      if (def != std::numeric_limits<uint32_t>::max()) {
+        out << "{" << maybe_K(def) << "}[";
+        for (size_t i = 0; i < num_au; i++) {
+          if (au_array[i] != def) {
+            out << i << "=" << maybe_K(au_array[i]);
+            ++i;
+            for (; i < num_au; i++) {
+              if (au_array[i] != def) {
+                out << "," << i << "=" << maybe_K(au_array[i]);
+              }
+            }
+          }
+        }
+        out << "] ";
+      } else {
+        out << "[";
+        for (size_t i = 0; i < num_au; i++) {
+          if (i != 0) out << ",";
+          out << maybe_K(au_array[i]);
+        }
+        out << "] ";
+      }
+    }
+  }
+  if (bblob.has_csum()) {
+    if (p.mode & (P::schk | P::chk)) {
+      out << Checksummer::get_csum_type_string(bblob.csum_type) << "/"
+          << (int)bblob.csum_chunk_order << "/" << bblob.csum_data.length();
+    }
+    if (p.mode & P::chk) {
+      std::vector<uint64_t> v;
+      unsigned n = bblob.get_csum_count();
+      for (unsigned i = 0; i < n; ++i)
+        v.push_back(bblob.get_csum_item(i));
+      out << std::hex << v << std::dec;
+    }
+    if (p.mode & (P::schk | P::chk)) {
+      out << " ";
+    }
+  }
+  if (p.blob.is_spanning()) {
+    out << " spanning.id=" << p.blob.id;
+  }
+  if (p.blob.shared_blob) {
+    if (p.blob.shared_blob->get_sbid() != 0) {
+      out << " " << *p.blob.shared_blob;
+    }
+  } else {
+    out << " (shared_blob=NULL)";
+  }
+  out << ")";
+  return out;
+}
+


### PR DESCRIPTION
Introduce printer class that allows to select parts of Blob that are to be printed.
It severly reduced amount of clutter in output.
Usage:
using P = Bluestore::Blob::printer;
dout << blob->printer(P::nick + P::sdisk + P::schk);

Now the Blob printout can look like this:
`Blob(rtrvlad disk=0x[12503~e,19589~1,12512~1]000 track=16*4K{4K}[] )`
instead of
`Blob(0x55555e735790 blob([0x12503000~e000,0x19589000~1000,0x12512000~1000] llen=0x10000 csum crc32c/0x1000/64) use_tracker(0x10*0x1000 0x[1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000]) SharedBlob(0x55555e9e8680 sbid 0x0))`

https://github.com/ceph/ceph/pull/54075 Nice debugs.
https://github.com/ceph/ceph/pull/54504 New write path.
https://github.com/ceph/ceph/pull/57448 Segmented onode.
https://github.com/ceph/ceph/pull/56975 Main
https://github.com/ceph/ceph/pull/57450 Test

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
