### PR TITLE
rgw: clean-up of rgw_user.cc

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -121,7 +121,7 @@ set(librgw_common_srcs
   rgw_tag.cc
   rgw_tag_s3.cc
   rgw_tools.cc
-  rgw_user.cc
+  rgw_user_global.cc
   rgw_website.cc
   rgw_xml.cc
   rgw_torrent.cc

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -3,6 +3,7 @@
 
 #include "common/errno.h"
 
+#include "rgw_user_global.h"
 #include "rgw_user.h"
 
 #include "rgw_bucket.h"

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -62,28 +62,9 @@ struct RGWUID
 };
 WRITE_CLASS_ENCODER(RGWUID)
 
-/** Entry for bucket metadata collection */
-struct bucket_meta_entry {
-  size_t size;
-  size_t size_rounded;
-  ceph::real_time creation_time;
-  uint64_t count;
-};
-
-extern int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver, rgw::sal::User* user, optional_yield y);
-extern int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
-  rgw::sal::Driver* driver, rgw::sal::User* user,
-  std::map<std::string, bucket_meta_entry>& buckets_usage_map, optional_yield y);
-
-/**
- * Get the anonymous (ie, unauthenticated) user info.
- */
-extern void rgw_get_anon_user(RGWUserInfo& info);
 
 extern void rgw_perm_to_str(uint32_t mask, char *buf, int len);
 extern uint32_t rgw_str_to_perm(const char *str);
-
-extern int rgw_validate_tenant_name(const std::string& t);
 
 enum ObjectKeyType {
   KEY_TYPE_SWIFT,

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -34,6 +34,7 @@ extern "C" {
 #include "include/utime.h"
 #include "include/str_list.h"
 
+#include "rgw_user_global.h"
 #include "rgw_user.h"
 #include "rgw_otp.h"
 #include "rgw_rados.h"

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -7,6 +7,7 @@
 #include "rgw_common.h"
 #include "rgw_auth.h"
 #include "rgw_quota.h"
+#include "rgw_user_global.h"
 #include "rgw_user.h"
 #include "rgw_http_client.h"
 #include "rgw_keystone.h"

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -23,6 +23,7 @@
 #include "common/static_ptr.h"
 #include "common/perf_counters_key.h"
 #include "rgw_tracer.h"
+#include "rgw_user_global.h"
 
 #include "rgw_rados.h"
 #include "rgw_zone.h"

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -35,6 +35,7 @@
 #include "common/ceph_time.h"
 
 #include "rgw_common.h"
+#include "rgw_user_global.h"
 #include "rgw_dmclock.h"
 #include "rgw_sal.h"
 #include "rgw_user.h"

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -22,6 +22,8 @@
 
 #include "rgw_common.h"
 #include "rgw_sal.h"
+#include "rgw_user_global.h"
+
 #include "rgw_sal_rados.h"
 #include "rgw_quota.h"
 #include "rgw_bucket.h"

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -37,6 +37,7 @@
 #include "rgw_auth_s3.h"
 #include "rgw_acl.h"
 #include "rgw_policy_s3.h"
+#include "rgw_user_global.h"
 #include "rgw_user.h"
 #include "rgw_cors.h"
 #include "rgw_cors_s3.h"

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -13,6 +13,7 @@
 #include "common/utf8.h"
 #include "common/ceph_json.h"
 
+#include "rgw_user_global.h"
 #include "rgw_rest_swift.h"
 #include "rgw_acl_swift.h"
 #include "rgw_cors_swift.h"

--- a/src/rgw/rgw_user_global.cc
+++ b/src/rgw/rgw_user_global.cc
@@ -4,7 +4,7 @@
 #include "rgw_sal_rados.h"
 
 #include "include/types.h"
-#include "rgw_user.h"
+#include "rgw_user_global.h"
 
 // until everything is moved from rgw_common
 #include "rgw_common.h"


### PR DESCRIPTION
As part of the Zipper split, we ended up with two rgw_user.cc files, one in src/rgw and one in src/rgw/driver/rados. Presumably the former is more general and the latter more specific. However both had their interfaces combined in src/rgw/driver/rados/rgw_user.h.

The renames src/rgw/rgw_user.cc to src/rgw/rgw_user_global.cc and separates its interface into src/rgw/rgw_user_global.h.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
