### PR TITLE
ceph-volume: fix blkid on inaccessible devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -464,7 +464,7 @@ class Device(object):
         elif self.disk_api:
             return self.disk_api['TYPE']
         elif self.blkid_api:
-            return self.blkid_api['TYPE']
+            return self.blkid_api.get('TYPE')
 
     @property
     def is_mpath(self):
@@ -480,7 +480,7 @@ class Device(object):
         if self.disk_api:
             return self.disk_api['TYPE'] == 'part'
         elif self.blkid_api:
-            return self.blkid_api['TYPE'] == 'part'
+            return self.blkid_api.get('TYPE') == 'part'
         return False
 
     @property


### PR DESCRIPTION
There exists block devices which can not be accessed. For example DRBD /dev/drbdX in secondary state. `blkid` can not read from this:
```
  $ blkid -c /dev/null -p /dev/drbd4
  blkid: error: /dev/drbd4: Wrong medium type
```
Since release 17.2.7 this results in "CEPHADM_REFRESH_FAILED: failed to probe daemons or devices"[[1](https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/ZSD4OPDMCEXOW74IJH4L4D5PQXFFINGS/)] and the following trace:
```
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/device.py", line 482, in is_partition
    return self.blkid_api['TYPE'] == 'part'
KeyError: 'TYPE'
```
Fix this by using `get()` method, so that it defaults to `None` if the key does not exist. And while at it also switch to `get()` in an other reference to this key.

Probably caused by commit 2422ad867dff9d526d7e8be543178c897991097f ???
