### PR TITLE
reef: backport of rook orchestrator fixes and e2e automated testing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,4 +62,5 @@
 - `jenkins test ceph-volume all`
 - `jenkins test ceph-volume tox`
 - `jenkins test windows`
+- `jenkins test rook e2e`
 </details>

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -26,28 +26,53 @@ class PrometheusControllerTest(ControllerTestCase):
         mgr.get_module_option.side_effect = settings.get
         cls.setup_controllers([Prometheus, PrometheusNotifications, PrometheusReceiver])
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
-    def test_rules(self):
-        with patch('requests.request') as mock_request:
-            self._get('/api/prometheus/rules')
-            mock_request.assert_called_with('GET', self.prometheus_host_api + '/rules',
-                                            json=None, params={}, verify=True, auth=None)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", return_value='cephadm')
+    @patch("dashboard.controllers.prometheus.mgr.mon_command", return_value=(1, {}, None))
+    @patch('requests.request')
+    def test_rules_cephadm(self, mock_request, mock_mon_command, mock_get_module_option_ex):
+        # in this test we use:
+        # in the first call to get_module_option_ex we return 'cephadm' as backend
+        # in the second call we return 'True' for 'secure_monitoring_stack' option
+        mock_get_module_option_ex.side_effect = lambda module, key, default=None: 'cephadm' \
+            if module == 'orchestrator' else True
+        self._get('/api/prometheus/rules')
+        mock_request.assert_called_with('GET',
+                                        self.prometheus_host_api + '/rules',
+                                        json=None, params={},
+                                        verify=True, auth=None)
+        assert mock_mon_command.called
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", return_value='cephadm')
+    @patch("dashboard.controllers.prometheus.mgr.mon_command", return_value=(1, {}, None))
+    @patch('requests.request')
+    def test_rules_rook(self, mock_request, mock_mon_command, mock_get_module_option_ex):
+        # in this test we use:
+        # in the first call to get_module_option_ex we return 'rook' as backend
+        mock_get_module_option_ex.side_effect = lambda module, key, default=None: 'rook' \
+            if module == 'orchestrator' else None
+        self._get('/api/prometheus/rules')
+        mock_request.assert_called_with('GET',
+                                        self.prometheus_host_api + '/rules',
+                                        json=None,
+                                        params={},
+                                        verify=True, auth=None)
+        assert not mock_mon_command.called
+
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_list(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus')
             mock_request.assert_called_with('GET', self.alert_host_api + '/alerts',
                                             json=None, params={}, verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_get_silences(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus/silences')
             mock_request.assert_called_with('GET', self.alert_host_api + '/silences',
                                             json=None, params={}, verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_add_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'new-silence'})
@@ -55,7 +80,7 @@ class PrometheusControllerTest(ControllerTestCase):
                                             params=None, json={'id': 'new-silence'},
                                             verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_update_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'update-silence'})
@@ -63,7 +88,7 @@ class PrometheusControllerTest(ControllerTestCase):
                                             params=None, json={'id': 'update-silence'},
                                             verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_expire_silence(self):
         with patch('requests.request') as mock_request:
             self._delete('/api/prometheus/silence/0')

--- a/src/pybind/mgr/rook/ci/Dockerfile
+++ b/src/pybind/mgr/rook/ci/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/ceph/daemon-base:latest-main
+COPY ./tmp_build/orchestrator /usr/share/ceph/mgr/orchestrator
+COPY ./tmp_build/rook /usr/share/ceph/mgr/rook

--- a/src/pybind/mgr/rook/ci/run-rook-e2e-tests.sh
+++ b/src/pybind/mgr/rook/ci/run-rook-e2e-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Execute tests
+: ${CEPH_DEV_FOLDER:=${PWD}}
+${CEPH_DEV_FOLDER}/src/pybind/mgr/rook/ci/scripts/bootstrap-rook-cluster.sh
+cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/rook/ci/tests
+behave

--- a/src/pybind/mgr/rook/ci/scripts/bootstrap-rook-cluster.sh
+++ b/src/pybind/mgr/rook/ci/scripts/bootstrap-rook-cluster.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -eEx
+
+: ${CEPH_DEV_FOLDER:=${PWD}}
+KUBECTL="minikube kubectl --"
+
+# We build a local ceph image that contains the latest code
+# plus changes from the PR. This image will be used by the docker
+# running inside the minikube to start the different ceph pods
+LOCAL_CEPH_IMG="local/ceph"
+
+on_error() {
+    echo "on error"
+    minikube delete
+}
+
+configure_libvirt(){
+    sudo usermod -aG libvirt $(id -un)
+    sudo su -l $USER  # Avoid having to log out and log in for group addition to take effect.
+    sudo systemctl enable --now libvirtd
+    sudo systemctl restart libvirtd
+    sleep 10 # wait some time for libvirtd service to restart
+}
+
+setup_minikube_env() {
+
+    # Check if Minikube is running
+    if minikube status > /dev/null 2>&1; then
+	echo "Minikube is running"
+	minikube stop
+	minikube delete
+    else
+	echo "Minikube is not running"
+    fi
+
+    rm -rf ~/.minikube
+    minikube start --memory="4096" --cpus="2" --disk-size=10g --extra-disks=1 --driver kvm2
+    # point Docker env to use docker daemon running on minikube
+    eval $(minikube docker-env -p minikube)
+}
+
+build_ceph_image() {
+    wget -q -O cluster-test.yaml https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml
+    CURR_CEPH_IMG=$(grep -E '^\s*image:\s+' cluster-test.yaml | sed 's/.*image: *\([^ ]*\)/\1/')
+
+    cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/rook/ci
+    mkdir -p tmp_build/rook
+    mkdir -p tmp_build/orchestrator
+    cp ./../../orchestrator/*.py tmp_build/orchestrator
+    cp ../*.py tmp_build/rook
+
+    # we use the following tag to trick the Docker
+    # running inside minikube so it uses this image instead
+    # of pulling it from the registry
+    docker build --tag ${LOCAL_CEPH_IMG} .
+    docker tag ${LOCAL_CEPH_IMG} ${CURR_CEPH_IMG}
+
+    # cleanup
+    rm -rf tmp_build
+    cd ${CEPH_DEV_FOLDER}
+}
+
+create_rook_cluster() {
+    wget -q -O cluster-test.yaml https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml
+    $KUBECTL create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/crds.yaml
+    $KUBECTL create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/common.yaml
+    $KUBECTL create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml
+    $KUBECTL create -f cluster-test.yaml
+    $KUBECTL create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/dashboard-external-http.yaml
+    $KUBECTL create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml
+}
+
+wait_for_rook_operator() {
+    local max_attempts=10
+    local sleep_interval=20
+    local attempts=0
+    $KUBECTL rollout status deployment rook-ceph-operator -n rook-ceph --timeout=180s
+    PHASE=$($KUBECTL get cephclusters.ceph.rook.io -n rook-ceph -o jsonpath='{.items[?(@.kind == "CephCluster")].status.phase}')
+    echo "PHASE: $PHASE"
+    while ! $KUBECTL get cephclusters.ceph.rook.io -n rook-ceph -o jsonpath='{.items[?(@.kind == "CephCluster")].status.phase}' | grep -q "Ready"; do
+	echo "Waiting for cluster to be ready..."
+	sleep $sleep_interval
+	attempts=$((attempts+1))
+        if [ $attempts -ge $max_attempts ]; then
+            echo "Maximum number of attempts ($max_attempts) reached. Exiting..."
+            return 1
+        fi
+    done
+}
+
+wait_for_ceph_cluster() {
+    local max_attempts=10
+    local sleep_interval=20
+    local attempts=0
+    $KUBECTL rollout status deployment rook-ceph-tools -n rook-ceph --timeout=30s
+    while ! $KUBECTL get cephclusters.ceph.rook.io -n rook-ceph -o jsonpath='{.items[?(@.kind == "CephCluster")].status.ceph.health}' | grep -q "HEALTH_OK"; do
+	echo "Waiting for Ceph cluster installed"
+	sleep $sleep_interval
+	attempts=$((attempts+1))
+        if [ $attempts -ge $max_attempts ]; then
+            echo "Maximum number of attempts ($max_attempts) reached. Exiting..."
+            return 1
+        fi
+    done
+    echo "Ceph cluster installed and running"
+}
+
+show_info() {
+    DASHBOARD_PASSWORD=$($KUBECTL -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['data']['password']}" | base64 --decode && echo)
+    IP_ADDR=$($KUBECTL get po --selector="app=rook-ceph-mgr" -n rook-ceph --output jsonpath='{.items[*].status.hostIP}')
+    PORT="$($KUBECTL -n rook-ceph -o=jsonpath='{.spec.ports[?(@.name == "dashboard")].nodePort}' get services rook-ceph-mgr-dashboard-external-http)"
+    BASE_URL="http://$IP_ADDR:$PORT"
+    echo "==========================="
+    echo "Ceph Dashboard:  "
+    echo "   IP_ADDRESS: $BASE_URL"
+    echo "   PASSWORD: $DASHBOARD_PASSWORD"
+    echo "==========================="
+}
+
+####################################################################
+####################################################################
+
+trap 'on_error $? $LINENO' ERR
+
+configure_libvirt
+setup_minikube_env
+build_ceph_image
+create_rook_cluster
+wait_for_rook_operator
+wait_for_ceph_cluster
+show_info
+
+####################################################################
+####################################################################

--- a/src/pybind/mgr/rook/ci/tests/features/rook.feature
+++ b/src/pybind/mgr/rook/ci/tests/features/rook.feature
@@ -1,0 +1,12 @@
+Feature: Testing Rook orchestrator commands
+    Ceph has been installed using the cluster CRD available in deploy/examples/cluster-test.yaml and
+
+    Scenario: Verify ceph cluster health
+      When I run
+          """
+          ceph health | grep HEALTH
+          """
+      Then I get
+          """
+          HEALTH_OK
+          """

--- a/src/pybind/mgr/rook/ci/tests/features/steps/implementation.py
+++ b/src/pybind/mgr/rook/ci/tests/features/steps/implementation.py
@@ -1,0 +1,21 @@
+from behave import *
+from utils import *
+import re
+
+@when("I run")
+def run_step(context):
+    context.output = run_commands(context.text)
+
+@then("I get")
+def verify_result_step(context):
+    print(f"Output is:\n{context.output}\n--------------\n")
+    assert context.text == context.output
+
+@then("I get something like")
+def verify_fuzzy_result_step(context):
+    output_lines = context.output.split("\n")
+    expected_lines = context.text.split("\n")
+    num_lines = min(len(output_lines), len(expected_lines))
+    for n in range(num_lines):
+        if not re.match(expected_lines[n], output_lines[n]):
+            raise

--- a/src/pybind/mgr/rook/ci/tests/features/steps/utils.py
+++ b/src/pybind/mgr/rook/ci/tests/features/steps/utils.py
@@ -1,0 +1,29 @@
+import subprocess
+
+ROOK_CEPH_COMMAND = "minikube kubectl -- -n rook-ceph exec -it deploy/rook-ceph-tools -- "
+CLUSTER_COMMAND = "minikube kubectl -- "
+
+
+def execute_command(command: str) -> str:
+    output = ""
+    try:
+        proc = subprocess.run(command, shell=True, capture_output=True, text=True)
+        output = proc.stdout
+    except Exception as ex:
+        output = f"Error executing command: {ex}"
+
+    return output
+
+
+def run_commands(commands: str) -> str:
+    commands_list = commands.split("\n")
+    output = ""
+    for cmd in commands_list:
+        if cmd.startswith("ceph"):
+            prefix = ROOK_CEPH_COMMAND
+        else:
+            prefix = CLUSTER_COMMAND
+        command = prefix + cmd
+        output = execute_command(command)
+
+    return output.strip("\n")

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -130,7 +130,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         self._load_drive_groups()
         self._shutdown = threading.Event()
-        
+
     def config_notify(self) -> None:
         """
         This method is called whenever one of our config options is changed.
@@ -147,7 +147,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         assert isinstance(self.drive_group_interval, float)
 
         if self._rook_cluster:
-            self._rook_cluster.storage_class = self.storage_class
+            self._rook_cluster.storage_class_name = self.storage_class
 
     def shutdown(self) -> None:
         self._shutdown.set()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -457,7 +457,17 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         for p in pods:
             sd = orchestrator.DaemonDescription()
             sd.hostname = p['hostname']
-            sd.daemon_type = p['labels']['app'].replace('rook-ceph-', '')
+
+            # In Rook environments, the 'ceph-exporter' daemon is named 'exporter' whereas
+            # in the orchestrator interface, it is named 'ceph-exporter'. The purpose of the
+            # following adjustment is to ensure that the 'daemon_type' is correctly set.
+            # Without this adjustment, the 'service_to_daemon_types' lookup would fail, as
+            # it would be searching for a non-existent entry called 'exporter
+            if p['labels']['app'] == 'rook-ceph-exporter':
+                sd.daemon_type = 'ceph-exporter'
+            else:
+                sd.daemon_type = p['labels']['app'].replace('rook-ceph-', '')
+
             status = {
                 'Pending': orchestrator.DaemonDescriptionStatus.starting,
                 'Running': orchestrator.DaemonDescriptionStatus.running,

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -97,13 +97,15 @@ def threaded(f: Callable[..., None]) -> Callable[..., threading.Thread]:
 
 
 class DefaultFetcher():
-    def __init__(self, storage_class: str, coreV1_api: 'client.CoreV1Api'):
-        self.storage_class = storage_class
+    def __init__(self, storage_class_name: str, coreV1_api: 'client.CoreV1Api', rook_env: 'RookEnv'):
+        self.storage_class_name = storage_class_name
         self.coreV1_api = coreV1_api
+        self.rook_env = rook_env
+        self.pvs_in_sc: List[client.V1PersistentVolumeList] = []
 
     def fetch(self) -> None:
         self.inventory: KubernetesResource[client.V1PersistentVolumeList] = KubernetesResource(self.coreV1_api.list_persistent_volume)
-        self.pvs_in_sc = [i for i in self.inventory.items if i.spec.storage_class_name == self.storage_class]
+        self.pvs_in_sc = [i for i in self.inventory.items if i.spec.storage_class_name == self.storage_class_name]
 
     def convert_size(self, size_str: str) -> int:
         units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "", "K", "M", "G", "T", "P", "E")
@@ -148,11 +150,11 @@ class DefaultFetcher():
                 available = state,
         )
         return (node, device)
-        
+
 
 class LSOFetcher(DefaultFetcher):
-    def __init__(self, storage_class: 'str', coreV1_api: 'client.CoreV1Api', customObjects_api: 'client.CustomObjectsApi', nodenames: 'Optional[List[str]]' = None):
-        super().__init__(storage_class, coreV1_api)
+    def __init__(self, storage_class: 'str', coreV1_api: 'client.CoreV1Api', rook_env: 'RookEnv', customObjects_api: 'client.CustomObjectsApi', nodenames: 'Optional[List[str]]' = None):
+        super().__init__(storage_class, coreV1_api, rook_env)
         self.customObjects_api = customObjects_api
         self.nodenames = nodenames
 
@@ -219,13 +221,13 @@ class LSOFetcher(DefaultFetcher):
 
 class PDFetcher(DefaultFetcher):
     """ Physical Devices Fetcher"""
-    def __init__(self, coreV1_api: 'client.CoreV1Api'):
-        self.coreV1_api = coreV1_api
+    def __init__(self, coreV1_api: 'client.CoreV1Api', rook_env: 'RookEnv'):
+        super().__init__('', coreV1_api, rook_env)
 
     def fetch(self) -> None:
         """ Collect the devices information from k8s configmaps"""
         self.dev_cms: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_config_map,
-                                                              namespace='rook-ceph',
+                                                              namespace=self.rook_env.operator_namespace,
                                                               label_selector='app=rook-discover')
 
     def devices(self) -> Dict[str, List[Device]]:
@@ -371,9 +373,9 @@ class KubernetesCustomResource(KubernetesResource):
                             self.api_func))
 
 class DefaultCreator():
-    def __init__(self, inventory: 'Dict[str, List[Device]]', coreV1_api: 'client.CoreV1Api', storage_class: 'str'):
+    def __init__(self, inventory: 'Dict[str, List[Device]]', coreV1_api: 'client.CoreV1Api', storage_class_name: 'str'):
         self.coreV1_api = coreV1_api
-        self.storage_class = storage_class
+        self.storage_class_name = storage_class_name
         self.inventory = inventory
 
     def device_to_device_set(self, drive_group: DriveGroupSpec, d: Device) -> ccl.StorageClassDeviceSetsItem:
@@ -390,7 +392,7 @@ class DefaultCreator():
                     name="data"
                 ),
                 spec=ccl.Spec(
-                    storageClassName=self.storage_class,
+                    storageClassName=self.storage_class_name,
                     volumeMode="Block",
                     accessModes=ccl.CrdObjectList(["ReadWriteOnce"]),
                     resources={
@@ -699,7 +701,7 @@ class RookCluster(object):
         storageV1_api: 'client.StorageV1Api',
         appsV1_api: 'client.AppsV1Api',
         rook_env: 'RookEnv',
-        storage_class: 'str'
+        storage_class_name: 'str'
     ):
         self.rook_env = rook_env  # type: RookEnv
         self.coreV1_api = coreV1_api  # client.CoreV1Api
@@ -707,10 +709,11 @@ class RookCluster(object):
         self.customObjects_api = customObjects_api
         self.storageV1_api = storageV1_api  # client.StorageV1Api
         self.appsV1_api = appsV1_api  # client.AppsV1Api
-        self.storage_class = storage_class # type: str
+        self.storage_class_name = storage_class_name # type: str
 
         #  TODO: replace direct k8s calls with Rook API calls
-        self.storage_classes : KubernetesResource = KubernetesResource(self.storageV1_api.list_storage_class)
+        self.available_storage_classes : KubernetesResource = KubernetesResource(self.storageV1_api.list_storage_class)
+        self.configured_storage_classes = self.list_storage_classes()
 
         self.rook_pods: KubernetesResource[client.V1Pod] = KubernetesResource(self.coreV1_api.list_namespaced_pod,
                                                                               namespace=self.rook_env.namespace,
@@ -750,34 +753,57 @@ class RookCluster(object):
     def rook_api_post(self, path: str, **kwargs: Any) -> Any:
         return self.rook_api_call("POST", path, **kwargs)
 
+    def list_storage_classes(self) -> List[str]:
+        try:
+            crd = self.customObjects_api.get_namespaced_custom_object(
+                group="ceph.rook.io",
+                version="v1",
+                namespace=self.rook_env.namespace,
+                plural="cephclusters",
+                name=self.rook_env.cluster_name)
+
+            sc_devicesets = crd['spec']['storage']['storageClassDeviceSets']
+            sc_names = [vct['spec']['storageClassName'] for sc in sc_devicesets for vct in sc['volumeClaimTemplates']]
+            log.info(f"the cluster has the following configured sc: {sc_names}")
+            return sc_names
+        except Exception as e:
+            log.error(f"unable to list storage classes: {e}")
+            return []
+
+    # TODO: remove all the calls to code that uses rook_cluster.storage_class_name
     def get_storage_class(self) -> 'client.V1StorageClass':
-        matching_sc = [i for i in self.storage_classes.items if self.storage_class == i.metadata.name]
+        matching_sc = [i for i in self.available_storage_classes.items if self.storage_class_name == i.metadata.name]
         if len(matching_sc) == 0:
-            log.error(f"No storage class exists matching configured Rook orchestrator storage class which currently is <{self.storage_class}>. This storage class can be set in ceph config (mgr/rook/storage_class)")
+            log.error(f"No storage class exists matching configured Rook orchestrator storage class which currently is <{self.storage_class_name}>. This storage class can be set in ceph config (mgr/rook/storage_class)")
             raise Exception('No storage class exists matching name provided in ceph config at mgr/rook/storage_class')
         return matching_sc[0]
 
     def get_discovered_devices(self, nodenames: Optional[List[str]] = None) -> Dict[str, List[Device]]:
-        self.fetcher: Optional[DefaultFetcher] = None
-        op_settings = self.coreV1_api.read_namespaced_config_map(name="rook-ceph-operator-config", namespace='rook-ceph').data
+        discovered_devices: Dict[str, List[Device]] = {}
+        op_settings = self.coreV1_api.read_namespaced_config_map(name="rook-ceph-operator-config", namespace=self.rook_env.operator_namespace).data
+        fetcher: Optional[DefaultFetcher] = None
         if op_settings.get('ROOK_ENABLE_DISCOVERY_DAEMON', 'false').lower() == 'true':
-            self.fetcher = PDFetcher(self.coreV1_api)
+            fetcher = PDFetcher(self.coreV1_api, self.rook_env)
+            fetcher.fetch()
+            discovered_devices = fetcher.devices()
         else:
-            storage_class = self.get_storage_class()
-            if storage_class.metadata.labels and ('local.storage.openshift.io/owner-name' in storage_class.metadata.labels):
-                self.fetcher = LSOFetcher(self.storage_class, self.coreV1_api, self.customObjects_api, nodenames)
-            else:
-                self.fetcher = DefaultFetcher(self.storage_class, self.coreV1_api)
+            active_storage_classes = [sc for sc in self.available_storage_classes.items if sc.metadata.name in self.configured_storage_classes]
+            for sc in active_storage_classes:
+                if sc.metadata.labels and ('local.storage.openshift.io/owner-name' in sc.metadata.labels):
+                    fetcher = LSOFetcher(sc.metadata.name, self.coreV1_api, self.customObjects_api, nodenames)
+                else:
+                    fetcher = DefaultFetcher(sc.metadata.name, self.coreV1_api, self.rook_env)
+                fetcher.fetch()
+                discovered_devices.update(fetcher.devices())
 
-        self.fetcher.fetch()
-        return self.fetcher.devices()
+        return discovered_devices
 
     def get_osds(self) -> List:
         osd_pods: KubernetesResource = KubernetesResource(self.coreV1_api.list_namespaced_pod,
                                                           namespace=self.rook_env.namespace,
                                                           label_selector='app=rook-ceph-osd')
         return list(osd_pods.items)
-        
+
     def get_nfs_conf_url(self, nfs_cluster: str, instance: str) -> Optional[str]:
         #
         # Fetch cephnfs object for "nfs_cluster" and then return a rados://
@@ -1173,9 +1199,9 @@ class RookCluster(object):
             storage_class.metadata.labels
             and 'local.storage.openshift.io/owner-name' in storage_class.metadata.labels
         ):
-            creator = LSOCreator(inventory, self.coreV1_api, self.storage_class)    
+            creator = LSOCreator(inventory, self.coreV1_api, self.storage_class_name)
         else:
-            creator = DefaultCreator(inventory, self.coreV1_api, self.storage_class)
+            creator = DefaultCreator(inventory, self.coreV1_api, self.storage_class_name)
         return self._patch(
             ccl.CephCluster,
             'cephclusters',

--- a/src/pybind/mgr/rook/tests/fixtures.py
+++ b/src/pybind/mgr/rook/tests/fixtures.py
@@ -1,0 +1,11 @@
+from rook.module import RookOrchestrator
+from orchestrator import raise_if_exception, OrchResult
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+
+def wait(m: RookOrchestrator, c: OrchResult) -> Any:
+    return raise_if_exception(c)

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,0 +1,120 @@
+import orchestrator
+from .fixtures import wait
+import pytest
+from unittest.mock import patch, PropertyMock
+
+from rook.module import RookOrchestrator
+from rook.rook_cluster import RookCluster
+
+
+# we use this intermediate class as .rook_cluster property
+# is read only in the paretn class RookCluster
+class FakeRookCluster(RookCluster):
+    def __init__(self):
+        pass
+
+
+class TestRook(object):
+
+    @pytest.mark.parametrize("pods, expected_daemon_types", [
+        (
+            [
+                {
+                    'name': 'ceph-rook-exporter',
+                    'hostname': 'host1',
+                    "labels": {'app': 'rook-ceph-exporter',
+                               'ceph_daemon_id': 'exporter'},
+                    'phase': 'Pending',
+                    'container_image_name': 'quay.io/ceph/ceph:v18',
+                    'container_image_id': 'docker-pullable://quay.io/ceph/ceph@sha256:f239715e1c7756e32a202a572e2763a4ce15248e09fc6e8990985f8a09ffa784',
+                    'refreshed': 'pod1_ts',
+                    'started': 'pod1_ts',
+                    'created': 'pod1_1ts',
+                },
+                {
+                    'name': 'rook-ceph-mgr-a-68c7b9b6d8-vjjhl',
+                    'hostname': 'host1',
+                    "labels": {'app': 'rook-ceph-mgr',
+                               'ceph_daemon_type': 'mgr',
+                               'ceph_daemon_id': 'a'},
+                    'phase': 'Failed',
+                    'container_image_name': 'quay.io/ceph/ceph:v18',
+                    'container_image_id': '',
+                    'refreshed': 'pod2_ts',
+                    'started': 'pod2_ts',
+                    'created': 'pod2_1ts',
+                },
+                {
+                    'name': 'rook-ceph-mon-a-65fb8694b4-mmtl5',
+                    'hostname': 'host1',
+                    "labels": {'app': 'rook-ceph-mon',
+                               'ceph_daemon_type': 'mon',
+                               'ceph_daemon_id': 'b'},
+                    'phase': 'Running',
+                    'container_image_name': 'quay.io/ceph/ceph:v18',
+                    'container_image_id': '',
+                    'refreshed': 'pod3_ts',
+                    'started': 'pod3_ts',
+                    'created': 'pod3_1ts',
+                },
+                {
+                    'name': 'rook-ceph-osd-0-58cbd7b65c-6cjnr',
+                    'hostname': 'host1',
+                    "labels": {'app': 'rook-ceph-osd',
+                               'ceph-osd-id': '0',
+                               'ceph_daemon_type': 'osd',
+                               'ceph_daemon_id': '0'},
+                    'phase': 'Succeeded',
+                    'container_image_name': 'quay.io/ceph/ceph:v18',
+                    'container_image_id': '',
+                    'refreshed': 'pod4_ts',
+                    'started': 'pod4_ts',
+                    'created': 'pod4_1ts',
+                },
+                # unknown pod: has no labels are provided, it shouldn't
+                #  be part of the output
+                {
+                    'name': 'unknown-pod',
+                    'hostname': '',
+                    "labels": {'app': 'unkwon'},
+                    'phase': 'Pending',
+                    'container_image_name': 'quay.io/ceph/ceph:v18',
+                    'container_image_id': '',
+                    'refreshed': '',
+                    'started': '',
+                    'created': '',
+                }
+            ],
+            ['ceph-exporter', 'mgr', 'mon', 'osd']
+        )
+    ])
+    def test_list_daemons(self, pods, expected_daemon_types):
+
+        status = {
+            'Pending': orchestrator.DaemonDescriptionStatus.starting,
+            'Running': orchestrator.DaemonDescriptionStatus.running,
+            'Succeeded': orchestrator.DaemonDescriptionStatus.stopped,
+            'Failed': orchestrator.DaemonDescriptionStatus.error,
+            'Unknown': orchestrator.DaemonDescriptionStatus.unknown,
+        }
+
+        fake_rook_cluster = FakeRookCluster()
+        ro = RookOrchestrator('rook', None, self)
+        with patch('rook.RookOrchestrator.rook_cluster',
+                   new_callable=PropertyMock,
+                   return_value=fake_rook_cluster):
+            with patch.object(fake_rook_cluster, 'describe_pods') as mock_describe_pods:
+                mock_describe_pods.return_value = pods
+                dds = wait(ro, ro.list_daemons())
+                assert len(dds) == len(expected_daemon_types)
+                for i in range(0, len(dds)):
+                    assert dds[i].daemon_type == expected_daemon_types[i]
+                    assert dds[i].hostname == pods[i]['hostname']
+                    assert dds[i].status == status[pods[i]['phase']]
+                    assert dds[i].container_image_name == pods[i]['container_image_name']
+                    assert dds[i].container_image_id == pods[i]['container_image_id']
+                    assert dds[i].created == pods[i]['created']
+                    assert dds[i].last_configured == pods[i]['created']
+                    assert dds[i].last_deployed == pods[i]['created']
+                    assert dds[i].started == pods[i]['started']
+                    assert dds[i].last_refresh == pods[i]['refreshed']

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -49,6 +49,7 @@ setenv =
     UNITTEST = true
     PYTHONPATH = $PYTHONPATH:..
 deps =
+    behave
     -rrequirements.txt
     -rrook/requirements.txt
 commands =


### PR DESCRIPTION
Backport of: 

https://github.com/ceph/ceph/pull/54307 (mgr/dashboard: fix secure_monitoring_stack check)
Tracker: [63444](https://tracker.ceph.com/issues/63444)

https://github.com/ceph/ceph/pull/53747 (mgr/rook: Adding support to automatically discover storage classes)
Tracker: [63484](https://tracker.ceph.com/issues/63484)

https://github.com/ceph/ceph/pull/53910 (mgr/rook: fixing rook-ceph-exporter daemon type handling)
Tracker: [63266](https://tracker.ceph.com/issues/63266)

https://github.com/ceph/ceph/pull/54151 (mgr/rook: fix the namespaces used in rook and removes hard-coded)
Tracker: [63359](https://tracker.ceph.com/issues/63359)

https://github.com/ceph/ceph/pull/54056 (mgr/rook: adding e2e testing for rook orchestrator)
Tracker: [63463](https://tracker.ceph.com/issues/63463)

https://github.com/ceph/ceph/pull/54364 (github: adding command for rook e2e jenkins job)
Tracker: [63489](https://tracker.ceph.com/issues/63489)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
