### PR TITLE
cephadm: reorganize the remaining container setup methods

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1433,6 +1433,13 @@ class CephNvmeof(ContainerDaemonForm):
     ) -> Tuple[Optional[str], Optional[str]]:
         return get_config_and_keyring(ctx)
 
+    def customize_container_args(
+        self, ctx: CephadmContext, args: List[str]
+    ) -> None:
+        args.extend(['--ulimit', 'memlock=-1:-1'])
+        args.extend(['--ulimit', 'nofile=10240'])
+        args.extend(['--cap-add=SYS_ADMIN', '--cap-add=CAP_SYS_NICE'])
+
 
 ##################################
 
@@ -2903,10 +2910,8 @@ def get_container(
         container_args.extend(['--cap-add=NET_ADMIN', '--cap-add=NET_RAW'])
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == CephNvmeof.daemon_type:
-        name = ident.daemon_name
-        container_args.extend(['--ulimit', 'memlock=-1:-1'])
-        container_args.extend(['--ulimit', 'nofile=10240'])
-        container_args.extend(['--cap-add=SYS_ADMIN', '--cap-add=CAP_SYS_NICE'])
+        nvmeof = CephNvmeof.create(ctx, ident)
+        nvmeof.customize_container_args(ctx, container_args)
         binds = get_container_binds(ctx, ident)
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == CephIscsi.daemon_type:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1275,6 +1275,9 @@ done
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:
         return extract_uid_gid(ctx)
 
+    def default_entrypoint(self) -> str:
+        return self.entrypoint
+
 ##################################
 
 
@@ -2907,8 +2910,8 @@ def get_container(
         binds = get_container_binds(ctx, ident)
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == CephIscsi.daemon_type:
-        entrypoint = CephIscsi.entrypoint
-        name = ident.daemon_name
+        iscsi = CephIscsi.create(ctx, ident)
+        entrypoint = iscsi.default_entrypoint()
         # So the container can modprobe iscsi_target_mod and have write perms
         # to configfs we need to make this a privileged container.
         privileged = True

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1756,6 +1756,16 @@ class Keepalived(ContainerDaemonForm):
         ctr = get_container(ctx, self.identity)
         return to_deployment_container(ctx, ctr)
 
+    def customize_container_envs(
+        self, ctx: CephadmContext, envs: List[str]
+    ) -> None:
+        envs.extend(self.get_container_envs())
+
+    def customize_container_args(
+        self, ctx: CephadmContext, args: List[str]
+    ) -> None:
+        args.extend(['--cap-add=NET_ADMIN', '--cap-add=NET_RAW'])
+
 
 ##################################
 
@@ -2905,9 +2915,9 @@ def get_container(
         d_args.extend(haproxy.get_daemon_args())
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == Keepalived.daemon_type:
-        name = ident.daemon_name
-        envs.extend(Keepalived.get_container_envs())
-        container_args.extend(['--cap-add=NET_ADMIN', '--cap-add=NET_RAW'])
+        keepalived = Keepalived.create(ctx, ident)
+        keepalived.customize_container_envs(ctx, envs)
+        keepalived.customize_container_args(ctx, container_args)
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == CephNvmeof.daemon_type:
         nvmeof = CephNvmeof.create(ctx, ident)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -370,6 +370,11 @@ class Ceph(ContainerDaemonForm):
         args.extend(['-n', name, '-f'])
         args.extend(self.get_daemon_args())
 
+    def customize_container_envs(
+        self, ctx: CephadmContext, envs: List[str]
+    ) -> None:
+        envs.append('TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728')
+
     def default_entrypoint(self) -> str:
         ep = {
             'rgw': '/usr/bin/radosgw',
@@ -1597,6 +1602,11 @@ class CephExporter(ContainerDaemonForm):
         name = 'client.ceph-exporter.%s' % self.identity.daemon_id
         args.extend(['-n', name, '-f'])
         args.extend(self.get_daemon_args())
+
+    def customize_container_envs(
+        self, ctx: CephadmContext, envs: List[str]
+    ) -> None:
+        envs.append('TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728')
 
     def default_entrypoint(self) -> str:
         return self.entrypoint

--- a/src/cephadm/cephadmlib/container_daemon_form.py
+++ b/src/cephadm/cephadmlib/container_daemon_form.py
@@ -55,10 +55,30 @@ class ContainerDaemonForm(DaemonForm):
         """
         pass
 
-    def customize_container_args(self, args: List[str]) -> None:
+    def customize_container_args(
+        self, ctx: CephadmContext, args: List[str]
+    ) -> None:
         """Given a list of container arguments this function can update,
         delete, or otherwise mutate the arguments that the container engine
         will use.
+        """
+        pass
+
+    def customize_process_args(
+        self, ctx: CephadmContext, args: List[str]
+    ) -> None:
+        """Given a list of arguments for the containerized process, this
+        function can update, delete, or otherwise mutate the arguments that the
+        process will use.
+        """
+        pass
+
+    def customize_container_envs(
+        self, ctx: CephadmContext, envs: List[str]
+    ) -> None:
+        """Given a list of environment vars this function can update, delete,
+        or otherwise mutate the environment variables that are passed by the
+        container engine to the processes it executes.
         """
         pass
 
@@ -84,3 +104,9 @@ class ContainerDaemonForm(DaemonForm):
         expected to understand this.
         """
         return None
+
+    def default_entrypoint(self) -> str:
+        """Return the default entrypoint value when running a deamon process
+        in a container.
+        """
+        return ''


### PR DESCRIPTION
Depends on #54399

Continuing on with the refactoring work in #54399 and previous PRs, this series of patches aims to complete the conversion of code for setting up container params (args, env vars, and the like) from chunks of logic in the get_container method to regular (as in regulated) methods tied to the classes that handle the various daemon types. Most of these are simple enough... but of course tracing, monitoring, and ceph are less so.

At the end of this PR the `get_container` function should still be fairly long but much more pattern based than before. Future PRs will finish up this conversion making get_container based on the common base class & helper methods that do not need to live in cephadm.py [watch this space].



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> refactoring
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Existing tests & updates

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
