### PR TITLE
reef: osd: fix use-after-move in build_incremental_map_msg()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1418,14 +1418,14 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   for (epoch_t e = since + 1; e <= to; ++e) {
     bufferlist bl;
     if (get_inc_map_bl(e, bl)) {
-      m->incremental_maps[e] = std::move(bl);
+      m->incremental_maps[e] = bl;
     } else {
       dout(10) << __func__ << " missing incremental map " << e << dendl;
       if (!get_map_bl(e, bl)) {
 	derr << __func__ << " also missing full map " << e << dendl;
 	goto panic;
       }
-      m->maps[e] = std::move(bl);
+      m->maps[e] = bl;
     }
     max--;
     max_bytes -= bl.length();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63371

parent tracker: https://tracker.ceph.com/issues/63310

backport of https://github.com/ceph/ceph/pull/54177

(cherry picked from commit 9e2b8b0e8235b36e55310aab49b8f760e8d57cad)

