### PR TITLE
reef: crimson/os/seastore/transaction_manager: move intermediate_key by "remap_offset" when remapping the "back" half of the original pin

### DIFF
--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1206,7 +1206,7 @@ public:
 
   void maybe_set_intermediate_laddr(LBAMapping &mapping) {
     laddr = mapping.is_indirect()
-      ? mapping.get_intermediate_key()
+      ? mapping.get_intermediate_base()
       : mapping.get_key();
   }
 
@@ -1241,6 +1241,8 @@ protected:
   }
 
 private:
+  // the logical address of the extent, and if shared,
+  // it is the intermediate_base, see BtreeLBAMapping comments.
   laddr_t laddr = L_ADDR_NULL;
 };
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/53284

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

