### PR TITLE
pacific: mgr: remove out&down osd from mgr daemons

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -489,7 +489,7 @@ void Mgr::handle_osd_map()
   cluster_state.with_osdmap_and_pgmap([this, &names_exist](const OSDMap &osd_map,
 							   const PGMap &pg_map) {
     for (int osd_id = 0; osd_id < osd_map.get_max_osd(); ++osd_id) {
-      if (!osd_map.exists(osd_id)) {
+      if (!osd_map.exists(osd_id) || (osd_map.is_out(osd_id) && osd_map.is_down(osd_id))) {
         continue;
       }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63366

---

backport of https://github.com/ceph/ceph/pull/53993
parent tracker: https://tracker.ceph.com/issues/63195

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh