### PR TITLE
crimson: add initial scrub support

### DIFF
--- a/qa/suites/crimson-rados/perf/clusters/fixed-2.yaml
+++ b/qa/suites/crimson-rados/perf/clusters/fixed-2.yaml
@@ -2,6 +2,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
 overrides:
   ceph:
+    log-ignorelist:
+      - \(PG_
+      - \(OSD_
+      - \(OBJECT_
+      - overall HEALTH
     conf:
       osd:
         osd shutdown pgref assert: true

--- a/qa/suites/crimson-rados/thrash/thrashers/default.yaml
+++ b/qa/suites/crimson-rados/thrash/thrashers/default.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost

--- a/qa/suites/crimson-rados/thrash/thrashers/default.yaml
+++ b/qa/suites/crimson-rados/thrash/thrashers/default.yaml
@@ -32,3 +32,4 @@ tasks:
     ceph_objectstore_tool: false
     chance_inject_pause_short: 0
     chance_thrash_cluster_full: 0
+    chance_reset_purged_snaps_last: 0

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1303,7 +1303,7 @@ def osd_scrub_pgs(ctx, config):
                     # request was missed.  do not do it every time because
                     # the scrub may be in progress or not reported yet and
                     # we will starve progress.
-                    manager.raw_cluster_cmd('pg', 'deep-scrub', pgid)
+                    manager.raw_cluster_cmd('tell', pgid, 'deep_scrub')
             if gap_cnt > retries:
                 raise RuntimeError('Exiting scrub checking -- not all pgs scrubbed.')
         if loop:

--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -22,6 +22,8 @@
  * *or*
  * std::string alt_fmt_print(bool short_format) const
  * as public member functions.
+ * *or*
+ * auto fmt_print_ctx(auto &ctx) -> decltype(ctx.out());
  */
 template<class T>
 concept has_fmt_print = requires(T t) {
@@ -30,6 +32,11 @@ concept has_fmt_print = requires(T t) {
 template<class T>
 concept has_alt_fmt_print = requires(T t) {
   { t.alt_fmt_print(bool{}) } -> std::same_as<std::string>;
+};
+template<class T>
+concept has_fmt_print_ctx = requires(
+  T t, fmt::buffer_context<char> &ctx) {
+  { t.fmt_print_ctx(ctx) } -> std::same_as<decltype(ctx.out())>;
 };
 
 namespace fmt {
@@ -62,6 +69,16 @@ struct formatter<T> {
     return fmt::format_to(ctx.out(), "{}", k.alt_fmt_print(false));
   }
   bool verbose{true};
+};
+
+template <has_fmt_print_ctx T>
+struct formatter<T> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const T& k, FormatContext& ctx) const {
+    return k.fmt_print_ctx(ctx);
+  }
 };
 
 template <typename T>

--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -2,6 +2,8 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <optional>
+
 /**
  * \file default fmtlib formatters for specifically-tagged types
  */
@@ -61,4 +63,17 @@ struct formatter<T> {
   }
   bool verbose{true};
 };
+
+template <typename T>
+struct formatter<std::optional<T>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const std::optional<T> &v, FormatContext& ctx) const {
+    if (v.has_value()) {
+      return fmt::format_to(ctx.out(), "{}", *v);
+    }
+    return fmt::format_to(ctx.out(), "<null>");
+  }
+};
+
 }  // namespace fmt

--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -15,6 +15,10 @@
  * has a begin()/end() method pair. This is a problem because we have
  * such classes in Crimson.
  */
+
+template <typename T>
+concept has_formatter = fmt::has_formatter<T, fmt::format_context>::value;
+
 /**
  * Tagging classes that provide support for default fmtlib formatting,
  * by having either

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -166,12 +166,22 @@ public:
     return ret;
   }
 
+  /// @return min hobject_t ret s.t. ret.get_head() == get_head()
   hobject_t get_object_boundary() const {
     if (is_max())
       return *this;
     hobject_t ret = *this;
     ret.snap = 0;
     return ret;
+  }
+
+  /// @return max hobject_t ret s.t. ret.get_head() == get_head()
+  hobject_t get_max_object_boundary() const {
+    if (is_max())
+      return *this;
+    // CEPH_SNAPDIR happens to sort above HEAD and MAX_SNAP and is no longer used
+    // for actual objects
+    return get_snapdir();
   }
 
   /// @return head version of this hobject_t

--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -113,6 +113,10 @@ namespace librados {
 struct inconsistent_obj_wrapper : librados::inconsistent_obj_t {
   explicit inconsistent_obj_wrapper(const hobject_t& hoid);
 
+  void merge(obj_err_t other) {
+    errors |= other.errors;
+  }
+
   void set_object_info_inconsistency() {
     errors |= obj_err_t::OBJECT_INFO_INCONSISTENCY;
   }

--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_SCRUB_TYPES_H
 #define CEPH_SCRUB_TYPES_H
 
+#include <fmt/ranges.h>
+
 #include "osd/osd_types.h"
 
 // wrappers around scrub types to offer the necessary bits other than
@@ -206,5 +208,198 @@ struct scrub_ls_result_t {
 };
 
 WRITE_CLASS_ENCODER(scrub_ls_result_t);
+
+template <>
+struct fmt::formatter<librados::object_id_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &oid, FormatContext& ctx) const
+  {
+    return format_to(ctx.out(), "{}/{}/{}", oid.locator, oid.nspace, oid.name);
+  }
+};
+
+template <>
+struct fmt::formatter<librados::err_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &err, FormatContext& ctx) const
+  {
+    bool first = true;
+#define F(FLAG_NAME)					\
+    if (err.errors & librados::err_t::FLAG_NAME) {	\
+      if (!first) {					\
+	fmt::format_to(ctx.out(), "|");			\
+      } else {						\
+	first = false;					\
+      }							\
+      fmt::format_to(ctx.out(), #FLAG_NAME);		\
+    }
+    F(SHARD_MISSING);
+    F(SHARD_STAT_ERR);
+    F(SHARD_READ_ERR);
+    F(DATA_DIGEST_MISMATCH_INFO);
+    F(OMAP_DIGEST_MISMATCH_INFO);
+    F(SIZE_MISMATCH_INFO);
+    F(SHARD_EC_HASH_MISMATCH);
+    F(SHARD_EC_SIZE_MISMATCH);
+    F(INFO_MISSING);
+    F(INFO_CORRUPTED);
+    F(SNAPSET_MISSING);
+    F(SNAPSET_CORRUPTED);
+    F(OBJ_SIZE_INFO_MISMATCH);
+    F(HINFO_MISSING);
+    F(HINFO_CORRUPTED);
+#undef F
+    return ctx.out();
+  }
+};
+
+template <>
+struct fmt::formatter<librados::shard_info_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &err, FormatContext& ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "shard_info_t(error: {}, "
+      "size: {}, "
+      "omap_digest_present: {}, "
+      "omap_digest: {}, "
+      "data_digest_present: {}, "
+      "data_digest: {}, "
+      "selected_io: {}, "
+      "primary: {})",
+      static_cast<librados::err_t>(err),
+      err.size,
+      err.omap_digest_present,
+      err.omap_digest,
+      err.data_digest_present,
+      err.data_digest,
+      err.selected_oi,
+      err.primary);
+  }
+};
+
+template <>
+struct fmt::formatter<shard_info_wrapper> :
+  fmt::formatter<librados::shard_info_t> {};
+
+template <>
+struct fmt::formatter<librados::obj_err_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &err, FormatContext& ctx) const
+  {
+    bool first = true;
+#define F(FLAG_NAME)					\
+    if (err.errors & librados::obj_err_t::FLAG_NAME) {	\
+      if (!first) {					\
+	fmt::format_to(ctx.out(), "|");			\
+      } else {						\
+	first = false;					\
+      }							\
+      fmt::format_to(ctx.out(), #FLAG_NAME);		\
+    }
+    F(OBJECT_INFO_INCONSISTENCY);
+    F(DATA_DIGEST_MISMATCH);
+    F(OMAP_DIGEST_MISMATCH);
+    F(SIZE_MISMATCH);
+    F(ATTR_VALUE_MISMATCH);
+    F(ATTR_NAME_MISMATCH);
+    F(SNAPSET_INCONSISTENCY);
+    F(HINFO_INCONSISTENCY);
+    F(SIZE_TOO_LARGE);
+#undef F
+    return ctx.out();
+  }
+};
+
+template <>
+struct fmt::formatter<librados::osd_shard_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &shard, FormatContext& ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "osd_shard_t(osd: {}, shard: {})",
+      shard.osd, shard.shard);
+  }
+};
+
+template <>
+struct fmt::formatter<librados::inconsistent_obj_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &err, FormatContext& ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "inconsistent_obj_t(error: {}, "
+      "object: {}, "
+      "version: {}, "
+      "shards: {}, "
+      "union_shards: {})",
+      static_cast<librados::obj_err_t>(err),
+      err.object,
+      err.version,
+      err.shards,
+      err.union_shards);
+  }
+};
+
+template <>
+struct fmt::formatter<inconsistent_obj_wrapper> :
+  fmt::formatter<librados::inconsistent_obj_t> {};
+
+template <>
+struct fmt::formatter<librados::inconsistent_snapset_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &err, FormatContext& ctx) const
+  {
+    fmt::format_to(ctx.out(), "inconsistent_snapset_t(errors: ");
+    bool first = true;
+#define F(FLAG_NAME)							\
+    if (err.errors & librados::inconsistent_snapset_t::FLAG_NAME) {	\
+      if (!first) {							\
+	fmt::format_to(ctx.out(), "|");					\
+      } else {								\
+	first = false;							\
+      }									\
+      fmt::format_to(ctx.out(), #FLAG_NAME);				\
+    }
+    F(SNAPSET_MISSING);
+    F(SNAPSET_CORRUPTED);
+    F(CLONE_MISSING);
+    F(SNAP_ERROR);
+    F(HEAD_MISMATCH);
+    F(HEADLESS_CLONE);
+    F(SIZE_MISMATCH);
+    F(OI_MISSING);
+    F(INFO_MISSING);
+    F(OI_CORRUPTED);
+    F(INFO_CORRUPTED);
+    F(EXTRA_CLONES);
+#undef F
+    return fmt::format_to(
+      ctx.out(),
+      ", object: {}, clones: {}, missing: {}",
+      err.object, err.clones, err.missing);
+  }
+};
+
+template <>
+struct fmt::formatter<inconsistent_snapset_wrapper> :
+  fmt::formatter<librados::inconsistent_snapset_t> {};
 
 #endif

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/osd/HitSet.cc
   ${PROJECT_SOURCE_DIR}/src/osd/OSDMap.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
+  ${PROJECT_SOURCE_DIR}/src/common/scrub_types.cc
   ${PROJECT_SOURCE_DIR}/src/xxHash/xxhash.c
   ${crimson_common_srcs}
   $<TARGET_OBJECTS:common_mountcephfs_objs>

--- a/src/crimson/admin/pg_commands.h
+++ b/src/crimson/admin/pg_commands.h
@@ -6,5 +6,7 @@ namespace crimson::admin::pg {
 
 class QueryCommand;
 class MarkUnfoundLostCommand;
+template <bool deep>
+class ScrubCommand;
 
 }  // namespace crimson::admin::pg

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1212,7 +1212,7 @@ public:
 	    (typename Iterator::reference x) mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action),
+		      action,
 		      std::forward<decltype(*begin)>(x)).to_future();
 	  })
       );
@@ -1224,7 +1224,7 @@ public:
 	    (typename Iterator::reference x) mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action),
+		      action,
 		      std::forward<decltype(*begin)>(x)).to_future();
 	  })
       );
@@ -1243,7 +1243,7 @@ public:
 	    (typename Iterator::reference x) mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action),
+		      action,
 		      std::forward<decltype(*begin)>(x));
 	  })
       );
@@ -1255,7 +1255,7 @@ public:
 	    (typename Iterator::reference x) mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action),
+		      action,
 		      std::forward<decltype(*begin)>(x));
 	  })
       );
@@ -1270,10 +1270,10 @@ public:
       return make_interruptible(
 	  ::seastar::repeat(
 	    [action=std::move(action),
-	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond] {
+	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action)).to_future();
+		      action).to_future();
 	  })
       );
     } else {
@@ -1283,7 +1283,7 @@ public:
 	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action)).to_future();
+		      action).to_future();
 	  })
       );
     }
@@ -1296,20 +1296,20 @@ public:
       return make_interruptible(
 	  ::seastar::repeat(
 	    [action=std::move(action),
-	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond] {
+	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action));
+		      action);
 	  })
       );
     } else {
       return make_interruptible(
 	  ::crimson::repeat(
 	    [action=std::move(action),
-	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond] {
+	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
-		      std::move(action));
+		      action);
 	  })
       );
     }

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -53,6 +53,10 @@ namespace crimson::os::seastore {
   class TransactionConflictCondition;
 }
 
+namespace crimson::osd {
+  class IOInterruptCondition;
+}
+
 // GCC tries to instantiate
 // seastar::lw_shared_ptr<crimson::os::seastore::TransactionConflictCondition>.
 // but we *may* not have the definition of TransactionConflictCondition at this moment,
@@ -135,6 +139,9 @@ struct interrupt_cond_t {
 
 template <typename InterruptCond>
 thread_local interrupt_cond_t<InterruptCond> interrupt_cond;
+
+extern template thread_local interrupt_cond_t<crimson::osd::IOInterruptCondition>
+interrupt_cond<crimson::osd::IOInterruptCondition>;
 
 extern template thread_local interrupt_cond_t<crimson::os::seastore::TransactionConflictCondition>
 interrupt_cond<crimson::os::seastore::TransactionConflictCondition>;

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -202,7 +202,6 @@ AlienStore::list_objects(CollectionRef ch,
   assert(tp);
   return do_with_op_gate(std::vector<ghobject_t>(), ghobject_t(),
                          [=, this] (auto &objects, auto &next) {
-    objects.reserve(limit);
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
       [=, this, &objects, &next] {
       auto c = static_cast<AlienCollection*>(ch.get());

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(crimson-osd
   replicated_recovery_backend.cc
   scheduler/scheduler.cc
   scheduler/mclock_scheduler.cc
+  scrub/scrub_machine.cc
+  scrub/scrub_validator.cc
   osdmap_gate.cc
   pg_activation_blocker.cc
   pg_map.cc
@@ -40,6 +42,7 @@ add_executable(crimson-osd
   objclass.cc
   ${PROJECT_SOURCE_DIR}/src/objclass/class_api.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ClassHandler.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc
   ${PROJECT_SOURCE_DIR}/src/osd/osd_op_util.cc
   ${PROJECT_SOURCE_DIR}/src/osd/OSDCap.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(crimson-osd
   osd_operations/background_recovery.cc
   osd_operations/recovery_subrequest.cc
   osd_operations/snaptrim_event.cc
+  osd_operations/scrub_events.cc
   pg_recovery.cc
   recovery_backend.cc
   replicated_recovery_backend.cc
@@ -35,6 +36,7 @@ add_executable(crimson-osd
   scheduler/mclock_scheduler.cc
   scrub/scrub_machine.cc
   scrub/scrub_validator.cc
+  scrub/pg_scrubber.cc
   osdmap_gate.cc
   pg_activation_blocker.cc
   pg_map.cc

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1040,6 +1040,7 @@ std::pair<object_info_t, ObjectContextRef> OpsExecuter::prepare_clone(
 void OpsExecuter::apply_stats()
 {
   pg->get_peering_state().apply_op_stats(get_target(), delta_stats);
+  pg->scrubber.handle_op_stats(get_target(), delta_stats);
   pg->publish_stats_to_osd();
 }
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -206,8 +206,10 @@ private:
                                       Ref<MOSDPeeringOp> m);
   seastar::future<> handle_recovery_subreq(crimson::net::ConnectionRef conn,
                                            Ref<MOSDFastDispatchOp> m);
-  seastar::future<> handle_scrub(crimson::net::ConnectionRef conn,
-                                 Ref<MOSDScrub2> m);
+  seastar::future<> handle_scrub_command(crimson::net::ConnectionRef conn,
+					 Ref<MOSDScrub2> m);
+  seastar::future<> handle_scrub_message(crimson::net::ConnectionRef conn,
+					 Ref<MOSDFastDispatchOp> m);
   seastar::future<> handle_mark_me_down(crimson::net::ConnectionRef conn,
                                         Ref<MOSDMarkMeDown> m);
 

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -54,6 +54,11 @@ enum class OperationTypeCode {
   logmissing_request_reply,
   snaptrim_event,
   snaptrimobj_subevent,
+  scrub_requested,
+  scrub_message,
+  scrub_find_range,
+  scrub_reserve_range,
+  scrub_scan,
   last_op
 };
 
@@ -71,6 +76,11 @@ static constexpr const char* const OP_NAMES[] = {
   "logmissing_request_reply",
   "snaptrim_event",
   "snaptrimobj_subevent",
+  "scrub_requested",
+  "scrub_message",
+  "scrub_find_range",
+  "scrub_reserve_range",
+  "scrub_scan",
 };
 
 // prevent the addition of OperationTypeCode-s with no matching OP_NAMES entry:

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -14,6 +14,7 @@
 #include "crimson/osd/osd_operations/snaptrim_event.h"
 #include "crimson/osd/pg_activation_blocker.h"
 #include "crimson/osd/pg_map.h"
+#include "crimson/osd/scrub/pg_scrubber.h"
 
 namespace crimson::osd {
 
@@ -30,6 +31,7 @@ struct LttngBackend
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitForActive::BlockingEvent::Backend,
     PGActivationBlocker::BlockingEvent::Backend,
+    scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
@@ -89,6 +91,11 @@ struct LttngBackend
   void handle(PGActivationBlocker::BlockingEvent& ev,
               const Operation& op,
               const PGActivationBlocker& blocker) override {
+  }
+
+  void handle(scrub::PGScrubber::BlockingEvent& ev,
+              const Operation& op,
+              const scrub::PGScrubber& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
@@ -136,6 +143,7 @@ struct HistoricBackend
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitForActive::BlockingEvent::Backend,
     PGActivationBlocker::BlockingEvent::Backend,
+    scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
@@ -195,6 +203,11 @@ struct HistoricBackend
   void handle(PGActivationBlocker::BlockingEvent& ev,
               const Operation& op,
               const PGActivationBlocker& blocker) override {
+  }
+
+  void handle(scrub::PGScrubber::BlockingEvent& ev,
+              const Operation& op,
+              const scrub::PGScrubber& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -17,6 +17,7 @@
 #include "crimson/osd/osd_operations/common/pg_pipeline.h"
 #include "crimson/osd/pg_activation_blocker.h"
 #include "crimson/osd/pg_map.h"
+#include "crimson/osd/scrub/pg_scrubber.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/common/utility.h"
 #include "messages/MOSDOp.h"
@@ -103,6 +104,7 @@ public:
       PGPipeline::WaitForActive::BlockingEvent,
       PGActivationBlocker::BlockingEvent,
       PGPipeline::RecoverMissing::BlockingEvent,
+      scrub::PGScrubber::BlockingEvent,
       PGPipeline::GetOBC::BlockingEvent,
       PGPipeline::Process::BlockingEvent,
       PGPipeline::WaitRepop::BlockingEvent,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -194,7 +194,7 @@ public:
       intrusive_ptr_release(&request);
     }
     void requeue(ShardServices &shard_services, Ref<PG> pg);
-    void clear_and_cancel();
+    void clear_and_cancel(PG &pg);
   };
   void complete_request();
 
@@ -252,14 +252,16 @@ private:
   interruptible_future<> do_process(
     instance_handle_t &ihref,
     Ref<PG>& pg,
-    crimson::osd::ObjectContextRef obc);
+    crimson::osd::ObjectContextRef obc,
+    unsigned this_instance_id);
   ::crimson::interruptible::interruptible_future<
     ::crimson::osd::IOInterruptCondition> process_pg_op(
     Ref<PG> &pg);
   ::crimson::interruptible::interruptible_future<
     ::crimson::osd::IOInterruptCondition> process_op(
       instance_handle_t &ihref,
-      Ref<PG> &pg);
+      Ref<PG> &pg,
+      unsigned this_instance_id);
   bool is_pg_op() const;
 
   PGPipeline &client_pp(PG &pg);

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -23,19 +23,13 @@ class ShardServices;
 class PG;
 class BackfillRecovery;
 
-  class PGPeeringPipeline {
+  struct PGPeeringPipeline {
     struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
       static constexpr auto type_name = "PeeringEvent::PGPipeline::await_map";
     } await_map;
     struct Process : OrderedExclusivePhaseT<Process> {
       static constexpr auto type_name = "PeeringEvent::PGPipeline::process";
     } process;
-    template <class T>
-    friend class PeeringEvent;
-    friend class LocalPeeringEvent;
-    friend class RemotePeeringEvent;
-    friend class PGAdvanceMap;
-    friend class BackfillRecovery;
   };
 
 template <class T>

--- a/src/crimson/osd/osd_operations/scrub_events.cc
+++ b/src/crimson/osd/osd_operations/scrub_events.cc
@@ -1,0 +1,396 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/common/log.h"
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd_connection_priv.h"
+#include "messages/MOSDRepScrubMap.h"
+#include "scrub_events.h"
+
+SET_SUBSYS(osd);
+
+namespace crimson::osd {
+
+template <class T>
+PGPeeringPipeline &RemoteScrubEventBaseT<T>::get_peering_pipeline(PG &pg)
+{
+  return pg.peering_request_pg_pipeline;
+}
+
+template <class T>
+ConnectionPipeline &RemoteScrubEventBaseT<T>::get_connection_pipeline()
+{
+  return get_osd_priv(conn.get()).peering_request_conn_pipeline;
+}
+
+template <class T>
+PerShardPipeline &RemoteScrubEventBaseT<T>::get_pershard_pipeline(
+  ShardServices &shard_services)
+{
+  return shard_services.get_client_request_pipeline();
+}
+
+template <class T>
+seastar::future<> RemoteScrubEventBaseT<T>::with_pg(
+  ShardServices &shard_services, Ref<PG> pg)
+{
+  LOG_PREFIX(RemoteEventBaseT::with_pg);
+  return interruptor::with_interruption([FNAME, this, pg] {
+    DEBUGDPP("{} pg present", *pg, *that());
+    return this->template enter_stage<interruptor>(
+      get_peering_pipeline(*pg).await_map
+    ).then_interruptible([this, pg] {
+      return this->template with_blocking_event<
+	PG_OSDMapGate::OSDMapBlocker::BlockingEvent
+	>([this, pg](auto &&trigger) {
+	  return pg->osdmap_gate.wait_for_map(
+	    std::move(trigger), get_epoch());
+	});
+    }).then_interruptible([this, pg](auto) {
+      return this->template enter_stage<interruptor>(
+	get_peering_pipeline(*pg).process);
+    }).then_interruptible([this, pg] {
+      return handle_event(*pg);
+    });
+  }, [FNAME, pg, this](std::exception_ptr ep) {
+    DEBUGDPP("{} interrupted with {}", *pg, *that(), ep);
+  }, pg);
+}
+
+ScrubRequested::ifut<> ScrubRequested::handle_event(PG &pg)
+{
+  pg.scrubber.handle_scrub_requested(deep);
+  return seastar::now();
+}
+
+ScrubMessage::ifut<> ScrubMessage::handle_event(PG &pg)
+{
+  pg.scrubber.handle_scrub_message(*m);
+  return seastar::now();
+}
+
+template class RemoteScrubEventBaseT<ScrubRequested>;
+template class RemoteScrubEventBaseT<ScrubMessage>;
+
+template <typename T>
+ScrubAsyncOpT<T>::ScrubAsyncOpT(Ref<PG> pg) : pg(pg) {}
+
+template <typename T>
+typename ScrubAsyncOpT<T>::template ifut<> ScrubAsyncOpT<T>::start()
+{
+  LOG_PREFIX(ScrubAsyncOpT::start);
+  DEBUGDPP("{} starting", *pg, *this);
+  return run(*pg);
+}
+
+ScrubFindRange::ifut<> ScrubFindRange::run(PG &pg)
+{
+  LOG_PREFIX(ScrubFindRange::run);
+  using crimson::common::local_conf;
+  return interruptor::make_interruptible(
+    pg.shard_services.get_store().list_objects(
+      pg.get_collection_ref(),
+      ghobject_t(begin, ghobject_t::NO_GEN, pg.get_pgid().shard),
+      ghobject_t::get_max(),
+      local_conf().get_val<int64_t>("osd_scrub_chunk_max")
+    )
+  ).then_interruptible([FNAME, this, &pg](auto ret) {
+    auto &[_, next] = ret;
+
+    // We rely on seeing an entire set of snapshots in a single chunk
+    auto end = next.hobj.get_max_object_boundary();
+
+    DEBUGDPP("got next.hobj: {}, returning begin, end: {}, {}",
+	     pg, next.hobj, begin, end);
+    pg.scrubber.machine.process_event(
+      scrub::ScrubContext::request_range_complete_t{begin, end});
+  });
+}
+
+template class ScrubAsyncOpT<ScrubFindRange>;
+
+ScrubReserveRange::ifut<> ScrubReserveRange::run(PG &pg)
+{
+  LOG_PREFIX(ScrubReserveRange::run);
+  DEBUGDPP("", pg);
+  return pg.background_process_lock.lock(
+  ).then_interruptible([FNAME, this, &pg] {
+    DEBUGDPP("pg_background_io_mutex locked", pg);
+    auto &scrubber = pg.scrubber;
+    ceph_assert(!scrubber.blocked);
+    scrubber.blocked = scrub::blocked_range_t{begin, end};
+    blocked_set = true;
+    auto& log = pg.peering_state.get_pg_log().get_log().log;
+    auto p = find_if(
+      log.crbegin(), log.crend(),
+      [this](const auto& e) -> bool {
+	return e.soid >= begin && e.soid < end;
+      });
+
+    if (p == log.crend()) {
+      return scrubber.machine.process_event(
+	scrub::ScrubContext::reserve_range_complete_t{eversion_t{}});
+    } else {
+      return scrubber.machine.process_event(
+	scrub::ScrubContext::reserve_range_complete_t{p->version});
+    }
+  }).finally([&pg, this] {
+    if (!blocked_set) {
+      pg.background_process_lock.unlock();
+    }
+  });
+}
+
+template class ScrubAsyncOpT<ScrubReserveRange>;
+
+ScrubScan::ifut<> ScrubScan::run(PG &pg)
+{
+  LOG_PREFIX(ScrubScan::start);
+  // legacy value, unused
+  ret.valid_through = pg.get_info().last_update;
+
+  DEBUGDPP("begin: {}, end: {}", pg, begin, end);
+  return interruptor::make_interruptible(
+    pg.shard_services.get_store().list_objects(
+      pg.get_collection_ref(),
+      ghobject_t(begin, ghobject_t::NO_GEN, pg.get_pgid().shard),
+      ghobject_t(end, ghobject_t::NO_GEN, pg.get_pgid().shard),
+      std::numeric_limits<uint64_t>::max())
+  ).then_interruptible([FNAME, this, &pg](auto &&result) {
+    DEBUGDPP("listed {} objects", pg, std::get<0>(result).size());
+    return seastar::do_with(
+      std::move(std::get<0>(result)),
+      [this, &pg](auto &objects) {
+	return interruptor::do_for_each(
+	  objects,
+	  [this, &pg](auto &obj) {
+	    if (obj.is_pgmeta() || obj.hobj.is_temp()) {
+	      return interruptor::now();
+	    } else {
+	      return scan_object(pg, obj);
+	    }
+	  });
+      });
+  }).then_interruptible([FNAME, this, &pg] {
+    if (local) {
+      DEBUGDPP("complete, submitting local event", pg);
+      pg.scrubber.handle_event(
+	scrub::ScrubContext::scan_range_complete_t(
+	  pg.get_pg_whoami(),
+	  std::move(ret)));
+      return seastar::now();
+    } else {
+      DEBUGDPP("complete, sending response to primary", pg);
+      auto m = crimson::make_message<MOSDRepScrubMap>(
+	spg_t(pg.get_pgid().pgid, pg.get_primary().shard),
+	pg.get_osdmap_epoch(),
+	pg.get_pg_whoami());
+      encode(ret, m->get_data());
+      pg.scrubber.handle_event(
+	scrub::ScrubContext::generate_and_submit_chunk_result_complete_t{});
+      return pg.shard_services.send_to_osd(
+	pg.get_primary().osd,
+	std::move(m),
+	pg.get_osdmap_epoch());
+    }
+  });
+}
+
+ScrubScan::ifut<> ScrubScan::scan_object(
+  PG &pg,
+  const ghobject_t &obj)
+{
+  LOG_PREFIX(ScrubScan::scan_object);
+  DEBUGDPP("obj: {}", pg, obj);
+  auto &entry = ret.objects[obj.hobj];
+  return interruptor::make_interruptible(
+    pg.shard_services.get_store().stat(
+      pg.get_collection_ref(),
+      obj)
+  ).then_interruptible([FNAME, &pg, &obj, &entry](struct stat obj_stat) {
+    DEBUGDPP("obj: {}, stat complete, size {}", pg, obj, obj_stat.st_size);
+    entry.size = obj_stat.st_size;
+    return pg.shard_services.get_store().get_attrs(
+      pg.get_collection_ref(),
+      obj);
+  }).safe_then_interruptible([FNAME, &pg, &obj, &entry](auto &&attrs) {
+    DEBUGDPP("obj: {}, got {} attrs", pg, obj, attrs.size());
+    for (auto &i : attrs) {
+      i.second.rebuild();
+      if (i.second.length() == 0) {
+	entry.attrs[i.first];
+      } else {
+	entry.attrs.emplace(i.first, i.second.front());
+      }
+    }
+  }).handle_error_interruptible(
+    ct_error::all_same_way([FNAME, &pg, &obj, &entry](auto e) {
+      DEBUGDPP("obj: {} stat error", pg, obj);
+      entry.stat_error = true;
+    })
+  ).then_interruptible([FNAME, this, &pg, &obj] {
+    if (deep) {
+      DEBUGDPP("obj: {} doing deep scan", pg, obj);
+      return deep_scan_object(pg, obj);
+    } else {
+      return interruptor::now();
+    }
+  });
+
+}
+
+struct obj_scrub_progress_t {
+  // nullopt once complete
+  std::optional<uint64_t> offset = 0;
+  ceph::buffer::hash data_hash{std::numeric_limits<uint32_t>::max()};
+
+  bool header_done = false;
+  std::optional<std::string> next_key;
+  bool keys_done = false;
+  ceph::buffer::hash omap_hash{std::numeric_limits<uint32_t>::max()};
+};
+ScrubScan::ifut<> ScrubScan::deep_scan_object(
+  PG &pg,
+  const ghobject_t &obj)
+{
+  LOG_PREFIX(ScrubScan::deep_scan_object);
+  DEBUGDPP("obj: {}", pg, obj);
+  using crimson::common::local_conf;
+  auto &entry = ret.objects[obj.hobj];
+  return interruptor::repeat(
+    [FNAME, this, progress = obj_scrub_progress_t(),
+     &obj, &entry, &pg]() mutable
+    -> interruptible_future<seastar::stop_iteration> {
+      if (progress.offset) {
+	DEBUGDPP("op: {}, obj: {}, progress: {} scanning data",
+		 pg, *this, obj, progress);
+	const auto stride = local_conf().get_val<Option::size_t>(
+	  "osd_deep_scrub_stride");
+	return pg.shard_services.get_store().read(
+	  pg.get_collection_ref(),
+	  obj,
+	  *(progress.offset),
+	  stride
+	).safe_then([stride, &progress, &entry](auto bl) {
+	  progress.data_hash << bl;
+	  if (bl.length() < stride) {
+	    progress.offset = std::nullopt;
+	    entry.digest = progress.data_hash.digest();
+	    entry.digest_present = true;
+	  } else {
+	    ceph_assert(stride == bl.length());
+	    *(progress.offset) += stride;
+	  }
+	}).handle_error(
+	  ct_error::all_same_way([&progress, &entry](auto e) {
+	    entry.read_error = true;
+	    progress.offset = std::nullopt;
+	  })
+	).then([] {
+	  return interruptor::make_interruptible(
+	    seastar::make_ready_future<seastar::stop_iteration>(
+	      seastar::stop_iteration::no));
+	});
+      } else if (!progress.header_done) {
+	DEBUGDPP("op: {}, obj: {}, progress: {} scanning omap header",
+		 pg, *this, obj, progress);
+	return pg.shard_services.get_store().omap_get_header(
+	  pg.get_collection_ref(),
+	  obj
+	).safe_then([&progress](auto bl) {
+	  progress.omap_hash << bl;
+	}).handle_error(
+	  ct_error::enodata::handle([] {}),
+	  ct_error::all_same_way([&entry](auto e) {
+	    entry.read_error = true;
+	  })
+	).then([&progress] {
+	  progress.header_done = true;
+	  return interruptor::make_interruptible(
+	    seastar::make_ready_future<seastar::stop_iteration>(
+	      seastar::stop_iteration::no));
+	});
+      } else if (!progress.keys_done) {
+	DEBUGDPP("op: {}, obj: {}, progress: {} scanning omap keys",
+		 pg, *this, obj, progress);
+	return pg.shard_services.get_store().omap_get_values(
+	  pg.get_collection_ref(),
+	  obj,
+	  progress.next_key
+	).safe_then([FNAME, this, &obj, &progress, &entry, &pg](auto result) {
+	  const auto &[done, omap] = result;
+	  DEBUGDPP("op: {}, obj: {}, progress: {} got {} keys",
+		   pg, *this, obj, progress, omap.size());
+	  for (const auto &p : omap) {
+	    bufferlist bl;
+	    encode(p.first, bl);
+	    encode(p.second, bl);
+	    progress.omap_hash << bl;
+	    entry.object_omap_keys++;
+	    entry.object_omap_bytes += p.second.length();
+	  }
+	  if (done) {
+	    DEBUGDPP("op: {}, obj: {}, progress: {} omap done",
+		     pg, *this, obj, progress);
+	    progress.keys_done = true;
+	    entry.omap_digest = progress.omap_hash.digest();
+	    entry.omap_digest_present = true;
+
+	    if ((entry.object_omap_keys >
+		 local_conf().get_val<uint64_t>(
+		   "osd_deep_scrub_large_omap_object_key_threshold")) ||
+		(entry.object_omap_bytes >
+		 local_conf().get_val<Option::size_t>(
+		   "osd_deep_scrub_large_omap_object_value_sum_threshold"))) {
+	      entry.large_omap_object_found = true;
+	      entry.large_omap_object_key_count = entry.object_omap_keys;
+	      ret.has_large_omap_object_errors = true;
+	    }
+	  } else {
+	    ceph_assert(!omap.empty()); // omap_get_values invariant
+	    DEBUGDPP("op: {}, obj: {}, progress: {} omap not done, next {}",
+		     pg, *this, obj, progress, omap.crbegin()->first);
+	    progress.next_key = omap.crbegin()->first;
+	  }
+	}).handle_error(
+	  ct_error::all_same_way([FNAME, this, &obj, &progress, &entry, &pg]
+				 (auto e) {
+	    DEBUGDPP("op: {}, obj: {}, progress: {} error reading omap {}",
+		     pg, *this, obj, progress, e);
+	    progress.keys_done = true;
+	    entry.read_error = true;
+	  })
+	).then([] {
+	  return interruptor::make_interruptible(
+	    seastar::make_ready_future<seastar::stop_iteration>(
+	      seastar::stop_iteration::no));
+	});
+      } else {
+	DEBUGDPP("op: {}, obj: {}, progress: {} done",
+		 pg, *this, obj, progress);
+	return interruptor::make_interruptible(
+	  seastar::make_ready_future<seastar::stop_iteration>(
+	    seastar::stop_iteration::yes));
+      }
+    });
+}
+
+template class ScrubAsyncOpT<ScrubScan>;
+
+}
+
+template <>
+struct fmt::formatter<crimson::osd::obj_scrub_progress_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const crimson::osd::obj_scrub_progress_t &progress,
+	      FormatContext& ctx)
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "obj_scrub_progress_t(offset: {}, "
+      "header_done: {}, next_key: {}, keys_done: {})",
+      progress.offset, progress.header_done,
+      progress.next_key, progress.keys_done);
+  }
+};

--- a/src/crimson/osd/osd_operations/scrub_events.h
+++ b/src/crimson/osd/osd_operations/scrub_events.h
@@ -1,0 +1,290 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "common/Formatter.h"
+#include "crimson/osd/osd_operation.h"
+#include "crimson/osd/scrub/pg_scrubber.h"
+#include "osd/osd_types.h"
+#include "peering_event.h"
+
+namespace crimson::osd {
+
+class PG;
+
+template <typename T>
+class RemoteScrubEventBaseT : public PhasedOperationT<T> {
+  T* that() {
+    return static_cast<T*>(this);
+  }
+  const T* that() const {
+    return static_cast<const T*>(this);
+  }
+
+  PipelineHandle handle;
+
+  crimson::net::ConnectionRef conn;
+  epoch_t epoch;
+  spg_t pgid;
+
+protected:
+  using interruptor = InterruptibleOperation::interruptor;
+
+  template <typename U=void>
+  using ifut = InterruptibleOperation::interruptible_future<U>;
+
+  virtual ifut<> handle_event(PG &pg) = 0;
+public:
+  RemoteScrubEventBaseT(
+    crimson::net::ConnectionRef conn, epoch_t epoch, spg_t pgid)
+    : conn(conn), epoch(epoch), pgid(pgid) {}
+
+  PGPeeringPipeline &get_peering_pipeline(PG &pg);
+  ConnectionPipeline &get_connection_pipeline();
+  PerShardPipeline &get_pershard_pipeline(ShardServices &);
+
+  crimson::net::Connection &get_connection() {
+    assert(conn);
+    return *conn;
+  };
+
+  static constexpr bool can_create() { return false; }
+
+  spg_t get_pgid() const {
+    return pgid;
+  }
+
+  PipelineHandle &get_handle() { return handle; }
+  epoch_t get_epoch() const { return epoch; }
+
+  seastar::future<crimson::net::ConnectionFRef> prepare_remote_submission() {
+    assert(conn);
+    return conn.get_foreign(
+    ).then([this](auto f_conn) {
+      conn.reset();
+      return f_conn;
+    });
+  }
+  void finish_remote_submission(crimson::net::ConnectionFRef _conn) {
+    assert(!conn);
+    conn = make_local_shared_foreign(std::move(_conn));
+  }
+
+  seastar::future<> with_pg(
+    ShardServices &shard_services, Ref<PG> pg);
+
+  std::tuple<
+    class TrackableOperationT<T>::StartEvent,
+    ConnectionPipeline::AwaitActive::BlockingEvent,
+    ConnectionPipeline::AwaitMap::BlockingEvent,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    ConnectionPipeline::GetPGMapping::BlockingEvent,
+    PerShardPipeline::CreateOrWaitPG::BlockingEvent,
+    PGMap::PGCreationBlockingEvent,
+    PGPeeringPipeline::AwaitMap::BlockingEvent,
+    PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    PGPeeringPipeline::Process::BlockingEvent,
+    class TrackableOperationT<T>::CompletionEvent
+  > tracking_events;
+
+  virtual ~RemoteScrubEventBaseT() = default;
+};
+
+class ScrubRequested final : public RemoteScrubEventBaseT<ScrubRequested> {
+  bool deep = false;
+protected:
+  ifut<> handle_event(PG &pg) final;
+
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::scrub_requested;
+
+  template <typename... Args>
+  ScrubRequested(bool deep, Args&&... base_args)
+    : RemoteScrubEventBaseT<ScrubRequested>(std::forward<Args>(base_args)...),
+      deep(deep) {}
+
+  void print(std::ostream &out) const final {
+    out << "(deep=" << deep << ")";
+  }
+  void dump_detail(ceph::Formatter *f) const final {
+    f->dump_bool("deep", deep);
+  }
+
+};
+
+class ScrubMessage final : public RemoteScrubEventBaseT<ScrubMessage> {
+  MessageRef m;
+protected:
+  ifut<> handle_event(PG &pg) final;
+
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::scrub_message;
+
+  template <typename... Args>
+  ScrubMessage(MessageRef m, Args&&... base_args)
+    : RemoteScrubEventBaseT<ScrubMessage>(std::forward<Args>(base_args)...),
+      m(m) {
+    ceph_assert(scrub::PGScrubber::is_scrub_message(*m));
+  }
+
+  void print(std::ostream &out) const final {
+    out << "(m=" << *m << ")";
+  }
+  void dump_detail(ceph::Formatter *f) const final {
+    f->dump_stream("m") << *m;
+  }
+
+};
+
+template <typename T>
+class ScrubAsyncOpT : public TrackableOperationT<T> {
+  Ref<PG> pg;
+
+public:
+  using interruptor = InterruptibleOperation::interruptor;
+  template <typename U=void>
+  using ifut = InterruptibleOperation::interruptible_future<U>;
+
+  ScrubAsyncOpT(Ref<PG> pg);
+
+  ifut<> start();
+
+  virtual ~ScrubAsyncOpT() = default;
+
+protected:
+  virtual ifut<> run(PG &pg) = 0;
+};
+
+class ScrubFindRange : public ScrubAsyncOpT<ScrubFindRange> {
+  hobject_t begin;
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::scrub_find_range;
+
+  template <typename... Args>
+  ScrubFindRange(const hobject_t &begin, Args&&... args)
+    : ScrubAsyncOpT(std::forward<Args>(args)...), begin(begin) {}
+
+  void print(std::ostream &out) const final {
+    out << "(begin=" << begin << ")";
+  }
+  void dump_detail(ceph::Formatter *f) const final {
+    f->dump_stream("begin") << begin;
+  }
+
+
+protected:
+  ifut<> run(PG &pg) final;
+};
+
+class ScrubReserveRange : public ScrubAsyncOpT<ScrubReserveRange> {
+  hobject_t begin;
+  hobject_t end;
+
+  /// see run(), used to unlock background_io_mutex on interval change
+  bool blocked_set = false;
+public:
+  static constexpr OperationTypeCode type =
+    OperationTypeCode::scrub_reserve_range;
+
+  template <typename... Args>
+  ScrubReserveRange(const hobject_t &begin, const hobject_t &end, Args&&... args)
+    : ScrubAsyncOpT(std::forward<Args>(args)...), begin(begin), end(end) {}
+
+  void print(std::ostream &out) const final {
+    out << "(begin=" << begin << ", end=" << end << ")";
+  }
+  void dump_detail(ceph::Formatter *f) const final {
+    f->dump_stream("begin") << begin;
+    f->dump_stream("end") << end;
+  }
+
+
+protected:
+  ifut<> run(PG &pg) final;
+};
+
+class ScrubScan : public ScrubAsyncOpT<ScrubScan> {
+  /// deep or shallow scrub
+  const bool deep;
+
+  /// true: send event locally, false: send result to primary
+  const bool local;
+
+  /// object range to scan: [begin, end)
+  const hobject_t begin;
+  const hobject_t end;
+
+  /// result, see local
+  ScrubMap ret;
+
+  ifut<> scan_object(PG &pg, const ghobject_t &obj);
+  ifut<> deep_scan_object(PG &pg, const ghobject_t &obj);
+
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::scrub_scan;
+
+  void print(std::ostream &out) const final {
+    out << "(deep=" << deep
+	<< ", local=" << local
+	<< ", begin=" << begin
+	<< ", end=" << end
+	<< ")";
+  }
+  void dump_detail(ceph::Formatter *f) const final {
+    f->dump_bool("deep", deep);
+    f->dump_bool("local", local);
+    f->dump_stream("begin") << begin;
+    f->dump_stream("end") << end;
+  }
+
+  ScrubScan(
+    Ref<PG> pg, bool deep, bool local,
+    const hobject_t &begin, const hobject_t &end)
+    : ScrubAsyncOpT(pg), deep(deep), local(local), begin(begin), end(end) {}
+
+protected:
+  ifut<> run(PG &pg) final;
+};
+
+}
+
+namespace crimson {
+
+template <>
+struct EventBackendRegistry<osd::ScrubRequested> {
+  static std::tuple<> get_backends() {
+    return {};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::ScrubMessage> {
+  static std::tuple<> get_backends() {
+    return {};
+  }
+};
+
+}
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::osd::ScrubRequested>
+  : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<crimson::osd::ScrubMessage>
+  : fmt::ostream_formatter {};
+
+template <typename T>
+struct fmt::formatter<crimson::osd::ScrubAsyncOpT<T>>
+  : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<crimson::osd::ScrubFindRange>
+  : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<crimson::osd::ScrubReserveRange>
+  : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<crimson::osd::ScrubScan>
+  : fmt::ostream_formatter {};
+
+#endif

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -31,9 +31,9 @@ namespace crimson {
 namespace crimson::osd {
 
 PG::interruptible_future<>
-PG::SnapTrimMutex::lock(SnapTrimEvent &st_event) noexcept
+PG::BackgroundProcessLock::lock_with_op(SnapTrimEvent &st_event) noexcept
 {
-  return st_event.enter_stage<interruptor>(wait_pg
+  return st_event.enter_stage<interruptor>(wait
   ).then_interruptible([this] {
     return mutex.lock();
   });
@@ -115,7 +115,7 @@ SnapTrimEvent::start()
       return enter_stage<interruptor>(
         client_pp().get_obc);
     }).then_interruptible([this] {
-      return pg->snaptrim_mutex.lock(*this);
+      return pg->background_process_lock.lock_with_op(*this);
     }).then_interruptible([this] {
       return enter_stage<interruptor>(
         client_pp().process);
@@ -147,7 +147,7 @@ SnapTrimEvent::start()
         if (to_trim.empty()) {
           // the legit ENOENT -> done
           logger().debug("{}: to_trim is empty! Stopping iteration", *this);
-	  pg->snaptrim_mutex.unlock();
+	  pg->background_process_lock.unlock();
           return snap_trim_iertr::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         }
@@ -171,7 +171,7 @@ SnapTrimEvent::start()
           logger().debug("{}: awaiting completion", *this);
           return subop_blocker.wait_completion();
         }).finally([this] {
-	  pg->snaptrim_mutex.unlock();
+	  pg->background_process_lock.unlock();
 	}).si_then([this] {
           if (!needs_pause) {
             return interruptor::now();

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -104,12 +104,12 @@ public:
     CommonPGPipeline::GetOBC::BlockingEvent,
     CommonPGPipeline::Process::BlockingEvent,
     WaitSubop::BlockingEvent,
-    PG::SnapTrimMutex::WaitPG::BlockingEvent,
+    PG::BackgroundProcessLock::Wait::BlockingEvent,
     WaitTrimTimer::BlockingEvent,
     CompletionEvent
   > tracking_events;
 
-  friend class PG::SnapTrimMutex;
+  friend class PG::BackgroundProcessLock;
 };
 
 // remove single object. a SnapTrimEvent can create multiple subrequests.

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -142,6 +142,8 @@ public:
   CommonPGPipeline& client_pp();
 
 private:
+  /* TODO: we don't actually update the PG's stats
+   * https://tracker.ceph.com/issues/63307 */
   object_stat_sum_t delta_stats;
 
   remove_or_update_iertr::future<> remove_clone(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -64,17 +64,6 @@ std::ostream& operator<<(std::ostream& out, const signedspan& d)
 }
 }
 
-template <typename T>
-struct fmt::formatter<std::optional<T>> : fmt::formatter<T> {
-  template <typename FormatContext>
-  auto format(const std::optional<T>& v, FormatContext& ctx) const {
-    if (v.has_value()) {
-      return fmt::formatter<T>::format(*v, ctx);
-    }
-    return fmt::format_to(ctx.out(), "<null>");
-  }
-};
-
 namespace crimson::osd {
 
 using crimson::common::local_conf;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -547,19 +547,10 @@ void PG::on_active_advmap(const OSDMapRef &osdmap)
 
 void PG::scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type)
 {
-  // TODO: should update the stats upon finishing the scrub
-  peering_state.update_stats([scrub_level, this](auto& history, auto& stats) {
-    const utime_t now = ceph_clock_now();
-    history.last_scrub = peering_state.get_info().last_update;
-    history.last_scrub_stamp = now;
-    history.last_clean_scrub_stamp = now;
-    if (scrub_level == scrub_level_t::deep) {
-      history.last_deep_scrub = history.last_scrub;
-      history.last_deep_scrub_stamp = now;
-    }
-    // yes, please publish the stats
-    return true;
-  });
+  /* We don't actually route the scrub request message into the state machine.
+   * Instead, we handle it directly in PGScrubber::handle_scrub_requested).
+   */
+  ceph_assert(0 == "impossible in crimson");
 }
 
 void PG::log_state_enter(const char *state) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -801,6 +801,12 @@ PG::interruptible_future<> PG::repair_object(
   return std::move(fut);
 }
 
+PG::interruptible_future<>
+PG::BackgroundProcessLock::lock() noexcept
+{
+  return interruptor::make_interruptible(mutex.lock());
+}
+
 template <class Ret, class SuccessFunc, class FailureFunc>
 PG::do_osd_ops_iertr::future<PG::pg_rep_op_fut_t<Ret>>
 PG::do_osd_ops_execute(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1530,7 +1530,7 @@ void PG::on_change(ceph::os::Transaction &t) {
     client_request_orderer.requeue(shard_services, this);
   } else {
     logger().debug("{} {}: dropping requests", *this, __func__);
-    client_request_orderer.clear_and_cancel();
+    client_request_orderer.clear_and_cancel(*this);
   }
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -542,18 +542,19 @@ public:
 
 private:
 
-  struct SnapTrimMutex {
-    struct WaitPG : OrderedConcurrentPhaseT<WaitPG> {
-      static constexpr auto type_name = "SnapTrimEvent::wait_pg";
-    } wait_pg;
+  struct BackgroundProcessLock {
+    struct Wait : OrderedConcurrentPhaseT<Wait> {
+      static constexpr auto type_name = "PG::BackgroundProcessLock::wait";
+    } wait;
     seastar::shared_mutex mutex;
 
-    interruptible_future<> lock(SnapTrimEvent &st_event) noexcept;
+    interruptible_future<> lock_with_op(SnapTrimEvent &st_event) noexcept;
+    interruptible_future<> lock() noexcept;
 
     void unlock() noexcept {
       mutex.unlock();
     }
-  } snaptrim_mutex;
+  } background_process_lock;
 
   using do_osd_ops_ertr = crimson::errorator<
    crimson::ct_error::eagain>;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -39,6 +39,7 @@
 #include "crimson/osd/pg_recovery_listener.h"
 #include "crimson/osd/recovery_backend.h"
 #include "crimson/osd/object_context_loader.h"
+#include "crimson/osd/scrub/pg_scrubber.h"
 
 class MQuery;
 class OSDMap;
@@ -159,8 +160,6 @@ public:
     bool dirty_big_info,
     bool need_write_epoch,
     ceph::os::Transaction &t) final;
-
-  void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final;
 
   uint64_t get_snap_trimq_size() const final {
     return std::size(snap_trimq);
@@ -318,6 +317,7 @@ public:
   }
   void on_change(ceph::os::Transaction &t) final;
   void on_activate(interval_set<snapid_t> to_trim) final;
+  void on_replica_activate() final;
   void on_activate_complete() final;
   void on_new_interval() final {
     // Not needed yet
@@ -627,6 +627,18 @@ private:
   eversion_t projected_last_update;
 
 public:
+  // scrub state
+
+  friend class ScrubScan;
+  friend class ScrubFindRange;
+  friend class ScrubReserveRange;
+  friend class scrub::PGScrubber;
+  template <typename T> friend class RemoteScrubEventBaseT;
+
+  scrub::PGScrubber scrubber;
+
+  void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) final;
+
   ObjectContextRegistry obc_registry;
   ObjectContextLoader obc_loader;
 

--- a/src/crimson/osd/pg_interval_interrupt_condition.cc
+++ b/src/crimson/osd/pg_interval_interrupt_condition.cc
@@ -8,6 +8,11 @@
 
 SET_SUBSYS(osd);
 
+namespace crimson::interruptible {
+template thread_local interrupt_cond_t<crimson::osd::IOInterruptCondition>
+interrupt_cond<crimson::osd::IOInterruptCondition>;
+}
+
 namespace crimson::osd {
 
 IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg)

--- a/src/crimson/osd/scrub/pg_scrubber.cc
+++ b/src/crimson/osd/scrub/pg_scrubber.cc
@@ -1,0 +1,309 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#include <fmt/ranges.h>
+
+#include "crimson/common/log.h"
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd_operations/scrub_events.h"
+#include "messages/MOSDRepScrub.h"
+#include "messages/MOSDRepScrubMap.h"
+#include "pg_scrubber.h"
+
+SET_SUBSYS(osd);
+
+namespace crimson::osd::scrub {
+
+void PGScrubber::dump_detail(Formatter *f) const
+{
+  f->dump_stream("pgid") << pg.get_pgid();
+}
+
+PGScrubber::PGScrubber(PG &pg) : pg(pg), dpp(pg), machine(*this) {}
+
+void PGScrubber::on_primary_active_clean()
+{
+  LOG_PREFIX(PGScrubber::on_primary_active_clean);
+  DEBUGDPP("", pg);
+  handle_event(events::primary_activate_t{});
+}
+
+void PGScrubber::on_replica_activate()
+{
+  LOG_PREFIX(PGScrubber::on_replica_activate);
+  DEBUGDPP("", pg);
+  handle_event(events::replica_activate_t{});
+}
+
+void PGScrubber::on_interval_change()
+{
+  LOG_PREFIX(PGScrubber::on_interval_change);
+  DEBUGDPP("", pg);
+  /* Once reservations and scheduling are introduced, we'll need an
+   * IntervalChange event to drop remote resources (they'll be automatically
+   * released on the other side) */
+  handle_event(events::reset_t{});
+  waiting_for_update = std::nullopt;
+  ceph_assert(!blocked);
+}
+
+void PGScrubber::on_log_update(eversion_t v)
+{
+  LOG_PREFIX(PGScrubber::on_interval_change);
+  if (waiting_for_update && v >= *waiting_for_update) {
+    DEBUGDPP("waiting_for_update: {}, v: {}", pg, *waiting_for_update, v);
+    handle_event(await_update_complete_t{});
+    waiting_for_update = std::nullopt;
+  }
+}
+
+void PGScrubber::handle_scrub_requested(bool deep)
+{
+  LOG_PREFIX(PGScrubber::handle_scrub_requested);
+  DEBUGDPP("deep: {}", pg, deep);
+  handle_event(events::start_scrub_t{deep});
+}
+
+void PGScrubber::handle_scrub_message(Message &_m)
+{
+  LOG_PREFIX(PGScrubber::handle_scrub_requested);
+  switch (_m.get_type()) {
+  case MSG_OSD_REP_SCRUB: {
+    MOSDRepScrub &m = *static_cast<MOSDRepScrub*>(&_m);
+    DEBUGDPP("MOSDRepScrub: {}", pg, m);
+    handle_event(events::replica_scan_t{
+	m.start, m.end, m.scrub_from, m.deep
+      });
+    break;
+  }
+  case MSG_OSD_REP_SCRUBMAP: {
+    MOSDRepScrubMap &m = *static_cast<MOSDRepScrubMap*>(&_m);
+    DEBUGDPP("MOSDRepScrubMap: {}", pg, m);
+    ScrubMap map;
+    auto iter = m.get_data().cbegin();
+    ::decode(map, iter);
+    handle_event(scan_range_complete_t{
+	m.from, std::move(map)
+      });
+    break;
+  }
+  default:
+    DEBUGDPP("invalid message: {}", pg, _m);
+    ceph_assert(is_scrub_message(_m));
+  }
+}
+
+void PGScrubber::handle_op_stats(
+  const hobject_t &on_object,
+  object_stat_sum_t delta_stats) {
+  handle_event(events::op_stats_t{on_object, delta_stats});
+}
+
+PGScrubber::ifut<> PGScrubber::wait_scrub(
+  PGScrubber::BlockingEvent::TriggerI&& trigger,
+  const hobject_t &hoid)
+{
+  LOG_PREFIX(PGScrubber::wait_scrub);
+  if (blocked && (hoid >= blocked->begin) && (hoid < blocked->end)) {
+    DEBUGDPP("blocked: {}, hoid: {}", pg, *blocked, hoid);
+    return trigger.maybe_record_blocking(
+      blocked->p.get_shared_future(),
+      *this);
+  } else {
+    return seastar::now();
+  }
+}
+
+void PGScrubber::notify_scrub_start(bool deep)
+{
+  LOG_PREFIX(PGScrubber::notify_scrub_start);
+  DEBUGDPP("deep: {}", pg, deep);
+  pg.peering_state.state_set(PG_STATE_SCRUBBING);
+  if (deep) {
+    pg.peering_state.state_set(PG_STATE_DEEP_SCRUB);
+  }
+  pg.publish_stats_to_osd();
+}
+
+void PGScrubber::notify_scrub_end(bool deep)
+{
+  LOG_PREFIX(PGScrubber::notify_scrub_end);
+  DEBUGDPP("deep: {}", pg, deep);
+  pg.peering_state.state_clear(PG_STATE_SCRUBBING);
+  if (deep) {
+    pg.peering_state.state_clear(PG_STATE_DEEP_SCRUB);
+  }
+  pg.publish_stats_to_osd();
+}
+
+const std::set<pg_shard_t> &PGScrubber::get_ids_to_scrub() const
+{
+  return pg.peering_state.get_actingset();
+}
+
+chunk_validation_policy_t PGScrubber::get_policy() const
+{
+  return chunk_validation_policy_t{
+    pg.get_primary(),
+    std::nullopt /* stripe_info, populate when EC is implemented */,
+    crimson::common::local_conf().get_val<Option::size_t>(
+      "osd_max_object_size"),
+    crimson::common::local_conf().get_val<std::string>(
+      "osd_hit_set_namespace"),
+    crimson::common::local_conf().get_val<Option::size_t>(
+      "osd_deep_scrub_large_omap_object_value_sum_threshold"),
+    crimson::common::local_conf().get_val<uint64_t>(
+      "osd_deep_scrub_large_omap_object_key_threshold")
+  };
+}
+
+void PGScrubber::request_range(const hobject_t &start)
+{
+  LOG_PREFIX(PGScrubber::request_range);
+  DEBUGDPP("start: {}", pg, start);
+  std::ignore = pg.shard_services.start_operation_may_interrupt<
+    interruptor, ScrubFindRange
+    >(start, &pg);
+}
+
+/* TODO: This isn't actually enough.  Here, classic would
+ * hold the pg lock from the wait_scrub through to IO submission.
+ * ClientRequest, however, isn't in the processing ExclusivePhase
+ * bit yet, and so this check may miss ops between the wait_scrub
+ * check and adding the IO to the log. */
+
+void PGScrubber::reserve_range(const hobject_t &start, const hobject_t &end)
+{
+  LOG_PREFIX(PGScrubber::reserve_range);
+  DEBUGDPP("start: {}, end: {}", pg, start, end);
+  std::ignore = pg.shard_services.start_operation_may_interrupt<
+    interruptor, ScrubReserveRange
+    >(start, end, &pg);
+}
+
+void PGScrubber::release_range()
+{
+  LOG_PREFIX(PGScrubber::release_range);
+  ceph_assert(blocked);
+  DEBUGDPP("blocked: {}", pg, *blocked);
+  pg.background_process_lock.unlock();
+  blocked->p.set_value();
+  blocked = std::nullopt;
+}
+
+void PGScrubber::scan_range(
+  pg_shard_t target,
+  eversion_t version,
+  bool deep,
+  const hobject_t &start,
+  const hobject_t &end)
+{
+  LOG_PREFIX(PGScrubber::scan_range);
+  DEBUGDPP("target: {}, version: {}, deep: {}, start: {}, end: {}",
+	   pg, target, version, deep, start, end);
+  if (target == pg.get_pg_whoami()) {
+    std::ignore = pg.shard_services.start_operation_may_interrupt<
+      interruptor, ScrubScan
+      >(&pg, deep, true /* local */, start, end);
+  } else {
+    std::ignore = pg.shard_services.send_to_osd(
+      target.osd,
+      crimson::make_message<MOSDRepScrub>(
+	spg_t(pg.get_pgid().pgid, target.shard),
+	version,
+	pg.get_osdmap_epoch(),
+	pg.get_osdmap_epoch(),
+	start,
+	end,
+	deep,
+	false /* allow preemption -- irrelevant for replicas TODO */,
+	64 /* priority, TODO */,
+	false /* high_priority TODO */),
+      pg.get_osdmap_epoch());
+  }
+}
+
+bool PGScrubber::await_update(const eversion_t &version)
+{
+  LOG_PREFIX(PGScrubber::await_update);
+  DEBUGDPP("version: {}", pg, version);
+  ceph_assert(!waiting_for_update);
+  auto& log = pg.peering_state.get_pg_log().get_log().log;
+  eversion_t current = log.empty() ? eversion_t() : log.rbegin()->version;
+  if (version <= current) {
+    return true;
+  } else {
+    waiting_for_update = version;
+    return false;
+  }
+}
+
+void PGScrubber::generate_and_submit_chunk_result(
+  const hobject_t &begin,
+  const hobject_t &end,
+  bool deep)
+{
+  LOG_PREFIX(PGScrubber::generate_and_submit_chunk_result);
+  DEBUGDPP("begin: {}, end: {}, deep: {}", pg, begin, end, deep);
+  std::ignore = pg.shard_services.start_operation_may_interrupt<
+    interruptor, ScrubScan
+    >(&pg, deep, false /* local */, begin, end);
+}
+
+#define LOG_SCRUB_ERROR(MSG, ...) {					\
+    auto errorstr = fmt::format(MSG, __VA_ARGS__);			\
+    ERRORDPP("{}", pg, errorstr);					\
+    pg.get_clog_error() << "pg " << pg.get_pgid() << ": " << errorstr;	\
+  }
+
+void PGScrubber::emit_chunk_result(
+  const request_range_result_t &range,
+  chunk_result_t &&result)
+{
+  LOG_PREFIX(PGScrubber::emit_chunk_result);
+  if (result.has_errors()) {
+    LOG_SCRUB_ERROR(
+      "Scrub errors found. range: {}, result: {}",
+      range, result);
+  } else {
+    DEBUGDPP("Chunk complete. range: {}", pg, range);
+  }
+}
+
+void PGScrubber::emit_scrub_result(
+  bool deep,
+  object_stat_sum_t in_stats)
+{
+  LOG_PREFIX(PGScrubber::emit_scrub_result);
+  DEBUGDPP("", pg);
+  pg.peering_state.update_stats(
+    [this, FNAME, deep, &in_stats](auto &history, auto &pg_stats) {
+      foreach_scrub_maintained_stat(
+	[deep, &pg_stats, &in_stats](
+	  const auto &name, auto statptr, bool skip_for_shallow) {
+	  if (deep && !skip_for_shallow) {
+	    pg_stats.stats.sum.*statptr = in_stats.*statptr;
+	  }
+	});
+      foreach_scrub_checked_stat(
+	[this, FNAME, &pg_stats, &in_stats](
+	  const auto &name, auto statptr, const auto &invalid_predicate) {
+	  if (!invalid_predicate(pg_stats) &&
+	      (in_stats.*statptr != pg_stats.stats.sum.*statptr)) {
+	    LOG_SCRUB_ERROR(
+	      "stat mismatch for {}: scrubbed value: {}, stored pg value: {}",
+	      name, in_stats.*statptr, pg_stats.stats.sum.*statptr);
+	    ++pg_stats.stats.sum.num_shallow_scrub_errors;
+	  }
+	});
+      history.last_scrub = pg.peering_state.get_info().last_update;
+      auto now = ceph_clock_now();
+      history.last_scrub_stamp = now;
+      if (deep) {
+	history.last_deep_scrub_stamp = now;
+      }
+      return false; // notify_scrub_end will flush stats to osd
+    });
+}
+
+}

--- a/src/crimson/osd/scrub/pg_scrubber.h
+++ b/src/crimson/osd/scrub/pg_scrubber.h
@@ -1,0 +1,152 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#pragma once
+
+#include "crimson/osd/pg_interval_interrupt_condition.h"
+#include "scrub_machine.h"
+
+namespace crimson::osd {
+class PG;
+class ScrubScan;
+class ScrubFindRange;
+class ScrubReserveRange;
+}
+
+namespace crimson::osd::scrub {
+
+struct blocked_range_t {
+  hobject_t begin;
+  hobject_t end;
+  seastar::shared_promise<> p;
+};
+
+class PGScrubber : public crimson::BlockerT<PGScrubber>, ScrubContext {
+  friend class ::crimson::osd::ScrubScan;
+  friend class ::crimson::osd::ScrubFindRange;
+  friend class ::crimson::osd::ScrubReserveRange;
+
+  using interruptor = ::crimson::interruptible::interruptor<
+    ::crimson::osd::IOInterruptCondition>;
+  template <typename T = void>
+  using ifut =
+    ::crimson::interruptible::interruptible_future<
+      ::crimson::osd::IOInterruptCondition, T>;
+
+  PG &pg;
+
+  /// PG alias for logging in header functions
+  DoutPrefixProvider &dpp;
+
+  ScrubMachine machine;
+
+  std::optional<blocked_range_t> blocked;
+
+  std::optional<eversion_t> waiting_for_update;
+
+  template <typename E>
+  void handle_event(E &&e)
+  {
+    LOG_PREFIX(PGScrubber::handle_event);
+    SUBDEBUGDPP(osd, "handle_event: {}", dpp, e);
+    machine.process_event(std::forward<E>(e));
+  }
+
+public:
+  static constexpr const char *type_name = "PGScrubber";
+  using Blocker = PGScrubber;
+  void dump_detail(Formatter *f) const;
+
+  static inline bool is_scrub_message(Message &m) {
+    switch (m.get_type()) {
+    case MSG_OSD_REP_SCRUB:
+    case MSG_OSD_REP_SCRUBMAP:
+      return true;
+    default:
+      return false;
+    }
+    return false;
+  }
+
+  PGScrubber(PG &pg);
+
+  /// setup scrub machine state
+  void initiate() { machine.initiate(); }
+
+  /// notify machine on primary that PG is active+clean
+  void on_primary_active_clean();
+
+  /// notify machine on replica that PG is active
+  void on_replica_activate();
+
+  /// notify machine of interval change
+  void on_interval_change();
+
+  /// notify machine that PG has committed up to versino v
+  void on_log_update(eversion_t v);
+
+  /// handle scrub request
+  void handle_scrub_requested(bool deep);
+
+
+  /// handle other scrub message
+  void handle_scrub_message(Message &m);
+
+  /// notify machine of a mutation of on_object resulting in delta_stats
+  void handle_op_stats(
+    const hobject_t &on_object,
+    object_stat_sum_t delta_stats);
+
+  /// maybe block an op trying to mutate hoid until chunk is complete
+  ifut<> wait_scrub(
+    PGScrubber::BlockingEvent::TriggerI&& trigger,
+    const hobject_t &hoid);
+
+private:
+  DoutPrefixProvider &get_dpp() final { return dpp; }
+
+  void notify_scrub_start(bool deep) final;
+  void notify_scrub_end(bool deep) final;
+
+  const std::set<pg_shard_t> &get_ids_to_scrub() const final;
+
+  chunk_validation_policy_t get_policy() const final;
+
+  void request_range(const hobject_t &start) final;
+  void reserve_range(const hobject_t &start, const hobject_t &end) final;
+  void release_range() final;
+  void scan_range(
+    pg_shard_t target,
+    eversion_t version,
+    bool deep,
+    const hobject_t &start,
+    const hobject_t &end) final;
+  bool await_update(const eversion_t &version) final;
+  void generate_and_submit_chunk_result(
+    const hobject_t &begin,
+    const hobject_t &end,
+    bool deep) final;
+  void emit_chunk_result(
+    const request_range_result_t &range,
+    chunk_result_t &&result) final;
+  void emit_scrub_result(
+    bool deep,
+    object_stat_sum_t scrub_stats) final;
+};
+
+};
+
+template <>
+struct fmt::formatter<crimson::osd::scrub::blocked_range_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &range, FormatContext& ctx)
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "{}~{}",
+      range.begin,
+      range.end);
+  }
+};

--- a/src/crimson/osd/scrub/scrub_machine.cc
+++ b/src/crimson/osd/scrub/scrub_machine.cc
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/ceph_assert.h"
+
+#include "crimson/osd/scrub/scrub_machine.h"
+
+namespace crimson::osd::scrub {
+
+WaitUpdate::WaitUpdate(my_context ctx) : ScrubState(ctx)
+{
+  auto &cs = context<ChunkState>();
+  cs.range_reserved = true;
+  assert(cs.range);
+  get_scrub_context().reserve_range(cs.range->start, cs.range->end);
+}
+
+ScanRange::ScanRange(my_context ctx) : ScrubState(ctx)
+{
+  ceph_assert(context<ChunkState>().range);
+  const auto &cs = context<ChunkState>();
+  const auto &range = cs.range.value();
+  get_scrub_context(
+  ).foreach_id_to_scrub([this, &range, &cs](const auto &id) {
+    get_scrub_context().scan_range(
+      id, cs.version,
+      context<Scrubbing>().deep,
+      range.start, range.end);
+    waiting_on++;
+  });
+}
+
+sc::result ScanRange::react(const ScrubContext::scan_range_complete_t &event)
+{
+  auto [_, inserted] = maps.insert(event.value.to_pair());
+  ceph_assert(inserted);
+  ceph_assert(waiting_on > 0);
+  --waiting_on;
+
+  if (waiting_on > 0) {
+    return discard_event();
+  } else {
+    ceph_assert(context<ChunkState>().range);
+    {
+      auto results = validate_chunk(
+	get_scrub_context().get_dpp(),
+	context<Scrubbing>().policy,
+	maps);
+      context<Scrubbing>().stats.add(results.stats);
+      get_scrub_context().emit_chunk_result(
+	*(context<ChunkState>().range),
+	std::move(results));
+    }
+    if (context<ChunkState>().range->end.is_max()) {
+      get_scrub_context().emit_scrub_result(
+	context<Scrubbing>().deep,
+	context<Scrubbing>().stats);
+      return transit<PrimaryActive>();
+    } else {
+      context<Scrubbing>().advance_current(
+	context<ChunkState>().range->end);
+      return transit<ChunkState>();
+    }
+  }
+}
+
+ReplicaScanChunk::ReplicaScanChunk(my_context ctx) : ScrubState(ctx)
+{
+  auto &to_scan = context<ReplicaChunkState>().to_scan;
+  get_scrub_context().generate_and_submit_chunk_result(
+    to_scan.start,
+    to_scan.end,
+    to_scan.deep);
+}
+
+};

--- a/src/crimson/osd/scrub/scrub_machine.h
+++ b/src/crimson/osd/scrub/scrub_machine.h
@@ -1,0 +1,613 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+#include <ranges>
+
+#include <boost/statechart/custom_reaction.hpp>
+#include <boost/statechart/deferral.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/statechart/event_base.hpp>
+#include <boost/statechart/in_state_reaction.hpp>
+#include <boost/statechart/simple_state.hpp>
+#include <boost/statechart/state.hpp>
+#include <boost/statechart/state_machine.hpp>
+#include <boost/statechart/transition.hpp>
+
+#include "common/fmt_common.h"
+#include "common/hobject.h"
+#include "common/hobject_fmt.h"
+#include "crimson/common/log.h"
+#include "osd/osd_types_fmt.h"
+#include "scrub_validator.h"
+
+namespace crimson::osd::scrub {
+
+/* Development Notes
+ *
+ * Notes:
+ * - We're leaving out all of the throttle waits.  We actually want to handle
+ *   that using crimson's operation throttler machinery.
+ *
+ * TODOs:
+ * - Leaving SnapMapper validation to later work
+ *   - Note, each replica should validate and repair locally as the SnapMapper
+ *     is meant to be a local index of the local object contents
+ * - Leaving preemption for later
+ * - Leaving scheduling for later, for now the only way to trigger a scrub
+ *   is via the ceph tell <pgid> [deep_]scrub command
+ */
+
+namespace sc = boost::statechart;
+
+template <typename T>
+struct simple_event_t : sc::event<T> {
+  template <typename FormatContext>
+  auto fmt_print_ctx(FormatContext & ctx) const {
+    return fmt::format_to(ctx.out(), "{}", T::event_name);
+  }
+};
+
+template <typename T, has_formatter V>
+struct value_event_t : sc::event<T> {
+  const V value;
+
+  template <typename... Args>
+  value_event_t(Args&&... args) : value(std::forward<Args>(args)...) {}
+
+  value_event_t(const value_event_t &) = default;
+  value_event_t(value_event_t &&) = default;
+  value_event_t &operator=(const value_event_t&) = default;
+  value_event_t &operator=(value_event_t&&) = default;
+
+  template <typename FormatContext>
+  auto fmt_print_ctx(FormatContext & ctx) const {
+    return fmt::format_to(ctx.out(), "{}", T::event_name);
+  }
+};
+
+
+#define SIMPLE_EVENT(T) struct T : simple_event_t<T> {			\
+    static constexpr const char * event_name = #T;			\
+  };
+
+#define VALUE_EVENT(T, V) struct T : value_event_t<T, V> {		\
+    static constexpr const char * event_name = #T;			\
+									\
+    template <typename... Args>						\
+    T(Args&&... args) : value_event_t(					\
+      std::forward<Args>(args)...) {}					\
+  };
+
+/**
+ * ScrubContext
+ *
+ * Interface to external PG/OSD/IO machinery.
+ *
+ * Methods which may take time return immediately and define an event which
+ * will be asynchronously delivered to the state machine with the result.  This
+ * is a bit clumsy to use, but should render this component highly testable.
+ *
+ * Events sent as a completion to a ScrubContext interface method are defined
+ * within ScrubContext.  Other events are defined within ScrubMachine.
+ */
+struct ScrubContext {
+  /// return ids to scrub
+  virtual const std::set<pg_shard_t> &get_ids_to_scrub() const = 0;
+
+  /// iterates over each pg_shard_t to scrub
+  template <typename F>
+  void foreach_id_to_scrub(F &&f) {
+    for (const auto &id : get_ids_to_scrub()) {
+      std::invoke(f, id);
+    }
+  }
+
+  /// return struct defining chunk validation rules
+  virtual chunk_validation_policy_t get_policy() const = 0;
+
+  /// notifies implementation of scrub start
+  virtual void notify_scrub_start(bool deep) = 0;
+
+  /// notifies implementation of scrub end
+  virtual void notify_scrub_end(bool deep) = 0;
+
+  /// requests range to scrub starting at start
+  struct request_range_result_t {
+    hobject_t start;
+    hobject_t end;
+
+    request_range_result_t(
+      const hobject_t &start,
+      const hobject_t &end) : start(start), end(end) {}
+
+    auto fmt_print_ctx(auto &ctx) const -> decltype(ctx.out()) {
+      return fmt::format_to(ctx.out(), "start: {}, end: {}", start, end);
+    }
+  };
+  VALUE_EVENT(request_range_complete_t, request_range_result_t);
+  virtual void request_range(
+    const hobject_t &start) = 0;
+
+  /// reserves range [start, end)
+  VALUE_EVENT(reserve_range_complete_t, eversion_t);
+  virtual void reserve_range(
+    const hobject_t &start,
+    const hobject_t &end) = 0;
+
+  /// waits until implementation has committed up to version
+  SIMPLE_EVENT(await_update_complete_t);
+  virtual bool await_update(
+    const eversion_t &version) = 0;
+
+  /// cancel in progress or currently reserved range
+  virtual void release_range() = 0;
+
+  /// scans [begin, end) on target as of version
+  struct scan_range_value_t {
+    pg_shard_t from;
+    ScrubMap map;
+
+    template <typename Map>
+    scan_range_value_t(
+      pg_shard_t from,
+      Map &&map) : from(from), map(std::forward<Map>(map)) {}
+
+    auto to_pair() const { return std::make_pair(from, map); }
+    auto fmt_print_ctx(auto &ctx) const -> decltype(ctx.out()) {
+      return fmt::format_to(ctx.out(), "from: {}", from);
+    }
+  };
+  VALUE_EVENT(scan_range_complete_t, scan_range_value_t);
+  virtual void scan_range(
+    pg_shard_t target,
+    eversion_t version,
+    bool deep,
+    const hobject_t &start,
+    const hobject_t &end) = 0;
+
+  /// instructs implmentatino to scan [begin, end) and emit result to primary
+  SIMPLE_EVENT(generate_and_submit_chunk_result_complete_t);
+  virtual void generate_and_submit_chunk_result(
+    const hobject_t &begin,
+    const hobject_t &end,
+    bool deep) = 0;
+
+  /// notifies implementation of chunk scrub results
+  virtual void emit_chunk_result(
+    const request_range_result_t &range,
+    chunk_result_t &&result) = 0;
+
+  /// notifies implementation of full scrub results
+  virtual void emit_scrub_result(
+    bool deep,
+    object_stat_sum_t scrub_stats) = 0;
+
+  /// get dpp instance for logging
+  virtual DoutPrefixProvider &get_dpp() = 0;
+};
+
+struct Crash;
+struct Inactive;
+
+namespace events {
+/// reset ScrubMachine
+SIMPLE_EVENT(reset_t);
+
+/// start (deep) scrub
+struct start_scrub_event_t {
+  bool deep = false;
+
+  start_scrub_event_t(bool deep) : deep(deep) {}
+
+  auto fmt_print_ctx(auto &ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "deep: {}", deep);
+  }
+};
+VALUE_EVENT(start_scrub_t, start_scrub_event_t);
+
+/// notifies ScrubMachine about a write on oid resulting in delta_stats
+struct op_stat_event_t {
+  hobject_t oid;
+  object_stat_sum_t delta_stats;
+
+  op_stat_event_t(
+    hobject_t oid,
+    object_stat_sum_t delta_stats) : oid(oid), delta_stats(delta_stats) {}
+
+  auto fmt_print_ctx(auto &ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "oid: {}", oid);
+  }
+};
+VALUE_EVENT(op_stats_t, op_stat_event_t);
+
+/// Prepares statemachine for primary events
+SIMPLE_EVENT(primary_activate_t);
+
+/// Prepares statemachine for replica events
+SIMPLE_EVENT(replica_activate_t);
+
+/// Instructs replica to (deep) scrub [start, end) as of version version
+struct replica_scan_event_t {
+  hobject_t start;
+  hobject_t end;
+  eversion_t version;
+  bool deep = false;
+
+  replica_scan_event_t() = default;
+
+  replica_scan_event_t(
+    hobject_t start,
+    hobject_t end,
+    eversion_t version,
+    bool deep) : start(start), end(end), version(version), deep(deep) {}
+
+  auto fmt_print_ctx(auto &ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(), "start: {}, end: {}, version: {}, deep: {}",
+      start, end, version, deep);
+  }
+};
+VALUE_EVENT(replica_scan_t, replica_scan_event_t);
+
+}
+
+
+/**
+ * ScrubMachine
+ *
+ * Manages orchestration of rados's distributed scrub process.
+ *
+ * There are two general ways in which ScrubMachine may need to release
+ * resources:
+ * - interval_change_t -- represents case where PG as a whole undergoes
+ *   a distributed mapping change.  Distributed resources are released
+ *   implicitly as remote PG instances receive the new map.  Local
+ *   resources are still released by ScrubMachine via ScrubContext methods
+ *   generally via state destructors
+ * - otherwise, ScrubMachine is responsible for notifying remote PG
+ *   instances via the appropriate ScrubContext methods again generally
+ *   from state destructors.
+ *
+ * TODO: interval_change_t will be added with remote reservations.
+ */
+class ScrubMachine
+  : public sc::state_machine<ScrubMachine, Inactive> {
+public:
+  static constexpr std::string_view full_name = "ScrubMachine";
+
+  ScrubContext &context;
+  ScrubMachine(ScrubContext &context) : context(context) {}
+};
+
+/**
+ * ScrubState
+ *
+ * Template defining machinery/state common to all scrub state machine
+ * states.
+ */
+template <typename S, typename P, typename... T>
+struct ScrubState : sc::state<S, P, T...> {
+  using sc_base = sc::state<S, P, T...>;
+  DoutPrefixProvider &dpp;
+
+  /* machinery for populating a full_name member for each ScrubState with
+   * ScrubMachine/.../ParentState/ChildState full_name */
+  template <std::string_view const &PN, typename PI,
+	    std::string_view const &CN, typename CI>
+  struct concat;
+
+  template <std::string_view const &PN, std::size_t... PI,
+	    std::string_view const &CN, std::size_t... CI>
+  struct concat<PN, std::index_sequence<PI...>, CN, std::index_sequence<CI...>> {
+    static constexpr size_t value_size = PN.size() + CN.size() + 1;
+    static constexpr const char value[value_size]{PN[PI]..., '/', CN[CI]...};
+  };
+
+  template <std::string_view const &PN, std::string_view const &CN>
+  struct join {
+    using conc = concat<
+      PN, std::make_index_sequence<PN.size()>,
+      CN, std::make_index_sequence<CN.size()>>;
+    static constexpr std::string_view value{
+      conc::value,
+      conc::value_size
+    };
+  };
+
+  /// Populated with ScrubMachine/.../Parent/Child for each state Child
+  static constexpr std::string_view full_name =
+    join<P::full_name, S::state_name>::value;
+
+  template <typename C>
+  explicit ScrubState(C ctx) : sc_base(ctx), dpp(get_scrub_context().get_dpp()) {
+    LOG_PREFIX(ScrubState::ScrubState);
+    SUBDEBUGDPP(osd, "entering state {}", dpp, full_name);
+  }
+
+  ~ScrubState() {
+    LOG_PREFIX(ScrubState::~ScrubState);
+    SUBDEBUGDPP(osd, "exiting state {}", dpp, full_name);
+  }
+
+  auto &get_scrub_context() {
+    return sc_base::template context<ScrubMachine>().context;
+  }
+};
+
+struct Crash : ScrubState<Crash, ScrubMachine> {
+  static constexpr std::string_view state_name = "Crash";
+  explicit Crash(my_context ctx) : ScrubState(ctx) {
+    ceph_abort("Crash state impossible");
+  }
+
+};
+
+struct PrimaryActive;
+struct ReplicaActive;
+struct Inactive : ScrubState<Inactive, ScrubMachine> {
+  static constexpr std::string_view state_name = "Inactive";
+  explicit Inactive(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::transition<events::primary_activate_t, PrimaryActive>,
+    sc::transition<events::replica_activate_t, ReplicaActive>,
+    sc::custom_reaction<events::reset_t>,
+    sc::custom_reaction<events::start_scrub_t>,
+    sc::custom_reaction<events::op_stats_t>,
+    sc::transition< boost::statechart::event_base, Crash >
+    >;
+
+  sc::result react(const events::reset_t &) {
+    return discard_event();
+  }
+  sc::result react(const events::start_scrub_t &) {
+    return discard_event();
+  }
+  sc::result react(const events::op_stats_t &) {
+    return discard_event();
+  }
+};
+
+struct AwaitScrub;
+struct PrimaryActive : ScrubState<PrimaryActive, ScrubMachine, AwaitScrub> {
+  static constexpr std::string_view state_name = "PrimaryActive";
+  explicit PrimaryActive(my_context ctx) : ScrubState(ctx) {}
+
+  bool local_reservation_held = false;
+  std::set<pg_shard_t> remote_reservations_held;
+
+  using reactions = boost::mpl::list<
+    sc::transition<events::reset_t, Inactive>,
+    sc::custom_reaction<events::start_scrub_t>,
+    sc::custom_reaction<events::op_stats_t>,
+    sc::transition< boost::statechart::event_base, Crash >
+    >;
+
+  sc::result react(const events::start_scrub_t &event) {
+    return discard_event();
+  }
+
+  sc::result react(const events::op_stats_t &) {
+    return discard_event();
+  }
+};
+
+namespace internal_events {
+VALUE_EVENT(set_deep_t, bool);
+}
+
+struct Scrubbing;
+struct AwaitScrub : ScrubState<AwaitScrub, PrimaryActive> {
+  static constexpr std::string_view state_name = "AwaitScrub";
+  explicit AwaitScrub(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<events::start_scrub_t>
+    >;
+
+  sc::result react(const events::start_scrub_t &event) {
+    post_event(internal_events::set_deep_t{event.value.deep});
+    return transit<Scrubbing>();
+  }
+};
+
+struct ChunkState;
+struct Scrubbing : ScrubState<Scrubbing, PrimaryActive, ChunkState> {
+  static constexpr std::string_view state_name = "Scrubbing";
+  explicit Scrubbing(my_context ctx)
+    : ScrubState(ctx), policy(get_scrub_context().get_policy()) {}
+
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<internal_events::set_deep_t>,
+    sc::custom_reaction<events::op_stats_t>
+    >;
+
+  chunk_validation_policy_t policy;
+
+  /// hobjects < current have been scrubbed
+  hobject_t current;
+
+  /// true for deep scrub
+  bool deep = false;
+
+  /// stats for objects < current, maintained via events::op_stats_t
+  object_stat_sum_t stats;
+
+  void advance_current(const hobject_t &next) {
+    current = next;
+  }
+
+  sc::result react(const internal_events::set_deep_t &event) {
+    deep = event.value;
+    get_scrub_context().notify_scrub_start(deep);
+    return discard_event();
+  }
+
+  void exit() {
+    get_scrub_context().notify_scrub_end(deep);
+  }
+
+  sc::result react(const events::op_stats_t &event) {
+    if (event.value.oid < current) {
+      stats.add(event.value.delta_stats);
+    }
+    return discard_event();
+  }
+};
+
+struct GetRange;
+struct ChunkState : ScrubState<ChunkState, Scrubbing, GetRange> {
+  static constexpr std::string_view state_name = "ChunkState";
+  explicit ChunkState(my_context ctx) : ScrubState(ctx) {}
+
+  /// Current chunk includes objects in [range_start, range_end)
+  boost::optional<ScrubContext::request_range_result_t> range;
+
+  /// true once we have requested that the range be reserved
+  bool range_reserved = false;
+
+  /// version of last update for the reserved chunk
+  eversion_t version;
+
+  void exit() {
+    if (range_reserved) {
+      get_scrub_context().release_range();
+    }
+  }
+};
+
+struct WaitUpdate;
+struct GetRange : ScrubState<GetRange, ChunkState> {
+  static constexpr std::string_view state_name = "GetRange";
+  explicit GetRange(my_context ctx) : ScrubState(ctx) {
+    get_scrub_context().request_range(context<Scrubbing>().current);
+  }
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<ScrubContext::request_range_complete_t>
+    >;
+
+  sc::result react(const ScrubContext::request_range_complete_t &event) {
+    context<ChunkState>().range = event.value;
+    return transit<WaitUpdate>();
+  }
+};
+
+struct ScanRange;
+struct WaitUpdate : ScrubState<WaitUpdate, ChunkState> {
+  static constexpr std::string_view state_name = "WaitUpdate";
+  explicit WaitUpdate(my_context ctx);
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<ScrubContext::reserve_range_complete_t>
+    >;
+
+  sc::result react(const ScrubContext::reserve_range_complete_t &e) {
+    context<ChunkState>().version = e.value;
+    return transit<ScanRange>();
+  }
+};
+
+struct ScanRange : ScrubState<ScanRange, ChunkState> {
+  static constexpr std::string_view state_name = "ScanRange";
+  explicit ScanRange(my_context ctx);
+
+  scrub_map_set_t maps;
+  unsigned waiting_on = 0;
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<ScrubContext::scan_range_complete_t>
+    >;
+
+  sc::result react(const ScrubContext::scan_range_complete_t &);
+};
+
+struct ReplicaIdle;
+struct ReplicaActive :
+    ScrubState<ReplicaActive, ScrubMachine, ReplicaIdle> {
+  static constexpr std::string_view state_name = "ReplicaActive";
+  explicit ReplicaActive(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::transition<events::reset_t, Inactive>,
+    sc::custom_reaction<events::start_scrub_t>,
+    sc::custom_reaction<events::op_stats_t>,
+    sc::transition< boost::statechart::event_base, Crash >
+    >;
+
+  sc::result react(const events::start_scrub_t &) {
+    return discard_event();
+  }
+
+  sc::result react(const events::op_stats_t &) {
+    return discard_event();
+  }
+};
+
+struct ReplicaChunkState;
+struct ReplicaIdle : ScrubState<ReplicaIdle, ReplicaActive> {
+  static constexpr std::string_view state_name = "ReplicaIdle";
+  explicit ReplicaIdle(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<events::replica_scan_t>
+    >;
+
+  sc::result react(const events::replica_scan_t &event) {
+    LOG_PREFIX(ScrubState::ReplicaIdle::react(events::replica_scan_t));
+    SUBDEBUGDPP(osd, "event.value: {}", get_scrub_context().get_dpp(), event.value);
+    post_event(event);
+    return transit<ReplicaChunkState>();
+  }
+};
+
+struct ReplicaWaitUpdate;
+struct ReplicaChunkState : ScrubState<ReplicaChunkState, ReplicaActive, ReplicaWaitUpdate> {
+  static constexpr std::string_view state_name = "ReplicaChunkState";
+  explicit ReplicaChunkState(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::custom_reaction<events::replica_scan_t>
+    >;
+
+  events::replica_scan_event_t to_scan;
+
+  sc::result react(const events::replica_scan_t &event) {
+    LOG_PREFIX(ScrubState::ReplicaWaitUpdate::react(events::replica_scan_t));
+    SUBDEBUGDPP(osd, "event.value: {}", get_scrub_context().get_dpp(), event.value);
+    to_scan = event.value;
+    if (get_scrub_context().await_update(event.value.version)) {
+      post_event(ScrubContext::await_update_complete_t{});
+    }
+    return discard_event();
+  }
+};
+
+struct ReplicaScanChunk;
+struct ReplicaWaitUpdate : ScrubState<ReplicaWaitUpdate, ReplicaChunkState> {
+  static constexpr std::string_view state_name = "ReplicaWaitUpdate";
+  explicit ReplicaWaitUpdate(my_context ctx) : ScrubState(ctx) {}
+
+  using reactions = boost::mpl::list<
+    sc::transition<ScrubContext::await_update_complete_t, ReplicaScanChunk>
+    >;
+};
+
+struct ReplicaScanChunk : ScrubState<ReplicaScanChunk, ReplicaChunkState> {
+  static constexpr std::string_view state_name = "ReplicaScanChunk";
+  explicit ReplicaScanChunk(my_context ctx);
+
+  using reactions = boost::mpl::list<
+    sc::transition<ScrubContext::generate_and_submit_chunk_result_complete_t,
+		   ReplicaIdle>
+    >;
+};
+
+#undef SIMPLE_EVENT
+#undef VALUE_EVENT
+
+}

--- a/src/crimson/osd/scrub/scrub_validator.cc
+++ b/src/crimson/osd/scrub/scrub_validator.cc
@@ -1,0 +1,502 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <ranges>
+
+#include "osd/osd_types_fmt.h"
+
+#include "crimson/common/log.h"
+#include "crimson/osd/scrub/scrub_validator.h"
+#include "osd/ECUtil.h"
+
+SET_SUBSYS(osd);
+
+namespace crimson::osd::scrub {
+
+using object_set_t = std::set<hobject_t>;
+object_set_t get_object_set(const scrub_map_set_t &in)
+{
+  object_set_t ret;
+  for (const auto& [from, map] : in) {
+    std::transform(map.objects.begin(), map.objects.end(),
+                   std::inserter(ret, ret.end()),
+                   [](const auto& i) { return i.first; });
+  }
+  return ret;
+}
+
+struct shard_evaluation_t {
+  pg_shard_t source;
+  shard_info_wrapper shard_info;
+
+  std::optional<object_info_t> object_info;
+  std::optional<SnapSet> snapset;
+  std::optional<ECUtil::HashInfo> hinfo;
+
+  size_t omap_keys{0};
+  size_t omap_bytes{0};
+
+  bool has_errors() const {
+    return shard_info.has_errors();
+  }
+
+  bool is_primary() const {
+    return shard_info.primary;
+  }
+
+  std::weak_ordering operator<=>(const shard_evaluation_t &rhs) const {
+    return std::make_tuple(!has_errors(), is_primary()) <=>
+      std::make_tuple(!rhs.has_errors(), rhs.is_primary());
+  }
+};
+shard_evaluation_t evaluate_object_shard(
+  const chunk_validation_policy_t &policy,
+  const hobject_t &oid,
+  pg_shard_t from,
+  const ScrubMap::object *maybe_obj)
+{
+  shard_evaluation_t ret;
+  ret.source = from;
+  if (from == policy.primary) {
+    ret.shard_info.primary = true;
+  }
+  if (!maybe_obj || maybe_obj->negative) {
+    // impossible since chunky scrub was introduced
+    ceph_assert(!maybe_obj->negative);
+    ret.shard_info.set_missing();
+    return ret;
+  }
+
+  auto &obj = *maybe_obj;
+  /* We are ignoring ScrubMap::object::large_omap_object*, object_omap_* is all the
+   * info we need */
+  ret.omap_keys = obj.object_omap_keys;
+  ret.omap_bytes = obj.object_omap_bytes;
+
+  ret.shard_info.set_object(obj);
+
+  if (obj.ec_hash_mismatch) {
+    ret.shard_info.set_ec_hash_mismatch();
+  }
+
+  if (obj.ec_size_mismatch) {
+    ret.shard_info.set_ec_size_mismatch();
+  }
+
+  if (obj.read_error) {
+    ret.shard_info.set_read_error();
+  }
+
+  if (obj.stat_error) {
+    ret.shard_info.set_stat_error();
+  }
+
+  {
+    auto xiter = obj.attrs.find(OI_ATTR);
+    if (xiter == obj.attrs.end()) {
+      ret.shard_info.set_info_missing();
+    } else {
+      bufferlist bl;
+      bl.push_back(xiter->second);
+      ret.object_info = object_info_t{};
+      try {
+	auto bliter = bl.cbegin();
+	::decode(*(ret.object_info), bliter);
+      } catch (...) {
+	ret.shard_info.set_info_corrupted();
+	ret.object_info = std::nullopt;
+      }
+    }
+  }
+
+  ret.shard_info.size = obj.size;
+  if (ret.object_info &&
+      obj.size != policy.logical_to_ondisk_size(ret.object_info->size)) {
+    ret.shard_info.set_size_mismatch_info();
+  }
+
+  if (oid.is_head()) {
+    auto xiter = obj.attrs.find(SS_ATTR);
+    if (xiter == obj.attrs.end()) {
+      ret.shard_info.set_snapset_missing();
+    } else {
+      bufferlist bl;
+      bl.push_back(xiter->second);
+      ret.snapset = SnapSet{};
+      try {
+	auto bliter = bl.cbegin();
+	::decode(*(ret.snapset), bliter);
+      } catch (...) {
+	ret.shard_info.set_snapset_corrupted();
+	ret.snapset = std::nullopt;
+      }
+    }
+  }
+
+  if (policy.is_ec()) {
+    auto xiter = obj.attrs.find(ECUtil::get_hinfo_key());
+    if (xiter == obj.attrs.end()) {
+      ret.shard_info.set_hinfo_missing();
+    } else {
+      bufferlist bl;
+      bl.push_back(xiter->second);
+      ret.hinfo = ECUtil::HashInfo{};
+      try {
+	auto bliter = bl.cbegin();
+	decode(*(ret.hinfo), bliter);
+      } catch (...) {
+	ret.shard_info.set_hinfo_corrupted();
+	ret.hinfo = std::nullopt;
+      }
+    }
+  }
+
+  if (ret.object_info) {
+    if (ret.shard_info.data_digest_present &&
+	ret.object_info->is_data_digest() &&
+	(ret.object_info->data_digest != ret.shard_info.data_digest)) {
+      ret.shard_info.set_data_digest_mismatch_info();
+    }
+    if (ret.shard_info.omap_digest_present &&
+	ret.object_info->is_omap_digest() &&
+	(ret.object_info->omap_digest != ret.shard_info.omap_digest)) {
+      ret.shard_info.set_omap_digest_mismatch_info();
+    }
+  }
+
+  return ret;
+}
+
+librados::obj_err_t compare_candidate_to_authoritative(
+  const chunk_validation_policy_t &policy,
+  const hobject_t &oid,
+  const shard_evaluation_t &auth,
+  const shard_evaluation_t &cand)
+{
+  using namespace librados;
+  obj_err_t ret;
+
+  if (cand.shard_info.has_shard_missing()) {
+    return ret;
+  }
+
+  const auto &auth_si = auth.shard_info;
+  const auto &cand_si = cand.shard_info;
+
+  if (auth_si.data_digest != cand_si.data_digest) {
+    ret.errors |= obj_err_t::DATA_DIGEST_MISMATCH;
+  }
+
+  if (auth_si.omap_digest != cand_si.omap_digest) {
+    ret.errors |= obj_err_t::OMAP_DIGEST_MISMATCH;
+  }
+
+  {
+    auto aiter = auth_si.attrs.find(OI_ATTR);
+    ceph_assert(aiter != auth_si.attrs.end());
+
+    auto citer = cand_si.attrs.find(OI_ATTR);
+    if (citer == cand_si.attrs.end() ||
+	!aiter->second.contents_equal(citer->second)) {
+      ret.errors |= obj_err_t::OBJECT_INFO_INCONSISTENCY;
+    }
+  }
+
+  if (oid.is_head()) {
+    auto aiter = auth_si.attrs.find(SS_ATTR);
+    ceph_assert(aiter != auth_si.attrs.end());
+
+    auto citer = cand_si.attrs.find(SS_ATTR);
+    if (citer == cand_si.attrs.end() ||
+	!aiter->second.contents_equal(citer->second)) {
+      ret.errors |= obj_err_t::SNAPSET_INCONSISTENCY;
+    }
+  }
+
+  if (policy.is_ec()) {
+    auto aiter = auth_si.attrs.find(ECUtil::get_hinfo_key());
+    ceph_assert(aiter != auth_si.attrs.end());
+
+    auto citer = cand_si.attrs.find(ECUtil::get_hinfo_key());
+    if (citer == cand_si.attrs.end() ||
+	!aiter->second.contents_equal(citer->second)) {
+      ret.errors |= obj_err_t::HINFO_INCONSISTENCY;
+    }
+  }
+
+  if (auth_si.size != cand_si.size) {
+    ret.errors |= obj_err_t::SIZE_MISMATCH;
+  }
+
+  auto is_sys_attr = [&policy](const auto &str) {
+    return str == OI_ATTR || str == SS_ATTR ||
+      (policy.is_ec() && str == ECUtil::get_hinfo_key());
+  };
+  for (auto aiter = auth_si.attrs.begin(); aiter != auth_si.attrs.end(); ++aiter) {
+    if (is_sys_attr(aiter->first)) continue;
+
+    auto citer = cand_si.attrs.find(aiter->first);
+    if (citer == cand_si.attrs.end()) {
+      ret.errors |= obj_err_t::ATTR_NAME_MISMATCH;
+    } else if (!aiter->second.contents_equal(citer->second)) {
+      ret.errors |= obj_err_t::ATTR_VALUE_MISMATCH;
+    }
+  }
+  if (std::any_of(
+	cand_si.attrs.begin(), cand_si.attrs.end(),
+	[&is_sys_attr, &auth_si](auto &p) {
+	  return !is_sys_attr(p.first) &&
+	    auth_si.attrs.find(p.first) == auth_si.attrs.end();
+	})) {
+    ret.errors |= obj_err_t::ATTR_NAME_MISMATCH;
+  }
+
+  return ret;
+}
+
+struct object_evaluation_t {
+  std::optional<inconsistent_obj_wrapper> inconsistency;
+  std::optional<object_info_t> object_info;
+  std::optional<SnapSet> snapset;
+
+  size_t omap_keys{0};
+  size_t omap_bytes{0};
+};
+object_evaluation_t evaluate_object(
+  const chunk_validation_policy_t &policy,
+  const hobject_t &hoid,
+  const scrub_map_set_t &maps)
+{
+  ceph_assert(maps.size() > 0);
+  using evaluation_vec_t = std::vector<shard_evaluation_t>;
+  evaluation_vec_t shards;
+  std::transform(
+    maps.begin(), maps.end(),
+    std::inserter(shards, shards.end()),
+    [&hoid, &policy](const auto &item) -> evaluation_vec_t::value_type {
+      const auto &[shard, scrub_map] = item;
+      auto miter = scrub_map.objects.find(hoid);
+      auto maybe_shard = miter == scrub_map.objects.end() ?
+	nullptr : &(miter->second);
+      return evaluate_object_shard(policy, hoid, shard, maybe_shard);
+    });
+
+  std::sort(shards.begin(), shards.end());
+
+  auto &auth_eval = shards.back();
+
+  object_evaluation_t ret;
+  inconsistent_obj_wrapper iow{hoid};
+  if (!auth_eval.has_errors()) {
+    ret.object_info = auth_eval.object_info;
+    ret.omap_keys = auth_eval.omap_keys;
+    ret.omap_bytes = auth_eval.omap_bytes;
+    ret.snapset = auth_eval.snapset;
+    if (auth_eval.object_info->size > policy.max_object_size) {
+      iow.set_size_too_large();
+    }
+    auth_eval.shard_info.selected_oi = true;
+    std::for_each(
+      shards.begin(), shards.end() - 1,
+      [&policy, &hoid, &auth_eval, &iow](auto &cand_eval) {
+	auto err = compare_candidate_to_authoritative(
+	  policy, hoid, auth_eval, cand_eval);
+	iow.merge(err);
+      });
+  }
+
+  if (iow.errors ||
+      std::any_of(shards.begin(), shards.end(),
+		  [](auto &cand) { return cand.has_errors(); })) {
+    for (auto &eval : shards) {
+      iow.shards.emplace(
+	librados::osd_shard_t{eval.source.osd, eval.source.shard},
+	eval.shard_info);
+      iow.union_shards.errors |= eval.shard_info.errors;
+    }
+    if (auth_eval.object_info) {
+      iow.version = auth_eval.object_info->version.version;
+    }
+    ret.inconsistency = iow;
+  }
+  return ret;
+}
+
+using clone_meta_list_t = std::list<std::pair<hobject_t, object_info_t>>;
+std::optional<inconsistent_snapset_wrapper> evaluate_snapset(
+  DoutPrefixProvider &dpp,
+  const hobject_t &hoid,
+  const std::optional<SnapSet> &maybe_snapset,
+  const clone_meta_list_t &clones)
+{
+  LOG_PREFIX(evaluate_snapset);
+  /* inconsistent_snapset_t has several error codes that seem to pertain to
+   * specific objects rather than to the snapset specifically.  I'm choosing
+   * to ignore those for now */
+  inconsistent_snapset_wrapper ret{hoid};
+  if (!maybe_snapset) {
+    ret.set_headless();
+    return ret;
+  }
+  const auto &snapset = *maybe_snapset;
+
+  auto clone_iter = clones.begin();
+  for (auto ss_clone_id : snapset.clones) {
+    for (; clone_iter != clones.end() &&
+	   clone_iter->first.snap < ss_clone_id;
+	 ++clone_iter) {
+      ret.set_clone(clone_iter->first.snap);
+    }
+
+    if (clone_iter != clones.end() &&
+	clone_iter->first.snap == ss_clone_id) {
+      auto ss_clone_size_iter = snapset.clone_size.find(ss_clone_id);
+      if (ss_clone_size_iter == snapset.clone_size.end() ||
+	  ss_clone_size_iter->second != clone_iter->second.size) {
+	ret.set_size_mismatch();
+      }
+      ++clone_iter;
+    } else {
+      ret.set_clone_missing(ss_clone_id);
+    }
+  }
+
+  for (; clone_iter != clones.end(); ++clone_iter) {
+    ret.set_clone(clone_iter->first.snap);
+  }
+
+  if (ret.errors) {
+    DEBUGDPP(
+      "snapset {}, clones {}",
+      dpp, snapset, clones);
+    return ret;
+  } else {
+    return std::nullopt;
+  }
+}
+
+void add_object_to_stats(
+  const chunk_validation_policy_t &policy,
+  const object_evaluation_t &eval,
+  object_stat_sum_t *out)
+{
+  auto &ss = eval.snapset;
+  if (!eval.object_info) {
+    return;
+  }
+  auto &oi = *eval.object_info;
+  ceph_assert(out);
+  out->num_objects++;
+  if (ss) {
+    out->num_bytes += oi.size;
+    for (auto clone : ss->clones) {
+      out->num_bytes += ss->get_clone_bytes(clone);
+      out->num_object_clones++;
+    }
+    if (oi.is_whiteout()) {
+      out->num_whiteouts++;
+    }
+  }
+  if (oi.is_dirty()) {
+    out->num_objects_dirty++;
+  }
+  if (oi.is_cache_pinned()) {
+    out->num_objects_pinned++;
+  }
+  if (oi.has_manifest()) {
+    out->num_objects_manifest++;
+  }
+
+  if (eval.omap_keys > 0) {
+    out->num_objects_omap++;
+  }
+  out->num_omap_keys += eval.omap_keys;
+  out->num_omap_bytes += eval.omap_bytes;
+
+  if (oi.soid.nspace == policy.hitset_namespace) {
+    out->num_objects_hit_set_archive++;
+    out->num_bytes_hit_set_archive += oi.size;
+  }
+
+  if (eval.omap_keys > policy.omap_key_limit ||
+      eval.omap_bytes > policy.omap_bytes_limit) {
+    out->num_large_omap_objects++;
+  }
+}
+
+chunk_result_t validate_chunk(
+  DoutPrefixProvider &dpp,
+  const chunk_validation_policy_t &policy, const scrub_map_set_t &in)
+{
+  chunk_result_t ret;
+
+  const std::set<hobject_t> object_set = get_object_set(in);
+
+  std::list<std::pair<hobject_t, SnapSet>> heads;
+  clone_meta_list_t clones;
+  for (const auto &oid: object_set) {
+    object_evaluation_t eval = evaluate_object(policy, oid, in);
+    add_object_to_stats(policy, eval, &ret.stats);
+    if (eval.inconsistency) {
+      ret.object_errors.push_back(*eval.inconsistency);
+    }
+    if (oid.is_head()) {
+      /* We're only going to consider the head object as "existing" if
+       * evaluate_object was able to find a sensible, authoritative copy
+       * complete with snapset */
+      if (eval.snapset) {
+	heads.emplace_back(oid, *eval.snapset);
+      }
+    } else {
+      /* We're only going to consider the clone object as "existing" if
+       * evaluate_object was able to find a sensible, authoritative copy
+       * complete with an object_info */
+      if (eval.object_info) {
+	clones.emplace_back(oid, *eval.object_info);
+      }
+    }
+  }
+
+  const hobject_t max_oid = hobject_t::get_max();
+  while (heads.size() || clones.size()) {
+    const hobject_t &next_head = heads.size() ? heads.front().first : max_oid;
+    const hobject_t &next_clone = clones.size() ? clones.front().first : max_oid;
+    hobject_t head_to_process = std::min(next_head, next_clone).get_head();
+
+    clone_meta_list_t clones_to_process;
+    auto clone_iter = clones.begin();
+    while (clone_iter != clones.end() && clone_iter->first < head_to_process)
+      ++clone_iter;
+    clones_to_process.splice(
+      clones_to_process.end(), clones, clones.begin(), clone_iter);
+
+    const auto head_meta = [&]() -> std::optional<SnapSet> {
+      if (head_to_process == next_head) {
+	auto ret = std::move(heads.front().second);
+	heads.pop_front();
+	return ret;
+      } else {
+	return std::nullopt;
+      }
+    }();
+
+    if (auto result = evaluate_snapset(
+	  dpp, head_to_process, head_meta, clones_to_process); result) {
+      ret.snapset_errors.push_back(*result);
+    }
+  }
+
+  for (const auto &i: ret.object_errors) {
+    ret.stats.num_shallow_scrub_errors +=
+      (i.has_shallow_errors() || i.union_shards.has_shallow_errors());
+    ret.stats.num_deep_scrub_errors +=
+      (i.has_deep_errors() || i.union_shards.has_deep_errors());
+  }
+  ret.stats.num_shallow_scrub_errors += ret.snapset_errors.size();
+  ret.stats.num_scrub_errors = ret.stats.num_shallow_scrub_errors +
+    ret.stats.num_deep_scrub_errors;
+
+  return ret;
+}
+
+}

--- a/src/crimson/osd/scrub/scrub_validator.h
+++ b/src/crimson/osd/scrub/scrub_validator.h
@@ -1,0 +1,180 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+#include <map>
+
+#include "common/config_proxy.h"
+#include "common/scrub_types.h"
+#include "crimson/common/log.h"
+#include "osd/ECUtil.h"
+#include "osd/osd_types.h"
+
+namespace crimson::osd::scrub {
+
+struct chunk_validation_policy_t {
+  pg_shard_t primary;
+  std::optional<ECUtil::stripe_info_t> stripe_info;
+
+  // osd_max_object_size
+  size_t max_object_size;
+
+  // osd_hit_set_namespace
+  std::string hitset_namespace;
+
+  // osd_deep_scrub_large_omap_object_key_threshold
+  // osd_deep_scrub_large_omap_object_value_sum_threshold
+  uint64_t omap_key_limit;
+  size_t omap_bytes_limit;
+
+
+  bool is_ec() const {
+    return !!stripe_info;
+  }
+
+  size_t logical_to_ondisk_size(size_t size) const {
+    return stripe_info ? stripe_info->logical_to_next_chunk_offset(size) : size;
+  }
+};
+
+using scrub_map_set_t = std::map<pg_shard_t, ScrubMap>;
+
+struct chunk_result_t {
+  /* Scrub interacts with stats in two ways:
+   * 1. scrub accumulates a subset of object_stat_sum_t members to
+   *    to ultimately compare to the object_stat_sum_t value maintained
+   *    by the OSD. These members will be referred to as
+   *    *scrub_checked_stats*.
+   *    See iterate_scrub_checked_stats() for the relevant members.
+   * 2. scrub also updates some members that can't be maintained online
+   *    (like num_omap_*, num_large_omap_objects) or that pertain
+   *    specifically to scrub (like num_shallow_scrub_errors).
+   *    Let these by referred to as *scrub_maintained_stats*.
+   *    See iterate_scrub_maintained_stats() for the relevant members.
+   *
+   * The following stats member contains both, but the two sets are
+   * disjoint and treated seperately.
+   */
+  object_stat_sum_t stats;
+
+  // detected errors
+  std::vector<inconsistent_snapset_wrapper> snapset_errors;
+  std::vector<inconsistent_obj_wrapper> object_errors;
+
+  bool has_errors() const {
+    return !snapset_errors.empty() || !object_errors.empty();
+  }
+};
+
+/**
+ * validate_chunk
+ *
+ * Compares shard chunks and based on policy and returns a chunk_result_t
+ * containing the results.  See chunk_result_t for details.
+ */
+chunk_result_t validate_chunk(
+  DoutPrefixProvider &dpp,
+  const chunk_validation_policy_t &policy, const scrub_map_set_t &in);
+
+/**
+ * iterate_scrub_checked_stats
+ *
+ * For each scrub_checked_stat member of object_stat_sum_t, invokes
+ * op with three arguments:
+ * - name of member (string_view)
+ * - pointer to member (T object_stat_sum_t::*)
+ * - function to corresponding pg_stat_t invalid member
+ *   (bool func(const pg_stat_t &))
+ *
+ * Should be used to perform operations on all scrub_checked_stat members
+ * such as checking the accumlated scrub stats against the maintained
+ * pg stats.
+ */
+template <typename Func>
+void foreach_scrub_checked_stat(Func &&op) {
+  using namespace std::string_view_literals;
+  op("num_objects"sv,
+     &object_stat_sum_t::num_objects,
+     [](const pg_stat_t &in) { return false; });
+  op("num_bytes"sv,
+     &object_stat_sum_t::num_bytes,
+     [](const pg_stat_t &in) { return false; });
+  op("num_object_clones"sv,
+     &object_stat_sum_t::num_object_clones,
+     [](const pg_stat_t &in) { return false; });
+  op("num_whiteouts"sv,
+     &object_stat_sum_t::num_whiteouts,
+     [](const pg_stat_t &in) { return false; });
+  op("num_objects_dirty"sv,
+     &object_stat_sum_t::num_objects_dirty,
+     [](const pg_stat_t &in) { return in.dirty_stats_invalid; });
+  op("num_objects_omap"sv,
+     &object_stat_sum_t::num_objects_omap,
+     [](const pg_stat_t &in) { return in.omap_stats_invalid; });
+  op("num_objects_pinned"sv,
+     &object_stat_sum_t::num_objects_pinned,
+     [](const pg_stat_t &in) { return in.pin_stats_invalid; });
+  op("num_objects_hit_set_archive"sv,
+     &object_stat_sum_t::num_objects_hit_set_archive,
+     [](const pg_stat_t &in) { return in.hitset_stats_invalid; });
+  op("num_bytes_hit_set_archive"sv,
+     &object_stat_sum_t::num_bytes_hit_set_archive,
+     [](const pg_stat_t &in) { return in.hitset_bytes_stats_invalid; });
+  op("num_objects_manifest"sv,
+     &object_stat_sum_t::num_objects_manifest,
+     [](const pg_stat_t &in) { return in.manifest_stats_invalid; });
+}
+
+/**
+ * iterate_scrub_maintained_stats
+ *
+ * For each scrub_maintained_stat member of object_stat_sum_t, invokes
+ * op with three arguments:
+ * - name of member (string_view)
+ * - pointer to member (T object_stat_sum_t::*)
+ * - skip for shallow (bool)
+ *
+ * Should be used to perform operations on all scrub_maintained_stat members
+ * such as updating the pg maintained instance once scrub is complete.
+ */
+template <typename Func>
+void foreach_scrub_maintained_stat(Func &&op) {
+  using namespace std::string_view_literals;
+  op("num_scrub_errors"sv, &object_stat_sum_t::num_scrub_errors, false);
+  op("num_shallow_scrub_errors"sv,
+     &object_stat_sum_t::num_shallow_scrub_errors,
+     false);
+  op("num_deep_scrub_errors"sv, &object_stat_sum_t::num_deep_scrub_errors, true);
+  op("num_omap_bytes"sv, &object_stat_sum_t::num_omap_bytes, true);
+  op("num_omap_keys"sv, &object_stat_sum_t::num_omap_keys, true);
+  op("num_large_omap_objects"sv,
+     &object_stat_sum_t::num_large_omap_objects,
+     true);
+}
+
+}
+
+template <>
+struct fmt::formatter<crimson::osd::scrub::chunk_result_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(
+    const crimson::osd::scrub::chunk_result_t &result, FormatContext& ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "chunk_result_t("
+      "num_scrub_errors: {}, "
+      "num_deep_scrub_errors: {}, "
+      "snapset_errors: [{}], "
+      "object_errors: [{}])",
+      result.stats.num_scrub_errors,
+      result.stats.num_deep_scrub_errors,
+      result.snapset_errors,
+      result.object_errors
+    );
+  }
+};

--- a/src/include/rados/rados_types.hpp
+++ b/src/include/rados/rados_types.hpp
@@ -137,6 +137,9 @@ struct err_t {
   bool has_snapset_corrupted() const {
     return errors & SNAPSET_CORRUPTED;
   }
+  bool has_errors() const {
+    return errors;
+  }
   bool has_shallow_errors() const {
     return errors & SHALLOW_ERRORS;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13277,7 +13277,11 @@ int BlueStore::omap_get_values(
       r = -ENOENT;
       goto out;
     }
-    iter->upper_bound(*start_after);
+    if (start_after) {
+      iter->upper_bound(*start_after);
+    } else {
+      iter->seek_to_first();
+    }
     for (; iter->valid(); iter->next()) {
       output->insert(make_pair(iter->key(), iter->value()));
     }

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -328,6 +328,64 @@ struct fmt::formatter<ScrubMap> {
   bool debug_log{false};
 };
 
+template <>
+struct fmt::formatter<object_stat_sum_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const object_stat_sum_t &stats, FormatContext& ctx) const
+  {
+#define FORMAT(FIELD) fmt::format_to(ctx.out(), #FIELD"={}, ", stats.FIELD);
+    fmt::format_to(ctx.out(), "object_stat_sum_t(");
+    FORMAT(num_bytes);
+    FORMAT(num_objects);
+    FORMAT(num_object_clones);
+    FORMAT(num_object_copies);
+    FORMAT(num_objects_missing_on_primary);
+    FORMAT(num_objects_missing);
+    FORMAT(num_objects_degraded);
+    FORMAT(num_objects_misplaced);
+    FORMAT(num_objects_unfound);
+    FORMAT(num_rd);
+    FORMAT(num_rd_kb);
+    FORMAT(num_wr);
+    FORMAT(num_wr_kb);
+    FORMAT(num_large_omap_objects);
+    FORMAT(num_objects_manifest);
+    FORMAT(num_omap_bytes);
+    FORMAT(num_omap_keys);
+    FORMAT(num_shallow_scrub_errors);
+    FORMAT(num_deep_scrub_errors);
+    FORMAT(num_scrub_errors);
+    FORMAT(num_objects_recovered);
+    FORMAT(num_bytes_recovered);
+    FORMAT(num_keys_recovered);
+    FORMAT(num_objects_dirty);
+    FORMAT(num_whiteouts);
+    FORMAT(num_objects_omap);
+    FORMAT(num_objects_hit_set_archive);
+    FORMAT(num_bytes_hit_set_archive);
+    FORMAT(num_flush);
+    FORMAT(num_flush_kb);
+    FORMAT(num_evict);
+    FORMAT(num_evict_kb);
+    FORMAT(num_promote);
+    FORMAT(num_flush_mode_high);
+    FORMAT(num_flush_mode_low);
+    FORMAT(num_evict_mode_some);
+    FORMAT(num_evict_mode_full);
+    FORMAT(num_objects_pinned);
+    FORMAT(num_legacy_snapsets);
+    return fmt::format_to(
+      ctx.out(), "num_objects_repaired={})",
+      stats.num_objects_repaired);
+#undef FORMAT
+  }
+};
+inline std::ostream &operator<<(std::ostream &lhs, const object_stat_sum_t &sum) {
+  return lhs << fmt::format("{}", sum);
+}
+
 #if FMT_VERSION >= 90000
 template <bool TrackChanges> struct fmt::formatter<pg_missing_set<TrackChanges>> : fmt::ostream_formatter {};
 #endif

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -103,3 +103,13 @@ target_link_libraries(
   crimson::gtest)
 add_ceph_unittest(unittest-seastar-errorator
   --memory 256M --smp 1)
+
+add_executable(unittest-crimson-scrub
+  test_crimson_scrub.cc
+  ${PROJECT_SOURCE_DIR}/src/crimson/osd/scrub/scrub_machine.cc
+  ${PROJECT_SOURCE_DIR}/src/crimson/osd/scrub/scrub_validator.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc)
+target_link_libraries(
+  unittest-crimson-scrub
+  crimson-common
+  crimson::gtest)

--- a/src/test/crimson/test_crimson_scrub.cc
+++ b/src/test/crimson/test_crimson_scrub.cc
@@ -1,0 +1,1347 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/iterator/transform_iterator.hpp>
+
+#include <fmt/ranges.h>
+
+#include <seastar/core/sleep.hh>
+
+#include "test/crimson/gtest_seastar.h"
+
+#include "include/rados/rados_types.hpp"
+#include "common/scrub_types.h"
+#include "crimson/common/interruptible_future.h"
+#include "crimson/osd/scrub/scrub_machine.h"
+#include "crimson/osd/scrub/scrub_validator.h"
+
+#include "osd/osd_types_fmt.h"
+
+constexpr static size_t TEST_MAX_OBJECT_SIZE = 128<<20;
+constexpr static std::string_view TEST_INTERNAL_NAMESPACE = ".internal";
+constexpr static uint64_t TEST_OMAP_KEY_LIMIT = 200000;
+constexpr static size_t TEST_OMAP_BYTES_LIMIT = 1<<30;
+
+void so_set_attr_len(ScrubMap::object &obj, const std::string &name, size_t len)
+{
+  obj.attrs[name] = buffer::ptr(len);
+}
+
+void so_set_attr(ScrubMap::object &obj, const std::string &name, bufferlist bl)
+{
+  bl.rebuild();
+  obj.attrs[name] = bl.front();
+}
+
+std::optional<bufferlist> so_get_attr(
+  ScrubMap::object &obj, const std::string &name)
+{
+  if (obj.attrs.count(name)) {
+    bufferlist bl;
+    bl.push_back(obj.attrs[name]);
+    return bl;
+  } else {
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+void so_set_attr_type(
+  ScrubMap::object &obj, const std::string &name,
+  const std::optional<T> &v)
+{
+  if (v) {
+    bufferlist bl;
+    encode(*v, bl, CEPH_FEATURES_ALL);
+    so_set_attr(obj, name, std::move(bl));
+  } else {
+    obj.attrs.erase(name);
+  }
+}
+
+template <typename T>
+std::optional<T> so_get_attr_type(ScrubMap::object &obj, const std::string &name)
+{
+  auto maybe_bl = so_get_attr(obj, name);
+  if (!maybe_bl) {
+    return std::nullopt;
+  }
+  auto bl = std::move(*maybe_bl);
+  try {
+    T ret;
+    auto bliter = bl.cbegin();
+    decode(ret, bliter);
+    return ret;
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+void so_set_oi(ScrubMap::object &obj, const std::optional<object_info_t> &oi)
+{
+  return so_set_attr_type<object_info_t>(obj, OI_ATTR, oi);
+}
+
+std::optional<object_info_t> so_get_oi(ScrubMap::object &obj)
+{
+  return so_get_attr_type<object_info_t>(obj, OI_ATTR);
+}
+
+template <typename F>
+void so_mut_oi(ScrubMap::object &obj, F &&f) {
+  so_set_oi(obj, std::invoke(std::forward<F>(f), so_get_oi(obj)));
+}
+
+void so_set_ss(ScrubMap::object &obj, const std::optional<SnapSet> &ss)
+{
+  return so_set_attr_type<SnapSet>(obj, SS_ATTR, ss);
+}
+
+std::optional<SnapSet> so_get_ss(ScrubMap::object &obj)
+{
+  return so_get_attr_type<SnapSet>(obj, SS_ATTR);
+}
+
+template <typename F>
+void so_mut_ss(ScrubMap::object &obj, F &&f) {
+  so_set_ss(obj, std::invoke(std::forward<F>(f), so_get_ss(obj)));
+}
+
+void so_set_hinfo(
+  ScrubMap::object &obj, const std::optional<ECUtil::HashInfo> &hinfo)
+{
+  return so_set_attr_type<ECUtil::HashInfo>(obj, ECUtil::get_hinfo_key(), hinfo);
+}
+
+std::optional<ECUtil::HashInfo> so_get_hinfo(ScrubMap::object &obj)
+{
+  return so_get_attr_type<ECUtil::HashInfo>(obj, ECUtil::get_hinfo_key());
+}
+
+template <typename F>
+void so_mut_hinfo(ScrubMap::object &obj, F &&f) {
+  auto maybe_hinfo = so_get_hinfo(obj);
+  auto new_maybe_hinfo = std::invoke(std::forward<F>(f), std::move(maybe_hinfo));
+  so_set_hinfo(obj, new_maybe_hinfo);
+}
+
+/**
+ * so_builder_t
+ *
+ * Utility class for constructing test objects.
+ */
+struct so_builder_t {
+  ScrubMap::object so;
+
+  void set_defaults() {
+    so.size = 0;
+    so_mut_oi(so, [](auto maybe_oi) {
+      if (maybe_oi) {
+	maybe_oi->size = 0;
+      }
+      return maybe_oi;
+    });
+  }
+
+  static hobject_t make_hoid(std::string name, snapid_t cloneid=CEPH_NOSNAP) {
+    auto oid = object_t(name);
+    return hobject_t{
+      oid,
+      "",
+      cloneid,
+      static_cast<uint32_t>(std::hash<object_t>()(oid)),
+      1,
+      ""
+    };
+  }
+
+  static so_builder_t make_head(std::string name) {
+    auto hoid = make_hoid(name);
+    so_builder_t ret;
+    so_set_oi(ret.so, object_info_t{hoid});
+    so_set_ss(ret.so, SnapSet{});
+    ret.set_defaults();
+    return ret;
+  }
+
+  static so_builder_t make_clone(
+    std::string name,
+    snapid_t cloneid = 4
+  ) {
+    auto hoid = make_hoid(name, cloneid);
+    so_builder_t ret;
+    so_set_oi(ret.so, object_info_t{hoid});
+    ret.set_defaults();
+    return ret;
+  }
+
+  static so_builder_t make_ec_head(std::string name) {
+    auto ret = make_head(name);
+    so_set_hinfo(ret.so, ECUtil::HashInfo{});
+    return ret;
+  }
+
+  static so_builder_t make_ec_clone(
+    std::string name,
+    snapid_t cloneid = 4
+  ) {
+    auto ret = make_clone(name, cloneid);
+    so_set_hinfo(ret.so, ECUtil::HashInfo{});
+    return ret;
+  }
+
+  so_builder_t &set_size(
+    size_t size,
+    const std::optional<ECUtil::stripe_info_t> stripe_info = std::nullopt) {
+    if (stripe_info) {
+      so.size = stripe_info->logical_to_next_chunk_offset(size);
+    } else {
+      so.size = size;
+    }
+
+    so_mut_oi(so, [size](auto maybe_oi) {
+      if (maybe_oi) {
+	maybe_oi->size = size;
+      }
+      return maybe_oi;
+    });
+    so_mut_hinfo(so, [size, &stripe_info](auto maybe_hinfo) {
+      if (maybe_hinfo) {
+	ceph_assert(stripe_info);
+	maybe_hinfo->set_total_chunk_size_clear_hash(
+	  stripe_info->logical_to_next_chunk_offset(size));
+      }
+      return maybe_hinfo;
+    });
+    return *this;
+  }
+
+  so_builder_t &add_attr(const std::string &name, size_t len) {
+    so_set_attr_len(so, name, len);
+    return *this;
+  }
+
+  ScrubMap::object get() const {
+    return so;
+  }
+};
+
+/**
+ * test_obj_t
+ *
+ * test param combining an so_builder_t with human readable description with
+ * a stripe_info.
+ */
+struct test_obj_t : so_builder_t {
+  std::optional<ECUtil::stripe_info_t> stripe_info;
+  std::string desc;
+  hobject_t hoid;
+
+  test_obj_t(
+    so_builder_t _builder,
+    std::optional<ECUtil::stripe_info_t> _stripe_info,
+    std::string _desc,
+    hobject_t _hoid) :
+    so_builder_t(std::move(_builder)),
+    stripe_info(std::move(_stripe_info)),
+    desc(std::move(_desc)),
+    hoid(std::move(_hoid)) {
+    ceph_assert(!desc.empty());
+  }
+
+  static test_obj_t make(
+    const std::string &desc,
+    std::optional<ECUtil::stripe_info_t> stripe_info,
+    so_builder_t builder) {
+    hobject_t hoid = so_get_oi(builder.so)->soid;
+    return test_obj_t{
+      std::move(builder),
+      stripe_info,
+      desc,
+      std::move(hoid)};
+  }
+
+  template <typename... Args>
+  static test_obj_t make_head(const std::string &desc, Args&&... args) {
+    return make(
+      desc,
+      std::nullopt,
+      so_builder_t::make_head(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static test_obj_t make_clone(const std::string &desc, Args&&... args) {
+    return make(
+      desc,
+      std::nullopt,
+      so_builder_t::make_clone(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static test_obj_t make_ec_head(const std::string &desc, Args&&... args) {
+    return make(
+      desc,
+      ECUtil::stripe_info_t{4, 1<<20},
+      so_builder_t::make_ec_head(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static test_obj_t make_ec_clone(const std::string &desc, Args&&... args) {
+    return make(
+      desc,
+      ECUtil::stripe_info_t{4, 1<<20},
+      so_builder_t::make_ec_clone(std::forward<Args>(args)...));
+  }
+
+  test_obj_t &set_size(
+    size_t size) {
+    so_builder_t::set_size(size, stripe_info);
+    return *this;
+  }
+
+  test_obj_t &add_attr(const std::string &name, size_t len) {
+    so_builder_t::add_attr(name, len);
+    return *this;
+  }
+
+  ScrubMap::object get() const {
+    return so_builder_t::get();
+  }
+};
+
+/**
+ * Interface for a test case on a single object.
+ */
+struct SingleErrorTestCase {
+  /// Describes limitations on test preconditions
+  enum class restriction_t {
+    NONE,         /// No limitations
+    REPLICA_ONLY, /// Only works if injected on replica
+    EC_ONLY,      /// Only valid for ec objects
+    HEAD_ONLY     /// Only valid for head objects
+  };
+
+  /// returns human-readable string describing the test for debugging
+  virtual std::string_view get_description() const = 0;
+
+  /// returns test_obj_t with error injected
+  virtual test_obj_t adjust_base_object(test_obj_t ret) const {
+    return ret;
+  }
+
+  /// returns test_obj_t with error injected
+  virtual test_obj_t inject_error(test_obj_t) const = 0;
+
+  /// returns expected shard error
+  virtual librados::err_t get_shard_error_sig() const = 0;
+
+  /// returns expected object error
+  virtual librados::obj_err_t get_object_error_sig() const = 0;
+
+  /// returns true if test should be run with passed restriction
+  virtual bool valid_for_restriction(restriction_t restriction) const = 0;
+
+  virtual ~SingleErrorTestCase() = default;
+};
+
+/// Utility template for implementing SimpleErrorTestCase
+template <typename T>
+struct SingleErrorTestCaseT : SingleErrorTestCase {
+  /// Defaults for REQUIRE_EC and REQUIRES_HEAD
+  constexpr static bool REQUIRES_EC = false;
+  constexpr static bool REQUIRES_HEAD = false;
+
+  /* Every implementor must define:
+  constexpr static librados::err_t shard_error_sig{
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+  };
+  */
+
+  librados::err_t get_shard_error_sig() const final {
+    return T::shard_error_sig;
+  }
+  librados::obj_err_t get_object_error_sig() const final {
+    return T::object_error_sig;
+  }
+
+  constexpr static bool requires_ec() {
+    return T::REQUIRES_EC;
+  }
+  constexpr static bool requires_head() {
+    return T::REQUIRES_HEAD;
+  }
+  constexpr static bool requires_replica() {
+    /* If there are no shard_errors, we'll take primary to be authoritative. */
+    return T::shard_error_sig.errors == 0;
+  }
+
+  bool valid_for_restriction(restriction_t restriction) const final {
+    // There aren't currently any tests with two restrictions, if this
+    // changes, the suite instantiations will need to change as well.
+    static_assert(
+      (requires_ec() + requires_head() + requires_replica()) <= 1);
+    return [] {
+      if constexpr (requires_replica()) {
+	return restriction_t::REPLICA_ONLY;
+      } else if constexpr (requires_head()) {
+	return restriction_t::HEAD_ONLY;
+      } else if constexpr (requires_ec()) {
+	return restriction_t::EC_ONLY;
+      } else {
+	return restriction_t::NONE;
+      }
+    }() == restriction;
+  }
+  virtual ~SingleErrorTestCaseT() = default;
+};
+
+/* The following classes exercise each possible error code detected
+ * by evaluate_object_shard and compare_candidate_to_authoritative
+ * in crimson/osd/scrub/scrub_validator.*
+ *
+ * Note, any newly added cases must also be added to the test_cases
+ * array below.
+ */
+
+struct ECHashMismatch : SingleErrorTestCaseT<ECHashMismatch> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SHARD_EC_HASH_MISMATCH
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+  };
+
+  std::string_view get_description() const {
+    return "ECHashMismatch";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.ec_hash_mismatch = true;
+    return obj;
+  }
+};
+
+struct ECSizeMismatch : SingleErrorTestCaseT<ECSizeMismatch> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SHARD_EC_SIZE_MISMATCH
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+  };
+
+  std::string_view get_description() const {
+    return "ECSizeMismatch";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.ec_size_mismatch = true;
+    return obj;
+  }
+};
+
+struct ReadError : SingleErrorTestCaseT<ReadError> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SHARD_READ_ERR
+  };
+  constexpr static librados::obj_err_t object_error_sig{};
+
+  std::string_view get_description() const {
+    return "ReadError";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.read_error = true;
+    return obj;
+  }
+};
+
+struct StatError : SingleErrorTestCaseT<StatError> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SHARD_STAT_ERR
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+  };
+
+  std::string_view get_description() const {
+    return "StatError";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.stat_error = true;
+    return obj;
+  }
+};
+
+struct MissingOI : SingleErrorTestCaseT<MissingOI> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::INFO_MISSING
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::OBJECT_INFO_INCONSISTENCY
+  };
+
+  std::string_view get_description() const {
+    return "MissingOI";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    so_mut_oi(obj.so, [](auto) { return std::nullopt; });
+    return obj;
+  }
+};
+
+struct CorruptOI: SingleErrorTestCaseT<CorruptOI> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::INFO_CORRUPTED
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::OBJECT_INFO_INCONSISTENCY
+  };
+
+  std::string_view get_description() const {
+    return "CorruptOI";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    so_set_attr_len(obj.so, OI_ATTR, 10);
+    return obj;
+  }
+};
+
+struct CorruptOndiskSize : SingleErrorTestCaseT<CorruptOndiskSize> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SIZE_MISMATCH_INFO
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::SIZE_MISMATCH
+  };
+
+  std::string_view get_description() const {
+    return "CorruptOndiskSize";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.size += 2;
+    return obj;
+  }
+};
+
+struct MissingSS : SingleErrorTestCaseT<MissingSS> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SNAPSET_MISSING
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::SNAPSET_INCONSISTENCY
+  };
+  constexpr static bool REQUIRES_HEAD = true;
+
+  std::string_view get_description() const {
+    return "MissingSS";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(obj.hoid.is_head());
+    so_mut_ss(obj.so, [](auto) { return std::nullopt; });
+    return obj;
+  }
+};
+
+struct CorruptSS : SingleErrorTestCaseT<CorruptSS> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::SNAPSET_CORRUPTED
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::SNAPSET_INCONSISTENCY
+  };
+  constexpr static bool REQUIRES_HEAD = true;
+
+  std::string_view get_description() const {
+    return "CorruptSS";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(obj.hoid.is_head());
+    so_set_attr_len(obj.so, SS_ATTR, 10);
+    return obj;
+  }
+};
+
+struct MissingHinfo : SingleErrorTestCaseT<MissingHinfo> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::HINFO_MISSING
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::HINFO_INCONSISTENCY
+  };
+  constexpr static bool REQUIRES_EC = true;
+
+  std::string_view get_description() const {
+    return "MissingHinfo";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(obj.stripe_info);
+    so_mut_hinfo(obj.so, [](auto) { return std::nullopt; });
+    return obj;
+  }
+};
+
+struct CorruptHinfo : SingleErrorTestCaseT<CorruptHinfo> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::HINFO_CORRUPTED
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::HINFO_INCONSISTENCY
+  };
+  constexpr static bool REQUIRES_EC = true;
+
+  std::string_view get_description() const {
+    return "CorruptHinfo";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(obj.stripe_info);
+    so_set_attr_len(obj.so, ECUtil::get_hinfo_key(), 10);
+    return obj;
+  }
+};
+
+struct DataDigestMismatch : SingleErrorTestCaseT<DataDigestMismatch> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::DATA_DIGEST_MISMATCH_INFO
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::DATA_DIGEST_MISMATCH
+  };
+
+  std::string_view get_description() const {
+    return "DataDigestMismatch";
+  };
+  test_obj_t adjust_base_object(test_obj_t obj) const {
+    so_mut_oi(obj.so, [](auto maybe_oi) {
+      ceph_assert(maybe_oi);
+      maybe_oi->set_data_digest(1);
+      return maybe_oi;
+    });
+    obj.so.digest_present = true;
+    obj.so.digest = 1;
+    return obj;
+  }
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(so_get_oi(obj.so)->is_data_digest());
+    obj.so.digest = 2;
+    return obj;
+  }
+};
+
+struct OmapDigestMismatch : SingleErrorTestCaseT<OmapDigestMismatch> {
+  constexpr static librados::err_t shard_error_sig{
+    librados::err_t::OMAP_DIGEST_MISMATCH_INFO
+  };
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::OMAP_DIGEST_MISMATCH
+  };
+
+  std::string_view get_description() const {
+    return "OmapDigestMismatch";
+  };
+  test_obj_t adjust_base_object(test_obj_t obj) const {
+    so_mut_oi(obj.so, [](auto maybe_oi) {
+      ceph_assert(maybe_oi);
+      maybe_oi->set_omap_digest(1);
+      return maybe_oi;
+    });
+    obj.so.omap_digest_present = true;
+    obj.so.omap_digest = 1;
+    return obj;
+  }
+  test_obj_t inject_error(test_obj_t obj) const {
+    ceph_assert(so_get_oi(obj.so)->is_omap_digest());
+    obj.so.omap_digest = 2;
+    return obj;
+  }
+};
+
+struct ExtraAttribute : SingleErrorTestCaseT<ExtraAttribute> {
+  constexpr static librados::err_t shard_error_sig{};
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::ATTR_NAME_MISMATCH
+  };
+
+  std::string_view get_description() const {
+    return "ExtraAttribute";
+  };
+  test_obj_t inject_error(test_obj_t obj) const {
+    so_set_attr_len(obj.so, "attr_added_erroneously", 10);
+    return obj;
+  }
+};
+
+struct MissingAttribute : SingleErrorTestCaseT<MissingAttribute> {
+  constexpr static librados::err_t shard_error_sig{};
+  constexpr static librados::obj_err_t object_error_sig{
+    librados::obj_err_t::ATTR_NAME_MISMATCH
+  };
+
+  std::string_view get_description() const {
+    return "MissingAttribute";
+  };
+  test_obj_t adjust_base_object(test_obj_t obj) const {
+    so_set_attr_len(obj.so, "attr_to_be_missing", 10);
+    return obj;
+  }
+  test_obj_t inject_error(test_obj_t obj) const {
+    obj.so.attrs.erase("attr_to_be_missing");
+    return obj;
+  }
+};
+
+template <>
+struct fmt::formatter<SingleErrorTestCase> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &test_case, FormatContext& ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(), "{}",
+      test_case.get_description());
+  }
+};
+
+std::unique_ptr<SingleErrorTestCase> test_cases[] = {
+  std::make_unique<ECHashMismatch>(),
+  std::make_unique<ECSizeMismatch>(),
+  std::make_unique<ReadError>(),
+  std::make_unique<StatError>(),
+  std::make_unique<MissingOI>(),
+  std::make_unique<CorruptOI>(),
+  std::make_unique<CorruptOndiskSize>(),
+  std::make_unique<MissingSS>(),
+  std::make_unique<CorruptSS>(),
+  std::make_unique<MissingHinfo>(),
+  std::make_unique<CorruptHinfo>(),
+  std::make_unique<DataDigestMismatch>(),
+  std::make_unique<OmapDigestMismatch>(),
+  std::make_unique<ExtraAttribute>(),
+  std::make_unique<MissingAttribute>()
+};
+const SingleErrorTestCase *to_ptr(
+  const std::unique_ptr<SingleErrorTestCase> &tc) {
+  return tc.get();
+}
+// iterator over the above set as pointers
+using test_case_ptr_iter_t = boost::transform_iterator<
+  std::function<decltype(to_ptr)>, decltype(std::begin(test_cases))>;
+template <SingleErrorTestCase::restriction_t restriction>
+struct test_case_filter_t {
+  bool operator()(const SingleErrorTestCase *tc) const {
+    return tc->valid_for_restriction(restriction);
+  }
+};
+template <SingleErrorTestCase::restriction_t restriction>
+// iterator over the above set filtered by restriction
+using test_case_filter_iter_t = boost::filter_iterator<
+  test_case_filter_t<restriction>,
+  test_case_ptr_iter_t>;
+template <SingleErrorTestCase::restriction_t restriction>
+// begin and end, used below to instantiate test suites
+auto test_cases_begin() {
+  return test_case_filter_iter_t<restriction>(
+    test_case_filter_t<restriction>(),
+    test_case_ptr_iter_t(std::begin(test_cases), to_ptr),
+    test_case_ptr_iter_t(std::end(test_cases), to_ptr));
+}
+template <SingleErrorTestCase::restriction_t restriction>
+auto test_cases_end() {
+  return test_case_filter_iter_t<restriction>(
+    test_case_filter_t<restriction>(),
+    test_case_ptr_iter_t(std::end(test_cases), to_ptr),
+    test_case_ptr_iter_t(std::end(test_cases), to_ptr));
+}
+
+/// tuple defining each generated test case
+using single_error_test_param_t = std::tuple<
+  test_obj_t,                /// initial test object
+  bool,                      /// inject on primary?
+  const SingleErrorTestCase* /// test case
+  >;
+template <>
+struct fmt::formatter<single_error_test_param_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const auto &param, FormatContext& ctx) const
+  {
+    const auto &[obj, is_primary, test_case] = param;
+    return fmt::format_to(
+      ctx.out(), "{}{}{}",
+      obj.desc,
+      is_primary ? "Primary" : "Replica",
+      test_case->get_description());
+  }
+};
+std::ostream &operator<<(std::ostream &out, const single_error_test_param_t &p)
+{
+  return out << fmt::format("{}", p);
+}
+
+class TestSingleError :
+  public testing::TestWithParam<single_error_test_param_t> {
+};
+
+/**
+ * compare_error_signatures
+ *
+ * Generic helper for comparing err_t, obj_err_t, and
+ * inconsistent_snapset_t with descriptive output.
+ */
+auto compare_error_signatures(const auto &lh, const auto &rh)
+{
+  if (lh.errors == rh.errors) {
+    return ::testing::AssertionSuccess() << fmt::format(
+      "Signature match: {}", lh);
+  } else {
+    return ::testing::AssertionFailure() << fmt::format(
+      "Signature mismatch: {} should be {}",
+      lh, rh);
+  }
+}
+
+TEST_P(TestSingleError, SingleError) {
+  const auto &[_obj, is_primary, test_case] = GetParam();
+  auto obj = test_case->adjust_base_object(_obj);
+
+  const pg_shard_t primary(0, shard_id_t::NO_SHARD);
+  const pg_shard_t replica(1, shard_id_t::NO_SHARD);
+  crimson::osd::scrub::chunk_validation_policy_t policy {
+    primary,
+    obj.stripe_info,
+    TEST_MAX_OBJECT_SIZE,
+    std::string{TEST_INTERNAL_NAMESPACE},
+    TEST_OMAP_KEY_LIMIT,
+    TEST_OMAP_BYTES_LIMIT
+  };
+  const pg_shard_t &target = is_primary ? primary : replica;
+  const std::vector<pg_shard_t> shards = {
+    primary, replica
+  };
+
+  auto with_error = test_case->inject_error(obj);
+  crimson::osd::scrub::scrub_map_set_t maps;
+  for (const auto &osd : shards) {
+    if (osd == target) {
+      maps[osd].objects[obj.hoid] = with_error.get();
+    } else {
+      maps[osd].objects[obj.hoid] = obj.get();
+    }
+  }
+
+  DoutPrefix dpp(nullptr, ceph_subsys_test, "test_crimson_scrub");
+  const auto ret = crimson::osd::scrub::validate_chunk(
+    dpp, policy, maps);
+  const auto &object_errors = ret.object_errors;
+
+  ASSERT_EQ(object_errors.size(), 1) << fmt::format(
+    "{}: generated an incorrect number of errors: {}\n",
+    *test_case, object_errors);
+
+  auto &obj_error = object_errors.front();
+
+  EXPECT_EQ(
+    ret.stats.num_shallow_scrub_errors,
+    (obj_error.has_shallow_errors() ||
+     obj_error.union_shards.has_shallow_errors()) +
+    ret.snapset_errors.size());
+  EXPECT_EQ(
+    ret.stats.num_deep_scrub_errors,
+    (obj_error.has_deep_errors() ||
+     obj_error.union_shards.has_deep_errors()));
+
+  EXPECT_TRUE(compare_error_signatures(
+    static_cast<const librados::obj_err_t&>(obj_error),
+    test_case->get_object_error_sig()));
+
+  EXPECT_EQ(obj_error.shards.size(), shards.size());
+  bool found_selected_oi = false;
+  for (const auto &shard : shards) {
+    auto siter = obj_error.shards.find(
+      librados::osd_shard_t(shard.osd, shard.shard)
+    );
+    if (siter == obj_error.shards.end()) {
+      EXPECT_NE(siter, obj_error.shards.end());
+      continue;
+    }
+    if (shard == target) {
+      EXPECT_TRUE(compare_error_signatures(
+	static_cast<const librados::err_t&>(siter->second),
+	test_case->get_shard_error_sig()));
+    } else {
+      EXPECT_FALSE(siter->second.has_errors());
+      if (siter->second.selected_oi) found_selected_oi = true;
+    }
+    if (shard == primary) {
+      EXPECT_TRUE(siter->second.primary);
+    }
+  }
+  EXPECT_TRUE(found_selected_oi);
+}
+
+/* Tests that don't have restrictions */
+INSTANTIATE_TEST_SUITE_P(
+  SingleErrorGeneral,
+  TestSingleError,
+  ::testing::Combine(
+    ::testing::Values(
+      test_obj_t::make_head("Small", "foo").set_size(64),
+      test_obj_t::make_clone("EmptyWithAttr", "foo2").add_attr("extra_attr", 64),
+      test_obj_t::make_head("ReplicatedRBD", "foo2").set_size(4<<20),
+      test_obj_t::make_ec_head("ECHead", "foo").set_size(4<<20),
+      test_obj_t::make_ec_clone("LargeECClone", "foo").set_size(16<<20)
+    ),
+    ::testing::Bool(),
+    ::testing::ValuesIn(
+      test_cases_begin<SingleErrorTestCase::restriction_t::NONE>(),
+      test_cases_end<SingleErrorTestCase::restriction_t::NONE>())
+  ),
+  [](const auto &info) {
+    return fmt::format("{}", info.param);
+  }
+);
+
+/* Some tests don't trigger shard errors, so we can't actually tell which
+ * replica is wrong.  Such tests are written for the error to be injected
+ * on the replica. */
+INSTANTIATE_TEST_SUITE_P(
+  SingleErrorPrimaryOnly,
+  TestSingleError,
+  ::testing::Combine(
+    ::testing::Values(
+      test_obj_t::make_head("Small", "foo").set_size(64),
+      test_obj_t::make_clone("EmptyWithAttr", "foo2").add_attr("extra_attr", 64),
+      test_obj_t::make_head("ReplicatedRBD", "foo2").set_size(4<<20),
+      test_obj_t::make_ec_head("ECHead", "foo").set_size(4<<20),
+      test_obj_t::make_ec_clone("LargeECClone", "foo").set_size(16<<20)
+    ),
+    ::testing::Values(false), // replica only
+    ::testing::ValuesIn(
+      test_cases_begin<SingleErrorTestCase::restriction_t::REPLICA_ONLY>(),
+      test_cases_end<SingleErrorTestCase::restriction_t::REPLICA_ONLY>())
+  ),
+  [](const auto &info) {
+    return fmt::format("{}", info.param);
+  }
+);
+
+/* Some tests only make sense on ec objects. */
+INSTANTIATE_TEST_SUITE_P(
+  SingleErrorOnly,
+  TestSingleError,
+  ::testing::Combine(
+    ::testing::Values(
+      test_obj_t::make_ec_head("ECHead", "foo").set_size(4<<20),
+      test_obj_t::make_ec_clone("LargeECClone", "foo").set_size(16<<20)
+    ),
+    ::testing::Bool(),
+    ::testing::ValuesIn(
+      test_cases_begin<SingleErrorTestCase::restriction_t::EC_ONLY>(),
+      test_cases_end<SingleErrorTestCase::restriction_t::EC_ONLY>())
+  ),
+  [](const auto &info) {
+    return fmt::format("{}", info.param);
+  }
+);
+
+/* Some tests only make sense on head objects. */
+INSTANTIATE_TEST_SUITE_P(
+  SingleErrorHEAD,
+  TestSingleError,
+  ::testing::Combine(
+    ::testing::Values(
+      test_obj_t::make_head("Small", "foo").set_size(64),
+      test_obj_t::make_head("ReplicatedRBD", "foo2").set_size(4<<20),
+      test_obj_t::make_ec_head("ECHead", "foo").set_size(4<<20)
+    ),
+    ::testing::Bool(),
+    ::testing::ValuesIn(
+      test_cases_begin<SingleErrorTestCase::restriction_t::HEAD_ONLY>(),
+      test_cases_end<SingleErrorTestCase::restriction_t::HEAD_ONLY>())
+  ),
+  [](const auto &info) {
+    return fmt::format("{}", info.param);
+  }
+);
+
+using test_clone_spec_t = std::pair<
+  snapid_t, // clone id
+  size_t    // clone size
+  >;
+
+/// descending order of clone id
+using test_clone_list_t = std::vector<test_clone_spec_t>;
+
+/**
+ * snapset_test_case_t
+ *
+ * This descriptor can express 3 types of error
+ * - missing clone
+ * - extra clone
+ * - clone size mismatch
+ * in 4 positions using one bit for each pair.
+ */
+class snapset_test_case_t {
+  uint32_t signature;
+
+  snapset_test_case_t(uint32_t signature) : signature(signature) {}
+
+  constexpr static uint32_t POSITION_BITS = 4;
+  constexpr static uint32_t position_mask[] = {
+    0x1, 0x2, 0x4, 0x8
+  };
+  constexpr static unsigned MAX_POS = std::size(position_mask);
+
+  constexpr static uint32_t MIN_VALID = 0;
+  constexpr static uint32_t MAX_VALID = 0xFFF;
+  enum type_t {
+    MISSING = 0,
+    EXTRA,
+    SIZE
+  };
+
+  bool should_inject(type_t type, unsigned position) const {
+    ceph_assert(position < MAX_POS);
+    return (signature >> (type * POSITION_BITS)) & position_mask[position];
+  }
+  static snapset_test_case_t make(type_t type, unsigned position) {
+    ceph_assert(position < std::size(position_mask));
+    return snapset_test_case_t{
+      position_mask[position] << (type * POSITION_BITS)
+    };
+  }
+  static auto generate_single_errors(type_t type) {
+    std::vector<snapset_test_case_t> ret;
+    ret.reserve(std::size(position_mask));
+    for (unsigned i = 0; i < MAX_POS; ++i) {
+      ret.push_back(make(type, i));
+    }
+    return ret;
+  }
+
+public:
+  constexpr static unsigned get_max_pos() { return MAX_POS; }
+
+  bool should_inject_missing(unsigned position) const {
+    return should_inject(MISSING, position);
+  }
+  bool should_inject_extra(unsigned position) const {
+    return should_inject(EXTRA, position);
+  }
+  bool should_inject_size(unsigned position) const {
+    return should_inject(SIZE, position);
+  }
+
+  static auto generate_single_missing_errors() {
+    return generate_single_errors(MISSING);
+  }
+  static auto generate_single_extra_errors() {
+    return generate_single_errors(EXTRA);
+  }
+  static auto generate_single_size_errors() {
+    return generate_single_errors(SIZE);
+  }
+  static auto generate_random_errors(size_t num, int seed = 0) {
+    std::default_random_engine e1(seed);
+    std::uniform_int_distribution<uint32_t> uniform_dist(1, MAX_VALID);
+
+    std::vector<snapset_test_case_t> ret;
+    ret.reserve(num);
+    for (unsigned i = 0; i < num; ++i) {
+      ret.push_back(snapset_test_case_t{uniform_dist(e1)});
+    }
+    return ret;
+  }
+  friend std::ostream &operator<<(std::ostream &out, snapset_test_case_t rhs);
+};
+std::ostream &operator<<(std::ostream &out, snapset_test_case_t rhs) {
+  for (auto &[s, type] :
+	 std::vector<std::pair<std::string, snapset_test_case_t::type_t>>(
+	   {{"M", snapset_test_case_t::MISSING},
+	    {"E", snapset_test_case_t::EXTRA},
+	    {"S", snapset_test_case_t::SIZE}})) {
+    out << s;
+    for (unsigned i = 0;
+	 i < snapset_test_case_t::MAX_POS; ++i) {
+      if (rhs.should_inject(type, i)) {
+	out << i;
+      }
+    }
+  }
+  return out;
+}
+
+class TestSnapSetCloneError :
+  public testing::TestWithParam<snapset_test_case_t> {
+};
+
+
+SnapSet make_snapset(const test_clone_list_t &clone_list)
+{
+  SnapSet ss;
+  for (const auto &[cloneid, size] : clone_list) {
+    ss.clones.push_back(cloneid);
+    ss.clone_size[cloneid] = size;
+    ss.clone_overlap[cloneid];
+    ss.clone_snaps[cloneid].push_back(cloneid);
+  }
+  return ss;
+}
+
+std::pair<hobject_t, ScrubMap::object> make_clone(
+  std::string name, std::pair<snapid_t, size_t> in)
+{
+  ScrubMap ret;
+  auto [cloneid, size] = in;
+  hobject_t hoid = so_builder_t::make_hoid(name, in.first);
+  auto so = so_builder_t::make_clone(
+    name, cloneid);
+  so.set_size(size);
+  return std::make_pair(hoid, so.get());
+}
+
+TEST_P(TestSnapSetCloneError, CloneError) {
+  const pg_shard_t primary(0, shard_id_t::NO_SHARD);
+  crimson::osd::scrub::chunk_validation_policy_t policy {
+    primary,
+    std::nullopt,
+    TEST_MAX_OBJECT_SIZE,
+    std::string{TEST_INTERNAL_NAMESPACE},
+    TEST_OMAP_KEY_LIMIT,
+    TEST_OMAP_BYTES_LIMIT
+  };
+
+  crimson::osd::scrub::scrub_map_set_t maps;
+  const std::string name = "test_obj";
+  auto &map = maps[primary];
+  inconsistent_snapset_wrapper expected_error;
+
+  test_clone_list_t should_exist = {
+    { 10, 32 }, { 25,  64 }, { 50,  32 }, { 100,  64 }
+  };
+  test_clone_list_t extra = {
+    { 9, 64 }, { 11, 32 }, { 99, 64 }, { 101, 32 }
+  };
+
+  for (unsigned i = 0; i < snapset_test_case_t::get_max_pos(); ++i) {
+    hobject_t hoid = so_builder_t::make_hoid(name, should_exist[i].first);
+    if (!GetParam().should_inject_missing(i)) {
+      auto to_insert = make_clone(name, should_exist[i]);
+      if (GetParam().should_inject_size(i)) {
+	expected_error.set_size_mismatch();
+	to_insert.second = so_builder_t(to_insert.second).set_size(
+	  so_get_oi(to_insert.second)->size + 1).get();
+      }
+      map.objects.insert(to_insert);
+    } else {
+      expected_error.set_clone_missing(should_exist[i].first);
+    }
+    if (GetParam().should_inject_extra(i)) {
+      map.objects.insert(make_clone(name, extra[i]));
+      expected_error.set_clone(extra[i].first);
+    }
+  }
+
+  hobject_t hoid = so_builder_t::make_hoid(name);
+  map.objects[hoid] = so_builder_t::make_head(name).get();
+
+  so_set_ss(map.objects[hoid], make_snapset(should_exist));
+
+  DoutPrefix dpp(nullptr, ceph_subsys_test, "test_crimson_scrub");
+  const auto ret = crimson::osd::scrub::validate_chunk(
+    dpp, policy, maps);
+  EXPECT_EQ(ret.object_errors.size(), 0);
+  ASSERT_EQ(ret.snapset_errors.size(), 1) << fmt::format(
+    "Got snapset_errors: {}", ret.snapset_errors);
+
+  EXPECT_TRUE(compare_error_signatures(
+    ret.snapset_errors.front(),
+    expected_error));
+
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  SingleMissing,
+  TestSnapSetCloneError,
+  ::testing::ValuesIn(snapset_test_case_t::generate_single_missing_errors())
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  SingleExtra,
+  TestSnapSetCloneError,
+  ::testing::ValuesIn(snapset_test_case_t::generate_single_extra_errors())
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  SingleSize,
+  TestSnapSetCloneError,
+  ::testing::ValuesIn(snapset_test_case_t::generate_single_size_errors())
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  MultipleRandom,
+  TestSnapSetCloneError,
+  ::testing::ValuesIn(snapset_test_case_t::generate_random_errors(100))
+);
+
+TEST(TestSnapSet, MissingHead) {
+  const pg_shard_t primary(0, shard_id_t::NO_SHARD);
+  crimson::osd::scrub::chunk_validation_policy_t policy {
+    primary,
+    std::nullopt,
+    TEST_MAX_OBJECT_SIZE,
+    std::string{TEST_INTERNAL_NAMESPACE},
+    TEST_OMAP_KEY_LIMIT,
+    TEST_OMAP_BYTES_LIMIT
+  };
+
+  crimson::osd::scrub::scrub_map_set_t maps;
+  inconsistent_snapset_wrapper expected_error;
+
+  test_clone_list_t clones = {
+    { 10, 64 }, { 25, 32 }, { 50, 64 }, { 100, 32 }
+  };
+  for (const auto &desc : test_clone_list_t{clones}) {
+    maps[primary].objects.emplace(make_clone("test_object", desc));
+  }
+  expected_error.set_headless();
+
+
+  DoutPrefix dpp(nullptr, ceph_subsys_test, "test_crimson_scrub");
+  const auto ret = crimson::osd::scrub::validate_chunk(
+    dpp, policy, maps);
+  EXPECT_EQ(ret.object_errors.size(), 0);
+  ASSERT_EQ(ret.snapset_errors.size(), 1) << fmt::format(
+    "Got snapset_errors: {}", ret.snapset_errors);
+
+  EXPECT_TRUE(compare_error_signatures(
+    ret.snapset_errors.front(),
+    expected_error));
+
+}
+
+TEST(TestSnapSet, Stats) {
+  const pg_shard_t primary(0, shard_id_t::NO_SHARD);
+  crimson::osd::scrub::chunk_validation_policy_t policy {
+    primary,
+    std::nullopt,
+    TEST_MAX_OBJECT_SIZE,
+    std::string{TEST_INTERNAL_NAMESPACE},
+    TEST_OMAP_KEY_LIMIT,
+    TEST_OMAP_BYTES_LIMIT
+  };
+
+
+  object_stat_sum_t expected_stats;
+  crimson::osd::scrub::scrub_map_set_t maps;
+  auto &objs = maps[primary].objects;
+
+  unsigned num = 0;
+  auto add_simple_head = [&](size_t size, auto &&f)
+    -> ScrubMap::object & {
+    auto name = fmt::format("obj-{}", ++num);
+    auto hoid = so_builder_t::make_hoid(name);
+    auto obj = so_builder_t::make_head(name).set_size(size).get();
+    so_mut_oi(obj, std::forward<decltype(f)>(f));
+    expected_stats.num_bytes += size;
+    expected_stats.num_objects++;
+    return objs[hoid] = obj;
+  };
+
+  add_simple_head(64, [&expected_stats](auto maybe_oi) {
+    ceph_assert(maybe_oi);
+    maybe_oi->set_flag(object_info_t::FLAG_DIRTY);
+    expected_stats.num_objects_dirty++;
+    return maybe_oi;
+  });
+
+  add_simple_head(128, [&expected_stats](auto maybe_oi) {
+    ceph_assert(maybe_oi);
+    maybe_oi->set_flag(object_info_t::FLAG_MANIFEST);
+    expected_stats.num_objects_manifest++;
+    return maybe_oi;
+  });
+
+  add_simple_head(0, [&expected_stats](auto maybe_oi) {
+    ceph_assert(maybe_oi);
+    maybe_oi->set_flag(object_info_t::FLAG_WHITEOUT);
+    expected_stats.num_whiteouts++;
+    return maybe_oi;
+  });
+
+  {
+    auto &so = add_simple_head(32, [](auto ret) { return ret; });
+    expected_stats.num_omap_keys += (so.object_omap_keys = 10);
+    expected_stats.num_omap_bytes += (so.object_omap_bytes = 100);
+    expected_stats.num_objects_omap++;
+  }
+
+  {
+    auto &so = add_simple_head(64, [](auto ret) { return ret; });
+    expected_stats.num_omap_keys +=
+      (so.object_omap_keys = (TEST_OMAP_KEY_LIMIT + 1));
+    expected_stats.num_omap_bytes +=
+      (so.object_omap_bytes = so.object_omap_keys);
+    expected_stats.num_objects_omap++;
+    expected_stats.num_large_omap_objects++;
+  }
+
+  {
+    auto &so = add_simple_head(64, [](auto ret) { return ret; });
+    expected_stats.num_omap_keys += (so.object_omap_keys = 1);
+    expected_stats.num_omap_bytes +=
+      (so.object_omap_bytes = (TEST_OMAP_BYTES_LIMIT + 1));
+    expected_stats.num_objects_omap++;
+    expected_stats.num_large_omap_objects++;
+  }
+
+  {
+    auto name = fmt::format("obj-{}", ++num);
+
+    std::map<snapid_t, interval_set<uint64_t>> clone_overlap;
+    test_clone_list_t clones;
+    auto add_clone = [&](std::pair<snapid_t, size_t> clone_desc,
+			 interval_set<uint64_t> overlap) -> ScrubMap::object & {
+      auto hoid = so_builder_t::make_hoid(name, clone_desc.first);
+      clones.push_back(clone_desc);
+      auto [_, obj] = make_clone(name, clone_desc);
+      expected_stats.num_object_clones++;
+      expected_stats.num_objects++;
+
+      expected_stats.num_bytes += clone_desc.second - overlap.size();
+      clone_overlap[clone_desc.first] = std::move(overlap);
+
+      return objs[hoid] = obj;
+    };
+
+    auto make_is = [](uint64_t off, uint64_t len) {
+      interval_set<uint64_t> ret;
+      ret.insert(off, len);
+      return ret;
+    };
+
+    add_clone({99, 32}, {});
+    add_clone({100, 64}, make_is(31, 33));
+
+    {
+      auto hoid = so_builder_t::make_hoid(name);
+      size_t size = 64;
+      auto obj = so_builder_t::make_head(name).set_size(size).get();
+      expected_stats.num_bytes += size;
+      expected_stats.num_objects++;
+
+      SnapSet ss = make_snapset(clones);
+      ss.clone_overlap = std::move(clone_overlap);
+      so_mut_ss(obj, [ss=std::move(ss)](auto) mutable {
+	return std::move(ss);
+      });
+
+      objs[hoid] = obj;
+    }
+  }
+
+  DoutPrefix dpp(nullptr, ceph_subsys_test, "test_crimson_scrub");
+  const auto ret = crimson::osd::scrub::validate_chunk(
+    dpp, policy, maps);
+  EXPECT_EQ(ret.object_errors.size(), 0);
+  ASSERT_EQ(ret.snapset_errors.size(), 0) << fmt::format(
+    "Got snapset_errors: {}", ret.snapset_errors);
+
+  EXPECT_EQ(ret.stats, expected_stats);
+}


### PR DESCRIPTION
This PR adds initial support for scrubs initiated via the ceph tell <pgid> (scrub|deep_scrub) commands.  Scheduling, preemption, repair, other features will be future work, but this suffices at least to scrub after teuthology jobs.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
