### PR TITLE
reef: crimson/net: consolidate messenger implementations and enable multi-shard UTs

### DIFF
--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -105,8 +105,8 @@ public:
   void get_defaults_bl(ceph::buffer::list *bl) {
     get_config().get_defaults_bl(get_config_values(), bl);
   }
-  // required by sharded<>
   seastar::future<> start();
+  // required by sharded<>
   seastar::future<> stop() {
     return seastar::make_ready_future<>();
   }

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -67,9 +67,9 @@ Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 
 void Client::ms_handle_connect(
     crimson::net::ConnectionRef c,
-    seastar::shard_id new_shard)
+    seastar::shard_id prv_shard)
 {
-  ceph_assert_always(new_shard == seastar::this_shard_id());
+  ceph_assert_always(prv_shard == seastar::this_shard_id());
   gate.dispatch_in_background(__func__, *this, [this, c] {
     if (conn == c) {
       // ask for the mgrconfigure message

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -121,9 +121,13 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   virtual void print(std::ostream& out) const = 0;
 
 #ifdef UNIT_TESTS_BUILT
-  virtual bool is_closed() const = 0;
+  virtual bool is_protocol_ready() const = 0;
 
-  virtual bool is_closed_clean() const = 0;
+  virtual bool is_protocol_standby() const = 0;
+
+  virtual bool is_protocol_closed() const = 0;
+
+  virtual bool is_protocol_closed_clean() const = 0;
 
   virtual bool peer_wins() const = 0;
 #endif

--- a/src/crimson/net/Interceptor.h
+++ b/src/crimson/net/Interceptor.h
@@ -45,16 +45,21 @@ enum class bp_action_t {
 class socket_blocker {
   std::optional<seastar::abort_source> p_blocked;
   std::optional<seastar::abort_source> p_unblocked;
+  const seastar::shard_id primary_sid;
 
  public:
+  socket_blocker() : primary_sid{seastar::this_shard_id()} {}
+
   seastar::future<> wait_blocked() {
+    ceph_assert(seastar::this_shard_id() == primary_sid);
     ceph_assert(!p_blocked);
     if (p_unblocked) {
       return seastar::make_ready_future<>();
     } else {
       p_blocked = seastar::abort_source();
-      return seastar::sleep_abortable(std::chrono::seconds(10),
-				      *p_blocked).then([] {
+      return seastar::sleep_abortable(
+        std::chrono::seconds(10), *p_blocked
+      ).then([] {
         throw std::runtime_error(
             "Timeout (10s) in socket_blocker::wait_blocked()");
       }).handle_exception_type([] (const seastar::sleep_aborted& e) {
@@ -64,21 +69,25 @@ class socket_blocker {
   }
 
   seastar::future<> block() {
-    if (p_blocked) {
-      p_blocked->request_abort();
-      p_blocked = std::nullopt;
-    }
-    ceph_assert(!p_unblocked);
-    p_unblocked = seastar::abort_source();
-    return seastar::sleep_abortable(std::chrono::seconds(10),
-				    *p_unblocked).then([] {
-      ceph_abort("Timeout (10s) in socket_blocker::block()");
-    }).handle_exception_type([] (const seastar::sleep_aborted& e) {
-      // wait done!
+    return seastar::smp::submit_to(primary_sid, [this] {
+      if (p_blocked) {
+        p_blocked->request_abort();
+        p_blocked = std::nullopt;
+      }
+      ceph_assert(!p_unblocked);
+      p_unblocked = seastar::abort_source();
+      return seastar::sleep_abortable(
+        std::chrono::seconds(10), *p_unblocked
+      ).then([] {
+        ceph_abort("Timeout (10s) in socket_blocker::block()");
+      }).handle_exception_type([] (const seastar::sleep_aborted& e) {
+        // wait done!
+      });
     });
   }
 
   void unblock() {
+    ceph_assert(seastar::this_shard_id() == primary_sid);
     ceph_assert(!p_blocked);
     ceph_assert(p_unblocked);
     p_unblocked->request_abort();

--- a/src/crimson/net/Interceptor.h
+++ b/src/crimson/net/Interceptor.h
@@ -120,7 +120,9 @@ struct Interceptor {
   virtual void register_conn_ready(ConnectionRef) = 0;
   virtual void register_conn_closed(ConnectionRef) = 0;
   virtual void register_conn_replaced(ConnectionRef) = 0;
-  virtual bp_action_t intercept(ConnectionRef, Breakpoint bp) = 0;
+
+  virtual seastar::future<bp_action_t>
+  intercept(Connection&, std::vector<Breakpoint> bp) = 0;
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -2112,6 +2112,13 @@ void ProtocolV2::execute_ready()
   // I'm not responsible to shutdown the socket at READY
   is_socket_valid = false;
   trigger_state(state_t::READY, io_state_t::open);
+#ifdef UNIT_TESTS_BUILT
+  if (conn.interceptor) {
+    // FIXME: doesn't support cross-core
+    conn.interceptor->register_conn_ready(
+        conn.get_local_shared_foreign_from_this());
+  }
+#endif
 }
 
 // STANDBY state

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1003,6 +1003,8 @@ void ProtocolV2::execute_connecting()
             }
 
             auto cc_seq = crosscore.prepare_submit();
+            // there are 2 hops with dispatch_connect()
+            crosscore.prepare_submit();
             logger().info("{} connected: gs={}, pgs={}, cs={}, "
                           "client_cookie={}, server_cookie={}, {}, new_sid={}, "
                           "send {} IOHandler::dispatch_connect()",
@@ -1797,6 +1799,8 @@ void ProtocolV2::execute_establishing(SocketConnectionRef existing_conn) {
 
     // set io_handler to a new shard
     auto cc_seq = crosscore.prepare_submit();
+    // there are 2 hops with dispatch_accept()
+    crosscore.prepare_submit();
     auto new_io_shard = frame_assembler->get_socket_shard_id();
     logger().debug("{} send {} IOHandler::dispatch_accept({})",
                    conn, cc_seq, new_io_shard);
@@ -1968,6 +1972,8 @@ void ProtocolV2::trigger_replacing(bool reconnect,
       // set io_handler to a new shard
       // we should prevent parallel switching core attemps
       auto cc_seq = crosscore.prepare_submit();
+      // there are 2 hops with dispatch_accept()
+      crosscore.prepare_submit();
       logger().debug("{} send {} IOHandler::dispatch_accept({})",
                      conn, cc_seq, new_io_shard);
       ConnectionFRef conn_fref = seastar::make_foreign(

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1904,7 +1904,7 @@ void ProtocolV2::trigger_replacing(bool reconnect,
   ceph_assert_always(state >= state_t::ESTABLISHING);
   ceph_assert_always(state <= state_t::WAIT);
   ceph_assert_always(has_socket || state == state_t::CONNECTING);
-  ceph_assert_always(!mover.socket->is_shutdown());
+  // mover.socket shouldn't be shutdown
 
   logger().info("{} start replacing ({}): pgs was {}, cs was {}, "
                 "client_cookie was {}, {}, new_sid={}",

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -53,6 +53,14 @@ public:
   seastar::future<> close_clean_yielded();
 
 #ifdef UNIT_TESTS_BUILT
+  bool is_ready() const {
+    return state == state_t::READY;
+  }
+
+  bool is_standby() const {
+    return state == state_t::STANDBY;
+  }
+
   bool is_closed_clean() const {
     return closed_clean;
   }

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -49,13 +49,24 @@ bool SocketConnection::is_connected() const
 }
 
 #ifdef UNIT_TESTS_BUILT
-bool SocketConnection::is_closed() const
+bool SocketConnection::is_protocol_ready() const
+{
+  assert(seastar::this_shard_id() == msgr_sid);
+  return protocol->is_ready();
+}
+
+bool SocketConnection::is_protocol_standby() const {
+  assert(seastar::this_shard_id() == msgr_sid);
+  return protocol->is_standby();
+}
+
+bool SocketConnection::is_protocol_closed() const
 {
   assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed();
 }
 
-bool SocketConnection::is_closed_clean() const
+bool SocketConnection::is_protocol_closed_clean() const
 {
   assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed_clean();

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -171,9 +171,13 @@ private:
   void set_socket(Socket *s);
 
 #ifdef UNIT_TESTS_BUILT
-  bool is_closed_clean() const override;
+  bool is_protocol_ready() const override;
 
-  bool is_closed() const override;
+  bool is_protocol_standby() const override;
+
+  bool is_protocol_closed_clean() const override;
+
+  bool is_protocol_closed() const override;
 
   // peer wins if myaddr > peeraddr
   bool peer_wins() const override;

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -25,11 +25,12 @@ public:
   bool empty() const {
     return dispatchers.empty();
   }
-  seastar::future<> ms_dispatch(crimson::net::ConnectionRef, MessageRef);
-  void ms_handle_accept(crimson::net::ConnectionRef conn, seastar::shard_id, bool is_replace);
-  void ms_handle_connect(crimson::net::ConnectionRef conn, seastar::shard_id);
-  void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace);
-  void ms_handle_remote_reset(crimson::net::ConnectionRef conn);
+  seastar::future<> ms_dispatch(ConnectionRef, MessageRef);
+  void ms_handle_shard_change(ConnectionRef, seastar::shard_id, bool);
+  void ms_handle_accept(ConnectionRef conn, seastar::shard_id, bool is_replace);
+  void ms_handle_connect(ConnectionRef conn, seastar::shard_id);
+  void ms_handle_reset(ConnectionRef conn, bool is_replace);
+  void ms_handle_remote_reset(ConnectionRef conn);
 
  private:
   dispatchers_t dispatchers;

--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -293,13 +293,6 @@ void IOHandler::do_set_io_state(
     ceph_assert_always(protocol_is_connected == true);
     assign_frame_assembler(std::move(fa));
     dispatch_in = true;
-#ifdef UNIT_TESTS_BUILT
-    if (conn.interceptor) {
-      // FIXME: doesn't support cross-core
-      conn.interceptor->register_conn_ready(
-          conn.get_local_shared_foreign_from_this());
-    }
-#endif
   } else if (prv_state == io_state_t::open) {
     // from open
     ceph_assert_always(protocol_is_connected == true);

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -447,7 +447,10 @@ public:
   seastar::future<> do_send_keepalive();
 
   seastar::future<> to_new_sid(
-      seastar::shard_id new_sid, ConnectionFRef);
+      crosscore_t::seq_t cc_seq,
+      seastar::shard_id new_sid,
+      ConnectionFRef,
+      std::optional<bool> is_replace);
 
   void dispatch_reset(bool is_replace);
 

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seastar/core/shared_future.hh>
 #include <seastar/util/later.hh>
 
@@ -475,7 +477,16 @@ public:
 
   seastar::future<> do_out_dispatch(shard_states_t &ctx);
 
-  ceph::bufferlist sweep_out_pending_msgs_to_sent(
+#ifdef UNIT_TESTS_BUILT
+  struct sweep_ret {
+    ceph::bufferlist bl;
+    std::vector<ceph::msgr::v2::Tag> tags;
+  };
+  sweep_ret
+#else
+  ceph::bufferlist
+#endif
+  sweep_out_pending_msgs_to_sent(
       bool require_keepalive,
       std::optional<utime_t> maybe_keepalive_ack,
       bool require_ack);

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -238,9 +238,9 @@ void Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replac
 
 void Heartbeat::ms_handle_connect(
     crimson::net::ConnectionRef conn,
-    seastar::shard_id new_shard)
+    seastar::shard_id prv_shard)
 {
-  ceph_assert_always(seastar::this_shard_id() == new_shard);
+  ceph_assert_always(seastar::this_shard_id() == prv_shard);
   auto peer = conn->get_peer_id();
   if (conn->get_peer_type() != entity_name_t::TYPE_OSD ||
       peer == entity_name_t::NEW) {
@@ -254,10 +254,10 @@ void Heartbeat::ms_handle_connect(
 
 void Heartbeat::ms_handle_accept(
     crimson::net::ConnectionRef conn,
-    seastar::shard_id new_shard,
+    seastar::shard_id prv_shard,
     bool is_replace)
 {
-  ceph_assert_always(seastar::this_shard_id() == new_shard);
+  ceph_assert_always(seastar::this_shard_id() == prv_shard);
   auto peer = conn->get_peer_id();
   if (conn->get_peer_type() != entity_name_t::TYPE_OSD ||
       peer == entity_name_t::NEW) {

--- a/src/crimson/tools/perf_crimson_msgr.cc
+++ b/src/crimson/tools/perf_crimson_msgr.cc
@@ -605,8 +605,8 @@ static seastar::future<> run(
 
       void ms_handle_connect(
           crimson::net::ConnectionRef conn,
-          seastar::shard_id new_shard) override {
-        ceph_assert_always(new_shard == seastar::this_shard_id());
+          seastar::shard_id prv_shard) override {
+        ceph_assert_always(prv_shard == seastar::this_shard_id());
         assert(is_active());
         unsigned index = static_cast<ConnectionPriv&>(conn->get_user_private()).index;
         auto &conn_state = conn_states[index];

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -21,12 +21,12 @@ target_link_libraries(unittest-seastar-denc crimson GTest::Main)
 
 add_executable(unittest-seastar-socket test_socket.cc)
 add_ceph_unittest(unittest-seastar-socket
-  --memory 256M --smp 2)
+  --memory 256M --smp 4)
 target_link_libraries(unittest-seastar-socket crimson)
 
 add_executable(unittest-seastar-messenger test_messenger.cc)
 add_ceph_unittest(unittest-seastar-messenger
-  --memory 256M --smp 1)
+  --memory 256M --smp 4)
 target_link_libraries(unittest-seastar-messenger crimson)
 
 add_executable(test-seastar-messenger-peer test_messenger_peer.cc)

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -1225,7 +1225,7 @@ class FailoverSuite : public Dispatcher {
           entity_name_t::OSD(TEST_OSD),
           "Test",
           TEST_NONCE,
-          true),
+          false),
         test_peer_addr,
         interceptor,
         gates);

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -1298,13 +1298,16 @@ class FailoverSuite : public Dispatcher {
     assert(seastar::this_shard_id() == primary_sid);
     ceph_assert(tracked_conn);
     // sleep to propagate potential remaining acks
-    return seastar::sleep(100ms
+    return seastar::sleep(50ms
     ).then([this] {
       return seastar::smp::submit_to(
           tracked_conn->get_shard_id(), [tracked_conn=tracked_conn] {
         assert(tracked_conn->get_shard_id() == seastar::this_shard_id());
         tracked_conn->mark_down();
       });
+    }).then([] {
+      // sleep to wait for markdown propagate to the primary sid
+      return seastar::sleep(100ms);
     });
   }
 

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -122,10 +122,10 @@ static seastar::future<> test_echo(unsigned rounds,
 
       void ms_handle_accept(
           crimson::net::ConnectionRef conn,
-          seastar::shard_id new_shard,
+          seastar::shard_id prv_shard,
           bool is_replace) override {
         logger().info("server accepted {}", *conn);
-        ceph_assert(new_shard == seastar::this_shard_id());
+        ceph_assert(prv_shard == seastar::this_shard_id());
         ceph_assert(!is_replace);
       }
 
@@ -196,8 +196,8 @@ static seastar::future<> test_echo(unsigned rounds,
 
       void ms_handle_connect(
           crimson::net::ConnectionRef conn,
-          seastar::shard_id new_shard) override {
-        assert(new_shard == seastar::this_shard_id());
+          seastar::shard_id prv_shard) override {
+        assert(prv_shard == seastar::this_shard_id());
         auto session = seastar::make_shared<PingSession>();
         auto [i, added] = sessions.emplace(conn, session);
         std::ignore = i;
@@ -937,9 +937,9 @@ class FailoverSuite : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard,
+      seastar::shard_id prv_shard,
       bool is_replace) override {
-    assert(new_shard == seastar::this_shard_id());
+    assert(prv_shard == seastar::this_shard_id());
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
       logger().error("Untracked accepted connection: {}", *conn);
@@ -964,8 +964,8 @@ class FailoverSuite : public Dispatcher {
 
   void ms_handle_connect(
       ConnectionRef conn,
-      seastar::shard_id new_shard) override {
-    assert(new_shard == seastar::this_shard_id());
+      seastar::shard_id prv_shard) override {
+    assert(prv_shard == seastar::this_shard_id());
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
       logger().error("Untracked connected connection: {}", *conn);
@@ -1533,9 +1533,9 @@ class FailoverSuitePeer : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard,
+      seastar::shard_id prv_shard,
       bool is_replace) override {
-    assert(new_shard == seastar::this_shard_id());
+    assert(prv_shard == seastar::this_shard_id());
     logger().info("[TestPeer] got accept from Test");
     ceph_assert(!tracked_conn ||
                 tracked_conn->is_closed() ||
@@ -1693,9 +1693,9 @@ class FailoverTestPeer : public Dispatcher {
 
   void ms_handle_accept(
       ConnectionRef conn,
-      seastar::shard_id new_shard,
+      seastar::shard_id prv_shard,
       bool is_replace) override {
-    assert(new_shard == seastar::this_shard_id());
+    assert(prv_shard == seastar::this_shard_id());
     cmd_conn = conn;
   }
 

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -3726,8 +3726,11 @@ seastar::future<int> do_test(seastar::app_template& app)
                                               CEPH_ENTITY_TYPE_CLIENT,
                                               &cluster,
                                               &conf_file_list);
-  return crimson::common::sharded_conf().start(init_params.name, cluster)
-  .then([conf_file_list] {
+  return crimson::common::sharded_conf().start(
+    init_params.name, cluster
+  ).then([] {
+    return local_conf().start();
+  }).then([conf_file_list] {
     return local_conf().parse_config_files(conf_file_list);
   }).then([&app] {
     auto&& config = app.configuration();

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -632,8 +632,11 @@ seastar::future<int> do_test(seastar::app_template& app)
                                               CEPH_ENTITY_TYPE_CLIENT,
                                               &cluster,
                                               &conf_file_list);
-  return crimson::common::sharded_conf().start(init_params.name, cluster)
-  .then([conf_file_list] {
+  return crimson::common::sharded_conf().start(
+    init_params.name, cluster
+  ).then([] {
+    return local_conf().start();
+  }).then([conf_file_list] {
     return local_conf().parse_config_files(conf_file_list);
   }).then([&app] {
     auto&& config = app.configuration();

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -136,17 +136,17 @@ class SyntheticDispatcher final
 
   void ms_handle_accept(
       crimson::net::ConnectionRef conn,
-      seastar::shard_id new_shard,
+      seastar::shard_id prv_shard,
       bool is_replace) final {
     logger().info("{} - Connection:{}", __func__, *conn);
-    assert(new_shard == seastar::this_shard_id());
+    assert(prv_shard == seastar::this_shard_id());
   }
 
   void ms_handle_connect(
       crimson::net::ConnectionRef conn,
-      seastar::shard_id new_shard) final {
+      seastar::shard_id prv_shard) final {
     logger().info("{} - Connection:{}", __func__, *conn);
-    assert(new_shard == seastar::this_shard_id());
+    assert(prv_shard == seastar::this_shard_id());
   }
 
   void ms_handle_reset(crimson::net::ConnectionRef con, bool is_replace) final;

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -520,8 +520,11 @@ seastar::future<int> do_test(seastar::app_template& app)
                                               CEPH_ENTITY_TYPE_CLIENT,
                                               &cluster,
                                               &conf_file_list);
-  return crimson::common::sharded_conf().start(init_params.name, cluster
-  ).then([conf_file_list] {
+  return crimson::common::sharded_conf().start(
+    init_params.name, cluster
+  ).then([] {
+    return local_conf().start();
+  }).then([conf_file_list] {
     return local_conf().parse_config_files(conf_file_list);
   }).then([] {
     return local_conf().set_val("ms_inject_internal_delays", "0");


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52896

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

