### PR TITLE
quincy: doc/cephadm/services: remove excess rendered indentation in osd.rst

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -15,10 +15,9 @@ To print a list of devices discovered by ``cephadm``, run this command:
 
 .. prompt:: bash #
 
-    ceph orch device ls [--hostname=...] [--wide] [--refresh]
+  ceph orch device ls [--hostname=...] [--wide] [--refresh]
 
-Example
-::
+Example::
 
   Hostname  Path      Type  Serial              Size   Health   Ident  Fault  Available
   srv-01    /dev/sdb  hdd   15P0A0YFFRD6         300G  Unknown  N/A    N/A    No
@@ -44,7 +43,7 @@ enable cephadm's "enhanced device scan" option as follows;
 
 .. prompt:: bash #
 
-    ceph config set mgr mgr/cephadm/device_enhanced_scan true
+  ceph config set mgr mgr/cephadm/device_enhanced_scan true
 
 .. warning::
     Although the libstoragemgmt library performs standard SCSI inquiry calls,
@@ -161,16 +160,16 @@ will happen without actually creating the OSDs.
 
 For example:
 
-   .. prompt:: bash #
+.. prompt:: bash #
 
-     ceph orch apply osd --all-available-devices --dry-run
+  ceph orch apply osd --all-available-devices --dry-run
 
-   ::
+::
 
-     NAME                  HOST  DATA      DB  WAL
-     all-available-devices node1 /dev/vdb  -   -
-     all-available-devices node2 /dev/vdc  -   -
-     all-available-devices node3 /dev/vdd  -   -
+  NAME                  HOST  DATA      DB  WAL
+  all-available-devices node1 /dev/vdb  -   -
+  all-available-devices node2 /dev/vdc  -   -
+  all-available-devices node3 /dev/vdd  -   -
 
 .. _cephadm-osd-declarative:
 
@@ -185,9 +184,9 @@ command completes will be automatically found and added to the cluster.
 
 We will examine the effects of the following command:
 
-   .. prompt:: bash #
+.. prompt:: bash #
 
-     ceph orch apply osd --all-available-devices
+  ceph orch apply osd --all-available-devices
 
 After running the above command: 
 
@@ -203,17 +202,17 @@ If you want to avoid this behavior (disable automatic creation of OSD on availab
 
 .. prompt:: bash #
 
-   ceph orch apply osd --all-available-devices --unmanaged=true
+  ceph orch apply osd --all-available-devices --unmanaged=true
 
 .. note::
 
-  Keep these three facts in mind:
+    Keep these three facts in mind:
 
-  - The default behavior of ``ceph orch apply`` causes cephadm constantly to reconcile. This means that cephadm creates OSDs as soon as new drives are detected.
+    - The default behavior of ``ceph orch apply`` causes cephadm constantly to reconcile. This means that cephadm creates OSDs as soon as new drives are detected.
 
-  - Setting ``unmanaged: True`` disables the creation of OSDs. If ``unmanaged: True`` is set, nothing will happen even if you apply a new OSD service.
+    - Setting ``unmanaged: True`` disables the creation of OSDs. If ``unmanaged: True`` is set, nothing will happen even if you apply a new OSD service.
 
-  - ``ceph orch daemon add`` creates OSDs, but does not add an OSD service.
+    - ``ceph orch daemon add`` creates OSDs, but does not add an OSD service.
 
 * For cephadm, see also :ref:`cephadm-spec-unmanaged`.
 
@@ -241,7 +240,7 @@ Example:
 
 Expected output::
 
-   Scheduled OSD(s) for removal
+  Scheduled OSD(s) for removal
 
 OSDs that are not safe to destroy will be rejected.
 
@@ -264,14 +263,14 @@ You can query the state of OSD operation with the following command:
 
 .. prompt:: bash #
 
-   ceph orch osd rm status
+  ceph orch osd rm status
 
 Expected output::
 
-    OSD_ID  HOST         STATE                    PG_COUNT  REPLACE  FORCE  STARTED_AT
-    2       cephadm-dev  done, waiting for purge  0         True     False  2020-07-17 13:01:43.147684
-    3       cephadm-dev  draining                 17        False    True   2020-07-17 13:01:45.162158
-    4       cephadm-dev  started                  42        False    True   2020-07-17 13:01:45.162158
+  OSD_ID  HOST         STATE                    PG_COUNT  REPLACE  FORCE  STARTED_AT
+  2       cephadm-dev  done, waiting for purge  0         True     False  2020-07-17 13:01:43.147684
+  3       cephadm-dev  draining                 17        False    True   2020-07-17 13:01:45.162158
+  4       cephadm-dev  started                  42        False    True   2020-07-17 13:01:45.162158
 
 
 When no PGs are left on the OSD, it will be decommissioned and removed from the cluster.
@@ -293,11 +292,11 @@ Example:
 
 .. prompt:: bash #
 
-    ceph orch osd rm stop 4
+  ceph orch osd rm stop 4
 
 Expected output::
 
-    Stopped OSD(s) removal
+  Stopped OSD(s) removal
 
 This resets the initial state of the OSD and takes it off the removal queue.
 
@@ -318,7 +317,7 @@ Example:
 
 Expected output::
 
-   Scheduled OSD(s) for replacement
+  Scheduled OSD(s) for replacement
 
 This follows the same procedure as the procedure in the "Remove OSD" section, with
 one exception: the OSD is not permanently removed from the CRUSH hierarchy, but is
@@ -425,10 +424,10 @@ the ``ceph orch ps`` output in the ``MEM LIMIT`` column::
 To exclude an OSD from memory autotuning, disable the autotune option
 for that OSD and also set a specific memory target.  For example,
 
-  .. prompt:: bash #
+.. prompt:: bash #
 
-    ceph config set osd.123 osd_memory_target_autotune false
-    ceph config set osd.123 osd_memory_target 16G
+  ceph config set osd.123 osd_memory_target_autotune false
+  ceph config set osd.123 osd_memory_target 16G
 
 
 .. _drivegroups:
@@ -491,7 +490,7 @@ Example
 
 .. prompt:: bash [monitor.1]#
 
-   ceph orch apply -i /path/to/osd_spec.yml --dry-run
+  ceph orch apply -i /path/to/osd_spec.yml --dry-run
 
 
 
@@ -501,9 +500,9 @@ Filters
 -------
 
 .. note::
-   Filters are applied using an `AND` gate by default. This means that a drive
-   must fulfill all filter criteria in order to get selected. This behavior can
-   be adjusted by setting ``filter_logic: OR`` in the OSD specification. 
+    Filters are applied using an `AND` gate by default. This means that a drive
+    must fulfill all filter criteria in order to get selected. This behavior can
+    be adjusted by setting ``filter_logic: OR`` in the OSD specification. 
 
 Filters are used to assign disks to groups, using their attributes to group
 them. 
@@ -513,7 +512,7 @@ information about the attributes with this command:
 
 .. code-block:: bash
 
-  ceph-volume inventory </path/to/disk>
+    ceph-volume inventory </path/to/disk>
 
 Vendor or Model
 ^^^^^^^^^^^^^^^
@@ -622,9 +621,9 @@ but want to use only the first two, you could use `limit`:
 
 .. code-block:: yaml
 
-  data_devices:
-    vendor: VendorA
-    limit: 2
+    data_devices:
+      vendor: VendorA
+      limit: 2
 
 .. note:: `limit` is a last resort and shouldn't be used if it can be avoided.
 
@@ -845,8 +844,8 @@ See :ref:`orchestrator-cli-placement-spec`
 
 .. note::
 
-   Assuming each host has a unique disk layout, each OSD 
-   spec needs to have a different service id
+    Assuming each host has a unique disk layout, each OSD 
+    spec needs to have a different service id
 
 
 Dedicated wal + db
@@ -976,7 +975,7 @@ activates all existing OSDs on a host.
 
 .. prompt:: bash #
 
-   ceph cephadm osd activate <host>...
+  ceph cephadm osd activate <host>...
 
 This will scan all existing disks for OSDs and deploy corresponding daemons.
 


### PR DESCRIPTION
Start bash command blocks at the left margin, removing excessive padding/indentation that would render the block too much towards the right.

At the same time ident the source consistently:
- Two spaces for command blocks and output blocks.
- Four spaces for notes, code blocks.

There seems to be no uniform style for this, sometimes commands are indented with three spaces but it would seem two spaces is common. In the end it all renders the same I guess.

Signed-off-by: Ville Ojamo <14869000+bluikko@users.noreply.github.com>
(cherry picked from commit 329df4959d08e9bc90d6e1d83f99bd344a13dc1e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
