### PR TITLE
pacific: client: always refresh mds feature bits on session open

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2322,6 +2322,12 @@ void Client::_closed_mds_session(MetaSession *s, int err, bool rejected)
     mds_sessions.erase(s->mds_num);
 }
 
+static void reinit_mds_features(MetaSession *session,
+				const MConstRef<MClientSession>& m) {
+  session->mds_features = std::move(m->supported_features);
+  session->mds_metric_flags = std::move(m->metric_spec.metric_flags);
+}
+
 void Client::handle_client_session(const MConstRef<MClientSession>& m)
 {
   mds_rank_t from = mds_rank_t(m->get_source().num());
@@ -2340,6 +2346,13 @@ void Client::handle_client_session(const MConstRef<MClientSession>& m)
       if (session->state == MetaSession::STATE_OPEN) {
         ldout(cct, 10) << "mds." << from << " already opened, ignore it"
                        << dendl;
+	// The MDS could send a client_session(open) message even when
+	// the session state is STATE_OPEN. Normally, its fine to
+	// ignore this message, but, if the MDS sent this message just
+	// after it got upgraded, the MDS feature bits could differ
+	// than the one before the upgrade - so, refresh the feature
+	// bits the client holds.
+	reinit_mds_features(session, m);
         return;
       }
       /*
@@ -2358,8 +2371,7 @@ void Client::handle_client_session(const MConstRef<MClientSession>& m)
 	_closed_mds_session(session, -CEPHFS_EPERM, true);
 	break;
       }
-      session->mds_features = std::move(m->supported_features);
-      session->mds_metric_flags = std::move(m->metric_spec.metric_flags);
+      reinit_mds_features(session, m);
 
       renew_caps(session);
       session->state = MetaSession::STATE_OPEN;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63283

---

backport of https://github.com/ceph/ceph/pull/54030
parent tracker: https://tracker.ceph.com/issues/63188

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh