### PR TITLE
rgw/posix: fix unused variable warning

### DIFF
--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -34,7 +34,6 @@ const std::string ATTR_PREFIX = "user.X-RGW-";
 #define RGW_POSIX_ATTR_OWNER "POSIX-Owner"
 const std::string mp_ns = "multipart";
 const std::string MP_OBJ_PART_PFX = "part-";
-const std::string MP_OBJ_PART_FMT = "{:0>5}";
 const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
 
 static inline bool get_attr(Attrs& attrs, const char* name, bufferlist& bl)


### PR DESCRIPTION
```
ceph/src/rgw/driver/posix/rgw_sal_posix.cc:37:19: warning: unused variable 'MP_OBJ_PART_FMT' [-Wunused-const-variable]
const std::string MP_OBJ_PART_FMT = "{:0>5}";
                  ^
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
