### PR TITLE
rgw/sal: Bucket owner as rgw_user

### DIFF
--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -326,7 +326,6 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
     ldpp_dout(dpp, 20) << "D4N Filter: Cache get object operation failed." << dendl;
   } else {
     /* Set metadata locally */
-    RGWQuotaInfo quota_info;
     RGWObjState* astate;
     source->get_obj_state(dpp, &astate, y);
 
@@ -343,16 +342,9 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
 	source->set_instance(it->second);
       } else if (!std::strcmp(it->first.data(), "source_zone_short_id")) {
 	astate->zone_short_id = static_cast<uint32_t>(std::stoul(it->second));
-      } else if (!std::strcmp(it->first.data(), "user_quota.max_size")) {
-        quota_info.max_size = std::stoull(it->second);
-      } else if (!std::strcmp(it->first.data(), "user_quota.max_objects")) {
-        quota_info.max_objects = std::stoull(it->second);
-      } else if (!std::strcmp(it->first.data(), "max_buckets")) {
-        source->get_bucket()->get_owner()->set_max_buckets(std::stoull(it->second));
       }
     }
 
-    source->get_bucket()->get_owner()->set_info(quota_info);
     source->set_obj_state(*astate);
    
     /* Set attributes locally */
@@ -490,19 +482,6 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
     baseAttrs.insert({"source_zone_short_id", bl});
     bl.clear();
   }
-
-  RGWUserInfo info = obj->get_bucket()->get_owner()->get_info();
-  bl.append(std::to_string(info.quota.user_quota.max_size));
-  baseAttrs.insert({"user_quota.max_size", bl});
-  bl.clear();
-
-  bl.append(std::to_string(info.quota.user_quota.max_objects));
-  baseAttrs.insert({"user_quota.max_objects", bl});
-  bl.clear();
-
-  bl.append(std::to_string(obj->get_bucket()->get_owner()->get_max_buckets()));
-  baseAttrs.insert({"max_buckets", bl});
-  bl.clear();
 
   baseAttrs.insert(attrs.begin(), attrs.end());
 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -78,8 +78,8 @@ class D4NFilterBucket : public FilterBucket {
     D4NFilterDriver* filter;
 
   public:
-    D4NFilterBucket(std::unique_ptr<Bucket> _next, User* _user, D4NFilterDriver* _filter) :
-      FilterBucket(std::move(_next), _user), 
+    D4NFilterBucket(std::unique_ptr<Bucket> _next, D4NFilterDriver* _filter) :
+      FilterBucket(std::move(_next)),
       filter(_filter) {}
     virtual ~D4NFilterBucket() = default;
    

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -52,10 +52,9 @@ public:
 				std::string& user_str, optional_yield y,
 				std::unique_ptr<User>* user) override;
   virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-  virtual std::unique_ptr<Bucket> get_bucket(User* u, const RGWBucketInfo& i)  override;
-  virtual int load_bucket(const DoutPrefixProvider* dpp, User* u, const
-			  rgw_bucket& b, std::unique_ptr<Bucket>* bucket,
-			  optional_yield y) override;
+  virtual std::unique_ptr<Bucket> get_bucket(const RGWBucketInfo& i)  override;
+  virtual int load_bucket(const DoutPrefixProvider* dpp, const rgw_bucket& b,
+                          std::unique_ptr<Bucket>* bucket, optional_yield y) override;
   virtual std::string zone_unique_trans_id(const uint64_t unique_num) override;
 
   virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
@@ -143,16 +142,16 @@ private:
   std::optional<std::string> ns;
 
 public:
-  POSIXBucket(POSIXDriver *_dr, int _p_fd, const rgw_bucket& _b, User* _u, std::optional<std::string> _ns = std::nullopt)
-    : StoreBucket(_b, _u),
+  POSIXBucket(POSIXDriver *_dr, int _p_fd, const rgw_bucket& _b, std::optional<std::string> _ns = std::nullopt)
+    : StoreBucket(_b),
     driver(_dr),
     parent_fd(_p_fd),
     acls(),
     ns(_ns)
     { }
 
-  POSIXBucket(POSIXDriver *_dr, int _p_fd, const RGWBucketInfo& _i, User* _u)
-    : StoreBucket(_i, _u),
+  POSIXBucket(POSIXDriver *_dr, int _p_fd, const RGWBucketInfo& _i)
+    : StoreBucket(_i),
     driver(_dr),
     parent_fd(_p_fd),
     acls()
@@ -201,7 +200,7 @@ public:
                               RGWBucketEnt* ent) override;
   virtual int check_bucket_shards(const DoutPrefixProvider* dpp,
                                   uint64_t num_objs, optional_yield y) override;
-  virtual int chown(const DoutPrefixProvider* dpp, User& new_user, optional_yield y) override;
+  virtual int chown(const DoutPrefixProvider* dpp, const rgw_user& new_owner, optional_yield y) override;
   virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive,
 		       ceph::real_time mtime, optional_yield y) override;
   virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1350,7 +1350,7 @@ public:
     if (_zones_trace) {
       zones_trace = *_zones_trace;
     }
-    bucket = store->get_bucket(nullptr, _bucket_info);
+    bucket = store->get_bucket(_bucket_info);
     obj = bucket->get_object(_key);
   }
 };

--- a/src/rgw/driver/rados/rgw_cr_tools.cc
+++ b/src/rgw/driver/rados/rgw_cr_tools.cc
@@ -100,8 +100,7 @@ int RGWGetUserInfoCR::Request::_send_request(const DoutPrefixProvider *dpp)
 template<>
 int RGWGetBucketInfoCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
-  return store->load_bucket(dpp, nullptr,
-                            rgw_bucket(params.tenant, params.bucket_name),
+  return store->load_bucket(dpp, rgw_bucket(params.tenant, params.bucket_name),
                             &result->bucket, null_yield);
 }
 

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -873,8 +873,7 @@ static inline void populate_event(reservation_t& res,
   event.x_amz_id_2 = res.store->getRados()->host_id; // RGW on which the change was made
   // configurationId is filled from notification configuration
   event.bucket_name = res.bucket->get_name();
-  event.bucket_ownerIdentity = res.bucket->get_owner() ?
-    res.bucket->get_owner()->get_id().id : res.bucket->get_info().owner.id;
+  event.bucket_ownerIdentity = res.bucket->get_owner().id;
   const auto region = res.store->get_zone()->get_zonegroup().get_api_name();
   rgw::ARN bucket_arn(res.bucket->get_key());
   bucket_arn.region = region; 

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -201,7 +201,7 @@ int RGWObjectExpirer::garbage_single_object(const DoutPrefixProvider *dpp, objex
   RGWBucketInfo bucket_info;
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
-  int ret = driver->load_bucket(dpp, nullptr, rgw_bucket(hint.tenant, hint.bucket_name, hint.bucket_id), &bucket, null_yield);
+  int ret = driver->load_bucket(dpp, rgw_bucket(hint.tenant, hint.bucket_name, hint.bucket_id), &bucket, null_yield);
   if (-ENOENT == ret) {
     ldpp_dout(dpp, 15) << "NOTICE: cannot find bucket = " \
         << hint.bucket_name << ". The object must be already removed" << dendl;

--- a/src/rgw/driver/rados/rgw_rest_bucket.cc
+++ b/src/rgw/driver/rados/rgw_rest_bucket.cc
@@ -233,7 +233,7 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
     return;
   }
 
-  op_ret = driver->load_bucket(s, nullptr, rgw_bucket("", bucket_name),
+  op_ret = driver->load_bucket(s, rgw_bucket("", bucket_name),
                                &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "get_bucket returned ret=" << op_ret << dendl;
@@ -301,7 +301,7 @@ void RGWOp_Set_Bucket_Quota::execute(optional_yield y)
   }
   if (use_http_params) {
     std::unique_ptr<rgw::sal::Bucket> bucket;
-    op_ret = driver->load_bucket(s, nullptr, rgw_bucket(uid.tenant, bucket_name),
+    op_ret = driver->load_bucket(s, rgw_bucket(uid.tenant, bucket_name),
                                  &bucket, s->yield);
     if (op_ret < 0) {
       return;

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -414,7 +414,7 @@ void RGWOp_BILog_List::execute(optional_yield y) {
     b.name = bn;
     b.bucket_id = bucket_instance;
   }
-  op_ret = driver->load_bucket(s, nullptr, b, &bucket, y);
+  op_ret = driver->load_bucket(s, b, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 5) << "could not get bucket info for bucket=" << bucket_name << dendl;
     return;
@@ -541,7 +541,7 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
     b.name = bn;
     b.bucket_id = bucket_instance;
   }
-  op_ret = driver->load_bucket(s, nullptr, b, &bucket, y);
+  op_ret = driver->load_bucket(s, b, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 5) << "could not get bucket info for bucket=" << bucket_name << dendl;
     return;
@@ -635,7 +635,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
     b.name = bn;
     b.bucket_id = bucket_instance;
   }
-  op_ret = driver->load_bucket(s, nullptr, b, &bucket, y);
+  op_ret = driver->load_bucket(s, b, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 5) << "could not get bucket info for bucket=" << bucket_name << dendl;
     return;
@@ -985,7 +985,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
   // read the bucket instance info for num_shards
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->load_bucket(s, nullptr, b, &bucket, y);
+  op_ret = driver->load_bucket(s, b, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 4) << "failed to read bucket info: " << cpp_strerror(op_ret) << dendl;
     return;
@@ -1069,7 +1069,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
     if (*pipe.dest.bucket != pinfo->bucket) {
       opt_dest_info.emplace();
       std::unique_ptr<rgw::sal::Bucket> dest_bucket;
-      op_ret = driver->load_bucket(s, nullptr, *pipe.dest.bucket, &dest_bucket, y);
+      op_ret = driver->load_bucket(s, *pipe.dest.bucket, &dest_bucket, y);
       if (op_ret < 0) {
         ldpp_dout(this, 4) << "failed to read target bucket info (bucket=: " << cpp_strerror(op_ret) << dendl;
         return;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2229,7 +2229,7 @@ int RadosMultipartUpload::abort(const DoutPrefixProvider *dpp, CephContext *cct,
   }
 
   std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = meta_obj->get_delete_op();
-  del_op->params.bucket_owner = bucket->get_acl_owner();
+  del_op->params.bucket_owner = bucket->get_info().owner;
   del_op->params.versioning_status = 0;
   if (!remove_objs.empty()) {
     del_op->params.remove_objs = &remove_objs;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -135,8 +135,8 @@ class RadosStore : public StoreDriver {
     virtual int get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
     virtual int get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-    std::unique_ptr<Bucket> get_bucket(User* u, const RGWBucketInfo& i) override;
-    int load_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b,
+    std::unique_ptr<Bucket> get_bucket(const RGWBucketInfo& i) override;
+    int load_bucket(const DoutPrefixProvider* dpp, const rgw_bucket& b,
                     std::unique_ptr<Bucket>* bucket, optional_yield y) override;
     virtual bool is_meta_master() override;
     virtual Zone* get_zone() { return zone.get(); }
@@ -479,12 +479,6 @@ class RadosBucket : public StoreBucket {
         acls() {
     }
 
-    RadosBucket(RadosStore *_st, User* _u)
-      : StoreBucket(_u),
-	store(_st),
-        acls() {
-    }
-
     RadosBucket(RadosStore *_st, const rgw_bucket& _b)
       : StoreBucket(_b),
 	store(_st),
@@ -493,18 +487,6 @@ class RadosBucket : public StoreBucket {
 
     RadosBucket(RadosStore *_st, const RGWBucketInfo& _i)
       : StoreBucket(_i),
-	store(_st),
-        acls() {
-    }
-
-    RadosBucket(RadosStore *_st, const rgw_bucket& _b, User* _u)
-      : StoreBucket(_b, _u),
-	store(_st),
-        acls() {
-    }
-
-    RadosBucket(RadosStore *_st, const RGWBucketInfo& _i, User* _u)
-      : StoreBucket(_i, _u),
 	store(_st),
         acls() {
     }
@@ -535,7 +517,7 @@ class RadosBucket : public StoreBucket {
                         RGWBucketEnt* ent) override;
     int check_bucket_shards(const DoutPrefixProvider* dpp, uint64_t num_objs,
                             optional_yield y) override;
-    virtual int chown(const DoutPrefixProvider* dpp, User& new_user, optional_yield y) override;
+    virtual int chown(const DoutPrefixProvider* dpp, const rgw_user& new_owner, optional_yield y) override;
     virtual int put_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime, optional_yield y) override;
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
@@ -575,8 +557,8 @@ class RadosBucket : public StoreBucket {
         optional_yield y, const DoutPrefixProvider *dpp) override;
 
   private:
-    int link(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr);
-    int unlink(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint = true);
+    int link(const DoutPrefixProvider* dpp, const rgw_user& new_owner, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr);
+    int unlink(const DoutPrefixProvider* dpp, const rgw_user& owner, optional_yield y, bool update_entrypoint = true);
     friend class RadosUser;
 };
 

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -285,7 +285,7 @@ int RGWDataAccess::Bucket::finish_init()
 int RGWDataAccess::Bucket::init(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  int ret = sd->driver->load_bucket(dpp, nullptr, rgw_bucket(tenant, name), &bucket, y);
+  int ret = sd->driver->load_bucket(dpp, rgw_bucket(tenant, name), &bucket, y);
   if (ret < 0) {
     return ret;
   }
@@ -327,7 +327,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
 
   rgw::BlockingAioThrottle aio(driver->ctx()->_conf->rgw_put_obj_min_window_size);
 
-  std::unique_ptr<rgw::sal::Bucket> b = driver->get_bucket(nullptr, bucket_info);
+  std::unique_ptr<rgw::sal::Bucket> b = driver->get_bucket(bucket_info);
   std::unique_ptr<rgw::sal::Object> obj = b->get_object(key);
 
   auto& owner = bucket->policy.get_owner();

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -1579,7 +1579,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
     for (const auto& ent : listing.buckets) {
       std::unique_ptr<rgw::sal::Bucket> bucket;
-      ret = driver->load_bucket(dpp, old_user.get(), ent.bucket, &bucket, y);
+      ret = driver->load_bucket(dpp, ent.bucket, &bucket, y);
       if (ret < 0) {
         set_err_msg(err_msg, "failed to fetch bucket info for bucket=" + bucket->get_name());
         return ret;
@@ -1785,7 +1785,7 @@ int RGWUser::execute_remove(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
     for (const auto& ent : listing.buckets) {
       std::unique_ptr<rgw::sal::Bucket> bucket;
-      ret = driver->load_bucket(dpp, user, ent.bucket, &bucket, y);
+      ret = driver->load_bucket(dpp, ent.bucket, &bucket, y);
       if (ret < 0) {
         set_err_msg(err_msg, "unable to load bucket " + ent.bucket.name);
         return ret;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -137,7 +137,7 @@ int rgw_chown_bucket_and_objects(rgw::sal::Driver* driver, rgw::sal::Bucket* buc
 				 const DoutPrefixProvider *dpp, optional_yield y)
 {
   /* Chown on the bucket */
-  int ret = bucket->chown(dpp, *new_user, y);
+  int ret = bucket->chown(dpp, new_user->get_id(), y);
   if (ret < 0) {
     set_err_msg(err_msg, "Failed to change object ownership: " + cpp_strerror(-ret));
   }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1331,16 +1331,7 @@ public:
 
     /* notifications */
     auto& bucket = oc.bucket;
-    auto& bucket_info = oc.bucket->get_info();
     std::string version_id;
-
-    std::unique_ptr<rgw::sal::User> user;
-    user = oc.driver->get_user(bucket_info.owner);
-    if (! bucket->get_owner()) {
-      if (user) {
-	bucket->set_owner(user.get());
-      }
-    }
 
     auto& obj = oc.obj;
 
@@ -1619,18 +1610,10 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     return 0;
   }
 
-  int ret = driver->load_bucket(this, nullptr,
-                                rgw_bucket(bucket_tenant, bucket_name),
+  int ret = driver->load_bucket(this, rgw_bucket(bucket_tenant, bucket_name),
                                 &bucket, null_yield);
   if (ret < 0) {
     ldpp_dout(this, 0) << "LC:get_bucket for " << bucket_name
-		       << " failed" << dendl;
-    return ret;
-  }
-
-  ret = bucket->load_bucket(this, null_yield);
-  if (ret < 0) {
-    ldpp_dout(this, 0) << "LC:load_bucket for " << bucket_name
 		       << " failed" << dendl;
     return ret;
   }
@@ -1755,15 +1738,6 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       }
     }
     worker->workpool->drain();
-  }
-
-  std::unique_ptr<rgw::sal::User> user;
-  if (! bucket->get_owner()) {
-    auto& bucket_info = bucket->get_info();
-    std::unique_ptr<rgw::sal::User> user = driver->get_user(bucket_info.owner);
-      if (user) {
-	bucket->set_owner(user.get());
-      }
   }
 
   ret = handle_multipart_expiration(bucket.get(), prefix_map, worker, stop_at, once);

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -305,7 +305,7 @@ struct BucketMetaTable : public EmptyMetaTable {
       create_metatable<PlacementRuleMetaTable>(L, name, index, false, &(bucket->get_info().placement_rule));
     } else if (strcasecmp(index, "User") == 0) {
       create_metatable<UserMetaTable>(L, name, index, false, 
-          const_cast<rgw_user*>(&bucket->get_owner()->get_id()));
+          const_cast<rgw_user*>(&bucket->get_owner()));
     } else {
       return error_unknown_field(L, index, name);
     }

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -502,7 +502,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const DoutPrefixProvider *dpp,
   }
 
   std::unique_ptr<rgw::sal::Bucket> cur_bucket;
-  ret = store->load_bucket(dpp, nullptr, orphan_bucket, &cur_bucket, null_yield);
+  ret = store->load_bucket(dpp, orphan_bucket, &cur_bucket, null_yield);
   if (ret < 0) {
     if (ret == -ENOENT) {
       /* probably raced with bucket removal */
@@ -529,7 +529,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const DoutPrefixProvider *dpp,
   rgw_bucket b;
   rgw_bucket_parse_bucket_key(store->ctx(), bucket_instance_id, &b, nullptr);
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  ret = store->load_bucket(dpp, nullptr, b, &bucket, null_yield);
+  ret = store->load_bucket(dpp, b, &bucket, null_yield);
   if (ret < 0) {
     if (ret == -ENOENT) {
       /* probably raced with bucket removal */
@@ -1241,7 +1241,7 @@ int RGWRadosList::process_bucket(
 	continue;
       }
 
-      auto bucket = store->get_bucket(nullptr, bucket_info);
+      auto bucket = store->get_bucket(bucket_info);
       // we need to do this in two cases below, so use a lambda
       auto do_stat_key =
 	[&](const rgw_obj_key& key) -> int {
@@ -1388,7 +1388,7 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp,
     bucket_process_map.erase(front);
 
     std::unique_ptr<rgw::sal::Bucket> bucket;
-    ret = store->load_bucket(dpp, nullptr, rgw_bucket(tenant_name, bucket_name),
+    ret = store->load_bucket(dpp, rgw_bucket(tenant_name, bucket_name),
                              &bucket, null_yield);
     if (ret == -ENOENT) {
       std::cerr << "WARNING: bucket " << bucket_name <<
@@ -1460,8 +1460,7 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp,
   // initial bucket
 
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  ret = store->load_bucket(dpp, nullptr,
-                           rgw_bucket(tenant_name, start_bucket_name),
+  ret = store->load_bucket(dpp, rgw_bucket(tenant_name, start_bucket_name),
                            &bucket, null_yield);
   if (ret == -ENOENT) {
     // bucket deletion race?

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -265,7 +265,7 @@ int BucketAsyncRefreshHandler::init_fetch()
   std::unique_ptr<rgw::sal::Bucket> rbucket;
 
   const DoutPrefix dp(driver->ctx(), dout_subsys, "rgw bucket async refresh handler: ");
-  int r = driver->load_bucket(&dp, nullptr, bucket, &rbucket, null_yield);
+  int r = driver->load_bucket(&dp, bucket, &rbucket, null_yield);
   if (r < 0) {
     ldpp_dout(&dp, 0) << "could not get bucket info for bucket=" << bucket << " r=" << r << dendl;
     return r;
@@ -340,7 +340,7 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_user& _u, const rgw_
   std::unique_ptr<rgw::sal::User> user = driver->get_user(_u);
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
-  int r = driver->load_bucket(dpp, user.get(), _b, &bucket, y);
+  int r = driver->load_bucket(dpp, _b, &bucket, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "could not get bucket info for bucket=" << _b << " r=" << r << dendl;
     return r;
@@ -613,7 +613,7 @@ int RGWUserStatsCache::sync_bucket(const rgw_user& _u, rgw_bucket& _b, optional_
   std::unique_ptr<rgw::sal::User> user = driver->get_user(_u);
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
-  int r = driver->load_bucket(dpp, user.get(), _b, &bucket, y);
+  int r = driver->load_bucket(dpp, _b, &bucket, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "could not get bucket info for bucket=" << _b << " r=" << r << dendl;
     return r;

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -960,10 +960,8 @@ void RGWPSCreateNotifOp::execute(optional_yield y) {
     return;
   }
 
-  std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->load_bucket(this, user.get(),
-                               rgw_bucket(s->bucket_tenant, s->bucket_name),
+  op_ret = driver->load_bucket(this, rgw_bucket(s->bucket_tenant, s->bucket_name),
                                &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 1) << "failed to get bucket '" << 
@@ -1110,10 +1108,8 @@ void RGWPSDeleteNotifOp::execute(optional_yield y) {
     return;
   }
 
-  std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->load_bucket(this, user.get(),
-                               rgw_bucket(s->bucket_tenant, s->bucket_name),
+  op_ret = driver->load_bucket(this, rgw_bucket(s->bucket_tenant, s->bucket_name),
                                &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 1) << "failed to get bucket '" << 
@@ -1209,10 +1205,8 @@ void RGWPSListNotifsOp::execute(optional_yield y) {
     return;
   }
 
-  std::unique_ptr<rgw::sal::User> user = driver->get_user(s->owner.get_id());
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  op_ret = driver->load_bucket(this, user.get(),
-                               rgw_bucket(s->bucket_tenant, s->bucket_name),
+  op_ret = driver->load_bucket(this, rgw_bucket(s->bucket_tenant, s->bucket_name),
                                &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 1) << "failed to get bucket '" << 

--- a/src/rgw/rgw_rest_ratelimit.cc
+++ b/src/rgw/rgw_rest_ratelimit.cc
@@ -36,8 +36,7 @@ void RGWOp_Ratelimit_Info::execute(optional_yield y)
 
   if (ratelimit_scope == "bucket" && !bucket_name.empty() && !global) {
     std::unique_ptr<rgw::sal::Bucket> bucket;
-    int r = driver->load_bucket(s, nullptr,
-                                rgw_bucket(tenant_name, bucket_name),
+    int r = driver->load_bucket(s, rgw_bucket(tenant_name, bucket_name),
                                 &bucket, y);
     if (r != 0) {
       op_ret = r;
@@ -275,8 +274,7 @@ void RGWOp_Ratelimit_Set::execute(optional_yield y)
   if (ratelimit_scope == "bucket" && !bucket_name.empty() && !global) {
     ldpp_dout(this, 0) << "getting bucket info" << dendl;
     std::unique_ptr<rgw::sal::Bucket> bucket;
-    op_ret = driver->load_bucket(this, nullptr,
-                                 rgw_bucket(tenant_name, bucket_name),
+    op_ret = driver->load_bucket(this, rgw_bucket(tenant_name, bucket_name),
                                  &bucket, y);
     if (op_ret) {
       ldpp_dout(this, 0) << "Error on getting bucket info" << dendl;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2343,7 +2343,7 @@ static void dump_bucket_metadata(req_state *s, rgw::sal::Bucket* bucket,
   dump_header(s, "X-RGW-Bytes-Used", static_cast<long long>(stats.size));
 
   // only bucket's owner is allowed to get the quota settings of the account
-  if (bucket->is_owner(s->user.get())) {
+  if (bucket->get_owner() == s->user->get_id()) {
     auto user_info = s->user->get_info();
     auto bucket_quota = s->bucket->get_info().quota; // bucket quota
     dump_header(s, "X-RGW-Quota-User-Size", static_cast<long long>(user_info.quota.user_quota.max_size));

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -858,8 +858,7 @@ int RGWPutObj_ObjStore_SWIFT::update_slo_segment_size(rgw_slo_entry& entry) {
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (bucket_name.compare(s->bucket->get_name()) != 0) {
-    r = driver->load_bucket(s, s->user.get(),
-                            rgw_bucket(s->user->get_id().tenant, bucket_name),
+    r = driver->load_bucket(s, rgw_bucket(s->user->get_tenant(), bucket_name),
                             &bucket, s->yield);
     if (r < 0) {
       ldpp_dout(this, 0) << "could not get bucket info for bucket="
@@ -2123,8 +2122,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
 
   /* Need to get user info of bucket owner. */
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  int ret = driver->load_bucket(s, user.get(),
-                                rgw_bucket(bucket_tenant, bucket_name),
+  int ret = driver->load_bucket(s, rgw_bucket(bucket_tenant, bucket_name),
                                 &bucket, s->yield);
   if (ret < 0) {
     throw ret;

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -30,18 +30,19 @@ void RGWOp_Usage_Get::execute(optional_yield y) {
 
   string uid_str;
   string bucket_name;
+  string tenant;
   uint64_t start, end;
   bool show_entries;
   bool show_summary;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket_name, &bucket_name);
+  RESTArgs::get_string(s, "tenant", "", &tenant);
   std::unique_ptr<rgw::sal::User> user = driver->get_user(rgw_user(uid_str));
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (!bucket_name.empty()) {
-    op_ret = driver->load_bucket(nullptr, user.get(),
-                                 rgw_bucket(std::string(), bucket_name),
+    op_ret = driver->load_bucket(this, rgw_bucket(tenant, bucket_name),
                                  &bucket, null_yield);
     if (op_ret < 0) {
       return;
@@ -84,16 +85,17 @@ public:
 void RGWOp_Usage_Delete::execute(optional_yield y) {
   string uid_str;
   string bucket_name;
+  string tenant;
   uint64_t start, end;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket_name, &bucket_name);
+  RESTArgs::get_string(s, "tenant", "", &tenant);
   std::unique_ptr<rgw::sal::User> user = driver->get_user(rgw_user(uid_str));
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (!bucket_name.empty()) {
-    op_ret = driver->load_bucket(nullptr, user.get(),
-                                 rgw_bucket(std::string(), bucket_name),
+    op_ret = driver->load_bucket(this, rgw_bucket(tenant, bucket_name),
                                  &bucket, null_yield);
     if (op_ret < 0) {
       return;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -699,8 +699,6 @@ class Bucket {
     virtual bool is_owner(User* user) = 0;
     /** Get the owner of this bucket */
     virtual User* get_owner(void) = 0;
-    /** Get the owner of this bucket in the form of an ACLOwner object */
-    virtual ACLOwner get_acl_owner(void) = 0;
     /** Check in the backing store if this bucket is empty */
     virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     /** Chec k if the given size fits within the quota */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -796,7 +796,7 @@ namespace rgw::sal {
     int ret;
 
     std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = meta_obj->get_delete_op();
-    del_op->params.bucket_owner = bucket->get_acl_owner();
+    del_op->params.bucket_owner = bucket->get_info().owner;
     del_op->params.versioning_status = 0;
 
     // Since the data objects are associated with meta obj till

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -121,12 +121,6 @@ protected:
         acls() {
         }
 
-      DBBucket(DBStore *_st, User* _u)
-        : StoreBucket(_u),
-        store(_st),
-        acls() {
-        }
-
       DBBucket(DBStore *_st, const rgw_bucket& _b)
         : StoreBucket(_b),
         store(_st),
@@ -135,18 +129,6 @@ protected:
 
       DBBucket(DBStore *_st, const RGWBucketInfo& _i)
         : StoreBucket(_i),
-        store(_st),
-        acls() {
-        }
-
-      DBBucket(DBStore *_st, const rgw_bucket& _b, User* _u)
-        : StoreBucket(_b, _u),
-        store(_st),
-        acls() {
-        }
-
-      DBBucket(DBStore *_st, const RGWBucketInfo& _i, User* _u)
-        : StoreBucket(_i, _u),
         store(_st),
         acls() {
         }
@@ -178,7 +160,7 @@ protected:
                           RGWBucketEnt* ent) override;
       int check_bucket_shards(const DoutPrefixProvider *dpp,
                               uint64_t num_objs, optional_yield y) override;
-      virtual int chown(const DoutPrefixProvider *dpp, User& new_user, optional_yield y) override;
+      virtual int chown(const DoutPrefixProvider *dpp, const rgw_user& new_owner, optional_yield y) override;
       virtual int put_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime, optional_yield y) override;
       virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;
       virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
@@ -763,8 +745,8 @@ public:
       virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
       virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
       virtual std::string get_cluster_id(const DoutPrefixProvider* dpp, optional_yield y);
-      std::unique_ptr<Bucket> get_bucket(User* u, const RGWBucketInfo& i) override;
-      int load_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b,
+      std::unique_ptr<Bucket> get_bucket(const RGWBucketInfo& i) override;
+      int load_bucket(const DoutPrefixProvider *dpp, const rgw_bucket& b,
                       std::unique_ptr<Bucket>* bucket, optional_yield y) override;
       virtual bool is_meta_master() override;
       virtual Zone* get_zone() { return &zone; }

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -413,7 +413,6 @@ public:
 		       ceph::real_time mtime, optional_yield y) override;
   virtual bool is_owner(User* user) override;
   virtual User* get_owner(void) override { return user; }
-  virtual ACLOwner get_acl_owner(void) override { return next->get_acl_owner(); }
   virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
   virtual int check_quota(const DoutPrefixProvider *dpp, RGWQuota& quota,
 			  uint64_t obj_size, optional_yield y,

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -80,7 +80,6 @@ class StoreUser : public User {
 class StoreBucket : public Bucket {
   protected:
     RGWBucketInfo info;
-    User* owner = nullptr;
     Attrs attrs;
     obj_version bucket_version;
     ceph::real_time mtime;
@@ -88,22 +87,13 @@ class StoreBucket : public Bucket {
   public:
 
     StoreBucket() = default;
-    StoreBucket(User* u) : owner(u) { }
     StoreBucket(const rgw_bucket& b) { info.bucket = b; }
     StoreBucket(const RGWBucketInfo& i) : info(i) {}
-    StoreBucket(const rgw_bucket& b, User* u) : owner(u) { info.bucket = b; }
-    StoreBucket(const RGWBucketInfo& i, User* u) : info(i), owner(u) {}
     virtual ~StoreBucket() = default;
 
     virtual Attrs& get_attrs(void) override { return attrs; }
     virtual int set_attrs(Attrs a) override { attrs = a; return 0; }
-    virtual void set_owner(rgw::sal::User* _owner) override {
-      owner = _owner;
-      info.owner = owner->get_id();
-    }
-    virtual User* get_owner(void) override { return owner; };
-    /* Make sure to call get_bucket_info() if you need it first */
-    virtual bool is_owner(User* user) override { return (info.owner.compare(user->get_id()) == 0); }
+    virtual const rgw_user& get_owner() const override { return info.owner; };
     virtual bool empty() const override { return info.bucket.name.empty(); }
     virtual const std::string& get_name() const override { return info.bucket.name; }
     virtual const std::string& get_tenant() const override { return info.bucket.tenant; }

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -104,7 +104,6 @@ class StoreBucket : public Bucket {
     virtual User* get_owner(void) override { return owner; };
     /* Make sure to call get_bucket_info() if you need it first */
     virtual bool is_owner(User* user) override { return (info.owner.compare(user->get_id()) == 0); }
-    virtual ACLOwner get_acl_owner(void) override { return ACLOwner(info.owner); };
     virtual bool empty() const override { return info.bucket.name.empty(); }
     virtual const std::string& get_name() const override { return info.bucket.name; }
     virtual const std::string& get_tenant() const override { return info.bucket.tenant; }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -119,7 +119,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
   b.tenant = std::move(bucket_tenant);
   b.name = std::move(bucket_name);
   std::unique_ptr<rgw::sal::Bucket> bucket;
-  int ret = driver->load_bucket(dpp, nullptr, b, &bucket, s->yield);
+  int ret = driver->load_bucket(dpp, b, &bucket, s->yield);
   if (ret < 0) {
     throw ret;
   }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -30,7 +30,7 @@ int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::Driver* dri
 
     for (auto& ent : listing.buckets) {
       std::unique_ptr<rgw::sal::Bucket> bucket;
-      ret = driver->load_bucket(dpp, user, ent.bucket, &bucket, y);
+      ret = driver->load_bucket(dpp, ent.bucket, &bucket, y);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: could not read bucket info: bucket=" << bucket << " ret=" << ret << dendl;
         continue;

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -117,7 +117,7 @@ class D4NFilterFixture : public ::testing::Test {
       RGWBucketInfo info;
       info.bucket.name = "test_bucket";
 
-      testBucket = driver->get_bucket(testUser.get(), info);
+      testBucket = driver->get_bucket(info);
 
       rgw::sal::Bucket::CreateParams params;
       params.zonegroup_id = "test_id";
@@ -1699,9 +1699,6 @@ TEST_F(D4NFilterFixture, StoreGetMetadata) {
   value.push_back(make_pair("source_zone_short_id", "300"));
   value.push_back(make_pair("bucket_count", "10"));
   value.push_back(make_pair("bucket_size", "20"));
-  value.push_back(make_pair("user_quota.max_size", "0"));
-  value.push_back(make_pair("user_quota.max_objects", "0"));
-  value.push_back(make_pair("max_buckets", "2000"));
 
   client.hmset("rgw-object:test_object_StoreGetMetadata:cache", value, [](cpp_redis::reply& reply) {
     if (!reply.is_null()) {
@@ -1730,7 +1727,6 @@ TEST_F(D4NFilterFixture, StoreGetMetadata) {
   ASSERT_EQ(testROp->prepare(null_yield, dpp), 0);
 
   /* Check updated metadata values */ 
-  RGWUserInfo info = testObject_StoreGetMetadata->get_bucket()->get_owner()->get_info();
   static StoreObject* storeObject = static_cast<StoreObject*>(dynamic_cast<rgw::sal::FilterObject*>(testObject_StoreGetMetadata.get())->get_next());
 
   EXPECT_EQ(to_iso_8601(storeObject->state.mtime), "2021-11-08T21:13:38.334696731Z");
@@ -1738,9 +1734,6 @@ TEST_F(D4NFilterFixture, StoreGetMetadata) {
   EXPECT_EQ(storeObject->state.accounted_size, (uint64_t)200);
   EXPECT_EQ(storeObject->state.epoch, (uint64_t)3);
   EXPECT_EQ(storeObject->state.zone_short_id, (uint32_t)300);
-  EXPECT_EQ(info.quota.user_quota.max_size, (int64_t)0);
-  EXPECT_EQ(info.quota.user_quota.max_objects, (int64_t)0);
-  EXPECT_EQ(testObject_StoreGetMetadata->get_bucket()->get_owner()->get_max_buckets(), (int32_t)2000);
 }
 
 TEST_F(D4NFilterFixture, StoreModifyAttr) {

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -338,13 +338,14 @@ TEST(TestRGWLua, Bucket)
 
   DEFINE_REQ_STATE;
 
-  rgw_bucket b;
-  b.tenant = "mytenant";
-  b.name = "myname";
-  b.marker = "mymarker";
-  b.bucket_id = "myid"; 
-  s.bucket.reset(new sal::RadosBucket(nullptr, b));
-  s.bucket->set_owner(new sal::RadosUser(nullptr, rgw_user("mytenant", "myuser")));
+  RGWBucketInfo info;
+  info.bucket.tenant = "mytenant";
+  info.bucket.name = "myname";
+  info.bucket.marker = "mymarker";
+  info.bucket.bucket_id = "myid";
+  info.owner.id = "myuser";
+  info.owner.tenant = "mytenant";
+  s.bucket.reset(new sal::RadosBucket(nullptr, info));
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, script);
   ASSERT_EQ(rc, 0);
@@ -1558,10 +1559,11 @@ TEST(TestRGWLua, DifferentContextUser)
   DEFINE_REQ_STATE;
 
   s.user.reset(new sal::RadosUser(nullptr, rgw_user("tenant1", "user1")));
-  rgw_bucket b;
-  b.name = "bucket1";
-  s.bucket.reset(new sal::RadosBucket(nullptr, b));
-  s.bucket->set_owner(new sal::RadosUser(nullptr, rgw_user("tenant2", "user2")));
+  RGWBucketInfo info;
+  info.bucket.name = "bucket1";
+  info.owner.id = "user2";
+  info.owner.tenant = "tenant2";
+  s.bucket.reset(new sal::RadosBucket(nullptr, info));
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, nullptr, script);
   ASSERT_EQ(rc, 0);


### PR DESCRIPTION
~~based on top of https://github.com/ceph/ceph/pull/50599.~~ prepares for an abstraction where buckets/objects can be owned either by a user or an account. the use of `rgw_user` will be replaced with the `rgw_owner` variant from https://github.com/ceph/ceph/pull/54333

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
