### PR TITLE
doc/rados: remove cache-tiering-related keys

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -499,41 +499,6 @@ You may set values for the following keys:
    :Type: Integer
    :Valid Range: ``1`` sets flag, ``0`` unsets flag
 
-.. _cache_target_dirty_ratio:
-
-.. describe:: cache_target_dirty_ratio
-
-   :Description: Sets a flush threshold for the percentage of the cache pool
-                 containing modified (dirty) objects. When this threshold is
-                 reached, the cache-tiering agent will flush these objects to
-                 the backing storage pool.
-   :Type: Double
-   :Default: ``.4``
-
-.. _cache_target_dirty_high_ratio:
-
-.. describe:: cache_target_dirty_high_ratio
-   
-   :Description: Sets a flush threshold for the percentage of the cache pool
-                 containing modified (dirty) objects. When this threshold is
-                 reached, the cache-tiering agent will flush these objects to
-                 the backing storage pool with a higher speed (as compared with
-                 ``cache_target_dirty_ratio``).
-   :Type: Double
-   :Default: ``.6``
-
-.. _cache_target_full_ratio:
-
-.. describe:: cache_target_full_ratio
-   
-   :Description: Sets an eviction threshold for the percentage of the cache
-                 pool containing unmodified (clean) objects. When this
-                 threshold is reached, the cache-tiering agent will evict 
-                 these objects from the cache pool.
-
-   :Type: Double
-   :Default: ``.8``
-
 .. _target_max_bytes:
 
 .. describe:: target_max_bytes
@@ -551,24 +516,6 @@ You may set values for the following keys:
                  ``max_objects`` threshold is triggered.
    :Type: Integer
    :Example: ``1000000`` #1M objects
-
-.. _cache_min_flush_age:
-
-.. describe:: cache_min_flush_age
-   
-   :Description: Sets the time (in seconds) before the cache-tiering agent
-                 flushes an object from the cache pool to the storage pool.
-   :Type: Integer
-   :Example: ``600`` (600 seconds: ten minutes)
-
-.. _cache_min_evict_age:
-
-.. describe:: cache_min_evict_age
-   
-   :Description: Sets the time (in seconds) before the cache-tiering agent
-                 evicts an object from the cache pool.
-   :Type: Integer
-   :Example: ``1800`` (1800 seconds: thirty minutes)
 
 .. _fast_read:
 
@@ -681,27 +628,6 @@ You may get values from the following keys:
 :Description: See crush_rule_.
 
 
-``cache_target_dirty_ratio``
-
-:Description: See cache_target_dirty_ratio_.
-
-:Type: Double
-
-
-``cache_target_dirty_high_ratio``
-
-:Description: See cache_target_dirty_high_ratio_.
-
-:Type: Double
-
-
-``cache_target_full_ratio``
-
-:Description: See cache_target_full_ratio_.
-
-:Type: Double
-
-
 ``target_max_bytes``
 
 :Description: See target_max_bytes_.
@@ -712,20 +638,6 @@ You may get values from the following keys:
 ``target_max_objects``
 
 :Description: See target_max_objects_.
-
-:Type: Integer
-
-
-``cache_min_flush_age``
-
-:Description: See cache_min_flush_age_.
-
-:Type: Integer
-
-
-``cache_min_evict_age``
-
-:Description: See cache_min_evict_age_.
 
 :Type: Integer
 


### PR DESCRIPTION
Remove information related to cache-tiering-related keys from doc/rados/operations/pools.rst. Cache-tiering is deprecated in Reef. This PR is suitable for backporting to the Reef release branch, but not to release branches prior to Reef.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
