### PR TITLE
rgw/rgw_period : remove realm name from period config

### DIFF
--- a/src/rgw/driver/rados/rgw_rest_realm.cc
+++ b/src/rgw/driver/rados/rgw_rest_realm.cc
@@ -65,17 +65,16 @@ class RGWOp_Period_Get : public RGWOp_Period_Base {
 
 void RGWOp_Period_Get::execute(optional_yield y)
 {
-  string realm_id, realm_name, period_id;
+  string realm_id, period_id;
   epoch_t epoch = 0;
   RESTArgs::get_string(s, "realm_id", realm_id, &realm_id);
-  RESTArgs::get_string(s, "realm_name", realm_name, &realm_name);
   RESTArgs::get_string(s, "period_id", period_id, &period_id);
   RESTArgs::get_uint32(s, "epoch", 0, &epoch);
 
   period.set_id(period_id);
   period.set_epoch(epoch);
 
-  op_ret = period.init(this, driver->ctx(), static_cast<rgw::sal::RadosStore*>(driver)->svc()->sysobj, realm_id, y, realm_name);
+  op_ret = period.init(this, driver->ctx(), static_cast<rgw::sal::RadosStore*>(driver)->svc()->sysobj, realm_id, y);
   if (op_ret < 0)
     ldpp_dout(this, 5) << "failed to read period" << dendl;
 }

--- a/src/rgw/driver/rados/rgw_trim_mdlog.cc
+++ b/src/rgw/driver/rados/rgw_trim_mdlog.cc
@@ -729,8 +729,8 @@ bool sanity_check_endpoints(const DoutPrefixProvider *dpp, rgw::sal::RadosStore*
 	<< __PRETTY_FUNCTION__ << ":" << __LINE__
 	<< " WARNING: Cluster is is misconfigured! "
 	<< " Zonegroup " << zonegroup.get_name()
-	<< " (" << zonegroup.get_id() << ") in Realm "
-	<< period.get_realm_name() << " ( " << period.get_realm() << ") "
+	<< " (" << zonegroup.get_id() << ") in Realm id ( "
+  << period.get_realm() << ") "
 	<< " has no endpoints!" << dendl;
     }
     for (const auto& [_, zone] : zonegroup.zones) {
@@ -740,8 +740,7 @@ bool sanity_check_endpoints(const DoutPrefixProvider *dpp, rgw::sal::RadosStore*
 	  << " ERROR: Cluster is is misconfigured! "
 	  << " Zone " << zone.name << " (" << zone.id << ") in Zonegroup "
 	  << zonegroup.get_name() << " ( " << zonegroup.get_id()
-	  << ") in Realm " << period.get_realm_name()
-	  << " ( " << period.get_realm() << ") "
+	  << ") in Realm id ( " << period.get_realm() << ") "
 	  << " has no endpoints! Trimming is impossible." << dendl;
 	retval = false;
       }

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -516,7 +516,6 @@ int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
     period->period_map.id = period->id;
     period->epoch = FIRST_EPOCH;
     period->realm_id = info.id;
-    period->realm_name = info.name;
 
     r = cfgstore->create_period(dpp, y, true, *period);
     if (r < 0) {

--- a/src/rgw/driver/rados/rgw_zone.h
+++ b/src/rgw/driver/rados/rgw_zone.h
@@ -642,7 +642,6 @@ public:
   rgw_zone_id master_zone;
 
   std::string realm_id;
-  std::string realm_name;
   epoch_t realm_epoch{1}; //< realm epoch when period was made current
 
   CephContext *cct{nullptr};
@@ -678,7 +677,6 @@ public:
   const rgw_zone_id& get_master_zone() const { return master_zone; }
   const std::string& get_master_zonegroup() const { return master_zonegroup; }
   const std::string& get_realm() const { return realm_id; }
-  const std::string& get_realm_name() const { return realm_name; }
   const RGWPeriodMap& get_map() const { return period_map; }
   RGWPeriodConfig& get_config() { return period_config; }
   const RGWPeriodConfig& get_config() const { return period_config; }
@@ -750,7 +748,7 @@ public:
   int update_latest_epoch(const DoutPrefixProvider *dpp, epoch_t epoch, optional_yield y);
 
   int init(const DoutPrefixProvider *dpp, CephContext *_cct, RGWSI_SysObj *_sysobj_svc, const std::string &period_realm_id, optional_yield y,
-	   const std::string &period_realm_name = "", bool setup_obj = true);
+	    bool setup_obj = true);
   int init(const DoutPrefixProvider *dpp, CephContext *_cct, RGWSI_SysObj *_sysobj_svc, optional_yield y, bool setup_obj = true);  
 
   int create(const DoutPrefixProvider *dpp, optional_yield y, bool exclusive = true);
@@ -780,7 +778,6 @@ public:
     encode(master_zonegroup, bl);
     encode(period_config, bl);
     encode(realm_id, bl);
-    encode(realm_name, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -796,7 +793,6 @@ public:
     decode(master_zonegroup, bl);
     decode(period_config, bl);
     decode(realm_id, bl);
-    decode(realm_name, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_period.cc
+++ b/src/rgw/rgw_period.cc
@@ -22,10 +22,10 @@ int RGWPeriod::init(const DoutPrefixProvider *dpp,
     return 0;
 
   if (id.empty()) {
-    RGWRealm realm(realm_id, realm_name);
+    RGWRealm realm(realm_id);
     int ret = realm.init(dpp, cct, sysobj_svc, y);
     if (ret < 0) {
-      ldpp_dout(dpp, 4) << "RGWPeriod::init failed to init realm " << realm_name << " id " << realm_id << " : " <<
+      ldpp_dout(dpp, 4) << "RGWPeriod::init failed to init realm  id " << realm_id << " : " <<
 	cpp_strerror(-ret) << dendl;
       return ret;
     }
@@ -36,7 +36,7 @@ int RGWPeriod::init(const DoutPrefixProvider *dpp,
   if (!epoch) {
     int ret = use_latest_epoch(dpp, y);
     if (ret < 0) {
-      ldpp_dout(dpp, 0) << "failed to use_latest_epoch period id " << id << " realm " << realm_name  << " id " << realm_id
+      ldpp_dout(dpp, 0) << "failed to use_latest_epoch period id " << id << " realm id " << realm_id
 	   << " : " << cpp_strerror(-ret) << dendl;
       return ret;
     }
@@ -46,14 +46,12 @@ int RGWPeriod::init(const DoutPrefixProvider *dpp,
 }
 
 int RGWPeriod::init(const DoutPrefixProvider *dpp, CephContext *_cct, RGWSI_SysObj *_sysobj_svc,
-		    const string& period_realm_id, optional_yield y,
-		    const string& period_realm_name, bool setup_obj)
+		    const string& period_realm_id, optional_yield y, bool setup_obj)
 {
   cct = _cct;
   sysobj_svc = _sysobj_svc;
 
   realm_id = period_realm_id;
-  realm_name = period_realm_name;
 
   if (!setup_obj)
     return 0;
@@ -244,7 +242,6 @@ void RGWPeriod::dump(Formatter *f) const
   encode_json("master_zone", master_zone, f);
   encode_json("period_config", period_config, f);
   encode_json("realm_id", realm_id, f);
-  encode_json("realm_name", realm_name, f);
   encode_json("realm_epoch", realm_epoch, f);
 }
 
@@ -259,7 +256,6 @@ void RGWPeriod::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("master_zone", master_zone, obj);
   JSONDecoder::decode_json("period_config", period_config, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
-  JSONDecoder::decode_json("realm_name", realm_name, obj);
   JSONDecoder::decode_json("realm_epoch", realm_epoch, obj);
 }
 

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -175,7 +175,7 @@ RGWPeriodPusher::RGWPeriodPusher(const DoutPrefixProvider *dpp, rgw::sal::Driver
   // always send out the current period on startup
   RGWPeriod period;
   // XXX dang
-  int r = period.init(dpp, cct, static_cast<rgw::sal::RadosStore* >(driver)->svc()->sysobj, realm_id, y, zone->get_realm_name());
+  int r = period.init(dpp, cct, static_cast<rgw::sal::RadosStore* >(driver)->svc()->sysobj, realm_id, y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "failed to load period for realm " << realm_id << dendl;
     return;

--- a/src/rgw/rgw_realm.cc
+++ b/src/rgw/rgw_realm.cc
@@ -64,7 +64,7 @@ int RGWRealm::create(const DoutPrefixProvider *dpp, optional_yield y, bool exclu
   RGWPeriod period;
   if (current_period.empty()) {
     /* create new period for the realm */
-    ret = period.init(dpp, cct, sysobj_svc, id, y, name, false);
+    ret = period.init(dpp, cct, sysobj_svc, id, y, false);
     if (ret < 0 ) {
       return ret;
     }
@@ -75,7 +75,7 @@ int RGWRealm::create(const DoutPrefixProvider *dpp, optional_yield y, bool exclu
     }
   } else {
     period = RGWPeriod(current_period, 0);
-    int ret = period.init(dpp, cct, sysobj_svc, id, y, name);
+    int ret = period.init(dpp, cct, sysobj_svc, id, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to init period " << current_period << dendl;
       return ret;
@@ -228,7 +228,7 @@ int RGWRealm::find_zone(const DoutPrefixProvider *dpp,
   epoch_t epoch = 0;
 
   RGWPeriod period(period_id, epoch);
-  int r = period.init(dpp, cct, sysobj_svc, get_id(), y, get_name());
+  int r = period.init(dpp, cct, sysobj_svc, get_id(), y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "WARNING: period init failed: " << cpp_strerror(-r) << " ... skipping" << dendl;
     return r;

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -146,8 +146,7 @@ int RGWSI_Zone::do_start(optional_yield y, const DoutPrefixProvider *dpp)
   }
 
   ldpp_dout(dpp, 20) << "realm  " << realm->get_name() << " " << realm->get_id() << dendl;
-  ret = current_period->init(dpp, cct, sysobj_svc, realm->get_id(), y,
-                             realm->get_name());
+  ret = current_period->init(dpp, cct, sysobj_svc, realm->get_id(), y);
   if (ret < 0 && ret != -ENOENT) {
     ldpp_dout(dpp, 0) << "failed reading current period info: " << " " << cpp_strerror(-ret) << dendl;
     return ret;


### PR DESCRIPTION
The realm name is used in period configuration, only initialised in the beginning. Only value which is needed is the realm_id, hence removing realm_name from period config.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
