### PR TITLE
reef: ceph_mon: Fix MonitorDBStore usage

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -367,7 +367,7 @@ int main(int argc, const char **argv)
     exit(1);
   }
 
-  MonitorDBStore *store = new MonitorDBStore(g_conf()->mon_data);
+  MonitorDBStore store(g_conf()->mon_data);
 
   // -- mkfs --
   if (mkfs) {
@@ -525,7 +525,7 @@ int main(int argc, const char **argv)
 
     // go
     ostringstream oss;
-    int r = store->create_and_open(oss);
+    int r = store.create_and_open(oss);
     if (oss.tellp())
       derr << oss.str() << dendl;
     if (r < 0) {
@@ -535,13 +535,13 @@ int main(int argc, const char **argv)
     }
     ceph_assert(r == 0);
 
-    Monitor mon(g_ceph_context, g_conf()->name.get_id(), store, 0, 0, &monmap);
+    Monitor mon(g_ceph_context, g_conf()->name.get_id(), &store, 0, 0, &monmap);
     r = mon.mkfs(osdmapbl);
     if (r < 0) {
       derr << argv[0] << ": error creating monfs: " << cpp_strerror(r) << dendl;
       exit(1);
     }
-    store->close();
+    store.close();
     dout(0) << argv[0] << ": created monfs at " << g_conf()->mon_data 
 	    << " for " << g_conf()->name << dendl;
     return 0;
@@ -622,7 +622,7 @@ int main(int argc, const char **argv)
   // make sure we aren't upgrading too fast
   {
     string val;
-    int r = store->read_meta("min_mon_release", &val);
+    int r = store.read_meta("min_mon_release", &val);
     if (r >= 0 && val.size()) {
       ceph_release_t from_release = ceph_release_from_name(val);
       ostringstream err;
@@ -635,7 +635,7 @@ int main(int argc, const char **argv)
 
   {
     ostringstream oss;
-    err = store->open(oss);
+    err = store.open(oss);
     if (oss.tellp())
       derr << oss.str() << dendl;
     if (err < 0) {
@@ -646,7 +646,7 @@ int main(int argc, const char **argv)
   }
 
   bufferlist magicbl;
-  err = store->get(Monitor::MONITOR_NAME, "magic", magicbl);
+  err = store.get(Monitor::MONITOR_NAME, "magic", magicbl);
   if (err || !magicbl.length()) {
     derr << "unable to read magic from mon data" << dendl;
     prefork.exit(1);
@@ -657,7 +657,7 @@ int main(int argc, const char **argv)
     prefork.exit(1);
   }
 
-  err = Monitor::check_features(store);
+  err = Monitor::check_features(&store);
   if (err < 0) {
     derr << "error checking features: " << cpp_strerror(err) << dendl;
     prefork.exit(1);
@@ -675,7 +675,7 @@ int main(int argc, const char **argv)
     }
 
     // get next version
-    version_t v = store->get("monmap", "last_committed");
+    version_t v = store.get("monmap", "last_committed");
     dout(0) << "last committed monmap epoch is " << v << ", injected map will be " << (v+1)
             << dendl;
     v++;
@@ -699,7 +699,7 @@ int main(int argc, const char **argv)
     t->put("monmap", v, mapbl);
     t->put("monmap", "latest", final);
     t->put("monmap", "last_committed", v);
-    store->apply_transaction(t);
+    store.apply_transaction(t);
 
     dout(0) << "done." << dendl;
     prefork.exit(0);
@@ -711,7 +711,7 @@ int main(int argc, const char **argv)
     // note that even if we don't find a viable monmap, we should go ahead
     // and try to build it up in the next if-else block.
     bufferlist mapbl;
-    int err = obtain_monmap(*store, mapbl);
+    int err = obtain_monmap(store, mapbl);
     if (err >= 0) {
       try {
         monmap.decode(mapbl);
@@ -856,7 +856,7 @@ int main(int argc, const char **argv)
     prefork.exit(1);
   }
 
-  mon = new Monitor(g_ceph_context, g_conf()->name.get_id(), store,
+  mon = new Monitor(g_ceph_context, g_conf()->name.get_id(), &store,
 		    msgr, mgr_msgr, &monmap);
 
   mon->orig_argc = argc;
@@ -912,7 +912,7 @@ int main(int argc, const char **argv)
   msgr->wait();
   mgr_msgr->wait();
 
-  store->close();
+  store.close();
 
   unregister_async_signal_handler(SIGHUP, handle_mon_signal);
   unregister_async_signal_handler(SIGINT, handle_mon_signal);
@@ -920,7 +920,6 @@ int main(int argc, const char **argv)
   shutdown_async_signal_handler();
 
   delete mon;
-  delete store;
   delete msgr;
   delete mgr_msgr;
   delete client_throttler;

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -818,20 +818,20 @@ int main(int argc, const char **argv)
                    Messenger::Policy::stateless_server(0));
 
   // throttle client traffic
-  Throttle *client_throttler = new Throttle(g_ceph_context, "mon_client_bytes",
-					    g_conf()->mon_client_bytes);
+  Throttle client_throttler(g_ceph_context, "mon_client_bytes",
+                            g_conf()->mon_client_bytes);
   msgr->set_policy_throttlers(entity_name_t::TYPE_CLIENT,
-				     client_throttler, NULL);
+                              &client_throttler, NULL);
 
   // throttle daemon traffic
   // NOTE: actual usage on the leader may multiply by the number of
   // monitors if they forward large update messages from daemons.
-  Throttle *daemon_throttler = new Throttle(g_ceph_context, "mon_daemon_bytes",
-					    g_conf()->mon_daemon_bytes);
-  msgr->set_policy_throttlers(entity_name_t::TYPE_OSD, daemon_throttler,
-				     NULL);
-  msgr->set_policy_throttlers(entity_name_t::TYPE_MDS, daemon_throttler,
-				     NULL);
+  Throttle daemon_throttler(g_ceph_context, "mon_daemon_bytes",
+                            g_conf()->mon_daemon_bytes);
+  msgr->set_policy_throttlers(entity_name_t::TYPE_OSD, &daemon_throttler,
+                              NULL);
+  msgr->set_policy_throttlers(entity_name_t::TYPE_MDS, &daemon_throttler,
+                              NULL);
 
   entity_addrvec_t bind_addrs = ipaddrs;
   entity_addrvec_t public_addrs = ipaddrs;
@@ -922,8 +922,6 @@ int main(int argc, const char **argv)
   delete mon;
   delete msgr;
   delete mgr_msgr;
-  delete client_throttler;
-  delete daemon_throttler;
 
   // cd on exit, so that gmon.out (if any) goes into a separate directory for each node.
   char s[20];

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -367,6 +367,8 @@ int main(int argc, const char **argv)
     exit(1);
   }
 
+  MonitorDBStore *store = new MonitorDBStore(g_conf()->mon_data);
+
   // -- mkfs --
   if (mkfs) {
 
@@ -522,9 +524,8 @@ int main(int argc, const char **argv)
     }
 
     // go
-    MonitorDBStore store(g_conf()->mon_data);
     ostringstream oss;
-    int r = store.create_and_open(oss);
+    int r = store->create_and_open(oss);
     if (oss.tellp())
       derr << oss.str() << dendl;
     if (r < 0) {
@@ -534,13 +535,13 @@ int main(int argc, const char **argv)
     }
     ceph_assert(r == 0);
 
-    Monitor mon(g_ceph_context, g_conf()->name.get_id(), &store, 0, 0, &monmap);
+    Monitor mon(g_ceph_context, g_conf()->name.get_id(), store, 0, 0, &monmap);
     r = mon.mkfs(osdmapbl);
     if (r < 0) {
       derr << argv[0] << ": error creating monfs: " << cpp_strerror(r) << dendl;
       exit(1);
     }
-    store.close();
+    store->close();
     dout(0) << argv[0] << ": created monfs at " << g_conf()->mon_data 
 	    << " for " << g_conf()->name << dendl;
     return 0;
@@ -617,8 +618,6 @@ int main(int argc, const char **argv)
 
   // set up signal handlers, now that we've daemonized/forked.
   init_async_signal_handler();
-
-  MonitorDBStore *store = new MonitorDBStore(g_conf()->mon_data);
 
   // make sure we aren't upgrading too fast
   {

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -38,6 +38,12 @@ void Finisher::wait_for_empty()
   finisher_empty_wait = false;
 }
 
+bool Finisher::is_empty()
+{
+  std::unique_lock ul(finisher_lock);
+  return finisher_queue.empty();
+}
+
 void *Finisher::finisher_thread_entry()
 {
   std::unique_lock ul(finisher_lock);

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -135,6 +135,8 @@ class Finisher {
    * finishes, but this class should never be used in this way. */
   void wait_for_empty();
 
+  bool is_empty();
+
   /// Construct an anonymous Finisher.
   /// Anonymous finishers do not log their queue length.
   explicit Finisher(CephContext *cct_) :

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -710,6 +710,7 @@ class MonitorDBStore
 
   void close() {
     // there should be no work queued!
+    ceph_assert(io_work.is_empty());
     io_work.stop();
     is_open = false;
     db.reset(NULL);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63289

---

backport of https://github.com/ceph/ceph/pull/52539
parent tracker: https://tracker.ceph.com/issues/61820

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh