### PR TITLE
qa/rgw/multisite: double cluster nodes and osd count

### DIFF
--- a/qa/suites/rgw/multisite/clusters.yaml
+++ b/qa/suites/rgw/multisite/clusters.yaml
@@ -1,3 +1,5 @@
 roles:
-- [c1.mon.a, c1.mgr.x, c1.osd.0, c1.osd.1, c1.osd.2, c1.client.0, c1.client.1]
-- [c2.mon.a, c2.mgr.x, c2.osd.0, c2.osd.1, c2.osd.2, c2.client.0, c2.client.1]
+- [c1.mon.a, c1.osd.0, c1.osd.1, c1.osd.2, c1.client.0]
+- [c1.mgr.x, c1.osd.3, c1.osd.4, c1.osd.5, c1.client.1]
+- [c2.mon.a, c2.osd.0, c2.osd.1, c2.osd.2, c2.client.0]
+- [c2.mgr.x, c2.osd.3, c2.osd.4, c2.osd.5, c2.client.1]

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -13,6 +13,8 @@ overrides:
         rgw curl low speed time: 300
         rgw md log max shards: 4
         rgw data log num shards: 4
+        rgw data sync poll interval: 5
+        rgw meta sync poll interval: 5
         rgw sync obj etag verify: true
         rgw sync meta inject err probability: 0.1
         rgw sync data inject err probability: 0.1


### PR DESCRIPTION
> WARNING: The OSD cluster is overloaded and struggling to complete ops. You need more capacity to serve this level of demand.
    
give each cluster 2 nodes instead of 1, and 6 osds instead of 3

also reduces the sync polling intervals to (hopefully) help with checkpoint failures

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
