### PR TITLE
quincy: rgw/amqp: store CA location string in connection object

### DIFF
--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -130,7 +130,7 @@ struct connection_t {
   bool mandatory;
   bool use_ssl;
   bool verify_ssl;
-  boost::optional<const std::string&> ca_location;
+  boost::optional<std::string> ca_location;
   utime_t timestamp = ceph_clock_now();
 
   // default ctor


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57888

---

backport of https://github.com/ceph/ceph/pull/48444
parent tracker: https://tracker.ceph.com/issues/57850

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh