### PR TITLE
quincy: prevent anonymous topic operations

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -921,6 +921,8 @@ rgw::auth::AnonymousEngine::authenticate(const DoutPrefixProvider* dpp, const re
 {
   if (! is_applicable(s)) {
     return result_t::deny(-EPERM);
+  } else if (s->op_type == RGW_OP_PUBSUB_TOPIC_CREATE) {
+    return result_t::deny(-EACCES);
   } else {
     RGWUserInfo user_info;
     rgw_get_anon_user(user_info);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58906

---

backport of https://github.com/ceph/ceph/pull/49335
parent tracker: https://tracker.ceph.com/issues/58167

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh