### PR TITLE
mgr/dashboard: info on why RBD graphs are empty

### DIFF
--- a/monitoring/ceph-mixin/dashboards/rbd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rbd.libsonnet
@@ -1,12 +1,22 @@
 local g = import 'grafonnet/grafana.libsonnet';
 local u = import 'utils.libsonnet';
 
+local info_rbd_stats = std.join(
+  '',
+  [
+    'RBD per-image IO statistics are disabled by default.\n\n',
+    'Please refer to ',
+    'https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics ',
+    'for information about how to enable those optionally.',
+  ]
+);
+
 (import 'utils.libsonnet') {
   'rbd-details.json':
-    local RbdDetailsPanel(title, formatY1, expr1, expr2, x, y, w, h) =
+    local RbdDetailsPanel(title, description, formatY1, expr1, expr2, x, y, w, h) =
       $.graphPanelSchema({},
                          title,
-                         '',
+                         description,
                          'null as zero',
                          false,
                          formatY1,
@@ -83,6 +93,7 @@ local u = import 'utils.libsonnet';
     .addPanels([
       RbdDetailsPanel(
         'IOPS',
+        info_rbd_stats,
         'iops',
         'rate(ceph_rbd_write_ops{%(matchers)s, pool="$pool", image="$image"}[$__rate_interval])' % $.matchers()
         ,
@@ -94,6 +105,7 @@ local u = import 'utils.libsonnet';
       ),
       RbdDetailsPanel(
         'Throughput',
+        info_rbd_stats,
         'Bps',
         'rate(ceph_rbd_write_bytes{%(matchers)s, pool="$pool", image="$image"}[$__rate_interval])' % $.matchers(),
         'rate(ceph_rbd_read_bytes{%(matchers)s, pool="$pool", image="$image"}[$__rate_interval])' % $.matchers(),
@@ -104,6 +116,7 @@ local u = import 'utils.libsonnet';
       ),
       RbdDetailsPanel(
         'Average Latency',
+        info_rbd_stats,
         'ns',
         |||
           rate(ceph_rbd_write_latency_sum{%(matchers)s, pool="$pool", image="$image"}[$__rate_interval]) /
@@ -121,6 +134,7 @@ local u = import 'utils.libsonnet';
     ]),
   'rbd-overview.json':
     local RbdOverviewPanel(title,
+                           description,
                            formatY1,
                            expr1,
                            expr2,
@@ -132,7 +146,7 @@ local u = import 'utils.libsonnet';
                            h) =
       $.graphPanelSchema({},
                          title,
-                         '',
+                         description,
                          'null as zero',
                          false,
                          formatY1,
@@ -196,6 +210,7 @@ local u = import 'utils.libsonnet';
     .addPanels([
       RbdOverviewPanel(
         'IOPS',
+        info_rbd_stats,
         'short',
         'round(sum(rate(ceph_rbd_write_ops{%(matchers)s}[$__rate_interval])))' % $.matchers(),
         'round(sum(rate(ceph_rbd_read_ops{%(matchers)s}[$__rate_interval])))' % $.matchers(),
@@ -208,6 +223,7 @@ local u = import 'utils.libsonnet';
       ),
       RbdOverviewPanel(
         'Throughput',
+        info_rbd_stats,
         'Bps',
         'round(sum(rate(ceph_rbd_write_bytes{%(matchers)s}[$__rate_interval])))' % $.matchers(),
         'round(sum(rate(ceph_rbd_read_bytes{%(matchers)s}[$__rate_interval])))' % $.matchers(),
@@ -220,6 +236,7 @@ local u = import 'utils.libsonnet';
       ),
       RbdOverviewPanel(
         'Average Latency',
+        info_rbd_stats,
         'ns',
         |||
           round(
@@ -242,7 +259,7 @@ local u = import 'utils.libsonnet';
       ),
       $.addTableSchema(
         '$datasource',
-        '',
+        info_rbd_stats,
         { col: 3, desc: true },
         [
           $.overviewStyle('Pool', 'pool', 'string', 'short'),
@@ -273,7 +290,7 @@ local u = import 'utils.libsonnet';
       ) + { gridPos: { x: 0, y: 7, w: 8, h: 7 } },
       $.addTableSchema(
         '$datasource',
-        '',
+        info_rbd_stats,
         { col: 3, desc: true },
         [
           $.overviewStyle('Pool', 'pool', 'string', 'short'),
@@ -304,7 +321,7 @@ local u = import 'utils.libsonnet';
       ) + { gridPos: { x: 8, y: 7, w: 8, h: 7 } },
       $.addTableSchema(
         '$datasource',
-        '',
+        info_rbd_stats,
         { col: 3, desc: true },
         [
           $.overviewStyle('Pool', 'pool', 'string', 'short'),

--- a/monitoring/ceph-mixin/dashboards_out/rbd-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/rbd-details.json
@@ -43,7 +43,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -136,7 +136,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -229,7 +229,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {

--- a/monitoring/ceph-mixin/dashboards_out/rbd-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/rbd-overview.json
@@ -55,7 +55,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -148,7 +148,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -241,7 +241,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -331,7 +331,7 @@
       {
          "columns": [ ],
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "gridPos": {
             "h": 7,
             "w": 8,
@@ -433,7 +433,7 @@
       {
          "columns": [ ],
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "gridPos": {
             "h": 7,
             "w": 8,
@@ -535,7 +535,7 @@
       {
          "columns": [ ],
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "gridPos": {
             "h": 7,
             "w": 8,


### PR DESCRIPTION
Those RBD IO statistics graphs are empty out of the box and it's on purpose. Instead of giving an impression that those graphs are broken, point users to a documentation explaining about optional steps to enable those statistics.
https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics



[before]
![image](https://github.com/ceph/ceph/assets/4356209/6a8cf781-a7e1-47bc-8421-6ca0f7b959d1)

and

[after]
![image](https://github.com/ceph/ceph/assets/4356209/45853135-3b48-4c8c-8842-90462e9c47b2)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
