### PR TITLE
pybind/mgr: remove __del__() of mgr modules

### DIFF
--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -45,10 +45,6 @@ class CephFS(object):
             self.cfs.mount()
         logger.debug("mounted cephfs filesystem")
 
-    def __del__(self):
-        logger.debug("shutting down cephfs filesystem")
-        self.cfs.shutdown()
-
     @contextmanager
     def opendir(self, dirpath):
         d = None

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -836,13 +836,6 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
         # for backwards compatibility
         self._logger = self.getLogger()
 
-    def __del__(self) -> None:
-        self._cleanup()
-        self._unconfigure_logging()
-
-    def _cleanup(self) -> None:
-        pass
-
     @classmethod
     def _register_options(cls, module_name: str) -> None:
         cls.MODULE_OPTIONS.append(
@@ -1044,9 +1037,6 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         self._mgr_ips: Optional[str] = None
 
         self._db_lock = threading.Lock()
-
-    def __del__(self) -> None:
-        self._unconfigure_logging()
 
     @classmethod
     def _register_options(cls, module_name: str) -> None:

--- a/src/pybind/mgr/telegraf/basesocket.py
+++ b/src/pybind/mgr/telegraf/basesocket.py
@@ -38,9 +38,6 @@ class BaseSocket(object):
     def send(self, data: str, flags: int = 0) -> int:
         return self.sock.send(data.encode('utf-8') + b'\n', flags)
 
-    def __del__(self) -> None:
-        self.sock.close()
-
     def __enter__(self) -> 'BaseSocket':
         self.connect()
         return self

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -506,9 +506,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             self.vc = VolumeClient(self)
             self.inited = True
 
-    def __del__(self):
-        self.vc.shutdown()
-
     def shutdown(self):
         self.vc.shutdown()
 


### PR DESCRIPTION
It's strongly recommended for objects that have references to external resources (e.g., files) to explicitly release them. Python doesn't guarantee garbage collection of objects and hence doesn't guarantee freeing of external resources that occur on garbage collection.

The `__del__()` methods in the python mgr modules may not even be called since garbage collection of objects is not guaranteed in python. And some of the `__del__()` methods try to cleanup that seem redundant.

- In volumes/module.py, vc.shutdown() is called in Module.shutdown(). No need to call it again in Module.`__del__()`

- In telegraf/basesocket.py, BaseSocker.close() is called in BaseSocket.`__exit__()`. No need to call it again in BaseSocket.`__del__()`.

- In mgr_module.py, MgrModuleLoggingMixin._unconfigure_logging() is called in MgrModule.`__init__()`and MgrStandbyModule.`__init__()`. No need to call it in MgrModule.`__del__()` and MgrStandbyModule.`__del__()`.

- In dashboard/services/cephfs.py, the libcephfs mount is not shutdown explicitly by the mgr module. However, the cython libcephfs bindings has a LibCephFS`.__dealloc__()` finalizer method that calls LibCephFS.shutdown(). This should unmount and cleanup the ceph mount handle.

Remove the `__del__()` of the python mgr modules.

Fixes: https://tracker.ceph.com/issues/63421

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
