### PR TITLE
reef: osd: fix logic in check_pg_upmaps

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2145,8 +2145,8 @@ bool OSDMap::check_pg_upmaps(
                        << j->first << " " << j->second
                        << dendl;
         to_cancel->push_back(pg);
-      } else {
-        //Josh--check partial no-op here.
+      } else if (newmap != j->second) {
+        // check partial no-op here.
         ldout(cct, 10) << __func__ << " simplifying partially no-op pg_upmap_items "
                        << j->first << " " << j->second
                        << " -> " << newmap


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63375

---

backport of https://github.com/ceph/ceph/pull/53720
parent tracker: https://tracker.ceph.com/issues/63029

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh