### PR TITLE
reef: crimson/os/seastore: create page aligned bufferptr in copy ctor of CachedExtent

### DIFF
--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -706,9 +706,10 @@ protected:
       length(other.get_length()),
       version(other.version),
       poffset(other.poffset) {
+      assert((length % CEPH_PAGE_SIZE) == 0);
       if (other.is_fully_loaded()) {
-        ptr = std::make_optional<ceph::bufferptr>
-          (other.ptr->c_str(), other.ptr->length());
+        ptr.emplace(buffer::create_page_aligned(length));
+        other.ptr->copy_out(0, length, ptr->c_str());
       } else {
         // the extent must be fully loaded before CoW
         assert(length == 0); // in case of root


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53501

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

