### PR TITLE
cephadm: remove get_daemon_args function

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2843,11 +2843,12 @@ def get_container(
         )
 
     _update_container_args_for_podman(ctx, ident, container_args)
+    d_args = _get_daemon_args(ctx, ident)
     return CephContainer.for_daemon(
         ctx,
         ident=ident,
         entrypoint=entrypoint,
-        args=ceph_args + _get_daemon_args(ctx, ident),
+        args=ceph_args + d_args,
         container_args=container_args,
         volume_mounts=get_container_mounts(ctx, ident),
         bind_mounts=get_container_binds(ctx, ident),

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2325,9 +2325,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     if Ceph.for_daemon_type(daemon_type) or OSD.for_daemon_type(daemon_type):
         daemon = Ceph.create(ctx, ident)
         r += daemon.get_daemon_args()
-    elif daemon_type in Monitoring.components:
-        monitoring = Monitoring.create(ctx, ident)
-        r += monitoring.get_daemon_args()
 
     return r
 
@@ -2781,6 +2778,8 @@ def get_container(
             # '--path.rootfs=/rootfs' for node-exporter we need to disable selinux separation
             # between the node-exporter container and the host to avoid selinux denials
             container_args.extend(['--security-opt', 'label=disable'])
+        monitoring = Monitoring.create(ctx, ident)
+        d_args.extend(monitoring.get_daemon_args())
     elif daemon_type in Tracing.components:
         entrypoint = ''
         name = ident.daemon_name

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2331,9 +2331,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type == 'jaeger-agent':
         tracing = Tracing.create(ctx, ident)
         r += tracing.get_daemon_args()
-    elif daemon_type == NFSGanesha.daemon_type:
-        nfs_ganesha = NFSGanesha.init(ctx, ident.fsid, ident.daemon_id)
-        r += nfs_ganesha.get_daemon_args()
 
     return r
 
@@ -2797,6 +2794,8 @@ def get_container(
         entrypoint = NFSGanesha.entrypoint
         name = ident.daemon_name
         envs.extend(NFSGanesha.get_container_envs())
+        nfs_ganesha = NFSGanesha.init(ctx, ident.fsid, ident.daemon_id)
+        d_args.extend(nfs_ganesha.get_daemon_args())
     elif daemon_type == CephExporter.daemon_type:
         entrypoint = CephExporter.entrypoint
         name = 'client.ceph-exporter.%s' % ident.daemon_id

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2334,9 +2334,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type == NFSGanesha.daemon_type:
         nfs_ganesha = NFSGanesha.init(ctx, ident.fsid, ident.daemon_id)
         r += nfs_ganesha.get_daemon_args()
-    elif daemon_type == CephExporter.daemon_type:
-        ceph_exporter = CephExporter.init(ctx, ident.fsid, ident.daemon_id)
-        r.extend(ceph_exporter.get_daemon_args())
 
     return r
 
@@ -2804,6 +2801,8 @@ def get_container(
         entrypoint = CephExporter.entrypoint
         name = 'client.ceph-exporter.%s' % ident.daemon_id
         ceph_args = ['-n', name, '-f']
+        ceph_exporter = CephExporter.init(ctx, ident.fsid, ident.daemon_id)
+        d_args.extend(ceph_exporter.get_daemon_args())
     elif daemon_type == HAproxy.daemon_type:
         name = ident.daemon_name
         container_args.extend(['--user=root'])  # haproxy 2.4 defaults to a different user

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2561,7 +2561,7 @@ def get_container_mounts(
     """
     # unpack fsid and daemon_type from ident because they're used very frequently
     fsid, daemon_type = ident.fsid, ident.daemon_type
-    mounts = get_container_mounts_for_type(ctx, fsid, daemon_type)
+    mounts = _get_container_mounts_for_type(ctx, fsid, daemon_type)
 
     assert ident.fsid
     assert ident.daemon_id

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2832,7 +2832,7 @@ def get_container(
         privileged = True
     elif daemon_type == CustomContainer.daemon_type:
         cc = CustomContainer.init(ctx, ident.fsid, ident.daemon_id)
-        entrypoint = cc.entrypoint
+        entrypoint = cc.entrypoint or ''
         host_network = False
         envs.extend(cc.get_container_envs())
         container_args.extend(cc.get_container_args())

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2328,9 +2328,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type in Monitoring.components:
         monitoring = Monitoring.create(ctx, ident)
         r += monitoring.get_daemon_args()
-    elif daemon_type == 'jaeger-agent':
-        tracing = Tracing.create(ctx, ident)
-        r += tracing.get_daemon_args()
 
     return r
 
@@ -2790,6 +2787,9 @@ def get_container(
         config = fetch_configs(ctx)
         Tracing.set_configuration(config, daemon_type)
         envs.extend(Tracing.components[daemon_type].get('envs', []))
+        if daemon_type == 'jaeger-agent':
+            tracing = Tracing.create(ctx, ident)
+            d_args.extend(tracing.get_daemon_args())
     elif daemon_type == NFSGanesha.daemon_type:
         entrypoint = NFSGanesha.entrypoint
         name = ident.daemon_name

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2924,7 +2924,7 @@ def deploy_daemon(
                 '--fsid', ident.fsid,
                 '-c', '/tmp/config',
                 '--keyring', '/tmp/keyring',
-            ] + get_daemon_args(ctx, ident),
+            ] + Ceph.create(ctx, ident).get_daemon_args(),
             volume_mounts={
                 log_dir: '/var/log/ceph:z',
                 mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (ident.daemon_id),
@@ -4305,7 +4305,7 @@ def prepare_create_mon(
             '-c', '/dev/null',
             '--monmap', '/tmp/monmap',
             '--keyring', '/tmp/keyring',
-        ] + get_daemon_args(ctx, ident),
+        ] + Ceph.create(ctx, ident).get_daemon_args(),
         volume_mounts={
             log_dir: '/var/log/ceph:z',
             mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1662,6 +1662,11 @@ class Tracing(ContainerDaemonForm):
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
         return 65534, 65534
 
+    def get_daemon_args(self) -> List[str]:
+        return self.components[self.identity.daemon_type].get(
+            'daemon_args', []
+        )
+
 ##################################
 
 
@@ -2324,7 +2329,8 @@ def get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
         monitoring = Monitoring.create(ctx, ident)
         r += monitoring.get_daemon_args()
     elif daemon_type == 'jaeger-agent':
-        r.extend(Tracing.components[daemon_type]['daemon_args'])
+        tracing = Tracing.create(ctx, ident)
+        r += tracing.get_daemon_args()
     elif daemon_type == NFSGanesha.daemon_type:
         nfs_ganesha = NFSGanesha.init(ctx, ident.fsid, ident.daemon_id)
         r += nfs_ganesha.get_daemon_args()

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2318,17 +2318,6 @@ def get_legacy_daemon_fsid(ctx, cluster,
     return fsid
 
 
-def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
-    r = list()  # type: List[str]
-
-    daemon_type = ident.daemon_type
-    if Ceph.for_daemon_type(daemon_type) or OSD.for_daemon_type(daemon_type):
-        daemon = Ceph.create(ctx, ident)
-        r += daemon.get_daemon_args()
-
-    return r
-
-
 def create_daemon_dirs(
     ctx: CephadmContext,
     ident: 'DaemonIdentity',
@@ -2740,6 +2729,9 @@ def get_container(
     if container_args is None:
         container_args = []
     _update_pids_limit(ctx, daemon_type, container_args)
+    if Ceph.for_daemon_type(daemon_type) or OSD.for_daemon_type(daemon_type):
+        ceph_daemon = Ceph.create(ctx, ident)
+        d_args.extend(ceph_daemon.get_daemon_args())
     if daemon_type in ['mon', 'osd']:
         # mon and osd need privileged in order for libudev to query devices
         privileged = True
@@ -2836,7 +2828,6 @@ def get_container(
         d_args.extend(sg.get_daemon_args())
 
     _update_container_args_for_podman(ctx, ident, container_args)
-    d_args.extend(_get_daemon_args(ctx, ident))
     return CephContainer.for_daemon(
         ctx,
         ident=ident,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5106,25 +5106,37 @@ def get_deployment_container(
     # wrapper for get_container specifically for containers made during the `cephadm deploy`
     # command. Adds some extra things such as extra container args and custom config files
     c = get_container(ctx, ident, privileged, ptrace, container_args)
+    return to_deployment_container(ctx, c)
+
+
+def to_deployment_container(
+    ctx: CephadmContext, ctr: CephContainer
+) -> CephContainer:
+    """Given a standard ceph container instance return a CephContainer
+    prepared for a deployment as a daemon, having the extra args and
+    custom configurations added.
+    NOTE: The `ctr` object is mutated before being returned.
+    """
     if 'extra_container_args' in ctx and ctx.extra_container_args:
-        c.container_args.extend(ctx.extra_container_args)
+        ctr.container_args.extend(ctx.extra_container_args)
     if 'extra_entrypoint_args' in ctx and ctx.extra_entrypoint_args:
-        c.args.extend(ctx.extra_entrypoint_args)
+        ctr.args.extend(ctx.extra_entrypoint_args)
     ccfiles = fetch_custom_config_files(ctx)
     if ccfiles:
         mandatory_keys = ['mount_path', 'content']
         for conf in ccfiles:
             if all(k in conf for k in mandatory_keys):
                 mount_path = conf['mount_path']
+                assert ctr.identity
                 file_path = os.path.join(
                     ctx.data_dir,
-                    ident.fsid,
+                    ctr.identity.fsid,
                     'custom_config_files',
-                    ident.daemon_name,
+                    ctr.identity.daemon_name,
                     os.path.basename(mount_path)
                 )
-                c.volume_mounts[file_path] = mount_path
-    return c
+                ctr.volume_mounts[file_path] = mount_path
+    return ctr
 
 
 def get_deployment_type(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2343,9 +2343,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type == CustomContainer.daemon_type:
         cc = CustomContainer.init(ctx, ident.fsid, ident.daemon_id)
         r.extend(cc.get_daemon_args())
-    elif daemon_type == SNMPGateway.daemon_type:
-        sc = SNMPGateway.init(ctx, ident.fsid, ident.daemon_id)
-        r.extend(sc.get_daemon_args())
 
     return r
 
@@ -2751,6 +2748,7 @@ def get_container(
     entrypoint: str = ''
     name: str = ''
     ceph_args: List[str] = []
+    d_args: List[str] = []
     envs: List[str] = []
     host_network: bool = True
 
@@ -2841,9 +2839,10 @@ def get_container(
         container_args.append(
             f'--env-file={sg.conf_file_path}'
         )
+        d_args.extend(sg.get_daemon_args())
 
     _update_container_args_for_podman(ctx, ident, container_args)
-    d_args = _get_daemon_args(ctx, ident)
+    d_args.extend(_get_daemon_args(ctx, ident))
     return CephContainer.for_daemon(
         ctx,
         ident=ident,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2337,9 +2337,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type == CephExporter.daemon_type:
         ceph_exporter = CephExporter.init(ctx, ident.fsid, ident.daemon_id)
         r.extend(ceph_exporter.get_daemon_args())
-    elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(ctx, ident.fsid, ident.daemon_id)
-        r += haproxy.get_daemon_args()
 
     return r
 
@@ -2810,6 +2807,8 @@ def get_container(
     elif daemon_type == HAproxy.daemon_type:
         name = ident.daemon_name
         container_args.extend(['--user=root'])  # haproxy 2.4 defaults to a different user
+        haproxy = HAproxy.init(ctx, ident.fsid, ident.daemon_id)
+        d_args.extend(haproxy.get_daemon_args())
     elif daemon_type == Keepalived.daemon_type:
         name = ident.daemon_name
         envs.extend(Keepalived.get_container_envs())

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2340,9 +2340,6 @@ def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     elif daemon_type == HAproxy.daemon_type:
         haproxy = HAproxy.init(ctx, ident.fsid, ident.daemon_id)
         r += haproxy.get_daemon_args()
-    elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(ctx, ident.fsid, ident.daemon_id)
-        r.extend(cc.get_daemon_args())
 
     return r
 
@@ -2834,6 +2831,7 @@ def get_container(
         host_network = False
         envs.extend(cc.get_container_envs())
         container_args.extend(cc.get_container_args())
+        d_args.extend(cc.get_daemon_args())
     elif daemon_type == SNMPGateway.daemon_type:
         sg = SNMPGateway.init(ctx, ident.fsid, ident.daemon_id)
         container_args.append(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2318,7 +2318,7 @@ def get_legacy_daemon_fsid(ctx, cluster,
     return fsid
 
 
-def get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
+def _get_daemon_args(ctx: CephadmContext, ident: 'DaemonIdentity') -> List[str]:
     r = list()  # type: List[str]
 
     daemon_type = ident.daemon_type
@@ -2847,7 +2847,7 @@ def get_container(
         ctx,
         ident=ident,
         entrypoint=entrypoint,
-        args=ceph_args + get_daemon_args(ctx, ident),
+        args=ceph_args + _get_daemon_args(ctx, ident),
         container_args=container_args,
         volume_mounts=get_container_mounts(ctx, ident),
         bind_mounts=get_container_binds(ctx, ident),

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -329,9 +329,9 @@ class TestCephAdm(object):
     @mock.patch('cephadm.logger')
     @mock.patch('cephadm.fetch_custom_config_files')
     @mock.patch('cephadm.get_container')
-    def test_get_deployment_container(self, _get_container, _get_config, _logger):
+    def test_to_deployment_container(self, _get_container, _get_config, _logger):
         """
-        test get_deployment_container properly makes use of extra container args and custom conf files
+        test to_deployment_container properly makes use of extra container args and custom conf files
         """
 
         ctx = _cephadm.CephadmContext()
@@ -365,7 +365,8 @@ class TestCephAdm(object):
             ptrace=False,
             host_network=True,
         )
-        c = _cephadm.get_deployment_container(ctx, ident)
+        c = _cephadm.get_container(ctx, ident)
+        c = _cephadm.to_deployment_container(ctx, c)
 
         assert '--pids-limit=12345' in c.container_args
         assert '--something' in c.container_args
@@ -380,9 +381,9 @@ class TestCephAdm(object):
     @mock.patch('cephadm.check_unit', lambda *args, **kwargs: (None, 'running', None))
     @mock.patch('cephadm.get_unit_name', lambda *args, **kwargs: 'mon-unit-name')
     @mock.patch('cephadm.extract_uid_gid', lambda *args, **kwargs: (0, 0))
-    @mock.patch('cephadm.get_deployment_container')
+    @mock.patch('cephadm.get_container')
     @mock.patch('cephadm.apply_deploy_config_to_ctx', lambda d, c: None)
-    def test_mon_crush_location(self, _get_deployment_container, _migrate_sysctl, _make_var_run, _deploy_daemon, _file_lock, _logger, monkeypatch):
+    def test_mon_crush_location(self, _get_container, _migrate_sysctl, _make_var_run, _deploy_daemon, _file_lock, _logger, monkeypatch):
         """
         test that crush location for mon is set if it is included in config_json
         """
@@ -390,6 +391,7 @@ class TestCephAdm(object):
         monkeypatch.setattr('cephadmlib.context_getters.fetch_configs', _fetch_configs)
         monkeypatch.setattr('cephadm.fetch_configs', _fetch_configs)
         monkeypatch.setattr('cephadm.read_configuration_source', lambda c: {})
+        monkeypatch.setattr('cephadm.fetch_custom_config_files', mock.MagicMock())
 
         ctx = _cephadm.CephadmContext()
         ctx.name = 'mon.test'
@@ -404,7 +406,7 @@ class TestCephAdm(object):
             'crush_location': 'database=a'
         }
 
-        _get_deployment_container.return_value = _cephadm.CephContainer.for_daemon(
+        _get_container.return_value = _cephadm.CephContainer.for_daemon(
             ctx,
             ident=_cephadm.DaemonIdentity(
                 fsid='9b9d7609-f4d5-4aba-94c8-effa764d96c9',

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1229,9 +1229,9 @@ class TestMonitoring(object):
         daemon_type = 'prometheus'
         daemon_id = 'home'
         fsid = 'aaf5a720-13fe-4a3b-82b9-2d99b7fd9704'
-        args = _cephadm.get_daemon_args(
+        args = _cephadm.Monitoring.create(
             ctx, _cephadm.DaemonIdentity(fsid, daemon_type, daemon_id)
-        )
+        ).get_daemon_args()
         assert any([x.startswith('--web.external-url=http://') for x in args])
 
     @mock.patch('cephadm.call')

--- a/src/cephadm/tests/test_custom_container.py
+++ b/src/cephadm/tests/test_custom_container.py
@@ -115,6 +115,9 @@ def test_deploy_custom_container(cephadm_fs):
             '--servers',
             '192.168.8.42,192.168.8.43,192.168.12.11',
         ]
+        ctx.config_blobs = {
+            'envs': ['FOO=1', 'BAR=77'],
+        }
 
         _cephadm._common_deploy(ctx)
 
@@ -132,6 +135,8 @@ def test_deploy_custom_container(cephadm_fs):
             ' --cgroups=split --no-hosts'
             ' -e CONTAINER_IMAGE=quay.io/foobar/quux:latest'
             ' -e NODE_NAME=host1'
+            ' -e FOO=1'
+            ' -e BAR=77'
             ' quay.io/foobar/quux:latest'
             ' --label frobnicationist --servers 192.168.8.42,192.168.8.43,192.168.12.11'
         )


### PR DESCRIPTION
Depends on #54104

From what I can tell, there are currently 4 large obstacles to moving the various daemon type classes out of cephadm.py. These are the functions: get_container, get_daemon_args, get_container_mounts, & get_container_binds.

All of them are used by and use the daemon type classes, creating a dependency loop. Until this loop is broken these classes can not attempt to be moved.

This PR starts the process of breaking down these functions by removing get_daemon_args. It has the fewest callers and the smallest scope and thus we can eliminiate it from the codebase entirely.



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactoring
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Existing and updated tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
