### PR TITLE
reef: mgr/snap_schedule: make fs argument mandatory if more than one filesystem exists

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -45,6 +45,8 @@
   recommend that users with versioned buckets, especially those that existed
   on prior releases, use these new tools to check whether their buckets are
   affected and to clean them up accordingly.
+* mgr/snap-schedule: For clusters with multiple CephFS file systems, all the
+  snap-schedule commands now expect the '--fs' argument.
 
 >=18.0.0
 

--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -167,6 +167,8 @@ Examples::
    To ensure a new snapshot can be created, one snapshot less than this will be
    retained. So by default, a maximum of 99 snapshots will be retained.
 
+.. note: The --fs argument is now required if there is more than one file system.
+
 Active and inactive schedules
 -----------------------------
 Snapshot schedules can be added for a path that doesn't exist yet in the

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -95,10 +95,10 @@ class Module(MgrModule):
         '''
         Get current snapshot schedule for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             scheds = self.client.list_snap_schedules(fs, path, recursive)
             self.log.debug(f'recursive is {recursive}')
         except CephfsConnectionException as e:
@@ -125,10 +125,10 @@ class Module(MgrModule):
         '''
         Set a snapshot schedule for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             subvol = None
             self.client.store_snap_schedule(fs,
@@ -157,10 +157,10 @@ class Module(MgrModule):
         '''
         Remove a snapshot schedule for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             self.client.rm_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:
@@ -178,10 +178,10 @@ class Module(MgrModule):
         '''
         Set a retention specification for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             self.client.add_retention_spec(fs, abs_path,
                                            retention_spec_or_period,
@@ -201,10 +201,10 @@ class Module(MgrModule):
         '''
         Remove a retention specification for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             self.client.rm_retention_spec(fs, abs_path,
                                           retention_spec_or_period,
@@ -224,10 +224,10 @@ class Module(MgrModule):
         '''
         Activate a snapshot schedule for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             self.client.activate_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:
@@ -245,10 +245,10 @@ class Module(MgrModule):
         '''
         Deactivate a snapshot schedule for <path>
         '''
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            rc, fs, err = self._validate_fs(fs)
-            if rc < 0:
-                return rc, fs, err
             abs_path = path
             self.client.deactivate_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -38,14 +38,24 @@ class Module(MgrModule):
         self.client = SnapSchedClient(self)
 
     @property
-    def default_fs(self) -> str:
+    def _default_fs(self) -> Tuple[int, str, str]:
         fs_map = self.get('fs_map')
-        if fs_map['filesystems']:
-            return fs_map['filesystems'][0]['mdsmap']['fs_name']
+        if len(fs_map['filesystems']) > 1:
+            return -errno.EINVAL, '', "filesystem argument is required when there is more than one file system"
+        elif len(fs_map['filesystems']) == 1:
+            return 0, fs_map['filesystems'][0]['mdsmap']['fs_name'], "Success"
         else:
             self.log.error('No filesystem instance could be found.')
-            raise CephfsConnectionException(
-                -errno.ENOENT, "no filesystem found")
+            return -errno.ENOENT, "", "no filesystem found"
+
+    def _validate_fs(self, fs: Optional[str]) -> Tuple[int, str, str]:
+        if not fs:
+            rc, fs, err = self._default_fs
+            if rc < 0:
+                return rc, fs, err
+        if not self.has_fs(fs):
+            return -errno.EINVAL, '', f"no such file system: {fs}"
+        return 0, fs, 'Success'
 
     def has_fs(self, fs_name: str) -> bool:
         return fs_name in self.client.get_all_filesystems()
@@ -65,11 +75,11 @@ class Module(MgrModule):
         '''
         List current snapshot schedules
         '''
-        use_fs = fs if fs else self.default_fs
-        if not self.has_fs(use_fs):
-            return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+        rc, fs, err = self._validate_fs(fs)
+        if rc < 0:
+            return rc, fs, err
         try:
-            ret_scheds = self.client.get_snap_schedules(use_fs, path)
+            ret_scheds = self.client.get_snap_schedules(fs, path)
         except CephfsConnectionException as e:
             return e.to_tuple()
         if format == 'json':
@@ -86,10 +96,10 @@ class Module(MgrModule):
         Get current snapshot schedule for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
-            scheds = self.client.list_snap_schedules(use_fs, path, recursive)
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
+            scheds = self.client.list_snap_schedules(fs, path, recursive)
             self.log.debug(f'recursive is {recursive}')
         except CephfsConnectionException as e:
             return e.to_tuple()
@@ -116,18 +126,18 @@ class Module(MgrModule):
         Set a snapshot schedule for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
             subvol = None
-            self.client.store_snap_schedule(use_fs,
+            self.client.store_snap_schedule(fs,
                                             abs_path,
                                             (abs_path, snap_schedule,
-                                             use_fs, path, start, subvol))
+                                             fs, path, start, subvol))
             suc_msg = f'Schedule set for path {path}'
         except sqlite3.IntegrityError:
-            existing_scheds = self.client.get_snap_schedules(use_fs, path)
+            existing_scheds = self.client.get_snap_schedules(fs, path)
             report = [s.report() for s in existing_scheds]
             error_msg = f'Found existing schedule {report}'
             self.log.error(error_msg)
@@ -148,15 +158,15 @@ class Module(MgrModule):
         Remove a snapshot schedule for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
-            self.client.rm_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
+            self.client.rm_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
         return 0, 'Schedule removed for path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule retention add')
@@ -169,17 +179,17 @@ class Module(MgrModule):
         Set a retention specification for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
-            self.client.add_retention_spec(use_fs, abs_path,
-                                          retention_spec_or_period,
-                                          retention_count)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
+            self.client.add_retention_spec(fs, abs_path,
+                                           retention_spec_or_period,
+                                           retention_count)
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
         return 0, 'Retention added to path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule retention remove')
@@ -192,11 +202,11 @@ class Module(MgrModule):
         Remove a retention specification for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
-            self.client.rm_retention_spec(use_fs, abs_path,
+            self.client.rm_retention_spec(fs, abs_path,
                                           retention_spec_or_period,
                                           retention_count)
         except CephfsConnectionException as e:
@@ -215,15 +225,15 @@ class Module(MgrModule):
         Activate a snapshot schedule for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
-            self.client.activate_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
+            self.client.activate_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
         return 0, 'Schedule activated for path {}'.format(path), ''
 
     @CLIWriteCommand('fs snap-schedule deactivate')
@@ -236,13 +246,13 @@ class Module(MgrModule):
         Deactivate a snapshot schedule for <path>
         '''
         try:
-            use_fs = fs if fs else self.default_fs
-            if not self.has_fs(use_fs):
-                return -errno.EINVAL, '', f"no such filesystem: {use_fs}"
+            rc, fs, err = self._validate_fs(fs)
+            if rc < 0:
+                return rc, fs, err
             abs_path = path
-            self.client.deactivate_snap_schedule(use_fs, abs_path, repeat, start)
-        except CephfsConnectionException as e:
-            return e.to_tuple()
+            self.client.deactivate_snap_schedule(fs, abs_path, repeat, start)
         except ValueError as e:
             return -errno.ENOENT, '', str(e)
+        except CephfsConnectionException as e:
+            return e.to_tuple()
         return 0, 'Schedule deactivated for path {}'.format(path), ''


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63242

---

backport of https://github.com/ceph/ceph/pull/52686
parent tracker: https://tracker.ceph.com/issues/62218

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh