### PR TITLE
osd/OSD: rewrite send_incremental_map()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1457,22 +1457,19 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
            << " to " << con << " " << con->get_peer_addr() << dendl;
 
   MOSDMap *m = NULL;
-  while (!m) {
-    OSDSuperblock sblock(get_superblock());
-    if (since < sblock.get_oldest_map()) {
-      // just send latest full map
-      MOSDMap *m = new MOSDMap(monc->get_fsid(),
-			       osdmap->get_encoding_features());
-      m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
-      m->newest_map = sblock.get_newest_map();
-      get_map_bl(to, m->maps[to]);
-      send_map(m, con);
-      return;
-    }
-
+  OSDSuperblock sblock(get_superblock());
+  if (since < sblock.get_oldest_map()) {
+    // just send latest full map
+    m = new MOSDMap(monc->get_fsid(),
+		       osdmap->get_encoding_features());
+    m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
+    m->newest_map = sblock.get_newest_map();
+    get_map_bl(to, m->maps[to]);
+  } else {
     if (to > since && (int64_t)(to - since) > cct->_conf->osd_map_share_max_epochs) {
-      dout(10) << "  " << (to - since) << " > max " << cct->_conf->osd_map_share_max_epochs
-	       << ", only sending most recent" << dendl;
+      dout(10) << "  " << (to - since) << " > max "
+               << cct->_conf->osd_map_share_max_epochs
+               << ", only sending most recent" << dendl;
       since = to - cct->_conf->osd_map_share_max_epochs;
     }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1402,7 +1402,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
     max_bytes -= bl.length();
     m->maps[since] = std::move(bl);
   }
-  for (epoch_t e = since + 1; e <= to; ++e) {
+  for (epoch_t e = since; e <= to; ++e) {
     bufferlist bl;
     if (get_inc_map_bl(e, bl)) {
       m->incremental_maps[e] = bl;
@@ -7372,8 +7372,9 @@ void OSDService::maybe_share_map(
                << session->projected_epoch << dendl;
       return;
     }
-
-    send_from = session->projected_epoch;
+    // send incremental maps in the range of:
+    // (projected_epoch, osdmap]
+    send_from = session->projected_epoch + 1;
     dout(10) << __func__ << ": con " << con->get_peer_addr()
              << " map epoch " << session->projected_epoch
              << " -> " << osdmap->get_epoch()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1458,23 +1458,13 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
 
   MOSDMap *m = NULL;
   OSDSuperblock sblock(get_superblock());
-  if (since < sblock.get_oldest_map()) {
-    // just send latest full map
-    m = new MOSDMap(monc->get_fsid(),
-		       osdmap->get_encoding_features());
-    m->cluster_osdmap_trim_lower_bound = sblock.cluster_osdmap_trim_lower_bound;
-    m->newest_map = sblock.get_newest_map();
-    get_map_bl(to, m->maps[to]);
-  } else {
-    if (to > since && (int64_t)(to - since) > cct->_conf->osd_map_share_max_epochs) {
-      dout(10) << "  " << (to - since) << " > max "
-               << cct->_conf->osd_map_share_max_epochs
-               << ", only sending most recent" << dendl;
-      since = to - cct->_conf->osd_map_share_max_epochs;
-    }
-
-    m = build_incremental_map_msg(since, to, sblock);
+  if (to > since && (int64_t)(to - since) > cct->_conf->osd_map_share_max_epochs) {
+    dout(10) << "  " << (to - since) << " > max "
+             << cct->_conf->osd_map_share_max_epochs
+             << ", only sending most recent" << dendl;
+    since = to - cct->_conf->osd_map_share_max_epochs;
   }
+  m = build_incremental_map_msg(since, to, sblock);
   send_map(m, con);
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1444,11 +1444,6 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   return m;
 }
 
-void OSDService::send_map(MOSDMap *m, Connection *con)
-{
-  con->send_message(m);
-}
-
 void OSDService::send_incremental_map(epoch_t since, Connection *con,
                                       const OSDMapRef& osdmap)
 {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1448,8 +1448,10 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
                                       const OSDMapRef& osdmap)
 {
   epoch_t to = osdmap->get_epoch();
-  dout(10) << "send_incremental_map " << since << " -> " << to
-           << " to " << con << " " << con->get_peer_addr() << dendl;
+  dout(10) << fmt::format("{} epoch range: ({}, {}] to {} {}",
+                          __func__, since, to,
+                          con->get_peer_entity_name().to_str(),
+                          con->get_peer_addr()) << dendl;
 
   OSDSuperblock sblock(get_superblock());
   if (to > since && (int64_t)(to - since) > cct->_conf->osd_map_share_max_epochs) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1456,7 +1456,6 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
   dout(10) << "send_incremental_map " << since << " -> " << to
            << " to " << con << " " << con->get_peer_addr() << dendl;
 
-  MOSDMap *m = NULL;
   OSDSuperblock sblock(get_superblock());
   if (to > since && (int64_t)(to - since) > cct->_conf->osd_map_share_max_epochs) {
     dout(10) << "  " << (to - since) << " > max "
@@ -1464,8 +1463,7 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
              << ", only sending most recent" << dendl;
     since = to - cct->_conf->osd_map_share_max_epochs;
   }
-  m = build_incremental_map_msg(since, to, sblock);
-  send_map(m, con);
+  con->send_message(build_incremental_map_msg(since, to, sblock));
 }
 
 bool OSDService::_get_map_bl(epoch_t e, bufferlist& bl)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -209,7 +209,6 @@ public:
 		       const OSDMapRef& osdmap,
 		       epoch_t peer_epoch_lb=0);
 
-  void send_map(class MOSDMap *m, Connection *con);
   void send_incremental_map(epoch_t since, Connection *con,
 			    const OSDMapRef& osdmap);
   MOSDMap *build_incremental_map_msg(epoch_t from, epoch_t to,


### PR DESCRIPTION
* See: 9fba69a11aa940ed36339bb24b05cb92165db516
   build_incremental_map_msg() no longer returns NULL on failures.
   while(!m) if-case is removed.

* Send all relevant maps even when adjusting `since`

* Simplify code readability

* Fix log message

* Avoid bufferlist copying


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
