### PR TITLE
OSDMap: adding 'reef' to pending_require_osd_release

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -673,7 +673,7 @@ Do I need to restart a monitor to adjust debug levels?
 No, restarting a monitor is not necessary. Debug levels may be adjusted by
 using two different methods, depending on whether or not there is a quorum:
 
-There is a quorum
+**If there is a quorum**
 
   Either inject the debug option into the specific monitor that needs to 
   be debugged::
@@ -685,7 +685,7 @@ There is a quorum
         ceph tell mon.* config set debug_mon 10/10
 
 
-There is no quorum
+**If there is no quorum**
 
   Use the admin socket of the specific monitor that needs to be debugged
   and directly adjust the monitor's configuration options::

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -474,12 +474,6 @@ int CrushTester::test(CephContext* cct)
   // make adjustments
   adjust_weights(weight);
 
-
-  int num_devices_active = 0;
-  for (vector<__u32>::iterator p = weight.begin(); p != weight.end(); ++p)
-    if (*p > 0)
-      num_devices_active++;
-
   if (output_choose_tries)
     crush.start_choose_profile();
   

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1576,13 +1576,11 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight,
   while (!q.empty()) {
     b = q.front();
     q.pop_front();
-    int local_changed = 0;
     for (unsigned i=0; i<b->size; ++i) {
       int n = b->items[i];
       if (n >= 0) {
 	adjust_item_weight_in_bucket(cct, n, weight, b->id, update_weight_sets);
 	++changed;
-	++local_changed;
       } else {
 	crush_bucket *sub = get_bucket(n);
 	if (IS_ERR(sub))

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7410,6 +7410,10 @@ unsigned OSDMap::get_device_class_flags(int id) const
 
 std::optional<std::string> OSDMap::pending_require_osd_release() const
 {
+  if (HAVE_FEATURE(get_up_osd_features(), SERVER_REEF) &&
+      require_osd_release < ceph_release_t::reef) {
+    return "reef";
+  }
   if (HAVE_FEATURE(get_up_osd_features(), SERVER_QUINCY) &&
       require_osd_release < ceph_release_t::quincy) {
     return "quincy";


### PR DESCRIPTION
It appears adding 'reef' to pending_require_osd_release has been forgotten. This PR adds it

Signed-off-by: Philipp Hufnagl <p.hufnagl@proxmox.com>