### PR TITLE
cephadm: move more container engine specific logic

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2647,17 +2647,8 @@ def get_container_mounts(
 
 def _update_podman_mounts(ctx: CephadmContext, mounts: Dict[str, str]) -> None:
     """Update the given mounts dict with mounts specific to podman."""
-    # Modifications podman makes to /etc/hosts causes issues with
-    # certain daemons (specifically referencing "host.containers.internal" entry
-    # being added to /etc/hosts in this case). To avoid that, but still
-    # allow users to use /etc/hosts for hostname resolution, we can
-    # mount the host's /etc/hosts file.
-    # https://tracker.ceph.com/issues/58532
-    # https://tracker.ceph.com/issues/57018
     if isinstance(ctx.container_engine, Podman):
-        if os.path.exists('/etc/hosts'):
-            if '/etc/hosts' not in mounts:
-                mounts['/etc/hosts'] = '/etc/hosts:ro'
+        ctx.container_engine.update_mounts(ctx, mounts)
 
 
 def get_ceph_volume_container(ctx: CephadmContext,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -70,7 +70,6 @@ from cephadmlib.constants import (
     LOGROTATE_DIR,
     LOG_DIR,
     LOG_DIR_MODE,
-    PIDS_LIMIT_UNLIMITED_PODMAN_VERSION,
     SYSCTL_DIR,
     UNIT_DIR,
 )
@@ -2692,13 +2691,7 @@ def _update_pids_limit(ctx: CephadmContext, daemon_type: str, container_args: Li
     unlimited_daemons.add(NFSGanesha.daemon_type)
     if daemon_type not in unlimited_daemons:
         return
-    if (
-        isinstance(ctx.container_engine, Podman)
-        and ctx.container_engine.version >= PIDS_LIMIT_UNLIMITED_PODMAN_VERSION
-    ):
-        container_args.append('--pids-limit=-1')
-    else:
-        container_args.append('--pids-limit=0')
+    container_args.append(ctx.container_engine.unlimited_pids_option)
 
 
 def get_container(

--- a/src/cephadm/cephadmlib/container_engine_base.py
+++ b/src/cephadm/cephadmlib/container_engine_base.py
@@ -11,5 +11,12 @@ class ContainerEngine:
     def EXE(self) -> str:
         raise NotImplementedError()
 
+    @property
+    def unlimited_pids_option(self) -> str:
+        """The option to pass to the container engine for allowing unlimited
+        pids (processes).
+        """
+        return '--pids-limit=0'
+
     def __str__(self) -> str:
         return f'{self.EXE} ({self.path})'

--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -175,3 +175,17 @@ def registry_login(
             'Failed to login to custom registry @ %s as %s with given password'
             % (ctx.registry_url, ctx.registry_username)
         )
+
+
+def pull_command(
+    ctx: CephadmContext, image: str, insecure: bool = False
+) -> List[str]:
+    """Return a command that can be run to pull an image."""
+    cmd = [ctx.container_engine.path, 'pull', image]
+    if isinstance(ctx.container_engine, Podman):
+        if insecure:
+            cmd.append('--tls-verify=false')
+
+        if os.path.exists('/etc/ceph/podman-auth.json'):
+            cmd.append('--authfile=/etc/ceph/podman-auth.json')
+    return cmd

--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -11,6 +11,7 @@ from .constants import (
     CGROUPS_SPLIT_PODMAN_VERSION,
     DEFAULT_MODE,
     MIN_PODMAN_VERSION,
+    PIDS_LIMIT_UNLIMITED_PODMAN_VERSION,
 )
 from .exceptions import Error
 
@@ -44,6 +45,15 @@ class Podman(ContainerEngine):
     def supports_split_cgroups(self) -> bool:
         """Return true if this version of podman supports split cgroups."""
         return self.version >= CGROUPS_SPLIT_PODMAN_VERSION
+
+    @property
+    def unlimited_pids_option(self) -> str:
+        """The option to pass to the container engine for allowing unlimited
+        pids (processes).
+        """
+        if self.version >= PIDS_LIMIT_UNLIMITED_PODMAN_VERSION:
+            return '--pids-limit=-1'
+        return '--pids-limit=0'
 
     def service_args(
         self, ctx: CephadmContext, service_name: str

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -21,6 +21,7 @@ def mock_docker():
 
     docker = mock.Mock(Docker)
     docker.path = '/usr/bin/docker'
+    type(docker).unlimited_pids_option = Docker.unlimited_pids_option
     return docker
 
 
@@ -37,6 +38,7 @@ def mock_podman():
     # https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock
     type(podman).supports_split_cgroups = Podman.supports_split_cgroups
     type(podman).service_args = Podman.service_args
+    type(podman).unlimited_pids_option = Podman.unlimited_pids_option
     return podman
 
 


### PR DESCRIPTION
Depends on #54081

More a handful more items into the container engines that they are tied to. This should improve the locality of items in  the code base so when you need to know you want to know what special option is passed to 'podman' for action X, you can generally look in container_engines.py.



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactor
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Existing tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
