### PR TITLE
crimson/osd/pg: extend pg lifetime on snap_trimq iteration

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -471,6 +471,7 @@ void PG::on_active_actmap()
   logger().debug("{}: {} snap_trimq={}", *this, __func__, snap_trimq);
   peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
   // loops until snap_trimq is empty or SNAPTRIM_ERROR.
+  Ref<PG> pg_ref = this;
   std::ignore = seastar::do_until(
     [this] { return snap_trimq.empty()
                     || peering_state.state_test(PG_STATE_SNAPTRIM_ERROR);
@@ -505,7 +506,7 @@ void PG::on_active_actmap()
       }).then([this, trimmed=to_trim] {
         logger().debug("{}: trimmed snap={}", *this, trimmed);
       });
-    }).finally([this] {
+    }).finally([this, pg_ref] {
       logger().debug("{}: PG::on_active_actmap() finished trimming",
                      *this);
       peering_state.state_clear(PG_STATE_SNAPTRIM);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -506,13 +506,14 @@ void PG::on_active_actmap()
       }).then([this, trimmed=to_trim] {
         logger().debug("{}: trimmed snap={}", *this, trimmed);
       });
-    }).finally([this, pg_ref] {
-      logger().debug("{}: PG::on_active_actmap() finished trimming",
-                     *this);
-      peering_state.state_clear(PG_STATE_SNAPTRIM);
-      peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
-      publish_stats_to_osd();
-    });
+    }
+  ).finally([this, pg_ref] {
+    logger().debug("{}: PG::on_active_actmap() finished trimming",
+                   *this);
+    peering_state.state_clear(PG_STATE_SNAPTRIM);
+    peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
+    publish_stats_to_osd();
+  });
 }
 
 void PG::on_active_advmap(const OSDMapRef &osdmap)


### PR DESCRIPTION
Beacuse the loop's returned future is ignored,
we should cover the scenario where the pg is removed and the
snap_trimq iteration didn't complete yet.

Fixes: https://tracker.ceph.com/issues/61653

Spotted in testing:
```
=================================================================
==81009==ERROR: AddressSanitizer: heap-use-after-free on address 0x625000f326d8 at pc 0x55c0a5fc6173 bp 0x7ffdd9397c00 sp 0x7ffdd9397bf0
READ of size 8 at 0x625000f326d8 thread T0
Reactor stalled for 36 ms on shard 0. Backtrace: 0x45d5d 0x2c67ec1e 0x2c67ffcc 0x2c68151a 0x2c68189e 0x2c6819e8 0x2c681e3e 0x54daf 0x29fcf07f8eec 0x29fcf07f9022 0x29fcf07f8fad 0x29fcf07f9022 0x29fcf07f8fad 0x29fcf07f9022 0x29fcf080923f 0x29fcf0809410 0x29fcee2a52d3 0x2c2d1aa9 0x29fcf0809684 0x29fcf07f8be9 0x29fcf07f8cb5 0x29fcf07ea165 0x29fcf07ebfea 0xd6280 0x32402 0xbd907 0xbd194 0xbdfda 0x1f6d5172 0x1fd5c708 0x1fd5cdbf 0x1fd5dcdc 0x1e62f198 0x1e76a046 0x1e76e196 0x1e76ebfe 0x1fc521dc 0x2d255050 0x2d39e3d1 0x1f87ad03 0x1f66a03b 0x1fbf8c45 0x1fcdb5ac 0x1fcdc712 0x2c62295b 0x2c6bc51c 0x2c8da55e 0x2c8dc281 0x2c3354f2 0x2c3373fb 0x1eb826c8 0x3feaf 0x3ff5f 0x1e62ba44
kernel callstack:
Reactor stalled for 94 ms on shard 0. Backtrace: 0x45d5d 0x2c67ec1e 0x2c67ffcc 0x2c68151a 0x2c68189e 0x2c6819e8 0x2c681e3e 0x54daf 0x29fcf0804ef3 0x29fcf0805a5e 0x29fcf080878a 0x29fcf0809410 0x29fcee2a52d3 0x2c2d1aa9 0x29fcf0809684 0x29fcf07f8be9 0x29fcf07f8cb5 0x29fcf07ea165 0x29fcf07ebfea 0xd6280 0x32402 0xbd907 0xbd194 0xbdfda 0x1f6d5172 0x1fd5c708 0x1fd5cdbf 0x1fd5dcdc 0x1e62f198 0x1e76a046 0x1e76e196 0x1e76ebfe 0x1fc521dc 0x2d255050 0x2d39e3d1 0x1f87ad03 0x1f66a03b 0x1fbf8c45 0x1fcdb5ac 0x1fcdc712 0x2c62295b 0x2c6bc51c 0x2c8da55e 0x2c8dc281 0x2c3354f2 0x2c3373fb 0x1eb826c8 0x3feaf 0x3ff5f 0x1e62ba44
kernel callstack:
    #0 0x55c0a5fc6172 in crimson::osd::operator<<(std::ostream&, crimson::osd::PG const&) (/usr/bin/ceph-osd+0x1f6d5172)
    #1 0x55c0a664d708 in void fmt::v9::detail::format_value<char, crimson::osd::PG>(fmt::v9::detail::buffer<char>&, crimson::osd::PG const&, fmt::v9::detail::locale_ref) (/usr/bin/ceph-osd+0x1fd5c708)
    #2 0x55c0a664ddbf in fmt::v9::appender fmt::v9::basic_ostream_formatter<char>::format<crimson::osd::PG, fmt::v9::appender>(crimson::osd::PG const&, fmt::v9::basic_format_context<fmt::v9::appender, char>&) const (/usr/bin/ceph-osd+0x1fd5cdbf)
    #3 0x55c0a664ecdc in void fmt::v9::detail::value<fmt::v9::basic_format_context<fmt::v9::appender, char> >::format_custom_arg<crimson::osd::PG, fmt::v9::formatter<crimson::osd::PG, char, void> >(void*, fmt::v9::basic_format_parse_context<char, fmt::v9::detail::error_handler>&, fmt::v9::basic_format_context<fmt::v9::appender, char>&) (/usr/bin/ceph-osd+0x1fd5dcdc)
    #4 0x55c0a4f20198 in fmt::v9::detail::default_arg_formatter<char>::operator()(fmt::v9::basic_format_arg<fmt::v9::basic_format_context<fmt::v9::appender, char> >::handle) (/usr/bin/ceph-osd+0x1e62f198)
    #5 0x55c0a505b046 in char const* fmt::v9::detail::parse_replacement_field<char, fmt::v9::detail::vformat_to<char>(fmt::v9::detail::buffer<char>&, fmt::v9::basic_string_view<char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<std::conditional<std::is_same<fmt::v9::type_identity<char>::type, char>::value, fmt::v9::appender, std::back_insert_iterator<fmt::v9::detail::buffer<fmt::v9::type_identity<char>::type> > >::type, fmt::v9::type_identity<char>::type> >, fmt::v9::detail::locale_ref)::format_handler&>(char const*, char const*, fmt::v9::detail::vformat_to<char>(fmt::v9::detail::buffer<char>&, fmt::v9::basic_string_view<char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<std::conditional<std::is_same<fmt::v9::type_identity<char>::type, char>::value, fmt::v9::appender, std::back_insert_iterator<fmt::v9::detail::buffer<fmt::v9::type_identity<char>::type> > >::type, fmt::v9::type_identity<char>::type> >, fmt::v9::detail::locale_ref)::format_handler&) (/usr/bin/ceph-osd+0x1e76a046)
    #6 0x55c0a505f196 in void fmt::v9::detail::vformat_to<char>(fmt::v9::detail::buffer<char>&, fmt::v9::basic_string_view<char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<std::conditional<std::is_same<fmt::v9::type_identity<char>::type, char>::value, fmt::v9::appender, std::back_insert_iterator<fmt::v9::detail::buffer<fmt::v9::type_identity<char>::type> > >::type, fmt::v9::type_identity<char>::type> >, fmt::v9::detail::locale_ref) (/usr/bin/ceph-osd+0x1e76e196)
    #7 0x55c0a505fbfe in seastar::internal::log_buf::inserter_iterator fmt::v9::vformat_to<seastar::internal::log_buf::inserter_iterator, 0>(seastar::internal::log_buf::inserter_iterator, fmt::v9::basic_string_view<char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<fmt::v9::appender, char> >) (/usr/bin/ceph-osd+0x1e76ebfe)
    #8 0x55c0a65431dc in seastar::logger::lambda_log_writer<seastar::logger::log<crimson::osd::PG&>(seastar::log_level, seastar::logger::format_info, crimson::osd::PG&)::{lambda(seastar::internal::log_buf::inserter_iterator)#1}>::operator()(seastar::internal::log_buf::inserter_iterator) (/usr/bin/ceph-osd+0x1fc521dc)
    #9 0x55c0b3b46050 in seastar::logger::do_log(seastar::log_level, seastar::logger::log_writer&)::{lambda(seastar::internal::log_buf::inserter_iterator)#1}::operator()(seastar::internal::log_buf::inserter_iterator) const (/usr/bin/ceph-osd+0x2d255050)
    #10 0x55c0b3c8f3d1 in seastar::logger::do_log(seastar::log_level, seastar::logger::log_writer&) (/usr/bin/ceph-osd+0x2d39e3d1)
    #11 0x55c0a616bd03 in void seastar::logger::log<crimson::osd::PG&>(seastar::log_level, seastar::logger::format_info, crimson::osd::PG&) (/usr/bin/ceph-osd+0x1f87ad03)
    #12 0x55c0a5f5b03b in _ZN7crimson9erroratorIJNS_19unthrowable_wrapperIRKSt10error_codeL_ZNS_2ecILi2EEEEEENS1_IS4_L_ZNS5_ILi11EEEEEEEE7_futureINS_23errorated_future_markerIN7seastar10bool_classINSB_18stop_iteration_tagEEEEEE24_safe_then_handle_errorsINSB_8futurizeINSB_6futureISE_EEEESK_ZNS_L8composerIZNS6_6handleIZZZNS_3osd2PG16on_active_actmapEvENKUlvE0_clEvENKUlvE_clEvEUlvE_EEDaOT_EUlRKS6_E_JZNS7_6handleIZZZNSP_16on_active_actmapEvENKSQ_clEvENKSR_clEvEUlvE0_EEDaSU_EUlRKS7_E_EEEDaSU_DpOT0_EUlDpOT_E_EEDaOT0_OT1_.lto_priv.0 (/usr/bin/ceph-osd+0x1f66a03b)
    #13 0x55c0a64e9c45 in _ZN7seastar20noncopyable_functionIFNS_6futureINS_10bool_classINS_18stop_iteration_tagEEEEEOS5_EE17direct_vtable_forIZNS5_24then_wrapped_maybe_eraseILb0ES5_ZN7crimson9erroratorIJNSB_19unthrowable_wrapperIRKSt10error_codeL_ZNSB_2ecILi2EEEEEENSD_ISG_L_ZNSH_ILi11EEEEEEEE7_futureINSB_23errorated_future_markerIS4_EEE12handle_errorIZNSB_L8composerIZNSI_6handleIZZZNSB_3osd2PG16on_active_actmapEvENKUlvE0_clEvENKUlvE_clEvEUlvE_EEDaOT_EUlRKSI_E_JZNSJ_6handleIZZZNST_16on_active_actmapEvENKSU_clEvENKSV_clEvEUlvE0_EEDaSY_EUlRKSJ_E_EEEDaSY_DpOT0_EUlDpOT_E_EEDaSY_EUlSY_E_EENS_8futurizeIT0_E4typeEOT1_EUlS6_E_E4callEPKS8_S6_.lto_priv.0 (/usr/bin/ceph-osd+0x1fbf8c45)
    #14 0x55c0a65cc5ac in void seastar::futurize<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > >::satisfy_with_result_of<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >::then_wrapped_nrvo<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)> >(seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&&)::{lambda(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&, seastar::future_state<seastar::bool_class<seastar::stop_iteration_tag> >&&)#1}::operator()(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&, seastar::future_state<seastar::bool_class<seastar::stop_iteration_tag> >&&) const::{lambda()#1}>(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >::then_wrapped_nrvo<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)> >(seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&&)::{lambda(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&, seastar::future_state<seastar::bool_class<seastar::stop_iteration_tag> >&&)#1}::operator()(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&, seastar::future_state<seastar::bool_class<seastar::stop_iteration_tag> >&&) const::{lambda()#1}&&) (/usr/bin/ceph-osd+0x1fcdb5ac)
    #15 0x55c0a65cd712 in seastar::continuation<seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>, seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >::then_wrapped_nrvo<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)> >(seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&&)::{lambda(seastar::internal::promise_base_with_type<seastar::bool_class<seastar::stop_iteration_tag> >&&, seastar::noncopyable_function<seastar::future<seastar::bool_class<seastar::stop_iteration_tag> > (seastar::future<seastar::bool_class<seastar::stop_iteration_tag> >&&)>&, seastar::future_state<seastar::bool_class<seastar::stop_iteration_tag> >&&)#1}, seastar::bool_class<seastar::stop_iteration_tag> >::run_and_dispose() (/usr/bin/ceph-osd+0x1fcdc712)
    #16 0x55c0b2f1395b in seastar::reactor::run_tasks(seastar::reactor::task_queue&) (/usr/bin/ceph-osd+0x2c62295b)
    #17 0x55c0b2fad51c in seastar::reactor::run_some_tasks() (/usr/bin/ceph-osd+0x2c6bc51c)
    #18 0x55c0b31cb55e in seastar::reactor::do_run() (/usr/bin/ceph-osd+0x2c8da55e)
    #19 0x55c0b31cd281 in seastar::reactor::run() (/usr/bin/ceph-osd+0x2c8dc281)
    #20 0x55c0b2c264f2 in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) (/usr/bin/ceph-osd+0x2c3354f2)
    #21 0x55c0b2c283fb in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) (/usr/bin/ceph-osd+0x2c3373fb)
    #22 0x55c0a54736c8 in main (/usr/bin/ceph-osd+0x1eb826c8)
    #23 0x7fbd74a3feaf in __libc_start_call_main (/lib64/libc.so.6+0x3feaf)
    #24 0x7fbd74a3ff5f in __libc_start_main_impl (/lib64/libc.so.6+0x3ff5f)
    #25 0x55c0a4f1ca44 in _start (/usr/bin/ceph-osd+0x1e62ba44)

0x625000f326d8 is located 1496 bytes inside of 9144-byte region [0x625000f32100,0x625000f344b8)
freed by thread T0 here:
    #0 0x7fbd770b73cf in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xb73cf)
    #1 0x55c0a5f1a02b in crimson::osd::PG::~PG() (/usr/bin/ceph-osd+0x1f62902b)

previously allocated by thread T0 here:
    #0 0x7fbd770b6367 in operator new(unsigned long) (/lib64/libasan.so.6+0xb6367)
Reactor stalled for 203 ms on shard 0. Backtrace: 0x45d5d 0x2c67ec1e 0x2c67ffcc 0x2c68151a 0x2c68189e 0x2c6819e8 0x2c681e3e 0x54daf 0xc4f5e 0xc53da 0xc54b7 0xc5a38 0xc4612 0xcd073 0x29fcf07ea36f 0x29fcf07ea597 0x29fcf07f8d34 0x29fcf07ea18b 0x29fcf07ebfea 0xd6280 0x2f11c 0x32813 0xbd907 0xbd194 0xbdfda 0x1f6d5172 0x1fd5c708 0x1fd5cdbf 0x1fd5dcdc 0x1e62f198 0x1e76a046 0x1e76e196 0x1e76ebfe 0x1fc521dc 0x2d255050 0x2d39e3d1 0x1f87ad03 0x1f66a03b 0x1fbf8c45 0x1fcdb5ac 0x1fcdc712 0x2c62295b 0x2c6bc51c 0x2c8da55e 0x2c8dc281 0x2c3354f2 0x2c3373fb 0x1eb826c8 0x3feaf 0x3ff5f 0x1e62ba44
kernel callstack: 0xffffffffffffff80 0xffffffff85c89a14 0xffffffff86865842 0xffffffff86a00b82
    #1 0x55c0a6c62ca6 in auto crimson::osd::ShardServices::make_pg(crimson::local_shared_foreign_ptr<boost::local_shared_ptr<OSDMap const> >, spg_t, bool)::{lambda(auto:1&&)#3}::operator()<std::tuple<seastar::future<std::tuple<pg_pool_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, seastar::future<boost::intrusive_ptr<crimson::os::FuturizedCollection> > > >(std::tuple<seastar::future<std::tuple<pg_pool_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, seastar::future<boost::intrusive_ptr<crimson::os::FuturizedCollection> > >&&) const (/usr/bin/ceph-osd+0x20371ca6)
    #2 0x55c0a6c63a9c in auto seastar::futurize_invoke<crimson::osd::ShardServices::make_pg(crimson::local_shared_foreign_ptr<boost::local_shared_ptr<OSDMap const> >, spg_t, bool)::{lambda(auto:1&&)#3}&, std::tuple<seastar::future<std::tuple<pg_pool_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, seastar::future<boost::intrusive_ptr<crimson::os::FuturizedCollection> > > >(crimson::osd::ShardServices::make_pg(crimson::local_shared_foreign_ptr<boost::local_shared_ptr<OSDMap const> >, spg_t, bool)::{lambda(auto:1&&)#3}&, std::tuple<seastar::future<std::tuple<pg_pool_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >, seastar::future<boost::intrusive_ptr<crimson::os::FuturizedCollection> > >&&) (/usr/bin/ceph-osd+0x20372a9c)
    #3 0x55c0b5c10b87  (/usr/bin/ceph-osd+0x2f31fb87)

SUMMARY: AddressSanitizer: heap-use-after-free (/usr/bin/ceph-osd+0x1f6d5172) in crimson::osd::operator<<(std::ostream&, crimson::osd::PG const&)
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
