### PR TITLE
pacific: MClientRequest: properly handle ceph_mds_request_head_legacy for ext_num_retry, ext_num_fwd, owner_uid, owner_gid

### DIFF
--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -224,6 +224,9 @@ public:
       copy_from_legacy_head(&head, &old_mds_head);
       head.version = 0;
 
+      head.ext_num_retry = head.num_retry;
+      head.ext_num_fwd = head.num_fwd;
+
       /* Can't set the btime from legacy struct */
       if (head.op == CEPH_MDS_OP_SETATTR) {
 	int localmask = head.args.setattr.mask;


### PR DESCRIPTION
In this packport ("MClientRequest: handle owner_uid and owner_gid from ceph_mds_request_head_legacy") commit was dropped because it is only relevant to the changes from https://github.com/ceph/ceph/pull/53137 pull request. But we decided not to take this change into the final pacific release

backport tracker: https://tracker.ceph.com/issues/63478

---

backport of https://github.com/ceph/ceph/pull/54149
parent tracker: https://tracker.ceph.com/issues/63288