### PR TITLE
reef: ceph-volume: fixes fallback to stat in is_device and is_partition

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -153,14 +153,6 @@ class TestDevice(object):
         assert disk.is_device is True
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
-    def test_is_partition(self, fake_call, device_info):
-        data = {"/dev/sda1": {"foo": "bar"}}
-        lsblk = {"TYPE": "part", "NAME": "sda1", "PKNAME": "sda"}
-        device_info(devices=data, lsblk=lsblk)
-        disk = device.Device("/dev/sda1")
-        assert disk.is_partition
-
-    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
     def test_mpath_device_is_device(self, fake_call, device_info):
         data = {"/dev/foo": {"foo": "bar"}}
         lsblk = {"TYPE": "mpath", "NAME": "foo"}

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -3,6 +3,11 @@ import pytest
 from ceph_volume.util import disk
 from mock.mock import patch
 
+    @patch('ceph_volume.util.disk.os.path.exists', MagicMock(return_value=True))
+    @patch('ceph_volume.util.disk.get_partitions', MagicMock(return_value={"sda1": "sda"}))
+    def test_is_partition(self):
+        assert disk.is_partition('sda1')
+
 
 class TestLsblkParser(object):
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -360,30 +360,18 @@ def is_device(dev):
             return False
 
     # fallback to stat
-    return _stat_is_device(os.lstat(dev).st_mode)
+    return _stat_is_device(os.lstat(dev).st_mode) and not is_partition(dev)
 
 
-def is_partition(dev):
+def is_partition(dev: str) -> bool:
     """
     Boolean to determine if a given device is a partition, like /dev/sda1
     """
     if not os.path.exists(dev):
         return False
-    # use lsblk first, fall back to using stat
-    TYPE = lsblk(dev).get('TYPE')
-    if TYPE:
-        return TYPE == 'part'
 
-    # fallback to stat
-    stat_obj = os.stat(dev)
-    if _stat_is_device(stat_obj.st_mode):
-        return False
-
-    major = os.major(stat_obj.st_rdev)
-    minor = os.minor(stat_obj.st_rdev)
-    if os.path.exists('/sys/dev/block/%d:%d/partition' % (major, minor)):
-        return True
-    return False
+    partitions = get_partitions()
+    return dev.split("/")[-1] in partitions
 
 
 def is_ceph_rbd(dev):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63599

---

backport of https://github.com/ceph/ceph/pull/53798
parent tracker: https://tracker.ceph.com/issues/58812

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh