### PR TITLE
quincy: mgr/dashboard: fix rgw port manipulation error in dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import cherrypy
@@ -105,7 +106,7 @@ class RgwDaemon(RESTController):
                     'zonegroup_name': metadata['zonegroup_name'],
                     'zone_name': metadata['zone_name'],
                     'default': instance.daemon.name == metadata['id'],
-                    'port': int(metadata['frontend_config#0'].split('port=')[1])
+                    'port': int(re.findall(r'port=(\d+)', metadata['frontend_config#0'])[0])
                 }
 
                 daemons.append(daemon)

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -96,7 +96,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'realm_name': 'realm2',
                 'zonegroup_name': 'zg2',
                 'zone_name': 'zone2',
-                'frontend_config#0': 'beast port=80'
+                'frontend_config#0': 'beast port=80 ssl_port=443 ssl_certificate=config:/config'
             }]
         self._get('/test/api/rgw/daemon')
         self.assertStatus(200)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63309

---

backport of https://github.com/ceph/ceph/pull/53323
parent tracker: https://tracker.ceph.com/issues/62735

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh