### PR TITLE
reef: crimson/osd/lsan_suppressions: add MallocExtension::Register

### DIFF
--- a/src/crimson/osd/lsan_suppressions.cc
+++ b/src/crimson/osd/lsan_suppressions.cc
@@ -11,7 +11,8 @@
 
 static char kLSanDefaultSuppressions[] =
   "leak:InitModule\n"
-  "leak:MallocExtension::Initialize\n";
+  "leak:MallocExtension::Initialize\n"
+  "leak:MallocExtension::Register\n";
 
 SANITIZER_HOOK_ATTRIBUTE const char *__lsan_default_suppressions() {
   return kLSanDefaultSuppressions;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53083

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

