### PR TITLE
add --progress flag to git submodule update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ following commands to move into the cloned `ceph/ceph` repository and to check
 out the git submodules associated with it:
 
     cd ceph
-	git submodule update --init --recursive
+	git submodule update --init --recursive --progress
 
 
 ## Build Prerequisites

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -2,7 +2,7 @@
 set -ex
 
 if [ -d .git ]; then
-    git submodule update --init --recursive
+    git submodule update --init --recursive --progress
 fi
 
 : ${BUILD_DIR:=build}

--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -27,7 +27,7 @@ script of ``script/gen-corpus.sh``, or by following the instructions below:
 
 	git clone ceph.git
 	cd ceph
-	git submodule update --init --recursive
+	git submodule update --init --recursive --progress
 
 #. Build with flag to dump objects to ``/tmp/foo``::
 

--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -154,13 +154,13 @@ Updating Submodules
 
    .. prompt:: bash $
 
-      git submodule update --force --init --recursive
+      git submodule update --force --init --recursive --progress
       git clean -fdx
       git submodule foreach git clean -fdx
 
    If you still have problems with a submodule directory, use ``rm -rf
    [directory name]`` to remove the directory. Then run ``git submodule update
-   --init --recursive`` again.
+   --init --recursive --progress`` again.
 
 #. Run ``git status`` again:
 

--- a/make-dist
+++ b/make-dist
@@ -35,7 +35,7 @@ echo "version $version"
 # update submodules
 echo "updating submodules..."
 force=$(if git submodule usage 2>&1 | grep --quiet 'update.*--force'; then echo --force ; fi)
-if ! git submodule sync || ! git submodule update $force --init --recursive; then
+if ! git submodule sync || ! git submodule update $force --init --recursive --progress; then
     echo "Error: could not initialize submodule projects"
     echo "  Network connectivity might be required."
     exit 1

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -58,7 +58,7 @@ if [ -e rocksdb ]; then
 fi
 
 pushd $(dirname /home/ubuntu/cephtest/clone.client.0/qa/workunits/rados/bash.sh)/../../../
-git submodule update --init src/rocksdb
+git submodule update --init --progress src/rocksdb
 popd
 git clone $(dirname /home/ubuntu/cephtest/clone.client.0/qa/workunits/rados/bash.sh)/../../../src/rocksdb rocksdb
 


### PR DESCRIPTION
Ceph has lots of submodules that needs to be cloned before building
binaries from the repository. Seeing the progress when these submodules
are being cloned is useful especially when developers have a network
issue or a slow network.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>