### PR TITLE
quincy: rbd-nbd: fix stuck with disable request

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -472,6 +472,16 @@ DEV=
 rbd feature disable ${POOL}/${IMAGE} journaling
 rbd config image rm ${POOL}/${IMAGE} rbd_discard_granularity_bytes
 
+# test that disabling a feature so that the op is proxied to rbd-nbd
+# (arranged here by blkdiscard before "rbd feature disable") doesn't hang
+DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`
+get_pid ${POOL}
+rbd feature enable ${POOL}/${IMAGE} journaling
+_sudo blkdiscard --offset 0 --length 4096 ${DEV}
+rbd feature disable ${POOL}/${IMAGE} journaling
+unmap_device ${DEV} ${PID}
+DEV=
+
 # test that rbd_op_threads setting takes effect
 EXPECTED=`ceph-conf --show-config-value librados_thread_count`
 DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1149,6 +1149,8 @@ int
 krbd_resize(struct rbd_ctx *ctx, uint64_t size)
 {
 	int ret;
+	int count = 0;
+	uint64_t effective_size;
 
 	ceph_assert(size % truncbdy == 0);
 
@@ -1170,7 +1172,29 @@ krbd_resize(struct rbd_ctx *ctx, uint64_t size)
 	if (ret < 0)
 		return ret;
 
-	return __librbd_resize(ctx, size);
+	ret = __librbd_resize(ctx, size);
+	if (ret < 0)
+		return ret;
+
+	for (;;) {
+		ret = krbd_get_size(ctx, &effective_size);
+		if (ret < 0)
+			return ret;
+
+		if (effective_size == size)
+			break;
+
+		if (count++ >= 15) {
+			prt("BLKGETSIZE64 size error: expected 0x%llx, actual 0x%llx\n",
+			    (unsigned long long)size,
+			    (unsigned long long)effective_size);
+			return -EINVAL;
+		}
+
+		usleep(count * 250 * 1000);
+	}
+
+	return 0;
 }
 
 int


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63349

---

backport of https://github.com/ceph/ceph/pull/50593
parent tracker: https://tracker.ceph.com/issues/58740

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh