### PR TITLE
pacific: rgw/s3: DeleteObjects response uses correct delete_marker flag

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7169,7 +7169,7 @@ void RGWDeleteMultiObj::handle_individual_object(const rgw_obj_key& o, optional_
     op_ret = 0;
   }
 
-  send_partial_response(o, obj->get_delete_marker(), version_id, op_ret, formatter_flush_cond);
+  send_partial_response(o, del_op->result.delete_marker, del_op->result.version_id, op_ret, formatter_flush_cond);
 
   // send request to notification manager
   const auto ret = rgw::notify::publish_commit(obj.get(), obj_size, ceph::real_clock::now(), etag, event_type, res, this);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59131

---

backport of https://github.com/ceph/ceph/pull/50504
parent tracker: https://tracker.ceph.com/issues/59048

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh