### PR TITLE
reef: mgr/dashboard: fix rgw multisite error when no rgw entity is present

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -29,8 +29,6 @@ import { CrudFormComponent } from '~/app/shared/forms/crud-form/crud-form.compon
 import { RgwMultisiteDetailsComponent } from './rgw-multisite-details/rgw-multisite-details.component';
 import { TreeModule } from '@circlon/angular-tree-component';
 import { DataTableModule } from '~/app/shared/datatable/datatable.module';
-import { FeatureTogglesGuardService } from '~/app/shared/services/feature-toggles-guard.service';
-import { ModuleStatusGuardService } from '~/app/shared/services/module-status-guard.service';
 import { RgwMultisiteRealmFormComponent } from './rgw-multisite-realm-form/rgw-multisite-realm-form.component';
 import { RgwMultisiteZonegroupFormComponent } from './rgw-multisite-zonegroup-form/rgw-multisite-zonegroup-form.component';
 import { RgwMultisiteZoneFormComponent } from './rgw-multisite-zone-form/rgw-multisite-zone-form.component';
@@ -185,22 +183,6 @@ const routes: Routes = [
   },
   {
     path: 'multisite',
-    canActivate: [FeatureTogglesGuardService, ModuleStatusGuardService],
-    data: {
-      moduleStatusGuardConfig: {
-        uiApiPath: 'rgw/multisite',
-        redirectTo: 'error',
-        header: 'Multi-site not configured',
-        button_name: 'Add Multi-site Configuration',
-        button_route: '/rgw/multisite/create',
-        button_title: 'Add multi-site configuration (realms/zonegroups/zones)',
-        secondary_button_name: 'Import Multi-site Configuration',
-        secondary_button_route: 'rgw/multisite/import',
-        secondary_button_title:
-          'Import multi-site configuration (import realm token from a secondary cluster)'
-      },
-      breadcrumbs: 'Multi-Site'
-    },
     children: [{ path: '', component: RgwMultisiteDetailsComponent }]
   }
 ];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63369

---

backport of https://github.com/ceph/ceph/pull/54247
parent tracker: https://tracker.ceph.com/issues/63356

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh