### PR TITLE
CephContext: acquire _fork_watchers_lock in notify_post_fork()

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -1042,7 +1042,7 @@ void CephContext::notify_pre_fork()
 
 void CephContext::notify_post_fork()
 {
-  ceph::spin_unlock(&_fork_watchers_lock);
+  std::lock_guard lg(_fork_watchers_lock);
   for (auto &&t : _fork_watchers)
     t->handle_post_fork();
 }


### PR DESCRIPTION
https://tracker.ceph.com/issues/63494

The ceph::spin_unlock() seems incorrect here.

Was debugging a ceph-fuse crash reported downstream which has the following backtrace:

```
#0  0x00007f66b42a2a4f raise (libc.so.6)
#1  0x00007f66b4275db5 abort (libc.so.6)
#2  0x00007f66b4275c89 __assert_fail_base.cold.0 (libc.so.6)
#3  0x00007f66b429b3a6 __assert_fail (libc.so.6)
#4  0x00007f66b583ccb1 __pthread_mutex_lock (libpthread.so.0)
#5  0x0000563393237387 _Z15global_pre_initPKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_St4lessIS5_ESaISt4pairIKS5_S5_EEERSt6vectorIPKcSaISH_EEj18code_environment_ti (ceph-fuse)
#6  0x0000563393239576 _Z11global_initPKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_St4lessIS5_ESaISt4pairIKS5_S5_EEERSt6vectorIPKcSaISH_EEj18code_environment_tib (ceph-fuse)
#7  0x000056339314a01e main (ceph-fuse)
#8  0x00007f66b428eca3 __libc_start_main (libc.so.6)
#9  0x000056339315173e _start (ceph-fuse)  
```

No debug logs were available. Although the backtrace shows global_pre_init() leading into a call that involves pthread mutex (lock), I found this via code reading and _might_ just be related to the issue.

@rzarzynski 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
