### PR TITLE
reef: rgw/lua: fix CopyFrom crash

### DIFF
--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -786,7 +786,7 @@ struct RequestMetaTable : public EmptyMetaTable {
       create_metatable<ObjectMetaTable>(L, false, s->object);
     } else if (strcasecmp(index, "CopyFrom") == 0) {
       if (s->op_type == RGW_OP_COPY_OBJ) {
-        create_metatable<CopyFromMetaTable>(L, s);
+        create_metatable<CopyFromMetaTable>(L, false, s);
       } else {
         lua_pushnil(L);
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59498

---

backport of https://github.com/ceph/ceph/pull/50975
parent tracker: https://tracker.ceph.com/issues/59381

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh