### PR TITLE
os/bluestore: BufferSpace per Onode

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1328,7 +1328,6 @@ public:
     dout(20) << __func__ << " level " << level << " near " << near
              << " on " << *b
              << " which has cache_private " << b->cache_private << dendl;
-    ceph_assert(ceph_mutex_is_locked(cache));  // see _txc_finish_io
     ceph_assert(b->is_clean() || b->is_empty());
     if (near) {
       b->cache_private = near->cache_private;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1758,9 +1758,6 @@ void BlueStore::BufferSpace::read(
     for (auto i = _data_lower_bound(offset);
          i != buffer_map.end() && offset < end && i->first < end; ++i) {
       Buffer *b = &i->second;
-      if (b->end() <= offset) {
-        break;
-      }
       ceph_assert(b->end() > offset);
 
       bool val = false;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1675,8 +1675,9 @@ int BlueStore::BufferSpace::_discard(BufferCacheShard* cache, uint32_t offset, u
   uint32_t end = offset + length;
   while (i != buffer_map.end()) {
     Buffer *b = &i->second;
-    // If no overlap is found between what we want to read and what we have
-    // cached, then forget about continuing
+    // First iteration either finds a buffer that contains the offset or the next buffer after it.
+    // Subsequent iterations are either buffers inside range or after the range.
+    // If we already found a buffer that doesn't overlaps with the range, we can break, as it must be next to the range.
     bool overlaps = offset < b->end() && end > b->offset;
     if (!overlaps) {
       break;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1762,11 +1762,6 @@ void BlueStore::BufferSpace::read(
         break;
       }
 
-      // If no overlap is found between what we want to read and what we have cached, then forget about continuing
-      if (std::max(b->end(), offset+length) - std::min(b->offset, offset) > length + b->length) {
-        break;
-      }
-
       bool val = false;
       if (flags & BYPASS_CLEAN_CACHE)
         val = b->is_writing();
@@ -15499,8 +15494,6 @@ void BlueStore::_do_write_small(
           dout(20) << __func__ << "  write to unused 0x" << std::hex << b_off
                    << "~" << b_len << " pad 0x" << head_pad << " + 0x"
                    << tail_pad << std::dec << " of mutable " << *b << dendl;
-          _buffer_cache_write(txc, b, o, offset - head_pad, bl,
-                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
           if (b_len < prefer_deferred_size) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1873,11 +1873,11 @@ void BlueStore::BufferSpace::_dup_writing(TransContext* txc, Collection* collect
           uint64_t tail = b.end() - end;
           auto new_length = b.data.length() - tail;
           buffer_to_copy.substr_of(b.data, 0, new_length);
-          buffer_to_copy = b.offset;
+          offset_to_copy = b.offset;
         } else {
           // take whole buffer
           buffer_to_copy = b.data;
-          buffer_to_copy = b.offset;
+          offset_to_copy = b.offset;
         }
       } else {
         if (b.end() > end) {
@@ -1903,8 +1903,8 @@ void BlueStore::BufferSpace::_dup_writing(TransContext* txc, Collection* collect
       if (collection->is_deferred_seq(to_b.seq)) {
         collection->add_deferred_dependency(to_b.seq, onode);
       } else {
-      txc->buffers_written.insert({onode.get(), b.seq});
-    }
+        txc->buffers_written.insert({onode.get(), b.seq});
+      }
       to._discard(collection->cache, to_b.offset, to_b.length);
       to._add_buffer(collection->cache, &to, std::move(to_b), to_b.cache_private, 0, nullptr);
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15508,9 +15508,7 @@ void BlueStore::_do_write_small(
 	  }
           logger->inc(l_bluestore_write_small_pre_read);
 
-          bufferlist without_padding;
-          without_padding.substr_of(bl, head_pad, bl.length() - head_pad);
-          _buffer_cache_write(txc, o, offset - head_read, std::move(without_padding),
+          _buffer_cache_write(txc, o, offset - head_read - head_pad, bl,
                               wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
           b->dirty_blob().calc_csum(b_off, bl);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1861,7 +1861,8 @@ void BlueStore::BufferSpace::_dup_writing(TransContext* txc, Collection* collect
     for (auto it = writing.begin(); it != writing.end(); ++it) {
       Buffer& b = *it;
       // If no overlap is found between buffer and range to dup then continue
-      if (std::max(b.end(), offset+length) - std::min(b.offset, offset) > length + b.length) {
+      bool overlaps = offset < b.end() && end > b.offset;
+      if (!overlaps) {
         continue;
       }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16829,7 +16829,6 @@ void BlueStore::_do_truncate(
     o->bc.discard(o->c->cache, offset, length);
     o->extent_map.fault_range(db, offset, length);
     o->extent_map.punch_hole(c, offset, length, &wctx.old_extents);
-    o->bc.discard(o->c->cache, offset, length);
     o->extent_map.dirty_range(offset, length);
 
     _wctx_finish(txc, c, o, &wctx, maybe_unshared_blobs);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2811,11 +2811,7 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 
 
 void BlueStore::Blob::maybe_prune_tail() {
-  if (get_blob().is_shared()) {
-    return;
-  }
-
-  if (!get_blob().is_compressed() && get_blob().can_prune_tail()) {
+  if (get_blob().can_prune_tail()) {
     dirty_blob().prune_tail();
     used_in_blob.prune_tail(get_blob().get_ondisk_length());
     dout(20) << __func__ << " pruned tail, now " << get_blob() << dendl;
@@ -5083,6 +5079,7 @@ void BlueStore::Collection::split_cache(
       }
 
       for (auto &i : o->bc.buffer_map) {
+        ceph_assert(!i.second.is_writing());
         ldout(store->cct, 1)
           << __func__ << "   moving " << i.second << dendl;
         dest->cache->_move(cache, &i.second);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13801,6 +13801,7 @@ void BlueStore::_txc_finish(TransContext *txc)
 
   for (auto &[onode, seq] : txc->buffers_written) {
     if (txc->deferred_txn && txc->deferred_txn->txc_seq == seq) {
+      std::unique_lock l(onode->c->lock);
       auto it = onode->c->deferred_seq_dependencies.find(seq);
       if (it != onode->c->deferred_seq_dependencies.end()) {
         for (auto &dependent_onode : it->second) {
@@ -18167,6 +18168,7 @@ void BlueStore::_shutdown_cache()
   }
   for (auto& p : coll_map) {
     // Clear deferred write buffers before clearing up Onodes
+    std::unique_lock l(p.second->lock);
     for (auto &[seq, onodes] : p.second->deferred_seq_dependencies) {
       for (auto &onode : onodes) {
         onode->bc._finish_write(onode->c->cache, seq);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11921,6 +11921,7 @@ int BlueStore::_generate_read_result_bl(
       ceph_assert(p != compressed_blob_bls.end());
       bufferlist& compressed_bl = *p++;
       uint32_t offset = r2r.front().regs.front().logical_offset;
+      uint32_t blob_offset = r2r.front().regs.front().blob_xoffset;
       uint32_t length = r2r.front().regs.front().length;
       if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl, offset) < 0) {
         *csum_error = true;
@@ -11932,11 +11933,8 @@ int BlueStore::_generate_read_result_bl(
         return r;
       if (buffered) {
         bufferlist region_buffer;
-        // todo bad offset
-        region_buffer.substr_of(raw_bl, offset, length);
-        // need offset before padding
-        o->bc.did_read(o->c->cache, offset,
-                       length, std::move(region_buffer));
+        region_buffer.substr_of(raw_bl, blob_offset, length);
+        o->bc.did_read(o->c->cache, offset, region_buffer.length(), std::move(region_buffer));
       }
       for (auto& req : r2r) {
         for (auto& r : req.regs) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1585,7 +1585,7 @@ public:
 #ifdef DEBUG_CACHE
   void _audit(const char *when) override
   {
-    dout(10) << __func__ << " " << when << " start" << dendl;
+    dout(10) << __func__ << " start" << dendl;
     uint64_t s = 0;
     for (auto i = hot.begin(); i != hot.end(); ++i) {
       ceph_assert(i->cache_private == BUFFER_HOT);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15439,7 +15439,7 @@ void BlueStore::_do_write_small(
             b->get_blob().get_ondisk_length() >= b_off + b_len &&
             b->get_blob().is_unused(b_off, b_len) &&
             b->get_blob().is_allocated(b_off, b_len)) {
-          _buffer_cache_write(txc, b, o, offset, bl,
+          _buffer_cache_write(txc, o, offset, bl,
                               wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
           _apply_padding(head_pad, tail_pad, bl);
 
@@ -15536,7 +15536,7 @@ void BlueStore::_do_write_small(
 
           bufferlist without_padding;
           without_padding.substr_of(bl, head_pad, bl.length() - head_pad);
-          _buffer_cache_write(txc, b, o, offset - head_read, std::move(without_padding),
+          _buffer_cache_write(txc, o, offset - head_read, std::move(without_padding),
                               wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
           b->dirty_blob().calc_csum(b_off, bl);
@@ -15825,7 +15825,7 @@ void BlueStore::_do_write_big_apply_deferred(
     logger->inc(l_bluestore_write_penalty_read_ops);
   }
   auto& b0 = dctx.blob_ref;
-  _buffer_cache_write(txc, b0, o, dctx.off - dctx.head_read, bl,
+  _buffer_cache_write(txc, o, dctx.off - dctx.head_read, bl,
     wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
   b0->dirty_blob().calc_csum(dctx.b_off, bl);
@@ -16365,7 +16365,7 @@ int BlueStore::_do_alloc_write(
     dout(20) << __func__ << "  lex " << *le << dendl;
     bufferlist without_pad;
     without_pad.substr_of(wi.bl, wi.b_off0-wi.b_off, wi.length0);
-    _buffer_cache_write(txc, wi.b, o, wi.logical_offset, std::move(without_pad),
+    _buffer_cache_write(txc, o, wi.logical_offset, std::move(without_pad),
                         wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
     // queue io

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11895,7 +11895,7 @@ int BlueStore::_generate_read_result_bl(
       if (buffered) {
         bufferlist region_buffer;
         region_buffer.substr_of(raw_bl, blob_offset, length);
-        o->bc.did_read(o->c->cache, offset, region_buffer.length(), std::move(region_buffer));
+        o->bc.did_read(o->c->cache, offset, std::move(region_buffer));
       }
       for (auto& req : r2r) {
         for (auto& r : req.regs) {
@@ -11917,7 +11917,7 @@ int BlueStore::_generate_read_result_bl(
             bufferlist region_buffer;
             region_buffer.substr_of(req.bl, r.front, r.length);
             // need offset before padding
-            o->bc.did_read(o->c->cache, r.logical_offset, r.length, std::move(region_buffer));
+            o->bc.did_read(o->c->cache, r.logical_offset, std::move(region_buffer));
           }
           ready_regions[r.logical_offset].substr_of(req.bl, r.front, r.length);
         }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15475,6 +15475,7 @@ void BlueStore::_do_write_small(
 	    b_len % chunk_size == 0 &&
 	    b->get_blob().is_allocated(b_off, b_len)) {
 
+          _buffer_cache_write(txc, o, offset, bl, wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 	  _apply_padding(head_pad, tail_pad, bl);
 
 	  dout(20) << __func__ << "  reading head 0x" << std::hex << head_read
@@ -15507,11 +15508,6 @@ void BlueStore::_do_write_small(
 	    logger->inc(l_bluestore_write_penalty_read_ops);
 	  }
           logger->inc(l_bluestore_write_small_pre_read);
-
-          bufferlist without_padding;
-          without_padding.substr_of(bl, head_pad, bl.length() - head_pad);
-          _buffer_cache_write(txc, o, offset - head_read, std::move(without_padding),
-                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
           b->dirty_blob().calc_csum(b_off, bl);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3778,7 +3778,7 @@ void BlueStore::ExtentMap::reshard(
           // shard boundary.
           bool must_span = false;
           BlobRef b = e->blob;
-          if (onode->bc.writing.empty() && b->can_split()) {
+          if (b->can_split()) {
             uint32_t bstart = e->blob_start();
             uint32_t bend = e->blob_end();
             for (const auto& sh : shards) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1654,18 +1654,64 @@ BlueStore::BufferCacheShard *BlueStore::BufferCacheShard::create(
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.BufferSpace(" << this << " in " << cache << ") "
 
-bool BlueStore::BufferSpace::_dup_writing(TransContext* txc, BufferCacheShard* cache, OnodeRef onode)
+bool BlueStore::BufferSpace::_dup_writing(TransContext* txc, Collection* collection, OnodeRef onode, uint64_t offset, uint64_t length)
 {
   bool copied = false;
+  uint64_t end = offset + length;
+  BufferSpace &to = onode->bc;
+  BufferCacheShard *cache = collection->cache;
+  ldout(cache->cct, 20) << __func__ << " offset=" << std::hex << offset << " length=" << std::hex << length << dendl; 
   if (!writing.empty()) {
     copied = true;
     for (auto it = writing.begin(); it != writing.end(); ++it) {
       Buffer& b = *it;
-      Buffer to_b(&onode->bc, b.state, b.seq, b.offset, b.data, b.flags);
-      BufferSpace& to = onode->bc;
+      // If no overlap is found between buffer and range to dup then continue
+      if (std::max((uint64_t)b.end(), offset+length) - std::min((uint64_t)b.offset, offset) > length + (uint64_t)b.length) {
+        continue;
+      }
+
+      bufferlist buffer_to_copy;
+      uint32_t offset_to_copy = 0;
+      if (b.offset >= offset) {
+        if (b.end() > end) {
+          // take head
+          uint64_t tail = b.end() - end;
+          auto new_length = b.data.length() - tail;
+          buffer_to_copy.substr_of(b.data, 0, new_length);
+          buffer_to_copy = b.offset;
+        } else {
+          // take whole buffer
+          buffer_to_copy = b.data;
+          buffer_to_copy = b.offset;
+        }
+      } else {
+        if (b.end() > end) {
+          uint64_t front = offset - b.offset;
+          uint64_t tail = b.end() - end;
+          // take middle
+          uint64_t new_length = b.data.length() - front - tail;
+          buffer_to_copy.substr_of(b.data, front, new_length);
+          offset_to_copy = b.offset + front;
+        } else {
+          // take tail
+          uint64_t front = offset - b.offset;
+          uint64_t new_length = b.data.length() - front;
+          buffer_to_copy.substr_of(b.data, front, new_length);
+          offset_to_copy = b.offset + front;
+        }
+      }
+      Buffer to_b(&onode->bc, b.state, b.seq, offset_to_copy, 
+                               std::move(buffer_to_copy), b.flags);
+      ldout(cache->cct, 20) << __func__ << " offset=" << std::hex << offset
+                            << " length=" << std::hex << length << " buffer=" << to_b << dendl;
       ceph_assert(to_b.is_writing());
-      to._add_buffer(cache, &to, std::move(to_b), b.cache_private, 0, nullptr);
+      if (collection->is_deferred_seq(to_b.seq)) {
+        collection->add_deferred_dependency(to_b.seq, onode);
+      } else {
       txc->buffers_written.insert({onode.get(), b.offset, b.seq});
+    }
+      to._discard(collection->cache, to_b.offset, to_b.length);
+      to._add_buffer(collection->cache, &to, std::move(to_b), to_b.cache_private, 0, nullptr);
     }
   }
   return copied;
@@ -1829,6 +1875,7 @@ void BlueStore::BufferSpace::read(
 
 void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint32_t offset, uint64_t seq)
 {
+  std::lock_guard l(cache->lock);
   auto i = writing.begin();
   while (i != writing.end()) {
     if (i->seq > seq) {
@@ -3205,7 +3252,7 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
   // By default do not copy buffers to clones, and let them read data by
   // themselves. The exception are 'writing' buffers, which are not yet
   // stable on device.
-  oldo->bc._dup_writing(txc, onode->c->cache, newo);
+  oldo->bc._dup_writing(txc, newo->c, newo, dstoff, length);
 
   if (src_dirty) {
     oldo->extent_map.dirty_range(dirty_range_begin,
@@ -3334,7 +3381,7 @@ void BlueStore::ExtentMap::dup_esb(BlueStore* b, TransContext* txc,
   // By default do not copy buffers to clones, and let them read data by
   // themselves. The exception are 'writing' buffers, which are not yet
   // stable on device.
-  oldo->bc._dup_writing(txc, onode->c->cache, newo);
+  oldo->bc._dup_writing(txc, newo->c, newo, dstoff, length);
 
   if (src_dirty) {
     dirty_range(dirty_range_begin, dirty_range_end - dirty_range_begin);
@@ -5140,6 +5187,22 @@ void BlueStore::Collection::split_cache(
   dest->cache->_trim();
 }
 
+bool BlueStore::Collection::is_deferred_seq(uint64_t seq) {
+  auto it = deferred_seq_dependencies.find(seq);
+  return it != deferred_seq_dependencies.end();
+
+}
+
+void BlueStore::Collection::add_deferred_dependency(uint64_t seq, OnodeRef onode) {
+  BufferCacheShard* cache = onode->c->cache;
+  ldout(cache->cct, 20) << __func__ << " seq=" << seq << " onode=" << onode << dendl;
+  auto it = deferred_seq_dependencies.find(seq);
+  if (it == deferred_seq_dependencies.end()) {
+    deferred_seq_dependencies.insert({seq, {onode}});
+  } else {
+    it->second.insert(onode);
+  }
+}
 // =======================================================
 
 // MempoolThread
@@ -13733,7 +13796,16 @@ void BlueStore::_txc_finish(TransContext *txc)
   dout(20) << __func__ << " " << txc << " onodes " << txc->onodes << dendl;
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
-  for (auto& [onode, offset, seq] : txc->buffers_written) {
+  for (auto &[onode, offset, seq] : txc->buffers_written) {
+    if (txc->deferred_txn && txc->deferred_txn->txc_seq == seq) {
+      auto it = onode->c->deferred_seq_dependencies.find(seq);
+      if (it != onode->c->deferred_seq_dependencies.end()) {
+        for (auto &dependent_onode : it->second) {
+          dependent_onode->bc._finish_write(onode->c->cache, offset, seq);
+        }
+        onode->c->deferred_seq_dependencies.erase(it);
+      }
+    }
     onode->bc._finish_write(onode->c->cache, offset, seq);
   }
   txc->buffers_written.clear();
@@ -14381,6 +14453,7 @@ bluestore_deferred_op_t *BlueStore::_get_deferred_op(
 {
   if (!txc->deferred_txn) {
     txc->deferred_txn = new bluestore_deferred_transaction_t;
+    txc->deferred_txn->txc_seq = txc->seq;
   }
   txc->deferred_txn->ops.push_back(bluestore_deferred_op_t());
   logger->inc(l_bluestore_issued_deferred_writes);
@@ -15432,6 +15505,7 @@ void BlueStore::_do_write_small(
                                   return 0;
                                 });
               op->data = bl;
+              o->c->add_deferred_dependency(txc->seq, o);
           } else {
               b->get_blob().map_bl(
                   b_off, bl,
@@ -15523,9 +15597,10 @@ void BlueStore::_do_write_small(
               });
           ceph_assert(r == 0);
           op->data = std::move(bl);
-          dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off << "~"
-		     << b_len << std::dec << " of mutable " << *b
-		     << " at " << op->extents << dendl;
+          o->c->add_deferred_dependency(txc->seq, o);
+          dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off
+                   << "~" << b_len << std::dec << " of mutable " << *b << " at "
+                   << op->extents << dendl;
           }
 
           Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
@@ -15813,6 +15888,7 @@ void BlueStore::_do_write_big_apply_deferred(
     op->op = bluestore_deferred_op_t::OP_WRITE;
     op->extents.swap(dctx.res_extents);
     op->data = std::move(bl);
+    o->c->add_deferred_dependency(txc->seq, o);
   }
 }
 
@@ -16353,7 +16429,8 @@ int BlueStore::_do_alloc_write(
 	    return 0;
 	  });
         ceph_assert(r == 0);
-	op->data = *l;
+        op->data = *l;
+        o->c->add_deferred_dependency(txc->seq, o);
       } else {
 	wi.b->get_blob().map_bl(
 	  b_off, *l,
@@ -18088,6 +18165,14 @@ void BlueStore::_shutdown_cache()
     ceph_assert(i->empty());
   }
   for (auto& p : coll_map) {
+    // Clear deferred write buffers before clearing up Onodes
+    for (auto &[seq, onodes] : p.second->deferred_seq_dependencies) {
+      for (auto &onode : onodes) {
+        onode->bc._finish_write(onode->c->cache, 0, seq);
+      }
+    }
+    p.second->deferred_seq_dependencies.clear();
+
     p.second->onode_space.clear();
     if (!p.second->shared_blob_set.empty()) {
       derr << __func__ << " stray shared blobs on " << p.first << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -15475,7 +15475,6 @@ void BlueStore::_do_write_small(
 	    b_len % chunk_size == 0 &&
 	    b->get_blob().is_allocated(b_off, b_len)) {
 
-          _buffer_cache_write(txc, o, offset, bl, wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 	  _apply_padding(head_pad, tail_pad, bl);
 
 	  dout(20) << __func__ << "  reading head 0x" << std::hex << head_read
@@ -15508,6 +15507,11 @@ void BlueStore::_do_write_small(
 	    logger->inc(l_bluestore_write_penalty_read_ops);
 	  }
           logger->inc(l_bluestore_write_small_pre_read);
+
+          bufferlist without_padding;
+          without_padding.substr_of(bl, head_pad, bl.length() - head_pad);
+          _buffer_cache_write(txc, o, offset - head_read, std::move(without_padding),
+                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
           b->dirty_blob().calc_csum(b_off, bl);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2440,7 +2440,7 @@ void BlueStore::Blob::dup(const Blob& from, bool copy_used_in_blob)
   }
   for (auto p : blob.get_extents()) {
     if (p.is_valid()) {
-      shared_blob->get_ref(p.offset, p.length);
+      get_dirty_shared_blob()->get_ref(p.offset, p.length);
     }
   }
 }
@@ -2611,7 +2611,7 @@ void BlueStore::Blob::copy_extents_over_empty(
     if (prev != exto.end()) {
       if (prev->is_valid()) {
 	if (prev->offset + prev->length == disk_offset) {
-	  shared_blob->get_ref(disk_offset, disk_len);
+	  get_dirty_shared_blob()->get_ref(disk_offset, disk_len);
 	  prev->length += disk_len;
 	  return;
 	}
@@ -2620,7 +2620,7 @@ void BlueStore::Blob::copy_extents_over_empty(
     it = exto.insert(it, bluestore_pextent_t(disk_offset, disk_len));
     prev = it;
     ++it;
-    shared_blob->get_ref(disk_offset, disk_len);
+    get_dirty_shared_blob()->get_ref(disk_offset, disk_len);
   };
 
   while (ito != exto.end() && sto >= ito->length) {
@@ -3128,7 +3128,7 @@ void BlueStore::ExtentMap::make_range_shared_maybe_merge(
         uint32_t b_logical_length = b->merge_blob(store->cct, e.blob.get());
         for (auto p : blob.get_extents()) {
           if (p.is_valid()) {
-            b->shared_blob->get_ref(p.offset, p.length);
+            b->get_dirty_shared_blob()->get_ref(p.offset, p.length);
           }
         }
         // reblob extents might erase e

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -25,6 +25,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_real.hpp>
 
+#include "common/dout.h"
 #include "include/cpp-btree/btree_set.h"
 
 #include "BlueStore.h"
@@ -582,12 +583,6 @@ void _dump_extent_map(CephContext *cct, const BlueStore::ExtentMap &em)
       dout(LogLevelV) << __func__ << "      csum: " << std::hex << v << std::dec
 		      << dendl;
     }
-    std::lock_guard l(e.blob->get_cache()->lock);
-    for (auto& i : e.blob->get_bc().buffer_map) {
-      dout(LogLevelV) << __func__ << "       0x" << std::hex << i.first
-		      << "~" << i.second.length << std::dec
-		      << " " << i.second << dendl;
-    }
   }
 }
 
@@ -617,6 +612,12 @@ void _dump_onode(CephContext *cct, const BlueStore::Onode& o)
 		    << " len " << p->second.length() << dendl;
   }
   _dump_extent_map<LogLevelV>(cct, o.extent_map);
+
+  for (auto& i : o.bc.buffer_map) {
+    dout(LogLevelV) << __func__ << "       0x" << std::hex << i.first << "~"
+                    << i.second.length << std::dec << " " << i.second
+                    << dendl;
+  }
 }
 
 template <int LogLevelV>
@@ -1653,20 +1654,29 @@ BlueStore::BufferCacheShard *BlueStore::BufferCacheShard::create(
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.BufferSpace(" << this << " in " << cache << ") "
 
-void BlueStore::BufferSpace::_clear(BufferCacheShard* cache)
+bool BlueStore::BufferSpace::_dup_writing(TransContext* txc, BufferCacheShard* cache, OnodeRef onode)
 {
-  // note: we already hold cache->lock
-  ldout(cache->cct, 20) << __func__ << dendl;
-  while (!buffer_map.empty()) {
-    _rm_buffer(cache, buffer_map.begin());
+  bool copied = false;
+  if (!writing.empty()) {
+    copied = true;
+    for (auto it = writing.begin(); it != writing.end(); ++it) {
+      Buffer& b = *it;
+      Buffer to_b(&onode->bc, b.state, b.seq, b.offset, b.data, b.flags);
+      BufferSpace& to = onode->bc;
+      ceph_assert(to_b.is_writing());
+      to._add_buffer(cache, &to, std::move(to_b), b.cache_private, 0, nullptr);
+      txc->buffers_written.insert({onode.get(), b.offset, b.seq});
+    }
   }
+  return copied;
 }
+
 
 int BlueStore::BufferSpace::_discard(BufferCacheShard* cache, uint32_t offset, uint32_t length)
 {
   // note: we already hold cache->lock
-  ldout(cache->cct, 20) << __func__ << std::hex << " 0x" << offset << "~" << length
-           << std::dec << dendl;
+  ldout(cache->cct, 20) << __func__ << std::hex << " 0x" << offset << "~"
+                        << length << std::dec << dendl;
   int cache_private = 0;
   cache->_audit("discard start");
   auto i = _data_lower_bound(offset);
@@ -1674,6 +1684,12 @@ int BlueStore::BufferSpace::_discard(BufferCacheShard* cache, uint32_t offset, u
   while (i != buffer_map.end()) {
     Buffer *b = &i->second;
     if (b->offset >= end) {
+      break;
+    }
+    // If no overlap is found between what we want to read and what we have
+    // cached, then forget about continuing
+    if (std::max(b->end(), offset + length) - std::min(b->offset, offset) >
+        length + b->length) {
       break;
     }
     if (b->cache_private > cache_private) {
@@ -1750,7 +1766,14 @@ void BlueStore::BufferSpace::read(
     for (auto i = _data_lower_bound(offset);
          i != buffer_map.end() && offset < end && i->first < end; ++i) {
       Buffer *b = &i->second;
-      ceph_assert(b->end() > offset);
+      if (b->end() <= offset) {
+        break;
+      }
+
+      // If no overlap is found between what we want to read and what we have cached, then forget about continuing
+      if (std::max(b->end(), offset+length) - std::min(b->offset, offset) > length + b->length) {
+        break;
+      }
 
       bool val = false;
       if (flags & BYPASS_CLEAN_CACHE)
@@ -1804,7 +1827,7 @@ void BlueStore::BufferSpace::read(
   cache->logger->inc(l_bluestore_buffer_miss_bytes, miss_bytes);
 }
 
-void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint64_t seq)
+void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint32_t offset, uint64_t seq)
 {
   auto i = writing.begin();
   while (i != writing.end()) {
@@ -1834,28 +1857,6 @@ void BlueStore::BufferSpace::_finish_write(BufferCacheShard* cache, uint64_t seq
   }
   cache->_trim();
   cache->_audit("finish_write end");
-}
-
-/*
-  copy Buffers that are in writing queue
-  returns:
-  true  if something copied
-  false if nothing copied
-*/
-bool BlueStore::BufferSpace::_dup_writing(BufferCacheShard* cache, BufferSpace* to)
-{
-  bool copied = false;
-  if (!writing.empty()) {
-    copied = true;
-    for (auto it = writing.begin(); it != writing.end(); ++it) {
-      Buffer& b = *it;
-      ceph_assert(b.is_writing());
-      to->_add_buffer(cache, to,
-                      Buffer(to, b.state, b.seq, b.offset, b.data, b.flags), 0,
-                      0, nullptr);
-    }
-  }
-  return copied;
 }
 
 void BlueStore::BufferSpace::split(BufferCacheShard* cache, size_t pos, BlueStore::BufferSpace &r)
@@ -2170,11 +2171,8 @@ BlueStore::Blob::~Blob()
     if (coll_cache != get_cache()) {
       goto again;
     }
-    bc._clear(coll_cache);
     coll_cache->rm_blob();
   }
-  SharedBlob* sb = shared_blob.get();
-  ceph_assert(sb || (!sb && bc.buffer_map.empty()));
 }
 
 void BlueStore::Blob::dump(Formatter* f) const
@@ -2204,7 +2202,7 @@ ostream& operator<<(ostream& out, const BlueStore::Blob& b)
   return out;
 }
 
-void BlueStore::Blob::discard_unallocated(Collection *coll)
+void BlueStore::Blob::discard_unallocated(Collection *coll, Onode* onode, uint32_t logical_offset)
 {
   if (get_blob().is_shared()) {
     return;
@@ -2222,17 +2220,17 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
     ceph_assert(discard == all_invalid); // in case of compressed blob all
 				    // or none pextents are invalid.
     if (discard) {
-      dirty_bc().discard(get_cache(), 0,
+      onode->bc.discard(onode->c->cache, logical_offset,
                               get_blob().get_logical_length());
     }
   } else {
     size_t pos = 0;
     for (auto e : get_blob().get_extents()) {
       if (!e.is_valid()) {
-	dout(20) << __func__ << " 0x" << std::hex << pos
+        dout(20) << __func__ << " 0x" << std::hex << pos
 		 << "~" << e.length
-		 << std::dec << dendl;
-	dirty_bc().discard(get_cache(), pos, e.length);
+                 << std::dec << dendl;
+        onode->bc.discard(onode->c->cache, logical_offset + pos, e.length);
       }
       pos += e.length;
     }
@@ -2374,32 +2372,6 @@ bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
 #define dout_prefix *_dout << "bluestore.blob(" << this << ") "
 #undef dout_context
 #define dout_context cct
-
-// Cut Buffers that are not covered by extents.
-// It happens when we punch hole in Blob, but not refill with new data.
-// Normally it is not a problem (other then wasted memory),
-// but when 2 Blobs are merged Buffers might collide.
-// Todo: in future cut Buffers when we delete extents from Blobs,
-//       and get rid of this function.
-void BlueStore::Blob::discard_unused_buffers(CephContext* cct, BufferCacheShard* cache)
-{
-  dout(25) << __func__ << " input " << *this << " bc=" << bc << dendl;
-  const PExtentVector& extents = get_blob().get_extents();
-  uint32_t epos = 0;
-  auto e = extents.begin();
-  while(e != extents.end()) {
-    if (!e->is_valid()) {
-      bc._discard(cache, epos, e->length);
-    }
-    epos += e->length;
-    ++e;
-  }
-  ceph_assert(epos <= blob.get_logical_length());
-  // Preferably, we would trim up to blob.get_logical_length(),
-  // but we copied writing buffers (see _dup_writing) before blob logical_length is fixed.
-  bc._discard(cache, epos, OBJECT_MAX_SIZE - epos);
-  dout(25) << __func__ << " output bc=" << bc << dendl;
-}
 
 void BlueStore::Blob::dup(const Blob& from, bool copy_used_in_blob)
 {
@@ -2857,48 +2829,12 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
   // now apply freshly merged tmp_extents into dst blob
   dst_blob.dirty_extents().swap(tmp_extents);
 
-  // move BufferSpace buffers
-  while(!src->bc.buffer_map.empty()) {
-    auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
-    buf.mapped().space = &dst->bc;
-    if (dst->bc.buffer_map.count(buf.key()) == 0) {
-      dst->bc.buffer_map.emplace(buf.key(), std::move(buf.mapped()));
-    }
-  }
-  // move BufferSpace writing
-  auto wrt_dst_it = dst->bc.writing.begin();
-  while(!src->bc.writing.empty()) {
-    Buffer& buf = src->bc.writing.front();
-    src->bc.writing.pop_front();
-    while (wrt_dst_it != dst->bc.writing.end() && wrt_dst_it->seq < buf.seq) {
-      ++wrt_dst_it;
-    }
-    dst->bc.writing.insert(wrt_dst_it, buf);
-  }
   dout(20) << __func__ << " result=" << *dst << dendl;
   return dst_blob.get_logical_length();
 }
 
 #undef dout_context
 #define dout_context collection->store->cct
-
-void BlueStore::Blob::finish_write(uint64_t seq)
-{
-  while (true) {
-    auto coll = get_collection();
-    BufferCacheShard *cache = coll->cache;
-    std::lock_guard l(cache->lock);
-    if (coll->cache != cache) {
-      dout(20) << __func__
-	       << " raced with sb cache update, was " << cache
-	       << ", now " << coll->cache << ", retrying"
-	       << dendl;
-      continue;
-    }
-    bc._finish_write(cache, seq);
-    break;
-  }
-}
 
 void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 {
@@ -2914,7 +2850,6 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
     &(r->used_in_blob));
 
   lb.split(blob_offset, rb);
-  dirty_bc().split(get_cache(), blob_offset, r->dirty_bc());
 
   dout(10) << __func__ << " 0x" << std::hex << blob_offset << std::dec
 	   << " finish " << *this << dendl;
@@ -3122,44 +3057,42 @@ void BlueStore::ExtentMap::make_range_shared_maybe_merge(
     if (e.logical_offset >= end) {
       break;
     }
-    dout(25) << __func__ << " src " << e
-	     << " bc=" << e.blob->bc << dendl;
-    const bluestore_blob_t& blob = e.blob->get_blob();
+    dout(25) << __func__ << " src " << e << " bc=" << onoderef->bc << dendl;
+    const bluestore_blob_t &blob = e.blob->get_blob();
     // make sure it is shared
     if (!blob.is_shared()) {
       dirty_range_begin = std::min<uint32_t>(dirty_range_begin, e.blob_start());
       // first try to find a shared blob nearby
       // that can accomodate extra extents
-      uint32_t blob_width; //to signal when extents end
-      dout(20) << __func__ << std::hex
-	       << " e.blob_start=" << e.blob_start()
-	       << " e.logical_offset=" << e.logical_offset
-	       << std::dec << dendl;
-      Blob* b = blob.is_compressed() ? nullptr :
-	find_mergable_companion(e.blob.get(), e.blob_start(), blob_width, candidates);
+      uint32_t blob_width; // to signal when extents end
+      dout(20) << __func__ << std::hex << " e.blob_start=" << e.blob_start()
+               << " e.logical_offset=" << e.logical_offset << std::dec << dendl;
+      Blob *b = blob.is_compressed()
+                    ? nullptr
+                    : find_mergable_companion(e.blob.get(), e.blob_start(),
+                                              blob_width, candidates);
       if (b) {
-	dout(20) << __func__ << " merging to: " << *b << " bc=" << b->bc << dendl;
-	e.blob->discard_unused_buffers(store->cct, c->cache);
-	b->discard_unused_buffers(store->cct, c->cache);
-	uint32_t b_logical_length = b->merge_blob(store->cct, e.blob.get());
-	for (auto p : blob.get_extents()) {
-	  if (p.is_valid()) {
-	    b->get_shared_blob()->get_ref(p.offset, p.length);
-	  }
-	}
-	// reblob extents might erase e
-	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.blob_start() + b_logical_length);
-	uint32_t goto_logical_offset = e.logical_offset + e.length;
-	reblob_extents(e.blob_start(), e.blob_start() + blob_width,
+        dout(20) << __func__ << " merging to: " << *b << " bc=" << onode->bc
+                 << dendl;
+        uint32_t b_logical_length = b->merge_blob(store->cct, e.blob.get());
+        for (auto p : blob.get_extents()) {
+          if (p.is_valid()) {
+            b->shared_blob->get_ref(p.offset, p.length);
+          }
+        }
+        // reblob extents might erase e
+        dirty_range_end = std::max<uint32_t>(dirty_range_end, e.blob_start() + b_logical_length);
+        uint32_t goto_logical_offset = e.logical_offset + e.length;
+        reblob_extents(e.blob_start(), e.blob_start() + blob_width,
 		       e.blob, b);
-	ep = seek_lextent(goto_logical_offset);
-	dout(20) << __func__ << " merged: " << *b << dendl;
+        ep = seek_lextent(goto_logical_offset);
+        dout(20) << __func__ << " merged: " << *b << dendl;
       } else {
-	// no candidate, has to convert to shared
-	c->make_blob_shared(store->_assign_blobid(txc), e.blob);
-	ceph_assert(e.logical_end() > 0);
-	dirty_range_end = std::max<uint32_t>(dirty_range_end, e.logical_end());
-	++ep;
+        // no candidate, has to convert to shared
+        c->make_blob_shared(store->_assign_blobid(txc), e.blob);
+        ceph_assert(e.logical_end() > 0);
+        dirty_range_end = std::max<uint32_t>(dirty_range_end, e.logical_end());
+        ++ep;
       }
     } else {
       c->load_shared_blob(e.blob->get_shared_blob());
@@ -3229,15 +3162,6 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       e.blob->last_encoded_id = n;
       id_to_blob[n] = cb;
       e.blob->dup(*cb);
-      // By default do not copy buffers to clones, and let them read data by themselves.
-      // The exception are 'writing' buffers, which are not yet stable on device.
-      bool some_copied = e.blob->bc._dup_writing(cb->get_cache(), &cb->bc);
-      if (some_copied) {
-	// Pretend we just wrote those buffers;
-	// we need to get _finish_write called, so we can clear then from writing list.
-	// Otherwise it will be stuck until someone does write-op on clone.
-	txc->blobs_written.insert(cb);
-      }
 
       // bump the extent refs on the copied blob's extents
       for (auto p : blob.get_extents()) {
@@ -3272,12 +3196,17 @@ void BlueStore::ExtentMap::dup(BlueStore* b, TransContext* txc,
       txc->statfs_delta.compressed_original() += ne->length;
       if (blob_duped) {
         txc->statfs_delta.compressed() +=
-          cb->get_blob().get_compressed_payload_length();
+            cb->get_blob().get_compressed_payload_length();
       }
     }
     dout(20) << __func__ << "  dst " << *ne << dendl;
     ++n;
   }
+  // By default do not copy buffers to clones, and let them read data by
+  // themselves. The exception are 'writing' buffers, which are not yet
+  // stable on device.
+  oldo->bc._dup_writing(txc, onode->c->cache, newo);
+
   if (src_dirty) {
     oldo->extent_map.dirty_range(dirty_range_begin,
       dirty_range_end - dirty_range_begin);
@@ -3356,15 +3285,6 @@ void BlueStore::ExtentMap::dup_esb(BlueStore* b, TransContext* txc,
 	cb->dirty_blob().set_flag(bluestore_blob_t::FLAG_SHARED);
 	cb->set_shared_blob(e.blob->get_shared_blob());
       }
-      // By default do not copy buffers to clones, and let them read data by themselves.
-      // The exception are 'writing' buffers, which are not yet stable on device.
-      bool some_copied = e.blob->bc._dup_writing(cb->get_cache(), &cb->bc);
-      if (some_copied) {
-	// Pretend we just wrote those buffers;
-	// we need to get _finish_write called, so we can clear then from writing list.
-	// Otherwise it will be stuck until someone does write-op on the clone.
-	txc->blobs_written.insert(cb);
-      }
 
       txc->write_shared_blob(e.blob->get_shared_blob());
       dout(20) << __func__ << "    new " << *cb << dendl;
@@ -3411,6 +3331,11 @@ void BlueStore::ExtentMap::dup_esb(BlueStore* b, TransContext* txc,
     dout(20) << __func__ << "  dst " << *ne << dendl;
     ++n;
   }
+  // By default do not copy buffers to clones, and let them read data by
+  // themselves. The exception are 'writing' buffers, which are not yet
+  // stable on device.
+  oldo->bc._dup_writing(txc, onode->c->cache, newo);
+
   if (src_dirty) {
     dirty_range(dirty_range_begin, dirty_range_end - dirty_range_begin);
     txc->write_onode(oldo);
@@ -3794,40 +3719,40 @@ void BlueStore::ExtentMap::reshard(
       }
 
       if (e->blob_escapes_range(shard_start, shard_end - shard_start)) {
-	if (!e->blob->is_spanning()) {
-	  // We have two options: (1) split the blob into pieces at the
-	  // shard boundaries (and adjust extents accordingly), or (2)
-	  // mark it spanning.  We prefer to cut the blob if we can.  Note that
-	  // we may have to split it multiple times--potentially at every
-	  // shard boundary.
-	  bool must_span = false;
-	  BlobRef b = e->blob;
-	  if (b->can_split()) {
-	    uint32_t bstart = e->blob_start();
-	    uint32_t bend = e->blob_end();
-	    for (const auto& sh : shards) {
-	      if (bstart < sh.shard_info->offset &&
-		  bend > sh.shard_info->offset) {
-		uint32_t blob_offset = sh.shard_info->offset - bstart;
-		if (b->can_split_at(blob_offset)) {
-		  dout(20) << __func__ << "    splitting blob, bstart 0x"
-			   << std::hex << bstart << " blob_offset 0x"
-			   << blob_offset << std::dec << " " << *b << dendl;
-		  b = split_blob(b, blob_offset, sh.shard_info->offset);
-		  // switch b to the new right-hand side, in case it
-		  // *also* has to get split.
-		  bstart += blob_offset;
-		  onode->c->store->logger->inc(l_bluestore_blob_split);
-		} else {
-		  must_span = true;
-		  break;
-		}
-	      }
-	    }
-	  } else {
-	    must_span = true;
-	  }
-	  if (must_span) {
+        if (!e->blob->is_spanning()) {
+          // We have two options: (1) split the blob into pieces at the
+          // shard boundaries (and adjust extents accordingly), or (2)
+          // mark it spanning.  We prefer to cut the blob if we can.  Note that
+          // we may have to split it multiple times--potentially at every
+          // shard boundary.
+          bool must_span = false;
+          BlobRef b = e->blob;
+          if (onode->bc.writing.empty() && b->can_split()) {
+            uint32_t bstart = e->blob_start();
+            uint32_t bend = e->blob_end();
+            for (const auto& sh : shards) {
+              if (bstart < sh.shard_info->offset &&
+                  bend > sh.shard_info->offset) {
+                uint32_t blob_offset = sh.shard_info->offset - bstart;
+                if (b->can_split_at(blob_offset)) {
+                  dout(20) << __func__ << "    splitting blob, bstart 0x"
+                           << std::hex << bstart << " blob_offset 0x"
+                           << blob_offset << std::dec << " " << *b << dendl;
+                  b = split_blob(b, blob_offset, sh.shard_info->offset);
+                  // switch b to the new right-hand side, in case it
+                  // *also* has to get split.
+                  bstart += blob_offset;
+                  onode->c->store->logger->inc(l_bluestore_blob_split);
+                } else {
+                  must_span = true;
+                  break;
+                }
+              }
+            }
+          } else {
+            must_span = true;
+          }
+          if (must_span) {
             auto bid = allocate_spanning_blob_id();
             b->id = bid;
 	    spanning_blob_map[b->id] = b;
@@ -5153,16 +5078,6 @@ void BlueStore::Collection::split_cache(
       // may not be faulted in)
 
       auto rehome_blob = [&](Blob* b) {
-	for (auto& i : b->bc.buffer_map) {
-	  if (!i.second.is_writing()) {
-	    ldout(store->cct, 1) << __func__ << "   moving " << i.second
-				 << dendl;
-	    dest->cache->_move(cache, &i.second);
-	  } else {
-	    ldout(store->cct, 1) << __func__ << "   not moving " << i.second
-				 << dendl;
-	  }
-	}
 	cache->rm_blob();
 	dest->cache->add_blob();
 	SharedBlob* sb = b->get_shared_blob().get();
@@ -5182,10 +5097,23 @@ void BlueStore::Collection::split_cache(
       };
 
       for (auto& e : o->extent_map.extent_map) {
-	e.blob->last_encoded_id = -1;
+        e.blob->last_encoded_id = -1;
       }
       for (auto& b : o->extent_map.spanning_blob_map) {
-	b.second->last_encoded_id = -1;
+        b.second->last_encoded_id = -1;
+      }
+      // By default do not copy buffers to clones, and let them read data by
+      // themselves. The exception are 'writing' buffers, which are not yet
+      // stable on device.
+      for (auto &i : o->bc.buffer_map) {
+        if (!i.second.is_writing()) {
+          ldout(store->cct, 1)
+              << __func__ << "   moving " << i.second << dendl;
+          dest->cache->_move(cache, &i.second);
+        } else {
+          ldout(store->cct, 1)
+              << __func__ << "   not moving " << i.second << dendl;
+        }
       }
       for (auto& e : o->extent_map.extent_map) {
         cache->rm_extent();
@@ -11766,11 +11694,11 @@ void BlueStore::_read_cache(
 
     ready_regions_t cache_res;
     interval_set<uint32_t> cache_interval;
-    bptr->dirty_bc().read(
-      bptr->get_cache(), b_off, b_len, cache_res, cache_interval,
+    o->bc.read(
+      o->c->cache, pos, b_len, cache_res, cache_interval,
       read_cache_policy);
     dout(20) << __func__ << "  blob " << *bptr << std::hex
-             << " need 0x" << b_off << "~" << b_len
+             << " need 0x" << pos << "~" << b_len
              << " cache has 0x" << cache_interval
              << std::dec << dendl;
 
@@ -11779,17 +11707,17 @@ void BlueStore::_read_cache(
     while (b_len > 0) {
       unsigned l;
       if (pc != cache_res.end() &&
-          pc->first == b_off) {
+          pc->first == pos) {
         l = pc->second.length();
         ready_regions[pos] = std::move(pc->second);
         dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
-                 << b_off << "~" << l << std::dec << dendl;
+                 << pos << "~" << l << std::dec << dendl;
         ++pc;
       } else {
         l = b_len;
         if (pc != cache_res.end()) {
-          ceph_assert(pc->first > b_off);
-          l = pc->first - b_off;
+          ceph_assert(pc->first > pos);
+          l = pc->first - pos;
         }
         dout(30) << __func__ << "    will read 0x" << std::hex << pos << ": 0x"
                  << b_off << "~" << l << std::dec << dendl;
@@ -11924,8 +11852,9 @@ int BlueStore::_generate_read_result_bl(
     if (bptr->get_blob().is_compressed()) {
       ceph_assert(p != compressed_blob_bls.end());
       bufferlist& compressed_bl = *p++;
-      if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl,
-                       r2r.front().regs.front().logical_offset) < 0) {
+      uint32_t offset = r2r.front().regs.front().logical_offset;
+      uint32_t length = r2r.front().regs.front().length;
+      if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl, offset) < 0) {
         *csum_error = true;
         return -EIO;
       }
@@ -11934,8 +11863,12 @@ int BlueStore::_generate_read_result_bl(
       if (r < 0)
         return r;
       if (buffered) {
-        bptr->dirty_bc().did_read(bptr->get_cache(), 0,
-                                       raw_bl);
+        bufferlist region_buffer;
+        // todo bad offset
+        region_buffer.substr_of(raw_bl, offset, length);
+        // need offset before padding
+        o->bc.did_read(o->c->cache, offset,
+                       length, std::move(region_buffer));
       }
       for (auto& req : r2r) {
         for (auto& r : req.regs) {
@@ -11945,18 +11878,20 @@ int BlueStore::_generate_read_result_bl(
       }
     } else {
       for (auto& req : r2r) {
-        if (_verify_csum(o, &bptr->get_blob(), req.r_off, req.bl,
-                         req.regs.front().logical_offset) < 0) {
+        uint64_t offset = r2r.front().regs.front().logical_offset;
+        if (_verify_csum(o, &bptr->get_blob(), req.r_off, req.bl, offset) < 0) {
           *csum_error = true;
           return -EIO;
-        }
-        if (buffered) {
-          bptr->dirty_bc().did_read(bptr->get_cache(),
-                                         req.r_off, req.bl);
         }
 
         // prune and keep result
         for (const auto& r : req.regs) {
+          if (buffered) {
+            bufferlist region_buffer;
+            region_buffer.substr_of(req.bl, r.front, r.length);
+            // need offset before padding
+            o->bc.did_read(o->c->cache, r.logical_offset, r.length, std::move(region_buffer));
+          }
           ready_regions[r.logical_offset].substr_of(req.bl, r.front, r.length);
         }
       }
@@ -13798,10 +13733,11 @@ void BlueStore::_txc_finish(TransContext *txc)
   dout(20) << __func__ << " " << txc << " onodes " << txc->onodes << dendl;
   ceph_assert(txc->get_state() == TransContext::STATE_FINISHING);
 
-  for (auto& sb : txc->blobs_written) {
-    sb->finish_write(txc->seq);
+  for (auto& [onode, offset, seq] : txc->buffers_written) {
+    onode->bc._finish_write(onode->c->cache, offset, seq);
   }
-  txc->blobs_written.clear();
+  txc->buffers_written.clear();
+
   while (!txc->removed_collections.empty()) {
     _queue_reap_collection(txc->removed_collections.front());
     txc->removed_collections.pop_front();
@@ -15468,45 +15404,46 @@ void BlueStore::_do_write_small(
 	uint64_t b_off = offset - head_pad - bstart;
 	uint64_t b_len = length + head_pad + tail_pad;
 
-	// direct write into unused blocks of an existing mutable blob?
-	if ((b_off % chunk_size == 0 && b_len % chunk_size == 0) &&
-	    b->get_blob().get_ondisk_length() >= b_off + b_len &&
-	    b->get_blob().is_unused(b_off, b_len) &&
-	    b->get_blob().is_allocated(b_off, b_len)) {
-	  _apply_padding(head_pad, tail_pad, bl);
+        // direct write into unused blocks of an existing mutable blob?
+        if ((b_off % chunk_size == 0 && b_len % chunk_size == 0) &&
+            b->get_blob().get_ondisk_length() >= b_off + b_len &&
+            b->get_blob().is_unused(b_off, b_len) &&
+            b->get_blob().is_allocated(b_off, b_len)) {
+          _buffer_cache_write(txc, b, o, offset, bl,
+                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+          _apply_padding(head_pad, tail_pad, bl);
 
-	  dout(20) << __func__ << "  write to unused 0x" << std::hex
-		   << b_off << "~" << b_len
-		   << " pad 0x" << head_pad << " + 0x" << tail_pad
-		   << std::dec << " of mutable " << *b << dendl;
-	  _buffer_cache_write(txc, b, b_off, bl,
-			      wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+          dout(20) << __func__ << "  write to unused 0x" << std::hex << b_off
+                   << "~" << b_len << " pad 0x" << head_pad << " + 0x"
+                   << tail_pad << std::dec << " of mutable " << *b << dendl;
+          _buffer_cache_write(txc, b, o, offset - head_pad, bl,
+                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
-	  if (!g_conf()->bluestore_debug_omit_block_device_write) {
-	    if (b_len < prefer_deferred_size) {
-	      dout(20) << __func__ << " deferring small 0x" << std::hex
+          if (!g_conf()->bluestore_debug_omit_block_device_write) {
+          if (b_len < prefer_deferred_size) {
+              dout(20) << __func__ << " deferring small 0x" << std::hex
 		       << b_len << std::dec << " unused write via deferred" << dendl;
-	      bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
-	      op->op = bluestore_deferred_op_t::OP_WRITE;
-	      b->get_blob().map(
+              bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
+              op->op = bluestore_deferred_op_t::OP_WRITE;
+              b->get_blob().map(
 		b_off, b_len,
-		[&](uint64_t offset, uint64_t length) {
-		  op->extents.emplace_back(bluestore_pextent_t(offset, length));
-		  return 0;
-		});
-	      op->data = bl;
-	    } else {
-	      b->get_blob().map_bl(
-		b_off, bl,
+                                [&](uint64_t offset, uint64_t length) {
+                                  op->extents.emplace_back(bluestore_pextent_t(offset, length));
+                                  return 0;
+                                });
+              op->data = bl;
+          } else {
+              b->get_blob().map_bl(
+                  b_off, bl,
 		[&](uint64_t offset, bufferlist& t) {
-		  bdev->aio_write(offset, t,
+                    bdev->aio_write(offset, t,
 				  &txc->ioc, wctx->buffered);
-		});
-	    }
-	  }
-	  b->dirty_blob().calc_csum(b_off, bl);
-	  dout(20) << __func__ << "  lex old " << *ep << dendl;
-	  Extent *le = o->extent_map.set_lextent(c, offset, b_off + head_pad, length,
+                  });
+          }
+          }
+          b->dirty_blob().calc_csum(b_off, bl);
+          dout(20) << __func__ << "  lex old " << *ep << dendl;
+          Extent *le = o->extent_map.set_lextent(c, offset, b_off + head_pad, length,
 						 b,
 						 &wctx->old_extents);
 	  b->dirty_blob().mark_used(le->blob_offset, le->length);
@@ -15568,36 +15505,38 @@ void BlueStore::_do_write_small(
 	  }
           logger->inc(l_bluestore_write_small_pre_read);
 
-	  _buffer_cache_write(txc, b, b_off, bl,
-			      wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+          bufferlist without_padding;
+          without_padding.substr_of(bl, head_pad, bl.length() - head_pad);
+          _buffer_cache_write(txc, b, o, offset - head_read, std::move(without_padding),
+                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
-	  b->dirty_blob().calc_csum(b_off, bl);
+          b->dirty_blob().calc_csum(b_off, bl);
 
-	  if (!g_conf()->bluestore_debug_omit_block_device_write) {
-	    bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
-	    op->op = bluestore_deferred_op_t::OP_WRITE;
-	    int r = b->get_blob().map(
-	      b_off, b_len,
+          if (!g_conf()->bluestore_debug_omit_block_device_write) {
+          bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
+          op->op = bluestore_deferred_op_t::OP_WRITE;
+          int r = b->get_blob().map(
+              b_off, b_len,
 	      [&](uint64_t offset, uint64_t length) {
-		op->extents.emplace_back(bluestore_pextent_t(offset, length));
-		return 0;
-	      });
-	    ceph_assert(r == 0);
-	    op->data = std::move(bl);
-	    dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off << "~"
+                op->extents.emplace_back(bluestore_pextent_t(offset, length));
+                return 0;
+              });
+          ceph_assert(r == 0);
+          op->data = std::move(bl);
+          dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off << "~"
 		     << b_len << std::dec << " of mutable " << *b
 		     << " at " << op->extents << dendl;
-	  }
+          }
 
-	  Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
+          Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
 						 b, &wctx->old_extents);
-	  b->dirty_blob().mark_used(le->blob_offset, le->length);
-	  txc->statfs_delta.stored() += le->length;
-	  dout(20) << __func__ << "  lex " << *le << dendl;
-	  return;
-	}
-	// try to reuse blob if we can
-	if (b->can_reuse_blob(min_alloc_size,
+          b->dirty_blob().mark_used(le->blob_offset, le->length);
+          txc->statfs_delta.stored() += le->length;
+          dout(20) << __func__ << "  lex " << *le << dendl;
+          return;
+        }
+        // try to reuse blob if we can
+        if (b->can_reuse_blob(min_alloc_size,
 			      max_bsize,
 			      offset0 - bstart,
 			      &alloc_len)) {
@@ -15856,7 +15795,7 @@ void BlueStore::_do_write_big_apply_deferred(
     logger->inc(l_bluestore_write_penalty_read_ops);
   }
   auto& b0 = dctx.blob_ref;
-  _buffer_cache_write(txc, b0, dctx.b_off, bl,
+  _buffer_cache_write(txc, b0, o, dctx.off - dctx.head_read, bl,
     wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
   b0->dirty_blob().calc_csum(dctx.b_off, bl);
@@ -16393,7 +16332,9 @@ int BlueStore::_do_alloc_write(
     wi.b->dirty_blob().mark_used(le->blob_offset, le->length);
     txc->statfs_delta.stored() += le->length;
     dout(20) << __func__ << "  lex " << *le << dendl;
-    _buffer_cache_write(txc, wi.b, b_off, wi.bl,
+    bufferlist without_pad;
+    without_pad.substr_of(wi.bl, wi.b_off0-wi.b_off, wi.length0);
+    _buffer_cache_write(txc, wi.b, o, wi.logical_offset, std::move(without_pad),
                         wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
 
     // queue io
@@ -16444,7 +16385,7 @@ void BlueStore::_wctx_finish(
     const bluestore_blob_t& blob = b->get_blob();
     if (blob.is_compressed()) {
       if (lo.blob_empty) {
-	txc->statfs_delta.compressed() -= blob.get_compressed_payload_length();
+        txc->statfs_delta.compressed() -= blob.get_compressed_payload_length();
       }
       txc->statfs_delta.compressed_original() -= lo.e.length;
     }
@@ -16480,7 +16421,7 @@ void BlueStore::_wctx_finish(
     // longer allocated.  Note that this will leave behind edge bits
     // that are no longer referenced but not deallocated (until they
     // age out of the cache naturally).
-    b->discard_unallocated(c.get());
+    // b->discard_unallocated(c.get(), o.get(), lo.e.logical_offset);
     for (auto e : r) {
       dout(20) << __func__ << "  release " << e << dendl;
       txc->released.insert(e.offset, e.length);
@@ -16887,6 +16828,7 @@ void BlueStore::_do_truncate(
   WriteContext wctx;
   if (offset < o->onode.size) {
     uint64_t length = o->onode.size - offset;
+    o->bc.discard(o->c->cache, offset, length);
     o->extent_map.fault_range(db, offset, length);
     o->extent_map.punch_hole(c, offset, length, &wctx.old_extents);
     o->extent_map.dirty_range(offset, length);
@@ -17486,6 +17428,8 @@ int BlueStore::_do_clone_range(
 	   << " 0x" << dstoff << "~" << length << std::dec << dendl;
   oldo->extent_map.fault_range(db, srcoff, length);
   newo->extent_map.fault_range(db, dstoff, length);
+  // it is possible the onode had previous buffers written
+  newo->bc.discard(c->cache, dstoff, length);
   _dump_onode<30>(cct, *oldo);
   _dump_onode<30>(cct, *newo);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -520,7 +520,6 @@ public:
     }
 
     void _dup_writing(TransContext* txc, Collection* collection, OnodeRef onode, uint32_t offset, uint32_t length);
-    void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
     void dump(BufferCacheShard* cache, ceph::Formatter *f) const {
       std::lock_guard l(cache->lock);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1654,6 +1654,7 @@ private:
 
     // Deferred write dependencies. Buffers of deferred writes than get cloned must be marked as clean
     // on all cloned Onodes after the main deferred txc is completed.
+    std::mutex deferred_seq_dependencies_lock;
     std::map<uint64_t, std::set<OnodeRef>> deferred_seq_dependencies;
 
     OnodeCacheShard* get_onode_cache() const {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -705,7 +705,6 @@ public:
     }
 
     bool can_split() {
-      std::lock_guard l(get_cache()->lock);
       // splitting a BufferSpace writing list is too hard; don't try.
       return used_in_blob.can_split() &&
              get_blob().can_split();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -499,7 +499,7 @@ public:
                   nullptr);
       cache->_trim();
     }
-    void _finish_write(OnodeRef onode, uint64_t seq);
+    void _finish_write(BufferCacheShard* cache, uint64_t seq);
     void did_read(BufferCacheShard* cache, uint32_t offset, ceph::buffer::list&& bl) {
       std::lock_guard l(cache->lock);
       uint16_t cache_private = _discard(cache, offset, bl.length());
@@ -1438,6 +1438,8 @@ public:
 
     void rewrite_omap_key(const std::string& old, std::string *out);
     void decode_omap_key(const std::string& key, std::string *user_key);
+
+    void finish_write(uint64_t seq);
 
 private:
     void _decode(const ceph::buffer::list& v);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -505,7 +505,7 @@ public:
       uint16_t cache_private = _discard(cache, offset, bl.length());
       _add_buffer(
           cache, this,
-          Buffer(this, Buffer::STATE_CLEAN, 0, offset, bl, 0),
+          Buffer(this, Buffer::STATE_CLEAN, 0, offset, std::move(bl), 0),
           cache_private, 1, nullptr);
       cache->_trim();
     }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -499,7 +499,7 @@ public:
                   nullptr);
       cache->_trim();
     }
-    void _finish_write(BufferCacheShard* cache, uint64_t seq);
+    void _finish_write(OnodeRef onode, uint64_t seq);
     void did_read(BufferCacheShard* cache, uint32_t offset, uint32_t length, ceph::buffer::list&& bl) {
       std::lock_guard l(cache->lock);
       uint16_t cache_private = _discard(cache, offset, bl.length());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1381,6 +1381,12 @@ public:
 	  cct->_conf->
 	    bluestore_extent_map_inline_shard_prealloc_size) {
     }
+
+    ~Onode() {
+      std::lock_guard l(c->cache->lock);
+      bc._clear(c->cache);
+    }
+
     static void decode_raw(
       BlueStore::Onode* on,
       const bufferlist& v,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1383,8 +1383,10 @@ public:
     }
 
     ~Onode() {
-      std::lock_guard l(c->cache->lock);
-      bc._clear(c->cache);
+      if (c) {
+        std::lock_guard l(c->cache->lock);
+        bc._clear(c->cache);
+      }
     }
 
     static void decode_raw(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -500,7 +500,7 @@ public:
       cache->_trim();
     }
     void _finish_write(OnodeRef onode, uint64_t seq);
-    void did_read(BufferCacheShard* cache, uint32_t offset, uint32_t length, ceph::buffer::list&& bl) {
+    void did_read(BufferCacheShard* cache, uint32_t offset, ceph::buffer::list&& bl) {
       std::lock_guard l(cache->lock);
       uint16_t cache_private = _discard(cache, offset, bl.length());
       _add_buffer(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -755,6 +755,8 @@ public:
     /// split the blob
     void split(Collection *coll, uint32_t blob_offset, Blob *o);
 
+    void maybe_prune_tail();
+
     void get() {
       ++nref;
     }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2896,7 +2896,6 @@ private:
 
   void _buffer_cache_write(
     TransContext *txc,
-    BlobRef blob,
     OnodeRef onode,
     uint32_t offset,
     ceph::buffer::list&& bl,
@@ -2908,7 +2907,6 @@ private:
 
   void _buffer_cache_write(
     TransContext *txc,
-    BlobRef blob,
     OnodeRef onode,
     uint32_t offset,
     ceph::buffer::list& bl,

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -909,6 +909,8 @@ public:
 
   bool can_prune_tail() const {
     return
+      !is_shared() &&
+      !is_compressed() &&
       extents.size() > 1 &&  // if it's all invalid it's not pruning.
       !extents.back().is_valid() &&
       !has_unused();

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1156,7 +1156,6 @@ WRITE_CLASS_DENC(bluestore_deferred_op_t)
 /// writeahead-logged transaction
 struct bluestore_deferred_transaction_t {
   uint64_t seq = 0;
-  uint64_t txc_seq = 0;
   std::list<bluestore_deferred_op_t> ops;
   interval_set<uint64_t> released;  ///< allocations to release after tx
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1154,6 +1154,7 @@ WRITE_CLASS_DENC(bluestore_deferred_op_t)
 /// writeahead-logged transaction
 struct bluestore_deferred_transaction_t {
   uint64_t seq = 0;
+  uint64_t txc_seq = 0;
   std::list<bluestore_deferred_op_t> ops;
   interval_set<uint64_t> released;  ///< allocations to release after tx
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -8831,6 +8831,152 @@ TEST_P(StoreTestSpecificAUSize, DeferredDifferentChunks) {
   }
 }
 
+TEST_P(StoreTestSpecificAUSize, DeferredAndClone) {
+
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  size_t alloc_size = 4096;
+  size_t prefer_deferred_size = 65536;
+ 
+  SetVal(g_conf(), "bluestore_block_db_create", "true");
+  SetVal(g_conf(), "bluestore_block_db_size", stringify(1 << 30).c_str());
+  
+  StartDeferred(alloc_size);
+  SetVal(g_conf(), "bluestore_prefer_deferred_size",
+    stringify(prefer_deferred_size).c_str());
+  g_conf().apply_changes(nullptr);
+
+  int r;
+  coll_t cid;
+
+  ghobject_t hoid(hobject_t("test", "", CEPH_NOSNAP, 0, -1, ""));
+  hoid.hobj.pool = -1;
+  ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  hoid2.hobj.pool = -1;
+
+  ObjectStore::CollectionHandle ch = store->create_new_collection(cid);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    t.touch(cid, hoid);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    bl.append(std::string(3, 'z'));
+    t.write(cid, hoid, 0, bl.length(), bl,
+            CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.clone_range(cid, hoid, hoid2, 0, 3, 0);
+    cerr << "Clone range object" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+ }
+ sleep(1);
+ {
+    bufferlist bl, expected;
+    r = store->read(ch, hoid2, 0, 3, bl);
+    ASSERT_EQ(r, 3);
+    expected.append(string(3, 'z'));
+    ASSERT_TRUE(bl_eq(bl, expected));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid);
+    t.remove(cid, hoid2);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTestSpecificAUSize, DeferredAndClone2) {
+
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  size_t alloc_size = 4096;
+  size_t prefer_deferred_size = 32768;
+ 
+  SetVal(g_conf(), "bluestore_block_db_create", "true");
+  SetVal(g_conf(), "bluestore_block_db_size", stringify(1 << 30).c_str());
+  
+  StartDeferred(alloc_size);
+  SetVal(g_conf(), "bluestore_prefer_deferred_size",
+    stringify(prefer_deferred_size).c_str());
+  g_conf().apply_changes(nullptr);
+
+  int r;
+  coll_t cid;
+
+  ghobject_t hoid(hobject_t("test", "", CEPH_NOSNAP, 0, -1, ""));
+  hoid.hobj.pool = -1;
+  ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  hoid2.hobj.pool = -1;
+
+  ObjectStore::CollectionHandle ch = store->create_new_collection(cid);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid);
+    bufferlist bl;
+    bl.append(std::string(0x10000, 'h'));
+    t.write(cid, hoid, 0, bl.length(), bl,
+            CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  sleep(1);
+
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    bl.append(std::string(0x400, 'z'));
+    t.write(cid, hoid, 0, bl.length(), bl,
+            CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.clone_range(cid, hoid, hoid2, 0, 0x10000, 0);
+    cerr << "Clone range object" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+ }
+ sleep(1);
+ {
+    bufferlist bl, expected;
+    r = store->read(ch, hoid2, 0, 0x1000, bl);
+    ASSERT_EQ(r, 0x1000);
+    expected.append(string(0x400, 'z'));
+    expected.append(string(0xc00, 'h'));
+    ASSERT_TRUE(bl_eq(bl, expected));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid);
+    t.remove(cid, hoid2);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
 TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
 
   if (string(GetParam()) != "bluestore")
@@ -11205,6 +11351,7 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf.set_val_or_die("bluefs_check_volume_selector_on_umount", "true");
 
   g_ceph_context->_conf.set_val_or_die("bdev_debug_aio", "true");
+  g_ceph_context->_conf.set_val_or_die("log_max_recent", "10000");
 
   // specify device size
   g_ceph_context->_conf.set_val_or_die("bluestore_block_size",

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1,18 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "include/types.h"
-#include "os/bluestore/bluestore_types.h"
-#include "gtest/gtest.h"
-#include "include/stringify.h"
-#include "common/ceph_time.h"
-#include "os/bluestore/BlueStore.h"
-#include "os/bluestore/simple_bitmap.h"
-#include "os/bluestore/AvlAllocator.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
+#include "common/ceph_time.h"
 #include "global/global_context.h"
+#include "global/global_init.h"
+#include "include/stringify.h"
+#include "include/types.h"
+#include "os/bluestore/AvlAllocator.h"
+#include "os/bluestore/BlueStore.h"
+#include "os/bluestore/bluestore_types.h"
+#include "os/bluestore/simple_bitmap.h"
 #include "perfglue/heap_profiler.h"
+#include "gtest/gtest.h"
 
 #include <sstream>
 
@@ -49,14 +49,15 @@ TEST(bluestore, sizeof) {
   P(range_seg_t);
   P(sb_info_t);
   P(SimpleBitmap);
-  cout << "map<uint64_t,uint64_t>\t" << sizeof(map<uint64_t,uint64_t>) << std::endl;
-  cout << "map<char,char>\t" << sizeof(map<char,char>) << std::endl;
+  cout << "map<uint64_t,uint64_t>\t" << sizeof(map<uint64_t, uint64_t>)
+       << std::endl;
+  cout << "map<char,char>\t" << sizeof(map<char, char>) << std::endl;
 }
 
-void dump_mempools()
-{
+void dump_mempools() {
   ostringstream ostr;
-  auto f = Formatter::create_unique("json-pretty", "json-pretty", "json-pretty");
+  auto f =
+      Formatter::create_unique("json-pretty", "json-pretty", "json-pretty");
   ostr << "Mempools: ";
   f->open_object_section("mempools");
   mempool::dump(f.get());
@@ -85,7 +86,7 @@ TEST(sb_info_space_efficient_map_t, basic) {
   sb_info_space_efficient_map_t sb_info;
   const size_t num_shared = 1000;
   for (size_t i = 0; i < num_shared; i += 2) {
-    auto& sbi = sb_info.add_maybe_stray(i);
+    auto &sbi = sb_info.add_maybe_stray(i);
     sbi.pool_id = i;
   }
   ASSERT_TRUE(sb_info.find(0) != sb_info.end());
@@ -120,23 +121,22 @@ TEST(sb_info_space_efficient_map_t, size) {
   sb_info_space_efficient_map_t sb_info;
 
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard* oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard* bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
 
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
 
   for (size_t i = 0; i < num_shared; i++) {
-    auto& sbi = sb_info.add_or_adopt(i);
+    auto &sbi = sb_info.add_or_adopt(i);
     // primarily to silent the 'unused' warning
     ceph_assert(sbi.pool_id == sb_info_t::INVALID_POOL_ID);
   }
   dump_mempools();
 }
 
-TEST(bluestore_extent_ref_map_t, add)
-{
+TEST(bluestore_extent_ref_map_t, add) {
   bluestore_extent_ref_map_t m;
   m.get(10, 10);
   ASSERT_EQ(1u, m.ref_map.size());
@@ -160,8 +160,7 @@ TEST(bluestore_extent_ref_map_t, add)
   ASSERT_EQ(1u, m.ref_map.size());
 }
 
-TEST(bluestore_extent_ref_map_t, get)
-{
+TEST(bluestore_extent_ref_map_t, get) {
   bluestore_extent_ref_map_t m;
   m.get(00, 30);
   cout << m << std::endl;
@@ -207,8 +206,7 @@ TEST(bluestore_extent_ref_map_t, get)
   ASSERT_EQ(1u, m.ref_map[28].refs);
 }
 
-TEST(bluestore_extent_ref_map_t, put)
-{
+TEST(bluestore_extent_ref_map_t, put) {
   bluestore_extent_ref_map_t m;
   PExtentVector r;
   bool maybe_unshared = false;
@@ -273,8 +271,7 @@ TEST(bluestore_extent_ref_map_t, put)
   ASSERT_TRUE(maybe_unshared);
 }
 
-TEST(bluestore_extent_ref_map_t, contains)
-{
+TEST(bluestore_extent_ref_map_t, contains) {
   bluestore_extent_ref_map_t m;
   m.get(10, 30);
   ASSERT_TRUE(m.contains(10, 30));
@@ -302,8 +299,7 @@ TEST(bluestore_extent_ref_map_t, contains)
   ASSERT_FALSE(m.contains(4000, 30));
 }
 
-TEST(bluestore_extent_ref_map_t, intersects)
-{
+TEST(bluestore_extent_ref_map_t, intersects) {
   bluestore_extent_ref_map_t m;
   m.get(10, 30);
   ASSERT_TRUE(m.intersects(10, 30));
@@ -329,8 +325,7 @@ TEST(bluestore_extent_ref_map_t, intersects)
   ASSERT_FALSE(m.intersects(55, 1));
 }
 
-TEST(bluestore_blob_t, calc_csum)
-{
+TEST(bluestore_blob_t, calc_csum) {
   bufferlist bl;
   bl.append("asdfghjkqwertyuizxcvbnm,");
   bufferlist bl2;
@@ -345,10 +340,9 @@ TEST(bluestore_blob_t, calc_csum)
   n.append("12345678");
 
   for (unsigned csum_type = Checksummer::CSUM_NONE + 1;
-       csum_type < Checksummer::CSUM_MAX;
-       ++csum_type) {
+       csum_type < Checksummer::CSUM_MAX; ++csum_type) {
     cout << "csum_type " << Checksummer::get_csum_type_string(csum_type)
-	 << std::endl;
+         << std::endl;
 
     bluestore_blob_t b;
     int bad_off;
@@ -397,46 +391,42 @@ TEST(bluestore_blob_t, calc_csum)
   }
 }
 
-TEST(bluestore_blob_t, csum_bench)
-{
+TEST(bluestore_blob_t, csum_bench) {
   bufferlist bl;
   bufferptr bp(10485760);
   for (char *a = bp.c_str(); a < bp.c_str() + bp.length(); ++a)
     *a = (unsigned long)a & 0xff;
   bl.append(bp);
   int count = 256;
-  for (unsigned csum_type = 1;
-       csum_type < Checksummer::CSUM_MAX;
-       ++csum_type) {
+  for (unsigned csum_type = 1; csum_type < Checksummer::CSUM_MAX; ++csum_type) {
     bluestore_blob_t b;
     b.init_csum(csum_type, 12, bl.length());
     ceph::mono_clock::time_point start = ceph::mono_clock::now();
-    for (int i = 0; i<count; ++i) {
+    for (int i = 0; i < count; ++i) {
       b.calc_csum(0, bl);
     }
     ceph::mono_clock::time_point end = ceph::mono_clock::now();
     auto dur = std::chrono::duration_cast<ceph::timespan>(end - start);
-    double mbsec = (double)count * (double)bl.length() / 1000000.0 / (double)dur.count() * 1000000000.0;
-    cout << "csum_type " << Checksummer::get_csum_type_string(csum_type)
-	 << ", " << dur << " seconds, "
-	 << mbsec << " MB/sec" << std::endl;
+    double mbsec = (double)count * (double)bl.length() / 1000000.0 /
+                   (double)dur.count() * 1000000000.0;
+    cout << "csum_type " << Checksummer::get_csum_type_string(csum_type) << ", "
+         << dur << " seconds, " << mbsec << " MB/sec" << std::endl;
   }
 }
 
-TEST(Blob, put_ref)
-{
+TEST(Blob, put_ref) {
   {
     BlueStore store(g_ceph_context, "", 4096);
-    BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-      g_ceph_context, "lru", NULL);
-    BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-      g_ceph_context, "lru", NULL);
+    BlueStore::OnodeCacheShard *oc =
+        BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+    BlueStore::BufferCacheShard *bc =
+        BlueStore::BufferCacheShard::create(&store, "lru", NULL);
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob b(coll.get());
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x40715000, 0x2000));
     b.dirty_blob().allocated_test(
-      bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
+        bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x4071f000, 0x5000));
     b.get_ref(coll.get(), 0, 0x1200);
     b.get_ref(coll.get(), 0xae00, 0x4200);
@@ -458,78 +448,78 @@ TEST(Blob, put_ref)
 
   unsigned mas = 4096;
   BlueStore store(g_ceph_context, "", 8192);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
 
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(0, mas * 2));
-    B.get_ref(coll.get(), 0, mas*2);
+    B.get_ref(coll.get(), 0, mas * 2);
     ASSERT_EQ(mas * 2, B.get_referenced_bytes());
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_TRUE(B.put_ref(coll.get(), 0, mas*2, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_TRUE(B.put_ref(coll.get(), 0, mas * 2, &r));
     ASSERT_EQ(0u, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
-    ASSERT_FALSE(b.is_allocated(0, mas*2));
+    ASSERT_EQ(mas * 2, r[0].length);
+    ASSERT_FALSE(b.is_allocated(0, mas * 2));
     ASSERT_FALSE(b.is_allocated(0, mas));
     ASSERT_FALSE(b.is_allocated(mas, 0));
     ASSERT_FALSE(b.get_extents()[0].is_valid());
-    ASSERT_EQ(mas*2, b.get_extents()[0].length);
+    ASSERT_EQ(mas * 2, b.get_extents()[0].length);
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(123, mas * 2));
-    B.get_ref(coll.get(), 0, mas*2);
+    B.get_ref(coll.get(), 0, mas * 2);
     ASSERT_EQ(mas * 2, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), 0, mas, &r));
     ASSERT_EQ(mas, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
     ASSERT_TRUE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(0u, B.get_referenced_bytes());
     ASSERT_EQ(0u, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(123u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
-    ASSERT_FALSE(b.is_allocated(0, mas*2));
+    ASSERT_EQ(mas * 2, r[0].length);
+    ASSERT_FALSE(b.is_allocated(0, mas * 2));
     ASSERT_FALSE(b.get_extents()[0].is_valid());
-    ASSERT_EQ(mas*2, b.get_extents()[0].length);
+    ASSERT_EQ(mas * 2, b.get_extents()[0].length);
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
     b.allocated_test(bluestore_pextent_t(2, mas));
     b.allocated_test(bluestore_pextent_t(3, mas));
     b.allocated_test(bluestore_pextent_t(4, mas));
-    B.get_ref(coll.get(), 0, mas*4);
+    B.get_ref(coll.get(), 0, mas * 4);
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*4));
+    ASSERT_TRUE(b.is_allocated(0, mas * 4));
     ASSERT_TRUE(b.is_allocated(mas, mas));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas, &r));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas, &r));
     ASSERT_EQ(mas * 2, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(mas*2, mas));
-    ASSERT_TRUE(b.is_allocated(0, mas*4));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*3, mas, &r));
+    ASSERT_TRUE(b.is_allocated(mas * 2, mas));
+    ASSERT_TRUE(b.is_allocated(0, mas * 4));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 3, mas, &r));
     ASSERT_EQ(mas, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(2u, r.size());
@@ -537,8 +527,8 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas, r[0].length);
     ASSERT_EQ(4u, r[1].offset);
     ASSERT_EQ(mas, r[1].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*2));
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 2));
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_TRUE(b.get_extents()[1].is_valid());
     ASSERT_FALSE(b.get_extents()[2].is_valid());
@@ -546,7 +536,7 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas));
     b.allocated_test(bluestore_pextent_t(2, mas));
@@ -554,19 +544,19 @@ TEST(Blob, put_ref)
     b.allocated_test(bluestore_pextent_t(4, mas));
     b.allocated_test(bluestore_pextent_t(5, mas));
     b.allocated_test(bluestore_pextent_t(6, mas));
-    B.get_ref(coll.get(), 0, mas*6);
+    B.get_ref(coll.get(), 0, mas * 6);
     ASSERT_EQ(mas * 6, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 5, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*6));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 6));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas, &r));
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*6));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*3, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 6));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 3, mas, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(2u, r.size());
@@ -574,9 +564,9 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas, r[0].length);
     ASSERT_EQ(4u, r[1].offset);
     ASSERT_EQ(mas, r[1].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*2));
-    ASSERT_TRUE(b.is_allocated(mas*4, mas*2));
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 2));
+    ASSERT_TRUE(b.is_allocated(mas * 4, mas * 2));
     ASSERT_EQ(5u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_TRUE(b.get_extents()[1].is_valid());
@@ -586,30 +576,30 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 6));
-    B.get_ref(coll.get(), 0, mas*6);
+    B.get_ref(coll.get(), 0, mas * 6);
     ASSERT_EQ(mas * 6, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 5, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*6));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 6));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas, &r));
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*6));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*3, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 6));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 3, mas, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x2001u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*2));
-    ASSERT_TRUE(b.is_allocated(mas*4, mas*2));
+    ASSERT_EQ(mas * 2, r[0].length);
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 2));
+    ASSERT_TRUE(b.is_allocated(mas * 4, mas * 2));
     ASSERT_EQ(3u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
@@ -617,36 +607,36 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
     b.allocated_test(bluestore_pextent_t(2, mas * 4));
     b.allocated_test(bluestore_pextent_t(3, mas * 4));
-    B.get_ref(coll.get(), 0, mas*12);
+    B.get_ref(coll.get(), 0, mas * 12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 11, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*9, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 9, mas, &r));
     ASSERT_EQ(mas * 10, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas*7, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas * 7, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(3u, r.size());
     ASSERT_EQ(0x2001u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(0x2u, r[1].offset);
-    ASSERT_EQ(mas*4, r[1].length);
+    ASSERT_EQ(mas * 4, r[1].length);
     ASSERT_EQ(0x3u, r[2].offset);
-    ASSERT_EQ(mas*2, r[2].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*8));
-    ASSERT_TRUE(b.is_allocated(mas*10, mas*2));
+    ASSERT_EQ(mas * 2, r[2].length);
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 8));
+    ASSERT_TRUE(b.is_allocated(mas * 10, mas * 2));
     ASSERT_EQ(3u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
@@ -654,36 +644,36 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll);
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
     b.allocated_test(bluestore_pextent_t(2, mas * 4));
     b.allocated_test(bluestore_pextent_t(3, mas * 4));
-    B.get_ref(coll.get(), 0, mas*12);
+    B.get_ref(coll.get(), 0, mas * 12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 11, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*9, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 9, mas, &r));
     ASSERT_EQ(mas * 10, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas*7, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas * 7, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(3u, r.size());
     ASSERT_EQ(0x2001u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(0x2u, r[1].offset);
-    ASSERT_EQ(mas*4, r[1].length);
+    ASSERT_EQ(mas * 4, r[1].length);
     ASSERT_EQ(0x3u, r[2].offset);
-    ASSERT_EQ(mas*2, r[2].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*8));
-    ASSERT_TRUE(b.is_allocated(mas*10, mas*2));
+    ASSERT_EQ(mas * 2, r[2].length);
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 8));
+    ASSERT_TRUE(b.is_allocated(mas * 10, mas * 2));
     ASSERT_EQ(3u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
@@ -693,61 +683,61 @@ TEST(Blob, put_ref)
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x1u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(2u, b.get_extents().size());
     ASSERT_FALSE(b.get_extents()[0].is_valid());
     ASSERT_TRUE(b.get_extents()[1].is_valid());
-    ASSERT_TRUE(B.put_ref(coll.get(), mas*10, mas*2, &r));
+    ASSERT_TRUE(B.put_ref(coll.get(), mas * 10, mas * 2, &r));
     ASSERT_EQ(mas * 0, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x2003u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(1u, b.get_extents().size());
     ASSERT_FALSE(b.get_extents()[0].is_valid());
   }
   {
     BlueStore::Blob B(coll);
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 4));
     b.allocated_test(bluestore_pextent_t(2, mas * 4));
     b.allocated_test(bluestore_pextent_t(3, mas * 4));
-    B.get_ref(coll.get(), 0, mas*12);
+    B.get_ref(coll.get(), 0, mas * 12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), mas, mas, &r));
     ASSERT_EQ(mas * 11, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*9, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 9, mas, &r));
     ASSERT_EQ(mas * 10, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*12));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas*7, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 12));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas * 7, &r));
     ASSERT_EQ(mas * 3, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(3u, r.size());
     ASSERT_EQ(0x2001u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(0x2u, r[1].offset);
-    ASSERT_EQ(mas*4, r[1].length);
+    ASSERT_EQ(mas * 4, r[1].length);
     ASSERT_EQ(0x3u, r[2].offset);
-    ASSERT_EQ(mas*2, r[2].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*8));
-    ASSERT_TRUE(b.is_allocated(mas*10, mas*2));
+    ASSERT_EQ(mas * 2, r[2].length);
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 8));
+    ASSERT_TRUE(b.is_allocated(mas * 10, mas * 2));
     ASSERT_EQ(3u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
     ASSERT_TRUE(b.get_extents()[2].is_valid());
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*10, mas*2, &r));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 10, mas * 2, &r));
     ASSERT_EQ(mas * 1, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x2003u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(2u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
@@ -756,39 +746,39 @@ TEST(Blob, put_ref)
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x1u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(1u, b.get_extents().size());
     ASSERT_FALSE(b.get_extents()[0].is_valid());
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
     b.allocated_test(bluestore_pextent_t(1, mas * 8));
-    B.get_ref(coll.get(), 0, mas*8);
+    B.get_ref(coll.get(), 0, mas * 8);
     ASSERT_EQ(mas * 8, B.get_referenced_bytes());
     ASSERT_FALSE(B.put_ref(coll.get(), 0, mas, &r));
     ASSERT_EQ(mas * 7, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*8));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*7, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 8));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 7, mas, &r));
     ASSERT_EQ(mas * 6, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*8));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*2, mas, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 8));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 2, mas, &r));
     ASSERT_EQ(mas * 5, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
     ASSERT_TRUE(b.is_allocated(0, 8));
-    ASSERT_FALSE(B.put_ref(coll.get(), mas*3, mas*4, &r));
+    ASSERT_FALSE(B.put_ref(coll.get(), mas * 3, mas * 4, &r));
     ASSERT_EQ(mas * 1, B.get_referenced_bytes());
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x2001u, r[0].offset);
-    ASSERT_EQ(mas*6, r[0].length);
-    ASSERT_TRUE(b.is_allocated(0, mas*2));
-    ASSERT_FALSE(b.is_allocated(mas*2, mas*6));
+    ASSERT_EQ(mas * 6, r[0].length);
+    ASSERT_TRUE(b.is_allocated(0, mas * 2));
+    ASSERT_FALSE(b.is_allocated(mas * 2, mas * 6));
     ASSERT_EQ(2u, b.get_extents().size());
     ASSERT_TRUE(b.get_extents()[0].is_valid());
     ASSERT_FALSE(b.get_extents()[1].is_valid());
@@ -797,34 +787,34 @@ TEST(Blob, put_ref)
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(1u, r.size());
     ASSERT_EQ(0x1u, r[0].offset);
-    ASSERT_EQ(mas*2, r[0].length);
+    ASSERT_EQ(mas * 2, r[0].length);
     ASSERT_EQ(1u, b.get_extents().size());
     ASSERT_FALSE(b.get_extents()[0].is_valid());
   }
   // verify csum chunk size if factored in properly
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     PExtentVector r;
-    b.allocated_test(bluestore_pextent_t(0, mas*4));
+    b.allocated_test(bluestore_pextent_t(0, mas * 4));
     b.init_csum(Checksummer::CSUM_CRC32C, 14, mas * 4);
-    B.get_ref(coll.get(), 0, mas*4);
+    B.get_ref(coll.get(), 0, mas * 4);
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
-    ASSERT_TRUE(b.is_allocated(0, mas*4));
-    ASSERT_FALSE(B.put_ref(coll.get(), 0, mas*3, &r));
+    ASSERT_TRUE(b.is_allocated(0, mas * 4));
+    ASSERT_FALSE(B.put_ref(coll.get(), 0, mas * 3, &r));
     ASSERT_EQ(mas * 1, B.get_referenced_bytes());
     cout << "r " << r << " " << b << std::endl;
     ASSERT_EQ(0u, r.size());
-    ASSERT_TRUE(b.is_allocated(0, mas*4));
+    ASSERT_TRUE(b.is_allocated(0, mas * 4));
     ASSERT_TRUE(b.get_extents()[0].is_valid());
-    ASSERT_EQ(mas*4, b.get_extents()[0].length);
+    ASSERT_EQ(mas * 4, b.get_extents()[0].length);
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(0x40101000, 0x4000));
-    b.allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
-					    0x13000));
+    b.allocated_test(
+        bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x13000));
 
     b.allocated_test(bluestore_pextent_t(0x40118000, 0x7000));
     B.get_ref(coll.get(), 0x0, 0x3800);
@@ -842,7 +832,7 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x5000));
     B.get_ref(coll.get(), 0x0, 0xa000);
@@ -859,7 +849,7 @@ TEST(Blob, put_ref)
   }
   {
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x7000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
     B.get_ref(coll.get(), 0x0, 0xe000);
@@ -875,19 +865,20 @@ TEST(Blob, put_ref)
     ASSERT_EQ(1u, r[0].offset);
     ASSERT_EQ(0x7000u, r[0].length);
     ASSERT_EQ(2u, r[1].offset);
-    ASSERT_EQ(0x3000u, r[1].length); // we have 0x1000 bytes less due to 
-                                     // alignment caused by min_alloc_size = 0x2000
+    ASSERT_EQ(0x3000u,
+              r[1].length); // we have 0x1000 bytes less due to
+                            // alignment caused by min_alloc_size = 0x2000
   }
   {
     BlueStore store(g_ceph_context, "", 0x4000);
-    BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-      g_ceph_context, "lru", NULL);
-    BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-      g_ceph_context, "lru", NULL);
+    BlueStore::OnodeCacheShard *oc =
+        BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+    BlueStore::BufferCacheShard *bc =
+        BlueStore::BufferCacheShard::create(&store, "lru", NULL);
 
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob B(coll.get());
-    bluestore_blob_t& b = B.dirty_blob();
+    bluestore_blob_t &b = B.dirty_blob();
     b.allocated_test(bluestore_pextent_t(1, 0x5000));
     b.allocated_test(bluestore_pextent_t(2, 0x7000));
     B.get_ref(coll.get(), 0x0, 0xc000);
@@ -908,8 +899,7 @@ TEST(Blob, put_ref)
   }
 }
 
-TEST(bluestore_blob_t, can_split)
-{
+TEST(bluestore_blob_t, can_split) {
   bluestore_blob_t a;
   ASSERT_TRUE(a.can_split());
   a.flags = bluestore_blob_t::FLAG_SHARED;
@@ -920,8 +910,7 @@ TEST(bluestore_blob_t, can_split)
   ASSERT_FALSE(a.can_split());
 }
 
-TEST(bluestore_blob_t, can_split_at)
-{
+TEST(bluestore_blob_t, can_split_at) {
   bluestore_blob_t a;
   a.allocated_test(bluestore_pextent_t(0x10000, 0x2000));
   a.allocated_test(bluestore_pextent_t(0x20000, 0x2000));
@@ -934,14 +923,13 @@ TEST(bluestore_blob_t, can_split_at)
   ASSERT_FALSE(a.can_split_at(0x2800));
 }
 
-TEST(bluestore_blob_t, prune_tail)
-{
+TEST(bluestore_blob_t, prune_tail) {
   bluestore_blob_t a;
   a.allocated_test(bluestore_pextent_t(0x10000, 0x2000));
   a.allocated_test(bluestore_pextent_t(0x20000, 0x2000));
   ASSERT_FALSE(a.can_prune_tail());
   a.allocated_test(
-    bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+      bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
   ASSERT_TRUE(a.can_prune_tail());
   a.prune_tail();
   ASSERT_FALSE(a.can_prune_tail());
@@ -949,7 +937,7 @@ TEST(bluestore_blob_t, prune_tail)
   ASSERT_EQ(0x4000u, a.get_logical_length());
 
   a.allocated_test(
-    bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+      bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
   a.init_csum(Checksummer::CSUM_CRC32C_8, 12, 0x6000);
   ASSERT_EQ(6u, a.csum_data.length());
   ASSERT_TRUE(a.can_prune_tail());
@@ -961,17 +949,16 @@ TEST(bluestore_blob_t, prune_tail)
 
   bluestore_blob_t b;
   b.allocated_test(
-    bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+      bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
   ASSERT_FALSE(a.can_prune_tail());
 }
 
-TEST(Blob, split)
-{
+TEST(Blob, split) {
   BlueStore store(g_ceph_context, "", 4096);
-    BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-      g_ceph_context, "lru", NULL);
-    BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-      g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   {
     BlueStore::Blob L(coll.get());
@@ -1017,13 +1004,12 @@ TEST(Blob, split)
   }
 }
 
-TEST(Blob, legacy_decode)
-{
+TEST(Blob, legacy_decode) {
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   bufferlist bl, bl2;
   {
@@ -1040,34 +1026,26 @@ TEST(Blob, legacy_decode)
 
     size_t bound = 0, bound2 = 0;
 
-    B.bound_encode(
-      bound,
-      1, /*struct_v*/
-      0, /*sbid*/
-      false);
+    B.bound_encode(bound, 1, /*struct_v*/
+                   0,        /*sbid*/
+                   false);
     fake_ref_map.bound_encode(bound);
 
-    B.bound_encode(
-      bound2,
-      2, /*struct_v*/
-      0, /*sbid*/
-      true);
+    B.bound_encode(bound2, 2, /*struct_v*/
+                   0,         /*sbid*/
+                   true);
 
     {
       auto app = bl.get_contiguous_appender(bound);
       auto app2 = bl2.get_contiguous_appender(bound2);
-      B.encode(
-        app,
-        1, /*struct_v*/
-        0, /*sbid*/
-        false);
+      B.encode(app, 1, /*struct_v*/
+               0,      /*sbid*/
+               false);
       fake_ref_map.encode(app);
 
-      B.encode(
-        app2,
-        2, /*struct_v*/
-        0, /*sbid*/
-        true);
+      B.encode(app2, 2, /*struct_v*/
+               0,       /*sbid*/
+               true);
     }
 
     auto p = bl.front().begin_deep();
@@ -1076,37 +1054,30 @@ TEST(Blob, legacy_decode)
     BlueStore::Blob Bres2(coll.get());
 
     uint64_t sbid, sbid2;
-    Bres.decode(
-      p,
-      1, /*struct_v*/
-      &sbid,
-      true,
-      coll.get());
-    Bres2.decode(
-      p2,
-      2, /*struct_v*/
-      &sbid2,
-      true,
-      coll.get());
+    Bres.decode(p, 1, /*struct_v*/
+                &sbid, true, coll.get());
+    Bres2.decode(p2, 2, /*struct_v*/
+                 &sbid2, true, coll.get());
 
     ASSERT_EQ(0xff0u + 1u, Bres.get_blob_use_tracker().get_referenced_bytes());
     ASSERT_EQ(0xff0u + 1u, Bres2.get_blob_use_tracker().get_referenced_bytes());
-    ASSERT_TRUE(Bres.get_blob_use_tracker().equal(Bres2.get_blob_use_tracker()));
+    ASSERT_TRUE(
+        Bres.get_blob_use_tracker().equal(Bres2.get_blob_use_tracker()));
   }
 }
 
-TEST(ExtentMap, seek_lextent)
-{
+TEST(ExtentMap, seek_lextent) {
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
 
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-  BlueStore::ExtentMap em(&onode,
-    g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap em(
+      &onode,
+      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
   BlueStore::BlobRef br(coll->new_blob());
 
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
@@ -1148,17 +1119,17 @@ TEST(ExtentMap, seek_lextent)
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(500));
 }
 
-TEST(ExtentMap, has_any_lextents)
-{
+TEST(ExtentMap, has_any_lextents) {
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-  BlueStore::ExtentMap em(&onode,
-    g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap em(
+      &onode,
+      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
   BlueStore::BlobRef b(coll->new_blob());
 
   ASSERT_FALSE(em.has_any_lextents(0, 0));
@@ -1198,26 +1169,25 @@ TEST(ExtentMap, has_any_lextents)
   ASSERT_FALSE(em.has_any_lextents(500, 1000));
 }
 
-void erase_and_delete(BlueStore::ExtentMap& em, size_t v)
-{
+void erase_and_delete(BlueStore::ExtentMap &em, size_t v) {
   auto d = em.find(v);
   ASSERT_NE(d, em.extent_map.end());
   em.extent_map.erase(d);
   delete &*d;
 }
 
-TEST(ExtentMap, compress_extent_map)
-{
+TEST(ExtentMap, compress_extent_map) {
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
+
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-  BlueStore::ExtentMap em(&onode,
-    g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap em(
+      &onode,
+      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
   BlueStore::BlobRef b1(coll->new_blob());
   BlueStore::BlobRef b2(coll->new_blob());
   BlueStore::BlobRef b3(coll->new_blob());
@@ -1273,7 +1243,7 @@ public:
 
   static constexpr uint32_t au_size = 4096;
   uint32_t blob_size = 65536;
-  size_t csum_order = 12; //1^12 = 4096 bytes
+  size_t csum_order = 12; // 1^12 = 4096 bytes
 
   struct au {
     uint32_t chksum;
@@ -1284,35 +1254,30 @@ public:
   // test onode that glues some simplifications in representation
   // with actual BlueStore's onode
   struct t_onode {
-    BlueStore::OnodeRef onode; //actual BS onode
-    std::vector<uint32_t> data; //map to AUs
+    BlueStore::OnodeRef onode;  // actual BS onode
+    std::vector<uint32_t> data; // map to AUs
     static constexpr uint32_t empty = std::numeric_limits<uint32_t>::max();
   };
-  void print(std::ostream& out, t_onode& onode)
-  {
+  void print(std::ostream &out, t_onode &onode) {
     for (size_t i = 0; i < onode.data.size(); ++i) {
-      if (i != 0) out << " ";
+      if (i != 0)
+        out << " ";
       if (onode.data[i] == t_onode::empty) {
-	out << "-";
+        out << "-";
       } else {
-	out << std::hex << onode.data[i]
-	    << "/" << disk[onode.data[i]].chksum
-	    << ":" << std::dec << disk[onode.data[i]].refs;
+        out << std::hex << onode.data[i] << "/" << disk[onode.data[i]].chksum
+            << ":" << std::dec << disk[onode.data[i]].refs;
       }
     }
   }
-  explicit ExtentMapFixture()
-    : store(g_ceph_context, "", au_size)
-  {
+  explicit ExtentMapFixture() : store(g_ceph_context, "", au_size) {
     oc = BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
-    bc = BlueStore::BufferCacheShard::create(g_ceph_context, "lru", NULL);
+    bc = BlueStore::BufferCacheShard::create(&store, "lru", NULL);
     coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   }
 
-  void SetUp() override {
-  }
-  void TearDown() override {
-  }
+  void SetUp() override {}
+  void TearDown() override {}
 
   // takes new space from disk, initializes csums
   // returns index of first au
@@ -1326,15 +1291,13 @@ public:
     }
     return pos;
   }
-  void release(uint32_t& au_idx) {
+  void release(uint32_t &au_idx) {
     if (au_idx != t_onode::empty) {
       disk_unref(au_idx);
     }
     au_idx = t_onode::empty;
   }
-  void disk_ref(uint32_t au_idx) {
-    ++disk[au_idx].refs;
-  }
+  void disk_ref(uint32_t au_idx) { ++disk[au_idx].refs; }
   void disk_unref(uint32_t au_idx) {
     ceph_assert(disk[au_idx].refs > 0);
     --disk[au_idx].refs;
@@ -1346,16 +1309,16 @@ public:
     return res;
   }
 
-  void fillup(t_onode& onode, uint32_t end) {
+  void fillup(t_onode &onode, uint32_t end) {
     if (end > onode.data.size()) {
       size_t e = onode.data.size();
       onode.data.resize(end);
       for (; e < end; ++e) {
-	onode.data[e] = t_onode::empty;
+        onode.data[e] = t_onode::empty;
       }
     }
   }
-  void punch_hole(t_onode& onode, uint32_t off, uint32_t len) {
+  void punch_hole(t_onode &onode, uint32_t off, uint32_t len) {
     ceph_assert((off % au_size) == 0);
     ceph_assert((len % au_size) == 0);
     uint32_t i = off / au_size;
@@ -1363,14 +1326,14 @@ public:
     fillup(onode, end);
     while (i < end && i < onode.data.size()) {
       if (onode.data[i] != t_onode::empty)
-	release(onode.data[i]);
+        release(onode.data[i]);
       onode.data[i] = t_onode::empty;
       i++;
     }
     store.debug_punch_hole(coll, onode.onode, off, len);
   }
 
-  void write(t_onode& onode, uint32_t off, uint32_t len) {
+  void write(t_onode &onode, uint32_t off, uint32_t len) {
     ceph_assert((off % au_size) == 0);
     ceph_assert((len % au_size) == 0);
     punch_hole(onode, off, len);
@@ -1389,30 +1352,30 @@ public:
     }
 
     // below simulation of write performed by BlueStore::do_write()
-    auto helper_blob_write = [&](
-      uint32_t log_off,   // logical offset of blob to put to onode
-      uint32_t empty_aus, // amount of unreferenced aus in the beginning
-      uint32_t first_au,  // first au that will be referenced
-      uint32_t num_aus     // number of aus, first, first+1.. first+num_au-1
-    ) {
-      uint32_t blob_length = (empty_aus + num_aus) * au_size;
-      BlueStore::BlobRef b(coll->new_blob());
-      bluestore_blob_t& bb = b->dirty_blob();
-      bb.init_csum(Checksummer::CSUM_CRC32C, csum_order, blob_length);
-      for(size_t i = 0; i < num_aus; ++i) {
-	bb.set_csum_item(empty_aus + i, disk[first_au + i].chksum);
-      }
+    auto helper_blob_write =
+        [&](uint32_t log_off,   // logical offset of blob to put to onode
+            uint32_t empty_aus, // amount of unreferenced aus in the beginning
+            uint32_t first_au,  // first au that will be referenced
+            uint32_t num_aus // number of aus, first, first+1.. first+num_au-1
+        ) {
+          uint32_t blob_length = (empty_aus + num_aus) * au_size;
+          BlueStore::BlobRef b(coll->new_blob());
+          bluestore_blob_t &bb = b->dirty_blob();
+          bb.init_csum(Checksummer::CSUM_CRC32C, csum_order, blob_length);
+          for (size_t i = 0; i < num_aus; ++i) {
+            bb.set_csum_item(empty_aus + i, disk[first_au + i].chksum);
+          }
 
-      PExtentVector pextents;
-      pextents.emplace_back(first_au * au_size, num_aus * au_size);
-      bb.allocated(empty_aus * au_size, num_aus * au_size, pextents);
+          PExtentVector pextents;
+          pextents.emplace_back(first_au * au_size, num_aus * au_size);
+          bb.allocated(empty_aus * au_size, num_aus * au_size, pextents);
 
-      auto *ext = new BlueStore::Extent(log_off, empty_aus * au_size,
-					 num_aus * au_size, b);
-      onode.onode->extent_map.extent_map.insert(*ext);
-      b->get_ref(coll.get(), empty_aus * au_size, num_aus * au_size);
-      bb.mark_used(empty_aus * au_size, num_aus * au_size);
-    };
+          auto *ext = new BlueStore::Extent(log_off, empty_aus * au_size,
+                                            num_aus * au_size, b);
+          onode.onode->extent_map.extent_map.insert(*ext);
+          b->get_ref(coll.get(), empty_aus * au_size, num_aus * au_size);
+          bb.mark_used(empty_aus * au_size, num_aus * au_size);
+        };
 
     size_t off_blob_aligned = p2align(off, blob_size);
     size_t off_blob_roundup = p2align(off + blob_size, blob_size);
@@ -1431,7 +1394,7 @@ public:
     };
   }
 
-  void dup(t_onode& ofrom, t_onode& oto, uint64_t off, uint64_t len) {
+  void dup(t_onode &ofrom, t_onode &oto, uint64_t off, uint64_t len) {
     ceph_assert((off % au_size) == 0);
     ceph_assert((len % au_size) == 0);
     punch_hole(oto, off, len);
@@ -1443,84 +1406,87 @@ public:
     while (i < end) {
       oto.data[i] = ofrom.data[i];
       if (oto.data[i] != t_onode::empty) {
-	disk_ref(oto.data[i]);
+        disk_ref(oto.data[i]);
       }
       ++i;
     }
     BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
-    ofrom.onode->extent_map.dup_esb(&store, &txc, coll, ofrom.onode, oto.onode, off, len, off);
+    ofrom.onode->extent_map.dup_esb(&store, &txc, coll, ofrom.onode, oto.onode,
+                                    off, len, off);
   }
 
-  int32_t compare(t_onode& onode) {
+  int32_t compare(t_onode &onode) {
     BlueStore::ExtentMap::debug_au_vector_t debug =
-      onode.onode->extent_map.debug_list_disk_layout();
+        onode.onode->extent_map.debug_list_disk_layout();
     size_t pos = 0;
     for (size_t i = 0; i < debug.size(); ++i) {
       if (debug[i].disk_offset == -1ULL) {
-	size_t len = debug[i].disk_length;
-	size_t l = len / au_size;
-	if (pos + l > onode.data.size()) {
-	  return pos + l;
-	}
-	while (l > 0) {
-	  if (onode.data[pos] != t_onode::empty) {
-	    return pos;
-	  }
-	  --l;
-	  ++pos;
-	};
+        size_t len = debug[i].disk_length;
+        size_t l = len / au_size;
+        if (pos + l > onode.data.size()) {
+          return pos + l;
+        }
+        while (l > 0) {
+          if (onode.data[pos] != t_onode::empty) {
+            return pos;
+          }
+          --l;
+          ++pos;
+        };
       } else {
-	ceph_assert(pos < onode.data.size());
-	uint32_t au = onode.data[pos];
-	if (debug[i].disk_offset != au * au_size ||
-	    debug[i].disk_length != au_size      ||
-	    debug[i].chksum != disk[au].chksum) {
-	  return pos;
-	}
-	if ((int32_t)debug[i].ref_cnts == -1) {
-	  if (disk[au].refs != 1) {
-	    return pos;
-	  }
-	} else {
-	  if (disk[au].refs != debug[i].ref_cnts) {
-	    return pos;
-	  }
-	}
-	++pos;
+        ceph_assert(pos < onode.data.size());
+        uint32_t au = onode.data[pos];
+        if (debug[i].disk_offset != au * au_size ||
+            debug[i].disk_length != au_size ||
+            debug[i].chksum != disk[au].chksum) {
+          return pos;
+        }
+        if ((int32_t)debug[i].ref_cnts == -1) {
+          if (disk[au].refs != 1) {
+            return pos;
+          }
+        } else {
+          if (disk[au].refs != debug[i].ref_cnts) {
+            return pos;
+          }
+        }
+        ++pos;
       }
     }
     // remaining aus must be empty
     while (pos < onode.data.size()) {
       if (onode.data[pos] != t_onode::empty) {
-	return pos;
+        return pos;
       }
       ++pos;
     }
     return -1;
   }
 
-  bool check(t_onode& onode) {
+  bool check(t_onode &onode) {
     int32_t res = compare(onode);
     if (res != -1) {
-      cout << "Discrepancy at 0x" << std::hex << res * au_size << std::dec << std::endl;
+      cout << "Discrepancy at 0x" << std::hex << res * au_size << std::dec
+           << std::endl;
       cout << "Simulated: ";
       print(cout, onode);
       cout << std::endl;
-      cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout() << std::endl;
+      cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout()
+           << std::endl;
       return false;
     }
     return true;
   }
-  void print(t_onode& onode) {
+  void print(t_onode &onode) {
     cout << "Simulated: ";
     print(cout, onode);
     cout << std::endl;
-    cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout() << std::endl;
+    cout << "Onode: " << onode.onode->extent_map.debug_list_disk_layout()
+         << std::endl;
   }
 };
 
-TEST_F(ExtentMapFixture, walk)
-{
+TEST_F(ExtentMapFixture, walk) {
   std::vector<t_onode> X;
   for (size_t i = 0; i < 100; i++) {
     X.push_back(create());
@@ -1528,15 +1494,14 @@ TEST_F(ExtentMapFixture, walk)
 
   for (size_t i = 0; i < 100 - 1; i++) {
     write(X[i], (i + 2) * au_size, 4 * au_size);
-    dup(X[i], X[i+1], (i + 1) * au_size, 8 * au_size);
+    dup(X[i], X[i + 1], (i + 1) * au_size, 8 * au_size);
   }
   for (size_t i = 0; i < 100; i++) {
     ASSERT_EQ(check(X[i]), true);
   }
 }
 
-TEST_F(ExtentMapFixture, pyramid)
-{
+TEST_F(ExtentMapFixture, pyramid) {
   constexpr size_t H = 100;
   std::vector<t_onode> X;
   for (size_t i = 0; i < H; i++) {
@@ -1552,8 +1517,7 @@ TEST_F(ExtentMapFixture, pyramid)
   }
 }
 
-TEST_F(ExtentMapFixture, rain)
-{
+TEST_F(ExtentMapFixture, rain) {
   constexpr size_t H = 100;
   constexpr size_t W = 100;
   std::vector<t_onode> X;
@@ -1569,8 +1533,7 @@ TEST_F(ExtentMapFixture, rain)
   }
 }
 
-TEST_F(ExtentMapFixture, pollock)
-{
+TEST_F(ExtentMapFixture, pollock) {
   constexpr size_t H = 100;
   constexpr size_t W = 100;
   std::vector<t_onode> X;
@@ -1590,8 +1553,7 @@ TEST_F(ExtentMapFixture, pollock)
   }
 }
 
-TEST_F(ExtentMapFixture, carousel)
-{
+TEST_F(ExtentMapFixture, carousel) {
   constexpr size_t R = 10;
   constexpr size_t CNT = 300;
   constexpr size_t W = 100;
@@ -1612,8 +1574,7 @@ TEST_F(ExtentMapFixture, carousel)
   }
 }
 
-TEST_F(ExtentMapFixture, petri)
-{
+TEST_F(ExtentMapFixture, petri) {
   constexpr size_t R = 10;
   constexpr size_t CNT = 300;
   constexpr size_t W = 100;
@@ -1637,25 +1598,25 @@ TEST_F(ExtentMapFixture, petri)
   }
 }
 
-TEST(ExtentMap, dup_extent_map)
-{
+TEST(ExtentMap, dup_extent_map) {
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
 
-  size_t csum_order = 12; //1^12 = 4096 bytes
+  size_t csum_order = 12; // 1^12 = 4096 bytes
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   std::unique_ptr<ceph::Formatter> formatter(Formatter::create("json"));
 
   ///////////////////////////
-  //constructing onode1
-  BlueStore::OnodeRef onode1(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
-  
-  //BlueStore::ExtentMap em1(&onode1,
-  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::ExtentMap& em1 = onode1->extent_map;
+  // constructing onode1
+  BlueStore::OnodeRef onode1(
+      new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+
+  // BlueStore::ExtentMap em1(&onode1,
+  //   g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap &em1 = onode1->extent_map;
   ///////////////////////////
   // constructing extent/Blob: 0x0~2000 at <0x100000~2000>
   size_t ext1_offs = 0x0;
@@ -1664,7 +1625,7 @@ TEST(ExtentMap, dup_extent_map)
   BlueStore::BlobRef b1 = coll->new_blob();
   auto &_b1 = b1->dirty_blob();
   _b1.init_csum(Checksummer::CSUM_CRC32C, csum_order, ext1_len);
-  for(size_t i = 0; i < _b1.get_csum_count(); i++) {
+  for (size_t i = 0; i < _b1.get_csum_count(); i++) {
     *(_b1.get_csum_item_ptr(i)) = i + 1;
   }
   PExtentVector pextents;
@@ -1677,16 +1638,18 @@ TEST(ExtentMap, dup_extent_map)
   _b1.mark_used(ext1->blob_offset, ext1->length);
 
   ///////////////////////////
-  //constructing onode2 which is a full clone from onode1
-  BlueStore::OnodeRef onode2(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
-  //BlueStore::ExtentMap em2(&onode2,
-  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::ExtentMap& em2 = onode2->extent_map;
+  // constructing onode2 which is a full clone from onode1
+  BlueStore::OnodeRef onode2(
+      new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  // BlueStore::ExtentMap em2(&onode2,
+  //   g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap &em2 = onode2->extent_map;
   {
     BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
 
-    //em1.dup(&store, &txc, coll, em2, ext1_offs, ext1_len, ext1_offs);
-    onode1->extent_map.dup_esb(&store, &txc, coll, onode1, onode2, ext1_offs, ext1_len, ext1_offs);
+    // em1.dup(&store, &txc, coll, em2, ext1_offs, ext1_len, ext1_offs);
+    onode1->extent_map.dup_esb(&store, &txc, coll, onode1, onode2, ext1_offs,
+                               ext1_len, ext1_offs);
 
     em1.dump(formatter.get()); // see the log if any
     formatter->flush(std::cout);
@@ -1704,17 +1667,18 @@ TEST(ExtentMap, dup_extent_map)
     ASSERT_EQ(b1->get_shared_blob(), b2->get_shared_blob());
     auto &_b2 = b2->get_blob();
     ASSERT_EQ(_b1.get_csum_count(), _b2.get_csum_count());
-    for(size_t i = 0; i < _b2.get_csum_count(); i++) {
+    for (size_t i = 0; i < _b2.get_csum_count(); i++) {
       ASSERT_EQ(*(_b1.get_csum_item_ptr(i)), *(_b2.get_csum_item_ptr(i)));
     }
   }
 
   ///////////////////////////
-  //constructing onode3 which is partial clone (tail part) from onode2
-  BlueStore::OnodeRef onode3(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
-  //BlueStore::ExtentMap em3(&onode3,
-  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::ExtentMap& em3 = onode3->extent_map;
+  // constructing onode3 which is partial clone (tail part) from onode2
+  BlueStore::OnodeRef onode3(
+      new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  // BlueStore::ExtentMap em3(&onode3,
+  //   g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap &em3 = onode3->extent_map;
   {
     size_t clone_shift = 0x1000;
     ceph_assert(ext1_len > clone_shift);
@@ -1722,7 +1686,8 @@ TEST(ExtentMap, dup_extent_map)
     size_t clone_len = ext1_len - clone_shift;
     BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
 
-    onode1->extent_map.dup_esb(&store, &txc, coll, onode1, onode3, clone_offs, clone_len, clone_offs);
+    onode1->extent_map.dup_esb(&store, &txc, coll, onode1, onode3, clone_offs,
+                               clone_len, clone_offs);
     em1.dump(formatter.get()); // see the log if any
     formatter->flush(std::cout);
     std::cout << std::endl;
@@ -1746,17 +1711,18 @@ TEST(ExtentMap, dup_extent_map)
     ASSERT_EQ(ll, ext1_len);
     auto &_b3 = b3->get_blob();
     ASSERT_EQ(_b1.get_csum_count(), _b3.get_csum_count());
-    for(size_t i = 0; i < _b3.get_csum_count(); i++) {
+    for (size_t i = 0; i < _b3.get_csum_count(); i++) {
       ASSERT_EQ(*(_b1.get_csum_item_ptr(i)), *(_b3.get_csum_item_ptr(i)));
     }
   }
 
   ///////////////////////////
-  //constructing onode4 which is partial clone (head part) from onode2
-  BlueStore::OnodeRef onode4(new BlueStore::Onode(coll.get(), ghobject_t(), ""));
-  //BlueStore::ExtentMap em4(&onode4,
-  //  g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
-  BlueStore::ExtentMap& em4 = onode4->extent_map;
+  // constructing onode4 which is partial clone (head part) from onode2
+  BlueStore::OnodeRef onode4(
+      new BlueStore::Onode(coll.get(), ghobject_t(), ""));
+  // BlueStore::ExtentMap em4(&onode4,
+  //   g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap &em4 = onode4->extent_map;
 
   {
     size_t clone_shift = 0;
@@ -1765,7 +1731,8 @@ TEST(ExtentMap, dup_extent_map)
     size_t clone_offs = ext1_offs + clone_shift;
     BlueStore::TransContext txc(store.cct, coll.get(), nullptr, nullptr);
 
-    onode2->extent_map.dup_esb(&store, &txc, coll, onode2, onode4, clone_offs, clone_len, clone_offs);
+    onode2->extent_map.dup_esb(&store, &txc, coll, onode2, onode4, clone_offs,
+                               clone_len, clone_offs);
     em2.dump(formatter.get()); // see the log if any
     formatter->flush(std::cout);
     std::cout << std::endl;
@@ -1795,15 +1762,13 @@ TEST(ExtentMap, dup_extent_map)
     ASSERT_EQ(csum_entries, _b4.get_csum_count());
 
     ASSERT_GT(_b2.get_csum_count(), csum_entries);
-    for(size_t i = 0; i < csum_entries; i++) {
+    for (size_t i = 0; i < csum_entries; i++) {
       ASSERT_EQ(*(_b2.get_csum_item_ptr(i)), *(_b4.get_csum_item_ptr(i)));
     }
   }
 }
 
-
-void clear_and_dispose(BlueStore::old_extent_map_t& old_em)
-{
+void clear_and_dispose(BlueStore::old_extent_map_t &old_em) {
   auto oep = old_em.begin();
   while (oep != old_em.end()) {
     auto &lo = *oep;
@@ -1812,43 +1777,42 @@ void clear_and_dispose(BlueStore::old_extent_map_t& old_em)
   }
 }
 
-TEST(GarbageCollector, BasicTest)
-{
-  BlueStore::OnodeCacheShard *oc = BlueStore::OnodeCacheShard::create(
-    g_ceph_context, "lru", NULL);
-  BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
-    g_ceph_context, "lru", NULL);
-
+TEST(GarbageCollector, BasicTest) {
   BlueStore store(g_ceph_context, "", 4096);
+  BlueStore::OnodeCacheShard *oc =
+      BlueStore::OnodeCacheShard::create(g_ceph_context, "lru", NULL);
+  BlueStore::BufferCacheShard *bc =
+      BlueStore::BufferCacheShard::create(&store, "lru", NULL);
+
   auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-  BlueStore::ExtentMap em(&onode,
-    g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+  BlueStore::ExtentMap em(
+      &onode,
+      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
 
   BlueStore::old_extent_map_t old_extents;
 
-
- /*
-  min_alloc_size = 4096
-  original disposition
-  extent1 <loffs = 100, boffs = 100, len  = 10>
-    -> blob1<compressed, len_on_disk=4096, logical_len=8192>
-  extent2 <loffs = 200, boffs = 200, len  = 10>
-    -> blob2<raw, len_on_disk=4096, llen=4096>
-  extent3 <loffs = 300, boffs = 300, len  = 10>
-    -> blob1<compressed, len_on_disk=4096, llen=8192>
-  extent4 <loffs = 4096, boffs = 0, len  = 10>
-    -> blob3<raw, len_on_disk=4096, llen=4096>
-  on write(300~100) resulted in
-  extent1 <loffs = 100, boffs = 100, len  = 10>
-    -> blob1<compressed, len_on_disk=4096, logical_len=8192>
-  extent2 <loffs = 200, boffs = 200, len  = 10>
-    -> blob2<raw, len_on_disk=4096, llen=4096>
-  extent3 <loffs = 300, boffs = 300, len  = 100>
-    -> blob4<raw, len_on_disk=4096, llen=4096>
-  extent4 <loffs = 4096, boffs = 0, len  = 10>
-    -> blob3<raw, len_on_disk=4096, llen=4096>
-  */  
+  /*
+   min_alloc_size = 4096
+   original disposition
+   extent1 <loffs = 100, boffs = 100, len  = 10>
+     -> blob1<compressed, len_on_disk=4096, logical_len=8192>
+   extent2 <loffs = 200, boffs = 200, len  = 10>
+     -> blob2<raw, len_on_disk=4096, llen=4096>
+   extent3 <loffs = 300, boffs = 300, len  = 10>
+     -> blob1<compressed, len_on_disk=4096, llen=8192>
+   extent4 <loffs = 4096, boffs = 0, len  = 10>
+     -> blob3<raw, len_on_disk=4096, llen=4096>
+   on write(300~100) resulted in
+   extent1 <loffs = 100, boffs = 100, len  = 10>
+     -> blob1<compressed, len_on_disk=4096, logical_len=8192>
+   extent2 <loffs = 200, boffs = 200, len  = 10>
+     -> blob2<raw, len_on_disk=4096, llen=4096>
+   extent3 <loffs = 300, boffs = 300, len  = 100>
+     -> blob4<raw, len_on_disk=4096, llen=4096>
+   extent4 <loffs = 4096, boffs = 0, len  = 10>
+     -> blob3<raw, len_on_disk=4096, llen=4096>
+   */
   {
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
@@ -1870,11 +1834,11 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(4096, 0, 10, b3));
     b3->get_ref(coll.get(), 0, 10);
 
-    old_extents.push_back(*new BlueStore::OldExtent(300, 300, 10, b1)); 
+    old_extents.push_back(*new BlueStore::OldExtent(300, 300, 10, b1));
 
     saving = gc.estimate(300, 100, em, old_extents, 4096);
     ASSERT_EQ(saving, 1);
-    auto& to_collect = gc.get_extents_to_collect();
+    auto &to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 1u);
     {
       auto it = to_collect.begin();
@@ -1885,31 +1849,32 @@ TEST(GarbageCollector, BasicTest)
     em.clear();
     clear_and_dispose(old_extents);
   }
- /*
-  original disposition
-  min_alloc_size = 0x10000
-  extent1 <loffs = 0, boffs = 0, len  = 0x40000>
-    -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
-  Write 0x8000~37000 resulted in the following extent map prior to GC
-  for the last write_small(0x30000~0xf000):
+  /*
+   original disposition
+   min_alloc_size = 0x10000
+   extent1 <loffs = 0, boffs = 0, len  = 0x40000>
+     -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
+   Write 0x8000~37000 resulted in the following extent map prior to GC
+   for the last write_small(0x30000~0xf000):
 
-  extent1 <loffs = 0, boffs = 0, len  = 0x8000>
-    -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
-  extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
-    -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
-  extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
-    -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
-  extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
-    -> blob4<raw, len_on_disk=0x10000, llen=0x10000>
-  extent5 <loffs = 0x3f000, boffs = 0x3f000, len  = 0x1000>
-    -> blob1<compressed, len_on_disk=0x20000, llen=0x40000>
-  */  
+   extent1 <loffs = 0, boffs = 0, len  = 0x8000>
+     -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
+   extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
+     -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
+   extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
+     -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
+   extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
+     -> blob4<raw, len_on_disk=0x10000, llen=0x10000>
+   extent5 <loffs = 0x3f000, boffs = 0x3f000, len  = 0x1000>
+     -> blob1<compressed, len_on_disk=0x20000, llen=0x40000>
+   */
   {
     BlueStore store(g_ceph_context, "", 0x10000);
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-    BlueStore::ExtentMap em(&onode,
-      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+    BlueStore::ExtentMap em(
+        &onode,
+        g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
 
     BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
@@ -1927,32 +1892,34 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b1));
     b1->get_ref(coll.get(), 0, 0x8000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
+        *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
     b2->get_ref(coll.get(), 0x8000, 0x8000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
+        *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
     b3->get_ref(coll.get(), 0, 0x20000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
+        *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
     b4->get_ref(coll.get(), 0, 0xf000);
     em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x3f000, 0x1000, b1));
     b1->get_ref(coll.get(), 0x3f000, 0x1000);
 
-    old_extents.push_back(*new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b1)); 
     old_extents.push_back(
-      *new BlueStore::OldExtent(0x10000, 0x10000, 0x20000, b1));
-    old_extents.push_back(*new BlueStore::OldExtent(0x30000, 0x30000, 0xf000, b1)); 
+        *new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b1));
+    old_extents.push_back(
+        *new BlueStore::OldExtent(0x10000, 0x10000, 0x20000, b1));
+    old_extents.push_back(
+        *new BlueStore::OldExtent(0x30000, 0x30000, 0xf000, b1));
 
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);
-    auto& to_collect = gc.get_extents_to_collect();
+    auto &to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 2u);
     {
       auto it1 = to_collect.begin();
       auto it2 = ++to_collect.begin();
       using p = decltype(*it1);
       {
-        auto v1 = p{0x0ul ,0x8000ul};
+        auto v1 = p{0x0ul, 0x8000ul};
         auto v2 = p{0x0ul, 0x8000ul};
         ASSERT_TRUE(*it1 == v1 || *it2 == v2);
       }
@@ -1966,20 +1933,20 @@ TEST(GarbageCollector, BasicTest)
     em.clear();
     clear_and_dispose(old_extents);
   }
- /*
-  original disposition
-  min_alloc_size = 0x1000
-  extent1 <loffs = 0, boffs = 0, len  = 0x4000>
-    -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
-  write 0x3000~4000 resulted in the following extent map
-  (future feature - suppose we can compress incoming write prior to
-  GC invocation)
+  /*
+   original disposition
+   min_alloc_size = 0x1000
+   extent1 <loffs = 0, boffs = 0, len  = 0x4000>
+     -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
+   write 0x3000~4000 resulted in the following extent map
+   (future feature - suppose we can compress incoming write prior to
+   GC invocation)
 
-  extent1 <loffs = 0, boffs = 0, len  = 0x4000>
-    -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
-  extent2 <loffs = 0x3000, boffs = 0, len  = 0x4000>
-    -> blob2<compressed, len_on_disk=0x2000, llen=0x4000>
-  */  
+   extent1 <loffs = 0, boffs = 0, len  = 0x4000>
+     -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
+   extent2 <loffs = 0x3000, boffs = 0, len  = 0x4000>
+     -> blob2<compressed, len_on_disk=0x2000, llen=0x4000>
+   */
   {
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
@@ -1993,45 +1960,47 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x3000, b1));
     b1->get_ref(coll.get(), 0, 0x3000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x3000, 0, 0x4000, b2)); // new extent
+        *new BlueStore::Extent(0x3000, 0, 0x4000, b2)); // new extent
     b2->get_ref(coll.get(), 0, 0x4000);
 
-    old_extents.push_back(*new BlueStore::OldExtent(0x3000, 0x3000, 0x1000, b1)); 
+    old_extents.push_back(
+        *new BlueStore::OldExtent(0x3000, 0x3000, 0x1000, b1));
 
     saving = gc.estimate(0x3000, 0x4000, em, old_extents, 0x1000);
     ASSERT_EQ(saving, 0);
-    auto& to_collect = gc.get_extents_to_collect();
+    auto &to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 0u);
     em.clear();
     clear_and_dispose(old_extents);
   }
- /*
-  original disposition
-  min_alloc_size = 0x10000
-  extent0 <loffs = 0, boffs = 0, len  = 0x20000>
-    -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
-  extent1 <loffs = 0x20000, boffs = 0, len  = 0x20000>
-     -> blob1<compressed, len_on_disk=0x10000, logical_len=0x20000>
-  write 0x8000~37000 resulted in the following extent map prior
-  to GC for the last write_small(0x30000~0xf000)
+  /*
+   original disposition
+   min_alloc_size = 0x10000
+   extent0 <loffs = 0, boffs = 0, len  = 0x20000>
+     -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
+   extent1 <loffs = 0x20000, boffs = 0, len  = 0x20000>
+      -> blob1<compressed, len_on_disk=0x10000, logical_len=0x20000>
+   write 0x8000~37000 resulted in the following extent map prior
+   to GC for the last write_small(0x30000~0xf000)
 
-  extent0 <loffs = 0, boffs = 0, len  = 0x8000>
-    -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
-  extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
-    -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
-  extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
-    -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
-  extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
-    -> blob4<raw, len_on_disk=0x1000, llen=0x1000>
-  extent5 <loffs = 0x3f000, boffs = 0x1f000, len  = 0x1000>
-   -> blob1<compressed, len_on_disk=0x10000, llen=0x20000>
-  */  
+   extent0 <loffs = 0, boffs = 0, len  = 0x8000>
+     -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
+   extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
+     -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
+   extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
+     -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
+   extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
+     -> blob4<raw, len_on_disk=0x1000, llen=0x1000>
+   extent5 <loffs = 0x3f000, boffs = 0x1f000, len  = 0x1000>
+    -> blob1<compressed, len_on_disk=0x10000, llen=0x20000>
+   */
   {
     BlueStore store(g_ceph_context, "", 0x10000);
     auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
-    BlueStore::ExtentMap em(&onode,
-      g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
+    BlueStore::ExtentMap em(
+        &onode,
+        g_ceph_context->_conf->bluestore_extent_map_inline_shard_prealloc_size);
 
     BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
@@ -2052,26 +2021,27 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b0));
     b0->get_ref(coll.get(), 0, 0x8000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
+        *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
     b2->get_ref(coll.get(), 0x8000, 0x8000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
+        *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
     b3->get_ref(coll.get(), 0, 0x20000);
     em.extent_map.insert(
-      *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
+        *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
     b4->get_ref(coll.get(), 0, 0xf000);
     em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x1f000, 0x1000, b1));
     b1->get_ref(coll.get(), 0x1f000, 0x1000);
 
-    old_extents.push_back(*new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b0)); 
     old_extents.push_back(
-      *new BlueStore::OldExtent(0x10000, 0x10000, 0x10000, b0)); 
+        *new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b0));
     old_extents.push_back(
-      *new BlueStore::OldExtent(0x20000, 0x00000, 0x1f000, b1)); 
+        *new BlueStore::OldExtent(0x10000, 0x10000, 0x10000, b0));
+    old_extents.push_back(
+        *new BlueStore::OldExtent(0x20000, 0x00000, 0x1f000, b1));
 
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);
-    auto& to_collect = gc.get_extents_to_collect();
+    auto &to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 2u);
     {
       auto it1 = to_collect.begin();
@@ -2080,7 +2050,7 @@ TEST(GarbageCollector, BasicTest)
       {
         auto v1 = p{0x0ul, 0x8000ul};
         auto v2 = p{0x0ul, 0x8000ul};
-        ASSERT_TRUE(*it1 == v1 || *it2  == v2);
+        ASSERT_TRUE(*it1 == v1 || *it2 == v2);
       }
       {
         auto v1 = p{0x3f000ul, 0x1000ul};
@@ -2094,8 +2064,7 @@ TEST(GarbageCollector, BasicTest)
   }
 }
 
-TEST(BlueStoreRepairer, StoreSpaceTracker)
-{
+TEST(BlueStoreRepairer, StoreSpaceTracker) {
   BlueStoreRepairer::StoreSpaceTracker bmap0;
   bmap0.init((uint64_t)4096 * 1024 * 1024 * 1024, 0x1000);
   ASSERT_EQ(bmap0.granularity, 2 * 1024 * 1024U);
@@ -2171,16 +2140,16 @@ TEST(BlueStoreRepairer, StoreSpaceTracker)
   ASSERT_TRUE(bmap.is_used(hoid, 0xc1000));
 
   interval_set<uint64_t> extents;
-  extents.insert(0,0x500);
-  extents.insert(0x800,0x100);
-  extents.insert(0x1000,0x1000);
-  extents.insert(0xa001,1);
-  extents.insert(0xa0000,0xff8);
+  extents.insert(0, 0x500);
+  extents.insert(0x800, 0x100);
+  extents.insert(0x1000, 0x1000);
+  extents.insert(0xa001, 1);
+  extents.insert(0xa0000, 0xff8);
 
   ASSERT_EQ(3u, bmap.filter_out(extents));
   ASSERT_TRUE(bmap.is_used(cid));
   ASSERT_TRUE(bmap.is_used(hoid));
- 
+
   BlueStoreRepairer::StoreSpaceTracker bmap2;
   bmap2.init((uint64_t)0x3223b1d1000, 0x10000);
   ASSERT_EQ(0x1a0000u, bmap2.granularity);
@@ -2193,8 +2162,7 @@ TEST(BlueStoreRepairer, StoreSpaceTracker)
   ASSERT_TRUE(bmap2.is_used(hoid, 0x3223b19ffff));
 }
 
-TEST(bluestore_blob_t, unused)
-{
+TEST(bluestore_blob_t, unused) {
   {
     bluestore_blob_t b;
     uint64_t min_alloc_size = 64 << 10; // 64 kB
@@ -2205,7 +2173,8 @@ TEST(bluestore_blob_t, unused)
     uint64_t suggested_boff = 0;
     PExtentVector extents;
     extents.emplace_back(0x1a560000, min_alloc_size);
-    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/, extents);
+    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/,
+                extents);
     b.mark_used(offset, length);
     ASSERT_FALSE(b.is_unused(offset, length));
 
@@ -2235,7 +2204,8 @@ TEST(bluestore_blob_t, unused)
     uint64_t suggested_boff = 0x11000;
     PExtentVector extents;
     extents.emplace_back(0x1a560000, min_alloc_size);
-    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/, extents);
+    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/,
+                extents);
     b.add_unused(0, offset);
     b.add_unused(offset + length, min_alloc_size * 2 - offset - length);
     b.mark_used(offset, length);
@@ -2278,7 +2248,8 @@ TEST(bluestore_blob_t, unused)
     ASSERT_FALSE(b.is_unused(offset, length));
     ASSERT_FALSE(b.is_unused(offset, unused_granularity));
 
-    ASSERT_TRUE(b.is_unused(0, offset / unused_granularity * unused_granularity));
+    ASSERT_TRUE(
+        b.is_unused(0, offset / unused_granularity * unused_granularity));
     ASSERT_TRUE(b.is_unused(offset + length, offset0 - offset - length));
     auto end0_aligned = round_up_to(offset0 + length, unused_granularity);
     ASSERT_TRUE(b.is_unused(end0_aligned, min_alloc_size * 3 - end0_aligned));
@@ -2289,18 +2260,15 @@ TEST(bluestore_blob_t, unused)
 // https://tracker.ceph.com/issues/51682
 // Basic map_any functionality is tested as well though.
 //
-TEST(bluestore_blob_t, wrong_map_bl_in_51682)
-{
+TEST(bluestore_blob_t, wrong_map_bl_in_51682) {
   {
     bluestore_blob_t b;
     uint64_t min_alloc_size = 4 << 10; // 64 kB
 
     b.allocated_test(bluestore_pextent_t(0x17ba000, 4 * min_alloc_size));
     b.allocated_test(bluestore_pextent_t(0x17bf000, 4 * min_alloc_size));
-    b.allocated_test(
-      bluestore_pextent_t(
-        bluestore_pextent_t::INVALID_OFFSET,
-        1 * min_alloc_size));
+    b.allocated_test(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
+                                         1 * min_alloc_size));
     b.allocated_test(bluestore_pextent_t(0x153c44d000, 7 * min_alloc_size));
 
     b.mark_used(0, 0x8000);
@@ -2310,34 +2278,31 @@ TEST(bluestore_blob_t, wrong_map_bl_in_51682)
     bufferlist bl;
     bl.append(s);
     const size_t num_expected_entries = 5;
-    uint64_t expected[num_expected_entries][2] = {
-      {0x17ba000, 0x4000},
-      {0x17bf000, 0x3000},
-      {0x17c0000, 0x3000},
-      {0xffffffffffffffff, 0x1000},
-      {0x153c44d000, 0x3000}};
+    uint64_t expected[num_expected_entries][2] = {{0x17ba000, 0x4000},
+                                                  {0x17bf000, 0x3000},
+                                                  {0x17c0000, 0x3000},
+                                                  {0xffffffffffffffff, 0x1000},
+                                                  {0x153c44d000, 0x3000}};
     size_t expected_pos = 0;
-    b.map_bl(0, bl,
-      [&](uint64_t o, bufferlist& bl) {
-        ASSERT_EQ(o, expected[expected_pos][0]);
-        ASSERT_EQ(bl.length(), expected[expected_pos][1]);
-        ++expected_pos;
-      });
+    b.map_bl(0, bl, [&](uint64_t o, bufferlist &bl) {
+      ASSERT_EQ(o, expected[expected_pos][0]);
+      ASSERT_EQ(bl.length(), expected[expected_pos][1]);
+      ++expected_pos;
+    });
     // 0x5000 is an improper offset presumably provided when doing a repair
-    b.map_bl(0x5000, bl,
-      [&](uint64_t o, bufferlist& bl) {
-        ASSERT_EQ(o, expected[expected_pos][0]);
-        ASSERT_EQ(bl.length(), expected[expected_pos][1]);
-        ++expected_pos;
-      });
+    b.map_bl(0x5000, bl, [&](uint64_t o, bufferlist &bl) {
+      ASSERT_EQ(o, expected[expected_pos][0]);
+      ASSERT_EQ(bl.length(), expected[expected_pos][1]);
+      ++expected_pos;
+    });
     ASSERT_EQ(expected_pos, num_expected_entries);
   }
 }
 
 //---------------------------------------------------------------------------------
-static int verify_extent(const extent_t & ext, const extent_t *ext_arr, uint64_t ext_arr_size, uint64_t idx)
-{
-  const extent_t & ext_ref = ext_arr[idx];
+static int verify_extent(const extent_t &ext, const extent_t *ext_arr,
+                         uint64_t ext_arr_size, uint64_t idx) {
+  const extent_t &ext_ref = ext_arr[idx];
   if (ext.offset == ext_ref.offset && ext.length == ext_ref.length) {
     return 0;
   } else {
@@ -2346,25 +2311,27 @@ static int verify_extent(const extent_t & ext, const extent_t *ext_arr, uint64_t
       std::cerr << "Null extent was returned at idx = " << idx << std::endl;
     }
     unsigned start = std::max(((int32_t)(idx)-3), 0);
-    unsigned end   = std::min(idx+3, ext_arr_size);
+    unsigned end = std::min(idx + 3, ext_arr_size);
     for (unsigned j = start; j < end; j++) {
-      const extent_t & ext_ref = ext_arr[j];
-      std::cerr << j << ") ref_ext = [" << ext_ref.offset << ", " << ext_ref.length << "]" << std::endl;
+      const extent_t &ext_ref = ext_arr[j];
+      std::cerr << j << ") ref_ext = [" << ext_ref.offset << ", "
+                << ext_ref.length << "]" << std::endl;
     }
-    std::cerr << idx << ") ext     = [" << ext.offset     << ", " << ext.length     << "]" << std::endl;
+    std::cerr << idx << ") ext     = [" << ext.offset << ", " << ext.length
+              << "]" << std::endl;
     return -1;
   }
 }
 
 //---------------------------------------------------------------------------------
-static int test_extents(uint64_t index, extent_t *ext_arr, uint64_t ext_arr_size, SimpleBitmap& sbmap, bool set)
-{
-  const uint64_t  MAX_JUMP_BIG   = 1523;
-  const uint64_t  MAX_JUMP_SMALL =   19;
-  const uint64_t  MAX_LEN_BIG    =  523;
-  const uint64_t  MAX_LEN_SMALL  =   23;
+static int test_extents(uint64_t index, extent_t *ext_arr,
+                        uint64_t ext_arr_size, SimpleBitmap &sbmap, bool set) {
+  const uint64_t MAX_JUMP_BIG = 1523;
+  const uint64_t MAX_JUMP_SMALL = 19;
+  const uint64_t MAX_LEN_BIG = 523;
+  const uint64_t MAX_LEN_SMALL = 23;
 
-  uint64_t n      = sbmap.get_size();
+  uint64_t n = sbmap.get_size();
   uint64_t offset = 0;
   unsigned length, jump, i;
   for (i = 0; i < ext_arr_size; i++) {
@@ -2392,28 +2359,30 @@ static int test_extents(uint64_t index, extent_t *ext_arr, uint64_t ext_arr_size
       success = sbmap.clr(offset, length);
     }
     if (!success) {
-      std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset << ", " << length << ")"<< std::endl;
+      std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset << ", "
+                << length << ")" << std::endl;
       return -1;
     }
 
     // if this is not the first entry and no jump -> merge extents
-    if ( (i==0) || (jump > 0) ) {
+    if ((i == 0) || (jump > 0)) {
       ext_arr[i] = {offset, length};
     } else {
       // merge 2 extents
-      i --;
+      i--;
       ext_arr[i].length += length;
     }
     offset += length;
   }
   unsigned arr_size = std::min((uint64_t)i, ext_arr_size);
   std::cout << std::hex << std::right;
-  std::cout << "[" << index << "] " << (set ? "Set::" : "Clr::") << " extents count = 0x" << arr_size;
+  std::cout << "[" << index << "] " << (set ? "Set::" : "Clr::")
+            << " extents count = 0x" << arr_size;
   std::cout << std::dec << std::endl;
 
   offset = 0;
   extent_t ext;
-  for(unsigned i = 0; i < arr_size; i++) {
+  for (unsigned i = 0; i < arr_size; i++) {
     if (set) {
       ext = sbmap.get_next_set_extent(offset);
     } else {
@@ -2434,43 +2403,46 @@ static int test_extents(uint64_t index, extent_t *ext_arr, uint64_t ext_arr_size
   if (ext.length == 0) {
     return 0;
   } else {
-    std::cerr << "sbmap.get_next_" << (set ? "set" : "clr") << "_extent(" << offset << ") return length = " << ext.length << std::endl;
+    std::cerr << "sbmap.get_next_" << (set ? "set" : "clr") << "_extent("
+              << offset << ") return length = " << ext.length << std::endl;
     return -1;
   }
 }
 
 //---------------------------------------------------------------------------------
-TEST(SimpleBitmap, basic)
-{
+TEST(SimpleBitmap, basic) {
   const uint64_t MAX_EXTENTS_COUNT = 7131177;
-  std::unique_ptr<extent_t[]> ext_arr = std::make_unique<extent_t[]>(MAX_EXTENTS_COUNT);
+  std::unique_ptr<extent_t[]> ext_arr =
+      std::make_unique<extent_t[]>(MAX_EXTENTS_COUNT);
   ASSERT_TRUE(ext_arr != nullptr);
   const uint64_t BIT_COUNT = 4ULL << 30; // 4Gb = 512MB
   SimpleBitmap sbmap(g_ceph_context, BIT_COUNT);
 
   // use current time as seed for random generator
   std::srand(std::time(nullptr));
-  for (unsigned i = 0; i < 3; i++ ) {
-    memset(ext_arr.get(), 0, sizeof(extent_t)*MAX_EXTENTS_COUNT);
+  for (unsigned i = 0; i < 3; i++) {
+    memset(ext_arr.get(), 0, sizeof(extent_t) * MAX_EXTENTS_COUNT);
     sbmap.clear_all();
-    ASSERT_TRUE(test_extents(i, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, true) == 0);
+    ASSERT_TRUE(
+        test_extents(i, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, true) == 0);
 
-    memset(ext_arr.get(), 0, sizeof(extent_t)*MAX_EXTENTS_COUNT);
+    memset(ext_arr.get(), 0, sizeof(extent_t) * MAX_EXTENTS_COUNT);
     sbmap.set_all();
-    ASSERT_TRUE(test_extents(i, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, false) == 0);
+    ASSERT_TRUE(
+        test_extents(i, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, false) == 0);
   }
 }
 
 //---------------------------------------------------------------------------------
-static int test_intersections(unsigned test_idx, SimpleBitmap &sbmap, uint8_t map[], uint64_t map_size)
-{
-  const uint64_t  MAX_LEN_BIG    =  523;
-  const uint64_t  MAX_LEN_SMALL  =   23;
+static int test_intersections(unsigned test_idx, SimpleBitmap &sbmap,
+                              uint8_t map[], uint64_t map_size) {
+  const uint64_t MAX_LEN_BIG = 523;
+  const uint64_t MAX_LEN_SMALL = 23;
 
-  bool     success;
+  bool success;
   uint64_t set_op_count = 0, clr_op_count = 0;
   unsigned length, i;
-  for (i = 0; i < map_size / (MAX_LEN_BIG*2); i++) {
+  for (i = 0; i < map_size / (MAX_LEN_BIG * 2); i++) {
     uint64_t offset = (std::rand() % (map_size - 1));
     if (i & 1) {
       length = std::rand() % MAX_LEN_BIG;
@@ -2486,22 +2458,23 @@ static int test_intersections(unsigned test_idx, SimpleBitmap &sbmap, uint8_t ma
     bool set = (std::rand() % 3);
     if (set) {
       success = sbmap.set(offset, length);
-      memset(map+offset, 0xFF, length);
+      memset(map + offset, 0xFF, length);
       set_op_count++;
     } else {
       success = sbmap.clr(offset, length);
-      memset(map+offset, 0x0, length);
+      memset(map + offset, 0x0, length);
       clr_op_count++;
     }
     if (!success) {
-      std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset << ", " << length << ")"<< std::endl;
+      std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset << ", "
+                << length << ")" << std::endl;
       return -1;
     }
   }
 
   uint64_t set_bit_count = 0;
   uint64_t clr_bit_count = 0;
-  for(uint64_t idx = 0; idx < map_size; idx++) {
+  for (uint64_t idx = 0; idx < map_size; idx++) {
     if (map[idx]) {
       set_bit_count++;
       success = sbmap.bit_is_set(idx);
@@ -2510,37 +2483,42 @@ static int test_intersections(unsigned test_idx, SimpleBitmap &sbmap, uint8_t ma
       success = sbmap.bit_is_clr(idx);
     }
     if (!success) {
-      std::cerr << "expected: sbmap.bit_is_" << (map[idx] ? "set(" : "clr(") << idx << ")"<< std::endl;
+      std::cerr << "expected: sbmap.bit_is_" << (map[idx] ? "set(" : "clr(")
+                << idx << ")" << std::endl;
       return -1;
     }
-
   }
-  std::cout << std::hex << std::right << __func__ ;
-  std::cout << " [" << test_idx << "] set_bit_count = 0x" << std::setfill('0') << std::setw(8) << set_bit_count
-	    << ", clr_bit_count = 0x" << std::setfill('0') << std::setw(8) << clr_bit_count
-	    << ", sum = 0x" << set_bit_count + clr_bit_count  << std::endl;
+  std::cout << std::hex << std::right << __func__;
+  std::cout << " [" << test_idx << "] set_bit_count = 0x" << std::setfill('0')
+            << std::setw(8) << set_bit_count << ", clr_bit_count = 0x"
+            << std::setfill('0') << std::setw(8) << clr_bit_count
+            << ", sum = 0x" << set_bit_count + clr_bit_count << std::endl;
   std::cout << std::dec;
   uint64_t offset = 0;
-  for(uint64_t i = 0; i < (set_op_count + clr_op_count); i++) {
+  for (uint64_t i = 0; i < (set_op_count + clr_op_count); i++) {
     extent_t ext = sbmap.get_next_set_extent(offset);
-    //std::cout << "set_ext:: " << i << ") [" << ext.offset     << ", " << ext.length     << "]" << std::endl;
+    // std::cout << "set_ext:: " << i << ") [" << ext.offset     << ", " <<
+    // ext.length     << "]" << std::endl;
     for (uint64_t idx = ext.offset; idx < ext.offset + ext.length; idx++) {
       if (map[idx] != 0xFF) {
-	std::cerr << "map[" << idx << "] is clear, but extent [" << ext.offset     << ", " << ext.length     << "] is set"  << std::endl;
-	return -1;
+        std::cerr << "map[" << idx << "] is clear, but extent [" << ext.offset
+                  << ", " << ext.length << "] is set" << std::endl;
+        return -1;
       }
     }
     offset = ext.offset + ext.length;
   }
 
   offset = 0;
-  for(uint64_t i = 0; i < (set_op_count + clr_op_count); i++) {
+  for (uint64_t i = 0; i < (set_op_count + clr_op_count); i++) {
     extent_t ext = sbmap.get_next_clr_extent(offset);
-    //std::cout << "clr_ext:: " << i << ") [" << ext.offset     << ", " << ext.length     << "]" << std::endl;
+    // std::cout << "clr_ext:: " << i << ") [" << ext.offset     << ", " <<
+    // ext.length     << "]" << std::endl;
     for (uint64_t idx = ext.offset; idx < ext.offset + ext.length; idx++) {
-      if (map[idx] ) {
-	std::cerr << "map[" << idx << "] is set, but extent [" << ext.offset     << ", " << ext.length     << "] is free"  << std::endl;
-	return -1;
+      if (map[idx]) {
+        std::cerr << "map[" << idx << "] is set, but extent [" << ext.offset
+                  << ", " << ext.length << "] is free" << std::endl;
+        return -1;
       }
     }
     offset = ext.offset + ext.length;
@@ -2550,18 +2528,17 @@ static int test_intersections(unsigned test_idx, SimpleBitmap &sbmap, uint8_t ma
 }
 
 //---------------------------------------------------------------------------------
-TEST(SimpleBitmap, intersection)
-{
-  const uint64_t MAP_SIZE = 1ULL << 30;  // 1G
+TEST(SimpleBitmap, intersection) {
+  const uint64_t MAP_SIZE = 1ULL << 30; // 1G
   SimpleBitmap sbmap(g_ceph_context, MAP_SIZE);
 
   // use current time as seed for random generator
   std::srand(std::time(nullptr));
 
-  std::unique_ptr<uint8_t[]> map = std::make_unique<uint8_t[]> (MAP_SIZE);
+  std::unique_ptr<uint8_t[]> map = std::make_unique<uint8_t[]>(MAP_SIZE);
   ASSERT_TRUE(map != nullptr);
 
-  for (unsigned i = 0; i < 1; i++ ) {
+  for (unsigned i = 0; i < 1; i++) {
     sbmap.clear_all();
     memset(map.get(), 0, MAP_SIZE);
     ASSERT_TRUE(test_intersections(i, sbmap, map.get(), MAP_SIZE) == 0);
@@ -2572,41 +2549,42 @@ TEST(SimpleBitmap, intersection)
   }
 }
 
-
 //---------------------------------------------------------------------------------
-static int test_extents_boundaries(uint64_t index, extent_t *ext_arr, uint64_t ext_arr_size, SimpleBitmap& sbmap, bool set)
-{
-  uint64_t n      = sbmap.get_size();
+static int test_extents_boundaries(uint64_t index, extent_t *ext_arr,
+                                   uint64_t ext_arr_size, SimpleBitmap &sbmap,
+                                   bool set) {
+  uint64_t n = sbmap.get_size();
   uint64_t offset = 0, k = 0;
-  for(unsigned i = 0; i < 64; i++) {
+  for (unsigned i = 0; i < 64; i++) {
     offset += i;
     if (offset >= n) {
       break;
     }
 
-    for(unsigned length = 1; length <= 128; length++) {
+    for (unsigned length = 1; length <= 128; length++) {
       if (offset + length >= n) {
-	break;
+        break;
       }
 
       if (k >= ext_arr_size) {
-	break;
+        break;
       }
       bool success;
       if (set) {
-	success = sbmap.set(offset, length);
+        success = sbmap.set(offset, length);
       } else {
-	success = sbmap.clr(offset, length);
+        success = sbmap.clr(offset, length);
       }
       if (!success) {
-	std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset << ", " << length << ")"<< std::endl;
-	return -1;
+        std::cerr << "Failed sbmap." << (set ? "set(" : "clr(") << offset
+                  << ", " << length << ")" << std::endl;
+        return -1;
       }
       ext_arr[k++] = {offset, length};
       if (length < 64) {
-	offset += 64;
+        offset += 64;
       } else {
-	offset += 128;
+        offset += 128;
       }
     }
     if (k >= ext_arr_size) {
@@ -2615,13 +2593,14 @@ static int test_extents_boundaries(uint64_t index, extent_t *ext_arr, uint64_t e
   }
 
   unsigned arr_size = std::min((uint64_t)k, ext_arr_size);
-  std::cout << std::hex << std::right << __func__ ;
-  std::cout << " [" << index << "] " << (set ? "Set::" : "Clr::") << " extents count = 0x" << arr_size;
+  std::cout << std::hex << std::right << __func__;
+  std::cout << " [" << index << "] " << (set ? "Set::" : "Clr::")
+            << " extents count = 0x" << arr_size;
   std::cout << std::dec << std::endl;
 
   offset = 0;
   extent_t ext;
-  for(unsigned i = 0; i < arr_size; i++) {
+  for (unsigned i = 0; i < arr_size; i++) {
     if (set) {
       ext = sbmap.get_next_set_extent(offset);
     } else {
@@ -2642,17 +2621,17 @@ static int test_extents_boundaries(uint64_t index, extent_t *ext_arr, uint64_t e
   if (ext.length == 0) {
     return 0;
   } else {
-    std::cerr << "sbmap.get_next_" << (set ? "set" : "clr") << "_extent(" << offset << ") return length = " << ext.length << std::endl;
+    std::cerr << "sbmap.get_next_" << (set ? "set" : "clr") << "_extent("
+              << offset << ") return length = " << ext.length << std::endl;
     return -1;
   }
-
 }
 
 //---------------------------------------------------------------------------------
-TEST(SimpleBitmap, boundaries)
-{
+TEST(SimpleBitmap, boundaries) {
   const uint64_t MAX_EXTENTS_COUNT = 64 << 10;
-  std::unique_ptr<extent_t[]> ext_arr = std::make_unique<extent_t[]>(MAX_EXTENTS_COUNT);
+  std::unique_ptr<extent_t[]> ext_arr =
+      std::make_unique<extent_t[]>(MAX_EXTENTS_COUNT);
   ASSERT_TRUE(ext_arr != nullptr);
 
   // use current time as seed for random generator
@@ -2661,26 +2640,27 @@ TEST(SimpleBitmap, boundaries)
   uint64_t bit_count = 32 << 20; // 32Mb = 4MB
   unsigned count = 0;
   for (unsigned i = 0; i < 64; i++) {
-    SimpleBitmap sbmap(g_ceph_context, bit_count+i);
-    memset(ext_arr.get(), 0, sizeof(extent_t)*MAX_EXTENTS_COUNT);
+    SimpleBitmap sbmap(g_ceph_context, bit_count + i);
+    memset(ext_arr.get(), 0, sizeof(extent_t) * MAX_EXTENTS_COUNT);
     sbmap.clear_all();
-    ASSERT_TRUE(test_extents_boundaries(count, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, true) == 0);
+    ASSERT_TRUE(test_extents_boundaries(count, ext_arr.get(), MAX_EXTENTS_COUNT,
+                                        sbmap, true) == 0);
 
-    memset(ext_arr.get(), 0, sizeof(extent_t)*MAX_EXTENTS_COUNT);
+    memset(ext_arr.get(), 0, sizeof(extent_t) * MAX_EXTENTS_COUNT);
     sbmap.set_all();
-    ASSERT_TRUE(test_extents_boundaries(count++, ext_arr.get(), MAX_EXTENTS_COUNT, sbmap, false) == 0);
+    ASSERT_TRUE(test_extents_boundaries(count++, ext_arr.get(),
+                                        MAX_EXTENTS_COUNT, sbmap, false) == 0);
   }
 }
 
 //---------------------------------------------------------------------------------
-TEST(SimpleBitmap, boundaries2)
-{
+TEST(SimpleBitmap, boundaries2) {
   const uint64_t bit_count_base = 64 << 10; // 64Kb = 8MB
-  const extent_t null_extent    = {0, 0};
+  const extent_t null_extent = {0, 0};
 
   for (unsigned i = 0; i < 64; i++) {
-    uint64_t     bit_count   = bit_count_base + i;
-    extent_t     full_extent = {0, bit_count};
+    uint64_t bit_count = bit_count_base + i;
+    extent_t full_extent = {0, bit_count};
     SimpleBitmap sbmap(g_ceph_context, bit_count);
 
     sbmap.set(0, bit_count);
@@ -2705,8 +2685,7 @@ TEST(SimpleBitmap, boundaries2)
   }
 }
 
-TEST(shared_blob_2hash_tracker_t, basic_test)
-{
+TEST(shared_blob_2hash_tracker_t, basic_test) {
   shared_blob_2hash_tracker_t t1(1024 * 1024, 4096);
 
   ASSERT_TRUE(t1.count_non_zero() == 0);
@@ -2756,7 +2735,7 @@ TEST(shared_blob_2hash_tracker_t, basic_test)
 
   ASSERT_TRUE(t1.count_non_zero() != 0);
 
-  ASSERT_TRUE(!t1.test_all_zero(5,0x1000));
+  ASSERT_TRUE(!t1.test_all_zero(5, 0x1000));
   ASSERT_TRUE(!t1.test_all_zero(5, 0x2000));
   ASSERT_TRUE(!t1.test_all_zero(5, 0x3000));
   ASSERT_TRUE(t1.test_all_zero(5, 0x4000));
@@ -2771,14 +2750,13 @@ TEST(shared_blob_2hash_tracker_t, basic_test)
   ASSERT_TRUE(!t1.test_all_zero_range(5, 0, 0x9000));
 }
 
-TEST(bluestore_blob_use_tracker_t, mempool_stats_test)
-{
-  using mempool::bluestore_cache_other::allocated_items;
+TEST(bluestore_blob_use_tracker_t, mempool_stats_test) {
   using mempool::bluestore_cache_other::allocated_bytes;
+  using mempool::bluestore_cache_other::allocated_items;
   uint64_t other_items0 = allocated_items();
   uint64_t other_bytes0 = allocated_bytes();
   {
-    bluestore_blob_use_tracker_t* t1 = new bluestore_blob_use_tracker_t;
+    bluestore_blob_use_tracker_t *t1 = new bluestore_blob_use_tracker_t;
 
     t1->init(1024 * 1024, 4096);
     ASSERT_EQ(256, allocated_items() - other_items0);  // = 1M / 4K
@@ -2789,7 +2767,7 @@ TEST(bluestore_blob_use_tracker_t, mempool_stats_test)
     ASSERT_EQ(allocated_bytes(), other_bytes0);
   }
   {
-    bluestore_blob_use_tracker_t* t1 = new bluestore_blob_use_tracker_t;
+    bluestore_blob_use_tracker_t *t1 = new bluestore_blob_use_tracker_t;
 
     t1->init(1024 * 1024, 4096);
     t1->add_tail(2048 * 1024, 4096);
@@ -2802,7 +2780,7 @@ TEST(bluestore_blob_use_tracker_t, mempool_stats_test)
     ASSERT_EQ(allocated_bytes(), other_bytes0);
   }
   {
-    bluestore_blob_use_tracker_t* t1 = new bluestore_blob_use_tracker_t;
+    bluestore_blob_use_tracker_t *t1 = new bluestore_blob_use_tracker_t;
 
     t1->init(1024 * 1024, 4096);
     t1->prune_tail(512 * 1024);
@@ -2815,8 +2793,8 @@ TEST(bluestore_blob_use_tracker_t, mempool_stats_test)
     ASSERT_EQ(allocated_bytes(), other_bytes0);
   }
   {
-    bluestore_blob_use_tracker_t* t1 = new bluestore_blob_use_tracker_t;
-    bluestore_blob_use_tracker_t* t2 = new bluestore_blob_use_tracker_t;
+    bluestore_blob_use_tracker_t *t1 = new bluestore_blob_use_tracker_t;
+    bluestore_blob_use_tracker_t *t2 = new bluestore_blob_use_tracker_t;
 
     t1->init(1024 * 1024, 4096);
 
@@ -2839,9 +2817,9 @@ TEST(bluestore_blob_use_tracker_t, mempool_stats_test)
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  auto cct =
+      global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+                  CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Instead of indexing buffers by blob offset we do it by logical offset. Previously we tried using physical offsets but it was a pretty bad idea is it required extra bound checks of physical extents and extra loops for to add them, that includes chopping off buffer data.

Logical offsets don't have these problems but we have different ones. Bufferlist data is padded before being used in `_do_alloc_write` which means before adding it to BufferSpace, we are required to get the unpadded substr_of data because padded data might overflow to an invalid logical offset in contrast to when we used blob offsets where padded data was wonderful. This is true in in `generate_read_result_bl` too, we read by regions of blob extents but we must translate it back to logical offsets, that means an extra loop to include correct logical regions was added.

BufferSpace::read now has an extra early return check that makes sure that there is an overlap between what we want to read and the buffers we get.

This pr also includes some identation fixes because it's driving me nuts.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
