### PR TITLE
mon: resolve warning about inconsistent variable types

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -762,7 +762,7 @@ void Elector::notify_rank_removed(unsigned rank_removed, unsigned new_rank)
      In the case where we are removing the highest rank,
      we erase the removed rank from all sets.
    */
-  if (rank_removed < paxos_size()) {
+  if (std::cmp_less(rank_removed, paxos_size())) {
     for (unsigned i = rank_removed + 1; i <= paxos_size() ; ++i) {
       if (live_pinging.count(i)) {
         dead_pinging.erase(i-1);

--- a/src/test/common/test_fair_mutex.cc
+++ b/src/test/common/test_fair_mutex.cc
@@ -47,7 +47,7 @@ TEST(FairMutex, fair)
                                        scoreboard.end(),
                                        0);
       for (unsigned score : scoreboard) {
-        if (total < NR_ROUNDS) {
+        if (std::cmp_less(total, NR_ROUNDS)) {
           // not quite statistically significant. to reduce the false positive,
           // just consider it fair
           continue;


### PR DESCRIPTION
resolve a warning issue about inconsistent variable types with Building CXX object src/mon/CMakeFiles/mon.dir/Elector.cc.o ../src/mon/Elector.cc: In member function 'void Elector::notify_rank_removed(int)': ../src/mon/Elector.cc:765:15: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
   if (rank_removed < paxos_size()) {

Fixes: https://tracker.ceph.com/issues/63917

Signed-off-by: cuiming <cuiming_yewu@cmss.chinamobile.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
