### PR TITLE
doc/start: explain "OSD"

### DIFF
--- a/doc/start/intro.rst
+++ b/doc/start/intro.rst
@@ -9,10 +9,10 @@ System`.  All :term:`Ceph Storage Cluster` deployments begin with setting up
 each :term:`Ceph Node` and then setting up the network. 
 
 A Ceph Storage Cluster requires the following: at least one Ceph Monitor and at
-least one Ceph Manager, and at least as many Ceph OSDs as there are copies of
-an object stored on the Ceph cluster (for example, if three copies of a given
-object are stored on the Ceph cluster, then at least three OSDs must exist in
-that Ceph cluster). 
+least one Ceph Manager, and at least as many :term:`Ceph Object Storage
+Daemon<Ceph OSD>`\s (OSDs) as there are copies of a given object stored in the
+Ceph cluster (for example, if three copies of a given object are stored in the
+Ceph cluster, then at least three OSDs must exist in that Ceph cluster).
 
 The Ceph Metadata Server is necessary to run Ceph File System clients.
 


### PR DESCRIPTION
Explain the initialism "OSD" and link to its definition in the glossary. This PR is raised in response to an anonymous documentation bug that reads

  "Paragraph 2 uses the acronym OSD without any explanation.
   This makes it very difficult to understand this part of
   the documentation as there is no indication of what this
   acronym is until much further into the documentation. Replace
   first occurence of OSD with Object Storage Daemon (OSD) or
   link it to the glossary."
     -- https://pad.ceph.com/p/Report_Documentation_Bugs





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
