### PR TITLE
mds: use explicitly sized types for network and disk encoding

### DIFF
--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -381,7 +381,7 @@ private:
   ceph_seq_t mseq = 0;
 
   int suppress = 0;
-  unsigned state = 0;
+  uint32_t state = 0;
 
   int lock_cache_allowed = 0;
 };

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -113,7 +113,7 @@ protected:
 
   version_t omap_version = 0;
 
-  unsigned omap_num_objs = 0;
+  uint32_t omap_num_objs = 0;
   std::vector<unsigned> omap_num_items;
 
   std::map<inodeno_t, OpenedAnchor> anchor_map;

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -57,7 +57,7 @@ private:
   uint32_t caller_gid = 0;
 
   /* advisory CLIENT_CAPS_* flags to send to mds */
-  unsigned flags = 0;
+  uint32_t flags = 0;
 
   std::vector<uint8_t> fscrypt_auth;
   std::vector<uint8_t> fscrypt_file;

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -28,7 +28,7 @@ public:
   ceph_mds_session_head head;
   static constexpr unsigned SESSION_BLOCKLISTED = (1<<0);
 
-  unsigned flags = 0;
+  uint32_t flags = 0;
   std::map<std::string, std::string> metadata;
   feature_bitset_t supported_features;
   metric_spec_t metric_spec;

--- a/src/messages/MMDSScrub.h
+++ b/src/messages/MMDSScrub.h
@@ -130,11 +130,11 @@ private:
   static constexpr unsigned FLAG_RECURSIVE	= 1<<2;
   static constexpr unsigned FLAG_REPAIR		= 1<<3;
 
-  int op;
+  int32_t op;
   inodeno_t ino;
   fragset_t frags;
   std::string tag;
   inodeno_t origin;
-  unsigned flags = 0;
+  uint32_t flags = 0;
 };
 #endif // CEPH_MMDSSCRUB_H

--- a/src/messages/MMDSScrubStats.h
+++ b/src/messages/MMDSScrubStats.h
@@ -68,7 +68,7 @@ protected:
   ~MMDSScrubStats() override {}
 
 private:
-  unsigned epoch;
+  uint32_t epoch;
   std::set<std::string> scrubbing_tags;
   bool update_scrubbing = false;
   bool aborting = false;


### PR DESCRIPTION
The size of 'unsigned' type maybe not different from different OSes. And we should always use explicitly sized type.

Fixes: https://tracker.ceph.com/issues/63552





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
