### PR TITLE
qa/upgrade/quincy-p2p: remove s3tests

### DIFF
--- a/qa/suites/upgrade/quincy-p2p/quincy-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/quincy-p2p/quincy-p2p-parallel/point-to-point-upgrade.yaml
@@ -129,12 +129,6 @@ workload_quincy:
    - sequential:
      - rgw: [client.0]
      - print: "**** done rgw workload_quincy"
-     - s3tests:
-         client.0:
-           force-branch: ceph-quincy
-           rgw_server: client.0
-           scan_for_encryption_keys: false
-     - print: "**** done s3tests workload_quincy"
      - rbd_fsx:
          clients: [client.0]
          size: 134217728


### PR DESCRIPTION
s3test cases on the ceph-quincy branch pass against the tip of quincy, but fail against earlier point releases. remove the s3tests task from upgrade/quincy-p2p

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
