### PR TITLE
rgw-check-policy: remove check for nonempty tenant

### DIFF
--- a/src/rgw/rgw_polparser.cc
+++ b/src/rgw/rgw_polparser.cc
@@ -78,11 +78,6 @@ int main(int argc, const char** argv)
     }
   }
 
-  if (tenant.empty()) {
-    std::cerr << cmdname << ": must specify tenant name" << std::endl;
-    helpful_exit(cmdname);
-  }
-
   bool success = true;
 
   if (args.empty()) {


### PR DESCRIPTION
the tool should be usable with the default empty tenant to check principals like `arn:aws:iam:::user/my-user-id`

Fixes: https://tracker.ceph.com/issues/63333

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
