### PR TITLE
reef: debian: add missing bcrypt to ceph-mgr .requires to fix resulting package dependencies

### DIFF
--- a/debian/ceph-mgr.requires
+++ b/debian/ceph-mgr.requires
@@ -1,3 +1,4 @@
+bcrypt
 pyOpenSSL
 cephfs
 ceph-argparse


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63638

---

backport of https://github.com/ceph/ceph/pull/53290
parent tracker: https://tracker.ceph.com/issues/63637

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh