### PR TITLE
rgw: make subclass dependencies explicit

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -287,7 +287,6 @@ target_link_libraries(rgw_common
     ${FMT_LIB})
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${LUA_INCLUDE_DIR}")
 

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -18,8 +18,9 @@
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "common/ceph_context.h"
-#include "rgw_obj_manifest.h"
 #include "rgw_multi.h"
+
+#include "driver/rados/rgw_obj_manifest.h" // FIXME: subclass dependency
 
 namespace rgw { namespace store {
 

--- a/src/rgw/driver/dbstore/config/sqlite.cc
+++ b/src/rgw/driver/dbstore/config/sqlite.cc
@@ -25,7 +25,8 @@
 #include "include/encoding.h"
 #include "common/dout.h"
 #include "common/random_string.h"
-#include "rgw_zone.h"
+
+#include "driver/rados/rgw_zone.h" // FIXME: subclass dependency
 
 #include "common/connection_pool.h"
 #include "sqlite/connection.h"

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -31,7 +31,8 @@
 #include "rgw_user_types.h"
 #include "rgw_bucket_types.h"
 #include "rgw_obj_types.h"
-#include "rgw_obj_manifest.h"
+
+#include "driver/rados/rgw_obj_manifest.h" // FIXME: subclass dependency
 
 #include "common/Formatter.h"
 

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -6,10 +6,11 @@
 #include <map>
 #include "rgw_xml.h"
 #include "rgw_obj_types.h"
-#include "rgw_obj_manifest.h"
 #include "rgw_compression_types.h"
 #include "common/dout.h"
 #include "rgw_sal_fwd.h"
+
+#include "driver/rados/rgw_obj_manifest.h" // FIXME: subclass dependency
 
 #define MULTIPART_UPLOAD_ID_PREFIX_LEGACY "2/"
 #define MULTIPART_UPLOAD_ID_PREFIX "2~" // must contain a unique char that may not come up in gen_rand_alpha()

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -18,11 +18,13 @@
 #include "common/tracer.h"
 #include "rgw_sal_fwd.h"
 #include "rgw_lua.h"
-#include "rgw_user.h"
 #include "rgw_notify_event_type.h"
 #include "rgw_req_context.h"
-#include "rgw_datalog_notify.h"
 #include "include/random.h"
+
+// FIXME: following subclass dependencies
+#include "driver/rados/rgw_user.h"
+#include "driver/rados/rgw_datalog_notify.h"
 
 struct RGWBucketEnt;
 class RGWRESTMgr;

--- a/src/rgw/services/svc_bucket_sync.h
+++ b/src/rgw/services/svc_bucket_sync.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "rgw_service.h"
+#include "driver/rados/rgw_service.h" // FIXME: subclass dependency
 
 #include "svc_bucket_types.h"
 

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -10,7 +10,8 @@
 #include "rgw_mdlog.h"
 #include "rgw_coroutine.h"
 #include "rgw_cr_rados.h"
-#include "rgw_zone.h"
+
+#include "driver/rados/rgw_zone.h" // FIXME: subclass dependency
 
 #include "common/errno.h"
 

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -19,8 +19,9 @@
 
 #include "svc_meta_be_params.h"
 
-#include "rgw_service.h"
 #include "rgw_mdlog_types.h"
+
+#include "driver/rados/rgw_service.h" // FIXME: subclass dependency
 
 class RGWMetadataLogData;
 

--- a/src/rgw/services/svc_user_rados.h
+++ b/src/rgw/services/svc_user_rados.h
@@ -20,7 +20,8 @@
 
 #include "svc_meta_be.h"
 #include "svc_user.h"
-#include "rgw_bucket.h"
+
+#include "driver/rados/rgw_bucket.h" // FIXME: subclass dependency
 
 class RGWSI_RADOS;
 class RGWSI_Zone;


### PR DESCRIPTION
As part of the Zipper project generic back-end code is being teased apart from rados-specific back-end code. This is a work in progress, so currently generic code and other subclasses of StoreDriver (and related high-level classes) depend on the rados-specific declarations. Some of these dependencies are not always obvious since src/rgw/driver/rados was put on the include path. That is now removed, so any includes needing files from that subclass have to give a more fully specified path.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
