### PR TITLE
Detect NFS availability without mgr crash

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -268,12 +268,19 @@ class NFSGaneshaUi(BaseController):
     @Endpoint()
     @ReadPermission
     def status(self):
-        status = {'available': True, 'message': None}
         try:
-            mgr.remote('nfs', 'cluster_ls')
+            available = mgr.remote('nfs', 'available')
         except (ImportError, RuntimeError) as error:
             logger.exception(error)
-            status['available'] = False
-            status['message'] = str(error)  # type: ignore
+            return {'available': False, 'message': str(error)}
 
-        return status
+        return {
+            'available': available,
+            'message': (
+                '' if available
+                else (
+                    'NFS-Ganesha is unavailable, '
+                    'or Orchestrator is not configured.'
+                )
+            )
+        }

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -5,7 +5,7 @@ from typing import Tuple, Optional, List, Dict, Any
 from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
-from orchestrator.module import IngressType
+from orchestrator.module import IngressType, NoOrchestrator
 
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
@@ -186,4 +186,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo)
 
     def cluster_ls(self) -> List[str]:
-        return available_clusters(self)
+        try:
+            return available_clusters(self)
+        except NoOrchestrator as e:
+            log.error(str(e))
+            return []
+
+    def available(self) -> bool:
+        try:
+            available_clusters(self)
+        except Exception:
+            return False
+        return True


### PR DESCRIPTION
Ceph Dashboard needs to check availability of the NFS service
for the NFS tab.
However, the existing method caused the nfs mgr module to crash,
as ceph dashboard called `cluster_ls`,
which crashed if the orchestrator was not available.

Resolve the issue with two things:

1. Avoid crashing the module if orchestrator is not available.
The `cluster_ls` function now returns an empty list if no orchestrator.

2. Add a function to check if NFS is available.  This should be separate
from the `cluster_ls`, as we should avoid overloading the `cluster_ls`
function.  This way, we have a new function that can provide information
about whether the NFS + Orchestrator is available or not.

Fixes: https://tracker.ceph.com/issues/56246

Fixes: https://bugs.launchpad.net/charm-ceph-dashboard/+bug/2039955

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
