### PR TITLE
crush: remove unused variables

### DIFF
--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -474,12 +474,6 @@ int CrushTester::test(CephContext* cct)
   // make adjustments
   adjust_weights(weight);
 
-
-  int num_devices_active = 0;
-  for (vector<__u32>::iterator p = weight.begin(); p != weight.end(); ++p)
-    if (*p > 0)
-      num_devices_active++;
-
   if (output_choose_tries)
     crush.start_choose_profile();
   

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1576,13 +1576,11 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight,
   while (!q.empty()) {
     b = q.front();
     q.pop_front();
-    int local_changed = 0;
     for (unsigned i=0; i<b->size; ++i) {
       int n = b->items[i];
       if (n >= 0) {
 	adjust_item_weight_in_bucket(cct, n, weight, b->id, update_weight_sets);
 	++changed;
-	++local_changed;
       } else {
 	crush_bucket *sub = get_bucket(n);
 	if (IS_ERR(sub))


### PR DESCRIPTION
resolves warnings about 'set but unused' variables:
```
[161/715] Building CXX object src/crush/CMakeFiles/crush_objs.dir/CrushTester.cc.o
ceph/src/crush/CrushTester.cc:478:7: warning: variable 'num_devices_active' set but not used [-Wunused-but-set-variable]
  int num_devices_active = 0;
      ^
1 warning generated.
[165/715] Building CXX object src/crush/CMakeFiles/crush_objs.dir/CrushWrapper.cc.o
ceph/src/crush/CrushWrapper.cc:1579:9: warning: variable 'local_changed' set but not used [-Wunused-but-set-variable]
    int local_changed = 0;
        ^
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
