### PR TITLE
qa: use Remote.run_unit_test and ValgrindScanner

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
@@ -209,6 +209,14 @@ For example: for the above test ID, the path is::
 
 This method can be used to view the log more quickly than would be possible through a browser.
 
+In addition to teuthology.log, there are other files included for debugging purposes:
+
+* unit_test_summary.yaml: It provides a summary of all unit test failures and 
+  is optionally generated when the ``unit_test_scan`` configuration option is 
+  used in the job's YAML file.
+
+* valgrind.yaml: It summarizes any Valgrind errors that may occur.
+
 .. note:: To access archives more conveniently, ``/a/`` has been symbolically
    linked to ``/ceph/teuthology-archive/``. For instance, to access the previous
    example, we can use something like::

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -25,4 +25,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rados/test.sh
+        - rados/test.sh unit_test_scan

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -6,6 +6,7 @@ tasks:
 - s3tests:
     client.0:
       force-branch: ceph-master
+      unit_test_scan: True
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -28,6 +28,7 @@ from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology import exceptions
 from teuthology.orchestra import run
+from teuthology.util.scanner import ValgrindScanner
 from tasks import ceph_client as cclient
 from teuthology.orchestra.daemon import DaemonGroup
 from tasks.daemonwatchdog import DaemonWatchdog
@@ -327,38 +328,15 @@ def valgrind_post(ctx, config):
     try:
         yield
     finally:
-        lookup_procs = list()
-        log.info('Checking for errors in any valgrind logs...')
-        for remote in ctx.cluster.remotes.keys():
-            # look at valgrind logs for each node
-            proc = remote.run(
-                args="sudo zgrep '<kind>' /var/log/ceph/valgrind/* "
-                     # include a second file so that we always get
-                     # a filename prefix on the output
-                     "/dev/null | sort | uniq",
-                wait=False,
-                check_status=False,
-                stdout=StringIO(),
-            )
-            lookup_procs.append((proc, remote))
-
         valgrind_exception = None
-        for (proc, remote) in lookup_procs:
-            proc.wait()
-            out = proc.stdout.getvalue()
-            for line in out.split('\n'):
-                if line == '':
-                    continue
-                try:
-                    (file, kind) = line.split(':')
-                except Exception:
-                    log.error('failed to split line %s', line)
-                    raise
-                log.debug('file %s kind %s', file, kind)
-                if (file.find('mds') >= 0) and kind.find('Lost') > 0:
-                    continue
-                log.error('saw valgrind issue %s in %s', kind, file)
-                valgrind_exception = Exception('saw valgrind issues')
+        valgrind_yaml = os.path.join(ctx.archive, 'valgrind.yaml')
+        for remote in ctx.cluster.remotes.keys():
+            scanner = ValgrindScanner(remote)
+            errors = scanner.scan_all_files('/var/log/ceph/valgrind/*')
+            scanner.write_summary(valgrind_yaml)
+            if errors and not valgrind_exception:
+                log.debug('valgrind exception message: %s', errors[0])
+                valgrind_exception = Exception(errors[0])
 
         if config.get('expect_valgrind_errors'):
             if not valgrind_exception:

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -421,11 +421,21 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                         workunit=workunit,
                     ),
                 ])
-                remote.run(
-                    logger=log.getChild(role),
-                    args=args + optional_args,
-                    label="workunit test {workunit}".format(workunit=workunit)
-                )
+                if 'unit_test_scan' in optional_args:
+                    optional_args.remove('unit_test_scan')
+                    remote.run_unit_test(
+                        logger=log.getChild(role),
+                        args=args + optional_args,
+                        label="workunit test {workunit}".format(workunit=workunit),
+                        xml_path_regex=f'{testdir}/archive/gtest_xml_report-*.xml',
+                        output_yaml=os.path.join(ctx.archive, 'unit_test_summary.yaml'),
+                    )
+                else:
+                    remote.run(
+                        logger=log.getChild(role),
+                        args=args + optional_args,
+                        label="workunit test {workunit}".format(workunit=workunit)
+                    )
                 if cleanup:
                     args=['sudo', 'rm', '-rf', '--', scratch_tmp]
                     remote.run(logger=log.getChild(role), args=args, timeout=(60*60))

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -12,6 +12,8 @@ function cleanup() {
 }
 trap cleanup EXIT ERR HUP INT QUIT
 
+GTEST_OUTPUT="xml:/home/ubuntu/cephtest/archive/gtest_xml_report"
+
 declare -A pids
 
 for f in \
@@ -37,7 +39,7 @@ do
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
 	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "ceph_test_rados_$f $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
+	bash -o pipefail -exc "ceph_test_rados_$f --gtest_output=$GTEST_OUTPUT-$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid


### PR DESCRIPTION
1. add "unit_test_scan" optional config uses `Remote.run_unit_test()`
to scan xml files generated by unit tests to throw better failure
messages (for s3tests and gtests run by workunit).
It also creates "unit_test_summary.yaml" for more exception details
from xml files.
2. previously, valgrind_post() func used grep to find error
from valgrind logs.
now, it uses `ValgrindScanner` to log better exceptions with
traceback and exception kind, along with creating a more detailed
summary in valgrind.yaml in archive.

teuthology PR: https://github.com/ceph/teuthology/pull/1792

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
