### PR TITLE
fix: osd stuck with preboot when boot due to OSDMap consumes slowly in advance_pg

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -757,12 +757,42 @@ options:
   level: advanced
   default: 40
   with_legacy: true
+- name: osd_map_bl_cache_size
+  type: int
+  level: advanced
+  default: 50
+  fmt_desc: OSDMap bufferlist max cache size.
+  with_legacy: true
+- name: osd_map_bl_inc_cache_size
+  type: int
+  level: advanced
+  default: 50
+  fmt_desc: OSDMap inc bufferlist max cache size.
+  with_legacy: true
 - name: osd_map_cache_size
   type: int
   level: advanced
   default: 50
   fmt_desc: The number of OSD maps to keep cached.
   with_legacy: true
+- name: osd_map_cache_burst_size
+  type: int
+  level: advanced
+  default: 500
+  fmt_desc: when osd receives osdmap, osd is allowed to temporarily increase
+    the size of map_cache to improve the cache hit rate and reduce latency
+    when reading osdmap during advance_pg.
+  with_legacy: true
+  see_also:
+  - osd_map_cache_size
+- name: osd_map_cache_reduce_step
+  type: int
+  level: advanced
+  default: 10
+  fmt_desc: reduce the number of map_cache at one time.
+  with_legacy: true
+  see_also:
+  - osd_map_cache_size
 - name: osd_pg_epoch_max_lag_factor
   type: float
   level: advanced

--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -209,6 +209,11 @@ public:
     }
   }
 
+  int get_max_size() {
+    std::lock_guard locker{lock};
+    return max_size;
+  }
+
   // Returns K key s.t. key <= k for all currently cached k,v
   K cached_key_lower_bound() {
     std::lock_guard l{lock};

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -666,7 +666,9 @@ public:
   // osd map cache (past osd maps)
   ceph::mutex map_cache_lock = ceph::make_mutex("OSDService::map_cache_lock");
   SharedLRU<epoch_t, const OSDMap> map_cache;
+  ceph::mutex map_bl_cache_lock = ceph::make_mutex("OSDService::map_bl_cache_lock");
   SimpleLRU<epoch_t, ceph::buffer::list> map_bl_cache;
+  ceph::mutex map_bl_inc_cache_lock = ceph::make_mutex("OSDService::map_bl_inc_cache_lock");
   SimpleLRU<epoch_t, ceph::buffer::list> map_bl_inc_cache;
 
   OSDMapRef try_get_map(epoch_t e);
@@ -683,7 +685,7 @@ public:
 
   void _add_map_bl(epoch_t e, ceph::buffer::list& bl);
   bool get_map_bl(epoch_t e, ceph::buffer::list& bl) {
-    std::lock_guard l(map_cache_lock);
+    std::lock_guard l(map_bl_cache_lock);
     return _get_map_bl(e, bl);
   }
   bool _get_map_bl(epoch_t e, ceph::buffer::list& bl);


### PR DESCRIPTION
commit-1
```
- MOSDMap receive 40 epochs osdmap once,
  - store to bluestore
  - then consume_map for every pg
    - OSD::advance_pg call try_get_map
    - try_get_map will acquire map_cache_lock
      - but very high latency
      - 40 epoch osdmaps need cost 1.7~2.5s
- resolve
  - Split map_cache_lock to reduce the lock range
```

commit-2

    fix: osd stuck with preboot when boot due to OSDMap consumes slowly in advance_pg

    question
    - handle_osd_map receives 40 osdmaps and persists them to the osd store
    - after persistence is completed, these 40 osdmaps will be applied to 128 pg
      - 1 osd has 128 pg, 5 shard-queue/thread
      - 1 shard-queue/thread is divided into about 26 pg
      - When pg consumes 40 osdmaps and map_cache misses, it takes about 2 seconds.
      - 26 pg, takes about 52 seconds
        - pg consumes osdmap with too long delay
        - This will cause handle_osd_map to block receiving subsequent osdmaps
        - Makes osd unable to track the latest osdmap epoch
        - This will cause the osd to stay in the preboot state for a long time
        - and even affect business IO.

    Solution: Exchange space for time
    - separate parameters to avoid mutual interference after setting
      - osd_map_bl_cache_size
      - osd_map_bl_inc_cache_size
      - osd_map_cache_size
      - osd_map_cache_burst_size
      - osd_map_cache_reduce_step
    - added osd_map_cache_burst_size configuration parameter
      - When OSD::handle_osd_map receives a new osdmap
        - allows temporarily increasing the max_size of map_cache to cache more osdmaps
      - OSD::tick periodically checks the max_size of map_cache
        - when 128 pg osdmap epochs have caught up with superblock.newest_map
        - restore the max_size of map_cache to osd_map_cache_size
        - avoid taking up too much physical memory

- issue: https://tracker.ceph.com/issues/63609

