### PR TITLE
cephadm: reorganize container mounts functions

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2708,36 +2708,14 @@ def get_container_mounts(
 
     assert ident.fsid
     assert ident.daemon_id
+    # Ceph daemon types are special cased here beacause of the no_config
+    # option which JJM thinks is *only* used by cephadm shell
     if daemon_type in ceph_daemons():
         mounts = Ceph.get_ceph_mounts(ctx, ident, no_config=no_config)
-
-    if daemon_type in Monitoring.components:
-        monitoring = Monitoring.create(ctx, ident)
-        monitoring.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == NFSGanesha.daemon_type:
-        nfs_ganesha = NFSGanesha.create(ctx, ident)
-        nfs_ganesha.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.create(ctx, ident)
-        haproxy.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == CephNvmeof.daemon_type:
-        nvmeof = CephNvmeof.create(ctx, ident)
-        nvmeof.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == CephIscsi.daemon_type:
-        iscsi = CephIscsi.create(ctx, ident)
-        iscsi.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == Keepalived.daemon_type:
-        keepalive = Keepalived.create(ctx, ident)
-        keepalive.customize_container_mounts(ctx, mounts)
-
-    if daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.create(ctx, ident)
-        cc.customize_container_mounts(ctx, mounts)
+    else:
+        daemon = daemon_form_create(ctx, ident)
+        assert isinstance(daemon, ContainerDaemonForm)
+        daemon.customize_container_mounts(ctx, mounts)
 
     _update_podman_mounts(ctx, mounts)
     return mounts

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -341,12 +341,15 @@ class Ceph(ContainerDaemonForm):
             )
         return mounts
 
-    def get_container_mounts(self) -> Dict[str, str]:
-        return self.get_ceph_mounts(
-            self.ctx,
+    def customize_container_mounts(
+        self, ctx: CephadmContext, mounts: Dict[str, str]
+    ) -> None:
+        cm = self.get_ceph_mounts(
+            ctx,
             self.identity,
             no_config=self.ctx.config and self.user_supplied_config,
         )
+        mounts.update(cm)
 
 ##################################
 
@@ -1496,8 +1499,11 @@ class CephExporter(ContainerDaemonForm):
     ) -> Tuple[Optional[str], Optional[str]]:
         return get_config_and_keyring(ctx)
 
-    def get_container_mounts(self) -> Dict[str, str]:
-        return Ceph.get_ceph_mounts(self.ctx, self.identity)
+    def customize_container_mounts(
+        self, ctx: CephadmContext, mounts: Dict[str, str]
+    ) -> None:
+        cm = Ceph.get_ceph_mounts(ctx, self.identity)
+        mounts.update(cm)
 
 
 ##################################

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2872,13 +2872,14 @@ def get_container(
         d_args.extend(sg.get_daemon_args())
 
     _update_container_args_for_podman(ctx, ident, container_args)
+    mounts = get_container_mounts(ctx, ident)
     return CephContainer.for_daemon(
         ctx,
         ident=ident,
         entrypoint=entrypoint,
         args=ceph_args + d_args,
         container_args=container_args,
-        volume_mounts=get_container_mounts(ctx, ident),
+        volume_mounts=mounts,
         bind_mounts=binds,
         envs=envs,
         privileged=privileged,

--- a/src/cephadm/tests/test_custom_container.py
+++ b/src/cephadm/tests/test_custom_container.py
@@ -72,7 +72,10 @@ class TestCustomContainer(unittest.TestCase):
         self.assertEqual(result, ['SECRET=password'])
 
     def test_get_container_mounts(self):
-        result = self.cc.get_container_mounts('/xyz')
+        # TODO: get_container_mounts was made private. test the private func for
+        # now. in the future update to test base class func
+        # customize_container_mounts
+        result = self.cc._get_container_mounts('/xyz')
         self.assertDictEqual(result, {
             '/CONFIG_DIR': '/foo/conf',
             '/xyz/bar/config': '/bar:ro'

--- a/src/cephadm/tests/test_ingress.py
+++ b/src/cephadm/tests/test_ingress.py
@@ -90,7 +90,7 @@ def test_haproxy_container_mounts():
             good_haproxy_json(),
             SAMPLE_HAPROXY_IMAGE,
         )
-        cmounts = hap.get_container_mounts("/var/tmp")
+        cmounts = hap._get_container_mounts("/var/tmp")
         assert len(cmounts) == 1
         assert cmounts["/var/tmp/haproxy"] == "/var/lib/haproxy"
 

--- a/src/cephadm/tests/test_ingress.py
+++ b/src/cephadm/tests/test_ingress.py
@@ -244,7 +244,7 @@ def test_keepalived_container_mounts():
             good_keepalived_json(),
             SAMPLE_KEEPALIVED_IMAGE,
         )
-        cmounts = kad.get_container_mounts("/var/tmp")
+        cmounts = kad._get_container_mounts("/var/tmp")
         assert len(cmounts) == 1
         assert (
             cmounts["/var/tmp/keepalived.conf"]

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -117,7 +117,7 @@ def test_nfsganesha_container_mounts():
             "fred",
             good_nfs_json(),
         )
-        cmounts = nfsg.get_container_mounts("/var/tmp")
+        cmounts = nfsg._get_container_mounts("/var/tmp")
         assert len(cmounts) == 3
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"
@@ -130,7 +130,7 @@ def test_nfsganesha_container_mounts():
             "fred",
             nfs_json(pool=True, files=True, rgw=True),
         )
-        cmounts = nfsg.get_container_mounts("/var/tmp")
+        cmounts = nfsg._get_container_mounts("/var/tmp")
         assert len(cmounts) == 4
         assert cmounts["/var/tmp/config"] == "/etc/ceph/ceph.conf:z"
         assert cmounts["/var/tmp/keyring"] == "/etc/ceph/keyring:z"


### PR DESCRIPTION
Depends on #54398

Like #54398 does for binds, update and expand the customize_container_mounts functions on the set of deamon type classes that were named in get_container_mounts ultimately reworking that function to use common class methods to get the mounts. One special case remains for ceph daemon types for functionality specifcially related to `cephadm shell`.

As there are more daemon types wanting mounts than there are binds this PR is a bit longer than the last but you should see similarities between the approach taken.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] existing tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
