### PR TITLE
cephadm: add more deployment test assertions

### DIFF
--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -370,6 +370,9 @@ def test_deploy_ceph_mgr_container(cephadm_fs, monkeypatch):
     )
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
     assert '--pids-limit' in runfile_lines[-1]
+    assert '--entrypoint /usr/bin/ceph-mgr' in runfile_lines[-1]
+    assert f'-v /var/lib/ceph/{fsid}/mgr.foo:/var/lib/ceph/mgr/ceph-foo:z' in runfile_lines[-1]
+    assert f'-v /var/log/ceph/{fsid}:/var/log/ceph:z' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -302,6 +302,8 @@ def test_deploy_a_monitoring_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith(
         'quay.io/titans/prometheus:latest --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.listen-address=:9095 --storage.tsdb.retention.time=15d --storage.tsdb.retention.size=0 --web.external-url=http://10.10.10.10:9095'
     )
+    assert '--user 8765' in runfile_lines[-1]
+    assert f'-v /var/lib/ceph/{fsid}/prometheus.fire/etc/prometheus:/etc/prometheus:Z' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -227,6 +227,9 @@ def test_deploy_iscsi_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith('quay.io/ayeaye/iscsi:latest')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     assert '--pids-limit' in runfile_lines[-1]
+    assert '--privileged' in runfile_lines[-1]
+    assert f'-v {basedir}/iscsi-gateway.cfg:/etc/ceph/iscsi-gateway.cfg:z' in runfile_lines[-1]
+    assert '--mount type=bind,source=/lib/modules,destination=/lib/modules' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -63,6 +63,7 @@ def test_deploy_nfs_container(cephadm_fs, monkeypatch):
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ceph/ceph:latest -F -L STDERR')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
     _firewalld().open_ports.assert_called_with([2049])
     with open(f'/var/lib/ceph/{fsid}/nfs.fun/config') as f:
         assert f.read() == 'BALONEY'
@@ -95,6 +96,7 @@ def test_deploy_snmp_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith(
         'quay.io/aaabbb/snmp:latest --web.listen-address=:9464 --snmp.destination=192.168.100.10:8899 --snmp.version=V2c --log.level=info --snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl'
     )
+    assert '--pids-limit' not in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/snmp-gateway.sunmop')
     assert basedir.is_dir()
@@ -173,6 +175,7 @@ def test_deploy_haproxy_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith(
         'quay.io/lfeuwbo/haproxy:latest haproxy -f /var/lib/haproxy/haproxy.cfg'
     )
+    assert '--pids-limit' not in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()
@@ -213,6 +216,7 @@ def test_deploy_iscsi_container(cephadm_fs, monkeypatch):
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ayeaye/iscsi:latest')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -253,6 +257,7 @@ def test_deploy_nvmeof_container(cephadm_fs, monkeypatch):
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ownf/nmve:latest')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -364,6 +369,7 @@ def test_deploy_ceph_mgr_container(cephadm_fs, monkeypatch):
         'quay.io/ceph/ceph:latest -n mgr.foo -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false'
     )
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -413,6 +419,7 @@ def test_deploy_ceph_exporter_container(cephadm_fs, monkeypatch):
     )
     assert '--entrypoint /usr/bin/ceph-exporter' in runfile_lines[-1]
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -334,6 +334,7 @@ def test_deploy_a_tracing_container(cephadm_fs, monkeypatch):
     with open(basedir / 'unit.run') as f:
         runfile_lines = f.read().splitlines()
     assert 'podman' in runfile_lines[-1]
+    assert '-e discovery.type=single-node' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/rubber/elasticsearch:latest')
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -97,6 +97,7 @@ def test_deploy_snmp_container(cephadm_fs, monkeypatch):
         'quay.io/aaabbb/snmp:latest --web.listen-address=:9464 --snmp.destination=192.168.100.10:8899 --snmp.version=V2c --log.level=info --snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl'
     )
     assert '--pids-limit' not in runfile_lines[-1]
+    assert f'--env-file=/var/lib/ceph/{fsid}/snmp-gateway.sunmop/snmp-gateway.conf' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/snmp-gateway.sunmop')
     assert basedir.is_dir()

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -271,6 +271,11 @@ def test_deploy_nvmeof_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith('quay.io/ownf/nmve:latest')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     assert '--pids-limit' in runfile_lines[-1]
+    assert '--ulimit memlock=-1:-1' in runfile_lines[-1]
+    assert '--cap-add=SYS_ADMIN' in runfile_lines[-1]
+    assert '--cap-add=CAP_SYS_NICE' in runfile_lines[-1]
+    assert f'-v {basedir}/ceph-nvmeof.conf:/src/ceph-nvmeof.conf:z' in runfile_lines[-1]
+    assert '--mount type=bind,source=/lib/modules,destination=/lib/modules' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -134,6 +134,11 @@ def test_deploy_keepalived_container(cephadm_fs, monkeypatch):
         runfile_lines = f.read().splitlines()
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/eeranimated/keepalived:latest')
+    assert '-e KEEPALIVED_AUTOCONF=false' in runfile_lines[-1]
+    assert '-e KEEPALIVED_DEBUG=false' in runfile_lines[-1]
+    assert '--cap-add=NET_ADMIN' in runfile_lines[-1]
+    assert '--cap-add=NET_RAW' in runfile_lines[-1]
+    assert f'-v {basedir}/keepalived.conf:/etc/keepalived/keepalived.conf' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -64,6 +64,8 @@ def test_deploy_nfs_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith('quay.io/ceph/ceph:latest -F -L STDERR')
     assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     assert '--pids-limit' in runfile_lines[-1]
+    assert '-e CEPH_CONF=' in runfile_lines[-1]
+    assert f'-v /var/lib/ceph/{fsid}/nfs.fun/etc/ganesha:/etc/ganesha:z' in runfile_lines[-1]
     _firewalld().open_ports.assert_called_with([2049])
     with open(f'/var/lib/ceph/{fsid}/nfs.fun/config') as f:
         assert f.read() == 'BALONEY'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -179,6 +179,8 @@ def test_deploy_haproxy_container(cephadm_fs, monkeypatch):
         'quay.io/lfeuwbo/haproxy:latest haproxy -f /var/lib/haproxy/haproxy.cfg'
     )
     assert '--pids-limit' not in runfile_lines[-1]
+    assert '--user=root' in runfile_lines[-1]
+    assert f'-v {basedir}/haproxy:/var/lib/haproxy' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     assert not (basedir / 'config').exists()
     assert not (basedir / 'keyring').exists()

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -62,6 +62,7 @@ def test_deploy_nfs_container(cephadm_fs, monkeypatch):
         runfile_lines = f.read().splitlines()
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ceph/ceph:latest -F -L STDERR')
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     _firewalld().open_ports.assert_called_with([2049])
     with open(f'/var/lib/ceph/{fsid}/nfs.fun/config') as f:
         assert f.read() == 'BALONEY'
@@ -211,6 +212,7 @@ def test_deploy_iscsi_container(cephadm_fs, monkeypatch):
         runfile_lines = f.read().splitlines()
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ayeaye/iscsi:latest')
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -250,6 +252,7 @@ def test_deploy_nvmeof_container(cephadm_fs, monkeypatch):
         runfile_lines = f.read().splitlines()
     assert 'podman' in runfile_lines[-1]
     assert runfile_lines[-1].endswith('quay.io/ownf/nmve:latest')
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' not in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -360,6 +363,7 @@ def test_deploy_ceph_mgr_container(cephadm_fs, monkeypatch):
     assert runfile_lines[-1].endswith(
         'quay.io/ceph/ceph:latest -n mgr.foo -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false'
     )
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'
@@ -408,6 +412,7 @@ def test_deploy_ceph_exporter_container(cephadm_fs, monkeypatch):
         'quay.io/ceph/ceph:latest -n client.ceph-exporter.zaq -f --sock-dir=/var/run/ceph/ --addrs=0.0.0.0 --port=9926 --prio-limit=12 --stats-period=5'
     )
     assert '--entrypoint /usr/bin/ceph-exporter' in runfile_lines[-1]
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
     _firewalld().open_ports.assert_not_called()
     with open(basedir / 'config') as f:
         assert f.read() == 'XXXXXXX'

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -404,6 +404,51 @@ def test_deploy_ceph_mgr_container(cephadm_fs, monkeypatch):
     assert _make_var_run.call_args[0][3] == 8765
 
 
+def test_deploy_ceph_osd_container(cephadm_fs, monkeypatch):
+    mocks = _common_mp(monkeypatch)
+    _firewalld = mocks['Firewalld']
+    _make_var_run = mock.MagicMock()
+    monkeypatch.setattr('cephadm.make_var_run', _make_var_run)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+    with with_cephadm_ctx([]) as ctx:
+        ctx.container_engine = mock_podman()
+        ctx.fsid = fsid
+        ctx.name = 'osd.quux'
+        ctx.image = 'quay.io/ceph/ceph:latest'
+        ctx.reconfig = False
+        ctx.allow_ptrace = False
+        ctx.osd_fsid = '00000000-0000-0000-0000-000000000000'
+        ctx.config_blobs = {
+            'config': 'XXXXXXX',
+            'keyring': 'YYYYYY',
+        }
+        _cephadm._common_deploy(ctx)
+
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/osd.quux')
+    assert basedir.is_dir()
+    with open(basedir / 'unit.run') as f:
+        runfile_lines = f.read().splitlines()
+    assert 'podman' in runfile_lines[-1]
+    assert runfile_lines[-1].endswith(
+        'quay.io/ceph/ceph:latest -n osd.quux -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false'
+    )
+    assert '-e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES' in runfile_lines[-1]
+    assert '--privileged' in runfile_lines[-1]
+    assert '--pids-limit' in runfile_lines[-1]
+    assert '--entrypoint /usr/bin/ceph-osd' in runfile_lines[-1]
+    assert f'-v /var/lib/ceph/{fsid}/osd.quux:/var/lib/ceph/osd/ceph-quux:z' in runfile_lines[-1]
+    assert f'-v /var/log/ceph/{fsid}:/var/log/ceph:z' in runfile_lines[-1]
+    assert '-v /dev:/dev' in runfile_lines[-1]
+    _firewalld().open_ports.assert_not_called()
+    with open(basedir / 'config') as f:
+        assert f.read() == 'XXXXXXX'
+    with open(basedir / 'keyring') as f:
+        assert f.read() == 'YYYYYY'
+    assert _make_var_run.call_count == 1
+    assert _make_var_run.call_args[0][2] == 8765
+    assert _make_var_run.call_args[0][3] == 8765
+
+
 def test_deploy_ceph_exporter_container(cephadm_fs, monkeypatch):
     mocks = _common_mp(monkeypatch)
     _firewalld = mocks['Firewalld']


### PR DESCRIPTION
This PR has a bunch of commits to increase coverage of deployment path features with regards to container engine options, env vars and mounts. This will serve future refactoring efforts. Most of these changes try to assert  important options that get set for the various daemon types  but not assert that they come in a particular order as future refactoring efforts need to retain the features/options but not their order.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactoring - tests only
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
