### PR TITLE
pacific: qa/cephfs: fix minor bug in caps_helper.py's run_mon_cap_tests()

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -13,10 +13,9 @@ class CapsHelper(CephFSTestCase):
         fsls = self.run_cluster_cmd(f'fs ls --id {self.client_id} -k '
                                     f'{keyring_path}')
 
-        # we need to check only for default FS when fsname clause is absent
-        # in MON/MDS caps
-        if 'fsname' not in moncap:
-            self.assertIn(self.fs.name, fsls)
+        if 'fsname=' not in moncap:
+            fsls_admin = self.run_cluster_cmd('fs ls')
+            self.assertEqual(fsls, fsls_admin)
             return
 
         fss = (self.fs1.name, self.fs2.name) if hasattr(self, 'fs1') else \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55863

---

backport of https://github.com/ceph/ceph/pull/46168
parent tracker: https://tracker.ceph.com/issues/55558

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh