### PR TITLE
qa/rgw/multisite: add two-zone configuration

### DIFF
--- a/qa/suites/rgw/multisite/clusters.yaml
+++ b/qa/suites/rgw/multisite/clusters.yaml
@@ -1,3 +1,5 @@
 roles:
-- [c1.mon.a, c1.mgr.x, c1.osd.0, c1.osd.1, c1.osd.2, c1.client.0, c1.client.1]
-- [c2.mon.a, c2.mgr.x, c2.osd.0, c2.osd.1, c2.osd.2, c2.client.0, c2.client.1]
+- [c1.mon.a, c1.osd.0, c1.osd.1, c1.osd.2, c1.client.0]
+- [c1.mgr.x, c1.osd.3, c1.osd.4, c1.osd.5, c1.client.1]
+- [c2.mon.a, c2.osd.0, c2.osd.1, c2.osd.2, c2.client.0]
+- [c2.mgr.x, c2.osd.3, c2.osd.4, c2.osd.5, c2.client.1]

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -13,6 +13,8 @@ overrides:
         rgw curl low speed time: 300
         rgw md log max shards: 4
         rgw data log num shards: 4
+        rgw data sync poll interval: 5
+        rgw meta sync poll interval: 5
         rgw sync obj etag verify: true
         rgw sync meta inject err probability: 0.1
         rgw sync data inject err probability: 0.1

--- a/qa/suites/rgw/multisite/realms/two-zones.yaml
+++ b/qa/suites/rgw/multisite/realms/two-zones.yaml
@@ -1,0 +1,21 @@
+overrides:
+  rgw-multisite:
+    realm:
+      name: test-realm
+      is default: true
+    zonegroups:
+      - name: test-zonegroup
+        is_master: true
+        is_default: true
+        endpoints: [c1.client.0]
+        enabled_features: ['resharding']
+        zones:
+          - name: test-zone1
+            is_master: true
+            is_default: true
+            endpoints: [c1.client.0]
+          - name: test-zone2
+            is_default: true
+            endpoints: [c2.client.0]
+  rgw-multisite-tests:
+    args: [tests.py]


### PR DESCRIPTION
we're having trouble getting the `three-zone.yaml` and `two-zonegroup.yaml` (two zones each) tests to pass reliably. try adding a job with just two zones

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
