### PR TITLE
quincy: common/admin_socket: add a command to raise a signal

### DIFF
--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -626,6 +626,21 @@ For example, the following commands are equivalent to each other:
    ceph daemon osd.0 foo
    ceph daemon /var/run/ceph/ceph-osd.0.asok foo
 
+There are two methods of running admin socket commands: (1)
+using ``ceph daemon`` as described above, which bypasses
+the monitor and assumes a direct login to the daemon's host,
+and (2) using the ``ceph tell {daemon-type}.{id}`` command,
+which is relayed by monitors and does not require access
+to the daemon's host.
+
+Use the ``raise`` command to send a signal to a daemon, as if by running ``kill -X {daemon.pid}``.
+When run via ``ceph tell`` it allows signalling a daemon without access to its host:
+
+.. prompt:: bash $
+
+   ceph daemon {daemon-name} raise HUP
+   ceph tell {daemon-type}.{id} raise -9
+
 To view the available admin-socket commands, run the following command:
 
 .. prompt:: bash $
@@ -634,11 +649,7 @@ To view the available admin-socket commands, run the following command:
 
 Admin-socket commands enable you to view and set your configuration at runtime.
 For more on viewing your configuration, see `Viewing a Configuration at
-Runtime`_. There are two methods of setting configuration value at runtime: (1)
-using the admin socket, which bypasses the monitor and requires a direct login
-to the host in question, and (2) using the ``ceph tell {daemon-type}.{id}
-config set`` command, which relies on the monitor and does not require a direct
-login.
+Runtime`_.
 
 .. _Viewing a Configuration at Runtime: ../../configuration/ceph-conf#viewing-a-configuration-at-runtime
 .. _Storage Capacity: ../../configuration/mon-config-ref#storage-capacity

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -190,6 +190,7 @@ private:
   std::unique_ptr<AdminSocketHook> version_hook;
   std::unique_ptr<AdminSocketHook> help_hook;
   std::unique_ptr<AdminSocketHook> getdescs_hook;
+  std::unique_ptr<AdminSocketHook> raise_hook;
 
   std::mutex tell_lock;
   std::list<ceph::cref_t<MCommand>> tell_queue;

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -17,12 +17,15 @@
 #include "common/admin_socket.h"
 #include "common/admin_socket_client.h"
 #include "common/ceph_argparse.h"
+#include "json_spirit/json_spirit.h"
 #include "gtest/gtest.h"
+#include "fmt/format.h"
 
 #include <stdint.h>
 #include <string.h>
 #include <string>
 #include <sys/un.h>
+#include <signal.h>
 
 using namespace std;
 
@@ -326,6 +329,218 @@ TEST(AdminSocket, bind_and_listen) {
     EXPECT_NE(std::string::npos, message.find("File exists"));
     ASSERT_TRUE(asoct.shutdown());
   }
+}
+
+class AdminSocketRaise: public ::testing::Test 
+{
+public:
+  struct TestSignal {
+    int sig;
+    const char * name;
+    std::atomic<int> count;
+  };
+
+  static void SetUpTestSuite() {
+    signal(sig1.sig, sighandler);
+    signal(sig2.sig, sighandler);
+  }
+  static void TearDownTestSuite()
+  {
+    signal(sig1.sig, SIG_DFL);
+    signal(sig2.sig, SIG_DFL);
+  }
+  void SetUp() override
+  {
+    std::string path = get_rand_socket_path();
+    asock = std::make_unique<AdminSocket>(g_ceph_context);
+    asock_client = std::make_unique<AdminSocketClient>(path);
+    ASSERT_TRUE(asock->init(path));
+    sig1.count = 0;
+    sig2.count = 0;
+  }
+  void TearDown() override
+  {
+    AdminSocketTest(asock.get()).shutdown();
+  }
+protected:
+  static TestSignal sig1;
+  static TestSignal sig2;
+
+  std::unique_ptr<AdminSocket> asock;
+  std::unique_ptr<AdminSocketClient> asock_client;
+
+  static void sighandler(int signal)
+  {
+    if (signal == sig1.sig) {
+      sig1.count++;
+    } else if (signal == sig2.sig) {
+      sig2.count++;
+    }
+
+    // Windows resets the handler upon signal delivery
+    // as apparently some linuxes do as well.
+    // The below shouldn't hurt in any case.
+    ::signal(signal, sighandler);
+  }
+  std::string send_raise(std::optional<std::string> arg, std::optional<double> after, bool cancel)
+  {
+    JSONFormatter f;
+    f.open_object_section("");
+    f.dump_string("prefix", "raise");
+    if (arg) {
+      f.dump_string("signal", *arg);
+    }
+    if (after) {
+      f.dump_float("after", *after);
+    }
+    if (cancel) {
+      f.dump_bool("cancel", true);
+    }
+    f.close_section();
+
+    bufferlist command;
+    f.flush(command);
+
+    std::string response;
+
+    asock_client->do_request(command.to_str(), &response);
+    return response;
+  }
+
+  std::string send_raise_cancel(std::optional<std::string> arg = std::nullopt) {
+    return send_raise(arg, std::nullopt, true);
+  }
+
+  std::string send_raise(std::string arg, std::optional<double> after = std::nullopt) {
+    return send_raise(arg, after, false);
+  }
+};
+
+AdminSocketRaise::TestSignal AdminSocketRaise::sig1 = { SIGINT, "INT", 0 };
+AdminSocketRaise::TestSignal AdminSocketRaise::sig2 = { SIGTERM, "TERM", 0 };
+
+TEST_F(AdminSocketRaise, List) {
+  auto r = send_raise("-l");
+  json_spirit::mValue v;
+  ASSERT_TRUE(json_spirit::read(r, v));
+  ASSERT_EQ(json_spirit::Value_type::obj_type, v.type());
+  EXPECT_EQ(sig1.sig, v.get_obj()[sig1.name].get_int());
+  EXPECT_EQ(sig2.sig, v.get_obj()[sig2.name].get_int());
+}
+
+TEST_F(AdminSocketRaise, ImmediateFormats) {
+  std::string name1, name2;
+
+  name1 = sig1.name;
+  std::transform(name1.begin(), name1.end(), name1.begin(), [](int c) { return std::tolower(c); });
+  name2 = fmt::format("-{}", sig2.name);
+  std::transform(name2.begin(), name2.end(), name2.begin(), [](int c) { return std::tolower(c); });
+
+  send_raise(fmt::format("-{}", sig1.sig));
+  send_raise(name1);
+  send_raise(name2);
+  send_raise(fmt::format("{}", sig2.sig));
+  EXPECT_EQ(2, sig1.count.load());
+  EXPECT_EQ(2, sig2.count.load());
+}
+
+TEST_F(AdminSocketRaise, Async)
+{
+  using std::chrono::milliseconds;
+
+#ifdef WIN32
+  GTEST_SKIP() << "Windows doesn't support --after behavior";
+#endif
+
+  ASSERT_EQ("", send_raise(fmt::format("{}", sig1.sig)));
+  ASSERT_EQ("", send_raise(sig2.name, 0.1));
+
+  EXPECT_EQ(1, sig1.count.load());
+  EXPECT_EQ(0, sig2.count.load());
+
+  this_thread::sleep_for(milliseconds(150));
+
+  EXPECT_EQ(1, sig1.count.load());
+  EXPECT_EQ(1, sig2.count.load());
+}
+
+TEST_F(AdminSocketRaise, AsyncReschedule)
+{
+  using std::chrono::milliseconds;
+
+#ifdef WIN32
+  GTEST_SKIP() << "Windows doesn't support --after behavior";
+#endif
+
+  ASSERT_EQ("", send_raise(sig1.name, 0.1));
+  ASSERT_EQ("", send_raise(sig2.name, 0.2));
+
+  EXPECT_EQ(0, sig1.count.load());
+  EXPECT_EQ(0, sig2.count.load());
+
+  this_thread::sleep_for(milliseconds(150));
+
+  // USR1 got overridden by the second async schedule
+  EXPECT_EQ(0, sig1.count.load());
+  EXPECT_EQ(0, sig2.count.load());
+
+  this_thread::sleep_for(milliseconds(100));
+  EXPECT_EQ(0, sig1.count.load());
+  EXPECT_EQ(1, sig2.count.load());
+}
+
+TEST_F(AdminSocketRaise, AsyncCancel)
+{
+  using std::chrono::milliseconds;
+
+#ifdef WIN32
+  GTEST_SKIP() << "Windows doesn't support --after behavior";
+#endif
+
+  ASSERT_EQ("", send_raise(sig1.name, 0.1));
+
+  EXPECT_EQ(0, sig1.count.load());
+  EXPECT_EQ(0, sig2.count.load());
+
+  ASSERT_EQ("", send_raise_cancel(sig2.name));
+
+  this_thread::sleep_for(milliseconds(150));
+
+  // cancel shouldn't have worked because the signals
+  // didn't match
+  EXPECT_EQ(1, sig1.count.load());
+
+  ASSERT_EQ("", send_raise(sig2.name, 0.1));
+  ASSERT_EQ("", send_raise_cancel(sig2.name));
+
+  this_thread::sleep_for(milliseconds(150));
+
+  // cancel must have worked
+  EXPECT_EQ(0, sig2.count.load());
+
+  ASSERT_EQ("", send_raise(sig1.name, 0.1));
+  ASSERT_EQ("", send_raise_cancel());
+
+  // cancel must have worked, the counter stays 1
+  EXPECT_EQ(1, sig1.count.load());
+}
+
+TEST_F(AdminSocketRaise, StopCont)
+{
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+  using std::chrono::system_clock;
+
+#ifdef WIN32
+  GTEST_SKIP() << "Windows doesn't support SIGSTOP/SIGCONT and --after";
+#endif
+
+  auto then = system_clock::now();
+  ASSERT_EQ("", send_raise("CONT", 0.2));
+  ASSERT_EQ("", send_raise("STOP"));
+  auto elapsed = system_clock::now() - then;
+  // give it a 1% slack
+  EXPECT_LE(milliseconds(198), duration_cast<milliseconds>(elapsed));
 }
 
 /*


### PR DESCRIPTION
Backport ticket: https://tracker.ceph.com/issues/63362
Original ticket: https://tracker.ceph.com/issues/63362
Original PR: https://github.com/ceph/ceph/pull/53689

---

The new command "raise <signal> [--after X]" accepts signals in the forms: '9', '-9', 'kill', '-KILL'
When --after is specified, the program will fork to wait for the timeout

The forked instance will bail out if it detects that the parent PID has changed which would indicate that the original parent has terminated.

Forking an instance allows to schedule delivery of signals even if the original process is suspended, e.g.:
```
  ceph tell mds.a raise CONT --after 10
  ceph tell mds.a raise STOP
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
