### PR TITLE
reef: rgw: fix cloud-sync multi-tenancy scenario

### DIFF
--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -487,7 +487,7 @@ struct AWSSyncConfig {
   }
 
   bool do_find_profile(const rgw_bucket bucket, std::shared_ptr<AWSSyncConfig_Profile> *result) {
-    const string& name = bucket.name;
+    const string& name = bucket.get_namespaced_name();
     auto iter = explicit_profiles.upper_bound(name);
     if (iter == explicit_profiles.begin()) {
       return false;

--- a/src/rgw/rgw_bucket_types.h
+++ b/src/rgw/rgw_bucket_types.h
@@ -136,6 +136,13 @@ struct rgw_bucket {
     DECODE_FINISH(bl);
   }
 
+  std::string get_namespaced_name() const {
+    if (tenant.empty()) {
+      return name;
+    }
+    return tenant + std::string("/") + name;
+  }
+
   void update_bucket_id(const std::string& new_bucket_id) {
     bucket_id = new_bucket_id;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63430

---

backport of https://github.com/ceph/ceph/pull/54299
parent tracker: https://tracker.ceph.com/issues/63395

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh