### PR TITLE
doc/rados: edit "Using the Monitor's Admin Socket"

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -85,23 +85,27 @@ Using the monitor's admin socket
 ================================
 
 A monitor's admin socket allows you to interact directly with a specific daemon
-by using a Unix socket file. This file is found in the monitor's ``run``
-directory. The admin socket's default directory is
-``/var/run/ceph/ceph-mon.ID.asok``, but this can be overridden and the admin
-socket might be elsewhere, especially if your cluster's daemons are deployed in
-containers. If you cannot find it, either check your ``ceph.conf`` for an
-alternative path or run the following command:
+by using a Unix socket file. This socket file is found in the monitor's ``run``
+directory. 
+
+The admin socket's default directory is ``/var/run/ceph/ceph-mon.ID.asok``. It
+is possible to override the admin socket's default location. If the default
+location has been overridden, then the admin socket will be elsewhere. This is
+often the case when a cluster's daemons are deployed in containers. 
+
+To find the directory of the admin socket, check either your ``ceph.conf`` for
+an alternative path or run the following command:
     
 .. prompt:: bash $
 
    ceph-conf --name mon.ID --show-config-value admin_socket
 
-The admin socket is available for use only when the monitor daemon is running.
-Whenever the monitor has been properly shut down, the admin socket is removed.
-However, if the monitor is not running and the admin socket persists, it is
-likely that the monitor has been improperly shut down.  In any case, if the
-monitor is not running, it will be impossible to use the admin socket, and the
-``ceph`` command is likely to return ``Error 111: Connection Refused``.
+The admin socket is available for use only when the Monitor daemon is running.
+Every time the Monitor is properly shut down, the admin socket is removed.  If
+the Monitor is not running and yet the admin socket persists, it is likely that
+the Monitor has been improperly shut down. If the Monitor is not running, it
+will be impossible to use the admin socket, and the ``ceph`` command is likely
+to return ``Error 111: Connection Refused``.
 
 To access the admin socket, run a ``ceph tell`` command of the following form
 (specifying the daemon that you are interested in):
@@ -110,7 +114,7 @@ To access the admin socket, run a ``ceph tell`` command of the following form
 
    ceph tell mon.<id> mon_status
 
-This command passes a ``help`` command to the specific running monitor daemon
+This command passes a ``help`` command to the specified running Monitor daemon
 ``<id>`` via its admin socket. If you know the full path to the admin socket
 file, this can be done more directly by running the following command:
 


### PR DESCRIPTION
Edit the section "Using the Monitor's Admin Socket" in doc/rados/troubleshooting/troubleshooting-mon.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
