### PR TITLE
cephfs_mirror: use snapdiff api for incremental syncing

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -304,6 +304,8 @@ private:
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
 
+  int do_synchronize(const std::string &dir_root, const Snapshot &current);
+
   int synchronize(const std::string &dir_root, const Snapshot &current,
                   boost::optional<Snapshot> prev);
   int do_sync_snaps(const std::string &dir_root);


### PR DESCRIPTION
Use snapdiff api to sync only the delta of files between two snapshots.

Fixes: https://tracker.ceph.com/issues/61334
