### PR TITLE
common/admin_socket: improvements to the RaiseHook

### DIFF
--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -19,6 +19,7 @@
 #include "common/ceph_argparse.h"
 #include "json_spirit/json_spirit.h"
 #include "gtest/gtest.h"
+#include "fmt/format.h"
 
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
After fixing the issues found when backporting the original implementation to past streams I decided to apply some of the changes to the upstream.

Specifically, an issue was spotted that resulted in an effectively infinite loop inside the killer fork

The problem was that the timespan deduced by the `auto` variable definition ended up to be unsigned (the default)
As a result, when the difference between now and ref was negative, it began awaiting some insane 64bit-second period

This improvement both addresses some inefficiency with the spin loop and avoids using the `auto` to explicitly request the expected span types.

Original PR: https://github.com/ceph/ceph/pull/53689

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
