### PR TITLE
reef: rgw: only buckets with reshardable layouts need to be considered for resharding

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9831,6 +9831,10 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
       return 0;
   }
 
+  if (! is_layout_reshardable(bucket_info.layout)) {
+    return 0;
+  }
+
   bool need_resharding = false;
   uint32_t num_source_shards = rgw::current_num_shards(bucket_info.layout);
   const uint32_t max_dynamic_shards =

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -994,11 +994,11 @@ int RGWBucketReshard::execute(int num_shards,
   return 0;
 } // execute
 
-bool RGWBucketReshard::can_reshard(const RGWBucketInfo& bucket,
-                                   const RGWSI_Zone* zone_svc)
+bool RGWBucketReshard::should_zone_reshard_now(const RGWBucketInfo& bucket,
+					       const RGWSI_Zone* zone_svc)
 {
   return !zone_svc->need_to_log_data() ||
-      bucket.layout.logs.size() < max_bilog_history;
+    bucket.layout.logs.size() < max_bilog_history;
 }
 
 
@@ -1240,7 +1240,7 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
     return 0;
   }
 
-  if (!RGWBucketReshard::can_reshard(bucket_info, store->svc()->zone)) {
+  if (!RGWBucketReshard::should_zone_reshard_now(bucket_info, store->svc()->zone)) {
     ldpp_dout(dpp, 1) << "Bucket " << bucket_info.bucket << " is not "
         "eligible for resharding until peer zones finish syncing one "
         "or more of its old log generations" << dendl;

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -175,8 +175,8 @@ public:
   // too large by refusing to reshard the bucket until the old logs get trimmed
   static constexpr size_t max_bilog_history = 4;
 
-  static bool can_reshard(const RGWBucketInfo& bucket,
-                          const RGWSI_Zone* zone_svc);
+  static bool should_zone_reshard_now(const RGWBucketInfo& bucket,
+				      const RGWSI_Zone* zone_svc);
 }; // RGWBucketReshard
 
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3025,6 +3025,14 @@ int check_reshard_bucket_params(rgw::sal::Driver* driver,
     return ret;
   }
 
+  if (! is_layout_reshardable((*bucket)->get_info().layout)) {
+    std::cerr << "Bucket '" << (*bucket)->get_name() <<
+      "' currently has layout '" <<
+      current_layout_desc((*bucket)->get_info().layout) <<
+      "', which does not support resharding." << std::endl;
+    return -EINVAL;
+  }
+
   int num_source_shards = rgw::current_num_shards((*bucket)->get_info().layout);
 
   if (num_shards <= num_source_shards && !yes_i_really_mean_it) {
@@ -8107,7 +8115,8 @@ next:
           "have the resharding feature enabled." << std::endl;
       return ENOTSUP;
     }
-    if (!RGWBucketReshard::can_reshard(bucket->get_info(), zone_svc) &&
+
+    if (!RGWBucketReshard::should_zone_reshard_now(bucket->get_info(), zone_svc) &&
         !yes_i_really_mean_it) {
       std::cerr << "Bucket '" << bucket->get_name() << "' already has too many "
           "log generations (" << bucket->get_info().layout.logs.size() << ") "

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -278,5 +278,14 @@ inline uint32_t current_num_shards(const BucketLayout& layout) {
 inline bool is_layout_indexless(const bucket_index_layout_generation& layout) {
   return layout.layout.type == BucketIndexType::Indexless;
 }
+inline bool is_layout_reshardable(const bucket_index_layout_generation& layout) {
+  return layout.layout.type == BucketIndexType::Normal;
+}
+inline bool is_layout_reshardable(const BucketLayout& layout) {
+  return is_layout_reshardable(layout.current_index);
+}
+inline std::string_view current_layout_desc(const BucketLayout& layout) {
+  return rgw::to_string(layout.current_index.layout.type);
+}
 
 } // namespace rgw


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63247

---

backport of https://github.com/ceph/ceph/pull/53929
parent tracker: https://tracker.ceph.com/issues/63170

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh