### PR TITLE
librbd: Append one journal event per object extent.

### DIFF
--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -473,7 +473,7 @@ void AbstractImageWriteRequest<I>::send_request() {
     if (journaling) {
       // in-flight ops are flushed prior to closing the journal
       ceph_assert(image_ctx.journal != NULL);
-      journal_tid = append_journal_event(m_synchronous);
+      journal_tid = append_journal_event();
     }
 
     // it's very important that IOContext is captured here instead of
@@ -518,7 +518,7 @@ void ImageWriteRequest<I>::assemble_extent(
 }
 
 template <typename I>
-uint64_t ImageWriteRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageWriteRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -530,7 +530,7 @@ uint64_t ImageWriteRequest<I>::append_journal_event(bool synchronous) {
     buffer_offset += extent.second;
 
     tid = image_ctx.journal->append_write_event(extent.first, extent.second,
-                                                sub_bl, synchronous);
+                                                sub_bl, false);
   }
 
   return tid;
@@ -566,7 +566,7 @@ void ImageWriteRequest<I>::update_stats(size_t length) {
 }
 
 template <typename I>
-uint64_t ImageDiscardRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageDiscardRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -578,7 +578,7 @@ uint64_t ImageDiscardRequest<I>::append_journal_event(bool synchronous) {
                                this->m_discard_granularity_bytes));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              extent.first, extent.second,
-                                             synchronous, 0);
+                                             false, 0);
   }
 
   return tid;
@@ -717,7 +717,7 @@ void ImageFlushRequest<I>::send_request() {
 }
 
 template <typename I>
-uint64_t ImageWriteSameRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageWriteSameRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -728,7 +728,7 @@ uint64_t ImageWriteSameRequest<I>::append_journal_event(bool synchronous) {
                                                                m_data_bl));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              extent.first, extent.second,
-                                             synchronous, 0);
+                                             false, 0);
   }
 
   return tid;
@@ -768,8 +768,7 @@ void ImageWriteSameRequest<I>::update_stats(size_t length) {
 }
 
 template <typename I>
-uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
-    bool synchronous) {
+uint64_t ImageCompareAndWriteRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -779,7 +778,7 @@ uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
                                                           extent.second,
                                                           m_cmp_bl,
                                                           m_bl,
-                                                          synchronous);
+                                                          false);
 
   return tid;
 }

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -114,11 +114,6 @@ private:
 
 template <typename ImageCtxT = ImageCtx>
 class AbstractImageWriteRequest : public ImageRequest<ImageCtxT> {
-public:
-  inline void flag_synchronous() {
-    m_synchronous = true;
-  }
-
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
 
@@ -127,8 +122,7 @@ protected:
                             const char *trace_name,
 			    const ZTracer::Trace &parent_trace)
     : ImageRequest<ImageCtxT>(image_ctx, aio_comp, std::move(image_extents),
-                              area, trace_name, parent_trace),
-      m_synchronous(false) {
+                              area, trace_name, parent_trace) {
   }
 
   void send_request() override;
@@ -144,11 +138,8 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) = 0;
 
-  virtual uint64_t append_journal_event(bool synchronous) = 0;
+  virtual uint64_t append_journal_event() = 0;
   virtual void update_stats(size_t length) = 0;
-
-private:
-  bool m_synchronous;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -180,7 +171,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
 private:
@@ -215,7 +206,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   int prune_object_extents(
@@ -283,7 +274,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 private:
   bufferlist m_data_bl;
@@ -315,7 +306,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   aio_type_t get_aio_type() const override {

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -133,12 +133,11 @@ protected:
   }
 
   void send_object_requests(const LightweightObjectExtents &object_extents,
-                            IOContext io_context, uint64_t journal_tid);
+                            IOContext io_context);
   virtual ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, IOContext io_context,
-      uint64_t journal_tid, bool single_extent, Context *on_finish) = 0;
+      bool journaling, bool single_extent, Context *on_finish) = 0;
 
-  virtual uint64_t append_journal_event() = 0;
   virtual void update_stats(size_t length) = 0;
 };
 
@@ -169,9 +168,8 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, IOContext io_context,
-      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
+      bool journaling, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
 private:
@@ -204,9 +202,8 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, IOContext io_context,
-      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
+      bool journaling, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   int prune_object_extents(
@@ -272,9 +269,8 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, IOContext io_context,
-      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
+      bool journaling, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 private:
   bufferlist m_data_bl;
@@ -304,9 +300,8 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, IOContext io_context,
-      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
+      bool journaling, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   aio_type_t get_aio_type() const override {


### PR DESCRIPTION
librbd: Append one journal event per object extent.

In the case where an image request is split across multiple object extents and journaling is enabled, multiple journal events are appended. Prior to this change, all object requests would wait for the last journal event to complete, since journal events complete in order and thus the last one completing implies that all prior journal events were safe at that point.

While conceptually correct, journal events don't have a mechanism for knowing how many requests might be associated with them. Thus, it's entirely possible for the following sequence to occur:
1. An image request gets split into two object requests. Journal events are appended, one object request gets submitted and starts waiting on the last journal event (which also causes a C_CommitIOEvent to be instantiated against that journal event), but the other object request gets delayed due to an overlap.
2. Journaling completes, and the C_CommitIOEvent fires, which causes the event to be cleaned up.
3. The second object request from above is allowed to make progress; it tries to wait for the journal event that was just cleaned up which causes the assert in wait_event() to fire.

It might seem that the simple solution exists of allowing for wait_event() to return early when the event no longer exists, and indeed the code worked this way when originally written and was later changed to enforce that the event existed. However, there appears to be another problem here, which is that there is no C_CommitIOEvent instantiated for the earlier journal event that were appended, which means they are actually leaked and hang around forever. As far as I can tell, this happens today whenever multiple journal events are appended.

The solution implemented here is to append a journal event for each object extent that we're going to create a object request for. This allows us to maintain a 1:1 relationship between object requests and journal events, which in turn means that we can always safely look up a journal event in the context of an object request and that a C_CommitIOEvent is instantiated for each journal event.

Fixes: https://tracker.ceph.com/issues/63422

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
