### PR TITLE
crimson/os/seastore:  introduce inplace rewrite for RBM

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -388,7 +388,7 @@ JournalTrimmerImpl::config_t::get_test(
     max_journal_bytes = 4 * roll_size;
   } else {
     assert(type == journal_type_t::RANDOM_BLOCK);
-    target_dirty_bytes = roll_size / 4;
+    target_dirty_bytes = roll_size / 36;
     target_alloc_bytes = roll_size / 4;
     max_journal_bytes = roll_size / 2;
   }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1288,7 +1288,7 @@ record_t Cache::prepare_record(
     i->dirty_from_or_retired_at = JOURNAL_SEQ_MIN;
     i->state = CachedExtent::extent_state_t::CLEAN;
     assert(i->is_logical());
-    i->cast<LogicalCachedExtent>()->clear_delta();
+    i->clear_modified_region();
     touch_extent(*i);
     DEBUGT("inplace rewrite ool block is commmitted -- {}", t, *i);
   }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1839,7 +1839,7 @@ Cache::replay_delta(
 	      journal_seq, record_base, delta);
 	assert(delta.pversion > 0);
 	return replay_delta_ertr::make_ready_future<std::pair<bool, CachedExtentRef>>(
-	  std::make_pair(true, nullptr));
+	  std::make_pair(false, nullptr));
       }
 
       DEBUG("replay extent delta at {} {} ... -- {}, prv_extent={}",

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1039,7 +1039,8 @@ public:
    */
   using replay_delta_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
-  using replay_delta_ret = replay_delta_ertr::future<bool>;
+  using replay_delta_ret = replay_delta_ertr::future<
+    std::pair<bool, CachedExtentRef>>;
   replay_delta_ret replay_delta(
     journal_seq_t seq,
     paddr_t record_block_base,

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1242,6 +1242,8 @@ public:
 
   void on_replace_prior(Transaction &t) final;
 
+  virtual void clear_delta() {}
+
   virtual ~LogicalCachedExtent();
 protected:
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1242,8 +1242,6 @@ public:
 
   void on_replace_prior(Transaction &t) final;
 
-  virtual void clear_delta() {}
-
   struct modified_region_t {
     extent_len_t offset;
     extent_len_t len;
@@ -1251,6 +1249,8 @@ public:
   virtual std::optional<modified_region_t> get_modified_region() {
     return std::nullopt;
   }
+
+  virtual void clear_modified_region() {}
 
   virtual ~LogicalCachedExtent();
 protected:

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -587,6 +587,11 @@ public:
     rewrite_generation = gen;
   }
 
+  void set_inplace_rewrite_generation() {
+    user_hint = placement_hint_t::REWRITE;
+    rewrite_generation = OOL_GENERATION;
+  }
+
   bool is_inline() const {
     return poffset.is_relative();
   }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1244,6 +1244,14 @@ public:
 
   virtual void clear_delta() {}
 
+  struct modified_region_t {
+    extent_len_t offset;
+    extent_len_t len;
+  };
+  virtual std::optional<modified_region_t> get_modified_region() {
+    return std::nullopt;
+  }
+
   virtual ~LogicalCachedExtent();
 protected:
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -611,6 +611,10 @@ public:
     return prior_instance;
   }
 
+  uint32_t get_last_committed_crc() const {
+    return last_committed_crc;
+  }
+
 private:
   template <typename T>
   friend class read_set_item_t;

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -802,13 +802,15 @@ RandomBlockOolWriter::do_write(
     } else {
       bp = ex->get_bptr();
     }
-    return rbm->write(paddr + offset,
-      bp
-    ).handle_error(
-      alloc_write_iertr::pass_further{},
-      crimson::ct_error::assert_all{
-	"Invalid error when writing record"}
-    ).safe_then([&t, &ex, paddr, this, FNAME]() {
+    return trans_intr::make_interruptible(
+      rbm->write(paddr + offset,
+	bp
+      ).handle_error(
+	alloc_write_iertr::pass_further{},
+	crimson::ct_error::assert_all{
+	  "Invalid error when writing record"}
+      )
+    ).si_then([this, &t, &ex, paddr, FNAME] {
       TRACET("ool extent written at {} -- {}",
 	     t, paddr, *ex);
       if (ex->is_initial_pending()) {

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -794,14 +794,11 @@ RandomBlockOolWriter::do_write(
     bufferptr bp;
     if (can_inplace_rewrite(t, ex)) {
       auto r = ex->get_modified_region();
-      if (r.has_value() && r->len > rbm->get_block_size()) {
-	offset = p2align(r->offset, rbm->get_block_size());
-	extent_len_t len =
-	  p2roundup(r->offset + r->len, rbm->get_block_size()) - offset;
-	bp = ceph::bufferptr(ex->get_bptr(), offset, len);
-      } else {
-	bp = ex->get_bptr();
-      }
+      ceph_assert(r.has_value());
+      offset = p2align(r->offset, rbm->get_block_size());
+      extent_len_t len =
+	p2roundup(r->offset + r->len, rbm->get_block_size()) - offset;
+      bp = ceph::bufferptr(ex->get_bptr(), offset, len);
     } else {
       bp = ex->get_bptr();
     }

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -8,6 +8,7 @@
 #include "crimson/os/seastore/ordering_handle.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/segment_seq_allocator.h"
+#include "crimson/os/seastore/cached_extent.h"
 
 namespace crimson::os::seastore {
 
@@ -88,7 +89,7 @@ public:
     crimson::ct_error::erange>;
   using replay_ret = replay_ertr::future<>;
   using delta_handler_t = std::function<
-    replay_ertr::future<bool>(
+    replay_ertr::future<std::pair<bool, CachedExtentRef>>(
       const record_locator_t&,
       const delta_info_t&,
       const journal_seq_t&, // dirty_tail

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -291,7 +291,8 @@ SegmentedJournal::replay_segment(
 	      trimmer.get_dirty_tail(),
 	      trimmer.get_alloc_tail(),
               modify_time
-            ).safe_then([&stats, delta_type=delta.type](bool is_applied) {
+            ).safe_then([&stats, delta_type=delta.type](auto ret) {
+	      auto [is_applied, ext] = ret;
               if (is_applied) {
                 // see Cache::replay_delta()
                 assert(delta_type != extent_types_t::JOURNAL_TAIL);

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -423,6 +423,7 @@ void ObjectDataBlock::apply_delta(const ceph::bufferlist &bl) {
   for (auto &&d : deltas) {
     auto iter = d.bl.cbegin();
     iter.copy(d.len, get_bptr().c_str() + d.offset);
+    modified_region.union_insert(d.offset, d.len);
   }
 }
 

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -35,10 +35,12 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
 
   std::vector<block_delta_t> delta = {};
 
+  interval_set<extent_len_t> modified_region;
+
   explicit ObjectDataBlock(ceph::bufferptr &&ptr)
     : LogicalCachedExtent(std::move(ptr)) {}
   explicit ObjectDataBlock(const ObjectDataBlock &other)
-    : LogicalCachedExtent(other) {}
+    : LogicalCachedExtent(other), modified_region(other.modified_region) {}
   explicit ObjectDataBlock(extent_len_t length)
     : LogicalCachedExtent(length) {}
 
@@ -55,28 +57,27 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
     auto iter = bl.cbegin();
     iter.copy(bl.length(), get_bptr().c_str() + offset);
     delta.push_back({offset, bl.length(), bl});
+    modified_region.union_insert(offset, bl.length());
   }
 
   ceph::bufferlist get_delta() final;
 
   void apply_delta(const ceph::bufferlist &bl) final;
 
-  void clear_delta() final {
-    delta.clear();
-  }
-
   std::optional<modified_region_t> get_modified_region() final {
-    interval_set<extent_len_t> range;
-    for (auto &p : delta) {
-      if (p.len > 0) {
-	range.union_insert(p.offset, p.len);
-      }
-    }
-    if (range.empty()) {
+    if (modified_region.empty()) {
       return std::nullopt;
     }
-    return modified_region_t{range.range_start(),
-      range.range_end() - range.range_start()};
+    return modified_region_t{modified_region.range_start(),
+      modified_region.range_end() - modified_region.range_start()};
+  }
+
+  void clear_modified_region() final {
+    modified_region.clear();
+  }
+
+  void logical_on_delta_write() final {
+    delta.clear();
   }
 };
 using ObjectDataBlockRef = TCachedExtentRef<ObjectDataBlock>;

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -60,6 +60,10 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
   ceph::bufferlist get_delta() final;
 
   void apply_delta(const ceph::bufferlist &bl) final;
+
+  void clear_delta() final {
+    delta.clear();
+  }
 };
 using ObjectDataBlockRef = TCachedExtentRef<ObjectDataBlock>;
 

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -64,6 +64,20 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalCachedExtent {
   void clear_delta() final {
     delta.clear();
   }
+
+  std::optional<modified_region_t> get_modified_region() final {
+    interval_set<extent_len_t> range;
+    for (auto &p : delta) {
+      if (p.len > 0) {
+	range.union_insert(p.offset, p.len);
+      }
+    }
+    if (range.empty()) {
+      return std::nullopt;
+    }
+    return modified_region_t{range.range_start(),
+      range.range_end() - range.range_start()};
+  }
 };
 using ObjectDataBlockRef = TCachedExtentRef<ObjectDataBlock>;
 

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -286,6 +286,10 @@ std::ostream &operator<<(std::ostream &out, data_category_t c)
   }
 }
 
+bool can_inplace_rewrite(extent_types_t type) {
+  return get_extent_category(type) == data_category_t::DATA;
+}
+
 std::ostream &operator<<(std::ostream &out, sea_time_point_printer_t tp)
 {
   if (tp.tp == NULL_TIME) {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1307,6 +1307,8 @@ constexpr data_category_t get_extent_category(extent_types_t type) {
   }
 }
 
+bool can_inplace_rewrite(extent_types_t type);
+
 // type for extent modification time, milliseconds since the epoch
 using sea_time_point = seastar::lowres_system_clock::time_point;
 using sea_duration = seastar::lowres_system_clock::duration;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -217,6 +217,12 @@ public:
     written_ool_block_list.push_back(ref);
   }
 
+  void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef& ref) {
+    assert(ref->get_paddr().is_absolute());
+    assert(!ref->is_inline());
+    written_inplace_ool_block_list.push_back(ref);
+  }
+
   void add_inplace_rewrite_extent(CachedExtentRef ref) {
    ceph_assert(!is_weak());
    ceph_assert(ref);
@@ -400,6 +406,7 @@ public:
     delayed_alloc_list.clear();
     inline_block_list.clear();
     written_ool_block_list.clear();
+    written_inplace_ool_block_list.clear();
     pre_alloc_list.clear();
     pre_inplace_rewrite_list.clear();
     retired_set.clear();
@@ -555,6 +562,8 @@ private:
   std::list<CachedExtentRef> inline_block_list;
   /// fresh blocks that will be committed with out-of-line record
   std::list<CachedExtentRef> written_ool_block_list;
+  /// dirty blocks that will be committed out-of-line with inplace rewrite
+  std::list<LogicalCachedExtentRef> written_inplace_ool_block_list;
 
   /// list of mutated blocks, holds refcounts, subset of write_set
   std::list<CachedExtentRef> mutated_block_list;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -487,6 +487,12 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
 
   assert(extent->is_valid() && !extent->is_initial_pending());
   if (extent->is_dirty()) {
+    if (epm->can_inplace_rewrite(t, extent)) {
+      DEBUGT("delta overwriting extent -- {}", t, *extent);
+      t.add_inplace_rewrite_extent(extent);
+      extent->set_inplace_rewrite_generation();
+      return rewrite_extent_iertr::now();
+    }
     extent->set_target_rewrite_generation(INIT_GENERATION);
   } else {
     extent->set_target_rewrite_generation(target_generation);

--- a/src/test/crimson/seastore/test_block.cc
+++ b/src/test/crimson/seastore/test_block.cc
@@ -19,6 +19,7 @@ void TestBlock::apply_delta(const ceph::bufferlist &bl) {
   decode(deltas, biter);
   for (auto &&d : deltas) {
     set_contents(d.val, d.offset, d.len);
+    modified_region.union_insert(d.offset, d.len);
   }
 }
 

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -83,6 +83,20 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
   void clear_delta() final {
     delta.clear();
   }
+
+  std::optional<modified_region_t> get_modified_region() final {
+    interval_set<extent_len_t> range;
+    for (auto &p : delta) {
+      if (p.len > 0) {
+	range.union_insert(p.offset, p.len);
+      }
+    }
+    if (range.empty()) {
+      return std::nullopt;
+    }
+    return modified_region_t{range.range_start(),
+      range.range_end() - range.range_start()};
+  }
 };
 using TestBlockRef = TCachedExtentRef<TestBlock>;
 

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -79,6 +79,10 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
   }
 
   void apply_delta(const ceph::bufferlist &bl) final;
+
+  void clear_delta() final {
+    delta.clear();
+  }
 };
 using TestBlockRef = TCachedExtentRef<TestBlock>;
 

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -24,8 +24,8 @@ struct test_extent_desc_t {
 
 struct test_block_delta_t {
   int8_t val = 0;
-  uint16_t offset = 0;
-  uint16_t len = 0;
+  extent_len_t offset = 0;
+  extent_len_t len = 0;
 
 
   DENC(test_block_delta_t, v, p) {
@@ -67,7 +67,9 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
 
   ceph::bufferlist get_delta() final;
 
-  void set_contents(char c, uint16_t offset, uint16_t len) {
+  void set_contents(char c, extent_len_t offset, extent_len_t len) {
+    assert(offset + len <= get_length());
+    assert(len > 0);
     ::memset(get_bptr().c_str() + offset, c, len);
     delta.push_back({c, offset, len});
     modified_region.union_insert(offset, len);
@@ -121,7 +123,7 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
     return TYPE;
   }
 
-  void set_contents(char c, uint16_t offset, uint16_t len) {
+  void set_contents(char c, extent_len_t offset, extent_len_t len) {
     ::memset(get_bptr().c_str() + offset, c, len);
     delta.push_back({c, offset, len});
   }
@@ -142,13 +144,13 @@ struct test_block_mutator_t {
     std::numeric_limits<int8_t>::min(),
     std::numeric_limits<int8_t>::max());
 
-  std::uniform_int_distribution<uint16_t>
-  offset_distribution = std::uniform_int_distribution<uint16_t>(
+  std::uniform_int_distribution<extent_len_t>
+  offset_distribution = std::uniform_int_distribution<extent_len_t>(
     0, TestBlock::SIZE - 1);
 
-  std::uniform_int_distribution<uint16_t> length_distribution(uint16_t offset) {
-    return std::uniform_int_distribution<uint16_t>(
-      0, TestBlock::SIZE - offset - 1);
+  std::uniform_int_distribution<extent_len_t> length_distribution(extent_len_t offset) {
+    return std::uniform_int_distribution<extent_len_t>(
+      1, TestBlock::SIZE - offset);
   }
 
 

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -246,7 +246,8 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
 	}
       }
       assert(found == true);
-      return Journal::replay_ertr::make_ready_future<bool>(true);
+      return Journal::replay_ertr::make_ready_future<
+	std::pair<bool, CachedExtentRef>>(true, nullptr);
     });
   }
 
@@ -576,7 +577,8 @@ TEST_F(cbjournal_test_t, multiple_submit_at_end)
 	     auto &dirty_seq,
 	     auto &alloc_seq,
 	     auto last_modified) {
-      return Journal::replay_ertr::make_ready_future<bool>(true);
+      return Journal::replay_ertr::make_ready_future<
+	std::pair<bool, CachedExtentRef>>(true, nullptr);
     }).unsafe_get0();
     assert(get_written_to() == old_written_to);
   });

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -218,7 +218,8 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
 	  delta_checker = std::nullopt;
 	  advance();
 	}
-	return Journal::replay_ertr::make_ready_future<bool>(true);
+	return Journal::replay_ertr::make_ready_future<
+	  std::pair<bool, CachedExtentRef>>(true, nullptr);
       }).unsafe_get0();
     ASSERT_EQ(record_iter, records.end());
     for (auto &i : records) {


### PR DESCRIPTION
Follow up https://github.com/ceph/ceph/pull/50419

The goal of this PR is to perform inplace overwrite during rewriting dirty data extents.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
