### PR TITLE
compressor: move QatAccel out of common

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -506,10 +506,6 @@ if(NOT WITH_SYSTEM_BOOST)
   list(APPEND ceph_common_deps ${ZLIB_LIBRARIES})
 endif()
 
-if(HAVE_QATZIP)
-  list(APPEND ceph_common_deps ${qatzip_LIBRARIES})
-endif()
-
 if(WITH_DPDK)
   list(APPEND ceph_common_deps common_async_dpdk)
 endif()

--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -1,19 +1,14 @@
-
-set(compressor_srcs
-  Compressor.cc)
-if (HAVE_QATZIP)
-  list(APPEND compressor_srcs QatAccel.cc)
-endif()
-add_library(compressor_objs OBJECT ${compressor_srcs})
+add_library(compressor_objs OBJECT Compressor.cc)
 add_dependencies(compressor_objs common-objs)
-if(HAVE_QATZIP AND HAVE_QATDRV)
-  target_link_libraries(compressor_objs PRIVATE
-                        QatDrv::qat_s
-                        QatDrv::usdm_drv_s
-                        qatzip::qatzip
-                       )
-endif()
 add_dependencies(compressor_objs legacy-option-headers)
+
+if(HAVE_QATZIP AND HAVE_QATDRV)
+  add_library(qat_compressor OBJECT QatAccel.cc)
+  target_link_libraries(qat_compressor PUBLIC
+    QatDrv::qat_s
+    QatDrv::usdm_drv_s
+    qatzip::qatzip)
+endif()
 
 ## compressor plugins
 
@@ -31,8 +26,8 @@ if(HAVE_BROTLI)
   add_subdirectory(brotli)
 endif()
 
-add_library(compressor STATIC $<TARGET_OBJECTS:compressor_objs>)
-target_link_libraries(compressor PRIVATE compressor_objs)
+add_library(compressor STATIC)
+target_link_libraries(compressor PUBLIC compressor_objs)
 
 set(ceph_compressor_libs
     ceph_snappy

--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -26,10 +26,6 @@
 
 namespace TOPNSPC {
 
-#ifdef HAVE_QATZIP
-  QatAccel Compressor::qat_accel;
-#endif
-
 const char* Compressor::get_comp_alg_name(int a) {
 
   auto p = std::find_if(std::cbegin(compression_algorithms), std::cend(compression_algorithms),

--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -23,9 +23,6 @@
 #include "include/common_fwd.h"
 #include "include/buffer.h"
 #include "include/int_types.h"
-#ifdef HAVE_QATZIP
-  #include "QatAccel.h"
-#endif
 
 namespace TOPNSPC {
 
@@ -69,11 +66,6 @@ public:
     COMP_AGGRESSIVE,            ///< compress unless hinted INCOMPRESSIBLE
     COMP_FORCE                  ///< compress always
   };
-
-#ifdef HAVE_QATZIP
-  bool qat_enabled;
-  static QatAccel qat_accel;
-#endif
 
   static const char* get_comp_alg_name(int a);
   static std::optional<CompressionAlgorithm> get_comp_alg_type(std::string_view s);

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -2,11 +2,15 @@
 
 set(lz4_sources
   CompressionPluginLZ4.cc
+  LZ4Compressor.cc
 )
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
 target_link_libraries(ceph_lz4
   PRIVATE LZ4::LZ4 compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
+if(HAVE_QATZIP AND HAVE_QATDRV)
+  target_link_libraries(ceph_lz4 PRIVATE qat_compressor)
+endif()
 set_target_properties(ceph_lz4 PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/lz4/LZ4Compressor.cc
+++ b/src/compressor/lz4/LZ4Compressor.cc
@@ -1,0 +1,149 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "LZ4Compressor.h"
+#include "common/ceph_context.h"
+#ifdef HAVE_QATZIP
+  #include "compressor/QatAccel.h"
+#endif
+
+#ifdef HAVE_QATZIP
+QatAccel LZ4Compressor::qat_accel;
+#endif
+
+LZ4Compressor::LZ4Compressor(CephContext* cct)
+  : Compressor(COMP_ALG_LZ4, "lz4")
+{
+#ifdef HAVE_QATZIP
+  if (cct->_conf->qat_compressor_enabled && qat_accel.init("lz4"))
+    qat_enabled = true;
+  else
+    qat_enabled = false;
+#endif
+}
+
+int LZ4Compressor::compress(const ceph::buffer::list &src,
+                            ceph::buffer::list &dst,
+                            std::optional<int32_t> &compressor_message)
+{
+  // older versions of liblz4 introduce bit errors when compressing
+  // fragmented buffers.  this was fixed in lz4 commit
+  // af127334670a5e7b710bbd6adb71aa7c3ef0cd72, which first
+  // appeared in v1.8.2.
+  //
+  // workaround: rebuild if not contiguous.
+  if (!src.is_contiguous()) {
+    ceph::buffer::list new_src = src;
+    new_src.rebuild();
+    return compress(new_src, dst, compressor_message);
+  }
+
+#ifdef HAVE_QATZIP
+  if (qat_enabled)
+    return qat_accel.compress(src, dst, compressor_message);
+#endif
+  ceph::buffer::ptr outptr = ceph::buffer::create_small_page_aligned(
+    LZ4_compressBound(src.length()));
+  LZ4_stream_t lz4_stream;
+  LZ4_resetStream(&lz4_stream);
+
+  using ceph::encode;
+
+  auto p = src.begin();
+  size_t left = src.length();
+  int pos = 0;
+  const char *data;
+  unsigned num = src.get_num_buffers();
+  encode((uint32_t)num, dst);
+  while (left) {
+    uint32_t origin_len = p.get_ptr_and_advance(left, &data);
+    int compressed_len = LZ4_compress_fast_continue(
+      &lz4_stream, data, outptr.c_str()+pos, origin_len,
+      outptr.length()-pos, 1);
+    if (compressed_len <= 0)
+      return -1;
+    pos += compressed_len;
+    left -= origin_len;
+    encode(origin_len, dst);
+    encode((uint32_t)compressed_len, dst);
+  }
+  ceph_assert(p.end());
+
+  dst.append(outptr, 0, pos);
+  return 0;
+}
+
+int LZ4Compressor::decompress(const ceph::buffer::list &src,
+                              ceph::buffer::list &dst,
+                              std::optional<int32_t> compressor_message)
+{
+#ifdef HAVE_QATZIP
+  if (qat_enabled)
+    return qat_accel.decompress(src, dst, compressor_message);
+#endif
+  auto i = std::cbegin(src);
+  return decompress(i, src.length(), dst, compressor_message);
+}
+
+int LZ4Compressor::decompress(ceph::buffer::list::const_iterator &p,
+                              size_t compressed_len,
+                              ceph::buffer::list &dst,
+                              std::optional<int32_t> compressor_message)
+{
+#ifdef HAVE_QATZIP
+  if (qat_enabled)
+    return qat_accel.decompress(p, compressed_len, dst, compressor_message);
+#endif
+  using ceph::decode;
+  uint32_t count;
+  decode(count, p);
+  std::vector<std::pair<uint32_t, uint32_t> > compressed_pairs(count);
+  uint32_t total_origin = 0;
+  for (auto& [dst_size, src_size] : compressed_pairs) {
+    decode(dst_size, p);
+    decode(src_size, p);
+    total_origin += dst_size;
+  }
+  compressed_len -= (sizeof(uint32_t) + sizeof(uint32_t) * count * 2);
+
+  ceph::buffer::ptr dstptr(total_origin);
+  LZ4_streamDecode_t lz4_stream_decode;
+  LZ4_setStreamDecode(&lz4_stream_decode, nullptr, 0);
+
+  ceph::buffer::ptr cur_ptr = p.get_current_ptr();
+  ceph::buffer::ptr *ptr = &cur_ptr;
+  std::optional<ceph::buffer::ptr> data_holder;
+  if (compressed_len != cur_ptr.length()) {
+    data_holder.emplace(compressed_len);
+    p.copy_deep(compressed_len, *data_holder);
+    ptr = &*data_holder;
+  }
+
+  char *c_in = ptr->c_str();
+  char *c_out = dstptr.c_str();
+  for (unsigned i = 0; i < count; ++i) {
+    int r = LZ4_decompress_safe_continue(
+        &lz4_stream_decode, c_in, c_out, compressed_pairs[i].second, compressed_pairs[i].first);
+    if (r == (int)compressed_pairs[i].first) {
+      c_in += compressed_pairs[i].second;
+      c_out += compressed_pairs[i].first;
+    } else if (r < 0) {
+      return -1;
+    } else {
+      return -2;
+    }
+  }
+  dst.push_back(std::move(dstptr));
+  return 0;
+}

--- a/src/compressor/lz4/LZ4Compressor.h
+++ b/src/compressor/lz4/LZ4Compressor.h
@@ -23,125 +23,29 @@
 #include "include/encoding.h"
 #include "common/config.h"
 
+class QatAccel;
 
 class LZ4Compressor : public Compressor {
+#ifdef HAVE_QATZIP
+  bool qat_enabled;
+  static QatAccel qat_accel;
+#endif
+
  public:
-  LZ4Compressor(CephContext* cct) : Compressor(COMP_ALG_LZ4, "lz4") {
-#ifdef HAVE_QATZIP
-    if (cct->_conf->qat_compressor_enabled && qat_accel.init("lz4"))
-      qat_enabled = true;
-    else
-      qat_enabled = false;
-#endif
-  }
+  explicit LZ4Compressor(CephContext* cct);
 
-  int compress(const ceph::buffer::list &src, ceph::buffer::list &dst, std::optional<int32_t> &compressor_message) override {
-    // older versions of liblz4 introduce bit errors when compressing
-    // fragmented buffers.  this was fixed in lz4 commit
-    // af127334670a5e7b710bbd6adb71aa7c3ef0cd72, which first
-    // appeared in v1.8.2.
-    //
-    // workaround: rebuild if not contiguous.
-    if (!src.is_contiguous()) {
-      ceph::buffer::list new_src = src;
-      new_src.rebuild();
-      return compress(new_src, dst, compressor_message);
-    }
+  int compress(const ceph::buffer::list &src,
+               ceph::buffer::list &dst,
+               std::optional<int32_t> &compressor_message) override;
 
-#ifdef HAVE_QATZIP
-    if (qat_enabled)
-      return qat_accel.compress(src, dst, compressor_message);
-#endif
-    ceph::buffer::ptr outptr = ceph::buffer::create_small_page_aligned(
-      LZ4_compressBound(src.length()));
-    LZ4_stream_t lz4_stream;
-    LZ4_resetStream(&lz4_stream);
-
-    using ceph::encode;
-
-    auto p = src.begin();
-    size_t left = src.length();
-    int pos = 0;
-    const char *data;
-    unsigned num = src.get_num_buffers();
-    encode((uint32_t)num, dst);
-    while (left) {
-      uint32_t origin_len = p.get_ptr_and_advance(left, &data);
-      int compressed_len = LZ4_compress_fast_continue(
-        &lz4_stream, data, outptr.c_str()+pos, origin_len,
-        outptr.length()-pos, 1);
-      if (compressed_len <= 0)
-        return -1;
-      pos += compressed_len;
-      left -= origin_len;
-      encode(origin_len, dst);
-      encode((uint32_t)compressed_len, dst);
-    }
-    ceph_assert(p.end());
-
-    dst.append(outptr, 0, pos);
-    return 0;
-  }
-
-  int decompress(const ceph::buffer::list &src, ceph::buffer::list &dst, std::optional<int32_t> compressor_message) override {
-#ifdef HAVE_QATZIP
-    if (qat_enabled)
-      return qat_accel.decompress(src, dst, compressor_message);
-#endif
-    auto i = std::cbegin(src);
-    return decompress(i, src.length(), dst, compressor_message);
-  }
+  int decompress(const ceph::buffer::list &src,
+                 ceph::buffer::list &dst,
+                 std::optional<int32_t> compressor_message) override;
 
   int decompress(ceph::buffer::list::const_iterator &p,
 		 size_t compressed_len,
 		 ceph::buffer::list &dst,
-		 std::optional<int32_t> compressor_message) override {
-#ifdef HAVE_QATZIP
-    if (qat_enabled)
-      return qat_accel.decompress(p, compressed_len, dst, compressor_message);
-#endif
-    using ceph::decode;
-    uint32_t count;
-    decode(count, p);
-    std::vector<std::pair<uint32_t, uint32_t> > compressed_pairs(count);
-    uint32_t total_origin = 0;
-    for (auto& [dst_size, src_size] : compressed_pairs) {
-      decode(dst_size, p);
-      decode(src_size, p);
-      total_origin += dst_size;
-    }
-    compressed_len -= (sizeof(uint32_t) + sizeof(uint32_t) * count * 2);
-
-    ceph::buffer::ptr dstptr(total_origin);
-    LZ4_streamDecode_t lz4_stream_decode;
-    LZ4_setStreamDecode(&lz4_stream_decode, nullptr, 0);
-
-    ceph::buffer::ptr cur_ptr = p.get_current_ptr();
-    ceph::buffer::ptr *ptr = &cur_ptr;
-    std::optional<ceph::buffer::ptr> data_holder;
-    if (compressed_len != cur_ptr.length()) {
-      data_holder.emplace(compressed_len);
-      p.copy_deep(compressed_len, *data_holder);
-      ptr = &*data_holder;
-    }
-
-    char *c_in = ptr->c_str();
-    char *c_out = dstptr.c_str();
-    for (unsigned i = 0; i < count; ++i) {
-      int r = LZ4_decompress_safe_continue(
-          &lz4_stream_decode, c_in, c_out, compressed_pairs[i].second, compressed_pairs[i].first);
-      if (r == (int)compressed_pairs[i].first) {
-        c_in += compressed_pairs[i].second;
-        c_out += compressed_pairs[i].first;
-      } else if (r < 0) {
-        return -1;
-      } else {
-        return -2;
-      }
-    }
-    dst.push_back(std::move(dstptr));
-    return 0;
-  }
+		 std::optional<int32_t> compressor_message) override;
 };
 
 #endif

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -91,6 +91,9 @@ endif()
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 target_link_libraries(ceph_zlib ZLIB::ZLIB compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
+if(HAVE_QATZIP AND HAVE_QATDRV)
+  target_link_libraries(ceph_zlib qat_compressor)
+endif()
 target_include_directories(ceph_zlib SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES
   VERSION 2.0.0

--- a/src/compressor/zlib/ZlibCompressor.h
+++ b/src/compressor/zlib/ZlibCompressor.h
@@ -20,19 +20,18 @@
 #include "common/config.h"
 #include "compressor/Compressor.h"
 
+class QatAccel;
+
 class ZlibCompressor : public Compressor {
   bool isal_enabled;
   CephContext *const cct;
-public:
-  ZlibCompressor(CephContext *cct, bool isal)
-    : Compressor(COMP_ALG_ZLIB, "zlib"), isal_enabled(isal), cct(cct) {
 #ifdef HAVE_QATZIP
-    if (cct->_conf->qat_compressor_enabled && qat_accel.init("zlib"))
-      qat_enabled = true;
-    else
-      qat_enabled = false;
+  bool qat_enabled;
+  static QatAccel qat_accel;
 #endif
-  }
+
+ public:
+  ZlibCompressor(CephContext *cct, bool isal);
 
   int compress(const ceph::buffer::list &in, ceph::buffer::list &out, std::optional<int32_t> &compressor_message) override;
   int decompress(const ceph::buffer::list &in, ceph::buffer::list &out, std::optional<int32_t> compressor_message) override;


### PR DESCRIPTION
move the QatAccel instance out of the Compressor base class and into the zlib and lz4 compressors that can use it

this avoids having to link QAT into the ceph-common library, and only the plugins where it's necessary

had to add LZ4Compressor.cc to store the new static variable

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
