### PR TITLE
qa/tasks/cephadm: enable mon_cluster_log_to_file

### DIFF
--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -3,6 +3,7 @@
 log_to_file = true
 log_to_stderr = false
 log to journald = false
+mon cluster log to file = true
 mon cluster log file level = debug
 
 mon clock drift allowed = 1.000


### PR DESCRIPTION
Without cluster_log_to_file we have nothing to grep for errors:

2023-10-27T16:06:59.111 DEBUG:teuthology.orchestra.run.smithi150:> sudo egrep '\[ERR\]|\[WRN\]|\[SEC\]' /var/log/ceph/38cc7fce-74d9-11ee-8db9-212e2dc638e7/ceph.log | egrep -v '\(MDS_ALL_DOWN\)' | egrep -v '\(MDS_UP_LESS_THAN_MAX\)' | head -n 1 2023-10-27T16:06:59.141 INFO:teuthology.orchestra.run.smithi150.stderr:grep: /var/log/ceph/38cc7fce-74d9-11ee-8db9-212e2dc638e7/ceph.log: No such file or directory

Set mon_cluster_log_to_file = true.

Fixes: https://tracker.ceph.com/issues/63425


See https://pulpito.ceph.com/teuthology-2023-10-28_14:23:03-upgrade:quincy-x-reef-distro-default-smithi/7439369/ for a broken example