### PR TITLE
RGW: fix cloud-sync not being able to sync folders

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -803,7 +803,8 @@ static void send_prepare_convert(const rgw_obj& obj, string *resource)
 {
   string urlsafe_bucket, urlsafe_object;
   url_encode(obj.bucket.get_key(':', 0), urlsafe_bucket);
-  url_encode(obj.key.name, urlsafe_object);
+  // do not encode slash. It leads to 404 errors when fetching objects inside folders.
+  url_encode(obj.key.name, urlsafe_object, false);
   *resource = urlsafe_bucket + "/" + urlsafe_object;
 }
 


### PR DESCRIPTION
Encoding the slash in object names breaks when the object we're trying to fetch is inside a folder. A side effect of this is that the cloud sync module fails to sync folders and objects nested within.

We've stumbled across this bug while trying to sync a bucket with folders inside it, against a MinIO instance. The logs showed that the requests being made to the primary rados gateway instance, included an object path, where the slash was being escaped into `%2F`. This resulted in a `404` error which bubbled up into an `ENOENT` error in the cloud sync module. The relevant snippet of the log is as follows:

```
2023-11-02T15:36:25.061+0000 7f3e10fae640 20 http_client[GET/https://10.10.10.112:443/17e3030a7fd04956b29d4f95e09f752c%3Agsamfira-test3/testfolder%2Fvirtio-win10-prewhql-0.0-100-sources.zip?rgwx-zonegroup=119cc5ef-a452-44de-a895-4b9de478540d&rgwx-prepend-metadata=true&rgwx-stat=true&rgwx-sync-man
ifest&rgwx-sync-cloudtiered&rgwx-skip-decrypt]sign_request_v4(): sigv4 header: x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
2023-11-02T15:36:25.061+0000 7f3e10fae640 20 http_client[GET/https://10.10.10.112:443/17e3030a7fd04956b29d4f95e09f752c%3Agsamfira-test3/testfolder%2Fvirtio-win10-prewhql-0.0-100-sources.zip?rgwx-zonegroup=119cc5ef-a452-44de-a895-4b9de478540d&rgwx-prepend-metadata=true&rgwx-stat=true&rgwx-sync-man
ifest&rgwx-sync-cloudtiered&rgwx-skip-decrypt]sign_request_v4(): sigv4 header: x-amz-date: 20231102T153625Z
2023-11-02T15:36:25.061+0000 7f3e10fae640 20 sending request to https://10.10.10.112:443/17e3030a7fd04956b29d4f95e09f752c%3Agsamfira-test3/testfolder%2Fvirtio-win10-prewhql-0.0-100-sources.zip?rgwx-zonegroup=119cc5ef-a452-44de-a895-4b9de478540d&rgwx-prepend-metadata=true&rgwx-stat=true&rgwx-sync-
manifest&rgwx-sync-cloudtiered&rgwx-skip-decrypt
2023-11-02T15:36:25.061+0000 7f3e10fae640 20 register_request mgr=0x5556785d3200 req_data->id=2, curl_handle=0x55567d5b5880
2023-11-02T15:36:25.061+0000 7f3e167b9640 20 link_request req_data=0x55567d53e5a0 req_data->id=2, curl_handle=0x55567d5b5880
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c0d5cc0:op=0x55567ca7ca00:27RGWReadRemoteDataLogShardCR: operate()
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c0d5cc0:op=0x55567d5f5e00:21RGWDataIncSyncShardCR: operate()
2023-11-02T15:36:25.065+0000 7f3df977f640 20 RGW-SYNC:data:sync:shard[120]: shard_id=120 sync_marker=00000000000000000000:00000000000000000685 next_marker= truncated=0
2023-11-02T15:36:25.065+0000 7f3df977f640 20 run: stack=0x55567c0d5cc0 is io blocked
2023-11-02T15:36:25.065+0000 7f3e10fae640  0 rgw async rados processor: store->stat_remote_obj() returned r=-2
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c9f5540:op=0x55567d430000:18RGWStatRemoteObjCR: operate()
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c9f5540:op=0x55567d430000:18RGWStatRemoteObjCR: operate() returned r=-2
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c9f5540:op=0x555695084800:23RGWAWSHandleRemoteObjCR: operate()
2023-11-02T15:36:25.065+0000 7f3df977f640 10 rgw rados thread: RGWStatRemoteObjCR() returned -2
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c9f5540:op=0x555695084800:23RGWAWSHandleRemoteObjCR: operate() returned r=-2
2023-11-02T15:36:25.065+0000 7f3df977f640 20 rgw rados thread: cr:s=0x55567c9f5540:op=0x55568379a000:26RGWBucketSyncSingleEntryCRINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE11rgw_obj_keyE: operate()
2023-11-02T15:36:25.065+0000 7f3df977f640 10 RGW-SYNC:data:sync:shard[45]:entry[17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7[0]]:bucket_sync_sources[source=17e3030a7fd04956b29d4f95e09f752c:gsamfira-test3[dae6f793-a9b9-4933-9d65-3e516ef20753.63322
61.1]):7:source_zone=dae6f793-a9b9-4933-9d65-3e516ef20753]:bucket[17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1<-17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7]:inc_sync[17e3030a7fd04956b29d4f95e09f7
52c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7]:entry[testfolder/virtio-win10-prewhql-0.0-100-sources.zip]: failed, retcode=-2 ((2) No such file or directory)
2023-11-02T15:36:25.065+0000 7f3df977f640 20 RGW-SYNC:data:sync:shard[45]:entry[17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7[0]]:bucket_sync_sources[source=17e3030a7fd04956b29d4f95e09f752c:gsamfira-test3[dae6f793-a9b9-4933-9d65-3e516ef20753.63322
61.1]):7:source_zone=dae6f793-a9b9-4933-9d65-3e516ef20753]:bucket[17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1<-17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7]:inc_sync[17e3030a7fd04956b29d4f95e09f7
52c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7]: updating marker marker_oid=bucket.sync-status.dae6f793-a9b9-4933-9d65-3e516ef20753:17e3030a7fd04956b29d4f95e09f752c/gsamfira-test3:dae6f793-a9b9-4933-9d65-3e516ef20753.6332261.1:7 marker=00000000001.2.6 timestamp=2023-11-02T15:3
5:56.032657+0000
```

The fix was trivial in our case. By just not escaping the slash, folders started syncing. 

I will be happy to open a ticket on the ceph tracker as soon as my account is approved. Opening this PR in the meantime.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
