### PR TITLE
reef: crimson/osd: cleanup and drop OSD::ShardDispatcher

### DIFF
--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -62,76 +62,6 @@ class PG;
 class OSD final : public crimson::net::Dispatcher,
 		  private crimson::common::AuthHandler,
 		  private crimson::mgr::WithStats {
-public:
-  class ShardDispatcher
-    : public seastar::peering_sharded_service<ShardDispatcher> {
-  friend class OSD;
-  public:
-    ShardDispatcher(
-      OSD& osd,
-      PGShardMapping& pg_to_shard_mapping)
-    : pg_shard_manager(osd.osd_singleton_state,
-                       osd.shard_services, pg_to_shard_mapping),
-      osd(osd) {}
-    ~ShardDispatcher() = default;
-
-    // Dispatcher methods
-    seastar::future<> ms_dispatch(crimson::net::ConnectionRef, MessageRef);
-
-  private:
-    bool require_mon_peer(crimson::net::Connection *conn, Ref<Message> m);
-
-    seastar::future<> handle_osd_map(Ref<MOSDMap> m);
-    seastar::future<> _handle_osd_map(Ref<MOSDMap> m);
-    seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
-                                       Ref<MOSDPGCreate2> m);
-    seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,
-                                    Ref<MOSDOp> m);
-    seastar::future<> handle_rep_op(crimson::net::ConnectionRef conn,
-                                    Ref<MOSDRepOp> m);
-    seastar::future<> handle_rep_op_reply(crimson::net::ConnectionRef conn,
-                                          Ref<MOSDRepOpReply> m);
-    seastar::future<> handle_peering_op(crimson::net::ConnectionRef conn,
-                                        Ref<MOSDPeeringOp> m);
-    seastar::future<> handle_recovery_subreq(crimson::net::ConnectionRef conn,
-                                             Ref<MOSDFastDispatchOp> m);
-    seastar::future<> handle_scrub(crimson::net::ConnectionRef conn,
-                                   Ref<MOSDScrub2> m);
-    seastar::future<> handle_mark_me_down(crimson::net::ConnectionRef conn,
-                                          Ref<MOSDMarkMeDown> m);
-
-    seastar::future<> committed_osd_maps(version_t first,
-                                         version_t last,
-                                         Ref<MOSDMap> m);
-
-    seastar::future<> check_osdmap_features();
-
-    seastar::future<> handle_command(crimson::net::ConnectionRef conn,
-                                     Ref<MCommand> m);
-    seastar::future<> handle_update_log_missing(crimson::net::ConnectionRef conn,
-                                                Ref<MOSDPGUpdateLogMissing> m);
-    seastar::future<> handle_update_log_missing_reply(
-      crimson::net::ConnectionRef conn,
-      Ref<MOSDPGUpdateLogMissingReply> m);
-
-  public:
-    void print(std::ostream&) const;
-
-    auto &get_pg_shard_manager() {
-      return pg_shard_manager;
-    }
-    auto &get_pg_shard_manager() const {
-      return pg_shard_manager;
-    }
-    ShardServices &get_shard_services() {
-      return pg_shard_manager.get_shard_services();
-    }
-
-  private:
-    crimson::osd::PGShardManager pg_shard_manager;
-    OSD& osd;
-  };
-
   const int whoami;
   const uint32_t nonce;
   seastar::abort_source& abort_source;
@@ -170,6 +100,8 @@ public:
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
 
+  std::optional<seastar::future<>> do_ms_dispatch(crimson::net::ConnectionRef, MessageRef);
+
   // mgr::WithStats methods
   // pg statistics including osd ones
   osd_stat_t osd_stat;
@@ -185,7 +117,8 @@ public:
   seastar::sharded<OSDSingletonState> osd_singleton_state;
   seastar::sharded<OSDState> osd_states;
   seastar::sharded<ShardServices> shard_services;
-  seastar::sharded<ShardDispatcher> shard_dispatchers;
+
+  crimson::osd::PGShardManager pg_shard_manager;
 
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> tick_timer;
@@ -202,6 +135,10 @@ public:
       crimson::net::MessengerRef hb_front_msgr,
       crimson::net::MessengerRef hb_back_msgr);
   ~OSD() final;
+
+  auto &get_pg_shard_manager() {
+    return pg_shard_manager;
+  }
 
   seastar::future<> open_meta_coll();
   static seastar::future<OSDMeta> open_or_create_meta_coll(
@@ -224,16 +161,7 @@ public:
   uint64_t send_pg_stats();
 
   auto &get_shard_services() {
-    ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
     return shard_services.local();
-  }
-
-  auto &get_pg_shard_manager() {
-    return shard_dispatchers.local().get_pg_shard_manager();
-  }
-
-  auto &get_pg_shard_manager() const {
-    return shard_dispatchers.local().get_pg_shard_manager();
   }
 
 private:
@@ -255,6 +183,39 @@ private:
 
   void write_superblock(ceph::os::Transaction& t);
   seastar::future<> read_superblock();
+
+  seastar::future<> handle_osd_map(Ref<MOSDMap> m);
+  seastar::future<> _handle_osd_map(Ref<MOSDMap> m);
+  seastar::future<> handle_pg_create(crimson::net::ConnectionRef conn,
+                                     Ref<MOSDPGCreate2> m);
+  seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,
+                                  Ref<MOSDOp> m);
+  seastar::future<> handle_rep_op(crimson::net::ConnectionRef conn,
+                                  Ref<MOSDRepOp> m);
+  seastar::future<> handle_rep_op_reply(crimson::net::ConnectionRef conn,
+                                        Ref<MOSDRepOpReply> m);
+  seastar::future<> handle_peering_op(crimson::net::ConnectionRef conn,
+                                      Ref<MOSDPeeringOp> m);
+  seastar::future<> handle_recovery_subreq(crimson::net::ConnectionRef conn,
+                                           Ref<MOSDFastDispatchOp> m);
+  seastar::future<> handle_scrub(crimson::net::ConnectionRef conn,
+                                 Ref<MOSDScrub2> m);
+  seastar::future<> handle_mark_me_down(crimson::net::ConnectionRef conn,
+                                        Ref<MOSDMarkMeDown> m);
+
+  seastar::future<> committed_osd_maps(version_t first,
+                                       version_t last,
+                                       Ref<MOSDMap> m);
+
+  seastar::future<> check_osdmap_features();
+
+  seastar::future<> handle_command(crimson::net::ConnectionRef conn,
+                                   Ref<MCommand> m);
+  seastar::future<> handle_update_log_missing(crimson::net::ConnectionRef conn,
+                                              Ref<MOSDPGUpdateLogMissing> m);
+  seastar::future<> handle_update_log_missing_reply(
+    crimson::net::ConnectionRef conn,
+    Ref<MOSDPGUpdateLogMissingReply> m);
 
 private:
   crimson::common::Gated gate;
@@ -283,15 +244,8 @@ inline std::ostream& operator<<(std::ostream& out, const OSD& osd) {
   return out;
 }
 
-inline std::ostream& operator<<(std::ostream& out,
-                                const OSD::ShardDispatcher& shard_dispatcher) {
-  shard_dispatcher.print(out);
-  return out;
-}
-
 }
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::osd::OSD> : fmt::ostream_formatter {};
-template <> struct fmt::formatter<crimson::osd::OSD::ShardDispatcher> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/osd/pg_shard_manager.cc
+++ b/src/crimson/osd/pg_shard_manager.cc
@@ -23,7 +23,7 @@ seastar::future<> PGShardManager::load_pgs(crimson::os::FuturizedStore& store)
         auto[coll, shard_core] = coll_core;
 	spg_t pgid;
 	if (coll.is_pg(&pgid)) {
-          return pg_to_shard_mapping.maybe_create_pg(
+          return get_pg_to_shard_mapping().maybe_create_pg(
             pgid, shard_core
           ).then([this, pgid] (auto core) {
             return this->template with_remote_shard_state(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52857

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

