### PR TITLE
ceph-volume: Revert "ceph-volume: fix raw list for lvm devices"

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -88,7 +88,11 @@ class List(object):
             # parent isn't bluestore, then the child could be a valid bluestore OSD. If we fail to
             # determine whether a parent is bluestore, we should err on the side of not reporting
             # the child so as not to give a false negative.
-            info_device = [info for info in info_devices if info['NAME'] == dev][0]
+            matched_info_devices = [info for info in info_devices if info['NAME'] == dev]
+            if not matched_info_devices:
+                logger.warning('device {} does not exist'.format(dev))
+                continue
+            info_device = matched_info_devices[0]
             if 'PKNAME' in info_device and info_device['PKNAME'] != "":
                 parent = info_device['PKNAME']
                 try:

--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -69,7 +69,7 @@ class List(object):
     def generate(self, devs=None):
         logger.debug('Listing block devices via lsblk...')
         info_devices = disk.lsblk_all(abspath=True)
-        if devs is None or devs == []:
+        if not devs or not any(devs):
             # If no devs are given initially, we want to list ALL devices including children and
             # parents. Parent disks with child partitions may be the appropriate device to return if
             # the parent disk has a bluestore header, but children may be the most appropriate
@@ -89,9 +89,6 @@ class List(object):
             # determine whether a parent is bluestore, we should err on the side of not reporting
             # the child so as not to give a false negative.
             info_device = [info for info in info_devices if info['NAME'] == dev][0]
-            if info_device['TYPE'] == 'lvm':
-                # lvm devices are not raw devices
-                continue
             if 'PKNAME' in info_device and info_device['PKNAME'] != "":
                 parent = info_device['PKNAME']
                 try:


### PR DESCRIPTION
This reverts commit e5e429617c1c27dcd631171f65d30571e32f7266.
This commit introduced a regression, see linked tracker for details.

Fixes: https://tracker.ceph.com/issues/63391
