### PR TITLE
rgw: fix RGWPeriod encoding after removing realm_name

### DIFF
--- a/src/rgw/driver/rados/rgw_zone.h
+++ b/src/rgw/driver/rados/rgw_zone.h
@@ -778,6 +778,8 @@ public:
     encode(master_zonegroup, bl);
     encode(period_config, bl);
     encode(realm_id, bl);
+    std::string realm_name; // removed
+    encode(realm_name, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -793,6 +795,8 @@ public:
     decode(master_zonegroup, bl);
     decode(period_config, bl);
     decode(realm_id, bl);
+    std::string realm_name; // removed
+    decode(realm_name, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/54264 removed `realm_name` from `RGWPeriod` encoding and broke backward compatibility. add the `realm_name` back as an empty/temporary string

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
