### PR TITLE
tools: modify ceph_dedup_tool to maintain Clang 15 compatibility

### DIFF
--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -581,9 +581,9 @@ public:
       } entry_into = NONE;
 
       /// Valid iterator into map for UNDER|OVER, default for NONE
-      map_t::iterator iter;
+      typename map_t::iterator iter;
 
-      entry_t(entry_into_t entry_into, map_t::iterator iter) :
+      entry_t(entry_into_t entry_into, typename map_t::iterator iter) :
 	entry_into(entry_into), iter(iter) {
 	ceph_assert(entry_into != NONE);
       }


### PR DESCRIPTION
Adding 'typename' in two instances, where version 15 of Clang still requires it. P0634R3, which made those 'typename' redundant, is only supported starting Clang 16.
