### PR TITLE
reef: crimson/os/seastore/cache: don't add EXIST_CLEAN extents to lru

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -780,7 +780,7 @@ void Cache::commit_replace_extent(
   extents.replace(*next, *prev);
 
   if (prev->get_type() == extent_types_t::ROOT) {
-    assert(prev->is_clean()
+    assert(prev->is_stable_clean()
       || prev->primary_ref_list_hook.is_linked());
     if (prev->is_dirty()) {
       stats.dirty_bytes -= prev->get_length();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1364,7 +1364,7 @@ private:
     }
 
     void add_to_lru(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
+      assert(extent.is_stable_clean() && !extent.is_placeholder());
       
       if (!extent.primary_ref_list_hook.is_linked()) {
 	contents += extent.get_length();
@@ -1390,7 +1390,7 @@ private:
     }
 
     void remove_from_lru(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
+      assert(extent.is_stable_clean() && !extent.is_placeholder());
 
       if (extent.primary_ref_list_hook.is_linked()) {
 	lru.erase(lru.s_iterator_to(extent));
@@ -1401,7 +1401,7 @@ private:
     }
 
     void move_to_top(CachedExtent &extent) {
-      assert(extent.is_clean() && !extent.is_placeholder());
+      assert(extent.is_stable_clean() && !extent.is_placeholder());
 
       if (extent.primary_ref_list_hook.is_linked()) {
 	lru.erase(lru.s_iterator_to(extent));

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -467,7 +467,8 @@ public:
             ret->cast<T>());
         });
       } else {
-        touch_extent(*ret);
+	assert(!ret->is_mutable());
+	touch_extent(*ret);
         SUBDEBUGT(seastore_cache, "{} {}~{} is present on t without been \
           fully loaded, reading ...", t, T::TYPE, offset, length);
         auto bp = alloc_cache_buf(ret->get_length());
@@ -566,6 +567,7 @@ public:
     // user should not see RETIRED_PLACEHOLDER extents
     ceph_assert(p_extent->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
     if (!p_extent->is_fully_loaded()) {
+      assert(!p_extent->is_mutable());
       touch_extent(*p_extent);
       LOG_PREFIX(Cache::get_extent_viewable_by_trans);
       SUBDEBUG(seastore_cache,
@@ -661,7 +663,8 @@ private:
 	  return seastar::make_ready_future<CachedExtentRef>(ret);
         });
       } else {
-        touch_extent(*ret);
+	assert(!ret->is_mutable());
+	touch_extent(*ret);
         SUBDEBUGT(seastore_cache, "{} {}~{} {} is present on t without been \
                   fully loaded, reading ...", t, type, offset, length, laddr);
         auto bp = alloc_cache_buf(ret->get_length());
@@ -1281,7 +1284,7 @@ public:
   {
     if (p_src && is_background_transaction(*p_src))
       return;
-    if (ext.is_clean() && !ext.is_placeholder()) {
+    if (ext.is_stable_clean() && !ext.is_placeholder()) {
       lru.move_to_top(ext);
     }
   }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -441,6 +441,13 @@ public:
            state == extent_state_t::EXIST_CLEAN;
   }
 
+  // Returs true if extent is stable and clean
+  bool is_stable_clean() const {
+    ceph_assert(is_valid());
+    return state == extent_state_t::CLEAN ||
+           state == extent_state_t::CLEAN_PENDING;
+  }
+
   /// Ruturns true if data is persisted while metadata isn't
   bool is_exist_clean() const {
     return state == extent_state_t::EXIST_CLEAN;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53455

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

