### PR TITLE
doc/rados: remove HitSet-related key information

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -287,7 +287,6 @@ by setting it in the ``[mon]`` section of the configuration file.
 .. confval:: mon_data_size_warn
 .. confval:: mon_data_avail_warn
 .. confval:: mon_data_avail_crit
-.. confval:: mon_warn_on_cache_pools_without_hit_sets
 .. confval:: mon_warn_on_crush_straw_calc_version_zero
 .. confval:: mon_warn_on_legacy_crush_tunables
 .. confval:: mon_crush_min_required_version

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -499,47 +499,6 @@ You may set values for the following keys:
    :Type: Integer
    :Valid Range: ``1`` sets flag, ``0`` unsets flag
 
-.. _hit_set_type:
-
-.. describe:: hit_set_type
-
-   :Description: Enables HitSet tracking for cache pools.
-                 For additional information, see `Bloom Filter`_.
-   :Type: String
-   :Valid Settings: ``bloom``, ``explicit_hash``, ``explicit_object``
-   :Default: ``bloom``. Other values are for testing.
-
-.. _hit_set_count:
-
-.. describe:: hit_set_count
-
-   :Description: Determines the number of HitSets to store for cache pools. The
-                 higher the value, the more RAM is consumed by the ``ceph-osd``
-                 daemon.
-   :Type: Integer
-   :Valid Range: ``1``. Agent doesn't handle > ``1`` yet.
-
-.. _hit_set_period:
-
-.. describe:: hit_set_period
-
-   :Description: Determines the duration of a HitSet period (in seconds) for
-                 cache pools. The higher the value, the more RAM is consumed
-                 by the ``ceph-osd`` daemon.
-   :Type: Integer
-   :Example: ``3600`` (3600 seconds: one hour)
-
-.. _hit_set_fpp:
-
-.. describe:: hit_set_fpp
-
-   :Description: Determines the probability of false positives for the
-                 ``bloom`` HitSet type. For additional information, see `Bloom
-                 Filter`_.
-   :Type: Double
-   :Valid Range: ``0.0`` - ``1.0``
-   :Default: ``0.05``
-
 .. _cache_target_dirty_ratio:
 
 .. describe:: cache_target_dirty_ratio
@@ -592,23 +551,6 @@ You may set values for the following keys:
                  ``max_objects`` threshold is triggered.
    :Type: Integer
    :Example: ``1000000`` #1M objects
-
-
-.. describe:: hit_set_grade_decay_rate
-   
-   :Description: Sets the temperature decay rate between two successive 
-                 HitSets.
-   :Type: Integer
-   :Valid Range: 0 - 100
-   :Default: ``20``
-
-.. describe:: hit_set_search_last_n
-   
-   :Description: Count at most N appearances in HitSets. Used for temperature 
-                 calculation.
-   :Type: Integer
-   :Valid Range: 0 - hit_set_count
-   :Default: ``1``
 
 .. _cache_min_flush_age:
 
@@ -737,35 +679,6 @@ You may get values from the following keys:
 ``crush_rule``
 
 :Description: See crush_rule_.
-
-
-``hit_set_type``
-
-:Description: See hit_set_type_.
-
-:Type: String
-:Valid Settings: ``bloom``, ``explicit_hash``, ``explicit_object``
-
-
-``hit_set_count``
-
-:Description: See hit_set_count_.
-
-:Type: Integer
-
-
-``hit_set_period``
-
-:Description: See hit_set_period_.
-
-:Type: Integer
-
-
-``hit_set_fpp``
-
-:Description: See hit_set_fpp_.
-
-:Type: Double
 
 
 ``cache_target_dirty_ratio``


### PR DESCRIPTION
Remove HitSet-related key information from
doc/rados/operations/pools.rst. HitSet-related keys are relevant only to releases of Ceph that support cache tiering. Only Quincy and earlier (inclusive) releases of Ceph support cache tiering. Backport this commit from main to Reef, but not to Quincy or to release branches earlier than Quincy.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
