### PR TITLE
librbd: additional logs for deep-copy debugging

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -39,6 +39,13 @@ ImageCopyRequest<I>::ImageCopyRequest(I *src_image_ctx, I *dst_image_ctx,
     m_flatten(flatten), m_object_number(object_number), m_snap_seqs(snap_seqs),
     m_handler(handler), m_on_finish(on_finish), m_cct(dst_image_ctx->cct),
     m_lock(ceph::make_mutex(unique_lock_name("ImageCopyRequest::m_lock", this))) {
+
+    ldout(m_cct, 20) << "src_image_id=" << m_src_image_ctx->id
+		     << ", dst_image_id=" << m_dst_image_ctx->id
+	             << ", src_snap_id_start=" << m_src_snap_id_start
+                     << ", src_snap_id_end=" << m_src_snap_id_end
+		     << ", dst_snap_id_start=" << m_dst_snap_id_start
+		     << dendl;
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/MetadataCopyRequest.cc
+++ b/src/librbd/deep_copy/MetadataCopyRequest.cc
@@ -30,6 +30,10 @@ MetadataCopyRequest<I>::MetadataCopyRequest(I *src_image_ctx, I *dst_image_ctx,
                                             Context *on_finish)
   : m_src_image_ctx(src_image_ctx), m_dst_image_ctx(dst_image_ctx),
     m_on_finish(on_finish), m_cct(dst_image_ctx->cct) {
+
+  ldout(m_cct, 20) << "src_image_id=" << m_src_image_ctx->id
+                   << ", dst_image_id=" << m_dst_image_ctx->id
+		   << dendl;
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -58,10 +58,12 @@ ObjectCopyRequest<I>::ObjectCopyRequest(I *src_image_ctx,
 
   m_dst_oid = m_dst_image_ctx->get_object_name(dst_object_number);
 
-  ldout(m_cct, 20) << "dst_oid=" << m_dst_oid << ", "
-                   << "src_snap_id_start=" << m_src_snap_id_start << ", "
-                   << "dst_snap_id_start=" << m_dst_snap_id_start << ", "
-                   << "snap_map=" << m_snap_map << dendl;
+  ldout(m_cct, 20) << "src_image_id=" << m_src_image_ctx->id
+		   << ", dst_image_id=" << m_dst_image_ctx->id
+	           << ", dst_oid=" << m_dst_oid
+		   << ", src_snap_id_start=" << m_src_snap_id_start
+		   << ", dst_snap_id_start=" << m_dst_snap_id_start
+                   << ", snap_map=" << m_snap_map << dendl;
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/SetHeadRequest.cc
+++ b/src/librbd/deep_copy/SetHeadRequest.cc
@@ -30,6 +30,12 @@ SetHeadRequest<I>::SetHeadRequest(I *image_ctx, uint64_t size,
     m_parent_overlap(parent_overlap), m_on_finish(on_finish),
     m_cct(image_ctx->cct) {
   ceph_assert(m_parent_overlap <= m_size);
+
+  ldout(m_cct, 20) << "image_id=" << m_image_ctx->id
+                   << ", size=" << m_size
+                   << ", parent_spec=" << m_parent_spec
+                   << ", parent_overlap=" << m_parent_overlap
+                   << dendl;
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/SnapshotCopyRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCopyRequest.cc
@@ -76,6 +76,15 @@ SnapshotCopyRequest<I>::SnapshotCopyRequest(I *src_image_ctx,
     m_src_snap_ids.erase(m_src_snap_ids.upper_bound(m_src_snap_id_end),
                          m_src_snap_ids.end());
   }
+
+  ldout(m_cct, 20) << "src_image_id=" << m_src_image_ctx->id
+                   << ", dst_image_id=" << m_dst_image_ctx->id
+                   << ", src_snap_id_start=" << m_src_snap_id_start
+                   << ", src_snap_id_end=" << m_src_snap_id_end
+                   << ", dst_snap_id_start=" << m_dst_snap_id_start
+                   << ", src_snap_ids=" << m_src_snap_ids
+                   << ", dst_snap_ids=" << m_dst_snap_ids
+		   << dendl;
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/SnapshotCreateRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.cc
@@ -33,6 +33,14 @@ SnapshotCreateRequest<I>::SnapshotCreateRequest(
     m_snap_namespace(snap_namespace), m_size(size),
     m_parent_spec(spec), m_parent_overlap(parent_overlap),
     m_on_finish(on_finish), m_cct(dst_image_ctx->cct) {
+
+  ldout(m_cct, 20) << "dst_image_id=" << m_dst_image_ctx->id
+                   << ", snap_name=" << m_snap_name
+                   << ", snap_namespace=" << m_snap_namespace
+                   << ", size=" << m_size
+                   << ", parent_spec=" << m_parent_spec
+                   << ", parent_overlap=" << m_parent_overlap
+		   << dendl;
 }
 
 template <typename I>


### PR DESCRIPTION
Added image and object information to the librbd deep_copy logs to make debugging easier.






## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
