### PR TITLE
doc/cephadm: Fix quorum restore process in troubleshooting.rst

### DIFF
--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -297,11 +297,11 @@ from the monmap by following these steps:
 
 4. Follow the steps in :ref:`rados-mon-remove-from-unhealthy` starting from step 3 ("extracing a copy of the monmap")
 
-.. _cephadm-manually-deploy-mgr:
-
 5. Start mon daemon on the surviving monitor::
 
     cephadm unit --name mon.`hostname` start
+
+.. _cephadm-manually-deploy-mgr:
 
 Manually Deploying a Manager Daemon
 -----------------------------------

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -280,20 +280,22 @@ If the Ceph monitor daemons (mons) cannot form a quorum, cephadm will not be
 able to manage the cluster until quorum is restored.
 
 In order to restore the quorum, remove unhealthy monitors
-form the monmap by following these steps:
+from the monmap by following these steps:
 
 1. Stop all mons. For each mon host::
 
     ssh {mon-host}
     cephadm unit --name mon.`hostname` stop
 
-
 2. Identify a surviving monitor and log in to that host::
 
     ssh {mon-host}
-    cephadm enter --name mon.`hostname`
 
-3. Follow the steps in :ref:`rados-mon-remove-from-unhealthy`
+3. Start an interactive container and mount the surviving monitor data directory as a volume for it::
+
+    cephadm shell -v /var/lib/ceph/{fsid}/mon.{mon-host}:/var/lib/ceph/mon/ceph-{mon-host}:z
+
+4. Follow the steps in :ref:`rados-mon-remove-from-unhealthy` starting from step 3 ("extracing a copy of the monmap")
 
 .. _cephadm-manually-deploy-mgr:
 

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -299,6 +299,10 @@ from the monmap by following these steps:
 
 .. _cephadm-manually-deploy-mgr:
 
+5. Start mon daemon on the surviving monitor::
+
+    cephadm unit --name mon.`hostname` start
+
 Manually Deploying a Manager Daemon
 -----------------------------------
 At least one manager (mgr) daemon is required by cephadm in order to manage the


### PR DESCRIPTION
The quorum restoring process as listed does
not currently work: `cephadm enter` will not
work if the mon container is first stopped.

Fix the process by using `cephadm shell` and
pass the monfs manually as a volume.

Also fix a typo "form" to "form" and remove
a double newline for consistency.


This is based on my own testing on Quincy.
I am not sure if this is the best way of going
about doing this but it works -- unlike the
current listed process.

Feedback would be appreciated.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
