### PR TITLE
osd/scrub: don't block high-priority scrubs on a too-high scrubs count

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -67,7 +67,6 @@ class ScrubBackend;
 namespace Scrub {
   class Store;
   class ReplicaReservations;
-  class LocalReservation;
   class ReservedByRemotePrimary;
   enum class schedule_result_t;
 }

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -65,7 +65,9 @@ class OsdScrub {
   // ---------------------------------------------------------------
 
   // updating the resource counters
-  bool inc_scrubs_local();
+
+  std::unique_ptr<Scrub::LocalResourceWrapper> inc_scrubs_local(
+    bool is_high_priority);
   void dec_scrubs_local();
   bool inc_scrubs_remote();
   void dec_scrubs_remote();

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -586,23 +586,23 @@ void PgScrubber::request_rescrubbing(requested_scrub_t& request_flags)
   update_scrub_job(request_flags);
 }
 
-bool PgScrubber::reserve_local()
+bool PgScrubber::reserve_local(bool high_priority)
 {
   // try to create the reservation object (which translates into asking the
-  // OSD for the local scrub resource). If failing - undo it immediately
-
-  m_local_osd_resource.emplace(m_osds);
-  if (m_local_osd_resource->is_reserved()) {
+  // OSD for a local scrub resource). The object returned is a
+  // a wrapper around the actual reservation, and that object releases
+  // the local resource automatically when reset.
+  m_local_osd_resource =
+      m_osds->get_scrub_services().inc_scrubs_local(high_priority);
+  if (m_local_osd_resource) {
     dout(15) << __func__ << ": local resources reserved" << dendl;
     return true;
   }
 
-  dout(10) << __func__ << ": failed to reserve local scrub resources" << dendl;
-  m_local_osd_resource.reset();
+  dout(15) << __func__ << ": failed to reserve local scrub resources" << dendl;
   return false;
 }
 
-// ----------------------------------------------------------------------------
 
 bool PgScrubber::has_pg_marked_new_updates() const
 {
@@ -2378,26 +2378,7 @@ void PgScrubber::preemption_data_t::reset()
 }
 
 
-// ///////////////////// LocalReservation //////////////////////////////////
-
 namespace Scrub {
-
-// note: no dout()s in LocalReservation functions. Client logs interactions.
-LocalReservation::LocalReservation(OSDService* osds) : m_osds{osds}
-{
-  if (m_osds->get_scrub_services().inc_scrubs_local()) {
-    // a failure is signalled by not having m_holding_local_reservation set
-    m_holding_local_reservation = true;
-  }
-}
-
-LocalReservation::~LocalReservation()
-{
-  if (m_holding_local_reservation) {
-    m_holding_local_reservation = false;
-    m_osds->get_scrub_services().dec_scrubs_local();
-  }
-}
 
 // ///////////////////// MapsCollectionStatus ////////////////////////////////
 

--- a/src/osd/scrubber/scrub_resources.cc
+++ b/src/osd/scrubber/scrub_resources.cc
@@ -11,6 +11,7 @@
 
 
 using ScrubResources = Scrub::ScrubResources;
+using LocalResourceWrapper = Scrub::LocalResourceWrapper;
 
 ScrubResources::ScrubResources(
     log_upwards_t log_access,
@@ -19,29 +20,20 @@ ScrubResources::ScrubResources(
     , conf{config}
 {}
 
-bool ScrubResources::can_inc_scrubs() const
+std::unique_ptr<LocalResourceWrapper> ScrubResources::inc_scrubs_local(
+    bool is_high_priority)
 {
   std::lock_guard lck{resource_lock};
-  if (scrubs_local + scrubs_remote < conf->osd_max_scrubs) {
-    return true;
-  }
-  log_upwards(fmt::format(
-      "{}== false. {} (local) + {} (remote) >= max ({})", __func__,
-      scrubs_local, scrubs_remote, conf->osd_max_scrubs));
-  return false;
-}
+  const int total_scrubs = scrubs_local + scrubs_remote;
 
-bool ScrubResources::inc_scrubs_local()
-{
-  std::lock_guard lck{resource_lock};
-  if (scrubs_local + scrubs_remote < conf->osd_max_scrubs) {
+  if (is_high_priority || total_scrubs < conf->osd_max_scrubs) {
     ++scrubs_local;
-    return true;
+    return std::make_unique<LocalResourceWrapper>(*this, is_high_priority);
   }
   log_upwards(fmt::format(
       "{}: {} (local) + {} (remote) >= max ({})", __func__, scrubs_local,
       scrubs_remote, conf->osd_max_scrubs));
-  return false;
+  return nullptr;
 }
 
 void ScrubResources::dec_scrubs_local()
@@ -88,3 +80,18 @@ void ScrubResources::dump_scrub_reservations(ceph::Formatter* f) const
   f->dump_int("scrubs_remote", scrubs_remote);
   f->dump_int("osd_max_scrubs", conf->osd_max_scrubs);
 }
+
+// --------------- LocalResourceWrapper
+
+Scrub::LocalResourceWrapper::LocalResourceWrapper(
+    ScrubResources& resource_bookkeeper,
+    bool is_high_priority)
+    : m_resource_bookkeeper{resource_bookkeeper}
+{}
+
+Scrub::LocalResourceWrapper::~LocalResourceWrapper()
+{
+  m_resource_bookkeeper.dec_scrubs_local();
+}
+
+

--- a/src/osd/scrubber/scrub_resources.h
+++ b/src/osd/scrubber/scrub_resources.h
@@ -18,6 +18,9 @@ namespace Scrub {
  */
 using log_upwards_t = std::function<void(std::string msg)>;
 
+class LocalResourceWrapper;
+
+
 /**
  * The number of concurrent scrub operations performed on an OSD is limited
  * by a configuration parameter. The 'ScrubResources' class is responsible for
@@ -25,7 +28,15 @@ using log_upwards_t = std::function<void(std::string msg)>;
  * acting as primary and acting as a replica, and for enforcing the limit.
  */
 class ScrubResources {
-  /// the number of concurrent scrubs performed by Primaries on this OSD
+  friend class LocalResourceWrapper;
+
+  /**
+   * the number of concurrent scrubs performed by Primaries on this OSD.
+   *
+   * Note that, as high priority scrubs are always allowed to proceed, this
+   * counter may exceed the configured limit. When in this state - no new
+   * regular scrubs will be allowed to start.
+   */
   int scrubs_local{0};
 
   /// the number of active scrub reservations granted by replicas
@@ -43,14 +54,8 @@ class ScrubResources {
       log_upwards_t log_access,
       const ceph::common::ConfigProxy& config);
 
-  /**
-   * \returns true if the number of concurrent scrubs is
-   *  below osd_max_scrubs
-   */
-  bool can_inc_scrubs() const;
-
   /// increments the number of scrubs acting as a Primary
-  bool inc_scrubs_local();
+  std::unique_ptr<LocalResourceWrapper> inc_scrubs_local(bool is_high_priority);
 
   /// decrements the number of scrubs acting as a Primary
   void dec_scrubs_local();
@@ -63,4 +68,22 @@ class ScrubResources {
 
   void dump_scrub_reservations(ceph::Formatter* f) const;
 };
+
+
+/**
+ * a wrapper around a "local scrub resource". The resources bookkeeper
+ * is handing these out to the PGs that acquired the local OSD's scrub
+ * resources. The PGs use these to release the resources when they are
+ * done scrubbing.
+ */
+class LocalResourceWrapper {
+  ScrubResources& m_resource_bookkeeper;
+
+ public:
+  LocalResourceWrapper(
+      ScrubResources& resource_bookkeeper,
+      bool is_high_priority);
+  ~LocalResourceWrapper();
+};
+
 }  // namespace Scrub

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -373,10 +373,13 @@ struct ScrubPgIF {
   /**
    * Reserve local scrub resources (managed by the OSD)
    *
-   * Fails if OSD's local-scrubs budget was exhausted
-   * \returns were local resources reserved?
+   * High priority scrubs are always allowed to proceed, even if the OSD's
+   * scrub budget is exhausted. But they are counted towards the budget,
+   * and once that budget is exhausted - no periodic scrubs will be allowed to
+   * start.
+   * \returns were local resources reserved, and we are allowed to proceed?
    */
-  virtual bool reserve_local() = 0;
+  virtual bool reserve_local(bool is_high_priority) = 0;
 
   /**
    * if activated as a Primary - register the scrub job with the OSD


### PR DESCRIPTION
A scrub can only be initiated if the number of active scrubs performed on the OSD when acting as a primary is below a certain configured limit. After this change - high priority scrubs are not blocked by this limit (although they are still counted towards it).

DNM

This is a draft for comments, as - without the changes to the scrub queue that is part
of the refactored scheduling - the 1Hz attempts to initiate a scrub would waste too much
CPU time and log lines.