### PR TITLE
[cephadm](BUG): honor --skip-firewalld in section Open ports explicitly required for the daemon

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2976,10 +2976,11 @@ def deploy_daemon(
     update_firewalld(ctx, daemon_form_create(ctx, ident))
 
     # Open ports explicitly required for the daemon
-    if endpoints:
-        fw = Firewalld(ctx)
-        fw.open_ports([e.port for e in endpoints] + fw.external_ports.get(daemon_type, []))
-        fw.apply_rules()
+    if not ('skip_firewalld' in ctx and ctx.skip_firewalld):
+        if endpoints:
+            fw = Firewalld(ctx)
+            fw.open_ports([e.port for e in endpoints] + fw.external_ports.get(daemon_type, []))
+            fw.apply_rules()
 
     # If this was a reconfig and the daemon is not a Ceph daemon, restart it
     # so it can pick up potential changes to its configuration files


### PR DESCRIPTION
Description:
with firewalld absent of a system the `--skip-firewalld` option is not honored for none firewall service defined daemon (eq. rgw)

```
DEBUG firewalld does not appear to be present
DEBUG Not possible to enable service <rgw>. firewalld.service is not available
DEBUG firewalld does not appear to be present
DEBUG Not possible to open ports <[10443]>. firewalld.service is not available
```

This behavior is coming from the `Open ports explicitly required for the daemon` code section which does not check for the flag.
