### PR TITLE
pacific: common:  intrusive_lru destructor add

### DIFF
--- a/src/common/intrusive_lru.h
+++ b/src/common/intrusive_lru.h
@@ -166,6 +166,10 @@ public:
     evict();
   }
 
+  ~intrusive_lru() {
+    set_target_size(0);
+  }
+
   friend void intrusive_ptr_add_ref<>(intrusive_lru_base<Config> *);
   friend void intrusive_ptr_release<>(intrusive_lru_base<Config> *);
 };

--- a/src/test/common/test_intrusive_lru.cc
+++ b/src/test/common/test_intrusive_lru.cc
@@ -18,7 +18,6 @@ struct TestLRUItem : public ceph::common::intrusive_lru_base<
     unsigned, TestLRUItem, item_to_unsigned<TestLRUItem>>> {
   unsigned key = 0;
   int value = 0;
-  bool seen = false;
 
   TestLRUItem(unsigned key) : key(key) {}
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57794

---

backport of https://github.com/ceph/ceph/pull/48128
parent tracker: https://tracker.ceph.com/issues/57573

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh