### PR TITLE
reef: crimson/os/seastore: OP_CLONE in seastore

### DIFF
--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -332,17 +332,6 @@ BtreeBackrefManager::merge_cached_backrefs(
   });
 }
 
-BtreeBackrefManager::check_child_trackers_ret
-BtreeBackrefManager::check_child_trackers(
-  Transaction &t) {
-  auto c = get_context(t);
-  return with_btree<BackrefBtree>(
-    cache, c,
-    [c](auto &btree) {
-    return btree.check_child_trackers(c);
-  });
-}
-
 BtreeBackrefManager::scan_mapped_space_ret
 BtreeBackrefManager::scan_mapped_space(
   Transaction &t,

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -114,10 +114,9 @@ BtreeBackrefManager::get_mapping(
       } else {
 	TRACET("{} got {}, {}",
 	       c.trans, offset, iter.get_key(), iter.get_val());
-	auto e = iter.get_pin(c);
 	return get_mapping_ret(
 	  interruptible::ready_future_marker{},
-	  std::move(e));
+	  iter.get_pin(c));
       }
     });
   });
@@ -151,7 +150,7 @@ BtreeBackrefManager::get_mappings(
 	  TRACET("{}~{} got {}, {}, repeat ...",
 	         c.trans, offset, end, pos.get_key(), pos.get_val());
 	  ceph_assert((pos.get_key().add_offset(pos.get_val().len)) > offset);
-	  ret.push_back(pos.get_pin(c));
+	  ret.emplace_back(pos.get_pin(c));
 	  return BackrefBtree::iterate_repeat_ret_inner(
 	    interruptible::ready_future_marker{},
 	    seastar::stop_iteration::no);
@@ -248,7 +247,8 @@ BtreeBackrefManager::new_mapping(
 	  });
 	});
     }).si_then([c](auto &&state) {
-      return state.ret->get_pin(c);
+      return new_mapping_iertr::make_ready_future<BackrefMappingRef>(
+	state.ret->get_pin(c));
     });
 }
 

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -75,8 +75,6 @@ public:
     Transaction &t,
     paddr_t offset) final;
 
-  check_child_trackers_ret check_child_trackers(Transaction &t) final;
-
   scan_mapped_space_ret scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) final;

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -34,6 +34,13 @@ public:
   extent_types_t get_type() const final {
     return type;
   }
+
+protected:
+  std::unique_ptr<BtreeNodeMapping<paddr_t, laddr_t>> _duplicate(
+    op_context_t<paddr_t> ctx) const final {
+    return std::unique_ptr<BtreeNodeMapping<paddr_t, laddr_t>>(
+      new BtreeBackrefMapping(ctx));
+  }
 };
 
 using BackrefBtree = FixedKVBtree<

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -127,9 +127,6 @@ public:
     Transaction &t,
     paddr_t offset) = 0;
 
-  using check_child_trackers_ret = base_iertr::future<>;
-  virtual check_child_trackers_ret check_child_trackers(Transaction &t) = 0;
-
   /**
    * scan all extents in both tree and cache,
    * including backref extents, logical extents and lba extents,

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -127,10 +127,14 @@ class BtreeNodeMapping : public PhysicalNodeMapping<key_t, val_t> {
    */
   CachedExtentRef parent;
 
-  val_t value;
+  pladdr_t value;
   extent_len_t len;
   fixed_kv_node_meta_t<key_t> range;
   uint16_t pos = std::numeric_limits<uint16_t>::max();
+
+  pladdr_t _get_val() const final {
+    return value;
+  }
 
 public:
   using val_type = val_t;
@@ -140,7 +144,7 @@ public:
     op_context_t<key_t> ctx,
     CachedExtentRef parent,
     uint16_t pos,
-    val_t &value,
+    pladdr_t value,
     extent_len_t len,
     fixed_kv_node_meta_t<key_t> &&meta)
     : ctx(ctx),

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -132,10 +132,6 @@ class BtreeNodeMapping : public PhysicalNodeMapping<key_t, val_t> {
   fixed_kv_node_meta_t<key_t> range;
   uint16_t pos = std::numeric_limits<uint16_t>::max();
 
-  pladdr_t _get_val() const final {
-    return value;
-  }
-
 public:
   using val_type = val_t;
   BtreeNodeMapping(op_context_t<key_t> ctx) : ctx(ctx) {}
@@ -186,7 +182,12 @@ public:
   }
 
   val_t get_val() const final {
-    return value;
+    if constexpr (std::is_same_v<val_t, paddr_t>) {
+      return value.get_paddr();
+    } else {
+      static_assert(std::is_same_v<val_t, laddr_t>);
+      return value.get_laddr();
+    }
   }
 
   key_t get_key() const final {

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -218,8 +218,7 @@ public:
       return leaf.pos == 0;
     }
 
-    PhysicalNodeMappingRef<node_key_t, typename pin_t::val_type>
-    get_pin(op_context_t<node_key_t> ctx) const {
+    std::unique_ptr<pin_t> get_pin(op_context_t<node_key_t> ctx) const {
       assert(!is_end());
       auto val = get_val();
       auto key = get_key();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -469,7 +469,7 @@ public:
       } else {
         touch_extent(*ret);
         SUBDEBUGT(seastore_cache, "{} {}~{} is present on t without been \
-          fully loaded, reading ...", t, T::TYPE, offset, length);
+          fully loaded, reading ... {}", t, T::TYPE, offset, length, *ret);
         auto bp = alloc_cache_buf(ret->get_length());
         ret->set_bptr(std::move(bp));
         return read_extent<T>(
@@ -910,8 +910,6 @@ public:
     laddr_t original_laddr,
     std::optional<ceph::bufferptr> &&original_bptr) {
     LOG_PREFIX(Cache::alloc_remapped_extent);
-    SUBTRACET(seastore_cache, "allocate {} {}B, hint={}",
-              t, T::TYPE, remap_length, remap_laddr);
     assert(remap_laddr >= original_laddr);
     TCachedExtentRef<T> ext;
     if (original_bptr.has_value()) {
@@ -934,6 +932,8 @@ public:
               t.get_trans_id());
 
     t.add_fresh_extent(ext);
+    SUBTRACET(seastore_cache, "allocated {} {}B, hint={}, has ptr? {} -- {}",
+      t, T::TYPE, remap_length, remap_laddr, original_bptr.has_value(), *ext);
     return ext;
   }
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -340,6 +340,7 @@ public:
 	<< ", last_committed_crc=" << last_committed_crc
 	<< ", refcount=" << use_count()
 	<< ", user_hint=" << user_hint
+	<< ", fully_loaded=" << is_fully_loaded()
 	<< ", rewrite_gen=" << rewrite_gen_printer_t{rewrite_generation};
     if (state != extent_state_t::INVALID &&
         state != extent_state_t::CLEAN_PENDING) {

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1019,6 +1019,15 @@ public:
   virtual bool has_been_invalidated() const = 0;
   virtual CachedExtentRef get_parent() const = 0;
   virtual uint16_t get_pos() const = 0;
+  // An lba pin may be indirect, see comments in lba_manager/btree/btree_lba_manager.h
+  virtual bool is_indirect() const { return false; }
+  virtual key_t get_intermediate_key() const { return min_max_t<key_t>::null; }
+  virtual key_t get_intermediate_base() const { return min_max_t<key_t>::null; }
+  virtual extent_len_t get_intermediate_length() const { return 0; }
+  // The start offset of the pin, must be 0 if the pin is not indirect
+  virtual extent_len_t get_intermediate_offset() const {
+    return std::numeric_limits<extent_len_t>::max();
+  }
 
   virtual get_child_ret_t<LogicalCachedExtent>
   get_logical_extent(Transaction &t) = 0;
@@ -1184,6 +1193,12 @@ public:
 
   void set_laddr(laddr_t nladdr) {
     laddr = nladdr;
+  }
+
+  void maybe_set_intermediate_laddr(LBAMapping* mapping) {
+    laddr = mapping.is_indirect()
+      ? mapping.get_intermediate_key()
+      : mapping.get_key();
   }
 
   void apply_delta_and_adjust_crc(

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1195,7 +1195,7 @@ public:
     laddr = nladdr;
   }
 
-  void maybe_set_intermediate_laddr(LBAMapping* mapping) {
+  void maybe_set_intermediate_laddr(LBAMapping &mapping) {
     laddr = mapping.is_indirect()
       ? mapping.get_intermediate_key()
       : mapping.get_key();

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -39,6 +39,8 @@ public:
    * Fetches mappings for laddr_t in range [offset, offset + len)
    *
    * Future will not resolve until all pins have resolved (set_paddr called)
+   * For indirect lba mappings, get_mappings will always retrieve the original
+   * lba value.
    */
   using get_mappings_iertr = base_iertr;
   using get_mappings_ret = get_mappings_iertr::future<lba_pin_list_t>;
@@ -50,6 +52,8 @@ public:
    * Fetches mappings for a list of laddr_t in range [offset, offset + len)
    *
    * Future will not resolve until all pins have resolved (set_paddr called)
+   * For indirect lba mappings, get_mappings will always retrieve the original
+   * lba value.
    */
   virtual get_mappings_ret get_mappings(
     Transaction &t,
@@ -59,6 +63,8 @@ public:
    * Fetches the mapping for laddr_t
    *
    * Future will not resolve until the pin has resolved (set_paddr called)
+   * For indirect lba mappings, get_mapping will always retrieve the original
+   * lba value.
    */
   using get_mapping_iertr = base_iertr::extend<
     crimson::ct_error::enoent>;
@@ -88,7 +94,8 @@ public:
     laddr_t hint,
     extent_len_t len,
     laddr_t intermediate_key,
-    paddr_t actual_addr) = 0;
+    paddr_t actual_addr,
+    laddr_t intermediate_base) = 0;
 
   virtual alloc_extent_ret reserve_region(
     Transaction &t,
@@ -97,7 +104,7 @@ public:
 
   struct ref_update_result_t {
     unsigned refcount = 0;
-    paddr_t addr;
+    pladdr_t addr;
     extent_len_t length = 0;
   };
   using ref_iertr = base_iertr::extend<

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -130,6 +130,16 @@ public:
     laddr_t addr) = 0;
 
   /**
+   * Increments ref count on extent
+   *
+   * @return returns resulting refcount
+   */
+  virtual ref_ret incref_extent(
+    Transaction &t,
+    laddr_t addr,
+    int delta) = 0;
+
+  /**
    * Should be called after replay on each cached extent.
    * Implementation must initialize the LBAMapping on any
    * LogicalCachedExtent's and may also read in any dependent

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -81,7 +81,19 @@ public:
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
-    LogicalCachedExtent *nextent) = 0;
+    LogicalCachedExtent &nextent) = 0;
+
+  virtual alloc_extent_ret clone_extent(
+    Transaction &t,
+    laddr_t hint,
+    extent_len_t len,
+    laddr_t intermediate_key,
+    paddr_t actual_addr) = 0;
+
+  virtual alloc_extent_ret reserve_region(
+    Transaction &t,
+    laddr_t hint,
+    extent_len_t len) = 0;
 
   struct ref_update_result_t {
     unsigned refcount = 0;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -118,7 +118,8 @@ public:
    */
   virtual ref_ret decref_extent(
     Transaction &t,
-    laddr_t addr) = 0;
+    laddr_t addr,
+    bool cascade_remove) = 0;
 
   /**
    * Increments ref count on extent

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -127,28 +127,93 @@ BtreeLBAManager::get_mappings(
   return with_btree_state<LBABtree, lba_pin_list_t>(
     cache,
     c,
-    [c, offset, length, FNAME](auto &btree, auto &ret) {
-      return LBABtree::iterate_repeat(
-	c,
-	btree.upper_bound_right(c, offset),
-	[&ret, offset, length, c, FNAME](auto &pos) {
-	  if (pos.is_end() || pos.get_key() >= (offset + length)) {
-	    TRACET("{}~{} done with {} results",
-	           c.trans, offset, length, ret.size());
-	    return typename LBABtree::iterate_repeat_ret_inner(
+    [c, offset, length, FNAME, this](auto &btree, auto &ret) {
+      return seastar::do_with(
+	std::list<BtreeLBAMappingRef>(),
+	[offset, length, c, FNAME, this, &ret, &btree](auto &pin_list) {
+	return LBABtree::iterate_repeat(
+	  c,
+	  btree.upper_bound_right(c, offset),
+	  [&pin_list, offset, length, c, FNAME](auto &pos) {
+	    if (pos.is_end() || pos.get_key() >= (offset + length)) {
+	      TRACET("{}~{} done with {} results",
+		     c.trans, offset, length, pin_list.size());
+	      return LBABtree::iterate_repeat_ret_inner(
+		interruptible::ready_future_marker{},
+		seastar::stop_iteration::yes);
+	    }
+	    TRACET("{}~{} got {}, {}, repeat ...",
+		   c.trans, offset, length, pos.get_key(), pos.get_val());
+	    ceph_assert((pos.get_key() + pos.get_val().len) > offset);
+	    pin_list.push_back(pos.get_pin(c));
+	    return LBABtree::iterate_repeat_ret_inner(
 	      interruptible::ready_future_marker{},
-	      seastar::stop_iteration::yes);
-	  }
-	  TRACET("{}~{} got {}, {}, repeat ...",
-	         c.trans, offset, length, pos.get_key(), pos.get_val());
-	  ceph_assert((pos.get_key() + pos.get_val().len) > offset);
-	  ret.push_back(pos.get_pin(c));
-	  return typename LBABtree::iterate_repeat_ret_inner(
-	    interruptible::ready_future_marker{},
-	    seastar::stop_iteration::no);
+	      seastar::stop_iteration::no);
+	  }).si_then([this, &ret, c, &pin_list] {
+	    return _get_original_mappings(c, pin_list
+	    ).si_then([&ret](auto _ret) {
+	      ret = std::move(_ret);
+	    });
+	  });
 	});
     });
 }
+
+BtreeLBAManager::_get_original_mappings_ret
+BtreeLBAManager::_get_original_mappings(
+  op_context_t<laddr_t> c,
+  std::list<BtreeLBAMappingRef> &pin_list)
+{
+  return seastar::do_with(
+    lba_pin_list_t(),
+    [this, c, &pin_list](auto &ret) {
+    return trans_intr::do_for_each(
+      pin_list,
+      [this, c, &ret](auto &pin) {
+	LOG_PREFIX(BtreeLBAManager::get_mappings);
+	if (pin->get_raw_val().is_paddr()) {
+	  ret.emplace_back(std::move(pin));
+	  return get_mappings_iertr::now();
+	}
+	TRACET(
+	  "getting original mapping for indirect mapping {}~{}",
+	  c.trans, pin->get_key(), pin->get_length());
+	return this->get_mappings(
+	  c.trans, pin->get_raw_val().get_laddr(), pin->get_length()
+	).si_then([&pin, &ret, c](auto new_pin_list) {
+	  LOG_PREFIX(BtreeLBAManager::get_mappings);
+	  assert(new_pin_list.size() == 1);
+	  auto &new_pin = new_pin_list.front();
+	  auto intermediate_key = pin->get_raw_val().get_laddr();
+	  assert(!new_pin->is_indirect());
+	  assert(new_pin->get_key() <= intermediate_key);
+	  assert(new_pin->get_key() + new_pin->get_length() >=
+	  intermediate_key + pin->get_length());
+
+	  TRACET("Got mapping {}~{} for indirect mapping {}~{}, "
+	    "intermediate_key {}",
+	    c.trans,
+	    new_pin->get_key(), new_pin->get_length(),
+	    pin->get_key(), pin->get_length(),
+	    pin->get_raw_val().get_laddr());
+	  auto &btree_new_pin = static_cast<BtreeLBAMapping&>(*new_pin);
+	  btree_new_pin.set_key_for_indirect(
+	    pin->get_key(),
+	    pin->get_length(),
+	    pin->get_raw_val().get_laddr());
+	  ret.emplace_back(std::move(new_pin));
+	  return seastar::now();
+	}).handle_error_interruptible(
+	  crimson::ct_error::input_output_error::pass_further{},
+	  crimson::ct_error::assert_all("unexpected enoent")
+	);
+      }
+    ).si_then([&ret] {
+      return std::move(ret);
+    });
+  });
+}
+
 
 BtreeLBAManager::get_mappings_ret
 BtreeLBAManager::get_mappings(
@@ -181,14 +246,27 @@ BtreeLBAManager::get_mapping(
 {
   LOG_PREFIX(BtreeLBAManager::get_mapping);
   TRACET("{}", t, offset);
+  return _get_mapping(t, offset
+  ).si_then([](auto pin) {
+    return get_mapping_iertr::make_ready_future<LBAMappingRef>(std::move(pin));
+  });
+}
+
+BtreeLBAManager::_get_mapping_ret
+BtreeLBAManager::_get_mapping(
+  Transaction &t,
+  laddr_t offset)
+{
+  LOG_PREFIX(BtreeLBAManager::_get_mapping);
+  TRACET("{}", t, offset);
   auto c = get_context(t);
-  return with_btree_ret<LBABtree, LBAMappingRef>(
+  return with_btree_ret<LBABtree, BtreeLBAMappingRef>(
     cache,
     c,
-    [FNAME, c, offset](auto &btree) {
+    [FNAME, c, offset, this](auto &btree) {
       return btree.lower_bound(
 	c, offset
-      ).si_then([FNAME, offset, c](auto iter) -> get_mapping_ret {
+      ).si_then([FNAME, offset, c](auto iter) -> _get_mapping_ret {
 	if (iter.is_end() || iter.get_key() != offset) {
 	  ERRORT("laddr={} doesn't exist", c.trans, offset);
 	  return crimson::ct_error::enoent::make();
@@ -196,9 +274,27 @@ BtreeLBAManager::get_mapping(
 	  TRACET("{} got {}, {}",
 	         c.trans, offset, iter.get_key(), iter.get_val());
 	  auto e = iter.get_pin(c);
-	  return get_mapping_ret(
+	  return _get_mapping_ret(
 	    interruptible::ready_future_marker{},
 	    std::move(e));
+	}
+      }).si_then([this, c](auto pin) -> _get_mapping_ret {
+	if (pin->get_raw_val().is_laddr()) {
+	  return seastar::do_with(
+	    std::move(pin),
+	    [this, c](auto &pin) {
+	    return _get_mapping(
+	      c.trans, pin->get_raw_val().get_laddr()
+	    ).si_then([&pin](auto new_pin) {
+	      ceph_assert(pin->get_length() == new_pin->get_length());
+	      new_pin->set_key_for_indirect(
+		pin->get_key(),
+		pin->get_length());
+	      return new_pin;
+	    });
+	  });
+	} else {
+	  return get_mapping_iertr::make_ready_future<BtreeLBAMappingRef>(std::move(pin));
 	}
       });
     });
@@ -211,6 +307,7 @@ BtreeLBAManager::_alloc_extent(
   extent_len_t len,
   pladdr_t addr,
   paddr_t actual_addr,
+  laddr_t intermediate_base,
   LogicalCachedExtent* nextent)
 {
   struct state_t {
@@ -287,11 +384,12 @@ BtreeLBAManager::_alloc_extent(
 	    state.ret = iter;
 	  });
 	});
-    }).si_then([c, actual_addr, addr](auto &&state) {
+    }).si_then([c, actual_addr, addr, intermediate_base](auto &&state) {
       auto ret_pin = state.ret->get_pin(c);
       if (actual_addr != P_ADDR_NULL) {
 	ceph_assert(addr.is_laddr());
 	ret_pin->set_paddr(actual_addr);
+	ret_pin->set_intermediate_base(intermediate_base);
       } else {
 	ceph_assert(addr.is_paddr());
       }
@@ -398,8 +496,8 @@ BtreeLBAManager::scan_mappings(
 	      seastar::stop_iteration::yes);
 	  }
 	  ceph_assert((pos.get_key() + pos.get_val().len) > begin);
-	  f(pos.get_key(), pos.get_val().pladdr, pos.get_val().len);
-	  return typename LBABtree::iterate_repeat_ret_inner(
+	  f(pos.get_key(), pos.get_val().pladdr.get_paddr(), pos.get_val().len);
+	  return LBABtree::iterate_repeat_ret_inner(
 	    interruptible::ready_future_marker{},
 	    seastar::stop_iteration::no);
 	});

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -276,6 +276,14 @@ public:
     return update_refcount(t, addr, 1);
   }
 
+  ref_ret incref_extent(
+    Transaction &t,
+    laddr_t addr,
+    int delta) final {
+    ceph_assert(delta > 0);
+    return update_refcount(t, addr, delta, false);
+  }
+
   /**
    * init_cached_extent
    *

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -39,7 +39,7 @@ public:
 	c,
 	parent,
 	pos,
-	val.paddr,
+	val.pladdr,
 	val.len,
 	std::forward<lba_node_meta_t>(meta))
   {}

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -375,6 +375,11 @@ private:
     op_context_t<laddr_t> c,
     std::list<BtreeLBAMappingRef> &pin_list);
 
+  ref_iertr::future<std::optional<std::pair<paddr_t, extent_len_t>>>
+  _decref_intermediate(
+    Transaction &t,
+    laddr_t addr,
+    extent_len_t len);
 };
 using BtreeLBAManagerRef = std::unique_ptr<BtreeLBAManager>;
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -89,12 +89,34 @@ public:
     Transaction &t,
     laddr_t offset) final;
 
+  alloc_extent_ret reserve_region(
+    Transaction &t,
+    laddr_t hint,
+    extent_len_t len)
+  {
+    return _alloc_extent(t, hint, len, P_ADDR_ZERO, P_ADDR_NULL, nullptr);
+  }
+
+  alloc_extent_ret clone_extent(
+    Transaction &t,
+    laddr_t hint,
+    extent_len_t len,
+    laddr_t intermediate_key,
+    paddr_t actual_addr)
+  {
+    return _alloc_extent(t, hint, len, intermediate_key, actual_addr, nullptr);
+  }
+
   alloc_extent_ret alloc_extent(
     Transaction &t,
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
-    LogicalCachedExtent*) final;
+    LogicalCachedExtent &ext) final
+  {
+    assert(ext);
+    return _alloc_extent(t, hint, len, addr, P_ADDR_NULL, &ext);
+  }
 
   ref_ret decref_extent(
     Transaction &t,
@@ -186,6 +208,14 @@ private:
     Transaction &t,
     laddr_t addr,
     update_func_t &&f,
+    LogicalCachedExtent*);
+
+  alloc_extent_ret _alloc_extent(
+    Transaction &t,
+    laddr_t hint,
+    extent_len_t len,
+    pladdr_t addr,
+    paddr_t actual_addr,
     LogicalCachedExtent*);
 };
 using BtreeLBAManagerRef = std::unique_ptr<BtreeLBAManager>;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -266,14 +266,15 @@ public:
 
   ref_ret decref_extent(
     Transaction &t,
-    laddr_t addr) final {
-    return update_refcount(t, addr, -1);
+    laddr_t addr,
+    bool cascade_remove) final {
+    return update_refcount(t, addr, -1, cascade_remove);
   }
 
   ref_ret incref_extent(
     Transaction &t,
     laddr_t addr) final {
-    return update_refcount(t, addr, 1);
+    return update_refcount(t, addr, 1, false);
   }
 
   ref_ret incref_extent(
@@ -346,7 +347,8 @@ private:
   update_refcount_ret update_refcount(
     Transaction &t,
     laddr_t addr,
-    int delta);
+    int delta,
+    bool cascade_remove);
 
   /**
    * _update_mapping

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -20,7 +20,7 @@ namespace crimson::os::seastore::lba_manager::btree {
 std::ostream& operator<<(std::ostream& out, const lba_map_val_t& v)
 {
   return out << "lba_map_val_t("
-             << v.paddr
+             << v.pladdr
              << "~" << v.len
              << ", refcount=" << v.refcount
              << ", checksum=" << v.checksum
@@ -42,10 +42,11 @@ void LBALeafNode::resolve_relative_addrs(paddr_t base)
 {
   LOG_PREFIX(LBALeafNode::resolve_relative_addrs);
   for (auto i: *this) {
-    if (i->get_val().paddr.is_relative()) {
-      auto val = i->get_val();
-      val.paddr = base.add_relative(val.paddr);
-      TRACE("{} -> {}", i->get_val().paddr, val.paddr);
+    auto val = i->get_val();
+    if (val.pladdr.is_paddr() &&
+	val.pladdr.get_paddr().is_relative()) {
+      val.pladdr = base.add_relative(val.pladdr.get_paddr());
+      TRACE("{} -> {}", i->get_val().pladdr, val.pladdr);
       i->set_val(val);
     }
   }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -33,17 +33,18 @@ using LBANode = FixedKVNode<laddr_t>;
  */
 struct lba_map_val_t {
   extent_len_t len = 0;  ///< length of mapping
-  paddr_t paddr;         ///< physical addr of mapping
+  pladdr_t pladdr;         ///< physical addr of mapping or
+			   //	laddr of a physical lba mapping(see btree_lba_manager.h)
   uint32_t refcount = 0; ///< refcount
   uint32_t checksum = 0; ///< checksum of original block written at paddr (TODO)
 
   lba_map_val_t() = default;
   lba_map_val_t(
     extent_len_t len,
-    paddr_t paddr,
+    pladdr_t pladdr,
     uint32_t refcount,
     uint32_t checksum)
-    : len(len), paddr(paddr), refcount(refcount), checksum(checksum) {}
+    : len(len), pladdr(pladdr), refcount(refcount), checksum(checksum) {}
   bool operator==(const lba_map_val_t&) const = default;
 };
 
@@ -103,14 +104,14 @@ using LBAInternalNodeRef = LBAInternalNode::Ref;
  *   size       : uint32_t[1]                4b
  *   (padding)  :                            4b
  *   meta       : lba_node_meta_le_t[3]      (1*24)b
- *   keys       : laddr_t[170]               (145*8)b
- *   values     : lba_map_val_t[170]         (145*20)b
+ *   keys       : laddr_t[170]               (140*8)b
+ *   values     : lba_map_val_t[170]         (140*21)b
  *                                           = 4092
  *
  * TODO: update FixedKVNodeLayout to handle the above calculation
  * TODO: the above alignment probably isn't portable without further work
  */
-constexpr size_t LEAF_NODE_CAPACITY = 145;
+constexpr size_t LEAF_NODE_CAPACITY = 140;
 
 /**
  * lba_map_val_le_t
@@ -119,7 +120,7 @@ constexpr size_t LEAF_NODE_CAPACITY = 145;
  */
 struct lba_map_val_le_t {
   extent_len_le_t len = init_extent_len_le(0);
-  paddr_le_t paddr;
+  pladdr_le_t pladdr;
   ceph_le32 refcount{0};
   ceph_le32 checksum{0};
 
@@ -127,12 +128,12 @@ struct lba_map_val_le_t {
   lba_map_val_le_t(const lba_map_val_le_t &) = default;
   explicit lba_map_val_le_t(const lba_map_val_t &val)
     : len(init_extent_len_le(val.len)),
-      paddr(paddr_le_t(val.paddr)),
+      pladdr(pladdr_le_t(val.pladdr)),
       refcount(val.refcount),
       checksum(val.checksum) {}
 
   operator lba_map_val_t() const {
-    return lba_map_val_t{ len, paddr, refcount, checksum };
+    return lba_map_val_t{ len, pladdr, refcount, checksum };
   }
 };
 
@@ -195,7 +196,9 @@ struct LBALeafNode
       // child-ptr may already be correct, see LBAManager::update_mappings()
       this->update_child_ptr(iter, nextent);
     }
-    val.paddr = this->maybe_generate_relative(val.paddr);
+    if (val.pladdr.is_paddr()) {
+      val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());
+    }
     return this->journal_update(
       iter,
       val,
@@ -214,7 +217,9 @@ struct LBALeafNode
       addr,
       (void*)nextent);
     this->insert_child_ptr(iter, nextent);
-    val.paddr = this->maybe_generate_relative(val.paddr);
+    if (val.pladdr.is_paddr()) {
+      val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());
+    }
     this->journal_insert(
       iter,
       addr,
@@ -245,9 +250,10 @@ struct LBALeafNode
     if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	auto val = i->get_val();
-	if (val.paddr.is_relative()) {
-	  assert(val.paddr.is_block_relative());
-	  val.paddr = this->get_paddr().add_relative(val.paddr);
+	if (val.pladdr.is_paddr()
+	    && val.pladdr.get_paddr().is_relative()) {
+	  assert(val.pladdr.get_paddr().is_block_relative());
+	  val.pladdr = this->get_paddr().add_relative(val.pladdr.get_paddr());
 	  i->set_val(val);
 	}
       }
@@ -260,10 +266,10 @@ struct LBALeafNode
     if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	auto val = i->get_val();
-	if (val.paddr.is_relative()) {
-	  auto val = i->get_val();
-	  assert(val.paddr.is_record_relative());
-	  val.paddr = val.paddr.block_relative_to(this->get_paddr());
+	if (val.pladdr.is_paddr()
+	    && val.pladdr.get_paddr().is_relative()) {
+	  assert(val.pladdr.get_paddr().is_record_relative());
+	  val.pladdr = val.pladdr.get_paddr().block_relative_to(this->get_paddr());
 	  i->set_val(val);
 	}
       }

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -1369,6 +1369,7 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
 		      current = end;
 		      return seastar::now();
 		    } else {
+		      LOG_PREFIX(ObjectDataHandler::read);
 		      auto key = pin->get_key();
 		      bool is_indirect = pin->is_indirect();
                       extent_len_t off = pin->get_intermediate_offset();

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -223,12 +223,16 @@ struct overwrite_ops_t {
 overwrite_ops_t prepare_ops_list(
   lba_pin_list_t &pins_to_remove,
   extent_to_write_list_t &to_write) {
-  assert(to_write.size() != 0 && pins_to_remove.size() != 0);
+  assert(pins_to_remove.size() != 0);
   overwrite_ops_t ops;
   ops.to_remove.swap(pins_to_remove);
+  if (to_write.empty()) {
+    logger().debug("empty to_write");
+    return ops;
+  }
+  long unsigned int visitted = 0;
   auto& front = to_write.front();
   auto& back = to_write.back();
-  long unsigned int visitted = 0;
 
   // prepare overwrite, happens in one original extent.
   if (ops.to_remove.size() == 1 &&
@@ -238,9 +242,9 @@ overwrite_ops_t prepare_ops_list(
       assert(front.addr == front.pin->get_key());
       assert(back.addr > back.pin->get_key());
       ops.to_remap.push_back(extent_to_remap_t::create_overwrite(
-        std::move(front.pin),
-        front.len,
-        back.addr - front.addr - front.len));
+	std::move(front.pin),
+	front.len,
+	back.addr - front.addr - front.len));
       ops.to_remove.pop_front();
   } else {
     // prepare to_remap, happens in one or multiple extents
@@ -249,20 +253,20 @@ overwrite_ops_t prepare_ops_list(
       assert(to_write.size() > 1);
       assert(front.addr == front.pin->get_key());
       ops.to_remap.push_back(extent_to_remap_t::create_remap(
-        std::move(front.pin),
-        0,
-        front.len));
+	std::move(front.pin),
+	0,
+	front.len));
       ops.to_remove.pop_front();
     }
     if (back.is_existing()) {
       visitted++;
       assert(to_write.size() > 1);
       assert(back.addr + back.len ==
-        back.pin->get_key() + back.pin->get_length());
+	back.pin->get_key() + back.pin->get_length());
       ops.to_remap.push_back(extent_to_remap_t::create_remap(
-        std::move(back.pin),
-        back.addr - back.pin->get_key(),
-        back.len));
+	std::move(back.pin),
+	back.addr - back.pin->get_key(),
+	back.len));
       ops.to_remove.pop_back();
     }
   }
@@ -273,12 +277,12 @@ overwrite_ops_t prepare_ops_list(
       visitted++;
       assert(region.to_write.has_value());
       ops.to_insert.push_back(extent_to_insert_t::create_data(
-        region.addr, region.len, region.to_write));
+	region.addr, region.len, region.to_write));
     } else if (region.is_zero()) {
       visitted++;
       assert(!(region.to_write.has_value()));
       ops.to_insert.push_back(extent_to_insert_t::create_zero(
-        region.addr, region.len));
+	region.addr, region.len));
     }
   }
 
@@ -962,6 +966,11 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
       ).si_then([ctx, size, &pins, &object_data, &to_write](auto _pins) {
 	_pins.swap(pins);
 	ceph_assert(pins.size());
+	if (!size) {
+	  // no need to reserve region if we are truncating the object's
+	  // size to 0
+	  return clear_iertr::now();
+	}
 	auto &pin = *pins.front();
 	ceph_assert(pin.get_key() >= object_data.get_reserved_data_base());
 	ceph_assert(
@@ -1023,7 +1032,6 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
           }
 	}
       }).si_then([ctx, size, &to_write, &object_data, &pins] {
-        assert(to_write.size());
         return seastar::do_with(
           prepare_ops_list(pins, to_write),
           [ctx, size, &object_data](auto &ops) {

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -58,6 +58,7 @@ public:
     TransactionManager &tm;
     Transaction &t;
     Onode &onode;
+    Onode *d_onode = nullptr; // The desination node in case of clone
   };
 
   /// Writes bl to [offset, offset + bl.length())
@@ -103,6 +104,11 @@ public:
   using clear_ret = clear_iertr::future<>;
   clear_ret clear(context_t ctx);
 
+  /// Clone data of an Onode
+  using clone_iertr = base_iertr;
+  using clone_ret = clone_iertr::future<>;
+  clone_ret clone(context_t ctx);
+
 private:
   /// Updates region [_offset, _offset + bl.length) to bl
   write_ret overwrite(
@@ -124,6 +130,13 @@ private:
     context_t ctx,
     object_data_t &object_data,
     extent_len_t size);
+
+  clone_ret clone_extents(
+    context_t ctx,
+    object_data_t &object_data,
+    lba_pin_list_t &pins,
+    laddr_t data_base);
+
 private:
   /**
    * max_object_size

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -62,6 +62,7 @@ public:
       default_metadata_range(dmr)
   {}
 
+  virtual bool is_alive() const = 0;
   virtual const onode_layout_t &get_layout() const = 0;
   virtual onode_layout_t &get_mutable_layout(Transaction &t) = 0;
   virtual ~Onode() = default;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -70,6 +70,9 @@ struct FLTreeOnode final : Onode, Value {
     }
   };
 
+  bool is_alive() const {
+    return status != status_t::DELETED;
+  }
   const onode_layout_t &get_layout() const final {
     assert(status != status_t::DELETED);
     return *read_payload<onode_layout_t>();

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1196,6 +1196,17 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
     op_type_t::TRANSACTION,
     [this](auto &ctx) {
       return with_trans_intr(*ctx.transaction, [&, this](auto &t) {
+#ifndef NDEBUG
+	LOG_PREFIX(SeaStore::Shard::do_transaction_no_callbacks);
+	TRACET(" transaction dump:\n", t);
+	JSONFormatter f(true);
+	f.open_object_section("transaction");
+	ctx.ext_transaction.dump(&f);
+	f.close_section();
+	std::stringstream str;
+	f.flush(str);
+	TRACET("{}", t, str.str());
+#endif
         return seastar::do_with(
 	  std::vector<OnodeRef>(ctx.iter.objects.size()),
           std::vector<OnodeRef>(ctx.iter.objects.size()),
@@ -1415,6 +1426,10 @@ SeaStore::Shard::_do_transaction_step(
       }
       case Transaction::OP_CLONE:
       {
+	TRACET("cloning {} to {}",
+	  *ctx.transaction,
+	  i.get_oid(op->oid),
+	  i.get_oid(op->dest_oid));
 	return _clone(ctx, onodes[op->oid], d_onodes[op->dest_oid]);
       }
       default:

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -353,6 +353,10 @@ public:
       uint64_t offset, size_t len,
       ceph::bufferlist &&bl,
       uint32_t fadvise_flags);
+    tm_ret _clone(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      OnodeRef &d_onode);
     tm_ret _zero(
       internal_context_t &ctx,
       OnodeRef &onode,

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -89,6 +89,15 @@ std::ostream& operator<<(std::ostream& out, segment_seq_printer_t seq)
   }
 }
 
+std::ostream &operator<<(std::ostream &out, const pladdr_t &pladdr)
+{
+  if (pladdr.is_laddr()) {
+    return out << pladdr.get_laddr();
+  } else {
+    return out << pladdr.get_paddr();
+  }
+}
+
 std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
 {
   auto id = rhs.get_device_id();

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1115,6 +1115,23 @@ struct __attribute((packed)) pladdr_le_t {
   }
 };
 
+template <typename T>
+struct min_max_t {};
+
+template <>
+struct min_max_t<laddr_t> {
+  static constexpr laddr_t max = L_ADDR_MAX;
+  static constexpr laddr_t min = L_ADDR_MIN;
+  static constexpr laddr_t null = L_ADDR_NULL;
+};
+
+template <>
+struct min_max_t<paddr_t> {
+  static constexpr paddr_t max = P_ADDR_MAX;
+  static constexpr paddr_t min = P_ADDR_MIN;
+  static constexpr paddr_t null = P_ADDR_NULL;
+};
+
 // logical offset, see LBAManager, TransactionManager
 using extent_len_t = uint32_t;
 constexpr extent_len_t EXTENT_LEN_MAX =

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1042,9 +1042,9 @@ struct pladdr_t {
 
   pladdr_t() = default;
   pladdr_t(const pladdr_t &) = default;
-  explicit pladdr_t(laddr_t laddr)
+  pladdr_t(laddr_t laddr)
     : pladdr(laddr) {}
-  explicit pladdr_t(paddr_t paddr)
+  pladdr_t(paddr_t paddr)
     : pladdr(paddr) {}
 
   bool is_laddr() const {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -216,7 +216,7 @@ TransactionManager::ref_ret TransactionManager::dec_ref(
 {
   LOG_PREFIX(TransactionManager::dec_ref);
   TRACET("{}", t, *ref);
-  return lba_manager->decref_extent(t, ref->get_laddr()
+  return lba_manager->decref_extent(t, ref->get_laddr(), true
   ).si_then([this, FNAME, &t, ref](auto result) {
     DEBUGT("extent refcount is decremented to {} -- {}",
            t, result.refcount, *ref);
@@ -227,13 +227,14 @@ TransactionManager::ref_ret TransactionManager::dec_ref(
   });
 }
 
-TransactionManager::ref_ret TransactionManager::dec_ref(
+TransactionManager::ref_ret TransactionManager::_dec_ref(
   Transaction &t,
-  laddr_t offset)
+  laddr_t offset,
+  bool cascade_remove)
 {
-  LOG_PREFIX(TransactionManager::dec_ref);
+  LOG_PREFIX(TransactionManager::_dec_ref);
   TRACET("{}", t, offset);
-  return lba_manager->decref_extent(t, offset
+  return lba_manager->decref_extent(t, offset, cascade_remove
   ).si_then([this, FNAME, offset, &t](auto result) -> ref_ret {
     DEBUGT("extent refcount is decremented to {} -- {}~{}, {}",
            t, result.refcount, offset, result.length, result.addr);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -237,9 +237,11 @@ TransactionManager::ref_ret TransactionManager::dec_ref(
   ).si_then([this, FNAME, offset, &t](auto result) -> ref_ret {
     DEBUGT("extent refcount is decremented to {} -- {}~{}, {}",
            t, result.refcount, offset, result.length, result.addr);
-    if (result.refcount == 0 && !result.addr.is_zero()) {
+    if (result.refcount == 0 &&
+        (result.addr.is_paddr() &&
+         !result.addr.get_paddr().is_zero())) {
       return cache->retire_extent_addr(
-	t, result.addr, result.length
+	t, result.addr.get_paddr(), result.length
       ).si_then([] {
 	return ref_ret(
 	  interruptible::ready_future_marker{},

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -237,21 +237,18 @@ TransactionManager::ref_ret TransactionManager::dec_ref(
   ).si_then([this, FNAME, offset, &t](auto result) -> ref_ret {
     DEBUGT("extent refcount is decremented to {} -- {}~{}, {}",
            t, result.refcount, offset, result.length, result.addr);
-    if (result.refcount == 0 &&
-        (result.addr.is_paddr() &&
-         !result.addr.get_paddr().is_zero())) {
-      return cache->retire_extent_addr(
-	t, result.addr.get_paddr(), result.length
-      ).si_then([] {
-	return ref_ret(
-	  interruptible::ready_future_marker{},
-	  0);
-      });
-    } else {
-      return ref_ret(
-	interruptible::ready_future_marker{},
-	result.refcount);
+    auto fut = ref_iertr::now();
+    if (result.refcount == 0) {
+      if (result.addr.is_paddr() &&
+          !result.addr.get_paddr().is_zero()) {
+        fut = cache->retire_extent_addr(
+          t, result.addr.get_paddr(), result.length);
+      }
     }
+
+    return fut.si_then([result=std::move(result)] {
+      return result.refcount;
+    });
   });
 }
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -253,7 +253,9 @@ public:
   /// Remove refcount for offset
   ref_ret dec_ref(
     Transaction &t,
-    laddr_t offset);
+    laddr_t offset) {
+    return _dec_ref(t, offset, true);
+  }
 
   /// remove refcount for list of offset
   using refs_ret = ref_iertr::future<std::vector<unsigned>>;
@@ -384,7 +386,7 @@ public:
         [this, &t, original_laddr, original_paddr,
 	original_len, intermediate_base, intermediate_key]
         (auto &ret, auto &count, auto &original_bptr, auto &remaps) {
-        return dec_ref(t, original_laddr
+        return _dec_ref(t, original_laddr, false
         ).si_then([this, &t, &original_bptr, &ret, &count,
 		   &remaps, intermediate_base, intermediate_key,
                    original_laddr, original_paddr, original_len](auto) {
@@ -731,6 +733,12 @@ private:
     Transaction &t,
     ExtentPlacementManager::dispatch_result_t dispatch_result,
     std::optional<journal_seq_t> seq_to_trim = std::nullopt);
+
+  /// Remove refcount for offset
+  ref_ret _dec_ref(
+    Transaction &t,
+    laddr_t offset,
+    bool cascade_remove);
 
   /**
    * pin_to_extent

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -282,7 +282,7 @@ public:
       laddr_hint,
       len,
       ext->get_paddr(),
-      ext.get()
+      *ext
     ).si_then([ext=std::move(ext), laddr_hint, &t](auto &&) mutable {
       LOG_PREFIX(TransactionManager::alloc_extent);
       SUBDEBUGT(seastore_tm, "new extent: {}, laddr_hint: {}", t, *ext, laddr_hint);
@@ -419,12 +419,50 @@ public:
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}", t, len, hint);
     ceph_assert(is_aligned(hint, epm->get_block_size()));
-    return lba_manager->alloc_extent(
+    return lba_manager->reserve_region(
       t,
       hint,
-      len,
-      P_ADDR_ZERO,
-      nullptr);
+      len);
+  }
+
+  /*
+   * clone_pin
+   *
+   * create an indirect lba mapping pointing to the physical
+   * lba mapping whose key is clone_offset. Resort to btree_lba_manager.h
+   * for the definition of "indirect lba mapping" and "physical lba mapping"
+   *
+   */
+  using clone_extent_iertr = alloc_extent_iertr;
+  using clone_extent_ret = clone_extent_iertr::future<LBAMappingRef>;
+  clone_extent_ret clone_pin(
+    Transaction &t,
+    laddr_t hint,
+    const LBAMapping &mapping) {
+    auto clone_offset =
+      mapping.is_indirect()
+	? mapping.get_intermediate_key()
+	: mapping.get_key();
+
+    LOG_PREFIX(TransactionManager::clone_pin);
+    SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}, clone_offset {}",
+      t, mapping.get_length(), hint, clone_offset);
+    ceph_assert(is_aligned(hint, epm->get_block_size()));
+    return lba_manager->clone_extent(
+      t,
+      hint,
+      mapping.get_length(),
+      clone_offset,
+      mapping.get_val()
+    ).si_then([this, &t, clone_offset](auto pin) {
+      return inc_ref(t, clone_offset
+      ).si_then([pin=std::move(pin)](auto) mutable {
+	return std::move(pin);
+      }).handle_error_interruptible(
+	crimson::ct_error::input_output_error::pass_further(),
+	crimson::ct_error::assert_all("not possible")
+      );
+    });
   }
 
   /* alloc_extents
@@ -780,7 +818,7 @@ private:
       remap_laddr,
       remap_length,
       remap_paddr,
-      ext.get()
+      *ext
     ).si_then([remap_laddr, remap_length, remap_paddr](auto &&ref) {
       assert(ref->get_key() == remap_laddr);
       assert(ref->get_val() == remap_paddr);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -761,7 +761,9 @@ private:
     return cache->get_absent_extent<T>(
       t,
       pref.get_val(),
-      pref.get_length(),
+      pref.is_indirect() ?
+	pref.get_intermediate_length() :
+	pref.get_length(),
       [pin=std::move(pin)]
       (T &extent) mutable {
 	assert(!extent.has_laddr());
@@ -801,7 +803,9 @@ private:
       type,
       pref.get_val(),
       pref.get_key(),
-      pref.get_length(),
+      pref.is_indirect() ?
+	pref.get_intermediate_length() :
+	pref.get_length(),
       [pin=std::move(pin)](CachedExtent &extent) mutable {
 	auto &lextent = static_cast<LogicalCachedExtent&>(extent);
 	assert(!lextent.has_laddr());

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -120,7 +120,11 @@ struct fltree_onode_manager_test_t
       }).unsafe_get0();
       std::invoke(f, t, *onode, p_kv->value);
       with_trans_intr(t, [&](auto &t) {
-        return manager->write_dirty(t, {onode});
+	if (onode->is_alive()) {
+	  return manager->write_dirty(t, {onode});
+	} else {
+	  return OnodeManager::write_dirty_iertr::now();
+	}
       }).unsafe_get0();
     });
   }

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -468,7 +468,8 @@ struct btree_lba_manager_test : btree_test_base {
       [=, this](auto &t) {
 	return lba_manager->decref_extent(
 	  t,
-	  target->first
+	  target->first,
+	  true
 	).si_then([this, &t, target](auto result) {
 	  EXPECT_EQ(result.refcount, target->second.refcount);
 	  if (result.refcount == 0) {

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -432,7 +432,7 @@ struct btree_lba_manager_test : btree_test_base {
 	    0,
 	    get_paddr());
 	return lba_manager->alloc_extent(
-	  t, hint, len, extent->get_paddr(), extent.get());
+	  t, hint, len, extent->get_paddr(), *extent);
       }).unsafe_get0();
     logger().debug("alloc'd: {}", *ret);
     EXPECT_EQ(len, ret->get_length());

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -472,7 +472,8 @@ struct btree_lba_manager_test : btree_test_base {
 	).si_then([this, &t, target](auto result) {
 	  EXPECT_EQ(result.refcount, target->second.refcount);
 	  if (result.refcount == 0) {
-	    return cache->retire_extent_addr(t, result.addr, result.length);
+	    return cache->retire_extent_addr(
+	      t, result.addr.get_paddr(), result.length);
 	  }
 	  return Cache::retire_extent_iertr::now();
 	});

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -249,7 +249,7 @@ struct lba_btree_test : btree_test_base {
   }
 
   static auto get_map_val(extent_len_t len) {
-    return lba_map_val_t{0, P_ADDR_NULL, len, 0};
+    return lba_map_val_t{0, (pladdr_t)P_ADDR_NULL, len, 0};
   }
 
   device_off_t next_off = 0;

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -34,6 +34,9 @@ public:
     dirty = true;
     return layout;
   }
+  bool is_alive() const {
+    return true;
+  }
   bool is_dirty() const { return dirty; }
   laddr_t get_hint() const final {return L_ADDR_MIN; }
   ~TestOnode() final = default;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/51141

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

