### PR TITLE
common: admin socket catches exception by reference

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -866,7 +866,7 @@ class RaiseHook: public AdminSocketHook {
           errss << "signal number should be an integer in the range [1..64]" << std::endl;
           return -EINVAL;
         }
-      } catch (std::invalid_argument) {
+      } catch (const std::invalid_argument&) {
         auto sig_it = known_signals.find(sigdesc);
         if (sig_it == known_signals.end()) {
           errss << "unknown signal name; use -l to see recognized names" << std::endl;


### PR DESCRIPTION
probably not a real bug, but resolves a compiler warning:
```
src/common/admin_socket.cc: In member function ‘int RaiseHook::parse_signal(std::string&&, ceph::Formatter*, std::ostream&)’:
src/common/admin_socket.cc:869:21: warning: catching polymorphic type ‘class std::invalid_argument’ by value [-Wcatch-value=]
  869 |       } catch (std::invalid_argument) {
      |                     ^~~~~~~~~~~~~~~~
```
Fixes: https://tracker.ceph.com/issues/63455

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
