### PR TITLE
osd/scrub: allow auto-repair on operator-initiated scrubs

### DIFF
--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -169,8 +169,7 @@ struct requested_scrub_t {
    * the value of auto_repair is determined in sched_scrub() (once per scrub.
    * previous value is not remembered). Set if
    * - allowed by configuration and backend, and
-   * - must_scrub is not set (i.e. - this is a periodic scrub),
-   * - time_for_deep was just set
+   * - for periodic scrubs: time_for_deep was just set
    */
   bool auto_repair{false};
 


### PR DESCRIPTION
Previously, operator-initiated scrubs would not auto-repair, regardless of the value of the 'osd_scrub_auto_repair' config option.  This was less confusing to the operator than it could have been, as most operator commands would in fact cause a regular periodic scrub to be initiated. However, that quirk is now fixed: operator commands now trigger 'op-initiated' scrubs. Thus the need for this patch.

