### PR TITLE
src/mon: init pool availability feature

### DIFF
--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -14,12 +14,14 @@ class MgrStatMonitor : public PaxosService {
   PGMapDigest digest;
   ServiceMap service_map;
   std::map<std::string,ProgressEvent> progress_events;
+  mempool::pgmap::map<uint64_t, PoolAvailability> pool_availability;
 
   // pending commit
   PGMapDigest pending_digest;
   health_check_map_t pending_health_checks;
   std::map<std::string,ProgressEvent> pending_progress_events;
   ceph::buffer::list pending_service_map_bl;
+  mempool::pgmap::map<uint64_t, PoolAvailability> pending_pool_availability;
 
 public:
   MgrStatMonitor(Monitor &mn, Paxos &p, const std::string& service_name);
@@ -48,6 +50,8 @@ public:
 
   bool preprocess_getpoolstats(MonOpRequestRef op);
   bool preprocess_statfs(MonOpRequestRef op);
+
+  void calc_pool_availability();
 
   void check_sub(Subscription *sub);
   void check_subs();
@@ -81,6 +85,10 @@ public:
 
   const PGMapDigest& get_digest() {
     return digest;
+  }
+
+  const mempool::pgmap::map<uint64_t, PoolAvailability>& get_pool_availability() {
+    return pool_availability;
   }
 
   ceph_statfs get_statfs(OSDMap& osdmap,

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1165,6 +1165,9 @@ COMMAND("osd pool application get "
         "name=key,type=CephString,req=false",
         "get value of key <key> of application <app> on pool <poolname>",
         "osd", "r")
+COMMAND("osd pool availability-status", \
+        "obtain availability stats from all pools", \
+        "osd", "r")
 COMMAND("osd utilization",
 	"get basic pg distribution stats",
 	"osd", "r")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -111,6 +111,8 @@ using ceph::ErasureCodeProfile;
 using ceph::Formatter;
 using ceph::JSONFormatter;
 using ceph::make_message;
+using ceph::make_timespan;
+using ceph::timespan_str;
 
 #define dout_subsys ceph_subsys_mon
 static const string OSD_PG_CREATING_PREFIX("osd_pg_creating");

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -28,6 +28,7 @@
 #include "include/mempool.h"
 #include "mon/health_check.h"
 #include <sstream>
+#include "mon/mon_types.h"
 
 namespace ceph { class Formatter; }
 
@@ -50,6 +51,7 @@ public:
   osd_stat_t osd_sum;
   mempool::pgmap::map<std::string,osd_stat_t> osd_sum_by_class;
   mempool::pgmap::unordered_map<uint64_t,int32_t> num_pg_by_state;
+  mempool::pgmap::map<uint64_t,std::vector<pg_t>> pool_pg_unavailable_map;
   struct pg_count {
     int32_t acting = 0;
     int32_t up_not_acting = 0;
@@ -421,6 +423,7 @@ public:
 
   void apply_incremental(CephContext *cct, const Incremental& inc);
   void calc_stats();
+  void calc_pool_stuck_unavailable_pg_map(const OSDMap& osdmap);
   void stat_pg_add(const pg_t &pgid, const pg_stat_t &s,
 		   bool sameosds=false);
   bool stat_pg_sub(const pg_t &pgid, const pg_stat_t &s,

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -672,4 +672,62 @@ struct ProgressEvent {
 };
 WRITE_CLASS_ENCODER(ProgressEvent)
 
+struct PoolAvailability {
+  std::string pool_name;
+  utime_t started_at;
+  uint64_t uptime;
+  utime_t last_uptime;
+  uint64_t downtime;
+  utime_t last_downtime;
+  uint64_t num_failures;
+  bool is_avail;
+
+  PoolAvailability()
+    : pool_name(""), started_at(ceph_clock_now()),
+      uptime(0), last_uptime(ceph_clock_now()),
+      downtime(0), last_downtime(ceph_clock_now()),
+      num_failures(0), is_avail(true)
+  {
+  }
+
+  void dump(ceph::Formatter *f) const {
+    ceph_assert(f != NULL);
+    f->dump_stream("pool_name") << pool_name;
+    f->dump_stream("started_at") << started_at;
+    f->dump_int("uptime", uptime);
+    f->dump_stream("last_uptime") << last_uptime;
+    f->dump_int("downtime", downtime);
+    f->dump_stream("last_downtime") << last_downtime;
+    f->dump_int("num_failures", num_failures);
+    f->dump_bool("is_avail", is_avail);
+  }
+
+  void encode(ceph::buffer::list &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(pool_name, bl);
+    encode(started_at, bl);
+    encode(uptime, bl);
+    encode(last_uptime, bl);
+    encode(downtime, bl);
+    encode(last_downtime, bl);
+    encode(num_failures, bl);
+    encode(is_avail, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator &p) {
+    DECODE_START(1, p);
+    decode(pool_name, p);
+    decode(started_at, p);
+    decode(uptime, p);
+    decode(last_uptime, p);
+    decode(downtime, p);
+    decode(last_downtime, p);
+    decode(num_failures, p);
+    decode(is_avail, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(PoolAvailability)
+
 #endif

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3918,7 +3918,8 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
       info.stats.last_active = now;
     if (info.stats.state & (PG_STATE_ACTIVE|PG_STATE_PEERED))
       info.stats.last_peered = now;
-    info.stats.last_unstale = now;
+    if ((info.stats.state & PG_STATE_STALE) == 0)
+      info.stats.last_unstale = now;
     if ((info.stats.state & PG_STATE_DEGRADED) == 0)
       info.stats.last_undegraded = now;
     if ((info.stats.state & PG_STATE_UNDERSIZED) == 0)

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -653,6 +653,7 @@ public:
   //       GetMissing
   //       WaitUpThru
   //       Incomplete
+  //       Down
   //     Active
   //       Activating
   //       Clean


### PR DESCRIPTION
Added `PoolAvailability Struct`

Modified PGMap.cc to include a k,v map:
`pool_availability`.
The key being the `poolid` and value
is `PoolAvailability`

Init the function:
`PGMap::calc_pool_stuck_unavailable_pg_map()`
to identify and aggregate all the PGs we
mark as `unavailable` as well as the pool
that associates with the unavailable PG.

Also, included `pool_availability`
to `PGMapDigest::dump()`.

```
ceph osd pool availability-status
```
outputs:

`POOL`
`UPTIME`
`DOWNTIME`
`NUMFAILURES`
`MTBF`
`MTTR`
`SCORE`
`AVAILABLE`

Fixes: 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
