### PR TITLE
quincy: rgw: beast frontend checks for local_endpoint() errors

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -257,10 +257,14 @@ void handle_connection(boost::asio::io_context& context,
         ldout(cct, 1) << "failed to connect client: " << ec.message() << dendl;
         return;
       }
+      const auto& local_endpoint = socket.local_endpoint(ec);
+      if (ec) {
+        ldout(cct, 1) << "failed to connect client: " << ec.message() << dendl;
+        return;
+      }
 
       StreamIO real_client{cct, stream, timeout, parser, yield, buffer,
-                           is_ssl, socket.local_endpoint(),
-                           remote_endpoint};
+                           is_ssl, local_endpoint, remote_endpoint};
 
       auto real_client_io = rgw::io::add_reordering(
                               rgw::io::add_buffering(cct,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58237

---

backport of https://github.com/ceph/ceph/pull/48390
parent tracker: https://tracker.ceph.com/issues/57784

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh