### PR TITLE
rgw: adding y2k38 annotations to supress coverity issues

### DIFF
--- a/src/rgw/driver/rados/rgw_trim_datalog.cc
+++ b/src/rgw/driver/rados/rgw_trim_datalog.cc
@@ -224,11 +224,11 @@ int DataLogTrimPollCR::operate(const DoutPrefixProvider *dpp)
       // prevent other gateways from attempting to trim for the duration
       set_status("acquiring trim lock");
 
-      // interval is a small number and unlikely to overflow
-      // coverity[store_truncates_time_t:SUPPRESS]
       yield call(new RGWSimpleRadosLockCR(store->svc()->rados->get_async_processor(), store,
                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, lock_oid),
                                           "data_trim", lock_cookie,
+                                          // interval is a small number and unlikely to overflow
+                                          // coverity[store_truncates_time_t:SUPPRESS]
                                           interval.sec()));
       if (retcode < 0) {
         // if the lock is already held, go back to sleep and try again later

--- a/src/rgw/driver/rados/rgw_trim_mdlog.cc
+++ b/src/rgw/driver/rados/rgw_trim_mdlog.cc
@@ -669,10 +669,11 @@ int MetaTrimPollCR::operate(const DoutPrefixProvider *dpp)
       // prevent others from trimming for our entire wait interval
       set_status("acquiring trim lock");
 
-      // interval is a small number and unlikely to overflow
-      // coverity[store_truncates_time_t:SUPPRESS]
       yield call(new RGWSimpleRadosLockCR(store->svc()->rados->get_async_processor(), store,
-                                          obj, name, cookie, interval.sec()));
+                                          obj, name, cookie, 
+                                          // interval is a small number and unlikely to overflow
+                                          // coverity[store_truncates_time_t:SUPPRESS]
+                                          interval.sec()));
       if (retcode < 0) {
         ldout(cct, 4) << "failed to lock: " << cpp_strerror(retcode) << dendl;
         continue;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3039,19 +3039,20 @@ static int scan_totp(CephContext *cct, ceph::real_time& now, rados::cls::otp::ot
   uint32_t max_skew = MAX_TOTP_SKEW_HOURS * 3600;
 
   while (time_ofs_abs < max_skew) {
+    // coverity supression: oath_totp_validate2 is an external library function, cannot fix internally
+    // Further, step_size is a small number and unlikely to overflow
     int rc = oath_totp_validate2(totp.seed_bin.c_str(), totp.seed_bin.length(),
                              start_time, 
+                             // coverity[store_truncates_time_t:SUPPRESS]
                              step_size,
                              time_ofs,
                              1,
                              nullptr,
                              pins[0].c_str());
     if (rc != OATH_INVALID_OTP) {
-      // oath_totp_validate2 is an external library function, cannot fix internally
-      // Further, step_size is a small number and unlikely to overflow
-      // coverity[store_truncates_time_t:SUPPRESS]
       rc = oath_totp_validate2(totp.seed_bin.c_str(), totp.seed_bin.length(),
                                start_time, 
+                               // coverity[store_truncates_time_t:SUPPRESS]
                                step_size,
                                time_ofs - step_size, /* smaller time_ofs moves time forward */
                                1,

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -298,6 +298,7 @@ TEST(ClsLock, TestLockDuration) {
     ASSERT_EQ(-EEXIST, r);
   }
 
+  // coverity[store_truncates_time_t:SUPPRESS]
   sleep(dur.sec());
   ASSERT_EQ(0, l.lock_exclusive(&ioctx, oid));
 

--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -79,6 +79,7 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
   int i;
 
   for (i = 0; i < max; i++) {
+    // coverity[store_truncates_time_t:SUPPRESS]
     uint32_t secs = start_time.sec();
     if (modify_time)
       secs += i;
@@ -94,6 +95,7 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
 
 utime_t get_time(utime_t& start_time, int i, bool modify_time)
 {
+  // coverity[store_truncates_time_t:SUPPRESS]
   uint32_t secs = start_time.sec();
   if (modify_time)
     secs += i;


### PR DESCRIPTION
the supression comments must be directly above the line where the issue is.

this is a followup on these commits:
edfb5b9049ee897779863d780bfbaa130a7fbc40
aca2668c88a048ab556c53411dcf2ccd43099d50

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
