### PR TITLE
reef: test/libcephfs: skip flaky timestamp assertion on Windows

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -3711,8 +3711,11 @@ TEST(LibCephFS, SnapdirAttrsOnSnapDelete) {
 
   struct ceph_statx stx_snap_dir_2;
   ASSERT_EQ(ceph_statx(cmount, snap_dir_path, &stx_snap_dir_2, CEPH_STATX_MTIME|CEPH_STATX_CTIME|CEPH_STATX_VERSION, 0), 0);
+  // Flaky assertion on Windows, potentially due to timestamp precision.
+  #ifndef _WIN32
   ASSERT_LT(utime_t(stx_snap_dir_1.stx_mtime), utime_t(stx_snap_dir_2.stx_mtime));
   ASSERT_LT(utime_t(stx_snap_dir_1.stx_ctime), utime_t(stx_snap_dir_2.stx_ctime));
+  #endif
   ASSERT_LT(stx_snap_dir_1.stx_version, stx_snap_dir_2.stx_version);
 
   ASSERT_EQ(0, ceph_rmdir(cmount, dir_path));
@@ -3764,8 +3767,11 @@ TEST(LibCephFS, SnapdirAttrsOnSnapRename) {
 
   struct ceph_statx stx_snap_dir_2;
   ASSERT_EQ(ceph_statx(cmount, snap_dir_path, &stx_snap_dir_2, CEPH_STATX_MTIME|CEPH_STATX_CTIME|CEPH_STATX_VERSION, 0), 0);
+  // Flaky assertion on Windows, potentially due to timestamp precision.
+  #ifndef _WIN32
   ASSERT_LT(utime_t(stx_snap_dir_1.stx_mtime), utime_t(stx_snap_dir_2.stx_mtime));
   ASSERT_LT(utime_t(stx_snap_dir_1.stx_ctime), utime_t(stx_snap_dir_2.stx_ctime));
+  #endif
   ASSERT_LT(stx_snap_dir_1.stx_version, stx_snap_dir_2.stx_version);
 
   ASSERT_EQ(0, ceph_rmdir(cmount, snap_path_r));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63611

---

backport of https://github.com/ceph/ceph/pull/50544
parent tracker: https://tracker.ceph.com/issues/63610

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh