### PR TITLE
ceph-volume: fix raw list for non-existent device

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -88,7 +88,11 @@ class List(object):
             # parent isn't bluestore, then the child could be a valid bluestore OSD. If we fail to
             # determine whether a parent is bluestore, we should err on the side of not reporting
             # the child so as not to give a false negative.
-            info_device = [info for info in info_devices if info['NAME'] == dev][0]
+            matched_info_devices = [info for info in info_devices if info['NAME'] == dev]
+            if not matched_info_devices:
+                logger.warning('device {} does not exist'.format(dev))
+                continue
+            info_device = matched_info_devices[0]
             if info_device['TYPE'] == 'lvm':
                 # lvm devices are not raw devices
                 continue


### PR DESCRIPTION
ceph-volume should not crash when given a device which doesn't exist.

Fixes: https://tracker.ceph.com/issues/63391