### PR TITLE
cmake: ceph-dencoder depends on ceph-dencoder-modules

### DIFF
--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -20,6 +20,7 @@ set_target_properties(ceph-dencoder PROPERTIES
 
 set(denc_plugin_dir ${CEPH_INSTALL_FULL_PKGLIBDIR}/denc)
 add_custom_target(ceph-dencoder-modules)
+add_dependencies(ceph-dencoder ceph-dencoder-modules)
 
 function(add_denc_mod name)
   add_library(${name} SHARED


### PR DESCRIPTION
building ceph-dencoder alone should also build the modules necessary to run it. otherwise these modules are only built if all targets are built

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
