### PR TITLE
reef: MClientRequest: properly handle ceph_mds_request_head_legacy for ext_num_retry, ext_num_fwd, owner_uid, owner_gid

### DIFF
--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -237,6 +237,9 @@ public:
       head.ext_num_retry = head.num_retry;
       head.ext_num_fwd = head.num_fwd;
 
+      head.owner_uid = head.caller_uid;
+      head.owner_gid = head.caller_gid;
+
       /* Can't set the btime from legacy struct */
       if (head.op == CEPH_MDS_OP_SETATTR) {
 	int localmask = head.args.setattr.mask;

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -234,6 +234,9 @@ public:
       copy_from_legacy_head(&head, &old_mds_head);
       head.version = 0;
 
+      head.ext_num_retry = head.num_retry;
+      head.ext_num_fwd = head.num_fwd;
+
       /* Can't set the btime from legacy struct */
       if (head.op == CEPH_MDS_OP_SETATTR) {
 	int localmask = head.args.setattr.mask;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63476

---

backport of https://github.com/ceph/ceph/pull/54149
parent tracker: https://tracker.ceph.com/issues/63288