### PR TITLE
mgr/cephadm: Expose nvmeof gateway configuration parameters through specifications

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -7,6 +7,9 @@ port = {{ port }}
 enable_auth = {{ spec.enable_auth }}
 state_update_notify = True
 state_update_interval_sec = 5
+min_controller_id = {{ spec.min_controller_id }}
+max_controller_id = {{ spec.max_controller_id }}
+enable_spdk_discovery_controller = {{ spec.enable_spdk_discovery_controller }}
 
 [ceph]
 pool = {{ spec.pool }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -390,6 +390,9 @@ port = {default_port}
 enable_auth = False
 state_update_notify = True
 state_update_interval_sec = 5
+min_controller_id = 1
+max_controller_id = 65519
+enable_spdk_discovery_controller = False
 
 [ceph]
 pool = {pool}

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1131,6 +1131,9 @@ class NvmeofServiceSpec(ServiceSpec):
                  port: Optional[int] = None,
                  pool: Optional[str] = None,
                  enable_auth: bool = False,
+                 min_controller_id: Optional[str] = '1',
+                 max_controller_id: Optional[str] = '65519',
+                 enable_spdk_discovery_controller: Optional[bool] = False,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
@@ -1171,6 +1174,12 @@ class NvmeofServiceSpec(ServiceSpec):
         self.group = group
         #: ``enable_auth`` enables user authentication on nvmeof gateway
         self.enable_auth = enable_auth
+        #: ``min_controller_id`` minimum controller id used by SPDK, essential for multipath
+        self.min_controller_id = min_controller_id
+        #: ``max_controller_id`` maximum controller id used by SPDK, essential for multipath
+        self.max_controller_id = max_controller_id
+        #: ``enable_spdk_discovery_controller`` SPDK or ceph-nvmeof discovery service
+        self.enable_spdk_discovery_controller = enable_spdk_discovery_controller
         #: ``server_key`` gateway server key
         self.server_key = server_key or './server.key'
         #: ``server_cert`` gateway server certificate


### PR DESCRIPTION
## Expose nvmeof gateway configuration parameters through specifications

- **min_controller_id**,   **max_controller_id**: Enable the specification of minimum and maximum controller IDs utilized by the SPDK. Having distinct controller IDs is vital for configuring multipath setups.
- **enable_spdk_discovery_controller**: Manage whether the SPDK or ceph-nvmeof discovery service is employed. The default value is set to False.
