### PR TITLE
Update rbd import-diff command help message

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -63,7 +63,8 @@
                                         associated.
       image-meta set                    Image metadata set key with value.
       import                            Import image from file.
-      import-diff                       Import an incremental diff.
+      import-diff                       Apply an incremental diff to image HEAD,
+                                        then create a snapshot.
       info                              Show information about image size,
                                         striping, etc.
       journal client disconnect         Flag image journal client as disconnected.
@@ -1254,7 +1255,7 @@
                          [--sparse-size <sparse-size>] [--no-progress] 
                          <path-name> <image-spec> 
   
-  Import an incremental diff.
+  Apply an incremental diff to image HEAD, then create a snapshot.
   
   Positional arguments
     <path-name>          import file (or '-' for stdin)

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -526,8 +526,9 @@ int execute_diff(const po::variables_map &vm,
 }
 
 Shell::Action action_diff(
-  {"import-diff"}, {}, "Import an incremental diff.", "", &get_arguments_diff,
-  &execute_diff);
+  {"import-diff"}, {},
+  "Apply an incremental diff to image HEAD, then create a snapshot.", "",
+  &get_arguments_diff, &execute_diff);
 
 class C_Import : public Context {
 public:


### PR DESCRIPTION
Try to update more clear help message for rbd import-diff message.

Since it confuse me for a while. When reading the old help message `Import an incremental diff.`. I think it just apply the diff base on from-snap. And generate a new snapshot. Without changing the current rbd image content.

I'm try to make it more clear that. This command will change the current rbd image content.
