### PR TITLE
pacific: mon: fix mds metadata lost in one case.

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -136,6 +136,7 @@ void MDSMonitor::update_from_paxos(bool *need_bootstrap)
 	   << ", my e " << get_fsmap().epoch << dendl;
   ceph_assert(version > get_fsmap().epoch);
 
+  load_metadata(pending_metadata);
   load_health();
 
   // read and decode


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63414

---

backport of https://github.com/ceph/ceph/pull/53883
parent tracker: https://tracker.ceph.com/issues/63166

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh