### PR TITLE
cephadm: add a more generic daemon_to_container function

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -600,7 +600,7 @@ class SNMPGateway(ContainerDaemonForm):
             raise Error('config is missing destination attribute(<ip>:<port>) of the target SNMP listener')
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -169,7 +169,10 @@ from cephadmlib.daemon_form import (
     register as register_daemon_form,
 )
 from cephadmlib.deploy import DeploymentType
-from cephadmlib.container_daemon_form import ContainerDaemonForm
+from cephadmlib.container_daemon_form import (
+    ContainerDaemonForm,
+    daemon_to_container,
+)
 from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
 from cephadmlib.firewalld import Firewalld, update_firewalld
 from cephadmlib import templating
@@ -246,7 +249,9 @@ class Ceph(ContainerDaemonForm):
         uid, gid = self.uid_gid(ctx)
         make_var_run(ctx, ctx.fsid, uid, gid)
 
-        ctr = get_container(ctx, self.identity)
+        # mon and osd need privileged in order for libudev to query devices
+        privileged = self.identity.daemon_type in ['mon', 'osd']
+        ctr = daemon_to_container(ctx, self, privileged=privileged)
         ctr = to_deployment_container(ctx, ctr)
         config_json = fetch_configs(ctx)
         if self.identity.daemon_type == 'mon' and config_json is not None:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3036,7 +3036,7 @@ def get_container(
         binds = get_container_binds(ctx, ident)
         mounts = get_container_mounts(ctx, ident)
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(ctx, ident.fsid, ident.daemon_id)
+        cc = CustomContainer.create(ctx, ident)
         entrypoint = cc.default_entrypoint()
         host_network = False
         cc.customize_container_envs(ctx, envs)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1753,7 +1753,7 @@ class HAproxy(ContainerDaemonForm):
         ]
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def customize_container_args(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1355,7 +1355,9 @@ done
         return tcmu_container
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        # So the container can modprobe iscsi_target_mod and have write perms
+        # to configfs we need to make this a privileged container.
+        ctr = daemon_to_container(ctx, self, privileged=True)
         return to_deployment_container(ctx, ctr)
 
     def config_and_keyring(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2985,7 +2985,7 @@ def get_container(
         ceph_daemon.customize_container_envs(ctx, envs)
         ceph_daemon.customize_container_args(ctx, container_args)
         ceph_daemon.customize_process_args(ctx, d_args)
-        mounts = get_container_mounts(ctx, ident)
+        ceph_daemon.customize_container_mounts(ctx, mounts)
     if daemon_type in ['mon', 'osd']:
         # mon and osd need privileged in order for libudev to query devices
         privileged = True
@@ -2994,7 +2994,7 @@ def get_container(
         entrypoint = monitoring.default_entrypoint()
         monitoring.customize_container_args(ctx, container_args)
         monitoring.customize_process_args(ctx, d_args)
-        mounts = get_container_mounts(ctx, ident)
+        monitoring.customize_container_mounts(ctx, mounts)
     elif daemon_type in Tracing.components:
         tracing = Tracing.create(ctx, ident)
         entrypoint = tracing.default_entrypoint()
@@ -3006,29 +3006,29 @@ def get_container(
         nfs_ganesha.customize_container_envs(ctx, envs)
         nfs_ganesha.customize_container_args(ctx, container_args)
         nfs_ganesha.customize_process_args(ctx, d_args)
-        mounts = get_container_mounts(ctx, ident)
+        nfs_ganesha.customize_container_mounts(ctx, mounts)
     elif daemon_type == CephExporter.daemon_type:
         ceph_exporter = CephExporter.create(ctx, ident)
         entrypoint = ceph_exporter.default_entrypoint()
         ceph_exporter.customize_container_envs(ctx, envs)
         ceph_exporter.customize_container_args(ctx, container_args)
         ceph_exporter.customize_process_args(ctx, d_args)
-        mounts = get_container_mounts(ctx, ident)
+        ceph_exporter.customize_container_mounts(ctx, mounts)
     elif daemon_type == HAproxy.daemon_type:
         haproxy = HAproxy.create(ctx, ident)
         haproxy.customize_container_args(ctx, container_args)
         haproxy.customize_process_args(ctx, d_args)
-        mounts = get_container_mounts(ctx, ident)
+        haproxy.customize_container_mounts(ctx, mounts)
     elif daemon_type == Keepalived.daemon_type:
         keepalived = Keepalived.create(ctx, ident)
         keepalived.customize_container_envs(ctx, envs)
         keepalived.customize_container_args(ctx, container_args)
-        mounts = get_container_mounts(ctx, ident)
+        keepalived.customize_container_mounts(ctx, mounts)
     elif daemon_type == CephNvmeof.daemon_type:
         nvmeof = CephNvmeof.create(ctx, ident)
         nvmeof.customize_container_args(ctx, container_args)
-        binds = get_container_binds(ctx, ident)
-        mounts = get_container_mounts(ctx, ident)
+        nvmeof.customize_container_binds(ctx, binds)
+        nvmeof.customize_container_mounts(ctx, mounts)
     elif daemon_type == CephIscsi.daemon_type:
         iscsi = CephIscsi.create(ctx, ident)
         entrypoint = iscsi.default_entrypoint()
@@ -3036,8 +3036,8 @@ def get_container(
         # So the container can modprobe iscsi_target_mod and have write perms
         # to configfs we need to make this a privileged container.
         privileged = True
-        binds = get_container_binds(ctx, ident)
-        mounts = get_container_mounts(ctx, ident)
+        iscsi.customize_container_binds(ctx, binds)
+        iscsi.customize_container_mounts(ctx, mounts)
     elif daemon_type == CustomContainer.daemon_type:
         cc = CustomContainer.create(ctx, ident)
         entrypoint = cc.default_entrypoint()
@@ -3045,14 +3045,15 @@ def get_container(
         cc.customize_container_envs(ctx, envs)
         cc.customize_container_args(ctx, container_args)
         cc.customize_process_args(ctx, d_args)
-        binds = get_container_binds(ctx, ident)
-        mounts = get_container_mounts(ctx, ident)
+        cc.customize_container_binds(ctx, binds)
+        cc.customize_container_mounts(ctx, mounts)
     elif daemon_type == SNMPGateway.daemon_type:
         sg = SNMPGateway.create(ctx, ident)
         sg.customize_container_args(ctx, container_args)
         sg.customize_process_args(ctx, d_args)
 
     _update_container_args_for_podman(ctx, ident, container_args)
+    _update_podman_mounts(ctx, mounts)
     return CephContainer.for_daemon(
         ctx,
         ident=ident,

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1607,7 +1607,7 @@ class CephExporter(ContainerDaemonForm):
             raise Error(f'Directory does not exist. Got: {self.sock_dir}')
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -344,10 +344,13 @@ class Ceph(ContainerDaemonForm):
     def customize_container_mounts(
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
+        no_config = bool(
+            getattr(ctx, 'config', None) and self.user_supplied_config
+        )
         cm = self.get_ceph_mounts(
             ctx,
             self.identity,
-            no_config=self.ctx.config and self.user_supplied_config,
+            no_config=no_config,
         )
         mounts.update(cm)
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1964,7 +1964,7 @@ class Tracing(ContainerDaemonForm):
         return self._identity
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1105,7 +1105,7 @@ class NFSGanesha(ContainerDaemonForm):
         return 'nfs'
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def customize_container_endpoints(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1885,7 +1885,7 @@ class Keepalived(ContainerDaemonForm):
         mounts.update(self._get_container_mounts(data_dir))
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def customize_container_envs(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2142,9 +2142,10 @@ class CustomContainer(ContainerDaemonForm):
 
     def container(self, ctx: CephadmContext) -> CephContainer:
         if self._container is None:
-            ctr = get_container(
+            ctr = daemon_to_container(
                 ctx,
-                self.identity,
+                self,
+                host_network=False,
                 privileged=self.privileged,
                 ptrace=ctx.allow_ptrace,
             )

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -774,7 +774,7 @@ class Monitoring(ContainerDaemonForm):
 
     def container(self, ctx: CephadmContext) -> CephContainer:
         self._prevalidate(ctx)
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1520,7 +1520,7 @@ class CephNvmeof(ContainerDaemonForm):
         ]
 
     def container(self, ctx: CephadmContext) -> CephContainer:
-        ctr = get_container(ctx, self.identity)
+        ctr = daemon_to_container(ctx, self)
         return to_deployment_container(ctx, ctr)
 
     def uid_gid(self, ctx: CephadmContext) -> Tuple[int, int]:


### PR DESCRIPTION
Depends on #54403

Complete the conversion effort started in #54403 by adding a new  daemon_to_container function that works similarly to how `get_container` worked but in a class based and much more uniform way.

By using daemon_to_container instead of get_container within the daemon type classes we break the last major (there could be some minor ones lingering) circular dependency that prevents us from moving the deamon type classes to files in cephadmlib.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Existing tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
