### PR TITLE
crimson/osd/osd_operations/snaptrim_event: fix lifetime management

### DIFF
--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -44,7 +44,7 @@ void SnapTrimEvent::SubOpBlocker::dump_detail(Formatter *f) const
   f->open_array_section("dependent_operations");
   {
     for (const auto &kv : subops) {
-      f->dump_unsigned("op_id", kv.first);
+      f->dump_unsigned("op_id", kv.first->get_id());
     }
   }
   f->close_section();
@@ -152,7 +152,7 @@ SnapTrimEvent::start()
 	      object,
 	      snapid);
 	    subop_blocker.emplace_back(
-	      op->get_id(),
+	      std::move(op),
 	      std::move(fut)
 	    );
 	  }

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -61,7 +61,7 @@ private:
   struct SubOpBlocker : crimson::BlockerT<SubOpBlocker> {
     static constexpr const char* type_name = "CompoundOpBlocker";
 
-    using id_done_t = std::pair<crimson::Operation::id_t,
+    using id_done_t = std::pair<crimson::OperationRef,
                                 remove_or_update_iertr::future<>>;
 
     void dump_detail(Formatter *f) const final;


### PR DESCRIPTION
The operation's id and future returned when starting SnapTrimObjSubEvent
is empalced into subop_blocker.
Later on, we await the completion of all the started operations futures.
Before this patch, we only stored the op id in the subop_blocker vector
which allowed `op` to go out of scope and lose all its references
(and get deleted) before exiting.

Storing the operation as a reference instead of the id
will maintain the SnapTrimObjSubEvent operation lifetime.

Fixes: https://tracker.ceph.com/issues/63299





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
