### PR TITLE
pacific: qa/cephfs: set omit_sudo False when sudo is set to True

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -662,7 +662,8 @@ class CephFSMount(object):
         if sudo:
             args.append('sudo')
         args += ['adjust-ulimits', 'daemon-helper', 'kill', py_version, '-c', pyscript]
-        return self.client_remote.run(args=args, wait=False, stdin=run.PIPE, stdout=StringIO())
+        return self.client_remote.run(args=args, wait=False, stdin=run.PIPE,
+                                      stdout=StringIO(), omit_sudo=(not sudo))
 
     def run_python(self, pyscript, py_version='python3', sudo=False):
         p = self._run_python(pyscript, py_version, sudo=sudo)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -738,13 +738,17 @@ class LocalKernelMount(KernelMount):
         if self.using_namespace:
             super(type(self), self).cleanup_netns()
 
-    def _run_python(self, pyscript, py_version='python'):
+    def _run_python(self, pyscript, py_version='python'. sudo=False):
         """
         Override this to remove the daemon-helper prefix that is used otherwise
         to make the process killable.
         """
-        return self.client_remote.run(args=[py_version, '-c', pyscript],
-                                      wait=False, stdout=StringIO())
+        args = []
+        if sudo:
+            args.append('sudo')
+        args += [py_version, '-c', pyscript]
+        return self.client_remote.run(args=args, wait=False,
+                                      stdout=StringIO(), omit_sudo=(not sudo))
 
 class LocalFuseMount(FuseMount):
     def __init__(self, ctx, test_dir, client_id, client_keyring_path=None,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55865

---

backport of https://github.com/ceph/ceph/pull/46165
parent tracker: https://tracker.ceph.com/issues/55557

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh