### PR TITLE
osd/scrubber: fix ambiguous call to format_to()

### DIFF
--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -238,7 +238,7 @@ struct formatter<Scrub::sched_conf_t> {
   template <typename FormatContext>
   auto format(const Scrub::sched_conf_t& cf, FormatContext& ctx)
   {
-    return format_to(
+    return fmt::format_to(
 	ctx.out(),
 	"periods: s:{}/{} d:{}/{} iv-ratio:{} deep-rand:{} on-inv:{}",
 	cf.shallow_interval, cf.max_shallow.value_or(-1.0), cf.deep_interval,


### PR DESCRIPTION
new call to `format_to()` from https://github.com/ceph/ceph/pull/54363 is ambiguous between std and fmt namespaces:
```
ceph/src/osd/scrubber/pg_scrubber.cc:654:26:   required from here
ceph/src/osd/scrubber/scrub_job.h:241:21: error: call of overloaded ‘format_to(fmt::v9::basic_format_context<fmt::v9::appender, char>::iterator, const char [60], const double&, double, const double&, const double&, const double&, const double&, const bool&)’ is ambiguous
...
ceph/src/fmt/include/fmt/core.h:3233:17: note: candidate: ‘OutputIt fmt::v9::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {const double&, double, const double&, const double&, const double&, const double&, const bool&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, const double&, double, const double&, const double&, const double&, const double&, const bool&>]’
 3233 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
...
/usr/include/c++/13/format:3824:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v9::appender; _Args = {const double&, double, const double&, const double&, const double&, const double&, const bool&}; format_string<_Args ...> = basic_format_string<char, const double&, double, const double&, const double&, const double&, const double&, const bool&>]’
 3824 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
```
gcc (GCC) 13.2.1 20231011 (Red Hat 13.2.1-4)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
