### PR TITLE
mgr/dashboard: fix secure_monitoring_stack check

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -26,28 +26,53 @@ class PrometheusControllerTest(ControllerTestCase):
         mgr.get_module_option.side_effect = settings.get
         cls.setup_controllers([Prometheus, PrometheusNotifications, PrometheusReceiver])
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
-    def test_rules(self):
-        with patch('requests.request') as mock_request:
-            self._get('/api/prometheus/rules')
-            mock_request.assert_called_with('GET', self.prometheus_host_api + '/rules',
-                                            json=None, params={}, verify=True, auth=None)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", return_value='cephadm')
+    @patch("dashboard.controllers.prometheus.mgr.mon_command", return_value=(1, {}, None))
+    @patch('requests.request')
+    def test_rules_cephadm(self, mock_request, mock_mon_command, mock_get_module_option_ex):
+        # in this test we use:
+        # in the first call to get_module_option_ex we return 'cephadm' as backend
+        # in the second call we return 'True' for 'secure_monitoring_stack' option
+        mock_get_module_option_ex.side_effect = lambda module, key, default=None: 'cephadm' \
+            if module == 'orchestrator' else True
+        self._get('/api/prometheus/rules')
+        mock_request.assert_called_with('GET',
+                                        self.prometheus_host_api + '/rules',
+                                        json=None, params={},
+                                        verify=True, auth=None)
+        assert mock_mon_command.called
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", return_value='cephadm')
+    @patch("dashboard.controllers.prometheus.mgr.mon_command", return_value=(1, {}, None))
+    @patch('requests.request')
+    def test_rules_rook(self, mock_request, mock_mon_command, mock_get_module_option_ex):
+        # in this test we use:
+        # in the first call to get_module_option_ex we return 'rook' as backend
+        mock_get_module_option_ex.side_effect = lambda module, key, default=None: 'rook' \
+            if module == 'orchestrator' else None
+        self._get('/api/prometheus/rules')
+        mock_request.assert_called_with('GET',
+                                        self.prometheus_host_api + '/rules',
+                                        json=None,
+                                        params={},
+                                        verify=True, auth=None)
+        assert not mock_mon_command.called
+
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_list(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus')
             mock_request.assert_called_with('GET', self.alert_host_api + '/alerts',
                                             json=None, params={}, verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_get_silences(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus/silences')
             mock_request.assert_called_with('GET', self.alert_host_api + '/silences',
                                             json=None, params={}, verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_add_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'new-silence'})
@@ -55,7 +80,7 @@ class PrometheusControllerTest(ControllerTestCase):
                                             params=None, json={'id': 'new-silence'},
                                             verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_update_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'update-silence'})
@@ -63,7 +88,7 @@ class PrometheusControllerTest(ControllerTestCase):
                                             params=None, json={'id': 'update-silence'},
                                             verify=True, auth=None)
 
-    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c: False)
+    @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_expire_silence(self):
         with patch('requests.request') as mock_request:
             self._delete('/api/prometheus/silence/0')


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63326

Testing:

**Using a rook environment:**
Start a cluster with a new changes, enter to the dashboard and make sure the module is not crashing anymore

**Using a normal ceph environment:**
I tested the PR on the latest main both with `secure_monitoring_stack` enabled and disabled. I haven't observed any crash related to the changes. Only some issues during the transition that are not related to this change (I opened an issue to track them separately https://tracker.ceph.com/issues/63439)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
