### PR TITLE
pacific: qa/cephfs: update xfstests_dev for centos stream

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -92,7 +92,7 @@ class XFSTestsDev(CephFSTestCase):
         # we keep fedora here so that right deps are installed when this test
         # is run locally by a dev.
         if distro in ('redhatenterpriseserver', 'redhatenterprise', 'fedora',
-                      'centos'):
+                      'centos', 'centosstream'):
             deps = """acl attr automake bc dbench dump e2fsprogs fio \
             gawk gcc indent libtool lvm2 make psmisc quota sed \
             xfsdump xfsprogs \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52954

---

backport of https://github.com/ceph/ceph/pull/43426
parent tracker: https://tracker.ceph.com/issues/52821

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh