### PR TITLE
reef: mgr/dashboard: Block Ui fails in angular with target es2022 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/tsconfig.json
+++ b/src/pybind/mgr/dashboard/frontend/tsconfig.json
@@ -17,7 +17,7 @@
     "noImplicitReturns": true,
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "ES2022",
+    "target": "ES2020",
     "module": "es2020",
     "baseUrl": "./",
     "resolveJsonModule": true,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63368

---

backport of https://github.com/ceph/ceph/pull/54240
parent tracker: https://tracker.ceph.com/issues/63347

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh