### PR TITLE
pacific: osd: mds: suggest clock skew when failing to obtain rotating service keys

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -541,7 +541,8 @@ int MDSDaemon::init()
       continue;
     }
     derr << "ERROR: failed to refresh rotating keys, "
-         << "maximum retry time reached." << dendl;
+         << "maximum retry time reached."
+	 << " Maybe I have a clock skew against the monitors?" << dendl;
     std::lock_guard locker{mds_lock};
     suicide();
     return -CEPHFS_ETIMEDOUT;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3835,7 +3835,8 @@ int OSD::init()
     derr << "unable to obtain rotating service keys; retrying" << dendl;
     ++rotating_auth_attempts;
     if (rotating_auth_attempts > g_conf()->max_rotating_auth_attempts) {
-        derr << __func__ << " wait_auth_rotating timed out" << dendl;
+        derr << __func__ << " wait_auth_rotating timed out"
+	     <<" -- maybe I have a clock skew against the monitors?" << dendl;
 	exit(1);
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58333

---

backport of https://github.com/ceph/ceph/pull/48318
parent tracker: https://tracker.ceph.com/issues/17170

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh