### PR TITLE
pacific: mgr/dashboard: add 'omit_usage' query param to dashboard api 'get rbd' endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -118,8 +118,18 @@ class Rbd(RESTController):
 
     @handle_rbd_error()
     @handle_rados_error('pool')
-    def get(self, image_spec):
-        return RbdService.get_image(image_spec)
+    @EndpointDoc("Get Rbd Image Info",
+                 parameters={
+                     'image_spec': (str, 'URL-encoded "pool/rbd_name". e.g. "rbd%2Ffoo"'),
+                     'omit_usage': (bool, 'When true, usage information is not returned'),
+                 },
+                 responses={200: RBD_SCHEMA})
+    def get(self, image_spec, omit_usage=False):
+        try:
+            omit_usage_bool = str_to_bool(omit_usage)
+        except ValueError:
+            omit_usage_bool = False
+        return RbdService.get_image(image_spec, omit_usage_bool)
 
     @RbdTask('create',
              {'pool_name': '{pool_name}', 'namespace': '{namespace}', 'image_name': '{name}'}, 2.0)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -524,16 +524,38 @@ paths:
       - Rbd
     get:
       parameters:
-      - in: path
+      - description: URL-encoded "pool/rbd_name". e.g. "rbd%2Ffoo"
+        in: path
         name: image_spec
         required: true
         schema:
           type: string
+      - default: false
+        description: When true, usage information is not returned
+        in: query
+        name: omit_usage
+        schema:
+          type: boolean
       responses:
         '200':
           content:
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                items:
+                  properties:
+                    pool_name:
+                      description: pool name
+                      type: string
+                    value:
+                      description: ''
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                required:
+                - value
+                - pool_name
+                type: array
           description: OK
         '400':
           description: Operation exception. Please check the response body for details.
@@ -546,6 +568,7 @@ paths:
             trace.
       security:
       - jwt: []
+      summary: Get Rbd Image Info
       tags:
       - Rbd
     put:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62621

---

backport of https://github.com/ceph/ceph/pull/51294
parent tracker: https://tracker.ceph.com/issues/59588

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh