### PR TITLE
reef: qa/suites/rados/verify/validater/valgrind: increase op thread timeout

### DIFF
--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -9,6 +9,8 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 80
+        # see https://tracker.ceph.com/issues/62992
+        osd op thread timeout: 150
       mon:
         mon osd crush smoke test: false
       osd:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63559

---

backport of https://github.com/ceph/ceph/pull/54492
parent tracker: https://tracker.ceph.com/issues/62992

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh