### PR TITLE
WIP mgr/dashboard: explicitly shutdown cephfs mounts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -254,8 +254,9 @@ class NFSGaneshaUi(BaseController):
         try:
             cfs = CephFS(fs_name)
             paths = [root_dir]
-            paths.extend([p['path'].rstrip('/')
-                          for p in cfs.ls_dir(root_dir, depth)])
+            with cfs:
+                paths.extend([p['path'].rstrip('/')
+                              for p in cfs.ls_dir(root_dir, depth)])
         except (cephfs.ObjectNotFound, cephfs.PermissionError):
             paths = []
         return {'paths': paths}

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -38,12 +38,19 @@ class CephFS(object):
     def __init__(self, fs_name=None):
         logger.debug("initializing cephfs connection")
         self.cfs = cephfs.LibCephFS(rados_inst=mgr.rados)
-        logger.debug("mounting cephfs filesystem: %s", fs_name)
-        if fs_name:
-            self.cfs.mount(filesystem_name=fs_name)
+        self.fs_name = fs_name
+
+    def __enter__(self):
+        logger.debug("mounting cephfs filesystem: %s", self.fs_name)
+        if self.fs_name:
+            self.cfs.mount(filesystem_name=self.fs_name)
         else:
             self.cfs.mount()
         logger.debug("mounted cephfs filesystem")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logger.debug("shutting down cephfs filesystem: %s", self.fs_name)
+        self.cfs.shutdown()
 
     @contextmanager
     def opendir(self, dirpath):


### PR DESCRIPTION
Don't rely on cython libcephfs binding's finalizer method, `__dealloc__()`,  to shut down and clean up the mount handle. Instead, use context managers to call libcephfs shutdown() once done using the CephFS mount.

Fixes: https://tracker.ceph.com/issues/63515


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
